### PR TITLE
Fix possible crash with AudioToolbox

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -176,16 +176,20 @@
         <Member fullName="System.Void Windows.Devices.Sensors.BarometerReading..ctor()"
                 reason="Parameter-less ctor does not exist in UWP" />
         <Member fullName="System.Void Windows.Devices.Sensors.BarometerReadingChangedEventArgs..ctor()"
-		reason="Parameter-less ctor does not exist in UWP" />
+				reason="Parameter-less ctor does not exist in UWP" />
         <Member fullName="System.Void Windows.Phone.Devices.Notification.VibrationDevice..ctor()"
                 reason="Parameter-less ctor does not exist in UWP" />
         <Member fullName="System.Void Windows.UI.Xaml.Controls.VirtualizingPanelLayout.UpdateLayoutAttributesForItem(UIKit.UICollectionViewLayoutAttributes layoutAttributes)"
                 reason="Implementation detail, made internal"/>
         <Member fullName="Android.Views.View Windows.UI.Xaml.Controls.Popup.get_Anchor()"
-	        reason="Invalid method visibility"/>
-	<Member fullName="System.Void Windows.UI.Xaml.Controls.Popup.set_Anchor(Android.Views.View value)"
-	        reason="Invalid method visibility"/>
-      </Methods>
+				reason="Invalid method visibility"/>
+		<Member fullName="System.Void Windows.UI.Xaml.Controls.Popup.set_Anchor(Android.Views.View value)"
+				reason="Invalid method visibility"/>
+		<Member fullName="System.Void Windows.Media.Playback.MediaPlayer.ObserveValue(Foundation.NSString keyPath, Foundation.NSObject ofObject, Foundation.NSDictionary change, System.IntPtr context)"
+				reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.Media.Playback.MediaPlayer.Dispose(System.Boolean disposing)"
+				reason="Invalid method visibility"/>
+	  </Methods>
 	  
 	  <Fields>
 	  	<Member fullName="Windows.UI.Xaml.TextWrapping Windows.UI.Xaml.TextWrapping::WordEllipsis"

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -21,6 +21,7 @@
     ```
   - `FrameworkElement.RequestedTheme ` is ignored for now.
   - Should be set when the application is starting (before first request to a static resource).
+* Prevent possible crash with `MediaPlayerElement` (tentative)
 
 ### Breaking changes
 *

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using AVFoundation;
 using CoreFoundation;
 using CoreMedia;
@@ -13,8 +14,83 @@ using Windows.Media.Core;
 
 namespace Windows.Media.Playback
 {
-	public partial class MediaPlayer : NSObject
+	public partial class MediaPlayer : IDisposable
 	{
+		/// <summary>
+		/// The property changed dispatcher for a the iOS MediaPlayer
+		/// </summary>
+		/// <remarks>
+		/// It seems that the AudioToolbox may try to raise some property changed on collected MediaPlayer, which may crash the application.
+		/// This object is a lightweight ** leaking ** object which acts as a proxy to receive the callbacks and propagate them
+		/// to the target MediaPlayer but only if was not collected yet. This is acceptable only as the MediaPlayer is not a control which
+		/// is created frequently and this proxy object is really thin in memory.
+		/// 
+		/// The stacktrace of the crash report that this object is expected to fix:
+		///		Crashed: AVAudioSession Notify Thread
+		///		0  AudioToolbox                   0x1a96762c0 AudioSessionPropertyListeners::CallPropertyListenersImp(AudioSessionPropertyListeners const&, unsigned int, unsigned int, void const*) + 456
+		///		1  AudioToolbox                   0x1a976c100 AudioSessionPropertyListeners::CallPropertyListeners(unsigned int, unsigned int, void const*) + 220
+		///		2  AudioToolbox                   0x1a97aa43c HandleCFPropertyListChange(unsigned int, unsigned int, unsigned long, unsigned char*, unsigned int) + 456
+		///		3  AudioToolbox                   0x1a97aea34 HandleAudioSessionCFTypePropertyChangedMessage(unsigned int, unsigned int, void*, unsigned int) + 268
+		///		4  AudioToolbox                   0x1a97adcf8 ProcessDeferredMessage(unsigned int, __CFData const*, unsigned int, unsigned int) + 1312
+		///		5  AudioToolbox                   0x1a97ad4e4 ASCallbackReceiver_AudioSessionPingMessage + 588
+		///		6  AudioToolbox                   0x1a9666ec0 _XAudioSessionPingMessage + 52
+		///		7  AudioToolbox                   0x1a99ae1a8 mshMIGPerform + 232
+		///		8  CoreFoundation                 0x1a56af690 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 56
+		///		9  CoreFoundation                 0x1a56aeddc __CFRunLoopDoSource1 + 440
+		///		10 CoreFoundation                 0x1a56a9c00 __CFRunLoopRun + 2096
+		///		11 CoreFoundation                 0x1a56a90b0 CFRunLoopRunSpecific + 436
+		///		12 AVFAudio                       0x1ab591334 GenericRunLoopThread::Entry(void*) + 156
+		///		13 AVFAudio                       0x1ab5bbc60 CAPThread::Entry(CAPThread*) + 88
+		///		14 libsystem_pthread.dylib        0x1a533c2c0 _pthread_body + 128
+		///		15 libsystem_pthread.dylib        0x1a533c220 _pthread_start + 44
+		///		16 libsystem_pthread.dylib        0x1a533fcdc thread_start + 4
+		/// </remarks>
+		private class Observer : NSObject
+		{
+			private readonly WeakReference<MediaPlayer> _target;
+
+			public Observer(MediaPlayer target)
+			{
+				_target = new WeakReference<MediaPlayer>(target);
+
+				// Explicitly leak this object! Cf. Remarks above.
+				GCHandle.Alloc(this);
+			}
+
+			public override void ObserveValue(NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
+			{
+				if (!_target.TryGetTarget(out var player))
+				{
+					return;
+				}
+
+				switch (keyPath)
+				{
+					case "status":
+						player.ObserveStatus();
+						return;
+
+					case "loadedTimeRanges":
+						player.ObserveBufferingProgress();
+						return;
+
+					case "duration":
+						player.ObserveCurrentItemDuration();
+						return;
+
+					case "rate":
+						player.ObserveRate();
+						return;
+
+					case "videoRect":
+						player.ObserveVideoRect();
+						return;
+				}
+			}
+		}
+
+		private Observer _observer;
+
 		private AVQueuePlayer _player;
 		private AVPlayerLayer _videoLayer;
 		private NSObject _periodicTimeObserverObject;
@@ -31,6 +107,7 @@ namespace Windows.Media.Playback
 
 		private void Initialize()
 		{
+			_observer = new Observer(this);
 		}
 
 		#region Player Initialization
@@ -41,13 +118,13 @@ namespace Windows.Media.Playback
 			{
 				try
 				{
-					_videoLayer.RemoveObserver(this, new NSString("videoRect"), _videoLayer.Handle);
+					_videoLayer.RemoveObserver(_observer, new NSString("videoRect"), _videoLayer.Handle);
 					_videoLayer.RemoveFromSuperLayer();
 
-					_player.CurrentItem?.RemoveObserver(this, new NSString("loadedTimeRanges"), _player.Handle);
-					_player.CurrentItem?.RemoveObserver(this, new NSString("status"), _player.Handle);
-					_player.CurrentItem?.RemoveObserver(this, new NSString("duration"), _player.Handle);
-					_player.RemoveObserver(this, new NSString("rate"), RateObservationContext.Handle);
+					_player.CurrentItem?.RemoveObserver(_observer, new NSString("loadedTimeRanges"), _player.Handle);
+					_player.CurrentItem?.RemoveObserver(_observer, new NSString("status"), _player.Handle);
+					_player.CurrentItem?.RemoveObserver(_observer, new NSString("duration"), _player.Handle);
+					_player.RemoveObserver(_observer, new NSString("rate"), RateObservationContext.Handle);
 					_player.RemoveTimeObserver(_periodicTimeObserverObject);
 					_player.RemoveAllItems();
 				}
@@ -84,8 +161,8 @@ namespace Windows.Media.Playback
 				this.Log().WarnIfEnabled(() => $"Could not activate audio session: {activationError.LocalizedDescription}");
 			}
 
-			_videoLayer.AddObserver(this, new NSString("videoRect"), NSKeyValueObservingOptions.New | NSKeyValueObservingOptions.Initial, _videoLayer.Handle);
-			_player.AddObserver(this, new NSString("rate"), NSKeyValueObservingOptions.New | NSKeyValueObservingOptions.Initial, RateObservationContext.Handle);
+			_videoLayer.AddObserver(_observer, new NSString("videoRect"), NSKeyValueObservingOptions.New | NSKeyValueObservingOptions.Initial, _videoLayer.Handle);
+			_player.AddObserver(_observer, new NSString("rate"), NSKeyValueObservingOptions.New | NSKeyValueObservingOptions.Initial, RateObservationContext.Handle);
 
 			_itemFailedToPlayToEndTimeNotification = AVPlayerItem.Notifications.ObserveItemFailedToPlayToEndTime((sender, args) => OnMediaFailed(new Exception(args.Error.LocalizedDescription)));
 			_playbackStalledNotification = AVPlayerItem.Notifications.ObservePlaybackStalled((sender, args) => OnMediaFailed());
@@ -122,10 +199,10 @@ namespace Windows.Media.Playback
 				InitializePlayer();
 
 				PlaybackSession.PlaybackState = MediaPlaybackState.Opening;
-
-				_player.CurrentItem?.RemoveObserver(this, new NSString("duration"), _player.Handle);
-				_player.CurrentItem?.RemoveObserver(this, new NSString("status"), _player.Handle);
-				_player.CurrentItem?.RemoveObserver(this, new NSString("loadedTimeRanges"), _player.Handle);
+				
+				_player.CurrentItem?.RemoveObserver(_observer, new NSString("duration"), _player.Handle);
+				_player.CurrentItem?.RemoveObserver(_observer, new NSString("status"), _player.Handle);
+				_player.CurrentItem?.RemoveObserver(_observer, new NSString("loadedTimeRanges"), _player.Handle);
 
 				if (Source is MediaPlaybackList)
 				{
@@ -144,9 +221,9 @@ namespace Windows.Media.Playback
 					_player.ReplaceCurrentItemWithPlayerItem(streamingItem);
 				}
 
-				_player.CurrentItem.AddObserver(this, new NSString("duration"), NSKeyValueObservingOptions.Initial, _player.Handle);
-				_player.CurrentItem.AddObserver(this, new NSString("status"), NSKeyValueObservingOptions.New | NSKeyValueObservingOptions.Initial, _player.Handle);
-				_player.CurrentItem.AddObserver(this, new NSString("loadedTimeRanges"), NSKeyValueObservingOptions.Initial | NSKeyValueObservingOptions.New, _player.Handle);
+				_player.CurrentItem.AddObserver(_observer, new NSString("duration"), NSKeyValueObservingOptions.Initial, _player.Handle);
+				_player.CurrentItem.AddObserver(_observer, new NSString("status"), NSKeyValueObservingOptions.New | NSKeyValueObservingOptions.Initial, _player.Handle);
+				_player.CurrentItem.AddObserver(_observer, new NSString("loadedTimeRanges"), NSKeyValueObservingOptions.Initial | NSKeyValueObservingOptions.New, _player.Handle);
 
 				_player.CurrentItem.SeekingWaitsForVideoCompositionRendering = true;
 
@@ -241,32 +318,6 @@ namespace Windows.Media.Playback
 			PlaybackSession.PlaybackState = MediaPlaybackState.None;
 
 			TryDisposePlayer();
-		}
-
-		public override void ObserveValue(NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
-		{
-			switch (keyPath)
-			{
-				case "status":
-					ObserveStatus();
-					return;
-
-				case "loadedTimeRanges":
-					ObserveBufferingProgress();
-					return;
-
-				case "duration":
-					ObserveCurrentItemDuration();
-					return;
-
-				case "rate":
-					ObserveRate();
-					return;
-
-				case "videoRect":
-					ObserveVideoRect();
-					return;
-			}
 		}
 
 		private void ObserveStatus()
@@ -403,7 +454,7 @@ namespace Windows.Media.Playback
 			}
 		}
 
-		protected override void Dispose(bool disposing)
+		public void Dispose()
 		{
 			TryDisposePlayer();
 		}

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
@@ -67,23 +67,23 @@ namespace Windows.Media.Playback
 				switch (keyPath)
 				{
 					case "status":
-						player.ObserveStatus();
+						player.OnStatusChanged();
 						return;
 
 					case "loadedTimeRanges":
-						player.ObserveBufferingProgress();
+						player.OnBufferingProgressChanged();
 						return;
 
 					case "duration":
-						player.ObserveCurrentItemDuration();
+						player.OnCurrentItemDurationChanged();
 						return;
 
 					case "rate":
-						player.ObserveRate();
+						player.OnRateChanged();
 						return;
 
 					case "videoRect":
-						player.ObserveVideoRect();
+						player.OnVideoRectChanged();
 						return;
 				}
 			}
@@ -320,7 +320,7 @@ namespace Windows.Media.Playback
 			TryDisposePlayer();
 		}
 
-		private void ObserveStatus()
+		private void OnStatusChanged()
 		{
 			if (_player?.CurrentItem != null)
 			{
@@ -345,7 +345,7 @@ namespace Windows.Media.Playback
 			}
 		}
 
-		private void ObserveVideoRect()
+		private void OnVideoRectChanged()
 		{
 			if (_videoLayer?.VideoRect != null)
 			{
@@ -353,7 +353,7 @@ namespace Windows.Media.Playback
 			}
 		}
 
-		private void ObserveRate()
+		private void OnRateChanged()
 		{
 			if (_player != null)
 			{
@@ -367,7 +367,7 @@ namespace Windows.Media.Playback
 			}
 		}
 
-		private void ObserveBufferingProgress()
+		private void OnBufferingProgressChanged()
 		{
 			var loadedTimeRanges = _player?.CurrentItem?.LoadedTimeRanges;
 			if (loadedTimeRanges == null || loadedTimeRanges.Length == 0 || PlaybackSession.NaturalDuration == TimeSpan.Zero)
@@ -381,7 +381,7 @@ namespace Windows.Media.Playback
 			}
 		}
 
-		private void ObserveCurrentItemDuration()
+		private void OnCurrentItemDurationChanged()
 		{
 			var duration = _player.CurrentItem.Duration;
 


### PR DESCRIPTION
## Bug fix tentative
**Tries** to prevent crash: 
```
Crashed: AVAudioSession Notify Thread
0  AudioToolbox                   0x1a96762c0 AudioSessionPropertyListeners::CallPropertyListenersImp(AudioSessionPropertyListeners const&, unsigned int, unsigned int, void const*) + 456
1  AudioToolbox                   0x1a976c100 AudioSessionPropertyListeners::CallPropertyListeners(unsigned int, unsigned int, void const*) + 220
2  AudioToolbox                   0x1a97aa43c HandleCFPropertyListChange(unsigned int, unsigned int, unsigned long, unsigned char*, unsigned int) + 456
3  AudioToolbox                   0x1a97aea34 HandleAudioSessionCFTypePropertyChangedMessage(unsigned int, unsigned int, void*, unsigned int) + 268
4  AudioToolbox                   0x1a97adcf8 ProcessDeferredMessage(unsigned int, __CFData const*, unsigned int, unsigned int) + 1312
5  AudioToolbox                   0x1a97ad4e4 ASCallbackReceiver_AudioSessionPingMessage + 588
6  AudioToolbox                   0x1a9666ec0 _XAudioSessionPingMessage + 52
7  AudioToolbox                   0x1a99ae1a8 mshMIGPerform + 232
8  CoreFoundation                 0x1a56af690 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 56
9  CoreFoundation                 0x1a56aeddc __CFRunLoopDoSource1 + 440
10 CoreFoundation                 0x1a56a9c00 __CFRunLoopRun + 2096
11 CoreFoundation                 0x1a56a90b0 CFRunLoopRunSpecific + 436
12 AVFAudio                       0x1ab591334 GenericRunLoopThread::Entry(void*) + 156
13 AVFAudio                       0x1ab5bbc60 CAPThread::Entry(CAPThread*) + 88
14 libsystem_pthread.dylib        0x1a533c2c0 _pthread_body + 128
15 libsystem_pthread.dylib        0x1a533c220 _pthread_start + 44
16 libsystem_pthread.dylib        0x1a533fcdc thread_start + 4
```

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)