### PR TITLE
Fix to iOS ComboBox initial selected value not null/empty

### DIFF
--- a/build/android-uitest-run.sh
+++ b/build/android-uitest-run.sh
@@ -15,10 +15,6 @@ nohup $ANDROID_HOME/emulator/emulator -avd xamarin_android_emulator -skin 1280x8
 
 export IsUiAutomationMappingEnabled=true
 
-export IsUiAutomationMappingEnabled=true
-
-export IsUiAutomationMappingEnabled=true
-
 # build the sample and tests, while the emulator is starting
 msbuild /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
 msbuild /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj

--- a/build/android-uitest-run.sh
+++ b/build/android-uitest-run.sh
@@ -15,6 +15,10 @@ nohup $ANDROID_HOME/emulator/emulator -avd xamarin_android_emulator -skin 1280x8
 
 export IsUiAutomationMappingEnabled=true
 
+export IsUiAutomationMappingEnabled=true
+
+export IsUiAutomationMappingEnabled=true
+
 # build the sample and tests, while the emulator is starting
 msbuild /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
 msbuild /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
@@ -1,18 +1,33 @@
-﻿using System;
+﻿using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using NUnit.Framework;
 using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
 
-namespace SamplesApp.UITests
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 {
 	[TestFixture]
-	partial class UnoSamples_Tests : SampleControlUITestBase
+	public partial class ComboBoxTests_Tests : SampleControlUITestBase
 	{
 		[Test]
-		public void ComboBox_Kidnapping()
+		[ActivePlatforms(Platform.iOS)]
+		public void ComboBoxTests_PickerDefaultValue()
+		{
+			Run("SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Picker");
+
+			_app.WaitForElement(_app.Marked("theComboBox"));
+			var theComboBox = _app.Marked("theComboBox");
+
+			Assert.IsNull(theComboBox.GetDependencyPropertyValue("SelectedItem"));
+		}
+
+		[Test]
+		public void ComboBoxTests_Kidnapping()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ComboBox.ComboBox_ComboBoxItem_Selection");
 
@@ -26,16 +41,16 @@ namespace SamplesApp.UITests
 			_app.Tap(button);
 
 			var first = _app.FindWithin("_tb1", presenter);
-			Assert.AreEqual("Item 1", GetText(first));
+			Assert.AreEqual("Item 1", first.GetDependencyPropertyValue<string>("Text"));
 
 			_app.Tap(comboBox);
 			_app.TapCoordinates(300, 100);
 			first = _app.FindWithin("_tb1", presenter);
-			Assert.AreEqual("Item 1", GetText(first));
+			Assert.AreEqual("Item 1", first.GetDependencyPropertyValue<string>("Text"));
 
 			_app.Tap(button);
 			var second = _app.FindWithin("_tb2", presenter);
-			Assert.AreEqual("Item 2", GetText(second));
+			Assert.AreEqual("Item 2", second.GetDependencyPropertyValue<string>("Text"));
 
 			Configuration.AttemptToFindTargetBeforeScrolling = scrollingInitial;
 		}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemsSource.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemsSource.xaml
@@ -14,7 +14,8 @@
 		<controls:SampleControl.SampleContent>
 			<DataTemplate>
 
-				<ComboBox ItemsSource="{Binding [SampleItems]}" />
+				<ComboBox x:Name="theComboBox"
+						  ItemsSource="{Binding [SampleItems]}" />
 
 			</DataTemplate>
 		</controls:SampleControl.SampleContent>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Picker.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Picker.xaml
@@ -359,8 +359,10 @@
   <StackPanel>
 
 	<TextBlock Text="This sample only works on iOS" />
-	<ios:ComboBox ItemsSource="{Binding VariableLengthItems}"
-				  Style="{StaticResource PickerComboBoxStyle}" />
+	<ios:ComboBox x:Name="theComboBox"
+				  ItemsSource="{Binding VariableLengthItems}"
+				  Style="{StaticResource PickerComboBoxStyle}"
+				  SelectedItem="{Binding test}" />
 
   </StackPanel>
 

--- a/src/Uno.UI/UI/Xaml/Controls/Picker/Picker.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Picker/Picker.iOS.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public object[] Items { get; private set; } = new object[] { null }; // ensure there's always a null present to allow deselection
-		
+
 		partial void OnItemsSourceChangedPartialNative(object oldItemsSource, object newItemsSource)
 		{
 			if (oldItemsSource is INotifyCollectionChanged oldObservableCollection)
@@ -81,7 +81,17 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnItemSourceChanged(object collection, NotifyCollectionChangedEventArgs _)
 		{
-			Items = (collection as IEnumerable)?.ToObjectArray() ?? new object[0];
+			if (SelectedItem == null)
+			{
+				Items = new[] { (object)null }
+				  .Concat((collection as IEnumerable)?.ToObjectArray() ?? new object[0])
+				  .ToObjectArray();
+			}
+			else
+			{
+				Items = (collection as IEnumerable)?.ToObjectArray() ?? new object[0];
+			}
+
 			ReloadAllComponents();
 
 			if (!Items.Contains(SelectedItem))
@@ -101,6 +111,13 @@ namespace Windows.UI.Xaml.Controls
 					SelectedItem = firstItem;
 					return;
 				}
+			}
+			else if (newSelectedItem != null && Items[0] == null)
+			{
+				// On ItemSelection remove initial null item at Items[0]
+				Items = Items
+					.Skip(1)
+					.ToObjectArray();
 			}
 
 			Select(row, component: 0, animated: true);


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
iOS initial value is the first item in the list 


## What is the new behavior?
iOS initial value is null


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/157456