### PR TITLE
automation: automatically create release notes/changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,14 @@
+name-template: v$NEXT_PATCH_VERSION
+tag-template: v$NEXT_PATCH_VERSION
+categories:
+  - title: 🚀 Features
+    label: feature
+  - title: 🐛 Bug Fixes
+    label: fix
+  - title: 🧰 Maintenance
+    label: chore
+tag-template: - $TITLE @$AUTHOR (#$NUMBER)
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,13 +1,24 @@
-name-template: v$NEXT_PATCH_VERSION
-tag-template: v$NEXT_PATCH_VERSION
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: '$NEXT_PATCH_VERSION'
 categories:
-  - title: 🚀 Features
-    label: feature
-  - title: 🐛 Bug Fixes
-    label: fix
-  - title: 🧰 Maintenance
-    label: chore
-tag-template: - $TITLE @$AUTHOR (#$NUMBER)
+  - title: '⚠️ Breaking Changes'
+    labels:
+      - 'kind/api-change-breaking'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'kind/bug'
+  - title: '🚀 Features'
+    labels:
+      - 'kind/enhancement'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'kind/dependency'
+      - 'kind/cleanup'
+      - 'kind/documentation'
+      - 'kind/maintainer-experience'
+      - 'kind/consumer-experience'
+      - 'kind/contributor-experience'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## Changes
 


### PR DESCRIPTION
GitHub Issue (If applicable): Replaces/fixes https://github.com/unoplatform/uno/pull/825

## PR Type
What kind of change does this PR introduce?

- Build or CI related changes


## What is the current behavior?

![bucket](https://user-images.githubusercontent.com/127353/60259257-3641eb80-991a-11e9-8460-49a61207c849.jpg)

## What is the new behavior?

- No more merge conflicts on the change log 🎉 
- Release notes automatically generated, the author is attributed and PR is referenced.
- The changelog resets when `master` is tagged (ie "edit draft release on github and untick the box")

![image](https://user-images.githubusercontent.com/127353/60259790-62aa3780-991b-11e9-9514-a17c81bec55b.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

We use this over at ReactiveUI. I'm opening this early for discussion. What configuration do you want? See https://github.com/toolmantim/release-drafter