### PR TITLE
Implemented Windows.ApplicationModel.Calls.PhoneCallManager

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## Next version
 ### Features
+* Add support for `Windows.ApplicationModel.Calls.PhoneCallManager`
 * Add support for `Windows.Phone.Devices.Notification.VibrationDevice` API on iOS, Android and WASM
 * Basic support for `Windows.Devices.Sensors.Barometer`
 

--- a/doc/articles/features/windows-applicationmodel-calls.md
+++ b/doc/articles/features/windows-applicationmodel-calls.md
@@ -1,0 +1,16 @@
+# Uno Support for Windows.ApplicationModel.Calls
+
+## `PhoneCallManager`
+
+### Limitations
+
+**Android**
+- `RequestStoreAsync` method is not implemented
+- Second parameter of `ShowPhoneCallUI` is ignored (`displayName` of the dialer cannot be set)
+
+**iOS**
+- `RequestStoreAsync` and `ShowPhoneCallSettingsUI` methods are not implemented
+- Second parameter of `ShowPhoneCallUI` is ignored (`displayName` of the dialer cannot be set)
+
+**WASM**
+- Only implements the `ShowPhoneCallUI` method. Similarly to the other platforms The `displayName` parameter is not used

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -17,6 +17,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_ApplicationModel\Calls\PhoneCallManagerTests.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_ApplicationModel\Chat\ComposeSms.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2054,6 +2058,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ViewModelBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lottie\SampleLottieAnimation.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Wasm\Wasm_CustomEvent.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_ApplicationModel\Calls\PhoneCallManagerTests.xaml.cs">
+      <DependentUpon>PhoneCallManagerTests.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_ApplicationModel\Chat\ComposeSms.xaml.cs">
       <DependentUpon>ComposeSms.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/Calls/PhoneCallManagerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/Calls/PhoneCallManagerTests.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_ApplicationModel.Calls.PhoneCallManagerTests"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_ApplicationModel.Calls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <StackPanel>
