### PR TITLE
ComboBox - fix disappearing items

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -161,6 +161,7 @@
 * RadioButton was not applying Checked state correctly with non-standard visual state grouping in style
 * [Android] Fix several bugs preventing AutoSuggestBox from working on Android. (#1012)
 * #1062 TextBlock measure caching can wrongly hit
+* Fix ComboBox disappearing items when items are views (#1078)
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml
@@ -35,5 +35,6 @@
 			Previous Combo VisualTree (first item):<LineBreak />
 			<Run x:Name="_combo2Txt"></Run>
 		</TextBlock>
+		<Button x:Name="ChangeSelectionButton" Content="Increment SelectedIndex" Click="ChangeSelectionButton_Click"/>
 	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml.cs
@@ -24,11 +24,17 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 		{
 			var items = _combo.Items;
 			var item = items.First() as FrameworkElement;
-			item.Loaded += (snd, evt) => { _combo1Txt.Text = GetVisualTree(item); };
+			item.Loaded += (snd, evt) =>
+			{
+				_combo1Txt.Text = GetVisualTree(item);
+			};
 
 			var items2 = _combo2.Items;
 			var item2 = items2.First() as FrameworkElement;
-			item2.Loaded += (snd, evt) => { _combo2Txt.Text = GetVisualTree(item2); };
+			item2.Loaded += (snd, evt) =>
+			{
+				_combo2Txt.Text = GetVisualTree(item2);
+			};
 		}
 
 		private void SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -46,7 +52,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 				{
 					var e = o as FrameworkElement;
 					yield return $"{o.GetType().Name}[{e?.Name}]-{o}";
-					if( e is Windows.UI.Xaml.Controls.ComboBox)
+					if (e is Windows.UI.Xaml.Controls.ComboBox)
 					{
 						yield break;
 					}
@@ -54,6 +60,17 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 			}
 
 			return string.Join("\n->", GetElements());
+		}
+
+		private void ChangeSelectionButton_Click(object sender, RoutedEventArgs e)
+		{
+			var newSelectedIndex = _combo2.SelectedIndex;
+			newSelectedIndex++;
+			if (newSelectedIndex >= _combo2.Items.Count)
+			{
+				newSelectedIndex = 0;
+			}
+			_combo2.SelectedIndex = newSelectedIndex;
 		}
 	}
 }

--- a/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
@@ -227,6 +227,21 @@ namespace AppKit
 			}
 		}
 
