### PR TITLE
[Android] Fix crash on grouped lists with no ItemTemplate

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBaseAdapter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBaseAdapter.Android.cs
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else
 			{
-				viewType = isGroupHeader ? NoTemplateGroupHeaderType : NoTemplateGroupHeaderType;
+				viewType = isGroupHeader ? NoTemplateGroupHeaderType : NoTemplateItemType;
 			}
 
 			if (isGroupHeader)


### PR DESCRIPTION
Fix typo that was causing items in a grouped list with no ItemTemplate to use ListViewHeaderItem instead of ListViewItem, causing a crash from failed assertion.