+		<CheckBox x:Name="IsCallActiveCheckBox" IsHitTestVisible="False" Content="IsCallActive" />
+		<CheckBox x:Name="IsCallIncomingCheckBox" IsHitTestVisible="False" Content="IsCallIncoming" />
+		<Button Click="ShowPhoneSettings_Click">Show Phone settings</Button>
+		<TextBox x:Name="PhoneNumberTextBox" PlaceholderText="Enter a number..." Margin="0,20,0,0" />
+		<Button Click="Dial_Click">Dial</Button>
+		<TextBlock x:Name="ErrorMessage" Foreground="Red" Margin="0,20,0,0" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/Calls/PhoneCallManagerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/Calls/PhoneCallManagerTests.xaml.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.ApplicationModel.Calls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_ApplicationModel.Calls
+{
+	[SampleControlInfo("Windows.ApplicationModel", "PhoneCallManager", ignoreInAutomatedTests: true, description: "PhoneCallManager APIs implementation.")]
+
+	public sealed partial class PhoneCallManagerTests : UserControl
+	{
+		public PhoneCallManagerTests()
+		{
+			this.InitializeComponent();
+
+			try
+			{
+				PhoneCallManager.CallStateChanged += PhoneCallManager_CallStateChanged;
+				UpdateCallState();
+			}
+			catch (Exception ex)
+			{
+				ErrorMessage.Text = ex.ToString();
+			}		
+		}
+
+		private void PhoneCallManager_CallStateChanged(object sender, object e) => UpdateCallState();
+
+		private async void UpdateCallState()
+		{
+			await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+			{
+				IsCallActiveCheckBox.IsChecked = PhoneCallManager.IsCallActive;
+				IsCallIncomingCheckBox.IsChecked = PhoneCallManager.IsCallIncoming;
+			});
+		}
+
+		private void ShowPhoneSettings_Click(object sender, RoutedEventArgs e)
+		{
+			try
+			{
+				PhoneCallManager.ShowPhoneCallSettingsUI();
+			}
+			catch (Exception ex)
+			{
+				ErrorMessage.Text = ex.ToString();
+			}
+		}
+
+		private void Dial_Click(object sender, RoutedEventArgs e)
+		{
+			try
+			{
+				PhoneCallManager.ShowPhoneCallUI(PhoneNumberTextBox.Text, "Jon Doe");
+			}
+			catch (Exception ex)
+			{
+				ErrorMessage.Text = ex.ToString();
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/Chat/ComposeSms.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/Chat/ComposeSms.xaml.cs
@@ -20,7 +20,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace UITests.Shared.Windows_ApplicationModel.Chat
 {
-	[SampleControlInfo("Chat", "ComposeSMS", ignoreInAutomatedTests: true, description: "Test the ChatMessageManager.ShowComposeSmsMessageAsync API.")]
+	[SampleControlInfo("Windows.ApplicationModel", "ChatMessageManager", ignoreInAutomatedTests: true, description: "Test the ChatMessageManager.ShowComposeSmsMessageAsync API.")]
 	public sealed partial class ComposeSms : UserControl, INotifyPropertyChanged
 	{
 		private string _phoneNumber;

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -761,6 +761,11 @@ declare namespace Windows.UI.Core {
         private clearStack;
     }
 }
+interface Navigator {
+    webkitVibrate(pattern: number | number[]): boolean;
+    mozVibrate(pattern: number | number[]): boolean;
+    msVibrate(pattern: number | number[]): boolean;
+}
 declare namespace Windows.Phone.Devices.Notification {
     class VibrationDevice {
         static initialize(): boolean;

--- a/src/Uno.UWP/ApplicationModel/Calls/Internal/CallObserverDelegate.iOS.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/Internal/CallObserverDelegate.iOS.cs
@@ -1,0 +1,17 @@
+﻿#if __IOS__
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CallKit;
+
+namespace Windows.ApplicationModel.Calls
+{
+	internal class CallObserverDelegate : CXCallObserverDelegate
+	{
+		public override void CallChanged(CXCallObserver callObserver, CXCall call)
+		{
+			
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/ApplicationModel/Calls/Internal/CallObserverDelegate.iOS.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/Internal/CallObserverDelegate.iOS.cs
@@ -8,10 +8,8 @@ namespace Windows.ApplicationModel.Calls
 {
 	internal class CallObserverDelegate : CXCallObserverDelegate
 	{
-		public override void CallChanged(CXCallObserver callObserver, CXCall call)
-		{
-			
-		}
+		public override void CallChanged(CXCallObserver callObserver, CXCall call) =>
+			PhoneCallManager.RaiseCallStateChanged();
 	}
 }
 #endif

--- a/src/Uno.UWP/ApplicationModel/Calls/Internal/CallStateListener.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/Internal/CallStateListener.Android.cs
@@ -1,0 +1,18 @@
+﻿#if __ANDROID__
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Android.Runtime;
+using Android.Telephony;
+
+namespace Windows.ApplicationModel.Calls
+{
+	internal class CallStateListener : PhoneStateListener
+	{
+		public override void OnCallStateChanged([GeneratedEnum] CallState state, string phoneNumber)
+		{
+			PhoneCallManager.RaiseCallStateChanged();
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
@@ -15,6 +15,12 @@ namespace Windows.ApplicationModel.Calls
 
 		static PhoneCallManager()
 		{
+			if (ContextHelper.Current == null)
+			{
+				throw new InvalidOperationException(
+					"PhoneCallManager was used too early in the application lifetime. " +
+					"Android app context needs to be available.");
+			}
 			_telephonyManager = (TelephonyManager)ContextHelper.Current
 				.GetSystemService(Context.TelephonyService);
 			_telephonyManager.Listen(new CallStateListener(), PhoneStateListenerFlags.CallState);

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
@@ -66,6 +66,5 @@ namespace Windows.ApplicationModel.Calls
 			ContextHelper.Current.StartActivity(phoneCallIntent);
 		}
 	}
-	}
 }
 #endif

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
@@ -1,0 +1,35 @@
+﻿#if __ANDROID__
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Android.Content;
+using Android.Telephony;
+using Uno.UI;
+
+namespace Windows.ApplicationModel.Calls
+{
+	public partial class PhoneCallManager
+	{
+		private static readonly TelephonyManager _telephonyManager;
+
+		public static PhoneCallManager()
+		{
+			_telephonyManager = (TelephonyManager)ContextHelper.Current
+				.GetSystemService(Context.TelephonyService);
+		}
+
+		public static bool IsCallActive =>
+			_telephonyManager.CallState == CallState.Offhook;
+
+		public static bool IsCallIncoming =>
+			_telephonyManager.CallState == CallState.Ringing;
+
+
+		public static void ShowPhoneCallSettingsUI()
+		{
+			var intent = new Intent(Android.Provider.Settings.ActionNetworkOperatorSettings);
+			ContextHelper.Current.StartActivity(intent);
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Android.Content;
+using Android.OS;
 using Android.Telephony;
 using Uno.UI;
 
@@ -12,11 +13,14 @@ namespace Windows.ApplicationModel.Calls
 	{
 		private static readonly TelephonyManager _telephonyManager;
 
-		public static PhoneCallManager()
+		static PhoneCallManager()
 		{
 			_telephonyManager = (TelephonyManager)ContextHelper.Current
 				.GetSystemService(Context.TelephonyService);
+			_telephonyManager.Listen(new CallStateListener(), PhoneStateListenerFlags.CallState);
 		}
+
+		public static event EventHandler<object> CallStateChanged;
 
 		public static bool IsCallActive =>
 			_telephonyManager.CallState == CallState.Offhook;
@@ -24,12 +28,44 @@ namespace Windows.ApplicationModel.Calls
 		public static bool IsCallIncoming =>
 			_telephonyManager.CallState == CallState.Ringing;
 
-
 		public static void ShowPhoneCallSettingsUI()
 		{
-			var intent = new Intent(Android.Provider.Settings.ActionNetworkOperatorSettings);
+			var intent = new Intent(Android.Provider.Settings.ActionNetworkOperatorSettings)
+				.SetFlags(ActivityFlags.ClearTop)
+				.SetFlags(ActivityFlags.NewTask);
 			ContextHelper.Current.StartActivity(intent);
+		}		
+
+		internal static void RaiseCallStateChanged() => CallStateChanged?.Invoke(null, null);
+
+		private static void ShowPhoneCallUIImpl(string phoneNumber, string displayName)
+		{
+			if (Build.VERSION.SdkInt >= BuildVersionCodes.N)
+			{
+#if __ANDROID_24__
+				phoneNumber = PhoneNumberUtils.FormatNumber(phoneNumber, Java.Util.Locale.GetDefault(Java.Util.Locale.Category.Format).Country);
+#endif
+			}
+			else if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
+			{
+				phoneNumber = PhoneNumberUtils.FormatNumber(phoneNumber, Java.Util.Locale.Default.Country);
+			}
+			else
+			{
+#pragma warning disable CS0618
+				phoneNumber = PhoneNumberUtils.FormatNumber(phoneNumber);
+#pragma warning restore CS0618
+			}
+
+			var phoneCallIntent = new Intent(
+				Intent.ActionDial,
+				Android.Net.Uri.Parse($"tel:{phoneNumber}"))
+					.SetFlags(ActivityFlags.ClearTop)
+					.SetFlags(ActivityFlags.NewTask);
+
+			ContextHelper.Current.StartActivity(phoneCallIntent);
 		}
+	}
 	}
 }
 #endif

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.cs
@@ -28,10 +28,8 @@ namespace Windows.ApplicationModel.Calls
 				throw new ArgumentNullException(nameof(displayName));
 			}
 
-			OpenCallUI(phoneNumber, displayName);
+			ShowPhoneCallUIImpl(phoneNumber, displayName);
 		}
-
-		private partial void OpenCallUI(string phoneNumber, string displayName);
 	}
 }
 #endif

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.cs
@@ -1,0 +1,37 @@
+﻿#if __ANDROID__ || __IOS__ || __WASM__
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.ApplicationModel.Calls
+{
+	public partial class PhoneCallManager
+	{
+		internal PhoneCallManager()
+		{
+		}
+
+		public static void ShowPhoneCallUI(string phoneNumber, string displayName)
+		{
+			if (phoneNumber == null)
+			{
+				throw new ArgumentNullException(nameof(phoneNumber));
+			}
+
+			if ( string.IsNullOrWhiteSpace(phoneNumber))
+			{
+				throw new ArgumentOutOfRangeException(nameof(phoneNumber), "Phone number must be provided");
+			}
+
+			if (displayName == null)
+			{
+				throw new ArgumentNullException(nameof(displayName));
+			}
+
+			OpenCallUI(phoneNumber, displayName);
+		}
+
+		private partial void OpenCallUI(string phoneNumber, string displayName);
+	}
+}
+#endif

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.cs
@@ -1,12 +1,18 @@
 ﻿#if __ANDROID__ || __IOS__ || __WASM__
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Windows.ApplicationModel.Calls
 {
 	public partial class PhoneCallManager
 	{
+		private static readonly char[] _allowedChars = new char[]
+		{
+			'+', ';', '=', '?', '#', '-'
+		};
+
 		internal PhoneCallManager()
 		{
 		}
@@ -18,9 +24,21 @@ namespace Windows.ApplicationModel.Calls
 				throw new ArgumentNullException(nameof(phoneNumber));
 			}
 
-			if ( string.IsNullOrWhiteSpace(phoneNumber))
+			if (string.IsNullOrWhiteSpace(phoneNumber))
 			{
 				throw new ArgumentOutOfRangeException(nameof(phoneNumber), "Phone number must be provided");
+			}
+
+			var disallowed = phoneNumber
+				.Where(c =>
+					!char.IsDigit(c) &&
+					!_allowedChars.Contains(c))
+				.Select(c=>(char?)c)
+				.FirstOrDefault();
+
+			if (disallowed != null)
+			{
+				throw new ArgumentOutOfRangeException(nameof(phoneNumber), $"Phone number contains disallowed character {disallowed}");
 			}
 
 			if (displayName == null)
@@ -28,7 +46,7 @@ namespace Windows.ApplicationModel.Calls
 				throw new ArgumentNullException(nameof(displayName));
 			}
 
-			ShowPhoneCallUIImpl(phoneNumber, displayName);
+			ShowPhoneCallUIImpl(phoneNumber.Trim(), displayName);
 		}
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.iOS.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.iOS.cs
@@ -9,7 +9,13 @@ namespace Windows.ApplicationModel.Calls
 {
 	public partial class PhoneCallManager
 	{
-		private static CXCallObserver _callObserver = new CXCallObserver();
+		private static readonly CXCallObserver _callObserver;
+
+		static PhoneCallManager()
+		{
+			_callObserver = new CXCallObserver();
+			_callObserver.SetDelegate(new CallObserverDelegate(), null);
+		}
 
 		public static bool IsCallActive =>
 			_callObserver.Calls?.Any(
@@ -23,6 +29,10 @@ namespace Windows.ApplicationModel.Calls
 						 !c.HasEnded &&
 						 !c.HasConnected &&
 						 !c.Outgoing) == true;
+
+		public static event EventHandler<object> CallStateChanged;
+
+		internal void RaiseCallStateChanged() => CallStateChanged?.Invoke(null, null);
 	}
 }
 #endif

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.iOS.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.iOS.cs
@@ -1,0 +1,28 @@
+﻿#if __IOS__
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CallKit;
+
+namespace Windows.ApplicationModel.Calls
+{
+	public partial class PhoneCallManager
+	{
+		private static CXCallObserver _callObserver = new CXCallObserver();
+
+		public static bool IsCallActive =>
+			_callObserver.Calls?.Any(
+				c => c != null &&
+					 c.HasConnected &&
+					 !c.HasEnded) == true;
+
+		public static bool IsCallIncoming =>
+			_callObserver.Calls?.Any(
+					c => c != null &&
+						 !c.HasEnded &&
+						 !c.HasConnected &&
+						 !c.Outgoing) == true;
+	}
+}
+#endif

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.iOS.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.iOS.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using CallKit;
+using Foundation;
+using UIKit;
 
 namespace Windows.ApplicationModel.Calls
 {
@@ -16,6 +18,9 @@ namespace Windows.ApplicationModel.Calls
 			_callObserver = new CXCallObserver();
 			_callObserver.SetDelegate(new CallObserverDelegate(), null);
 		}
+
+
+		public static event EventHandler<object> CallStateChanged;
 
 		public static bool IsCallActive =>
 			_callObserver.Calls?.Any(
@@ -30,9 +35,14 @@ namespace Windows.ApplicationModel.Calls
 						 !c.HasConnected &&
 						 !c.Outgoing) == true;
 
-		public static event EventHandler<object> CallStateChanged;
+		internal static void RaiseCallStateChanged() => CallStateChanged?.Invoke(null, null);
 
-		internal void RaiseCallStateChanged() => CallStateChanged?.Invoke(null, null);
+		private static void ShowPhoneCallUIImpl(string phoneNumber, string displayName)
+		{
+			var url = new NSUrl($"tel:{phoneNumber}");
+			UIApplication.SharedApplication.OpenUrl(url);
+		}
+
 	}
 }
 #endif

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.wasm.cs
@@ -1,0 +1,18 @@
+﻿#if __WASM__
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.ApplicationModel.Calls
+{
+	public partial class PhoneCallManager
+	{
+		private static void ShowPhoneCallUIImpl(string phoneNumber, string displayName)
+		{
+			var uri = new Uri($"tel:{phoneNumber}");
+			var command = $"Uno.UI.WindowManager.current.open(\"{uri.AbsoluteUri}\");";
+			Uno.Foundation.WebAssemblyRuntime.InvokeJS(command);			
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls.Provider/PhoneCallOrigin.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls.Provider/PhoneCallOrigin.cs
@@ -1,0 +1,99 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls.Provider
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneCallOrigin 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  string Location
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string PhoneCallOrigin.Location is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin", "string PhoneCallOrigin.Location");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  string CategoryDescription
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string PhoneCallOrigin.CategoryDescription is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin", "string PhoneCallOrigin.CategoryDescription");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  string Category
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string PhoneCallOrigin.Category is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin", "string PhoneCallOrigin.Category");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  string DisplayName
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string PhoneCallOrigin.DisplayName is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin", "string PhoneCallOrigin.DisplayName");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.Storage.StorageFile DisplayPicture
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StorageFile PhoneCallOrigin.DisplayPicture is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin", "StorageFile PhoneCallOrigin.DisplayPicture");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public PhoneCallOrigin() 
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin", "PhoneCallOrigin.PhoneCallOrigin()");
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.PhoneCallOrigin()
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.Category.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.Category.set
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.CategoryDescription.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.CategoryDescription.set
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.Location.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.Location.set
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.DisplayName.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.DisplayName.set
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.DisplayPicture.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin.DisplayPicture.set
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls.Provider/PhoneCallOriginManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls.Provider/PhoneCallOriginManager.cs
@@ -1,0 +1,43 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls.Provider
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneCallOriginManager 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static bool IsCurrentAppActiveCallOriginApp
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool PhoneCallOriginManager.IsCurrentAppActiveCallOriginApp is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static global::Windows.Foundation.IAsyncOperation<bool> RequestSetAsActiveCallOriginAppAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> PhoneCallOriginManager.RequestSetAsActiveCallOriginAppAsync() is not implemented in Uno.");
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.Provider.PhoneCallOriginManager.IsCurrentAppActiveCallOriginApp.get
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static void ShowPhoneCallOriginSettingsUI()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.Provider.PhoneCallOriginManager", "void PhoneCallOriginManager.ShowPhoneCallOriginSettingsUI()");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static void SetCallOrigin( global::System.Guid requestId,  global::Windows.ApplicationModel.Calls.Provider.PhoneCallOrigin callOrigin)
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.Provider.PhoneCallOriginManager", "void PhoneCallOriginManager.SetCallOrigin(Guid requestId, PhoneCallOrigin callOrigin)");
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/CallsPhoneContract.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/CallsPhoneContract.cs
@@ -1,0 +1,12 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial struct CallsPhoneContract 
+	{
+		// Forced skipping of method Windows.ApplicationModel.Calls.CallsPhoneContract.CallsPhoneContract()
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/CellularDtmfMode.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/CellularDtmfMode.cs
@@ -1,0 +1,19 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum CellularDtmfMode 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Continuous,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Burst,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneAudioRoutingEndpoint.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneAudioRoutingEndpoint.cs
@@ -1,0 +1,22 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum PhoneAudioRoutingEndpoint 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Default,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Bluetooth,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Speakerphone,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallBlocking.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallBlocking.cs
@@ -1,0 +1,50 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneCallBlocking 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static bool BlockUnknownNumbers
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool PhoneCallBlocking.BlockUnknownNumbers is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneCallBlocking", "bool PhoneCallBlocking.BlockUnknownNumbers");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static bool BlockPrivateNumbers
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool PhoneCallBlocking.BlockPrivateNumbers is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneCallBlocking", "bool PhoneCallBlocking.BlockPrivateNumbers");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallBlocking.BlockUnknownNumbers.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallBlocking.BlockUnknownNumbers.set
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallBlocking.BlockPrivateNumbers.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallBlocking.BlockPrivateNumbers.set
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static global::Windows.Foundation.IAsyncOperation<bool> SetCallBlockingListAsync( global::System.Collections.Generic.IEnumerable<string> phoneNumberList)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> PhoneCallBlocking.SetCallBlockingListAsync(IEnumerable<string> phoneNumberList) is not implemented in Uno.");
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel.Calls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || NET461 || false || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class PhoneCallManager 

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
@@ -52,7 +52,7 @@ namespace Windows.ApplicationModel.Calls
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneCallManager", "void PhoneCallManager.ShowPhoneCallUI(string phoneNumber, string displayName)");
 		}
 		#endif
-		#if __ANDROID__ || false || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static event global::System.EventHandler<object> CallStateChanged
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
@@ -7,7 +7,7 @@ namespace Windows.ApplicationModel.Calls
 	#endif
 	public  partial class PhoneCallManager 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static bool IsCallActive
 		{
@@ -17,7 +17,7 @@ namespace Windows.ApplicationModel.Calls
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static bool IsCallIncoming
 		{
@@ -31,7 +31,7 @@ namespace Windows.ApplicationModel.Calls
 		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallManager.CallStateChanged.remove
 		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallManager.IsCallActive.get
 		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallManager.IsCallIncoming.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static void ShowPhoneCallSettingsUI()
 		{
@@ -45,7 +45,7 @@ namespace Windows.ApplicationModel.Calls
 			throw new global::System.NotImplementedException("The member IAsyncOperation<PhoneCallStore> PhoneCallManager.RequestStoreAsync() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || false || __MACOS__
 		[global::Uno.NotImplemented]
 		public static void ShowPhoneCallUI( string phoneNumber,  string displayName)
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
@@ -52,7 +52,7 @@ namespace Windows.ApplicationModel.Calls
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneCallManager", "void PhoneCallManager.ShowPhoneCallUI(string phoneNumber, string displayName)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if __ANDROID__ || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static event global::System.EventHandler<object> CallStateChanged
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
@@ -1,0 +1,72 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneCallManager 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static bool IsCallActive
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool PhoneCallManager.IsCallActive is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static bool IsCallIncoming
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool PhoneCallManager.IsCallIncoming is not implemented in Uno.");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallManager.CallStateChanged.add
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallManager.CallStateChanged.remove
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallManager.IsCallActive.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallManager.IsCallIncoming.get
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static void ShowPhoneCallSettingsUI()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneCallManager", "void PhoneCallManager.ShowPhoneCallSettingsUI()");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static global::Windows.Foundation.IAsyncOperation<global::Windows.ApplicationModel.Calls.PhoneCallStore> RequestStoreAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<PhoneCallStore> PhoneCallManager.RequestStoreAsync() is not implemented in Uno.");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static void ShowPhoneCallUI( string phoneNumber,  string displayName)
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneCallManager", "void PhoneCallManager.ShowPhoneCallUI(string phoneNumber, string displayName)");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static event global::System.EventHandler<object> CallStateChanged
+		{
+			[global::Uno.NotImplemented]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneCallManager", "event EventHandler<object> PhoneCallManager.CallStateChanged");
+			}
+			[global::Uno.NotImplemented]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneCallManager", "event EventHandler<object> PhoneCallManager.CallStateChanged");
+			}
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallMedia.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallMedia.cs
@@ -1,0 +1,22 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum PhoneCallMedia 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Audio,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		AudioAndVideo,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		AudioAndRealTimeText,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallStore.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallStore.cs
@@ -1,0 +1,32 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneCallStore 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.Foundation.IAsyncOperation<bool> IsEmergencyPhoneNumberAsync( string number)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> PhoneCallStore.IsEmergencyPhoneNumberAsync(string number) is not implemented in Uno.");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.Foundation.IAsyncOperation<global::System.Guid> GetDefaultLineAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<Guid> PhoneCallStore.GetDefaultLineAsync() is not implemented in Uno.");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneLineWatcher RequestLineWatcher()
+		{
+			throw new global::System.NotImplementedException("The member PhoneLineWatcher PhoneCallStore.RequestLineWatcher() is not implemented in Uno.");
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallVideoCapabilities.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallVideoCapabilities.cs
@@ -1,0 +1,22 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneCallVideoCapabilities 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  bool IsVideoCallingCapable
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool PhoneCallVideoCapabilities.IsVideoCallingCapable is not implemented in Uno.");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneCallVideoCapabilities.IsVideoCallingCapable.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallVideoCapabilitiesManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallVideoCapabilitiesManager.cs
@@ -1,0 +1,18 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneCallVideoCapabilitiesManager 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static global::Windows.Foundation.IAsyncOperation<global::Windows.ApplicationModel.Calls.PhoneCallVideoCapabilities> GetCapabilitiesAsync( string phoneNumber)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<PhoneCallVideoCapabilities> PhoneCallVideoCapabilitiesManager.GetCapabilitiesAsync(string phoneNumber) is not implemented in Uno.");
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneDialOptions.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneDialOptions.cs
@@ -1,0 +1,115 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneDialOptions 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  string Number
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string PhoneDialOptions.Number is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneDialOptions", "string PhoneDialOptions.Number");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneCallMedia Media
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneCallMedia PhoneDialOptions.Media is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneDialOptions", "PhoneCallMedia PhoneDialOptions.Media");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  string DisplayName
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string PhoneDialOptions.DisplayName is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneDialOptions", "string PhoneDialOptions.DisplayName");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Contacts.ContactPhone ContactPhone
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member ContactPhone PhoneDialOptions.ContactPhone is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneDialOptions", "ContactPhone PhoneDialOptions.ContactPhone");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Contacts.Contact Contact
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Contact PhoneDialOptions.Contact is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneDialOptions", "Contact PhoneDialOptions.Contact");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneAudioRoutingEndpoint AudioEndpoint
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneAudioRoutingEndpoint PhoneDialOptions.AudioEndpoint is not implemented in Uno.");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneDialOptions", "PhoneAudioRoutingEndpoint PhoneDialOptions.AudioEndpoint");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public PhoneDialOptions() 
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneDialOptions", "PhoneDialOptions.PhoneDialOptions()");
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.PhoneDialOptions()
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.Number.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.Number.set
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.DisplayName.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.DisplayName.set
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.Contact.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.Contact.set
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.ContactPhone.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.ContactPhone.set
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.Media.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.Media.set
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.AudioEndpoint.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneDialOptions.AudioEndpoint.set
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLine.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLine.cs
@@ -1,0 +1,189 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneLine 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  bool CanDial
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool PhoneLine.CanDial is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneLineCellularDetails CellularDetails
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneLineCellularDetails PhoneLine.CellularDetails is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.UI.Color DisplayColor
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Color PhoneLine.DisplayColor is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  string DisplayName
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string PhoneLine.DisplayName is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::System.Guid Id
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Guid PhoneLine.Id is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneLineConfiguration LineConfiguration
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneLineConfiguration PhoneLine.LineConfiguration is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  string NetworkName
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string PhoneLine.NetworkName is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneNetworkState NetworkState
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneNetworkState PhoneLine.NetworkState is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  bool SupportsTile
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool PhoneLine.SupportsTile is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneLineTransport Transport
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneLineTransport PhoneLine.Transport is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneCallVideoCapabilities VideoCallingCapabilities
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneCallVideoCapabilities PhoneLine.VideoCallingCapabilities is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneVoicemail Voicemail
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneVoicemail PhoneLine.Voicemail is not implemented in Uno.");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.LineChanged.add
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.LineChanged.remove
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.Id.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.DisplayColor.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.NetworkState.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.DisplayName.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.Voicemail.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.NetworkName.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.CellularDetails.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.Transport.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.CanDial.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.SupportsTile.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.VideoCallingCapabilities.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLine.LineConfiguration.get
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.Foundation.IAsyncOperation<bool> IsImmediateDialNumberAsync( string number)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> PhoneLine.IsImmediateDialNumberAsync(string number) is not implemented in Uno.");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  void Dial( string number,  string displayName)
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLine", "void PhoneLine.Dial(string number, string displayName)");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  void DialWithOptions( global::Windows.ApplicationModel.Calls.PhoneDialOptions options)
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLine", "void PhoneLine.DialWithOptions(PhoneDialOptions options)");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public static global::Windows.Foundation.IAsyncOperation<global::Windows.ApplicationModel.Calls.PhoneLine> FromIdAsync( global::System.Guid lineId)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<PhoneLine> PhoneLine.FromIdAsync(Guid lineId) is not implemented in Uno.");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.ApplicationModel.Calls.PhoneLine, object> LineChanged
+		{
+			[global::Uno.NotImplemented]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLine", "event TypedEventHandler<PhoneLine, object> PhoneLine.LineChanged");
+			}
+			[global::Uno.NotImplemented]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLine", "event TypedEventHandler<PhoneLine, object> PhoneLine.LineChanged");
+			}
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineCellularDetails.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineCellularDetails.cs
@@ -1,0 +1,62 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneLineCellularDetails 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  bool IsModemOn
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool PhoneLineCellularDetails.IsModemOn is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  int RegistrationRejectCode
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member int PhoneLineCellularDetails.RegistrationRejectCode is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  int SimSlotIndex
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member int PhoneLineCellularDetails.SimSlotIndex is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneSimState SimState
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneSimState PhoneLineCellularDetails.SimState is not implemented in Uno.");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineCellularDetails.SimState.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineCellularDetails.SimSlotIndex.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineCellularDetails.IsModemOn.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineCellularDetails.RegistrationRejectCode.get
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  string GetNetworkOperatorDisplayText( global::Windows.ApplicationModel.Calls.PhoneLineNetworkOperatorDisplayTextLocation location)
+		{
+			throw new global::System.NotImplementedException("The member string PhoneLineCellularDetails.GetNetworkOperatorDisplayText(PhoneLineNetworkOperatorDisplayTextLocation location) is not implemented in Uno.");
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineConfiguration.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineConfiguration.cs
@@ -1,0 +1,33 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneLineConfiguration 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::System.Collections.Generic.IReadOnlyDictionary<string, object> ExtendedProperties
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyDictionary<string, object> PhoneLineConfiguration.ExtendedProperties is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  bool IsVideoCallingEnabled
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool PhoneLineConfiguration.IsVideoCallingEnabled is not implemented in Uno.");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineConfiguration.IsVideoCallingEnabled.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineConfiguration.ExtendedProperties.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineNetworkOperatorDisplayTextLocation.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineNetworkOperatorDisplayTextLocation.cs
@@ -1,0 +1,25 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum PhoneLineNetworkOperatorDisplayTextLocation 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Default,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Tile,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Dialer,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		InCallUI,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineTransport.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineTransport.cs
@@ -1,0 +1,19 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum PhoneLineTransport 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Cellular,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		VoipApp,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineWatcher.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineWatcher.cs
@@ -1,0 +1,126 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneLineWatcher 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneLineWatcherStatus Status
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneLineWatcherStatus PhoneLineWatcher.Status is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  void Start()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "void PhoneLineWatcher.Start()");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  void Stop()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "void PhoneLineWatcher.Stop()");
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.LineAdded.add
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.LineAdded.remove
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.LineRemoved.add
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.LineRemoved.remove
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.LineUpdated.add
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.LineUpdated.remove
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.EnumerationCompleted.add
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.EnumerationCompleted.remove
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.Stopped.add
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.Stopped.remove
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcher.Status.get
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.ApplicationModel.Calls.PhoneLineWatcher, object> EnumerationCompleted
+		{
+			[global::Uno.NotImplemented]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "event TypedEventHandler<PhoneLineWatcher, object> PhoneLineWatcher.EnumerationCompleted");
+			}
+			[global::Uno.NotImplemented]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "event TypedEventHandler<PhoneLineWatcher, object> PhoneLineWatcher.EnumerationCompleted");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.ApplicationModel.Calls.PhoneLineWatcher, global::Windows.ApplicationModel.Calls.PhoneLineWatcherEventArgs> LineAdded
+		{
+			[global::Uno.NotImplemented]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "event TypedEventHandler<PhoneLineWatcher, PhoneLineWatcherEventArgs> PhoneLineWatcher.LineAdded");
+			}
+			[global::Uno.NotImplemented]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "event TypedEventHandler<PhoneLineWatcher, PhoneLineWatcherEventArgs> PhoneLineWatcher.LineAdded");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.ApplicationModel.Calls.PhoneLineWatcher, global::Windows.ApplicationModel.Calls.PhoneLineWatcherEventArgs> LineRemoved
+		{
+			[global::Uno.NotImplemented]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "event TypedEventHandler<PhoneLineWatcher, PhoneLineWatcherEventArgs> PhoneLineWatcher.LineRemoved");
+			}
+			[global::Uno.NotImplemented]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "event TypedEventHandler<PhoneLineWatcher, PhoneLineWatcherEventArgs> PhoneLineWatcher.LineRemoved");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.ApplicationModel.Calls.PhoneLineWatcher, global::Windows.ApplicationModel.Calls.PhoneLineWatcherEventArgs> LineUpdated
+		{
+			[global::Uno.NotImplemented]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "event TypedEventHandler<PhoneLineWatcher, PhoneLineWatcherEventArgs> PhoneLineWatcher.LineUpdated");
+			}
+			[global::Uno.NotImplemented]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "event TypedEventHandler<PhoneLineWatcher, PhoneLineWatcherEventArgs> PhoneLineWatcher.LineUpdated");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.ApplicationModel.Calls.PhoneLineWatcher, object> Stopped
+		{
+			[global::Uno.NotImplemented]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "event TypedEventHandler<PhoneLineWatcher, object> PhoneLineWatcher.Stopped");
+			}
+			[global::Uno.NotImplemented]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Calls.PhoneLineWatcher", "event TypedEventHandler<PhoneLineWatcher, object> PhoneLineWatcher.Stopped");
+			}
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineWatcherEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineWatcherEventArgs.cs
@@ -1,0 +1,22 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneLineWatcherEventArgs 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::System.Guid LineId
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Guid PhoneLineWatcherEventArgs.LineId is not implemented in Uno.");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneLineWatcherEventArgs.LineId.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineWatcherStatus.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneLineWatcherStatus.cs
@@ -1,0 +1,25 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum PhoneLineWatcherStatus 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Created,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Started,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		EnumerationCompleted,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Stopped,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneNetworkState.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneNetworkState.cs
@@ -1,0 +1,37 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum PhoneNetworkState 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Unknown,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		NoSignal,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Deregistered,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Denied,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Searching,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Home,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		RoamingInternational,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		RoamingDomestic,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneSimState.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneSimState.cs
@@ -1,0 +1,37 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum PhoneSimState 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Unknown,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		PinNotRequired,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		PinUnlocked,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		PinLocked,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		PukLocked,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		NotInserted,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Invalid,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Disabled,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneVoicemail.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneVoicemail.cs
@@ -1,0 +1,51 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class PhoneVoicemail 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  int MessageCount
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member int PhoneVoicemail.MessageCount is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  string Number
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string PhoneVoicemail.Number is not implemented in Uno.");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.ApplicationModel.Calls.PhoneVoicemailType Type
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member PhoneVoicemailType PhoneVoicemail.Type is not implemented in Uno.");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneVoicemail.Number.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneVoicemail.MessageCount.get
+		// Forced skipping of method Windows.ApplicationModel.Calls.PhoneVoicemail.Type.get
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.Foundation.IAsyncAction DialVoicemailAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncAction PhoneVoicemail.DialVoicemailAsync() is not implemented in Uno.");
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneVoicemailType.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneVoicemailType.cs
@@ -1,0 +1,22 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.ApplicationModel.Calls
+{
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum PhoneVoicemailType 
+	{
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		None,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Traditional,
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		Visual,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Barometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Barometer.cs
@@ -5,7 +5,7 @@ namespace Windows.Devices.Sensors
 	#if false || false || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
-	public partial class Barometer 
+	public  partial class Barometer 
 	{
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/BarometerReading.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/BarometerReading.cs
@@ -2,51 +2,15 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-#if false || false || false || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
-#endif
-	public partial class BarometerReading 
+	#endif
+	public  partial class BarometerReading 
 	{
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  double StationPressureInHectopascals
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member double BarometerReading.StationPressureInHectopascals is not implemented in Uno.");
-			}
-		}
-#endif
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::System.DateTimeOffset Timestamp
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member DateTimeOffset BarometerReading.Timestamp is not implemented in Uno.");
-			}
-		}
-#endif
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::System.TimeSpan? PerformanceCount
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member TimeSpan? BarometerReading.PerformanceCount is not implemented in Uno.");
-			}
-		}
-#endif
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::System.Collections.Generic.IReadOnlyDictionary<string, object> Properties
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member IReadOnlyDictionary<string, object> BarometerReading.Properties is not implemented in Uno.");
-			}
-		}
-#endif
+		// Skipping already declared property StationPressureInHectopascals
+		// Skipping already declared property Timestamp
+		// Skipping already declared property PerformanceCount
+		// Skipping already declared property Properties
 		// Forced skipping of method Windows.Devices.Sensors.BarometerReading.Timestamp.get
 		// Forced skipping of method Windows.Devices.Sensors.BarometerReading.StationPressureInHectopascals.get
 		// Forced skipping of method Windows.Devices.Sensors.BarometerReading.PerformanceCount.get

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/BarometerReadingChangedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/BarometerReadingChangedEventArgs.cs
@@ -2,21 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-#if false || false || false || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
-#endif
-	public partial class BarometerReadingChangedEventArgs 
+	#endif
+	public  partial class BarometerReadingChangedEventArgs 
 	{
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.Devices.Sensors.BarometerReading Reading
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member BarometerReading BarometerReadingChangedEventArgs.Reading is not implemented in Uno.");
-			}
-		}
-#endif
+		// Skipping already declared property Reading
 		// Forced skipping of method Windows.Devices.Sensors.BarometerReadingChangedEventArgs.Reading.get
 	}
 }

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -65,12 +65,13 @@ namespace Uno.UWPSyncGenerator
 			var a = _referenceCompilation.GetTypeByMetadataName("Windows.UI.ViewManagement.StatusBar");
 
 
