### PR TITLE
ComboBox virtualization, item kidnapping fixes

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -224,6 +224,12 @@
 				reason="Removed obsolete property. TextBoxView is internal on UWP, shouldn't normally be created or manipulated by user code."/>
         <Member fullName="System.Void Windows.UI.Xaml.Controls.TextBoxView.NotifyTextChanged()"
 				reason="Removed obsolete method. TextBoxView is internal on UWP, shouldn't normally be created or manipulated by user code."/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.ComboBoxItem.OnLoaded()"
+				reason="Removed no-longer-needed override. Uno-only protected method that shouldn't be called by user code."/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.ComboBoxItem.OnUnloaded()"
+				reason="Removed no-longer-needed override. Uno-only protected method that shouldn't be called by user code."/>
+        <Member fullName="Windows.UI.Xaml.Controls.Popup Windows.UI.Xaml.Controls.ComboBoxItem.GetPopupControl()"
+				reason="Removed no-longer-needed method. Implementation detail."/>
 	  </Methods>
 	  
       <Fields>

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -129,6 +129,7 @@
 * [WASM] ListView - support item margins correctly
 * [iOS] Fix items dependency property propagation in ListView items
 * [Wasm] Add UI Testing support through for `Uno.UI.Helpers.Automation.GetDependencyPropertyValue`\
+* `ComboBox`'s dropdown list (`CarouselPanel`) is now virtualized (#1012)
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.
@@ -137,6 +138,12 @@
 * [Android] Unless nested under `SecondaryCommands`, the `AppBarButton.Label` property will no longer be used for the title of menu item, instead use the `AppBarButton.Content` property. For `SecondaryCommands`, keep using `AppBarButton.Label`.
 * The `WordEllipsis` was removed from the `TextWrapping` as it's not a valid value for UWP (And it was actually supported only on WASM) (The right way to get ellipsis is with the `TextTrimming.WordEllipsis`)
 * [Android] `Popup.Anchor` is no longer available
