### PR TITLE
Migrate CommandBar UI Tests

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/CommandBar/UnoSamples_Tests.CommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/CommandBar/UnoSamples_Tests.CommandBar.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.CommandBar
+{
+	[TestFixture]
+	public partial class UnoSamples_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[ActivePlatforms(Platform.Android, Platform.iOS)]
+		public void CommandBar_LongTitle_Validation()
+		{
+			Run("Uno.UI.Samples.Content.UITests.CommandBar.CommandBar_LongTitle");
+
+			_app.WaitForElement(_app.Marked("TextBlockWidthTest"));
+
+			// Initial state
+			_app.Screenshot("CommandBar - LongTitle - 1 - Initial State");
+
+			// Set orientation Landscape
+			_app.SetOrientationLandscape();
+			_app.Screenshot("CommandBar - LongTitle - 2 - Orientation Landscape");
+
+			// Set orientation Portrait
+			_app.SetOrientationPortrait();
+			_app.Screenshot("CommandBar - LongTitle - 3 - Orientation Portrait");
+
+			// Set orientation Landscape (Again)
+			_app.SetOrientationLandscape();
+			_app.Screenshot("CommandBar - LongTitle - 4 - Orientation Landscape");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_LongTitle.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_LongTitle.xaml
@@ -1,21 +1,21 @@
 ﻿<Page x:Class="Uno.UI.Samples.Content.UITests.CommandBar.CommandBar_LongTitle"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Uno.UI.Samples.Content.UITests.CommandBar"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-		xmlns:toolkit="using:Uno.UI.Toolkit">
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.Samples.Content.UITests.CommandBar"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:toolkit="using:Uno.UI.Toolkit">
 
 	<StackPanel VerticalAlignment="Top">
 
 		<!-- CommandBar without button -->
 		<CommandBar Content="This is a long sentence to test the command bar on ios and android - Ceci est une longue phrase pour tester la commandBar sur Android et iOS - 123456789"
-								Background="#1FA2E1"
-								Foreground="White"/>
+					Background="#1FA2E1"
+					Foreground="White" />
 
 		<!-- CommandBar with button and search button -->
-		<CommandBar Content ="This is a long sentence to test the command bar on ios and android - Ceci est une longue phrase pour tester la commandBar sur Android et iOS - 123456789"
-								Background="Red"
-								Foreground="White">
+		<CommandBar Content="This is a long sentence to test the command bar on ios and android - Ceci est une longue phrase pour tester la commandBar sur Android et iOS - 123456789"
+					Background="Red"
+					Foreground="White">
 			<CommandBar.PrimaryCommands>
 				<AppBarButton>
 					<AppBarButton.Icon>
@@ -28,26 +28,26 @@
 
 		<!-- CommandBar without button and inline content -->
 		<CommandBar Background="#FFFF00"
-								Foreground="Black">
+					Foreground="Black">
 			<CommandBar.Content>
 				<TextBlock x:Name="TextBlockWidthTest"
-									 Text="This is a long sentence to test the command bar on ios and android - Ceci est une longue phrase pour tester la commandBar sur Android et iOS - 123456789"
-									 TextTrimming="CharacterEllipsis"
-									 FontWeight="Bold"
-									 FontSize="18"
-									 VerticalAlignment="Center"/>
+						   Text="This is a long sentence to test the command bar on ios and android - Ceci est une longue phrase pour tester la commandBar sur Android et iOS - 123456789"
+						   TextTrimming="CharacterEllipsis"
+						   FontWeight="Bold"
+						   FontSize="18"
+						   VerticalAlignment="Center" />
 			</CommandBar.Content>
 		</CommandBar>
 
 		<!-- CommandBar with button and inline content -->
 		<CommandBar Background="#808000"
-								Foreground="White">
+					Foreground="White">
 			<CommandBar.Content>
-				<TextBlock Text ="This is a long sentence to test the command bar on ios and android - Ceci est une longue phrase pour tester la commandBar sur Android et iOS - 123456789"
-									 TextTrimming="CharacterEllipsis"
-									 FontWeight="Bold"
-									 FontSize="18"
-									 VerticalAlignment="Center"/>
+				<TextBlock Text="This is a long sentence to test the command bar on ios and android - Ceci est une longue phrase pour tester la commandBar sur Android et iOS - 123456789"
+						   TextTrimming="CharacterEllipsis"
+						   FontWeight="Bold"
+						   FontSize="18"
+						   VerticalAlignment="Center" />
 			</CommandBar.Content>
 			<CommandBar.PrimaryCommands>
 				<AppBarButton>
@@ -61,8 +61,8 @@
 
 		<!-- Exampl with toolkit	-->
 		<CommandBar Content="This is a long sentence to test the command bar on ios and android - Ceci est une longue phrase pour tester la commandBar sur Android et iOS"
-								Foreground="Red"
-								Background="Pink">
+					Foreground="Red"
+					Background="Pink">
 
 			<!-- Burger Menu -->
 			<toolkit:CommandBarExtensions.NavigationCommand>


### PR DESCRIPTION
Migrate private UI Tests to public Uno
https://github.com/unoplatform/private/issues/23

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR-->

- Added UI Test for CommandBar 


## What is the current behavior?

No test for CommandBar 


## What is the new behavior?

New Test:
CommandBar_LongTitle_Validation

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
