### PR TITLE
Generate and publish screenshot compare results

### DIFF
--- a/.azure-devops-wasm-uitests.yml
+++ b/.azure-devops-wasm-uitests.yml
@@ -179,7 +179,7 @@ jobs:
     condition: always()
     inputs:
       testResultsFiles: '$(build.artifactstagingdirectory)\*.xml'
-      testRunTitle: 'screenshots Compare Test Run'
+      testRunTitle: 'Screenshots Compare Test Run'
       testResultsFormat: 'NUnit'
       failTaskOnFailedTests: false
 

--- a/.azure-devops-wasm-uitests.yml
+++ b/.azure-devops-wasm-uitests.yml
@@ -174,6 +174,15 @@ jobs:
       GIT_SOURCEBRANCH: "$(Build.SourceBranch)"
     displayName: 'Compare UI Tests screenshots'
 
+
+  - task: PublishTestResults@2
+    condition: always()
+    inputs:
+      testResultsFiles: '$(build.artifactstagingdirectory)\*.xml'
+      testRunTitle: 'screenshots Compare Test Run'
+      testResultsFormat: 'NUnit'
+      failTaskOnFailedTests: false
+
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,7 +35,7 @@ Please check if your PR fulfills the following requirements:
 - [ ] Tested code with current [supported SDKs](../README.md#supported)
 - [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
 - [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
-- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
+- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
 - [ ] Contains **NO** breaking changes
 - [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
 - [ ] Associated with an issue (GitHub or internal)

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -31,6 +31,7 @@
 * Permit `DependencyProperty` to be set reentrantly. Eg this permits `TextBox.TextChanging` to modify the `Text` property (previously this could only be achieved using `Dispatcher.RunAsync()`).
 * Implement `TextBox.TextChanging` and `TextBox.BeforeTextChanging`. As on UWP, this allows the text to be intercepted and modified before the UI is updated. Previously on Android using the `TextChanged` event would lead to laggy response and dropped characters when typing rapidly; this is no longer the case with `TextChanging`.
 * [WASM] `ComboBox`'s dropdown list (`CarouselPanel`) is now virtualized (#1012)
+* Improve Screenshot comparer tool, CI test results now contain Screenshots compare data
 
 ### Breaking changes
 * `TextBox` no longer raises TextChanged when its template is applied, in line with UWP.

--- a/doc/articles/uno-development/working-with-the-samples-apps.md
+++ b/doc/articles/uno-development/working-with-the-samples-apps.md
@@ -85,7 +85,7 @@ To run the tests:
 - Press `F5`, node will start and run the tests sequentially
 - The screen shots are placed in a folder named `out`
 
-Note that the same operation is run during the CI, in a specific job running under Linux. The screen shots are located in an build artifact.
+Note that the same operation is run during the CI, in a specific job running under Linux. The screen shots are located in the Unit Tests section under `Screenshots Compare Test Run` as well as in the build artifact.
 
 ## Validating the WebAssembly UI Tests results
 

--- a/src/SamplesApp/SamplesApp.UITests/Constants.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Constants.cs
@@ -14,6 +14,6 @@ namespace SamplesApp.UITests
 		public readonly static string AndroidAppName = "uno.platform.unosampleapp";
 
 		// Default active platform when running under Visual Studio test runner
-		public const Platform CurrentPlatform = Platform.Browser;
+		public const Platform CurrentPlatform = Platform.Android;
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/AppInitializer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/AppInitializer.cs
@@ -96,7 +96,7 @@ namespace SamplesApp.UITests
 
 		private static IApp CreateAndroidApp(bool alreadyRunningApp)
 		{
-#if DEBUG
+#if true
 			// To set in case of Xamarin.UITest errors
 			//
 			Environment.SetEnvironmentVariable("ANDROID_HOME", @"C:\Program Files (x86)\Android\android-sdk");

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/AppInitializer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/AppInitializer.cs
@@ -96,7 +96,7 @@ namespace SamplesApp.UITests
 
 		private static IApp CreateAndroidApp(bool alreadyRunningApp)
 		{
-#if true
+#if DEBUG
 			// To set in case of Xamarin.UITest errors
 			//
 			Environment.SetEnvironmentVariable("ANDROID_HOME", @"C:\Program Files (x86)\Android\android-sdk");

--- a/src/Uno.UI.TestComparer/Comparer/CompareResult.cs
+++ b/src/Uno.UI.TestComparer/Comparer/CompareResult.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Uno.UI.TestComparer.Comparer
+{
+	internal class CompareResult
+	{
+		public int TotalTests { get; internal set; }
+		public int UnchangedTests { get; internal set; }
+		public List<CompareResultFile> Tests { get;} = new List<CompareResultFile>();
+		public List<(int index, string path)> Folders { get; } = new List<(int index, string path)>();
+	}
+}

--- a/src/Uno.UI.TestComparer/Comparer/CompareResultFile.cs
+++ b/src/Uno.UI.TestComparer/Comparer/CompareResultFile.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace Uno.UI.TestComparer.Comparer
+{
+	internal class CompareResultFile
+	{
+		public CompareResultFile()
+		{
+		}
+
+		public List<CompareResultFileRun> ResultRun { get; internal set; } = new List<CompareResultFileRun>();
+		public string TestName { get; internal set; }
+		public bool HasChanged { get; internal set; }
+	}
+}

--- a/src/Uno.UI.TestComparer/Comparer/CompareResultFileRun.cs
+++ b/src/Uno.UI.TestComparer/Comparer/CompareResultFileRun.cs
@@ -1,0 +1,12 @@
+﻿namespace Uno.UI.TestComparer.Comparer
+{
+	internal class CompareResultFileRun
+	{
+		public int ImageId { get; internal set; }
+		public string ImageSha { get; internal set; }
+		public string DiffResultImage { get; internal set; }
+		public string SourceFile { get; internal set; }
+		public string FilePath { get; internal set; }
+		public bool HasChanged { get; internal set; }
+	}
+}

--- a/src/Uno.UI.TestComparer/Comparer/TestFilesComparer.cs
+++ b/src/Uno.UI.TestComparer/Comparer/TestFilesComparer.cs
@@ -118,11 +118,11 @@ namespace Uno.UI.TestComparer.Comparer
 
 				testResult.Tests.Add(compareResultFile);
 
-				if (hasChanges)
+				// if (hasChanges)
 				{
 					var changeResult = increments[0];
 
-					if (changeResult.Count() > 1)
+					// if (changeResult.Count() > 1)
 					{
 						var firstFolder = changeResult.Where(i => i.FolderIndex != -1).Min(i => i.FolderIndex);
 
@@ -130,31 +130,34 @@ namespace Uno.UI.TestComparer.Comparer
 						{
 							var folderInfo = changeResult.FirstOrDefault(inc => inc.FolderIndex == folderIndex);
 
-							var hasChangedFromPrevious = folderIndex != firstFolder && folderInfo?.IdSha != null;
-
-							var compareResultFileRun = new CompareResultFileRun();
-							compareResultFile.ResultRun.Add(compareResultFileRun);
-
-							compareResultFileRun.ImageId = folderInfo.Id;
-							compareResultFileRun.ImageSha = folderInfo.IdSha;
-							compareResultFileRun.FilePath = folderInfo.Path;
-
-							compareResultFileRun.HasChanged = hasChangedFromPrevious;
-
 							if (folderInfo != null)
 							{
-								var previousFolderInfo = changeResult.FirstOrDefault(inc => inc.FolderIndex == folderIndex - 1);
-								if (hasChangedFromPrevious && previousFolderInfo != null)
+								var hasChangedFromPrevious = folderIndex != firstFolder && folderInfo?.IdSha != null;
+
+								var compareResultFileRun = new CompareResultFileRun();
+								compareResultFile.ResultRun.Add(compareResultFileRun);
+
+								compareResultFileRun.ImageId = folderInfo.Id;
+								compareResultFileRun.ImageSha = folderInfo.IdSha;
+								compareResultFileRun.FilePath = folderInfo.Path;
+
+								compareResultFileRun.HasChanged = hasChangedFromPrevious;
+
+								if (folderInfo != null)
 								{
-									var currentImage = DecodeImage(folderInfo.Path);
-									var previousImage = DecodeImage(previousFolderInfo.Path);
+									var previousFolderInfo = changeResult.FirstOrDefault(inc => inc.FolderIndex == folderIndex - 1);
+									if (hasChangedFromPrevious && previousFolderInfo != null)
+									{
+										var currentImage = DecodeImage(folderInfo.Path);
+										var previousImage = DecodeImage(previousFolderInfo.Path);
 
-									var diff = DiffImages(currentImage.pixels, previousImage.pixels);
+										var diff = DiffImages(currentImage.pixels, previousImage.pixels);
 
-									var diffFilePath = Path.Combine(diffPath, $"{folderInfo.Id}-{folderInfo.CompareeId}.png");
-									WriteImage(diffFilePath, diff, currentImage.frame);
+										var diffFilePath = Path.Combine(diffPath, $"{folderInfo.Id}-{folderInfo.CompareeId}.png");
+										WriteImage(diffFilePath, diff, currentImage.frame);
 
-									compareResultFileRun.DiffResultImage = diffFilePath;
+										compareResultFileRun.DiffResultImage = diffFilePath;
+									}
 								}
 							}
 						}

--- a/src/Uno.UI.TestComparer/Comparer/TestFilesComparer.cs
+++ b/src/Uno.UI.TestComparer/Comparer/TestFilesComparer.cs
@@ -1,0 +1,291 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+
+namespace Uno.UI.TestComparer.Comparer
+{
+	class TestFilesComparer
+	{
+		public TestFilesComparer(string basePath, string artifactsBasePath, string artifactsInnerBasePath, string platform)
+		{
+			_basePath = basePath;
+			_artifactsBasePath = artifactsBasePath;
+			_artifactsInnerBasePath = artifactsInnerBasePath;
+			_platform = platform;
+		}
+
+		internal CompareResult Compare()
+		{
+			var testResult = new CompareResult();
+
+			string path = _basePath;
+			var resultsId = $"{DateTime.Now:yyyyMMdd-hhmmss}";
+			string diffPath = Path.Combine(_basePath, $"Results-{_platform}-{resultsId}");
+			string resultsFilePath = Path.Combine(_basePath, $"Results-{_platform}-{resultsId}.html");
+
+			Directory.CreateDirectory(path);
+			Directory.CreateDirectory(diffPath);
+
+			var q1 = from directory in Directory.EnumerateDirectories(_artifactsBasePath)
+					 let info = new DirectoryInfo(directory)
+					 orderby info.CreationTime descending
+					 select directory;
+
+			q1 = q1.ToArray();
+
+			var orderedDirectories = from directory in q1
+									 orderby directory
+									 select directory;
+
+			var q = from directory in orderedDirectories.Select((v, i) => new { Index = i, Path = v })
+					let files = from sample in EnumerateFiles(Path.Combine(directory.Path, _artifactsInnerBasePath, _platform), "*.png").AsParallel()
+								select new { File = sample, Id = BuildSha1(sample) }
+					select new
+					{
+						Path = directory.Path,
+						Index = directory.Index,
+						Files = files.ToArray(),
+					};
+
+			var allFolders = LogForeach(q, i => Console.WriteLine($"Processed {i.Path}")).ToArray();
+
+			testResult.Folders.AddRange(allFolders.Select((p, index) => (index, p.Path)));
+
+			var allFiles = allFolders
+				.SelectMany(folder => folder
+					.Files.Select(file => Path.GetFileName(file.File))
+				)
+				.Distinct()
+				.ToArray();
+
+			var changedList = new List<string>();
+			foreach (var testFile in allFiles)
+			{
+				var testFileIncrements = from folder in allFolders
+										 orderby folder.Index ascending
+										 select new
+										 {
+											 Folder = folder.Path,
+											 FolderIndex = folder.Index,
+											 Files = new[] {
+												new { FileInfo = folder.Files.FirstOrDefault(f => Path.GetFileName(f.File) == testFile) }
+											 }
+										 };
+
+				var increments =
+					(
+						from platformIndex in Enumerable.Range(0, 1)
+						select testFileIncrements
+							.Aggregate(
+								new[] { new { FolderIndex = -1, Path = "", IdSha = "", Id = -1, CompareeId = -1 } },
+								(a, f) =>
+								{
+									var platformFiles = f.Files[platformIndex];
+
+									if (platformFiles?.FileInfo == null)
+									{
+										return a;
+									}
+
+									var otherMatch = a.Reverse().Where(i => i.IdSha != null).FirstOrDefault();
+									if (platformFiles.FileInfo?.Id.sha != otherMatch?.IdSha)
+									{
+										return a
+											.Concat(new[] { new { FolderIndex = f.FolderIndex, Path = platformFiles.FileInfo.File, IdSha = platformFiles.FileInfo?.Id.sha, Id = platformFiles.FileInfo?.Id.index ?? -1, CompareeId = otherMatch.Id } })
+											.ToArray();
+									}
+									else
+									{
+										return a
+											.Concat(new[] { new { FolderIndex = f.FolderIndex, Path = platformFiles.FileInfo.File, IdSha = (string)null, Id = platformFiles.FileInfo.Id.index, CompareeId = -1 } })
+											.ToArray();
+									}
+								}
+							)
+					).ToArray();
+
+				var hasChanges = increments.Any(i => i.Where(v => v.IdSha != null).Count() - 1 > 1);
+
+				var compareResultFile = new CompareResultFile();
+				compareResultFile.HasChanged = hasChanges;
+				compareResultFile.TestName = testFile;
+
+				testResult.Tests.Add(compareResultFile);
+
+				if (hasChanges)
+				{
+					var changeResult = increments[0];
+
+					if (changeResult.Count() > 1)
+					{
+						var firstFolder = changeResult.Where(i => i.FolderIndex != -1).Min(i => i.FolderIndex);
+
+						for (int folderIndex = 0; folderIndex < allFolders.Length; folderIndex++)
+						{
+							var folderInfo = changeResult.FirstOrDefault(inc => inc.FolderIndex == folderIndex);
+
+							var hasChangedFromPrevious = folderIndex != firstFolder && folderInfo?.IdSha != null;
+
+							var compareResultFileRun = new CompareResultFileRun();
+							compareResultFile.ResultRun.Add(compareResultFileRun);
+
+							compareResultFileRun.ImageId = folderInfo.Id;
+							compareResultFileRun.ImageSha = folderInfo.IdSha;
+							compareResultFileRun.FilePath = folderInfo.Path;
+
+							compareResultFileRun.HasChanged = hasChangedFromPrevious;
+
+							if (folderInfo != null)
+							{
+								var previousFolderInfo = changeResult.FirstOrDefault(inc => inc.FolderIndex == folderIndex - 1);
+								if (hasChangedFromPrevious && previousFolderInfo != null)
+								{
+									var currentImage = DecodeImage(folderInfo.Path);
+									var previousImage = DecodeImage(previousFolderInfo.Path);
+
+									var diff = DiffImages(currentImage.pixels, previousImage.pixels);
+
+									var diffFilePath = Path.Combine(diffPath, $"{folderInfo.Id}-{folderInfo.CompareeId}.png");
+									WriteImage(diffFilePath, diff, currentImage.frame);
+
+									compareResultFileRun.DiffResultImage = diffFilePath;
+								}
+							}
+						}
+					}
+
+					changedList.Add(testFile);
+				}
+			}
+
+			testResult.UnchangedTests = allFiles.Length - changedList.Count;
+			testResult.TotalTests = allFiles.Length;
+
+			return testResult;
+		}
+
+		private Dictionary<string, int> _fileHashesTable = new Dictionary<string, int>();
+		private readonly string _basePath;
+		private readonly string _artifactsBasePath;
+		private readonly string _artifactsInnerBasePath;
+		private readonly string _platform;
+
+		private (string sha, int index) BuildSha1(string sample)
+		{
+			// return "000";
+
+			using (var sha1 = SHA1.Create())
+			{
+				using (var file = File.OpenRead(sample))
+				{
+					var data = sha1.ComputeHash(file);
+
+					// Create a new Stringbuilder to collect the bytes
+					// and create a string.
+					var sBuilder = new StringBuilder();
+
+					// Loop through each byte of the hashed data 
+					// and format each one as a hexadecimal string.
+					for (int i = 0; i < data.Length; i++)
+					{
+						sBuilder.Append(data[i].ToString("x2", CultureInfo.InvariantCulture));
+					}
+
+					var sha = sBuilder.ToString();
+
+					lock (_fileHashesTable)
+					{
+						if (!_fileHashesTable.TryGetValue(sha, out var index))
+						{
+							index = _fileHashesTable.Count;
+							_fileHashesTable[sha] = index;
+						}
+
+						return (sha, index);
+					}
+				}
+			}
+		}
+
+		private IEnumerable<string> EnumerateFiles(string path, string pattern)
+		{
+			if (Directory.Exists(path))
+			{
+				return Directory.EnumerateFiles(path, pattern, SearchOption.AllDirectories);
+			}
+			else
+			{
+				return new string[0];
+			}
+		}
+
+		private void WriteImage(string diffPath, byte[] diff, BitmapFrame frameInfo)
+		{
+			using (var stream = new FileStream(diffPath, FileMode.Create))
+			{
+				var encoder = new PngBitmapEncoder();
+
+				encoder.Interlace = PngInterlaceOption.On;
+
+				var frame = BitmapSource.Create(
+					pixelWidth: (int)frameInfo.Width,
+					pixelHeight: (int)frameInfo.Height,
+					dpiX: frameInfo.DpiX,
+					dpiY: frameInfo.DpiY,
+					pixelFormat: frameInfo.Format,
+					palette: frameInfo.Palette,
+					pixels: diff,
+					stride: (int)(frameInfo.Width * 4)
+				);
+
+				encoder.Frames.Add(BitmapFrame.Create(frame));
+				encoder.Save(stream);
+			}
+		}
+
+		private byte[] DiffImages(byte[] currentImage, byte[] previousImage)
+		{
+			var result = new byte[currentImage.Length];
+
+			for (int i = 0; i < result.Length; i++)
+			{
+				result[i] = (byte)(currentImage[i] ^ previousImage[i]);
+			}
+
+			// Force result to be opaque
+			for (int i = 0; i < result.Length; i += 4)
+			{
+				result[i+3] = 0xFF;
+			}
+
+			return result;
+		}
+
+		private (BitmapFrame frame, byte[] pixels) DecodeImage(string path1)
+		{
+			Stream imageStreamSource = new FileStream(path1, FileMode.Open, FileAccess.Read, FileShare.Read);
+			var decoder = new PngBitmapDecoder(imageStreamSource, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.Default);
+
+			byte[] image = new byte[(int)(decoder.Frames[0].Width * decoder.Frames[0].Height * 4)];
+			decoder.Frames[0].CopyPixels(image, (int)(decoder.Frames[0].Width * 4), 0);
+
+			return (decoder.Frames[0], image);
+		}
+
+		private static IEnumerable<T> LogForeach<T>(IEnumerable<T> q, Action<T> action)
+		{
+			foreach (var item in q)
+			{
+				action(item);
+				yield return item;
+			}
+		}
+
+	}
+}

--- a/src/Uno.UI.TestComparer/Comparer/TestFilesComparer.cs
+++ b/src/Uno.UI.TestComparer/Comparer/TestFilesComparer.cs
@@ -65,107 +65,101 @@ namespace Uno.UI.TestComparer.Comparer
 				.ToArray();
 
 			var changedList = new List<string>();
-			foreach (var testFile in allFiles)
-			{
-				var testFileIncrements = from folder in allFolders
-										 orderby folder.Index ascending
-										 select new
-										 {
-											 Folder = folder.Path,
-											 FolderIndex = folder.Index,
-											 Files = new[] {
-												new { FileInfo = folder.Files.FirstOrDefault(f => Path.GetFileName(f.File) == testFile) }
-											 }
-										 };
+            foreach (var testFile in allFiles)
+            {
+                var testFileIncrements = from folder in allFolders
+                                         orderby folder.Index ascending
+                                         select new
+                                         {
+                                             Folder = folder.Path,
+                                             FolderIndex = folder.Index,
+                                             Files = new[] {
+                                                new { FileInfo = folder.Files.FirstOrDefault(f => Path.GetFileName(f.File) == testFile) }
+                                             }
+                                         };
 
-				var increments =
-					(
-						from platformIndex in Enumerable.Range(0, 1)
-						select testFileIncrements
-							.Aggregate(
-								new[] { new { FolderIndex = -1, Path = "", IdSha = "", Id = -1, CompareeId = -1 } },
-								(a, f) =>
-								{
-									var platformFiles = f.Files[platformIndex];
+                var increments =
+                    (
+                        from platformIndex in Enumerable.Range(0, 1)
+                        select testFileIncrements
+                            .Aggregate(
+                                new[] { new { FolderIndex = -1, Path = "", IdSha = "", Id = -1, CompareeId = -1 } },
+                                (a, f) =>
+                                {
+                                    var platformFiles = f.Files[platformIndex];
 
-									if (platformFiles?.FileInfo == null)
-									{
-										return a;
-									}
+                                    if (platformFiles?.FileInfo == null)
+                                    {
+                                        return a;
+                                    }
 
-									var otherMatch = a.Reverse().Where(i => i.IdSha != null).FirstOrDefault();
-									if (platformFiles.FileInfo?.Id.sha != otherMatch?.IdSha)
-									{
-										return a
-											.Concat(new[] { new { FolderIndex = f.FolderIndex, Path = platformFiles.FileInfo.File, IdSha = platformFiles.FileInfo?.Id.sha, Id = platformFiles.FileInfo?.Id.index ?? -1, CompareeId = otherMatch.Id } })
-											.ToArray();
-									}
-									else
-									{
-										return a
-											.Concat(new[] { new { FolderIndex = f.FolderIndex, Path = platformFiles.FileInfo.File, IdSha = (string)null, Id = platformFiles.FileInfo.Id.index, CompareeId = -1 } })
-											.ToArray();
-									}
-								}
-							)
-					).ToArray();
+                                    var otherMatch = a.Reverse().Where(i => i.IdSha != null).FirstOrDefault();
+                                    if (platformFiles.FileInfo?.Id.sha != otherMatch?.IdSha)
+                                    {
+                                        return a
+                                            .Concat(new[] { new { FolderIndex = f.FolderIndex, Path = platformFiles.FileInfo.File, IdSha = platformFiles.FileInfo?.Id.sha, Id = platformFiles.FileInfo?.Id.index ?? -1, CompareeId = otherMatch.Id } })
+                                            .ToArray();
+                                    }
+                                    else
+                                    {
+                                        return a
+                                            .Concat(new[] { new { FolderIndex = f.FolderIndex, Path = platformFiles.FileInfo.File, IdSha = (string)null, Id = platformFiles.FileInfo.Id.index, CompareeId = -1 } })
+                                            .ToArray();
+                                    }
+                                }
+                            )
+                    ).ToArray();
 
-				var hasChanges = increments.Any(i => i.Where(v => v.IdSha != null).Count() - 1 > 1);
+                var hasChanges = increments.Any(i => i.Where(v => v.IdSha != null).Count() - 1 > 1);
 
-				var compareResultFile = new CompareResultFile();
-				compareResultFile.HasChanged = hasChanges;
-				compareResultFile.TestName = testFile;
+                var compareResultFile = new CompareResultFile();
+                compareResultFile.HasChanged = hasChanges;
+                compareResultFile.TestName = testFile;
 
-				testResult.Tests.Add(compareResultFile);
+                testResult.Tests.Add(compareResultFile);
 
-				// if (hasChanges)
-				{
-					var changeResult = increments[0];
+                var changeResult = increments[0];
 
-					// if (changeResult.Count() > 1)
-					{
-						var firstFolder = changeResult.Where(i => i.FolderIndex != -1).Min(i => i.FolderIndex);
+                var firstFolder = changeResult.Where(i => i.FolderIndex != -1).Min(i => i.FolderIndex);
 
-						for (int folderIndex = 0; folderIndex < allFolders.Length; folderIndex++)
-						{
-							var folderInfo = changeResult.FirstOrDefault(inc => inc.FolderIndex == folderIndex);
+                for (int folderIndex = 0; folderIndex < allFolders.Length; folderIndex++)
+                {
+                    var folderInfo = changeResult.FirstOrDefault(inc => inc.FolderIndex == folderIndex);
 
-							if (folderInfo != null)
-							{
-								var hasChangedFromPrevious = folderIndex != firstFolder && folderInfo?.IdSha != null;
+                    if (folderInfo != null)
+                    {
+                        var hasChangedFromPrevious = folderIndex != firstFolder && folderInfo?.IdSha != null;
 
-								var compareResultFileRun = new CompareResultFileRun();
-								compareResultFile.ResultRun.Add(compareResultFileRun);
+                        var compareResultFileRun = new CompareResultFileRun();
+                        compareResultFile.ResultRun.Add(compareResultFileRun);
 
-								compareResultFileRun.ImageId = folderInfo.Id;
-								compareResultFileRun.ImageSha = folderInfo.IdSha;
-								compareResultFileRun.FilePath = folderInfo.Path;
+                        compareResultFileRun.ImageId = folderInfo.Id;
+                        compareResultFileRun.ImageSha = folderInfo.IdSha;
+                        compareResultFileRun.FilePath = folderInfo.Path;
 
-								compareResultFileRun.HasChanged = hasChangedFromPrevious;
+                        compareResultFileRun.HasChanged = hasChangedFromPrevious;
 
-								if (folderInfo != null)
-								{
-									var previousFolderInfo = changeResult.FirstOrDefault(inc => inc.FolderIndex == folderIndex - 1);
-									if (hasChangedFromPrevious && previousFolderInfo != null)
-									{
-										var currentImage = DecodeImage(folderInfo.Path);
-										var previousImage = DecodeImage(previousFolderInfo.Path);
+                        if (folderInfo != null)
+                        {
+                            var previousFolderInfo = changeResult.FirstOrDefault(inc => inc.FolderIndex == folderIndex - 1);
+                            if (hasChangedFromPrevious && previousFolderInfo != null)
+                            {
+                                var currentImage = DecodeImage(folderInfo.Path);
+                                var previousImage = DecodeImage(previousFolderInfo.Path);
 
-										var diff = DiffImages(currentImage.pixels, previousImage.pixels);
+                                var diff = DiffImages(currentImage.pixels, previousImage.pixels);
 
-										var diffFilePath = Path.Combine(diffPath, $"{folderInfo.Id}-{folderInfo.CompareeId}.png");
-										WriteImage(diffFilePath, diff, currentImage.frame);
+                                var diffFilePath = Path.Combine(diffPath, $"{folderInfo.Id}-{folderInfo.CompareeId}.png");
+                                WriteImage(diffFilePath, diff, currentImage.frame);
 
-										compareResultFileRun.DiffResultImage = diffFilePath;
-									}
-								}
-							}
-						}
-					}
+                                compareResultFileRun.DiffResultImage = diffFilePath;
+                            }
+                        }
+                    }
 
-					changedList.Add(testFile);
-				}
-			}
+                    changedList.Add(testFile);
+                }
+            }
 
 			testResult.UnchangedTests = allFiles.Length - changedList.Count;
 			testResult.TotalTests = allFiles.Length;
@@ -181,8 +175,6 @@ namespace Uno.UI.TestComparer.Comparer
 
 		private (string sha, int index) BuildSha1(string sample)
 		{
-			// return "000";
-
 			using (var sha1 = SHA1.Create())
 			{
 				using (var file = File.OpenRead(sample))

--- a/src/Uno.UI.TestComparer/Program.cs
+++ b/src/Uno.UI.TestComparer/Program.cs
@@ -176,7 +176,7 @@ namespace Umbrella.UI.TestComparer
 
 
 			testSuiteFixtureNode.SetAttribute("type", "TestFixture");
-			testSuiteFixtureNode.SetAttribute("name", resultsId);
+			testSuiteFixtureNode.SetAttribute("name", platform + "-" + resultsId);
 			testSuiteFixtureNode.SetAttribute("executed", "true");
 
 			testSuiteFixtureNode.SetAttribute("testcasecount", compareResult.TotalTests.ToString());
@@ -197,8 +197,8 @@ namespace Umbrella.UI.TestComparer
 
 				var lastTestRun = run.ResultRun.LastOrDefault();
 
-				testCaseNode.SetAttribute("name", SanitizeTestName(run.TestName));
-				testCaseNode.SetAttribute("fullname", SanitizeTestName(run.TestName));
+				testCaseNode.SetAttribute("name", platform + "-" + SanitizeTestName(run.TestName));
+				testCaseNode.SetAttribute("fullname", platform + "-" + SanitizeTestName(run.TestName));
 				testCaseNode.SetAttribute("duration", "0");
 				testCaseNode.SetAttribute("time", "0");
 

--- a/src/Uno.UI.TestComparer/Uno.UI.TestComparer.csproj
+++ b/src/Uno.UI.TestComparer/Uno.UI.TestComparer.csproj
@@ -14,6 +14,8 @@
 	  <PackageReference Include="Microsoft.AppCenter" Version="2.1.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.150.0-preview" />
 		<PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.150.0-preview" />
+		<PackageReference Include="NUnit" Version="3.12.0" />
+		<PackageReference Include="NUnit.Engine" Version="3.10.0" />
 		<PackageReference Include="Refit" Version="4.3.0" />
 		<PackageReference Include="Mono.Options" Version="5.3.0.1" />
 	</ItemGroup>

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -31,7 +31,7 @@
 		<UnoForceProcessPRIResource>true</UnoForceProcessPRIResource>
 
 		<!-- Generate automation IDs in debug builds, use by UI tests. -->
-		<IsUiAutomationMappingEnabled Condition="'$(Configuration)'=='Debug'">true</IsUiAutomationMappingEnabled>
+		<IsUiAutomationMappingEnabled>true</IsUiAutomationMappingEnabled>
 	</PropertyGroup>
 
 	<Import Project="..\Uno.CrossTargetting.props" />

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -31,8 +31,8 @@
 		<UnoForceProcessPRIResource>true</UnoForceProcessPRIResource>
 
 		<!-- Generate automation IDs in debug builds, use by UI tests. -->
-		<IsUiAutomationMappingEnabled>true</IsUiAutomationMappingEnabled>
-	</PropertyGroup>
+    <IsUiAutomationMappingEnabled Condition="'$(Configuration)'=='Debug'">true</IsUiAutomationMappingEnabled>
+  </PropertyGroup>
 
 	<Import Project="..\Uno.CrossTargetting.props" />
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Screenshots comparisons are now published in the CI's output as unit test runs. Screenshot and image diffs files are also available as test attachments.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
