### PR TITLE
[iOS] DatePickerFlyout displayed at the bottom

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -36,6 +36,7 @@
 * Fix invalid XAML x:Uid parsing with resource file name and prefix (#1130, #228)
 * Fixed an issue where a Two-Way binding would sometimes not update values back to source correctly
 * Adjust the behavior of `DisplayInformation.LogicalDpi` to match UWP's behavior
+* [iOS] DatePickerFlyout is displayed at the bottom of the screen instead of the center
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -201,6 +201,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewControl_JavaScript_Alert_Confirm_Prompt.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2419,6 +2423,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\PhaseBinding.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\PhaseBinding_Large.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\PhaseBinding_StartOne.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout.xaml.cs">
+      <DependentUpon>DatePickerFlyout.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewControl_JavaScript_Alert_Confirm_Prompt.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewObserverBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewSampleBehavior.cs" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout.xaml
@@ -1,0 +1,32 @@
+﻿<Page x:Class="SamplesApp.Samples.DatePicker.DatePickerFlyoutSample"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:ControlTests"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:xamarin="http://nventive.com/xamarin"
+      xmlns:ios="http://nventive.com/ios"
+      xmlns:android="http://nventive.com/android"
+      xmlns:native_ios="using:UIKit"
+      xmlns:native_android="using:Android.Widget"
+      xmlns:controls="using:Uno.UI.Samples.Controls"
+      mc:Ignorable="xamarin android ios native_ios native_android">
+
+	<controls:SampleControl SampleDescription="Sample for Date Picker Flyout. The DatePicker should appear at the bottom on iOS.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<Grid Margin="0,100,0,0">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
+					</Grid.RowDefinitions>
+
+					<Button Content="Click to open a date picker flyout">
+						<Button.Flyout>
+							<DatePickerFlyout ios:Placement="Full"/>
+						</Button.Flyout>
+					</Button>
+				</Grid>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using SamplesApp.Windows_UI_Xaml_Controls.Models;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace SamplesApp.Samples.DatePicker
+{
+	[SampleControlInfo("Date Picker", "Flyout", typeof(DatePickerViewModel))]
+	public sealed partial class DatePickerFlyoutSample : Page
+	{
+		public DatePickerFlyoutSample()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerPresenter.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerPresenter.xaml
@@ -1,0 +1,59 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:xamarin="http:///umbrella/ui/xamarin"
+      xmlns:android="http://nventive.com/android"
+      xmlns:ios="http://uno.ui/ios"
+      xmlns:u="using:Umbrella.View.Controls"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d xamarin ios android">
+
+	<ios:Style x:Key="DefaultDatePickerFlyoutPresenterStyle"
+			   TargetType="DatePickerFlyoutPresenter">
+		<Setter Property="HorizontalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Bottom" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalAlignment"
+				Value="Stretch" />
+		<Setter Property="IsTabStop"
+				Value="False" />
+		<Setter Property="Background"
+				Value="#FF000000" />
+		<Setter Property="BorderBrush"
+				Value="#FF000000" />
+		<Setter Property="BorderThickness"
+				Value="0" />
+		<Setter Property="Padding"
+				Value="10" />
+		<Setter Property="MinWidth"
+				Value="50" />
+		<Setter Property="MinHeight"
+				Value="30" />
+		<Setter Property="ScrollViewer.HorizontalScrollMode"
+				Value="Auto" />
+		<win:Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+					Value="Auto" />
+		<Setter Property="ScrollViewer.VerticalScrollMode"
+				Value="Auto" />
+		<win:Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+					Value="Auto" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="DatePickerFlyoutPresenter">
+					<ContentPresenter Content="{TemplateBinding Content}" />
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</ios:Style>
+
+	<!--Default Style-->
+	<ios:Style BasedOn="{StaticResource DefaultDatePickerFlyoutPresenterStyle}"
+			   TargetType="DatePickerFlyoutPresenter" />
+
+</ResourceDictionary>

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPopupPanel.cs
@@ -25,6 +25,16 @@ namespace Windows.UI.Xaml.Controls
 			_flyout = flyout;
 		}
 
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			if (this._flyout.Placement == FlyoutPlacementMode.Full)
+			{
+				return base.MeasureOverride(new Size(double.MaxValue, double.MaxValue));
+			}
+
+			return base.MeasureOverride(availableSize);
+		}
+
 		protected override Size ArrangeOverride(Size finalSize)
 		{
 			foreach (var child in Children)
@@ -35,7 +45,15 @@ namespace Windows.UI.Xaml.Controls
 				}
 
 				var desiredSize = elem.DesiredSize;
-				var rect = CalculateFlyoutPlacement(desiredSize);
+				Rect rect;
+				if (this._flyout.Placement == FlyoutPlacementMode.Full)
+				{
+					rect = CalculateFlyoutPlacement(new Size(double.MaxValue, double.MaxValue));
+				}
+				else
+				{
+					rect = CalculateFlyoutPlacement(desiredSize);
+				}
 				elem.Arrange(rect);
 			}
 

--- a/src/Uno.UI/UI/Xaml/Style/Generic/DatePickerSelector.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/DatePickerSelector.xaml
@@ -15,16 +15,48 @@
 		<ios:Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="DatePickerSelector">
-					<Border Background="White"
-							Margin="5"
-							CornerRadius="10">
-						<native:UIDatePicker/>
-					</Border>
+					<Grid VerticalAlignment="Stretch">
+						<Border x:Name="FlyoutScrim"
+								Background="#8000"
+								VerticalAlignment="Stretch"
+								HorizontalAlignment="Stretch"/>
+						<Border x:Name="FlyoutContent"
+								Background="White"
+								VerticalAlignment="Bottom">
+							<StackPanel>
+								<Border Height="44"
+										Background="White">
+									<!--Customize this section with the desired content. Don't forget to localize your resources-->
+									<Button Content="Done"
+											x:Name="AcceptButton"
+											x:Uid="ComboBox_Done"
+											Padding="0,0,15,0"
+											HorizontalAlignment="Right"
+											VerticalContentAlignment="Center"
+											HorizontalContentAlignment="Right"
+											VerticalAlignment="Stretch">
+										<Button.Template>
+											<ControlTemplate>
+												<TextBlock FontSize="16" 
+														   Foreground="Black" 
+														   Margin="0,0,15,0"
+														   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+														   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+														   Text="{TemplateBinding Content}" />
+											</ControlTemplate>
+										</Button.Template>
+									</Button>
+								</Border>
+								<!-- Native date picker -->
+								<native:UIDatePicker/>
+							</StackPanel>
+						</Border>
+					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
 		</ios:Setter>
-        <ios:Setter Property="FlyoutPlacement"
-				Value="Full" />		
+		<Setter Property="VerticalAlignment"
+				Value="Stretch"/>
 	</xamarin:Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
-Bugfix

## What is the current behavior?
On iOS, DatePickerFlyout (whether standalone in a button or on a DatePicker) is displayed at the center of the screen unless a workaround is applied.

## What is the new behavior?

On iOS, DatePickerFlyout is displayed at the bottom of the screen.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

ue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/157393