-			var origins = from externalRedfs in _referenceCompilation.ExternalReferences
+			var origins = (from externalRedfs in _referenceCompilation.ExternalReferences
 						  where Path.GetFileNameWithoutExtension(externalRedfs.Display).StartsWith("Windows.Foundation")
 						  || Path.GetFileNameWithoutExtension(externalRedfs.Display).StartsWith("Windows.Phone.PhoneContract")
+						  || Path.GetFileNameWithoutExtension(externalRedfs.Display).StartsWith("Windows.ApplicationModel.Calls.CallsPhoneContract")
 						  let asm = _referenceCompilation.GetAssemblyOrModuleSymbol(externalRedfs) as IAssemblySymbol
 						  where asm != null
-						  select asm;
+						  select asm).ToArray();
 
 			var q = from asm in origins
 					where asm.Name == sourceAssembly

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -65,13 +65,13 @@ namespace Uno.UWPSyncGenerator
 			var a = _referenceCompilation.GetTypeByMetadataName("Windows.UI.ViewManagement.StatusBar");
 
 
-			var origins = (from externalRedfs in _referenceCompilation.ExternalReferences
+			var origins = from externalRedfs in _referenceCompilation.ExternalReferences
 						  where Path.GetFileNameWithoutExtension(externalRedfs.Display).StartsWith("Windows.Foundation")
 						  || Path.GetFileNameWithoutExtension(externalRedfs.Display).StartsWith("Windows.Phone.PhoneContract")
 						  || Path.GetFileNameWithoutExtension(externalRedfs.Display).StartsWith("Windows.ApplicationModel.Calls.CallsPhoneContract")
 						  let asm = _referenceCompilation.GetAssemblyOrModuleSymbol(externalRedfs) as IAssemblySymbol
 						  where asm != null
-						  select asm).ToArray();
+						  select asm;
 
 			var q = from asm in origins
 					where asm.Name == sourceAssembly
