### PR TITLE
[UITest] Adjust the android startup script

### DIFF
--- a/build/android-uitest-wait-systemui.sh
+++ b/build/android-uitest-wait-systemui.sh
@@ -41,4 +41,4 @@ while [[ -z ${LAUNCHER_READY} ]]; do
     esac
 done
 
-echo "Launcher is ready :-)"
+echo "Launcher is ready!"

--- a/build/android-uitest-wait-systemui.sh
+++ b/build/android-uitest-wait-systemui.sh
@@ -32,6 +32,11 @@ while [[ -z ${LAUNCHER_READY} ]]; do
     *)
         echo "Waiting for launcher..."
         sleep 3
+
+		# For some reason the messaging app can be brought up in front
+		# (DEBUG) Current focus:   mCurrentFocus=Window{1170051 u0 com.google.android.apps.messaging/com.google.android.apps.messaging.ui.ConversationListActivity}
+		# Try bringing back the home screen to check on the launcher.
+        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_HOME
     ;;
     esac
 done

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.ContentControl.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.ContentControl.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
@@ -13,6 +14,7 @@ namespace SamplesApp.UITests
 	public partial class UnoSamples_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void ContentPresenter_Template()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ContentPresenter.ContentPresenter_Template");
@@ -37,6 +39,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void ContentPresenter_Changing_ContentTemplate()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ContentPresenter.ContentPresenter_Changing_ContentTemplate");
@@ -50,6 +53,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void ContentControl_Changing_ContentTemplate()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ContentControlTestsControl.ContentControl_Changing_ContentTemplate");

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Popup.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Popup.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SamplesApp.UITests;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
@@ -16,6 +17,7 @@ namespace SamplesApp.UITests
 	{
 
 		[Test]
+		[AutoRetry]
 		[Ignore("TODO Popups are not removed properly")]
 		public void Popup_Dismissable_Validation()
 		{
@@ -48,6 +50,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		[Ignore("TODO Popups are not removed properly")]
 		public void Popup_NonDismissable_Validation()
 		{
@@ -81,6 +84,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		[Ignore("TODO Popups are not removed properly")]
 		public void Popup_NoFixedHeight_Validation()
 		{

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.RadioButton.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.RadioButton.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 using Xamarin.UITest;
@@ -14,6 +15,7 @@ namespace SamplesApp.UITests
 	partial class UnoSamples_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void RadioButton_IsEnabled_Validation()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.RadioButtonTests.RadioButton_IsEnabled_Automated");
@@ -48,6 +50,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void RadioButton_DoubleTap_Validation()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.RadioButtonTests.RadioButton_IsEnabled_Automated");
@@ -83,6 +86,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void RadioButton_StatePreservation()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.RadioButtonTests.RadioButton_IsEnabled_Automated");

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Touch.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Touch.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
@@ -13,6 +14,7 @@ namespace SamplesApp.UITests
 	partial class UnoSamples_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void Touch_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.TouchEventsTests.Touch");

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.XBind.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.XBind.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
@@ -13,6 +14,7 @@ namespace SamplesApp.UITests
 	public partial class UnoSamples_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void XBind_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.XBind.XBind_Simple");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_ApplicationModel_Resources/ResourceLoader_Simple.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_ApplicationModel_Resources/ResourceLoader_Simple.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
@@ -13,6 +14,7 @@ namespace SamplesApp.UITests.Windows_ApplicationModel_Resources
 	public class ResourceLoader_Simple : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void ValidateResourceLoader_Simple()
 		{
 			Run("UITests.Shared.Windows_ApplicationModel_Resources_ResourceLoader.ResourceLoader_Simple");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerTests/UnoSamples_Tests.FocusManager.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerTests/UnoSamples_Tests.FocusManager.cs
@@ -16,6 +16,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 	public partial class FocusManagerTests_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_Border_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -39,6 +40,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_Button_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -63,6 +65,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_Button_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -89,6 +92,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_CheckBox_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -113,6 +117,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_CheckBox_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -139,6 +144,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_Grid_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -162,6 +168,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_HyperlinkButton_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -188,6 +195,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_HyperlinkButton_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -214,6 +222,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_Image_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -237,6 +246,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_Rectangle_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -260,6 +270,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_TextBlock_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -283,6 +294,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_TextBoxMultiLine_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -307,6 +319,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_TextBoxMultiLine_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -333,6 +346,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_TextBoxSingleLine_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -356,6 +370,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_TextBoxSingleLine_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -383,6 +398,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_ToggleButton_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -406,6 +422,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_ToggleButton_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -432,6 +449,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_ComboBox_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -456,6 +474,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_ComboBox_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -482,6 +501,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_ComboBoxItem_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -509,6 +529,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_ComboBoxItem_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -539,6 +560,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_ScrollViewer_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -563,6 +585,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_ListViewItem_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");
@@ -587,6 +610,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void FocusManager_GetFocusedElement_ListViewItem_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusManager.FocusManager_GetFocus_Automated");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_IsEnabled_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_IsEnabled_Automated.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SamplesApp.UITests;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 using Xamarin.UITest;
@@ -15,6 +16,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 	partial class Button_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void Button_IsEnabled_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ButtonTestsControl.Button_IsEnabled_Automated");
@@ -41,6 +43,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void CheckBox_IsEnabled_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ButtonTestsControl.CheckBox_IsEnabled_Automated");
@@ -73,6 +76,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void ToggleButton_IsEnabled_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ButtonTestsControl.ToggleButton_IsEnabled_Automated");
@@ -105,6 +109,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 		}
 		
 		[Test]
+		[AutoRetry]
 		public void ToggleSwitch_IsEnabled_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ButtonTestsControl.ToggleSwitch_IsEnable_Automated");
@@ -130,6 +135,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void HyperlinkButton_IsEnabled_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ButtonTestsControl.HyperlinkButton_IsEnabled_Automated");
@@ -156,6 +162,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 		}
 				
 		[Test]
+		[AutoRetry]
 		public void CheckBox_IsEnabled_StatePreservation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ButtonTestsControl.CheckBox_IsEnabled_Automated");
@@ -194,6 +201,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void CheckBox_DoubleTapValidation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ButtonTestsControl.CheckBox_IsEnabled_Automated");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_Opacity_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_Opacity_Automated.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using SamplesApp.UITests;
+using SamplesApp.UITests.TestFramework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,6 +15,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 	public partial class Button_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void Button_IsOpacity_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ButtonTestsControl.Button_Opacity_Automated");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -14,6 +15,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 	public partial class ContentDialog_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void Simple_ContentDialog_01_Primary()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Simple");
@@ -40,6 +42,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void Simple_ContentDialog_01_Primary_Disabled()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Simple");
@@ -75,6 +78,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void Simple_ContentDialog_01_Secondary()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Simple");
@@ -101,6 +105,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void Simple_ContentDialog_01_PrimaryCommand()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Simple");
@@ -129,6 +134,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void Simple_ContentDialog_01_Close()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Simple");
@@ -155,6 +161,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void Simple_ContentDialog_01_TypeInner()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Simple");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -14,6 +15,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 	public partial class TimePickerTests_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		[Ignore("Not available yet")]
 		public void TimePickerFlyout_DiscardChanges()
 		{
@@ -52,6 +54,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		[Ignore("Not available yet")]
 		public void TimePickerFlyout_ApplyChanges()
 		{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Try going to the android emulator home screen  as the messaging app may be brought in front.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