+* If `ComboBox` has a modified template (eg from overriding the default `Style`), then the `ScrollViewer` hosting the `ItemsPresenter` needs to have its `Style` set to `StaticResource ListViewBaseScrollViewerStyle` (as [here](https://github.com/nventive/Uno/blob/21c49fd1d6136352f71a894686a9b4130e300b95/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml#L754)). Eg:
+```xaml
+								<ScrollViewer x:Name="ScrollViewer"
+											  xamarin:Style="{StaticResource ListViewBaseScrollViewerStyle}"
+											  ...
+```
 
 ### Bug fixes
 * DatePicker FlyoutPlacement now set to Full by default

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -129,7 +129,7 @@
 * [WASM] ListView - support item margins correctly
 * [iOS] Fix items dependency property propagation in ListView items
 * [Wasm] Add UI Testing support through for `Uno.UI.Helpers.Automation.GetDependencyPropertyValue`\
-* `ComboBox`'s dropdown list (`CarouselPanel`) is now virtualized (#1012)
+* [WASM] `ComboBox`'s dropdown list (`CarouselPanel`) is now virtualized (#1012)
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.
@@ -138,12 +138,6 @@
 * [Android] Unless nested under `SecondaryCommands`, the `AppBarButton.Label` property will no longer be used for the title of menu item, instead use the `AppBarButton.Content` property. For `SecondaryCommands`, keep using `AppBarButton.Label`.
 * The `WordEllipsis` was removed from the `TextWrapping` as it's not a valid value for UWP (And it was actually supported only on WASM) (The right way to get ellipsis is with the `TextTrimming.WordEllipsis`)
 * [Android] `Popup.Anchor` is no longer available
-* If `ComboBox` has a modified template (eg from overriding the default `Style`), then the `ScrollViewer` hosting the `ItemsPresenter` needs to have its `Style` set to `StaticResource ListViewBaseScrollViewerStyle` (as [here](https://github.com/nventive/Uno/blob/21c49fd1d6136352f71a894686a9b4130e300b95/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml#L754)). Eg:
-```xaml
-								<ScrollViewer x:Name="ScrollViewer"
-											  xamarin:Style="{StaticResource ListViewBaseScrollViewerStyle}"
-											  ...
-```
 
 ### Bug fixes
 * DatePicker FlyoutPlacement now set to Full by default

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -214,6 +214,7 @@
 * Date and Time Picker Content fix and Refactored to use PickerFlyoutBase (to resemble UWP implementation)
 * `LinearGradientBrush.EndPoint` now defaults to (1,1) to match UWP
 * [Android] A ListView inside another ListView no longer causes an app freeze/crash
+* Fix ComboBox disappearing items when items are views (#1078)
 
 ## Release 1.44.0
 

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -25,6 +25,7 @@
 * Add support for `ContentDialog`
 * Permit `DependencyProperty` to be set reentrantly. Eg this permits `TextBox.TextChanging` to modify the `Text` property (previously this could only be achieved using `Dispatcher.RunAsync()`).
 * Implement `TextBox.TextChanging` and `TextBox.BeforeTextChanging`. As on UWP, this allows the text to be intercepted and modified before the UI is updated. Previously on Android using the `TextChanged` event would lead to laggy response and dropped characters when typing rapidly; this is no longer the case with `TextChanging`.
+* [WASM] `ComboBox`'s dropdown list (`CarouselPanel`) is now virtualized (#1012)
 
 ### Breaking changes
 * `TextBox` no longer raises TextChanged when its template is applied, in line with UWP.
@@ -42,6 +43,7 @@
 * Fixed an issue where a Two-Way binding would sometimes not update values back to source correctly
 * Adjust the behavior of `DisplayInformation.LogicalDpi` to match UWP's behavior
 * [Android] Ensure TextBox spell-check is properly enabled/disabled on all devices. 
+* Fix ComboBox disappearing items when items are views (#1078)
 
 ## Release 1.45.0
 ### Features
@@ -129,7 +131,6 @@
 * [WASM] ListView - support item margins correctly
 * [iOS] Fix items dependency property propagation in ListView items
 * [Wasm] Add UI Testing support through for `Uno.UI.Helpers.Automation.GetDependencyPropertyValue`\
-* [WASM] `ComboBox`'s dropdown list (`CarouselPanel`) is now virtualized (#1012)
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.
@@ -208,7 +209,6 @@
 * Date and Time Picker Content fix and Refactored to use PickerFlyoutBase (to resemble UWP implementation)
 * `LinearGradientBrush.EndPoint` now defaults to (1,1) to match UWP
 * [Android] A ListView inside another ListView no longer causes an app freeze/crash
-* Fix ComboBox disappearing items when items are views (#1078)
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.ComboBox.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.ComboBox.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Uno.UITest.Helpers;
+
+namespace SamplesApp.UITests
+{
+	[TestFixture]
+	partial class UnoSamples_Tests : SampleControlUITestBase
+	{
+		[Test]
+		public void ComboBox_Kidnapping()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ComboBox.ComboBox_ComboBoxItem_Selection");
+
+			var scrollingInitial = Configuration.AttemptToFindTargetBeforeScrolling;
+			Configuration.AttemptToFindTargetBeforeScrolling = true; //Needed on WASM because ScrollUpTo() currently not implemented
+			var comboBox = _app.Marked("_combo2");
+			_app.WaitForElement(comboBox);
+			var presenter = _app.FindWithin(marked: "ContentPresenter", within: comboBox);
+
+			var button = _app.Marked("ChangeSelectionButton");
+			_app.Tap(button);
+
+			var first = _app.FindWithin("_tb1", presenter);
+			Assert.AreEqual("Item 1", GetText(first));
+
+			_app.Tap(comboBox);
+			_app.TapCoordinates(300, 100);
+			first = _app.FindWithin("_tb1", presenter);
+			Assert.AreEqual("Item 1", GetText(first));
+
+			_app.Tap(button);
+			var second = _app.FindWithin("_tb2", presenter);
+			Assert.AreEqual("Item 2", GetText(second));
+
+			Configuration.AttemptToFindTargetBeforeScrolling = scrollingInitial;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -881,6 +881,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Aligned_Left.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Inside_ListView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2728,6 +2732,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Full_Wider.xaml.cs">
       <DependentUpon>Image_Stretch_Full_Wider.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Aligned_Left.xaml.cs">
+      <DependentUpon>ListView_Aligned_Left.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Inside_ListView.xaml.cs">
       <DependentUpon>ListView_Inside_ListView.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml
@@ -35,5 +35,6 @@
 			Previous Combo VisualTree (first item):<LineBreak />
 			<Run x:Name="_combo2Txt"></Run>
 		</TextBlock>
+		<Button x:Name="ChangeSelectionButton" Content="Increment SelectedIndex" Click="ChangeSelectionButton_Click"/>
 	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml
@@ -25,8 +25,8 @@
 			<Run x:Name="_combo1Txt"></Run>
 		</TextBlock>
 		<ComboBox x:Name="_combo2">
-			<TextBlock>Item 1</TextBlock>
-			<TextBlock>Item 2</TextBlock>
+			<TextBlock x:Name="_tb1">Item 1</TextBlock>
+			<TextBlock x:Name="_tb2">Item 2</TextBlock>
 			<TextBlock>Item 3</TextBlock>
 			<TextBlock>Item 4</TextBlock>
 			<TextBlock>Item 5</TextBlock>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml.cs
@@ -24,11 +24,17 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 		{
 			var items = _combo.Items;
 			var item = items.First() as FrameworkElement;
-			item.Loaded += (snd, evt) => { _combo1Txt.Text = GetVisualTree(item); };
+			item.Loaded += (snd, evt) =>
+			{
+				_combo1Txt.Text = GetVisualTree(item);
+			};
 
 			var items2 = _combo2.Items;
 			var item2 = items2.First() as FrameworkElement;
-			item2.Loaded += (snd, evt) => { _combo2Txt.Text = GetVisualTree(item2); };
+			item2.Loaded += (snd, evt) =>
+			{
+				_combo2Txt.Text = GetVisualTree(item2);
+			};
 		}
 
 		private void SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -46,7 +52,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 				{
 					var e = o as FrameworkElement;
 					yield return $"{o.GetType().Name}[{e?.Name}]-{o}";
-					if( e is Windows.UI.Xaml.Controls.ComboBox)
+					if (e is Windows.UI.Xaml.Controls.ComboBox)
 					{
 						yield break;
 					}
@@ -54,6 +60,17 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 			}
 
 			return string.Join("\n->", GetElements());
+		}
+
+		private void ChangeSelectionButton_Click(object sender, RoutedEventArgs e)
+		{
+			var newSelectedIndex = _combo2.SelectedIndex;
+			newSelectedIndex++;
+			if (newSelectedIndex >= _combo2.Items.Count)
+			{
+				newSelectedIndex = 0;
+			}
+			_combo2.SelectedIndex = newSelectedIndex;
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Aligned_Left.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Aligned_Left.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ListView.ListView_Aligned_Left"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ListView"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<ListView Margin="0,100,0,200"
+				  HorizontalAlignment="Left"
+				  ItemsSource="{Binding SampleTowns}"
+				  Background="LightGreen" />
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Aligned_Left.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Aligned_Left.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using SamplesApp.Windows_UI_Xaml_Controls.Models;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfo("ListView", "ListView_Aligned_Left", typeof(ListViewViewModel), description: "ListView with HorizontalAlignment=Left")]
+    public sealed partial class ListView_Aligned_Left : UserControl
+    {
+        public ListView_Aligned_Left()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Models/ListViewViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Models/ListViewViewModel.cs
@@ -58,6 +58,8 @@ namespace SamplesApp.Windows_UI_Xaml_Controls.Models
 
 		public string[] SampleItemsDuplicates => GetSampleItemsWithDuplicates();
 
+		public string[] SampleTowns { get; } = ListViewGroupedViewModel.SampleTowns;
+
 		public string SelectedItem
 		{
 			get => _selectedItem;

--- a/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
@@ -227,6 +227,21 @@ namespace AppKit
 			}
 		}
 
+		/// <summary>
+		/// Add view to parent.
+		/// </summary>
+		/// <param name="parent">Parent view</param>
+		/// <param name="child">Child view to add</param>
+		public static void AddChild(this _View parent, _View child)
+		{
+			parent.AddSubview(child);
+		}
+
+		/// <summary>
+		/// Get the parent view in the visual tree. This may differ from the logical <see cref="FrameworkElement.Parent"/>.
+		/// </summary>
+		public static _View GetVisualTreeParent(this _View child) => child?.Superview;
+
 		public static IEnumerable<T> FindSubviewsOfType<T>(this _View view, int maxDepth = 20) where T : class
 		{
 			return FindSubviews(view, (v) => v as T != null, maxDepth)

--- a/src/Uno.UI/Extensions/ViewExtensions.Android.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.Android.cs
@@ -51,10 +51,10 @@ namespace Uno.UI
 		/// <typeparam name="T"></typeparam>
 		/// <param name="view"></param>
 		/// <returns>First parent of the view of specified T type.</returns>
-		public static T FindFirstParent<T>(this IViewParent view)
+		public static T FindFirstParent<T>(this View childView)
 			where T : class
 		{
-			view = view?.Parent;
+			var view = childView?.Parent;
 
 			while (view != null)
 			{
@@ -305,6 +305,24 @@ namespace Uno.UI
 
 			return (T)view.EnumerateAllChildren(childSelector, maxDepth).FirstOrDefault();
 		}
+
+		/// <summary>
+		/// Add view to parent.
+		/// </summary>
+		/// <param name="parent">Parent view</param>
+		/// <param name="child">Child view to add</param>
+		public static void AddChild(this ViewGroup parent, View child)
+		{
+			// Remove from existing parent (for compatibility with other platforms).
+			(child.Parent as ViewGroup)?.RemoveView(child);
+
+			parent.AddView(child);
+		}
+
+		/// <summary>
+		/// Get the parent view in the visual tree. This may differ from the logical <see cref="FrameworkElement.Parent"/>.
+		/// </summary>
+		public static ViewGroup GetVisualTreeParent(this View child) => child?.Parent as ViewGroup;
 
 		/// <summary>
 		/// Removes a child view from the specified view, and disposes it if the specified view is the owner.

--- a/src/Uno.UI/Extensions/ViewExtensions.Android.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.Android.cs
@@ -45,13 +45,22 @@ namespace Uno.UI
 			return view.Parent != null;
 		}
 
+
 		/// <summary>
 		/// Return First parent of the view of specified T type.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="view"></param>
 		/// <returns>First parent of the view of specified T type.</returns>
-		public static T FindFirstParent<T>(this View childView)
+		public static T FindFirstParent<T>(this IViewParent view) where T : class => FindFirstParentOfView<T>(view as View);
+
+		/// <summary>
+		/// Return First parent of the view of specified T type.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="view"></param>
+		/// <returns>First parent of the view of specified T type.</returns>
+		public static T FindFirstParentOfView<T>(this View childView)
 			where T : class
 		{
 			var view = childView?.Parent;

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -18,10 +18,17 @@ using System.Linq;
 using Windows.UI.ViewManagement;
 using Microsoft.Extensions.Logging;
 
-#if __IOS__
+using Uno.UI.DataBinding;
+#if __ANDROID__
+using _View = Android.Views.View;
+#elif __IOS__
 using UIKit;
+using _View = UIKit.UIView;
 #elif __MACOS__
 using AppKit;
+using _View = _AppKit.NSView;
+#else
+using _View = Windows.UI.Xaml.FrameworkElement;
 #endif
 
 namespace Windows.UI.Xaml.Controls
@@ -36,6 +43,11 @@ namespace Windows.UI.Xaml.Controls
 		private Border _popupBorder;
 		private ContentPresenter _contentPresenter;
 		private ContentPresenter _headerContentPresenter;
+
+		/// <summary>
+		/// The 'inline' parent view of the selected item within the dropdown list. This is only set if SelectedItem is a view type.
+		/// </summary>
+		private ManagedWeakReference _selectionParentInDropdown;
 
 		public ComboBox()
 		{
@@ -168,6 +180,11 @@ namespace Windows.UI.Xaml.Controls
 
 		internal override void OnSelectedItemChanged(object oldSelectedItem, object selectedItem)
 		{
+			if (oldSelectedItem is _View view)
+			{
+				// Ensure previous SelectedItem is put back in the dropdown list if it's a view
+				RestoreSelectedItem(view);
+			}
 			base.OnSelectedItemChanged(oldSelectedItem, selectedItem);
 			UpdateContentPresenter();
 		}
@@ -182,8 +199,59 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (_contentPresenter != null)
 			{
-				var item = SelectedItem is ComboBoxItem cbi ? cbi.Content : SelectedItem;
+				var item = GetSelectionContent();
+
+				var itemView = item as _View;
+
+				if (itemView != null)
+				{
+					if (itemView.FindFirstParent<ComboBoxItem>() != null)
+					{
+						// Keep track of the former parent, so we can put the item back when the dropdown is shown
+						_selectionParentInDropdown = (itemView.GetVisualTreeParent() as IWeakReferenceProvider)?.WeakReference;
+					}
+				}
+				else
+				{
+					_selectionParentInDropdown = null;
+				}
+
 				_contentPresenter.Content = item;
+
+				if (itemView != null && itemView.GetVisualTreeParent() != _contentPresenter)
+				{
+					// Item may have been put back in list, reattach it to _contentPresenter
+					_contentPresenter.AddChild(itemView);
+				}
+			}
+		}
+
+		private object GetSelectionContent()
+		{
+			return SelectedItem is ComboBoxItem cbi ? cbi.Content : SelectedItem;
+		}
+
+		private void RestoreSelectedItem()
+		{
+			var selection = GetSelectionContent();
+			if (selection is _View selectionView)
+			{
+				RestoreSelectedItem(selectionView);
+			}
+		}
+
+		/// <summary>
+		/// Restore SelectedItem (or former SelectedItem) view to its position in the dropdown list.
+		/// </summary>
+		private void RestoreSelectedItem(_View selectionView)
+		{
+			var dropdownParent = _selectionParentInDropdown?.Target as FrameworkElement;
+			var comboBoxItem = dropdownParent?.FindFirstParent<ComboBoxItem>();
+
+			// Sanity check, ensure parent is still valid (ComboBoxItem may have been recycled)
+			if (comboBoxItem?.Content == selectionView && selectionView.GetVisualTreeParent() != dropdownParent)
+			{
+				dropdownParent.AddChild(selectionView);
 			}
 		}
 
@@ -209,6 +277,8 @@ namespace Windows.UI.Xaml.Controls
 			{
 				DropDownOpened?.Invoke(this, newIsDropDownOpen);
 
+				RestoreSelectedItem();
+
 				if (SelectedItem != null)
 				{
 					ScrollIntoView(SelectedItem);
@@ -217,6 +287,7 @@ namespace Windows.UI.Xaml.Controls
 			else
 			{
 				DropDownClosed?.Invoke(this, newIsDropDownOpen);
+				UpdateContentPresenter();
 			}
 
 			UpdateDropDownState();

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -208,6 +208,11 @@ namespace Windows.UI.Xaml.Controls
 			if (newIsDropDownOpen)
 			{
 				DropDownOpened?.Invoke(this, newIsDropDownOpen);
+
+				if (SelectedItem != null)
+				{
+					ScrollIntoView(SelectedItem);
+				}
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -26,7 +26,7 @@ using UIKit;
 using _View = UIKit.UIView;
 #elif __MACOS__
 using AppKit;
-using _View = _AppKit.NSView;
+using _View = AppKit.NSView;
 #else
 using _View = Windows.UI.Xaml.FrameworkElement;
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -205,7 +205,12 @@ namespace Windows.UI.Xaml.Controls
 
 				if (itemView != null)
 				{
-					if (itemView.FindFirstParent<ComboBoxItem>() != null)
+#if __ANDROID__
+					var comboBoxItem = itemView.FindFirstParentOfView<ComboBoxItem>();
+#else
+					var comboBoxItem = itemView.FindFirstParent<ComboBoxItem>();
+#endif
+					if (comboBoxItem != null)
 					{
 						// Keep track of the former parent, so we can put the item back when the dropdown is shown
 						_selectionParentInDropdown = (itemView.GetVisualTreeParent() as IWeakReferenceProvider)?.WeakReference;
@@ -246,7 +251,11 @@ namespace Windows.UI.Xaml.Controls
 		private void RestoreSelectedItem(_View selectionView)
 		{
 			var dropdownParent = _selectionParentInDropdown?.Target as FrameworkElement;
+#if __ANDROID__
+			var comboBoxItem = dropdownParent?.FindFirstParentOfView<ComboBoxItem>();
+#else
 			var comboBoxItem = dropdownParent?.FindFirstParent<ComboBoxItem>();
+#endif
 
 			// Sanity check, ensure parent is still valid (ComboBoxItem may have been recycled)
 			if (comboBoxItem?.Content == selectionView && selectionView.GetVisualTreeParent() != dropdownParent)

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
@@ -2,81 +2,14 @@
 using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
 	public partial class ComboBoxItem : SelectorItem
 	{
-		private Popup _popup;
-
-		protected override void OnLoaded()
+		public ComboBoxItem()
 		{
-			base.OnLoaded();
 
-			var popup = GetPopupControl();
-			if (popup != _popup)
-			{
-				if (_popup != null)
-				{
-					_popup.Opened -= OnPopupOpened;
-				}
-				popup.Opened += OnPopupOpened;
-				_popup = popup;
-			}
-
-			CheckContentKidnapped();
 		}
-
-		protected override void OnUnloaded()
-		{
-			base.OnUnloaded();
-
-			if (_popup != null)
-			{
-				_popup.Opened -= OnPopupOpened;
-				_popup = null;
-			}
-		}
-
-		private void OnPopupOpened(object sender, object e)
-		{
-			CheckContentKidnapped();
-		}
-
-		private void CheckContentKidnapped()
-		{
-			if (Content is DependencyObject content)
-			{
-				var currentParent = GetParent(content);
-
-				if (currentParent != Content)
-				{
-					// Content has been kidnapped: reconnect content with current element
-					Content = null;
-					Content = content;
-				}
-			}
-		}
-
-		public Popup GetPopupControl()
-		{
-			var parent = GetParent(this);
-
-			while (parent != null)
-			{
-				if (parent is PopupPanel pnl)
-				{
-					return pnl.Popup;
-				}
-
-				parent = GetParent(parent);
-			}
-
-			return null;
-		}
-
-		private DependencyObject GetParent(DependencyObject e)
-			=> (e as FrameworkElement)?.Parent ?? VisualTreeHelper.GetParent(e);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -787,6 +787,10 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		internal virtual void OnItemsSourceSingleCollectionChanged(object sender, NotifyCollectionChangedEventArgs args, int section)
 		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug($"Called {nameof(OnItemsSourceSingleCollectionChanged)}(), Action={args.Action}, NoOfItems={NumberOfItems}");
+			}
 			UpdateItems();
 		}
 
@@ -795,6 +799,10 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		internal virtual void OnItemsSourceGroupsChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug($"Called {nameof(OnItemsSourceGroupsChanged)}(), Action={args.Action}, NoOfItems={NumberOfItems}, NoOfGroups={NumberOfGroups}");
+			}
 			UpdateItems();
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnItemsPanelChanged(ItemsPanelTemplate oldItemsPanel, ItemsPanelTemplate newItemsPanel)
 		{
-			if (_isReady) // Panel is created on ApplyTemplate, so do not create it twice (first on set PanelTemplate, second on ApplyTemplate)
+			if (_isReady && !Equals(oldItemsPanel, newItemsPanel)) // Panel is created on ApplyTemplate, so do not create it twice (first on set PanelTemplate, second on ApplyTemplate)
 			{
 				UpdateItemsPanelRoot();
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -28,6 +28,7 @@ using Color = UIKit.UIColor;
 using Font = UIKit.UIFont;
 using UIKit;
 #elif __MACOS__
+using AppKit;
 using View = AppKit.NSView;
 using Color = Windows.UI.Color;
 #else

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/IVirtualizingPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/IVirtualizingPanel.cs
@@ -1,5 +1,4 @@
-﻿#if !NET461
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -17,5 +16,3 @@ namespace Windows.UI.Xaml.Controls
 		VirtualizingPanelLayout GetLayouter();
 	}
 }
-
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.cs
@@ -1,5 +1,4 @@
-﻿#if !NET461 && !__MACOS__
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -10,5 +9,3 @@ namespace Windows.UI.Xaml.Controls
 		public override Orientation ScrollOrientation { get { return Orientation; } }
 	}
 }
-
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
@@ -76,7 +76,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes updatingItem, bool shouldRecurse)
+		private protected override void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes updatingItem, bool shouldRecurse)
 		{
 			//Update extent of either subsequent item in group, subsequent group header, or footer
 			var currentIndex = updatingItem.IndexPath;

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
@@ -76,7 +76,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes updatingItem)
+		protected override void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes updatingItem, bool shouldRecurse)
 		{
 			//Update extent of either subsequent item in group, subsequent group header, or footer
 			var currentIndex = updatingItem.IndexPath;
@@ -115,6 +115,11 @@ namespace Windows.UI.Xaml.Controls
 				var frame = elementToAdjust.Frame;
 				SetExtentStart(ref frame, GetExtentEnd(updatingItem.Frame));
 				elementToAdjust.Frame = frame;
+
+				if (shouldRecurse)
+				{
+					UpdateLayoutAttributesForItem(elementToAdjust, shouldRecurse: true);
+				}
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Stub.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Stub.cs
@@ -1,0 +1,16 @@
+﻿#if NET461 || __MACOS__
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml.Controls;
+
+namespace Windows.UI.Xaml.Controls
+{
+	abstract partial class VirtualizingPanelLayout
+	{
+		public abstract Orientation ScrollOrientation { get; }
+
+		public Orientation Orientation { get; set; }
+	}
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.cs
@@ -15,6 +15,10 @@ namespace Windows.UI.Xaml.Controls
 	{
 		protected enum RelativeHeaderPlacement { Inline, Adjacent }
 
+		/// <summary>
+		/// The direction of scroll.
+		/// </summary>
+		/// <remarks>For <see cref="ItemsStackPanel"/> layouting this is identical to <see cref="Orientation"/> but for <see cref="ItemsWrapGrid"/> it is the opposite of <see cref="Orientation"/>.</remarks>
 		public abstract Orientation ScrollOrientation { get; }
 #if !__WASM__
 		protected readonly ILayouter _layouter = new VirtualizingPanelLayouter();
@@ -96,6 +100,9 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		/// <summary>
+		/// Bound to <see cref="ItemsStackPanel.Orientation"/> or <see cref="ItemsWrapGrid.Orientation"/>.
+		/// </summary>
 		public Orientation Orientation
 		{
 			get { return (Orientation)GetValue(OrientationProperty); }
@@ -104,6 +111,29 @@ namespace Windows.UI.Xaml.Controls
 
 		public static readonly DependencyProperty OrientationProperty =
 			DependencyProperty.Register("Orientation", typeof(Orientation), typeof(VirtualizingPanelLayout), new PropertyMetadata(Orientation.Vertical, (o, e) => ((VirtualizingPanelLayout)o).OnOrientationChanged((Orientation)e.NewValue)));
+
+		/// <summary>
+		/// Whether the content should be stretched in breadth (ie perpendicular to the direction of scroll).
+		/// </summary>
+		public bool ShouldBreadthStretch
+		{
+			get
+			{
+				if (XamlParent == null)
+				{
+					return true;
+				}
+
+				if (ScrollOrientation == Orientation.Vertical)
+				{
+					return XamlParent.HorizontalAlignment == HorizontalAlignment.Stretch;
+				}
+				else
+				{
+					return XamlParent.VerticalAlignment == VerticalAlignment.Stretch;
+				}
+			}
+		}
 
 		public IReadOnlyList<float> GetIrregularSnapPoints(Orientation orientation, SnapPointsAlignment alignment)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -179,7 +179,7 @@ namespace Windows.UI.Xaml.Controls
 					if (SupportsDynamicItemSizes && HasDynamicElementSizes && areItems)
 					{
 						//Propagate layout changes for materialized items that may have a different size to the non-databound template.
-						UpdateLayoutAttributesForItem(layoutAttributes);
+						UpdateLayoutAttributesForItem(layoutAttributes, shouldRecurse: false);
 					}
 
 					if (rect.Contains(frame) ||
@@ -1078,7 +1078,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (SupportsDynamicItemSizes && layoutAttributes.RepresentedElementKind == null)
 			{
-				UpdateLayoutAttributesForItem(layoutAttributes);
+				UpdateLayoutAttributesForItem(layoutAttributes, shouldRecurse: true);
 			}
 
 			// If this pushes content size bigger than viewport, and we 'left money on the table' when we requested desired size, send up a layout request
@@ -1173,7 +1173,7 @@ namespace Windows.UI.Xaml.Controls
 			_sectionEnd[groupHeaderLayout.IndexPath.Section] += extentDifference;
 		}
 
-		protected virtual void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes layoutAttributes)
+		protected virtual void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes layoutAttributes, bool shouldRecurse)
 		{
 			throw new NotSupportedException($"This should be overridden by types which set {nameof(SupportsDynamicItemSizes)} to true.");
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -588,7 +588,10 @@ namespace Windows.UI.Xaml.Controls
 				}
 
 				//Ensure container for group exists even if group contains no items, to simplify subsequent logic
-				_itemLayoutInfos[section] = new Dictionary<NSIndexPath, UICollectionViewLayoutAttributes>();
+				if (createLayoutInfo)
+				{
+					_itemLayoutInfos[section] = new Dictionary<NSIndexPath, UICollectionViewLayoutAttributes>(); 
+				}
 				//b. Layout items in group
 				var itemsBreadth = LayoutItemsInGroup(section, availableGroupBreadth, ref frame, createLayoutInfo, oldItemSizes);
 				var groupBreadth = itemsBreadth;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -64,7 +64,13 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		#region Members
+		/// <summary>
+		/// All cached item <see cref="UICollectionViewLayoutAttributes"/>s, grouped by collection group.
+		/// </summary>
 		private readonly Dictionary<int, LayoutInfoDictionary> _itemLayoutInfos = new Dictionary<int, LayoutInfoDictionary>();
+		/// <summary>
+		/// All cached <see cref="UICollectionViewLayoutAttributes"/> for supplementary elements (Header, Footer, group headers), grouped by element type.
+		/// </summary>
 		private readonly Dictionary<string, LayoutInfoDictionary> _supplementaryLayoutInfos = new Dictionary<string, LayoutInfoDictionary>();
 		/// <summary>
 		/// The last element in the list. This is set when the layout is created (and will point to the databound size and position of 
@@ -72,6 +78,9 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		private UICollectionViewLayoutAttributes _lastElement;
 
+		/// <summary>
+		/// Locations of group header frames if they were to appear inline with items (ie not 'sticky').
+		/// </summary>
 		private readonly Dictionary<int, CGRect> _inlineHeaderFrames = new Dictionary<int, CGRect>();
 		protected readonly Dictionary<int, nfloat> _sectionEnd = new Dictionary<int, nfloat>();
 
@@ -79,7 +88,13 @@ namespace Windows.UI.Xaml.Controls
 		private Dictionary<CachedTuple<int, int>, NSIndexPath> _indexPaths = new Dictionary<CachedTuple<int, int>, NSIndexPath>(CachedTuple<int, int>.Comparer);
 		private Dictionary<CachedTuple<int, int>, UICollectionViewLayoutAttributes> _layoutAttributesForIndexPaths = new Dictionary<CachedTuple<int, int>, UICollectionViewLayoutAttributes>(CachedTuple<int, int>.Comparer);
 		private DirtyState _dirtyState;
+		/// <summary>
+		/// The most recently returned desired size.
+		/// </summary>
 		private CGSize _lastReportedSize;
+		/// <summary>
+		/// The most recent available size given by measure.
+		/// </summary>
 		private CGSize _lastAvailableSize;
 		private bool _invalidatingHeadersOnBoundsChange;
 		private bool _invalidatingOnCollectionChanged;
@@ -354,6 +369,14 @@ namespace Windows.UI.Xaml.Controls
 			return PrepareLayout(false, size);
 		}
 
+		/// <summary>
+		/// Prepare layout if necessary and return its size.
+		/// </summary>
+		/// <param name="createLayoutInfo">Should we create <see cref="UICollectionViewLayoutAttributes"/>?</param>
+		/// <param name="size">The available size</param>
+		/// <returns>The total collection size</returns>
+		/// <remarks>This is called by overidden methods which need to know the total dimensions of the panel content. If a full relayout is required,
+		/// it calls <see cref="PrepareLayoutInternal(bool, bool, CGSize)"/>; otherwise it returns a cached value.</remarks>
 		private CGSize PrepareLayout(bool createLayoutInfo, CGSize? size = null)
 		{
 			using (
@@ -384,7 +407,7 @@ namespace Windows.UI.Xaml.Controls
 						_lastElement = null;
 					}
 					_lastReportedSize = PrepareLayoutInternal(createLayoutInfo, _dirtyState == DirtyState.CollectionChanged, availableSize);
-					
+
 					if (_dirtyState == DirtyState.NeedsRelayout && GetExtent(_lastReportedSize) < GetExtent(_lastAvailableSize))
 					{
 						SetHasUnusedSpace();
@@ -436,7 +459,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		/// <summary>
-		/// Determine the layout for all elements (items, header, footer, and group headers).
+		/// Recalculate the layout for all elements (items, header, footer, and group headers).
 		/// </summary>
 		/// <param name="createLayoutInfo">Should we create <see cref="UICollectionViewLayoutAttributes"/>?</param>
 		/// <param name="isCollectionChanged">Is this a partial layout in response to an INotifyCollectionChanged operation</param>
@@ -791,6 +814,9 @@ namespace Windows.UI.Xaml.Controls
 			return value;
 		}
 
+		/// <summary>
+		/// Apply 'stickiness' to group header positions.
+		/// </summary>
 		private void UpdateHeaderPositions()
 		{
 			// Get coordinate index to modify
@@ -1022,6 +1048,9 @@ namespace Windows.UI.Xaml.Controls
 			InvalidateLayout();
 		}
 
+		/// <summary>
+		/// Update cached layout attributes for an element after the materialized, databound element has been measured.
+		/// </summary>
 		public void UpdateLayoutAttributesForElement(UICollectionViewLayoutAttributes layoutAttributes)
 		{
 			//Update frame of target layoutAttributes

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -1205,7 +1205,7 @@ namespace Windows.UI.Xaml.Controls
 			_sectionEnd[groupHeaderLayout.IndexPath.Section] += extentDifference;
 		}
 
-		protected virtual void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes layoutAttributes, bool shouldRecurse)
+		private protected virtual void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes layoutAttributes, bool shouldRecurse)
 		{
 			throw new NotSupportedException($"This should be overridden by types which set {nameof(SupportsDynamicItemSizes)} to true.");
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.wasm.cs
@@ -253,6 +253,8 @@ namespace Windows.UI.Xaml.Controls
 
 		private void UpdateLayout(double? extentAdjustment = null)
 		{
+			OwnerPanel.ShouldInterceptInvalidate = true;
+
 			UnfillLayout(extentAdjustment ?? 0);
 			FillLayout(extentAdjustment ?? 0);
 
@@ -265,12 +267,18 @@ namespace Windows.UI.Xaml.Controls
 			{
 				UpdateCompleted();
 			}
+
+			OwnerPanel.ShouldInterceptInvalidate = false;
 		}
 
 		private void UpdateCompleted()
 		{
+			OwnerPanel.ShouldInterceptInvalidate = true;
+
 			Generator.ClearScrappedViews();
 			Generator.UpdateVisibilities();
+
+			OwnerPanel.ShouldInterceptInvalidate = false;
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.cs
@@ -6,10 +6,17 @@ using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	public partial class CarouselPanel : StackPanel // TODO: VirtualizingPanel
+	public partial class CarouselPanel : VirtualizingPanel
 	{
+		private readonly ItemsStackPanelLayout _layout = new ItemsStackPanelLayout();
+
 		public CarouselPanel()
 		{
+#if __WASM__
+			_layout.Initialize(this);
+#endif
 		}
+
+		private protected override VirtualizingPanelLayout GetLayouterCore() => _layout;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !__WASM__
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml.Controls;
@@ -6,17 +7,12 @@ using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	public partial class CarouselPanel : VirtualizingPanel
+	public partial class CarouselPanel : StackPanel //TODO: VirtualizingPanel https://github.com/nventive/Uno/issues/1133
 	{
-		private readonly ItemsStackPanelLayout _layout = new ItemsStackPanelLayout();
 
 		public CarouselPanel()
 		{
-#if __WASM__
-			_layout.Initialize(this);
-#endif
 		}
-
-		private protected override VirtualizingPanelLayout GetLayouterCore() => _layout;
 	}
 }
+#endif

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.wasm.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.Foundation;
+
+namespace Windows.UI.Xaml.Controls.Primitives
+{
+	public partial class CarouselPanel
+	{
+		protected override Size MeasureOverride(Size availableSize) => _layout.MeasureOverride(availableSize);
+
+		protected override Size ArrangeOverride(Size finalSize) => _layout.ArrangeOverride(finalSize);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.wasm.cs
@@ -5,10 +5,19 @@ using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	public partial class CarouselPanel
+	public partial class CarouselPanel : VirtualizingPanel
 	{
+		private readonly ItemsStackPanelLayout _layout = new ItemsStackPanelLayout();
+		
+		public CarouselPanel()
+		{
+			_layout.Initialize(this);
+		}
+
 		protected override Size MeasureOverride(Size availableSize) => _layout.MeasureOverride(availableSize);
 
 		protected override Size ArrangeOverride(Size finalSize) => _layout.ArrangeOverride(finalSize);
+
+		private protected override VirtualizingPanelLayout GetLayouterCore() => _layout;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/OrientedVirtualizingPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/OrientedVirtualizingPanel.cs
@@ -1,12 +1,7 @@
 #pragma warning disable 108 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__
 	[global::Uno.NotImplemented]
-	#endif
-	#if false
-	[global::Uno.NotImplemented]
-	#endif
 	public  partial class OrientedVirtualizingPanel 
 	{
 		public OrientedVirtualizingPanel()

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -23,6 +23,16 @@ namespace Windows.UI.Xaml.Controls
 
 		private static readonly string[] HorizontalModeClasses = { "scrollmode-x-disabled", "scrollmode-x-enabled", "scrollmode-x-auto" };
 
+		internal Size ScrollBarSize
+		{
+			get
+			{
+				var (clientSize, offsetSize) = WindowManagerInterop.GetClientViewSize(HtmlId);
+
+				return new Size(offsetSize.Width - clientSize.Width, offsetSize.Height - clientSize.Height);
+			}
+		}
+
 		public ScrollContentPresenter()
 		{
 			PointerReleased += ScrollViewer_PointerReleased;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.wasm.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.Generic;
+using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Controls
 {
 	partial class ScrollViewer
 	{
+		internal Size ScrollBarSize => (_sv as ScrollContentPresenter)?.ScrollBarSize ?? default;
+
 		private void UpdateZoomedContentAlignment()
 		{
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/VirtualizingPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/VirtualizingPanel.cs
@@ -1,17 +1,17 @@
 #pragma warning disable 108 // new keyword hiding
+using System;
+
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__
-	[global::Uno.NotImplemented]
-	#endif
-	#if false
-	[global::Uno.NotImplemented]
-	#endif
-	public  partial class VirtualizingPanel : global::Windows.UI.Xaml.Controls.Panel
+	public  partial class VirtualizingPanel : Panel, IVirtualizingPanel
 	{
 		public VirtualizingPanel()
 		{
 
 		}
+
+		public VirtualizingPanelLayout GetLayouter() => GetLayouterCore();
+
+		private protected virtual VirtualizingPanelLayout GetLayouterCore() => throw new NotSupportedException($"This method must be overridden by implementing classes.");
 	}
 }

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.net.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.net.cs
@@ -12,7 +12,7 @@ namespace Windows.UI.Xaml
 {
 	public partial class FrameworkElement : UIElement, IFrameworkElement
 	{
-		public T FindFirstParent<T>() where T:class
+		public T FindFirstParent<T>() where T : class
 		{
 			var view = this.Parent;
 			while (view != null)
@@ -55,14 +55,14 @@ namespace Windows.UI.Xaml
 
 		public TransitionCollection Transitions { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
-		public IFrameworkElement FindName(string name) 
+		public IFrameworkElement FindName(string name)
 			=> IFrameworkElementHelper.FindName(this, GetChildren(), name);
 
 
 		public void Dispose()
 		{
 			throw new NotImplementedException();
-        }
+		}
 
 		public Size AdjustArrange(Size finalSize)
 		{
@@ -110,7 +110,7 @@ namespace Windows.UI.Xaml
 
 		protected virtual void OnBackgroundChanged(DependencyPropertyChangedEventArgs e)
 		{
-			
+
 		}
 
 		#endregion

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -751,6 +751,7 @@
 									Margin="0,-1,0,-1"
 									HorizontalAlignment="Stretch">
 								<ScrollViewer x:Name="ScrollViewer"
+											  xamarin:Style="{StaticResource ListViewBaseScrollViewerStyle}"
 											  Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
 											  win:MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownContentMinWidth}"
 											  VerticalSnapPointsType="OptionalSingle"

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -751,7 +751,6 @@
 									Margin="0,-1,0,-1"
 									HorizontalAlignment="Stretch">
 								<ScrollViewer x:Name="ScrollViewer"
-											  xamarin:Style="{StaticResource ListViewBaseScrollViewerStyle}"
 											  Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
 											  win:MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownContentMinWidth}"
 											  VerticalSnapPointsType="OptionalSingle"

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.wasm.cs
@@ -14,8 +14,19 @@ namespace Windows.UI.Xaml
 
 		public Size DesiredSize => Visibility == Visibility.Collapsed ? new Size(0, 0) : _desiredSize;
 
+		/// <summary>
+		/// When set, measure and invalidate requests will not be propagated further up the visual tree, ie they won't trigger a relayout.
+		/// Used where repeated unnecessary measure/arrange passes would be unacceptable for performance (eg scrolling in a list).
+		/// </summary>
+		internal bool ShouldInterceptInvalidate { get; set; }
+
 		public void InvalidateMeasure()
 		{
+			if (ShouldInterceptInvalidate)
+			{
+				return;
+			}
+
 			// TODO: Figure out why this condition breaks layouting in some cases
 			//if (_isMeasureValid)
 			{
@@ -34,6 +45,11 @@ namespace Windows.UI.Xaml
 
 		public void InvalidateArrange()
 		{
+			if (ShouldInterceptInvalidate)
+			{
+				return;
+			}
+
 			if (_isArrangeValid)
 			{
 				_isArrangeValid = false;

--- a/src/Uno.UI/UI/Xaml/UIElementExtensions.net.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementExtensions.net.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.UI.Xaml
+{
+	public static partial class UIElementExtensions
+	{
+		public static UIElement GetVisualTreeParent(this UIElement uiElement) => (uiElement as FrameworkElement)?.Parent as UIElement;
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElementExtensions.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementExtensions.wasm.cs
@@ -50,5 +50,10 @@ namespace Uno.Extensions
 		{
 			element.UnregisterEventHandler(eventName, handler);
 		}
+		
+		/// <summary>
+		/// Get the parent view in the visual tree.
+		/// </summary>
+		public static UIElement GetVisualTreeParent(this UIElement element) => element?.GetParent() as UIElement;
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #555, partially addresses #556 and #1133, fixes #1078
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix 
 - Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
 - [WASM] ComboBox is now virtualized
 - [WASM] ListView supports non-Stretch alignments properly.
 - [All] Fixes issues with views in `Items`/`ItemsSource` being 'kidnapped' when closing and opening `ComboBox` dropdown.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
