### PR TITLE
Fix Arc command in paths

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -49,6 +49,7 @@
 * [Android] Ensure TextBox spell-check is properly enabled/disabled on all devices. 
 * Fix ComboBox disappearing items when items are views (#1078)
 * [iOS] TextBox with `AcceptsReturn=True` crashes ListView
+* [Android/iOS] Fixed Arc command in paths
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_Arc.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_Arc.xaml
@@ -39,6 +39,13 @@
 					  StrokeThickness="5" />
 			</Grid>
 
+			<TextBlock Text="Center computation of the following Arc implies possible sqrt of a negative number" />
+			<Grid>
+				<Path Data="M6.2 5.63a4.89 4.89 0 1 1 9.78 0z"
+					  Fill="Green"
+					  Stroke="Yellow" />
+			</Grid>
+
 		</StackPanel>
 
 	</ScrollViewer>

--- a/src/Uno.UI/Media/PathStreamGeometryContext.cs
+++ b/src/Uno.UI/Media/PathStreamGeometryContext.cs
@@ -151,12 +151,12 @@ namespace Uno.Media
 			var x3 = (x1 + x2) / 2;
 
 			var x = sign
-				? x3 + Sqrt(Pow(radius, 2) - Pow((q / 2), 2)) * (y1 - y2) / q
-				: x3 - Sqrt(Pow(radius, 2) - Pow((q / 2), 2)) * (y1 - y2) / q;
+				? x3 + Sqrt(Max(0, Pow(radius, 2) - Pow((q / 2), 2))) * (y1 - y2) / q
+				: x3 - Sqrt(Max(0, Pow(radius, 2) - Pow((q / 2), 2))) * (y1 - y2) / q;
 
 			var y = sign
-				? y3 + Sqrt(Pow(radius, 2) - Pow((q / 2), 2)) * (x2 - x1) / q
-				: y3 - Sqrt(Pow(radius, 2) - Pow((q / 2), 2)) * (x2 - x1) / q;
+				? y3 + Sqrt(Max(0, Pow(radius, 2) - Pow((q / 2), 2))) * (x2 - x1) / q
+				: y3 - Sqrt(Max(0, Pow(radius, 2) - Pow((q / 2), 2))) * (x2 - x1) / q;
 
 			return new Point(x, y);
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): #
None

## PR Type
- Bugfix


## What is the current behavior?
Some paths are truncated on iOS or not displayed on Android.

## What is the new behavior?
Paths displayed as expected

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
https://feedback.nventive.com/communities/1/topics/3536-androidpathcontrol-some-svg-shapes-are-not-displayed-on-android-there-are-missing-pieces-on-ios
