### PR TITLE
automation: automatically triage/label the most voted issues by the community

### DIFF
--- a/.github/topissuebot.yml
+++ b/.github/topissuebot.yml
@@ -1,0 +1,4 @@
+# Configuration for top-issue-bot - https://github.com/adamzolyak/gh-vote-bot
+labelName: "triage/most-wanted"
+labelColor: "#BB8FCE"
+numberOfIssuesToLabel: 10


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- Project automation

## What is the current behavior?

- Votes on issues are meaningless.

## What is the new behavior?

Provides the community with a way to influence the backlog, though we would prefer folks shipped PR's and talked to us about becoming regular contributors.

Anyway when this PR lands a bot will run every 25 minutes, labeling top issues and unlabeling issues that are no longer top issues. Top issues are issues with the most "+1" emoji reactions on the issue description. "+1" emoji reactions on issues comments are not considered.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information

Opening early. Should this be top 10 or top 25?

See https://github.com/adamzolyak/gh-vote-bot for documentation