### PR TITLE
Initial support for ThemeResources

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -11,6 +11,10 @@
 * Permit `DependencyProperty` to be set reentrantly. Eg this permits `TextBox.TextChanged` to modify the `Text` property (previously this could only be achieved using `Dispatcher.RunAsync()`).
 * Add support for filtered solutions development for Uno.UI contributions.
 * Add support for Android UI Tests in PRs for improved regression testing
+* Added static support for **ThemeResources**: `Application.Current.RequestedTheme` is supported
+  - Only `Dark` and `Light` are supported yet.
+  - Element's level `RequestedTheme` is ignored.
+  - Must be set when the application is starting.
 
 ### Breaking changes
 *

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -11,9 +11,9 @@
 * Permit `DependencyProperty` to be set reentrantly. Eg this permits `TextBox.TextChanged` to modify the `Text` property (previously this could only be achieved using `Dispatcher.RunAsync()`).
 * Add support for filtered solutions development for Uno.UI contributions.
 * Add support for Android UI Tests in PRs for improved regression testing
-* Added static support for **ThemeResources**: `Application.Current.RequestedTheme` is supported
+* Add static support for **ThemeResources**: `Application.Current.RequestedTheme` is supported
   - Only `Dark` and `Light` are supported yet.
-  - Element's level `RequestedTheme` is ignored.
+  - `FrameworkElement.RequestedTheme ` is ignored.
   - Must be set when the application is starting.
 
 ### Breaking changes

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -12,9 +12,15 @@
 * Add support for filtered solutions development for Uno.UI contributions.
 * Add support for Android UI Tests in PRs for improved regression testing
 * Add static support for **ThemeResources**: `Application.Current.RequestedTheme` is supported
-  - Only `Dark` and `Light` are supported yet.
-  - `FrameworkElement.RequestedTheme ` is ignored.
-  - Must be set when the application is starting.
+  - `Dark` and `Light` are supported.
+  - **Custom Themes** are supported. This let you specify `HighContrast` or any other custom themes.
+    (this is a feature not supported in UWP)
+    ``` csharp
+    // Put that somewhere during app initialization...
+    Uno.UI.ApplicationHelper.RequestedCustomTheme = "MyCustomTheme";
+    ```
+  - `FrameworkElement.RequestedTheme ` is ignored for now.
+  - Should be set when the application is starting (before first request to a static resource).
 
 ### Breaking changes
 *

--- a/doc/articles/api-differences.md
+++ b/doc/articles/api-differences.md
@@ -39,7 +39,7 @@ Overriding implicit styles is currently not supported.
 ### Theme Resources & Theme Dictionaries
 
 _Theme resources_ are also considered as `StaticResource`. In the current Uno's implementation, there's
-not difference between a `{StaticResource xxx}` and a `{ThemeResource xxx}`: they will both resolve on
+no difference between a `{StaticResource xxx}` and a `{ThemeResource xxx}`: they will both resolve to
 the resource.
 
 `FrameworkElement.RequestedTheme` is not supported yet. The `Application.Current.RequestedTheme` property

