### PR TITLE
add sample for textbox in a listview

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -873,6 +873,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_TextBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_TransformsOnList.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2639,6 +2643,9 @@
       <DependentUpon>ListView_ItemTemplateSelector_And_ItemContainerStyleSelector.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_OwnContainer_Virtualized.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_TextBox.xaml.cs">
+      <DependentUpon>ListView_TextBox.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_TransformsOnList.xaml.cs">
       <DependentUpon>ListView_TransformsOnList.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_TextBox.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_TextBox.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl x:Class="SamplesApp.Windows_UI_Xaml_Controls.ListView.ListView_TextBox"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ListView"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<ListView ItemsSource="{Binding [SampleItems]}">
+		<ListView.ItemTemplate>
+			<DataTemplate>
+				<TextBox Text="Example"
+						 AcceptsReturn="True"
+						 TextWrapping="Wrap" />
+			</DataTemplate>
+		</ListView.ItemTemplate>
+	</ListView>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_TextBox.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_TextBox.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.Models;
+
+namespace SamplesApp.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfoAttribute("ListView", "ListView_TextBox", typeof(ListViewViewModel), description: "On iOS, Textbox crashes with TextWrapping or AcceptsReturn")]
+	public sealed partial class ListView_TextBox : UserControl
+    {
+        public ListView_TextBox()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #

https://github.com/unoplatform/private/issues/20

## PR Type

What kind of change does this PR introduce?
- Sample for textbox in a listview

## What is the current behavior?

No sample with a textbox in a listview

## What is the new behavior?

New sample "ListView_TextBox" in Listview

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
