### PR TITLE
BugFix - Adds check to onFocusChanged unfocusing when setting focus causing loop

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
@@ -275,6 +275,16 @@ namespace SamplesApp.UITests
 			;
 		}
 
+		[Test]
+		public void TextBox_PageLoadedTest()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_TextChanged");
+
+			var appendOutput = _app.Marked("AppendTextBlock");
+
+			_app.WaitForElement(appendOutput);
+		}
+
 		private QueryEx TypeInto(string textBoxName, string inputText, string expectedText)
 		{
 			var tb = _app.Marked(textBoxName);

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.cs
@@ -60,8 +60,12 @@ namespace Windows.UI.Xaml.Input
 			}
 			else // Focused
 			{
-				(_focusedElement as Control)?.Unfocus();
-				_focusedElement = control;
+				if (_focusedElement != control)
+				{
+					(_focusedElement as Control)?.Unfocus();
+					_focusedElement = control;
+				}
+				
 				_fallbackFocusedElement = control;
 
 #if __ANDROID__


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

iOS Infinite loop


## What is the new behavior?

BugFix - Adds check to onFocusChanged unfocusing when setting focus causing loop


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/157061