--- a/doc/articles/api-differences.md
+++ b/doc/articles/api-differences.md
@@ -47,7 +47,7 @@ must be set at launch time. Documentation: [`Application.RequestedTheme`](https:
 
 ### Custom Themes
 
-On Windows, there is some _themes_ you can target, but there's no way to trigger them. The most
+On Windows, there are some _themes_ that can target, but there is no way to trigger them. The most
 known is the `HighContrast` theme.
 
 You can do something similar - an even create totally custom themes - by using the following helper:

--- a/doc/articles/api-differences.md
+++ b/doc/articles/api-differences.md
@@ -40,7 +40,7 @@ Overriding implicit styles is currently not supported.
 
 _Theme resources_ are also considered as `StaticResource`. In the current Uno's implementation, there's
 no difference between a `{StaticResource xxx}` and a `{ThemeResource xxx}`: they will both resolve to
-the resource.
+the resource `xxx`.
 
 `FrameworkElement.RequestedTheme` is not supported yet. The `Application.Current.RequestedTheme` property
 must be set at launch time. Documentation: [`Application.RequestedTheme`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.application.requestedtheme)

--- a/doc/articles/api-differences.md
+++ b/doc/articles/api-differences.md
@@ -44,3 +44,20 @@ the resource.
 
 `FrameworkElement.RequestedTheme` is not supported yet. The `Application.Current.RequestedTheme` property
 must be set at launch time. Documentation: [`Application.RequestedTheme`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.application.requestedtheme)
+
+### Custom Themes
+
+On Windows, there is some _themes_ you can target, but there's no way to trigger them. The most
+known is the `HighContrast` theme.
+
+You can do something similar - an even create totally custom themes - by using the following helper:
+
+``` csharp
+  // Set current theme to Hich contrast
+  Uno.UI.RequestedCustomTheme = "HighContrast";
+```
+
+* Beware, all themes are **CASE SENSITIVE**.
+* Themed dictionaries will fall back to `Application.Current.RequestedTheme` when they are not
+  defining a resource for the custom theme.
+* You can put any string and create totally custom themes, but they won't be supported by UWP.

--- a/doc/articles/api-differences.md
+++ b/doc/articles/api-differences.md
@@ -42,5 +42,5 @@ _Theme resources_ are also considered as `StaticResource`. In the current Uno's 
 not difference between a `{StaticResource xxx}` and a `{ThemeResource xxx}`: they will both resolve on
 the resource.
 
-Element's level `RequestedTheme` is not supported yet. The `Application.Current.RequestedTheme` property
+`FrameworkElement.RequestedTheme` is not supported yet. The `Application.Current.RequestedTheme` property
 must be set at launch time. Documentation: [`Application.RequestedTheme`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.application.requestedtheme)

--- a/doc/articles/api-differences.md
+++ b/doc/articles/api-differences.md
@@ -30,10 +30,17 @@ This difference is particularly visible for custom panel implementations.
 
 The implementations of the ListView for iOS and Android use the native controls for performance reasons, see the [ListViewBase implementation documentation][ListViewBase.md].
 
-## Styles 
+## Styles & XAML Resources
 
 The Xaml styles uno are currently supporting two levels: global and local a Xaml file. This means that any *named* style in a file containing only a `ResourceDictionary` is accessible everywhere without including that resource dictionary.
 
 Overriding implicit styles is currently not supported.
 
-Theme resources are also considered as `StaticResource`.
+### Theme Resources & Theme Dictionaries
+
+_Theme resources_ are also considered as `StaticResource`. In the current Uno's implementation, there's
+not difference between a `{StaticResource xxx}` and a `{ThemeResource xxx}`: they will both resolve on
+the resource.
+
+Element's level `RequestedTheme` is not supported yet. The `Application.Current.RequestedTheme` property
+must be set at launch time. Documentation: [`Application.RequestedTheme`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.application.requestedtheme)

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -125,6 +125,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ThemeResources\BasicThemeResources.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\TouchEventsTests\TappedEventTest.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2380,6 +2384,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\StyleTests\Style_Inline.xaml.cs">
       <DependentUpon>Style_Inline.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ThemeResources\BasicThemeResources.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\TouchEventsTests\ControlWithTouchEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\TouchEventsTests\TappedEventTest.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\TouchEventsTests\Touch.xaml.cs" />
@@ -4076,9 +4081,17 @@
     </Compile>
     <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_Static.xaml.cs">
       <DependentUpon>WebView_Static.xaml</DependentUpon>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml\Resources\ChangingStaticResource.xaml.cs">
+      <DependentUpon>ChangingStaticResource.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml\Resources\XamlGlobalResources.xaml.cs">
+      <DependentUpon>XamlGlobalResources.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_WithHeaders.xaml.cs">
       <DependentUpon>WebView_WithHeaders.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml\ThemeResources\BasicThemeResources.xaml.cs">
+      <DependentUpon>BasicThemeResources.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -4049,48 +4049,49 @@
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\ToggleSwitch_IsOn.xaml.cs">
       <DependentUpon>ToggleSwitch_IsOn.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml\WebViewToDelete.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml\WebViewToDelete.xaml.cs">
       <DependentUpon>WebViewToDelete.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebViewControl_JavaScript_Alert_Confirm_Prompt.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewControl_JavaScript_Alert_Confirm_Prompt.xaml.cs">
       <DependentUpon>WebViewControl_JavaScript_Alert_Confirm_Prompt.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebViewToDelete.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewToDelete.xaml.cs">
       <DependentUpon>WebViewToDelete.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_Alert.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Alert.xaml.cs">
       <DependentUpon>WebView_Alert.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_ChromeClient.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_ChromeClient.xaml.cs">
       <DependentUpon>WebView_ChromeClient.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_Events.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Events.xaml.cs">
       <DependentUpon>WebView_Events.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_JavascriptInvoke.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_JavascriptInvoke.xaml.cs">
       <DependentUpon>WebView_JavascriptInvoke.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_Mailto.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Mailto.xaml.cs">
       <DependentUpon>WebView_Mailto.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_NavigateToString.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_NavigateToString.xaml.cs">
       <DependentUpon>WebView_NavigateToString.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_NavigateToUri.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_NavigateToUri.xaml.cs">
       <DependentUpon>WebView_NavigateToUri.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_Static.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Static.xaml.cs">
       <DependentUpon>WebView_Static.xaml</DependentUpon>
-    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml\Resources\ChangingStaticResource.xaml.cs">
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Resources\ChangingStaticResource.xaml.cs">
       <DependentUpon>ChangingStaticResource.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml\Resources\XamlGlobalResources.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Resources\XamlGlobalResources.xaml.cs">
       <DependentUpon>XamlGlobalResources.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\WebView\WebView_WithHeaders.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_WithHeaders.xaml.cs">
       <DependentUpon>WebView_WithHeaders.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml\ThemeResources\BasicThemeResources.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ThemeResources\BasicThemeResources.xaml.cs">
       <DependentUpon>BasicThemeResources.xaml</DependentUpon>
     </Compile>
   </ItemGroup>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/BasicThemeResources.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/BasicThemeResources.xaml
@@ -1,0 +1,128 @@
+﻿<Page x:Class="UITests.Shared.Windows_UI_Xaml.ThemeResources.BasicThemeResources"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.ThemeDictionaries>
+				<ResourceDictionary x:Key="HighContrast">
+					<SolidColorBrush x:Key="LocalThemeColor"
+									 Color="Red" />
+				</ResourceDictionary>
+				<ResourceDictionary x:Key="Dark">
+					<SolidColorBrush x:Key="LocalThemeColor"
+									 Color="Blue" />
+				</ResourceDictionary>
+				<ResourceDictionary x:Key="Light">
+					<SolidColorBrush x:Key="LocalThemeColor"
+									 Color="Yellow" />
+				</ResourceDictionary>
+			</ResourceDictionary.ThemeDictionaries>
+
+			<SolidColorBrush x:Key="LocalThemeColor2"
+							 Color="Green" />
+		</ResourceDictionary>
+	</Page.Resources>
+
+	<StackPanel Spacing="10">
+		<TextBlock>
+			ApplicationTheme=<Run Text="{x:Bind ApplicationTheme}" />
+			<LineBreak />
+			LocalTheme=<Run Text="{Binding LocalTheme}" />
+			<LineBreak />
+			ParentTheme=<Run Text="{Binding ParentTheme}" />
+		</TextBlock>
+		<Grid>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition />
+				<ColumnDefinition />
+				<ColumnDefinition />
+			</Grid.ColumnDefinitions>
+			<StackPanel Spacing="10"
+						RequestedTheme="Default">
+				<Border Width="300"
+						Height="50"
+						Background="{ThemeResource LocalThemeColor}">
+					<TextBlock>{ThemeResource} on a themed resource</TextBlock>
+				</Border>
+				<Border Width="300"
+						Height="50"
+						Background="{StaticResource LocalThemeColor}">
+					<TextBlock>{StaticResource} on a themed resource</TextBlock>
+				</Border>
+				<Border Width="300"
+						Height="50"
+						Background="{ThemeResource LocalThemeColor2}">
+					<TextBlock>{ThemeResource} on a static resource (green)</TextBlock>
+				</Border>
+				<Border Width="300"
+						Height="50"
+						Background="{StaticResource LocalThemeColor2}">
+					<TextBlock>{StaticResource} on a static resource (green)</TextBlock>
+				</Border>
+			</StackPanel>
+			<StackPanel Spacing="10"
+						RequestedTheme="Dark"
+						Grid.Column="1">
+				<Border Width="300"
+						Height="50"
+						Background="{ThemeResource LocalThemeColor}">
+					<TextBlock>{ThemeResource} on a themed resource</TextBlock>
+				</Border>
+				<Border Width="300"
+						Height="50"
+						Background="{StaticResource LocalThemeColor}">
+					<TextBlock>{StaticResource} on a themed resource</TextBlock>
+				</Border>
+				<Border Width="300"
+						Height="50"
+						Background="{ThemeResource LocalThemeColor2}">
+					<TextBlock>{ThemeResource} on a static resource (green)</TextBlock>
+				</Border>
+				<Border Width="300"
+						Height="50"
+						Background="{StaticResource LocalThemeColor2}">
+					<TextBlock>{StaticResource} on a static resource (green)</TextBlock>
+				</Border>
+			</StackPanel>
+			<StackPanel Spacing="10"
+						RequestedTheme="Light"
+						Grid.Column="2">
+				<Border Width="300"
+						Height="50"
+						Background="{ThemeResource LocalThemeColor}">
+					<TextBlock>{ThemeResource} on a themed resource</TextBlock>
+				</Border>
+				<Border Width="300"
+						Height="50"
+						Background="{StaticResource LocalThemeColor}">
+					<TextBlock>{StaticResource} on a themed resource</TextBlock>
+				</Border>
+				<Border Width="300"
+						Height="50"
+						Background="{ThemeResource LocalThemeColor2}">
+					<TextBlock>{ThemeResource} on a static resource (green)</TextBlock>
+				</Border>
+				<Border Width="300"
+						Height="50"
+						Background="{StaticResource LocalThemeColor2}">
+					<TextBlock>{StaticResource} on a static resource (green)</TextBlock>
+				</Border>
+			</StackPanel>
+		</Grid>
+		<TextBlock>Blue=dark, Yellow=Light, Red=High Contrast</TextBlock>
+		<StackPanel Orientation="Horizontal">
+			<Button Click="LocalDefault">Local Default</Button>
+			<Button Click="LocalDark">Local Dark</Button>
+			<Button Click="LocalLight">Local Light</Button>
+			<Button Click="ParentDefault">Parent Default</Button>
+			<Button Click="ParentDark">Parent Dark</Button>
+			<Button Click="ParentLight">Parent Light</Button>
+		</StackPanel>
+
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/BasicThemeResources.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/BasicThemeResources.xaml
@@ -16,6 +16,7 @@
 				<ResourceDictionary x:Key="Dark">
 					<SolidColorBrush x:Key="LocalThemeColor"
 									 Color="Blue" />
+
 				</ResourceDictionary>
 				<ResourceDictionary x:Key="Light">
 					<SolidColorBrush x:Key="LocalThemeColor"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/BasicThemeResources.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/BasicThemeResources.xaml
@@ -13,6 +13,10 @@
 					<SolidColorBrush x:Key="LocalThemeColor"
 									 Color="Red" />
 				</ResourceDictionary>
+				<ResourceDictionary x:Key="Default">
+					<SolidColorBrush x:Key="LocalThemeColor"
+					                 Color="Gray" />
+				</ResourceDictionary>
 				<ResourceDictionary x:Key="Dark">
 					<SolidColorBrush x:Key="LocalThemeColor"
 									 Color="Blue" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/BasicThemeResources.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/BasicThemeResources.xaml.cs
@@ -1,0 +1,61 @@
+﻿using Windows.UI.Core;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml.ThemeResources
+{
+	[SampleControlInfo("XAML", "BasicThemeResources")]
+	public sealed partial class BasicThemeResources : Page
+	{
+		public BasicThemeResources()
+		{
+			InitializeComponent();
+
+			ApplicationTheme = Application.Current.RequestedTheme;
+
+			DataContext = this;
+		}
+
+		private ApplicationTheme ApplicationTheme { get; }
+
+		public static readonly DependencyProperty LocalThemeProperty = DependencyProperty.Register(
+			"LocalTheme", typeof(ElementTheme), typeof(BasicThemeResources), new PropertyMetadata(default(ElementTheme)));
+
+		public ElementTheme LocalTheme
+		{
+			get => RequestedTheme;
+			set
+			{
+				SetValue(LocalThemeProperty, value);
+				RequestedTheme = value;
+			}
+		}
+
+		public static readonly DependencyProperty ParentThemeProperty = DependencyProperty.Register(
+			"ParentTheme", typeof(ElementTheme), typeof(BasicThemeResources), new PropertyMetadata(default(ElementTheme)));
+
+		public ElementTheme ParentTheme
+		{
+			get => ((FrameworkElement)Parent).RequestedTheme;
+			set
+			{
+				SetValue(ParentThemeProperty, value);
+				((FrameworkElement) Parent).RequestedTheme = value;
+			}
+		}
+
+		private void LocalDefault(object sender, RoutedEventArgs e) => LocalTheme = ElementTheme.Default;
+
+		private void LocalDark(object sender, RoutedEventArgs e) => LocalTheme = ElementTheme.Dark;
+
+		private void LocalLight(object sender, RoutedEventArgs e) => LocalTheme = ElementTheme.Light;
+
+		private void ParentDefault(object sender, RoutedEventArgs e) => LocalTheme = ElementTheme.Default;
+
+		private void ParentDark(object sender, RoutedEventArgs e) => LocalTheme = ElementTheme.Dark;
+
+		private void ParentLight(object sender, RoutedEventArgs e) => LocalTheme = ElementTheme.Light;
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -958,7 +958,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						break;
 					default:
 					{
-						var appThemes = resources.Where(x => x.Key.Equals("Light") || x.Key.Equals("Dark")).ToArray();
+						var appThemes = resources.Where(x => x.Key.Equals("Light") || x.Key.Equals("Dark") || x.Key.Equals("Default")).ToArray();
 						var customThemes = resources.Except(appThemes).ToArray();
 
 						using (writer.BlockInvariant($"public static {GetGlobalizedTypeName(resourceTypeName)} {SanitizeResourceName(resourcePropertyName)}"))
@@ -992,16 +992,24 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									{
 										writer.AppendLineInvariant($"case global::Windows.UI.Xaml.ApplicationTheme.Dark: return {resourcePropertyName}___{theme.Key};");
 									}
+									// Default is not generated here
 								}
 							}
-							writer.AppendLine();
-							var msg = customThemes.Any()
-								? $"$\"The themed resource {resourcePropertyName} cannot be found for custom theme {{{{global::Uno.UI.ApplicationHelper.RequestedCustomTheme ?? global::Windows.UI.Xaml.Application.Current.RequestedTheme}}}}.\""
-								: $"$\"The themed resource {resourcePropertyName} cannot be found for theme {{{{global::Windows.UI.Xaml.Application.Current.RequestedTheme}}}}.\"";
-							writer.AppendLineInvariant($"throw new InvalidOperationException({msg});");
-						}
 
 							writer.AppendLine();
+							if (appThemes.Any(t=> t.Key.Equals("Default")))
+							{
+									writer.AppendLineInvariant("// .");
+									writer.AppendLineInvariant($"return {resourcePropertyName}___Default;");
+							}
+							else
+							{
+								var msg = customThemes.Any()
+									? $"$\"The themed resource {resourcePropertyName} cannot be found for custom theme {{{{global::Uno.UI.ApplicationHelper.RequestedCustomTheme ?? global::Windows.UI.Xaml.Application.Current.RequestedTheme}}}}.\""
+									: $"$\"The themed resource {resourcePropertyName} cannot be found for theme {{{{global::Windows.UI.Xaml.Application.Current.RequestedTheme}}}}.\"";
+								writer.AppendLineInvariant($"throw new InvalidOperationException({msg});");
+							}
+						}
 						break;
 					}
 				}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -966,22 +966,21 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						{
 							if (customThemes.Any())
 							{
-								writer.AppendLineInvariant("// Element's RequestedTheme not supported yet. Checking custom theme.");
-								writer.AppendLineInvariant("var currentApplicationCustomTheme = global::Uno.UI.ApplicationHelper.RequestedCustomTheme;");
-								using (writer.BlockInvariant($"switch(currentApplicationCustomTheme)"))
+								writer.AppendLineInvariant("// Custom themes defined for this resource: checking custom theme.");
+								using (writer.BlockInvariant($"switch(global::Uno.UI.ApplicationHelper.RequestedCustomTheme)"))
 								{
 									foreach (var theme in customThemes)
 									{
 										writer.AppendLineInvariant($"case \"{theme.Key}\": return {resourcePropertyName}___{theme.Key};");
 									}
 								}
+								writer.AppendLine();
 							}
 
 							writer.AppendLineInvariant("// Element's RequestedTheme not supported yet. Fallback on Application's RequestedTheme.");
-							writer.AppendLineInvariant("var currentApplicationTheme = global::Windows.UI.Xaml.Application.Current.RequestedTheme;");
 							writer.AppendLine();
 
-							using (writer.BlockInvariant($"switch(currentApplicationTheme)"))
+							using (writer.BlockInvariant($"switch(global::Windows.UI.Xaml.Application.Current.RequestedTheme)"))
 							{
 								foreach (var theme in appThemes)
 								{

--- a/src/SourceGenerators/XamlGenerationTests/GlobalStaticResources02.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/GlobalStaticResources02.xaml
@@ -1,5 +1,5 @@
 ﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="using:GenericApp.Styles.Application"
@@ -11,7 +11,22 @@
     mc:Ignorable="ios android xamarin"
 	xmlns:System="using:System"
 	xmlns:f="using:Windows.Foundation">
- 
+
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Default">
+			<x:Double x:Key="ThemedDouble">1.0</x:Double>
+			<SolidColorBrush x:Key="ThemedColor">Blue</SolidColorBrush>
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Light">
+			<x:Double x:Key="ThemedDouble">2.0</x:Double>
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Dark">
+			<x:Double x:Key="ThemedDouble">3.0</x:Double>
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Pink">
+			<x:Double x:Key="ThemedDouble">4.0</x:Double>
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
 
 	<x:Double x:Key="OtherResources01">280</x:Double>
 	<x:Double x:Key="OtherResources02">90</x:Double>
@@ -22,14 +37,14 @@
 	<GradientStop x:Key="ColorResource" Color="Yellow" />
 	<GradientStop x:Name="ColorResource_asName" Color="Yellow" />
 
-	<DataTemplate x:Key="testTemplate"> 
+	<DataTemplate x:Key="testTemplate">
 		<TextBlock x:Name="myTextBlock" />
 	</DataTemplate>
 
 	<Style x:Key="baseGridStyle" TargetType="Grid" xamarin:PartialOverride="true">
-		<Setter Property="Background" Value="Red" />
+		<Setter Property="Background" Value="{ThemeResource ThemedColor}" />
 	</Style>
-	
+
 	<Style x:Key="fromUno" TargetType="Grid" xamarin:PartialOverride="true">
 		<!-- Test for resource coming from generic.xaml -->
         <Setter Property="Height" Value="{StaticResource AppBarExpandButtonThemeHeight}" />
@@ -49,12 +64,12 @@
 		   BasedOn="{StaticResource baseGridStyle}">
 		<Setter Property="Background" Value="Blue" />
 	</Style>
-	
+
 	<x:Double x:Key="Double-Resource-With-Dashes">42</x:Double>
 
 	<x:String x:Key="testTimeSpanString">00:00:42</x:String>
 	<System:String x:Key="shortDateFormatString">{0:d}</System:String>
-	
+
 	<x:DoubleAnimation x:Key="testDoubleAnination"
 					   Duration="{StaticResource testTimeSpanString}" />
 
@@ -83,14 +98,14 @@
     <Style TargetType="ComboBox" BasedOn="{StaticResource ComboBoxWithSpinnerExStyle}">
         <Setter Property="Background" Value="Yellow" />
     </Style>
-	
+
     <Style TargetType="controls:ImplicitStyleControl">
         <Setter Property="Background" Value="Yellow" />
     </Style>
 
     <GridLength x:Key="DefaultColumnWidth">352</GridLength>
-	
-	
+
+
 		<x:Double x:Key="MyHeightNonLocal">33</x:Double>
 		<x:Boolean x:Key="MyAcceptsReturnNonLocal">true</x:Boolean>
 

--- a/src/SourceGenerators/XamlGenerationTests/ThemeResourcesTest.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/ThemeResourcesTest.xaml
@@ -1,0 +1,40 @@
+﻿<Page
+	x:Class="XamlGenerationTests.ThemeResourcesTest"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.ThemeDictionaries>
+				<ResourceDictionary x:Key="Dark">
+					<SolidColorBrush x:Key="LocalColor" Color="Blue" />
+					<SolidColorBrush x:Key="LocalThemeColor" Color="Green" />
+				</ResourceDictionary>
+
+				<ResourceDictionary x:Key="Light">
+					<SolidColorBrush x:Key="LocalColor" Color="Yellow" />
+					<SolidColorBrush x:Key="LocalThemeColor" Color="Red" />
+				</ResourceDictionary>
+			</ResourceDictionary.ThemeDictionaries>
+
+			<SolidColorBrush x:Key="LocalColor" Color="Brown" />
+		</ResourceDictionary>
+	</Page.Resources>
+
+	<Grid>
+		<Grid.Background>
+			<ThemeResource ResourceKey="LocalThemeColor" />
+		</Grid.Background>
+
+		<Border Background="{ThemeResource LocalThemeColor}">
+
+		</Border>
+
+		<Rectangle Fill="{StaticResource LocalColor}" Stroke="{ThemeResource LocalThemeColor}" />
+		<Rectangle Fill="{ThemeResource LocalColor}" Stroke="{StaticResource LocalThemeColor}" />
+
+	</Grid>
+</Page>

--- a/src/SourceGenerators/XamlGenerationTests/XBindUserControl.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/XBindUserControl.xaml
@@ -20,6 +20,7 @@
 	</UserControl.Resources>
 
 	<Grid>
+		<Rectangle Style="{StaticResource rectangleStyle}" />
 		<TextBlock Text="{x:Bind Test}" />
 		<TextBlock Text="{x:Bind TypeProperty.Value, FallbackValue=42}" />
 	</Grid>

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -51,6 +51,7 @@
 
 	<ItemGroup>
 	  <None Remove="NonDPAssignableTest.xaml" />
+	  <None Remove="ThemeResourcesTest.xaml" />
 	  <None Remove="xNameResources.xaml" />
 	</ItemGroup>
 

--- a/src/Uno.UI/UI/Xaml/ApplicationHelper.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationHelper.cs
@@ -1,11 +1,27 @@
-﻿namespace Uno.UI
+﻿using Windows.UI.Xaml;
+
+namespace Uno.UI
 {
 	public class ApplicationHelper
 	{
+		private static string _requestedCustomTheme;
+
 		public static string RequestedCustomTheme
 		{
-			get;
-			set;
+			get => _requestedCustomTheme;
+			set
+			{
+				_requestedCustomTheme = value;
+
+				if (_requestedCustomTheme.Equals("Dark"))
+				{
+					Application.Current.RequestedTheme = ApplicationTheme.Dark;
+				}
+				else if (_requestedCustomTheme.Equals("Light"))
+				{
+					Application.Current.RequestedTheme = ApplicationTheme.Light;
+				}
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/ApplicationHelper.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationHelper.cs
@@ -6,6 +6,13 @@ namespace Uno.UI
 	{
 		private static string _requestedCustomTheme;
 
+		/// <summary>
+		/// This is a custom theme that can be used in ThemeDictionaries
+		/// </summary>
+		/// <remarks>
+		/// When the custom theme key is not found in a theme dictionary, it will fallback to
+		/// Application.RequestedTheme (Dark/Light)
+		/// </remarks>
 		public static string RequestedCustomTheme
 		{
 			get => _requestedCustomTheme;

--- a/src/Uno.UI/UI/Xaml/ApplicationHelper.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationHelper.cs
@@ -1,0 +1,11 @@
+﻿namespace Uno.UI
+{
+	public class ApplicationHelper
+	{
+		public static string RequestedCustomTheme
+		{
+			get;
+			set;
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #935 #1047 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## Feature
First support for ThemeResources

## What is the current behavior?
* Using `{ThemeResource xxx}` were already working as an alias to `{StaticResource}`
* Declaring a _Theme Dictionary_ were leading to missing resources at runtime and/or
  compilation errors for duplicated members.

## What is the new behavior?
* You can now declare a _Theme Dictionary_ in your XAML dictionaries
* _Themed resources_ will now resolve to right theme (`Light` or `Dark`)
* **Custom Themes Supported**! You can trigger themes like `HighContrast` or
  totally custom themes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
* [154631](https://nventive.visualstudio.com/Umbrella/_workitems/edit/154631)

