### PR TITLE
Migrate StaticResource UI Tests

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.StaticResource.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.StaticResource.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+using Xamarin.UITest;
+
+namespace SamplesApp.UITests
+{
+	[TestFixture]
+	partial class UnoSamples_Tests : SampleControlUITestBase
+	{
+		[Test]
+		public void StaticResource_XAML_Validation()
+		{
+			Run("UITests.Shared.Resources.StaticResource.StaticResource_Simple");
+
+			_app.WaitForElement(_app.Marked("XAMLResource_Text"));
+
+			var resourceText = _app.Marked("XAMLResource_Text");
+
+			Assert.AreEqual("This resource was registered in XAML", resourceText.GetDependencyPropertyValue("Text")?.ToString());
+		}
+
+		[Test]
+		public void StaticResource_CSharp_Validation()
+		{
+			Run("UITests.Shared.Resources.StaticResource.StaticResource_Simple");
+
+			_app.WaitForElement(_app.Marked("CSharpResource_Text"));
+
+			var resourceText = _app.Marked("CSharpResource_Text");
+
+			Assert.AreEqual("This resource was registered in C#", resourceText.GetDependencyPropertyValue("Text")?.ToString());
+		}
+
+		[Test]
+		public void StaticResource_Converter_Validation()
+		{
+			Run("UITests.Shared.Resources.StaticResource.StaticResource_Simple");
+
+			_app.WaitForElement(_app.Marked("ConverterResource_Text"));
+
+			var resourceText = _app.Marked("ConverterResource_Text");
+
+			Assert.AreEqual("Hello Converter!", resourceText.GetDependencyPropertyValue("Text")?.ToString());
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Resources/StaticResource/StaticResource_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Resources/StaticResource/StaticResource_Simple.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl x:Class="UITests.Shared.Resources.StaticResource.StaticResource_Simple"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Resources.StaticResource"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="">
+
+	<UserControl.Resources>
+		<x:String x:Key="XAML_Resource">This resource was registered in XAML</x:String>
+	</UserControl.Resources>
+
+	<StackPanel>
+
+		<!-- XAML Resource -->
+		<TextBlock x:Name="XAMLResource_Text"
+				   Text="{StaticResource XAML_Resource}" />
+
+		<!-- C# Resource (See code-behind) -->
+		<TextBlock x:Name="CSharpResource_Text"
+				   Text="{StaticResource CSharp_Resource}" />
+
+		<!-- Converter Resource (See code-behind) -->
+		<TextBlock x:Name="ConverterResource_Text"
+				   Text="{Binding Converter={StaticResource HelloConverter}}" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Resources/StaticResource/StaticResource_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Resources/StaticResource/StaticResource_Simple.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Resources.StaticResource
+{
+	[SampleControlInfo("StaticResource", "StaticResource_Simple")]
+	public sealed partial class StaticResource_Simple : UserControl
+	{
+		public StaticResource_Simple()
+		{
+			Application.Current.Resources["CSharp_Resource"] = "This resource was registered in C#";
+			Application.Current.Resources["HelloConverter"] = new HelloConverter();
+
+			this.InitializeComponent();
+		}
+
+		private class HelloConverter : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, string language)
+			{
+				return "Hello Converter!";
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, string language)
+			{
+				return "Hello Converter!";
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -13,6 +13,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Resources\StaticResource\StaticResource_Simple.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Toolkit\Elevation.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2333,6 +2337,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ViewModelBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lottie\SampleLottieAnimation.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Resources\StaticResource\StaticResource_Simple.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\Elevation.xaml.cs">
       <DependentUpon>Elevation.xaml</DependentUpon>
     </Compile>
@@ -4131,6 +4136,9 @@
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ThemeResources\BasicThemeResources.xaml.cs">
       <DependentUpon>BasicThemeResources.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Resources\StaticResource\StaticResource_Simple.xaml.cs">
+      <DependentUpon>StaticResource_Simple.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Migrate private UI Tests to public Uno
https://github.com/unoplatform/private/issues/23

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR-->

- Added UI Test for StaticResource
- New Sample (StaticResource_Simple)


## What is the current behavior?

No sample/test for StaticResource


## What is the new behavior?

Sample for StaticResoucres set in xaml, C# and Converter

New Test:
StaticResource_XAML_Validation
StaticResource_CSharp_Validation
StaticResource_Converter_Validation

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
