### PR TITLE
fixed crash on android

### DIFF
--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -266,9 +266,9 @@ namespace Windows.UI.Xaml
 				throw new global::System.Exception("Cannot check NavigationBar visibility property. DecorView is not defined yet.");
 			}
 
-			var visibility = decorView.SystemUiVisibility;
-			return visibility.HasFlag(SystemUiFlags.HideNavigation)
-				|| visibility.HasFlag(SystemUiFlags.LayoutHideNavigation);
+			var uiFlags = (int)decorView.SystemUiVisibility;
+			return (uiFlags & (int)SystemUiFlags.HideNavigation) == 0
+				|| (uiFlags & (int)SystemUiFlags.LayoutHideNavigation) == 0;
 		}
 
 		private bool IsNavigationBarTranslucent()


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Android app crash at launch

## What is the new behavior?
Android app shouldn't crash at launch

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information
This PR is indented to fix an bug introduced in #850.
Can't invoke `Enum.HasFlag` with different enum types, even if [`View.SystemUiVisibility`](https://developer.android.com/reference/android/view/View.html#setSystemUiVisibility(int)) is meant to be used with `SystemUiFlags`.