+		/// <summary>
+		/// Add view to parent.
+		/// </summary>
+		/// <param name="parent">Parent view</param>
+		/// <param name="child">Child view to add</param>
+		public static void AddChild(this _View parent, _View child)
+		{
+			parent.AddSubview(child);
+		}
+
+		/// <summary>
+		/// Get the parent view in the visual tree. This may differ from the logical <see cref="FrameworkElement.Parent"/>.
+		/// </summary>
+		public static _View GetVisualTreeParent(this _View child) => child?.Superview;
+
 		public static IEnumerable<T> FindSubviewsOfType<T>(this _View view, int maxDepth = 20) where T : class
 		{
 			return FindSubviews(view, (v) => v as T != null, maxDepth)

--- a/src/Uno.UI/Extensions/ViewExtensions.Android.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.Android.cs
@@ -51,10 +51,10 @@ namespace Uno.UI
 		/// <typeparam name="T"></typeparam>
 		/// <param name="view"></param>
 		/// <returns>First parent of the view of specified T type.</returns>
-		public static T FindFirstParent<T>(this IViewParent view)
+		public static T FindFirstParent<T>(this View childView)
 			where T : class
 		{
-			view = view?.Parent;
+			var view = childView?.Parent;
 
 			while (view != null)
 			{
@@ -305,6 +305,24 @@ namespace Uno.UI
 
 			return (T)view.EnumerateAllChildren(childSelector, maxDepth).FirstOrDefault();
 		}
+
+		/// <summary>
+		/// Add view to parent.
+		/// </summary>
+		/// <param name="parent">Parent view</param>
+		/// <param name="child">Child view to add</param>
+		public static void AddChild(this ViewGroup parent, View child)
+		{
+			// Remove from existing parent (for compatibility with other platforms).
+			(child.Parent as ViewGroup)?.RemoveView(child);
+
+			parent.AddView(child);
+		}
+
+		/// <summary>
+		/// Get the parent view in the visual tree. This may differ from the logical <see cref="FrameworkElement.Parent"/>.
+		/// </summary>
+		public static ViewGroup GetVisualTreeParent(this View child) => child?.Parent as ViewGroup;
 
 		/// <summary>
 		/// Removes a child view from the specified view, and disposes it if the specified view is the owner.

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -16,10 +16,17 @@ using Windows.Foundation;
 using Uno.UI;
 using System.Linq;
 using Windows.UI.ViewManagement;
-#if __IOS__
+using Uno.UI.DataBinding;
+#if __ANDROID__
+using _View = Android.Views.View;
+#elif __IOS__
 using UIKit;
+using _View = UIKit.UIView;
 #elif __MACOS__
 using AppKit;
+using _View = _AppKit.NSView;
+#else
+using _View = Windows.UI.Xaml.FrameworkElement;
 #endif
 
 namespace Windows.UI.Xaml.Controls
@@ -34,6 +41,11 @@ namespace Windows.UI.Xaml.Controls
 		private Border _popupBorder;
 		private ContentPresenter _contentPresenter;
 		private ContentPresenter _headerContentPresenter;
+
+		/// <summary>
+		/// The 'inline' parent view of the selected item within the dropdown list. This is only set if SelectedItem is a view type.
+		/// </summary>
+		private ManagedWeakReference _selectionParentInDropdown;
 
 		public ComboBox()
 		{
@@ -156,6 +168,11 @@ namespace Windows.UI.Xaml.Controls
 
 		internal override void OnSelectedItemChanged(object oldSelectedItem, object selectedItem)
 		{
+			if (oldSelectedItem is _View view)
+			{
+				// Ensure previous SelectedItem is put back in the dropdown list if it's a view
+				RestoreSelectedItem(view);
+			}
 			base.OnSelectedItemChanged(oldSelectedItem, selectedItem);
 			UpdateContentPresenter();
 		}
@@ -170,8 +187,59 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (_contentPresenter != null)
 			{
-				var item = SelectedItem is ComboBoxItem cbi ? cbi.Content : SelectedItem;
+				var item = GetSelectionContent();
+
+				var itemView = item as _View;
+
+				if (itemView != null)
+				{
+					if (itemView.FindFirstParent<ComboBoxItem>() != null)
+					{
+						// Keep track of the former parent, so we can put the item back when the dropdown is shown
+						_selectionParentInDropdown = (itemView.GetVisualTreeParent() as IWeakReferenceProvider)?.WeakReference;
+					}
+				}
+				else
+				{
+					_selectionParentInDropdown = null;
+				}
+
 				_contentPresenter.Content = item;
+
+				if (itemView != null && itemView.GetVisualTreeParent() != _contentPresenter)
+				{
+					// Item may have been put back in list, reattach it to _contentPresenter
+					_contentPresenter.AddChild(itemView);
+				}
+			}
+		}
+
+		private object GetSelectionContent()
+		{
+			return SelectedItem is ComboBoxItem cbi ? cbi.Content : SelectedItem;
+		}
+
+		private void RestoreSelectedItem()
+		{
+			var selection = GetSelectionContent();
+			if (selection is _View selectionView)
+			{
+				RestoreSelectedItem(selectionView);
+			}
+		}
+
+		/// <summary>
+		/// Restore SelectedItem (or former SelectedItem) view to its position in the dropdown list.
+		/// </summary>
+		private void RestoreSelectedItem(_View selectionView)
+		{
+			var dropdownParent = _selectionParentInDropdown?.Target as FrameworkElement;
+			var comboBoxItem = dropdownParent?.FindFirstParent<ComboBoxItem>();
+
+			// Sanity check, ensure parent is still valid (ComboBoxItem may have been recycled)
+			if (comboBoxItem?.Content == selectionView && selectionView.GetVisualTreeParent() != dropdownParent)
+			{
+				dropdownParent.AddChild(selectionView);
 			}
 		}
 
@@ -203,6 +271,8 @@ namespace Windows.UI.Xaml.Controls
 					popupChild.SizeChanged += PopupChildChanged;
 				}
 
+				RestoreSelectedItem();
+
 				if (SelectedItem != null)
 				{
 					ScrollIntoView(SelectedItem);
@@ -215,6 +285,7 @@ namespace Windows.UI.Xaml.Controls
 					popupChild.SizeChanged -= PopupChildChanged;
 				}
 				DropDownClosed?.Invoke(this, newIsDropDownOpen);
+				UpdateContentPresenter();
 			}
 
 			UpdateDropDownState();

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
@@ -2,81 +2,14 @@
 using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
 	public partial class ComboBoxItem : SelectorItem
 	{
-		private Popup _popup;
-
-		protected override void OnLoaded()
+		public ComboBoxItem()
 		{
-			base.OnLoaded();
 
-			var popup = GetPopupControl();
-			if (popup != _popup)
-			{
-				if (_popup != null)
-				{
-					_popup.Opened -= OnPopupOpened;
-				}
-				popup.Opened += OnPopupOpened;
-				_popup = popup;
-			}
-
-			CheckContentKidnapped();
 		}
-
-		protected override void OnUnloaded()
-		{
-			base.OnUnloaded();
-
-			if (_popup != null)
-			{
-				_popup.Opened -= OnPopupOpened;
-				_popup = null;
-			}
-		}
-
-		private void OnPopupOpened(object sender, object e)
-		{
-			CheckContentKidnapped();
-		}
-
-		private void CheckContentKidnapped()
-		{
-			if (Content is DependencyObject content)
-			{
-				var currentParent = GetParent(content);
-
-				if (currentParent != Content)
-				{
-					// Content has been kidnapped: reconnect content with current element
-					Content = null;
-					Content = content;
-				}
-			}
-		}
-
-		public Popup GetPopupControl()
-		{
-			var parent = GetParent(this);
-
-			while (parent != null)
-			{
-				if (parent is PopupPanel pnl)
-				{
-					return pnl.Popup;
-				}
-
-				parent = GetParent(parent);
-			}
-
-			return null;
-		}
-
-		private DependencyObject GetParent(DependencyObject e)
-			=> (e as FrameworkElement)?.Parent ?? VisualTreeHelper.GetParent(e);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnItemsPanelChanged(ItemsPanelTemplate oldItemsPanel, ItemsPanelTemplate newItemsPanel)
 		{
-			if (_isReady) // Panel is created on ApplyTemplate, so do not create it twice (first on set PanelTemplate, second on ApplyTemplate)
+			if (_isReady && !Equals(oldItemsPanel, newItemsPanel)) // Panel is created on ApplyTemplate, so do not create it twice (first on set PanelTemplate, second on ApplyTemplate)
 			{
 				UpdateItemsPanelRoot();
 			}

--- a/src/Uno.UI/UI/Xaml/UIElementExtensions.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementExtensions.wasm.cs
@@ -50,5 +50,10 @@ namespace Uno.Extensions
 		{
 			element.UnregisterEventHandler(eventName, handler);
 		}
+		
+		/// <summary>
+		/// Get the parent view in the visual tree.
+		/// </summary>
+		public static UIElement GetVisualTreeParent(this UIElement element) => element?.GetParent() as UIElement;
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #1078 
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

Improves handling of the case where items (in Items or ItemsSource) are views. This case is tricky because the SelectedItem needs to be displayed in the dropdown list when the dropdown is open, and inside the ComboBox's template when it's not.

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
