### PR TITLE
Fix to Date/Time Pickers crashing from no content

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -11,8 +11,7 @@
 * #854 `BasedOn` on a `<Style>` in `App.Xaml` were not resolving properly
 * #706 `x:Name` in `App.Xaml`'s resources were crashing the compilation.
 * #846 `x:Name` on non-`DependencyObject` resources were crashing the compilation
-* 
-
+*
 ## Release 1.45.0
 ### Features
 * Add support for `Windows.System.Display.DisplayRequest` API on iOS and Android
@@ -170,6 +169,7 @@
 * `LinearGradientBrush.EndPoint` now defaults to (1,1) to match UWP
 * Fixed an issue where a Two-Way binding would sometimes not update values back to source correctly
 * [Android] A ListView inside another ListView no longer causes an app freeze/crash
+* Date and Time Picker Content fix + Refactored to use PickerFlyoutBase (to resemble UWP implementation)
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/PickerFlyoutBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/PickerFlyoutBase.cs
@@ -2,10 +2,10 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
-	public  partial class PickerFlyoutBase : global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase
+	public partial class PickerFlyoutBase : global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase
 	{
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
@@ -15,7 +15,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.PickerFlyoutBase), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		protected PickerFlyoutBase() : base()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.Android.cs
@@ -12,7 +12,7 @@ using Windows.UI.Xaml.Data;
 
 namespace Windows.UI.Xaml.Controls
 {
-    public partial class DatePickerFlyout : FlyoutBase // TODO: Inherit from PickerFlyoutBase
+    public partial class DatePickerFlyout : PickerFlyoutBase
     {
         private DatePickerDialog _dialog;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/PickerFlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/PickerFlyoutBase.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.UI.Xaml.Controls.Primitives
+{
+	public partial class PickerFlyoutBase : FlyoutBase
+	{
+#if __IOS__ || __ANDROID__
+		protected PickerFlyoutBase()
+		{
+		}
+#endif
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.Android.cs
@@ -9,7 +9,7 @@ using static Android.App.TimePickerDialog;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public partial class TimePickerFlyout : FlyoutBase
+	public partial class TimePickerFlyout : PickerFlyoutBase
 	{
 		private UnoTimePickerDialog _dialog;
 		private TimeSpan _initialTime;

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
@@ -3,16 +3,16 @@
 using Uno.Disposables;
 using Uno.UI.Common;
 using Uno.UI.DataBinding;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public partial class TimePickerFlyout : Flyout
+	public partial class TimePickerFlyout : PickerFlyoutBase
 	{
 		private readonly SerialDisposable _onLoad = new SerialDisposable();
 		private readonly SerialDisposable _onUnloaded = new SerialDisposable();
 		internal protected TimePickerSelector _timeSelector;
-		internal protected TimePickerFlyoutPresenter _timePickerPresenter;
 		internal protected FrameworkElement _headerUntapZone;
 		private bool _isInitialized;
 
@@ -53,6 +53,38 @@ namespace Windows.UI.Xaml.Controls
 			this.Binding(nameof(MinuteIncrement), nameof(MinuteIncrement), Content, BindingMode.TwoWay);
 			this.Binding(nameof(ClockIdentifier), nameof(ClockIdentifier), Content, BindingMode.TwoWay);
 		}
+
+		#region Content DependencyProperty
+		internal IUIElement Content
+		{
+
+			get { return (IUIElement)this.GetValue(ContentProperty); }
+			set { this.SetValue(ContentProperty, value); }
+		}
+
+		internal static readonly DependencyProperty ContentProperty =
+			DependencyProperty.Register(
+				"Content",
+				typeof(IUIElement),
+				typeof(TimePickerFlyout),
+				new FrameworkPropertyMetadata(default(IUIElement), FrameworkPropertyMetadataOptions.AffectsMeasure, OnContentChanged));
+		private TimePickerFlyoutPresenter _timePickerPresenter;
+
+		private static void OnContentChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			var flyout = dependencyObject as TimePickerFlyout;
+
+			if (flyout._timePickerPresenter != null)
+			{
+				if (args.NewValue is IDependencyObjectStoreProvider binder)
+				{
+					binder.Store.SetValue(binder.Store.TemplatedParentProperty, flyout.TemplatedParent, DependencyPropertyValuePrecedences.Local);
+				}
+
+				flyout._timePickerPresenter.Content = args.NewValue;
+			}
+		}
+		#endregion
 
 		protected override Control CreatePresenter()
 		{


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Bugfix
Refactor

## What is the current behavior?
App may crash on clicking flyout buttons

## What is the new behavior?
Flyout button are working


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

##Breaking Changes
Styles that previously basedOn FlyoutBase would need to be changed to basedOn PickerFlyoutBase

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/156490

azp run