### PR TITLE
Add support for `Windows.System.Profile.AnalyticsInfo` API on iOS and Android

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -39,6 +39,7 @@
 
 ## Release 1.45.0
 ### Features
+* Add support for `Windows.System.Profile.AnalyticsInfo` API on iOS and Android
 * Add support for `Windows.System.Display.DisplayRequest` API on iOS and Android
 * Add support for the following `Windows.System.Power.PowerManager` APIs on iOS and Android:
     - BatteryStatus

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Profile/AnalyticsInfo.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Profile/AnalyticsInfo.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System.Profile
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
-	#endif
-	public  partial class AnalyticsInfo 
+#endif
+	public partial class AnalyticsInfo
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static string DeviceForm
 		{
@@ -16,8 +16,8 @@ namespace Windows.System.Profile
 				throw new global::System.NotImplementedException("The member string AnalyticsInfo.DeviceForm is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.System.Profile.AnalyticsVersionInfo VersionInfo
 		{
@@ -26,14 +26,14 @@ namespace Windows.System.Profile
 				throw new global::System.NotImplementedException("The member AnalyticsVersionInfo AnalyticsInfo.VersionInfo is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
-		public static global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyDictionary<string, string>> GetSystemPropertiesAsync( global::System.Collections.Generic.IEnumerable<string> attributeNames)
+		public static global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyDictionary<string, string>> GetSystemPropertiesAsync(global::System.Collections.Generic.IEnumerable<string> attributeNames)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IReadOnlyDictionary<string, string>> AnalyticsInfo.GetSystemPropertiesAsync(IEnumerable<string> attributeNames) is not implemented in Uno.");
 		}
-		#endif
+#endif
 		// Forced skipping of method Windows.System.Profile.AnalyticsInfo.VersionInfo.get
 		// Forced skipping of method Windows.System.Profile.AnalyticsInfo.DeviceForm.get
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Profile/AnalyticsVersionInfo.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Profile/AnalyticsVersionInfo.cs
@@ -2,31 +2,31 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System.Profile
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
-	#endif
-	public  partial class AnalyticsVersionInfo 
+#endif
+	public partial class AnalyticsVersionInfo
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
-		public  string DeviceFamily
+		public string DeviceFamily
 		{
 			get
 			{
 				throw new global::System.NotImplementedException("The member string AnalyticsVersionInfo.DeviceFamily is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
-		public  string DeviceFamilyVersion
+		public string DeviceFamilyVersion
 		{
 			get
 			{
 				throw new global::System.NotImplementedException("The member string AnalyticsVersionInfo.DeviceFamilyVersion is not implemented in Uno.");
 			}
 		}
-		#endif
+#endif
 		// Forced skipping of method Windows.System.Profile.AnalyticsVersionInfo.DeviceFamily.get
 		// Forced skipping of method Windows.System.Profile.AnalyticsVersionInfo.DeviceFamilyVersion.get
 	}

--- a/src/Uno.UWP/System/Profile/AnalyticsInfo.cs
+++ b/src/Uno.UWP/System/Profile/AnalyticsInfo.cs
@@ -1,0 +1,20 @@
+﻿namespace Windows.System.Profile
+{
+	public partial class AnalyticsInfo
+	{
+#if __ANDROID__ || __IOS__
+		public static string DeviceForm
+		{
+			get
+			{
+				return VersionInfo.DeviceFamily;
+			}
+		}
+
+		public static AnalyticsVersionInfo VersionInfo
+		{
+			get;
+		} = new AnalyticsVersionInfo();
+#endif
+	}
+}

--- a/src/Uno.UWP/System/Profile/AnalyticsVersionInfo.Android.cs
+++ b/src/Uno.UWP/System/Profile/AnalyticsVersionInfo.Android.cs
@@ -1,0 +1,64 @@
+﻿#if __ANDROID__
+using System;
+using System.Globalization;
+using Android.App;
+using Android.Content.Res;
+using Android.OS;
+using Uno.Extensions;
+using Uno.Logging;
+using Uno.UI;
+
+namespace Windows.System.Profile
+{
+	public partial class AnalyticsVersionInfo 
+	{
+		public  string DeviceFamily
+		{
+			get
+			{
+				string idiom = "";
+
+				try
+				{
+					// Threshold in inches for diagonal screensize between what HardwareHelper will consider a tablet or a phone.
+					//This is the value given to us by microsoft documentation : https://docs.microsoft.com/en-us/windows/uwp/design/devices/
+					double _tabletMinimumSizeThreshold = 7.0;
+					
+					var displayMetrics = Application.Context.Resources.DisplayMetrics;
+
+					// Turn pixel sizes into inches
+					var screenWidth = displayMetrics.WidthPixels / displayMetrics.Xdpi;
+					var screenHeight = displayMetrics.HeightPixels / displayMetrics.Ydpi;
+
+					// Use Pythagore to find the diagonal
+					var diagonalSize = Math.Sqrt(Math.Pow(screenWidth, 2) + Math.Pow(screenHeight, 2));
+
+					// Is the diagonal larger than the threshold?
+					if (diagonalSize >= _tabletMinimumSizeThreshold)
+					{
+						idiom =  "Tablet";
+					}
+					else
+					{
+						idiom = "Phone";
+					}
+				}
+				catch (Exception e)
+				{
+					e.Log().Error("Could not detect if the device is a tablet or a phone.", e);
+				}
+
+				return idiom;
+			}
+		}
+
+		public  string DeviceFamilyVersion
+		{
+			get
+			{
+				return Build.VERSION.Release;
+			}
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/System/Profile/AnalyticsVersionInfo.iOS.cs
+++ b/src/Uno.UWP/System/Profile/AnalyticsVersionInfo.iOS.cs
@@ -1,0 +1,29 @@
+﻿#if __IOS__
+using System;
+using System.Globalization;
+using Uno.Extensions;
+using Uno.Logging;
+using Uno.UI;
+
+ namespace Windows.System.Profile
+{
+	public  partial class AnalyticsVersionInfo 
+	{
+		public  string DeviceFamily
+		{
+			get
+			{
+				return UIKit.UIDevice.CurrentDevice.UserInterfaceIdiom.ToString();
+			}
+		}
+
+ 		public  string DeviceFamilyVersion
+		{
+			get
+			{
+				return UIKit.UIDevice.CurrentDevice.SystemVersion;
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
Github issue: #74 and replaces #282

## PR Type

Feature

## What is the new behavior?

It is now possible to determine the device form, idiom and system version by using the AnalyticsInfo and AnalyticsVersionInfo classes on UWP, Android and iOS.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information

This PR rescues the contributions in https://github.com/nventive/Uno/pull/282 and replaces it. **I have not yet tested these changes** thus opening as a draft PR. I'm retiring for the night and this will be picked up again in the morning.

Internal issue :
https://nventive.visualstudio.com/Umbrella/Umbrella%20Team/_workitems/edit/123761