### PR TITLE
 Fix to infinite loop+refactored UpdateLayoutAttributesForItem iteratively

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
+{
+	[TestFixture]
+	public partial class ListViewTests_Tests : SampleControlUITestBase
+	{
+		[Test]
+		public void ListView_ListViewVariableItemHeightLong_InitializesTest()
+		{
+			Run("SamplesApp.Windows_UI_Xaml_Controls.ListView.ListViewVariableItemHeightLong");
+
+			_app.WaitForElement(_app.Marked("theListView"));
+			var theListView = _app.Marked("theListView");
+
+			// Assert initial state
+			Assert.IsNotNull(theListView.GetDependencyPropertyValue("DataContext"));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListViewVariableItemHeightLong.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListViewVariableItemHeightLong.xaml
@@ -1,35 +1,37 @@
-<UserControl
-	x:Class="SamplesApp.Windows_UI_Xaml_Controls.ListView.ListViewVariableItemHeightLong" 
-	xmlns:controls="using:Uno.UI.Samples.Controls"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:u="using:Uno.UI.Samples.Controls"
-	xmlns:ios="http://uno.ui/ios"
-	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:android="http://uno.ui/android"
-	xmlns:xamarin="http://uno.ui/xamarin"
-	mc:Ignorable="d ios android xamarin"
-	d:DesignHeight="2000"
-	d:DesignWidth="400">
+<UserControl x:Class="SamplesApp.Windows_UI_Xaml_Controls.ListView.ListViewVariableItemHeightLong"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:u="using:Uno.UI.Samples.Controls"
+			 xmlns:ios="http://uno.ui/ios"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:android="http://uno.ui/android"
+			 xmlns:xamarin="http://uno.ui/xamarin"
+			 mc:Ignorable="d ios android xamarin"
+			 d:DesignHeight="2000"
+			 d:DesignWidth="400">
 
 	<UserControl.Resources>
-		<Style TargetType="ListViewItem" x:Key="ListViewItemLowMinHeight">
-			<Setter Property="MinWidth" Value="1"/>
-			<Setter Property="MinHeight" Value="1"/>
+		<Style TargetType="ListViewItem"
+			   x:Key="ListViewItemLowMinHeight">
+			<Setter Property="MinWidth"
+					Value="1" />
+			<Setter Property="MinHeight"
+					Value="1" />
 			<Setter Property="Template">
 				<Setter.Value>
 					<ControlTemplate TargetType="ListViewItem">
 						<Border Background="RosyBrown">
 							<ContentPresenter x:Name="ContentPresenter"
-																  ContentTransitions="{TemplateBinding ContentTransitions}"
-																  ContentTemplate="{TemplateBinding ContentTemplate}"
-																  xamarin:ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-																  Content="{TemplateBinding Content}"
-																  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-																  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-																  Margin="{TemplateBinding Padding}"/>
+											  ContentTransitions="{TemplateBinding ContentTransitions}"
+											  ContentTemplate="{TemplateBinding ContentTemplate}"
+											  xamarin:ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+											  Content="{TemplateBinding Content}"
+											  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+											  Margin="{TemplateBinding Padding}" />
 						</Border>
 					</ControlTemplate>
 				</Setter.Value>
@@ -41,15 +43,16 @@
 		<controls:SampleControl.SampleContent>
 			<DataTemplate>
 				<Border Background="Indigo">
-					<ListView ItemsSource="{Binding VariableLengthItemsLong}"
-						  Width="150"
-						  Height="400"
+					<ListView x:Name="theListView"
+							  ItemsSource="{Binding VariableLengthItemsLong}"
+							  Width="150"
+							  Height="400"
 							  ItemContainerStyle="{StaticResource ListViewItemLowMinHeight}">
 						<ListView.ItemTemplate>
 							<DataTemplate>
 								<Border Background="PeachPuff">
 									<TextBlock Text="{Binding}"
-									   TextWrapping="Wrap"/>
+											   TextWrapping="Wrap" />
 								</Border>
 							</DataTemplate>
 						</ListView.ItemTemplate>

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
@@ -78,57 +78,64 @@ namespace Windows.UI.Xaml.Controls
 
 		private protected override void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes updatingItem, bool shouldRecurse)
 		{
-			//Update extent of either subsequent item in group, subsequent group header, or footer
-			var currentIndex = updatingItem.IndexPath;
-			var nextIndexInGroup = GetNSIndexPathFromRowSection(currentIndex.Row + 1, currentIndex.Section);
-
-			// Get next item in current group
-			var elementToAdjust = LayoutAttributesForItem(nextIndexInGroup);
-
-			if (elementToAdjust == null)
+			while (updatingItem != null)
 			{
-				// No more items in current group, get group header of next group
-				elementToAdjust = LayoutAttributesForSupplementaryView(
-					NativeListViewBase.ListViewSectionHeaderElementKindNS,
-					GetNSIndexPathFromRowSection(0, currentIndex.Section + 1));
+				//Update extent of either subsequent item in group, subsequent group header, or footer
+				var currentIndex = updatingItem.IndexPath;
+				var nextIndexInGroup = GetNSIndexPathFromRowSection(currentIndex.Row + 1, currentIndex.Section);
 
-				//This is the last item in section, update information used by sticky headers.
-				_sectionEnd[currentIndex.Section] = GetExtentEnd(updatingItem.Frame);
-			}
+				// Get next item in current group
+				var elementToAdjust = LayoutAttributesForItem(nextIndexInGroup);
 
-			if (elementToAdjust == null)
-			{
-				// No more groups in source, get footer
-				elementToAdjust = LayoutAttributesForSupplementaryView(
-					NativeListViewBase.ListViewFooterElementKindNS,
-					GetNSIndexPathFromRowSection(0, 0));
-			}
-
-			if (elementToAdjust == null)
-			{
-				return;
-			}
-
-			if (elementToAdjust.RepresentedElementKind != NativeListViewBase.ListViewSectionHeaderElementKind)
-			{
-				//Update position of subsequent item based on position of this item, which may have changed
-				var frame = elementToAdjust.Frame;
-				SetExtentStart(ref frame, GetExtentEnd(updatingItem.Frame));
-				elementToAdjust.Frame = frame;
-
-				if (shouldRecurse)
+				if (elementToAdjust == null)
 				{
-					UpdateLayoutAttributesForItem(elementToAdjust, shouldRecurse: true);
+					// No more items in current group, get group header of next group
+					elementToAdjust = LayoutAttributesForSupplementaryView(
+						NativeListViewBase.ListViewSectionHeaderElementKindNS,
+						GetNSIndexPathFromRowSection(0, currentIndex.Section + 1));
+
+					//This is the last item in section, update information used by sticky headers.
+					_sectionEnd[currentIndex.Section] = GetExtentEnd(updatingItem.Frame);
 				}
-			}
-			else
-			{
-				//Update group header
-				var inlineFrame = GetInlineHeaderFrame(elementToAdjust.IndexPath.Section);
-				var extentDifference = GetExtentEnd(updatingItem.Frame) - GetExtentStart(inlineFrame);
-				if (extentDifference != 0)
+
+				if (elementToAdjust == null)
 				{
-					UpdateLayoutAttributesForGroupHeader(elementToAdjust, extentDifference, true);
+					// No more groups in source, get footer
+					elementToAdjust = LayoutAttributesForSupplementaryView(
+						NativeListViewBase.ListViewFooterElementKindNS,
+						GetNSIndexPathFromRowSection(0, 0));
+				}
+
+				if (elementToAdjust == null)
+				{
+					break;
+				}
+
+				if (elementToAdjust.RepresentedElementKind != NativeListViewBase.ListViewSectionHeaderElementKind)
+				{
+					//Update position of subsequent item based on position of this item, which may have changed
+					var frame = elementToAdjust.Frame;
+					SetExtentStart(ref frame, GetExtentEnd(updatingItem.Frame));
+					elementToAdjust.Frame = frame;
+
+					if (shouldRecurse && elementToAdjust.RepresentedElementKind == null)
+					{
+						updatingItem = elementToAdjust;
+					}
+					else
+					{
+						updatingItem = null;
+					}
+				}
+				else
+				{
+					//Update group header
+					var inlineFrame = GetInlineHeaderFrame(elementToAdjust.IndexPath.Section);
+					var extentDifference = GetExtentEnd(updatingItem.Frame) - GetExtentStart(inlineFrame);
+					if (extentDifference != 0)
+					{
+						UpdateLayoutAttributesForGroupHeader(elementToAdjust, extentDifference, true);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix
- Refactoring


## What is the current behavior?
ListViews with footers and a lot of items may crash in ios
ListViews with a lot of variable items may crash from stackoverflow in ios 

## What is the new behavior?
ListView crashes fixed, Recursive function changed to iterative

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)(https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/158034
