### PR TITLE
Adjust DisplayInformation.LogicalDPI value to UWP's

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -24,6 +24,7 @@
 * [Android/iOS] Fixed generated x:uid setter not globalized for Uno.UI.Helpers.MarkupHelper.SetXUid and Uno.UI.FrameworkElementHelper.SetRenderPhase
 * Fix invalid XAML x:Uid parsing with resource file name and prefix (#1130, #228)
 * Fixed an issue where a Two-Way binding would sometimes not update values back to source correctly
+* Adjust the behavior of `DisplayInformation.LogicalDpi` to match UWP's behavior
 
 ## Release 1.45.0
 ### Features

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
@@ -36,8 +36,10 @@ namespace Windows.Graphics.Display
 
 		private void UpdateLogicalProperties(DisplayMetrics realDisplayMetrics)
 		{
-			LogicalDpi = realDisplayMetrics.Density * 100;
-			ResolutionScale = (ResolutionScale)(int)LogicalDpi;
+			// DisplayMetrics of 1.0 matches 100%, or UWP's default 96.0 DPI.
+			// https://stuff.mit.edu/afs/sipb/project/android/docs/reference/android/util/DisplayMetrics.html#density
+			LogicalDpi = realDisplayMetrics.Density * 96.0f;
+			ResolutionScale = (ResolutionScale)(int)(realDisplayMetrics.Density * 100.0);
 		}
 
 		private void UpdateRawProperties(DisplayMetrics realDisplayMetrics)

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.iOS.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.iOS.cs
@@ -37,8 +37,10 @@ namespace Windows.Graphics.Display
 
 		private void UpdateLogicalProperties()
 		{
-			LogicalDpi = (float)(UIScreen.MainScreen.Scale * 100);
-			ResolutionScale = (ResolutionScale)(int)LogicalDpi;
+			// Scale of 1 is considered @1x, which is the equivalent of 96.0 or 100% for UWP.
+			// https://developer.apple.com/documentation/uikit/uiscreen/1617836-scale
+			LogicalDpi = (float)(UIScreen.MainScreen.Scale * 96.0f);
+			ResolutionScale = (ResolutionScale)(int)(UIScreen.MainScreen.Scale * 100.0);
 		}
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): #1209

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The value returned by `DisplayInformation.LogicalDpi` does not match the base value of 100% or 96.0 dpi. This makes DPI dependent algorithms incorrectly adjust size based on this value.

## What is the new behavior?

Both iOS and Android return properly adjusted values.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