@@ -709,7 +709,7 @@ namespace Uno.UWPSyncGenerator
 		{
 			foreach (var eventMember in type.GetMembers().OfType<IEventSymbol>())
 			{
-				if(!IsNotUWPMapping(type, eventMember))
+				if (!IsNotUWPMapping(type, eventMember))
 				{
 					return;
 				}

--- a/src/Uno.UWPSyncGenerator/Program.cs
+++ b/src/Uno.UWPSyncGenerator/Program.cs
@@ -34,6 +34,7 @@ namespace Uno.UWPSyncGenerator
 				new SyncGenerator().Build(@"..\..\..\..\Uno.Foundation", "Uno.Foundation", "Windows.Foundation.FoundationContract");
 				new SyncGenerator().Build(@"..\..\..\..\Uno.UWP", "Uno", "Windows.Foundation.UniversalApiContract");
 				new SyncGenerator().Build(@"..\..\..\..\Uno.UWP", "Uno", "Windows.Phone.PhoneContract");
+				new SyncGenerator().Build(@"..\..\..\..\Uno.UWP", "Uno", "Windows.ApplicationModel.Calls.CallsPhoneContract");
 				new SyncGenerator().Build(@"..\..\..\..\Uno.UI", "Uno.UI", "Windows.Foundation.UniversalApiContract");
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #1114

## PR Type
What kind of change does this PR introduce?
 - Feature 

## What is the current behavior?
`PhoneCallManager` is not supported.


## What is the new behavior?
`PhoneCallManager` has support:

iOS - everything except `ShowPhoneCallSettingsUI` and `RequestStoreAsync`
Android - everything except `RequestStoreAsync`
WASM - only `ShowPhoneCallUI` is supported

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
Needed to add `Windows.ApplicationModel.Calls.CallsPhoneContract` to SyncGenerator

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
