### PR TITLE
Fix for UWPSyncGenerator issues, aligning generated files

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeer.cs
@@ -607,6 +607,6 @@ namespace Windows.UI.Xaml.Automation.Peers
 			throw new global::System.NotImplementedException("The member RawElementProviderRuntimeId AutomationPeer.GenerateRawElementProviderRuntimeId() is not implemented in Uno.");
 		}
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.ListenerExists()
+		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.ListenerExists(Windows.UI.Xaml.Automation.Peers.AutomationEvents)
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeerAnnotation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeerAnnotation.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Automation.Peers
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class AutomationPeerAnnotation : global::Windows.UI.Xaml.DependencyObject
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PeerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Peer", typeof(global::Windows.UI.Xaml.Automation.Peers.AutomationPeer), 
+			nameof(Peer), typeof(global::Windows.UI.Xaml.Automation.Peers.AutomationPeer), 
 			typeof(global::Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Automation.Peers.AutomationPeer)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TypeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Type", typeof(global::Windows.UI.Xaml.Automation.AnnotationType), 
+			nameof(Type), typeof(global::Windows.UI.Xaml.Automation.AnnotationType), 
 			typeof(global::Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Automation.AnnotationType)));
 		#endif
@@ -67,7 +67,13 @@ namespace Windows.UI.Xaml.Automation.Peers
 		}
 		#endif
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation.AutomationPeerAnnotation(Windows.UI.Xaml.Automation.AnnotationType, Windows.UI.Xaml.Automation.Peers.AutomationPeer)
-		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation.AutomationPeerAnnotation()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public AutomationPeerAnnotation() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation", "AutomationPeerAnnotation.AutomationPeerAnnotation()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation.AutomationPeerAnnotation()
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation.Type.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation.Type.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Provider/IRawElementProviderSimple.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Provider/IRawElementProviderSimple.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Automation.Provider
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class IRawElementProviderSimple : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation/AutomationAnnotation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation/AutomationAnnotation.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Automation
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class AutomationAnnotation : global::Windows.UI.Xaml.DependencyObject
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Automation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ElementProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Element", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(Element), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Automation.AutomationAnnotation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Automation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TypeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Type", typeof(global::Windows.UI.Xaml.Automation.AnnotationType), 
+			nameof(Type), typeof(global::Windows.UI.Xaml.Automation.AnnotationType), 
 			typeof(global::Windows.UI.Xaml.Automation.AutomationAnnotation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Automation.AnnotationType)));
 		#endif
@@ -67,7 +67,13 @@ namespace Windows.UI.Xaml.Automation
 		}
 		#endif
 		// Forced skipping of method Windows.UI.Xaml.Automation.AutomationAnnotation.AutomationAnnotation(Windows.UI.Xaml.Automation.AnnotationType, Windows.UI.Xaml.UIElement)
-		// Skipping already declared method Windows.UI.Xaml.Automation.AutomationAnnotation.AutomationAnnotation()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public AutomationAnnotation() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.AutomationAnnotation", "AutomationAnnotation.AutomationAnnotation()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Automation.AutomationAnnotation.AutomationAnnotation()
 		// Forced skipping of method Windows.UI.Xaml.Automation.AutomationAnnotation.Type.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.AutomationAnnotation.Type.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation/AutomationProperty.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation/AutomationProperty.cs
@@ -2,11 +2,10 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Automation
 {
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
 	public  partial class AutomationProperty 
 	{
-		internal AutomationProperty()
-		{
-
-		}
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation/ScrollPatternIdentifiers.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation/ScrollPatternIdentifiers.cs
@@ -2,7 +2,24 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Automation
 {
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
 	public  partial class ScrollPatternIdentifiers 
 	{
+		// Skipping already declared property HorizontalScrollPercentProperty
+		// Skipping already declared property HorizontalViewSizeProperty
+		// Skipping already declared property HorizontallyScrollableProperty
+		// Skipping already declared property NoScroll
+		// Skipping already declared property VerticalScrollPercentProperty
+		// Skipping already declared property VerticalViewSizeProperty
+		// Skipping already declared property VerticallyScrollableProperty
+		// Forced skipping of method Windows.UI.Xaml.Automation.ScrollPatternIdentifiers.HorizontallyScrollableProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Automation.ScrollPatternIdentifiers.HorizontalScrollPercentProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Automation.ScrollPatternIdentifiers.HorizontalViewSizeProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Automation.ScrollPatternIdentifiers.NoScroll.get
+		// Forced skipping of method Windows.UI.Xaml.Automation.ScrollPatternIdentifiers.VerticallyScrollableProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Automation.ScrollPatternIdentifiers.VerticalScrollPercentProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Automation.ScrollPatternIdentifiers.VerticalViewSizeProperty.get
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapBillboard.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapBillboard.cs
@@ -77,7 +77,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CollisionBehaviorDesiredProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CollisionBehaviorDesired", typeof(global::Windows.UI.Xaml.Controls.Maps.MapElementCollisionBehavior), 
+			nameof(CollisionBehaviorDesired), typeof(global::Windows.UI.Xaml.Controls.Maps.MapElementCollisionBehavior), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapBillboard), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Maps.MapElementCollisionBehavior)));
 		#endif
@@ -85,7 +85,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LocationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Location", typeof(global::Windows.Devices.Geolocation.Geopoint), 
+			nameof(Location), typeof(global::Windows.Devices.Geolocation.Geopoint), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapBillboard), 
 			new FrameworkPropertyMetadata(default(global::Windows.Devices.Geolocation.Geopoint)));
 		#endif
@@ -93,7 +93,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty NormalizedAnchorPointProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"NormalizedAnchorPoint", typeof(global::Windows.Foundation.Point), 
+			nameof(NormalizedAnchorPoint), typeof(global::Windows.Foundation.Point), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapBillboard), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapCamera.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapCamera.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapCamera : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapControl.cs
@@ -190,8 +190,20 @@ namespace Windows.UI.Xaml.Controls.Maps
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TryZoomInAsync()
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TryZoomOutAsync()
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TryZoomToAsync(double)
-		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TrySetSceneAsync(Windows.UI.Xaml.Controls.Maps.MapScene)
-		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TrySetSceneAsync(Windows.UI.Xaml.Controls.Maps.MapScene, Windows.UI.Xaml.Controls.Maps.MapAnimationKind)
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.Foundation.IAsyncOperation<bool> TrySetSceneAsync( global::Windows.UI.Xaml.Controls.Maps.MapScene scene)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> MapControl.TrySetSceneAsync(MapScene scene) is not implemented in Uno.");
+		}
+		#endif
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.Foundation.IAsyncOperation<bool> TrySetSceneAsync( global::Windows.UI.Xaml.Controls.Maps.MapScene scene,  global::Windows.UI.Xaml.Controls.Maps.MapAnimationKind animationKind)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> MapControl.TrySetSceneAsync(MapScene scene, MapAnimationKind animationKind) is not implemented in Uno.");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.MapRightTapped.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.MapRightTapped.remove
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.BusinessLandmarksEnabled.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapCustomExperience.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapCustomExperience.cs
@@ -2,12 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapCustomExperience : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapCustomExperience.MapCustomExperience()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public MapCustomExperience() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapCustomExperience", "MapCustomExperience.MapCustomExperience()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapCustomExperience.MapCustomExperience()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapElement.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapElement : global::Windows.UI.Xaml.DependencyObject
@@ -109,7 +109,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Visible", typeof(bool), 
+			nameof(Visible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ZIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ZIndex", typeof(int), 
+			nameof(ZIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -125,7 +125,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MapTabIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MapTabIndex", typeof(int), 
+			nameof(MapTabIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -133,7 +133,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MapStyleSheetEntryProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MapStyleSheetEntry", typeof(string), 
+			nameof(MapStyleSheetEntry), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -141,7 +141,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MapStyleSheetEntryStateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MapStyleSheetEntryState", typeof(string), 
+			nameof(MapStyleSheetEntryState), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -149,7 +149,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TagProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Tag", typeof(object), 
+			nameof(Tag), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -157,11 +157,17 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsEnabled", typeof(bool), 
+			nameof(IsEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapElement.MapElement()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public MapElement() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapElement", "MapElement.MapElement()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapElement.MapElement()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapElement.ZIndex.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapElement.ZIndex.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapElement3D.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapElement3D.cs
@@ -95,7 +95,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeadingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Heading", typeof(double), 
+			nameof(Heading), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LocationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Location", typeof(global::Windows.Devices.Geolocation.Geopoint), 
+			nameof(Location), typeof(global::Windows.Devices.Geolocation.Geopoint), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement3D), 
 			new FrameworkPropertyMetadata(default(global::Windows.Devices.Geolocation.Geopoint)));
 		#endif
@@ -111,7 +111,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PitchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Pitch", typeof(double), 
+			nameof(Pitch), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -119,7 +119,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RollProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Roll", typeof(double), 
+			nameof(Roll), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -127,7 +127,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ScaleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Scale", typeof(global::System.Numerics.Vector3), 
+			nameof(Scale), typeof(global::System.Numerics.Vector3), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement3D), 
 			new FrameworkPropertyMetadata(default(global::System.Numerics.Vector3)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapElementsLayer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapElementsLayer.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MapElementsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MapElements", typeof(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Controls.Maps.MapElement>), 
+			nameof(MapElements), typeof(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Controls.Maps.MapElement>), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElementsLayer), 
 			new FrameworkPropertyMetadata(default(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Controls.Maps.MapElement>)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapIcon.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapIcon.cs
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LocationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Location", typeof(global::Windows.Devices.Geolocation.Geopoint), 
+			nameof(Location), typeof(global::Windows.Devices.Geolocation.Geopoint), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapIcon), 
 			new FrameworkPropertyMetadata(default(global::Windows.Devices.Geolocation.Geopoint)));
 		#endif
@@ -89,7 +89,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty NormalizedAnchorPointProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"NormalizedAnchorPoint", typeof(global::Windows.Foundation.Point), 
+			nameof(NormalizedAnchorPoint), typeof(global::Windows.Foundation.Point), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapIcon), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point)));
 		#endif
@@ -97,7 +97,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TitleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Title", typeof(string), 
+			nameof(Title), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapIcon), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -105,7 +105,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CollisionBehaviorDesiredProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CollisionBehaviorDesired", typeof(global::Windows.UI.Xaml.Controls.Maps.MapElementCollisionBehavior), 
+			nameof(CollisionBehaviorDesired), typeof(global::Windows.UI.Xaml.Controls.Maps.MapElementCollisionBehavior), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapIcon), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Maps.MapElementCollisionBehavior)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapInputEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapInputEventArgs.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapInputEventArgs : global::Windows.UI.Xaml.DependencyObject
@@ -27,7 +27,13 @@ namespace Windows.UI.Xaml.Controls.Maps
 			}
 		}
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapInputEventArgs.MapInputEventArgs()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public MapInputEventArgs() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapInputEventArgs", "MapInputEventArgs.MapInputEventArgs()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapInputEventArgs.MapInputEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapInputEventArgs.Position.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapInputEventArgs.Location.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapItemsControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapItemsControl.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapItemsControl : global::Windows.UI.Xaml.DependencyObject
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(ItemTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapItemsControl), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -57,7 +57,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Items", typeof(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.DependencyObject>), 
+			nameof(Items), typeof(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.DependencyObject>), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapItemsControl), 
 			new FrameworkPropertyMetadata(default(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.DependencyObject>)));
 		#endif
@@ -65,11 +65,17 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemsSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemsSource", typeof(object), 
+			nameof(ItemsSource), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapItemsControl), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapItemsControl.MapItemsControl()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public MapItemsControl() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapItemsControl", "MapItemsControl.MapItemsControl()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapItemsControl.MapItemsControl()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapItemsControl.ItemsSource.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapItemsControl.ItemsSource.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapLayer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapLayer.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapLayer : global::Windows.UI.Xaml.DependencyObject
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MapTabIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MapTabIndex", typeof(int), 
+			nameof(MapTabIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapLayer), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Visible", typeof(bool), 
+			nameof(Visible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapLayer), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -69,11 +69,17 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ZIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ZIndex", typeof(int), 
+			nameof(ZIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapLayer), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapLayer.MapLayer()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public MapLayer() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapLayer", "MapLayer.MapLayer()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapLayer.MapLayer()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapLayer.MapTabIndex.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapLayer.MapTabIndex.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapModel3D.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapModel3D.cs
@@ -2,12 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapModel3D : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapModel3D.MapModel3D()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public MapModel3D() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapModel3D", "MapModel3D.MapModel3D()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapModel3D.MapModel3D()
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapPolygon.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapPolygon.cs
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PathProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Path", typeof(global::Windows.Devices.Geolocation.Geopath), 
+			nameof(Path), typeof(global::Windows.Devices.Geolocation.Geopath), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapPolygon), 
 			new FrameworkPropertyMetadata(default(global::Windows.Devices.Geolocation.Geopath)));
 		#endif
@@ -99,7 +99,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StrokeDashedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StrokeDashed", typeof(bool), 
+			nameof(StrokeDashed), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapPolygon), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -107,7 +107,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StrokeThicknessProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StrokeThickness", typeof(double), 
+			nameof(StrokeThickness), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapPolygon), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapPolyline.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapPolyline.cs
@@ -67,7 +67,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PathProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Path", typeof(global::Windows.Devices.Geolocation.Geopath), 
+			nameof(Path), typeof(global::Windows.Devices.Geolocation.Geopath), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapPolyline), 
 			new FrameworkPropertyMetadata(default(global::Windows.Devices.Geolocation.Geopath)));
 		#endif
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StrokeDashedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StrokeDashed", typeof(bool), 
+			nameof(StrokeDashed), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapPolyline), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapRouteView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapRouteView.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapRouteView : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapScene.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapScene.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapScene : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapStyleSheet.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapStyleSheet.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapStyleSheet : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapTileDataSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapTileDataSource.cs
@@ -2,12 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapTileDataSource : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapTileDataSource.MapTileDataSource()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public MapTileDataSource() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapTileDataSource", "MapTileDataSource.MapTileDataSource()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapTileDataSource.MapTileDataSource()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapTileSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapTileSource.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MapTileSource : global::Windows.UI.Xaml.DependencyObject
@@ -217,7 +217,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AllowOverstretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AllowOverstretch", typeof(bool), 
+			nameof(AllowOverstretch), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -225,7 +225,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BoundsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Bounds", typeof(global::Windows.Devices.Geolocation.GeoboundingBox), 
+			nameof(Bounds), typeof(global::Windows.Devices.Geolocation.GeoboundingBox), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.Devices.Geolocation.GeoboundingBox)));
 		#endif
@@ -233,7 +233,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DataSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DataSource", typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileDataSource), 
+			nameof(DataSource), typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileDataSource), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Maps.MapTileDataSource)));
 		#endif
@@ -241,7 +241,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFadingEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFadingEnabled", typeof(bool), 
+			nameof(IsFadingEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -249,7 +249,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsRetryEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsRetryEnabled", typeof(bool), 
+			nameof(IsRetryEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -257,7 +257,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTransparencyEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTransparencyEnabled", typeof(bool), 
+			nameof(IsTransparencyEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -265,7 +265,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LayerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Layer", typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileLayer), 
+			nameof(Layer), typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileLayer), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Maps.MapTileLayer)));
 		#endif
@@ -273,7 +273,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TilePixelSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TilePixelSize", typeof(int), 
+			nameof(TilePixelSize), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -281,7 +281,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Visible", typeof(bool), 
+			nameof(Visible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -289,7 +289,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ZIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ZIndex", typeof(int), 
+			nameof(ZIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -297,7 +297,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ZoomLevelRangeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ZoomLevelRange", typeof(global::Windows.UI.Xaml.Controls.Maps.MapZoomLevelRange), 
+			nameof(ZoomLevelRange), typeof(global::Windows.UI.Xaml.Controls.Maps.MapZoomLevelRange), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Maps.MapZoomLevelRange)));
 		#endif
@@ -305,7 +305,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AnimationStateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AnimationState", typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileAnimationState), 
+			nameof(AnimationState), typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileAnimationState), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Maps.MapTileAnimationState)));
 		#endif
@@ -313,7 +313,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AutoPlayProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AutoPlay", typeof(bool), 
+			nameof(AutoPlay), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -321,7 +321,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FrameCountProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FrameCount", typeof(int), 
+			nameof(FrameCount), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -329,11 +329,17 @@ namespace Windows.UI.Xaml.Controls.Maps
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FrameDurationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FrameDuration", typeof(global::System.TimeSpan), 
+			nameof(FrameDuration), typeof(global::System.TimeSpan), 
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(global::System.TimeSpan)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapTileSource.MapTileSource()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public MapTileSource() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapTileSource", "MapTileSource.MapTileSource()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapTileSource.MapTileSource()
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/StreetsidePanorama.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/StreetsidePanorama.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class StreetsidePanorama : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/AppBarButtonTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/AppBarButtonTemplateSettings.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class AppBarButtonTemplateSettings : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/AppBarToggleButtonTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/AppBarToggleButtonTemplateSettings.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class AppBarToggleButtonTemplateSettings : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ButtonBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ButtonBase.cs
@@ -38,7 +38,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ClickModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ClickMode", typeof(global::Windows.UI.Xaml.Controls.ClickMode), 
+			nameof(ClickMode), typeof(global::Windows.UI.Xaml.Controls.ClickMode), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ButtonBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ClickMode)));
 		#endif
@@ -48,7 +48,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsPointerOverProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsPointerOver", typeof(bool), 
+			nameof(IsPointerOver), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ButtonBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -56,7 +56,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsPressedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsPressed", typeof(bool), 
+			nameof(IsPressed), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ButtonBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/CalendarViewTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/CalendarViewTemplateSettings.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CalendarViewTemplateSettings : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ColorPickerSlider.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ColorPickerSlider.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ColorChannelProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ColorChannel", typeof(global::Windows.UI.Xaml.Controls.ColorPickerHsvChannel), 
+			nameof(ColorChannel), typeof(global::Windows.UI.Xaml.Controls.ColorPickerHsvChannel), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorPickerSlider), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ColorPickerHsvChannel)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ColorSpectrum.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ColorSpectrum.cs
@@ -151,7 +151,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Color", typeof(global::Windows.UI.Color), 
+			nameof(Color), typeof(global::Windows.UI.Color), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorSpectrum), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color)));
 		#endif
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ComponentsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Components", typeof(global::Windows.UI.Xaml.Controls.ColorSpectrumComponents), 
+			nameof(Components), typeof(global::Windows.UI.Xaml.Controls.ColorSpectrumComponents), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorSpectrum), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ColorSpectrumComponents)));
 		#endif
@@ -167,7 +167,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HsvColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HsvColor", typeof(global::System.Numerics.Vector4), 
+			nameof(HsvColor), typeof(global::System.Numerics.Vector4), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorSpectrum), 
 			new FrameworkPropertyMetadata(default(global::System.Numerics.Vector4)));
 		#endif
@@ -175,7 +175,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxHueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxHue", typeof(int), 
+			nameof(MaxHue), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorSpectrum), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -183,7 +183,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxSaturationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxSaturation", typeof(int), 
+			nameof(MaxSaturation), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorSpectrum), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -191,7 +191,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxValueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxValue", typeof(int), 
+			nameof(MaxValue), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorSpectrum), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -199,7 +199,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinHueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinHue", typeof(int), 
+			nameof(MinHue), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorSpectrum), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -207,7 +207,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinSaturationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinSaturation", typeof(int), 
+			nameof(MinSaturation), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorSpectrum), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -215,7 +215,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinValueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinValue", typeof(int), 
+			nameof(MinValue), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorSpectrum), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -223,7 +223,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ShapeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Shape", typeof(global::Windows.UI.Xaml.Controls.ColorSpectrumShape), 
+			nameof(Shape), typeof(global::Windows.UI.Xaml.Controls.ColorSpectrumShape), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ColorSpectrum), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ColorSpectrumShape)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/CommandBarFlyoutCommandBarTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/CommandBarFlyoutCommandBarTemplateSettings.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CommandBarFlyoutCommandBarTemplateSettings : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutBase.cs
@@ -140,7 +140,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AllowFocusOnInteractionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AllowFocusOnInteraction", typeof(bool), 
+			nameof(AllowFocusOnInteraction), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -148,7 +148,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AllowFocusWhenDisabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AllowFocusWhenDisabled", typeof(bool), 
+			nameof(AllowFocusWhenDisabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -156,7 +156,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ElementSoundModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ElementSoundMode", typeof(global::Windows.UI.Xaml.ElementSoundMode), 
+			nameof(ElementSoundMode), typeof(global::Windows.UI.Xaml.ElementSoundMode), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.ElementSoundMode)));
 		#endif
@@ -164,7 +164,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
+			nameof(LightDismissOverlayMode), typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
@@ -172,7 +172,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OverlayInputPassThroughElementProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OverlayInputPassThroughElement", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(OverlayInputPassThroughElement), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -180,7 +180,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AreOpenCloseAnimationsEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AreOpenCloseAnimationsEnabled", typeof(bool), 
+			nameof(AreOpenCloseAnimationsEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -188,7 +188,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty InputDevicePrefersPrimaryCommandsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"InputDevicePrefersPrimaryCommands", typeof(bool), 
+			nameof(InputDevicePrefersPrimaryCommands), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -196,7 +196,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsOpenProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsOpen", typeof(bool), 
+			nameof(IsOpen), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -204,7 +204,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ShowModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ShowMode", typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutShowMode), 
+			nameof(ShowMode), typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutShowMode), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutShowMode)));
 		#endif
@@ -212,7 +212,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Target", typeof(global::Windows.UI.Xaml.FrameworkElement), 
+			nameof(Target), typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.FrameworkElement)));
 		#endif
@@ -281,27 +281,9 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.FlyoutBase.ElementSoundModeProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.FlyoutBase.PlacementProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.FlyoutBase.AttachedFlyoutProperty.get
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase GetAttachedFlyout( global::Windows.UI.Xaml.FrameworkElement element)
-		{
-			return (global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)element.GetValue(AttachedFlyoutProperty);
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static void SetAttachedFlyout( global::Windows.UI.Xaml.FrameworkElement element,  global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase value)
-		{
-			element.SetValue(AttachedFlyoutProperty, value);
-		}
-#endif
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static void ShowAttachedFlyout( global::Windows.UI.Xaml.FrameworkElement flyoutOwner)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Primitives.FlyoutBase", "void FlyoutBase.ShowAttachedFlyout(FrameworkElement flyoutOwner)");
-		}
-#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.FlyoutBase.GetAttachedFlyout(Windows.UI.Xaml.FrameworkElement)
+		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.FlyoutBase.SetAttachedFlyout(Windows.UI.Xaml.FrameworkElement, Windows.UI.Xaml.Controls.Primitives.FlyoutBase)
+		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.FlyoutBase.ShowAttachedFlyout(Windows.UI.Xaml.FrameworkElement)
 		// Skipping already declared event Windows.UI.Xaml.Controls.Primitives.FlyoutBase.Closed
 		// Skipping already declared event Windows.UI.Xaml.Controls.Primitives.FlyoutBase.Opened
 		// Skipping already declared event Windows.UI.Xaml.Controls.Primitives.FlyoutBase.Opening

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutPlacementMode.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutPlacementMode.cs
@@ -13,33 +13,15 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.Left
 		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.Right
 		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.Full
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		TopEdgeAlignedLeft,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		TopEdgeAlignedRight,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		BottomEdgeAlignedLeft,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		BottomEdgeAlignedRight,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		LeftEdgeAlignedTop,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		LeftEdgeAlignedBottom,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		RightEdgeAlignedTop,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		RightEdgeAlignedBottom,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Auto,
-		#endif
+		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.TopEdgeAlignedLeft
+		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.TopEdgeAlignedRight
+		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.BottomEdgeAlignedLeft
+		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.BottomEdgeAlignedRight
+		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.LeftEdgeAlignedTop
+		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.LeftEdgeAlignedBottom
+		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.RightEdgeAlignedTop
+		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.RightEdgeAlignedBottom
+		// Skipping already declared field Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.Auto
 	}
 	#endif
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/GridViewItemPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/GridViewItemPresenter.cs
@@ -319,7 +319,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CheckBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CheckBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(CheckBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -327,7 +327,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CheckHintBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CheckHintBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(CheckHintBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -335,7 +335,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CheckSelectingBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CheckSelectingBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(CheckSelectingBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -343,7 +343,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentMarginProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentMargin", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(ContentMargin), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -351,7 +351,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisabledOpacityProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DisabledOpacity", typeof(double), 
+			nameof(DisabledOpacity), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -359,7 +359,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DragBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DragBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(DragBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -367,7 +367,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DragForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DragForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(DragForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -375,7 +375,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DragOpacityProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DragOpacity", typeof(double), 
+			nameof(DragOpacity), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -383,7 +383,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(FocusBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -391,7 +391,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GridViewItemPresenterHorizontalContentAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GridViewItemPresenterHorizontalContentAlignment", typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
+			nameof(GridViewItemPresenterHorizontalContentAlignment), typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.HorizontalAlignment)));
 		#endif
@@ -399,7 +399,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GridViewItemPresenterPaddingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GridViewItemPresenterPadding", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(GridViewItemPresenterPadding), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -407,7 +407,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GridViewItemPresenterVerticalContentAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GridViewItemPresenterVerticalContentAlignment", typeof(global::Windows.UI.Xaml.VerticalAlignment), 
+			nameof(GridViewItemPresenterVerticalContentAlignment), typeof(global::Windows.UI.Xaml.VerticalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.VerticalAlignment)));
 		#endif
@@ -415,7 +415,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaceholderBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(PlaceholderBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -423,7 +423,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PointerOverBackgroundMarginProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PointerOverBackgroundMargin", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(PointerOverBackgroundMargin), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -431,7 +431,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PointerOverBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PointerOverBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(PointerOverBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -439,7 +439,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ReorderHintOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ReorderHintOffset", typeof(double), 
+			nameof(ReorderHintOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -447,7 +447,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -455,7 +455,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedBorderThicknessProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedBorderThickness", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(SelectedBorderThickness), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -463,7 +463,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -471,7 +471,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedPointerOverBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedPointerOverBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedPointerOverBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -479,7 +479,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedPointerOverBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedPointerOverBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedPointerOverBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -487,7 +487,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionCheckMarkVisualEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionCheckMarkVisualEnabled", typeof(bool), 
+			nameof(SelectionCheckMarkVisualEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.GridViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/JumpListItemBackgroundConverter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/JumpListItemBackgroundConverter.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class JumpListItemBackgroundConverter : global::Windows.UI.Xaml.DependencyObject,global::Windows.UI.Xaml.Data.IValueConverter
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Disabled", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Disabled), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -47,11 +47,17 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Enabled", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Enabled), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter.JumpListItemBackgroundConverter()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public JumpListItemBackgroundConverter() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter", "JumpListItemBackgroundConverter.JumpListItemBackgroundConverter()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter.JumpListItemBackgroundConverter()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter.Enabled.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter.Enabled.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/JumpListItemForegroundConverter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/JumpListItemForegroundConverter.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class JumpListItemForegroundConverter : global::Windows.UI.Xaml.DependencyObject,global::Windows.UI.Xaml.Data.IValueConverter
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Disabled", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Disabled), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -47,11 +47,17 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Enabled", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Enabled), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter.JumpListItemForegroundConverter()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public JumpListItemForegroundConverter() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter", "JumpListItemForegroundConverter.JumpListItemForegroundConverter()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter.JumpListItemForegroundConverter()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter.Enabled.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter.Enabled.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/LayoutInformation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/LayoutInformation.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class LayoutInformation 
@@ -20,6 +20,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		{
 			throw new global::System.NotImplementedException("The member UIElement LayoutInformation.GetLayoutExceptionElement(object dispatcher) is not implemented in Uno.");
 		}
-#endif
+		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.LayoutInformation.GetLayoutSlot(Windows.UI.Xaml.FrameworkElement)
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ListViewItemPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ListViewItemPresenter.cs
@@ -459,7 +459,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CheckBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CheckBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(CheckBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -467,7 +467,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CheckHintBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CheckHintBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(CheckHintBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -475,7 +475,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CheckSelectingBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CheckSelectingBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(CheckSelectingBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -483,7 +483,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentMarginProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentMargin", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(ContentMargin), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -491,7 +491,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisabledOpacityProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DisabledOpacity", typeof(double), 
+			nameof(DisabledOpacity), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -499,7 +499,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DragBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DragBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(DragBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -507,7 +507,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DragForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DragForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(DragForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -515,7 +515,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DragOpacityProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DragOpacity", typeof(double), 
+			nameof(DragOpacity), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -523,7 +523,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(FocusBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -531,7 +531,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ListViewItemPresenterHorizontalContentAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ListViewItemPresenterHorizontalContentAlignment", typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
+			nameof(ListViewItemPresenterHorizontalContentAlignment), typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.HorizontalAlignment)));
 		#endif
@@ -539,7 +539,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ListViewItemPresenterPaddingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ListViewItemPresenterPadding", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(ListViewItemPresenterPadding), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -547,7 +547,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ListViewItemPresenterVerticalContentAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ListViewItemPresenterVerticalContentAlignment", typeof(global::Windows.UI.Xaml.VerticalAlignment), 
+			nameof(ListViewItemPresenterVerticalContentAlignment), typeof(global::Windows.UI.Xaml.VerticalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.VerticalAlignment)));
 		#endif
@@ -555,7 +555,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaceholderBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(PlaceholderBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -563,7 +563,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PointerOverBackgroundMarginProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PointerOverBackgroundMargin", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(PointerOverBackgroundMargin), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -571,7 +571,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PointerOverBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PointerOverBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(PointerOverBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -579,7 +579,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ReorderHintOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ReorderHintOffset", typeof(double), 
+			nameof(ReorderHintOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -587,7 +587,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -595,7 +595,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedBorderThicknessProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedBorderThickness", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(SelectedBorderThickness), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -603,7 +603,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -611,7 +611,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedPointerOverBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedPointerOverBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedPointerOverBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -619,7 +619,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedPointerOverBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedPointerOverBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedPointerOverBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -627,7 +627,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionCheckMarkVisualEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionCheckMarkVisualEnabled", typeof(bool), 
+			nameof(SelectionCheckMarkVisualEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -635,7 +635,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CheckBoxBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CheckBoxBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(CheckBoxBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -643,7 +643,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CheckModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CheckMode", typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenterCheckMode), 
+			nameof(CheckMode), typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenterCheckMode), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenterCheckMode)));
 		#endif
@@ -651,7 +651,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusSecondaryBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusSecondaryBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(FocusSecondaryBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -659,7 +659,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PointerOverForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PointerOverForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(PointerOverForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -667,7 +667,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PressedBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PressedBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(PressedBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -675,7 +675,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedPressedBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedPressedBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedPressedBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -683,7 +683,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RevealBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RevealBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(RevealBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -691,7 +691,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RevealBackgroundShowsAboveContentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RevealBackgroundShowsAboveContent", typeof(bool), 
+			nameof(RevealBackgroundShowsAboveContent), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -699,7 +699,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RevealBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RevealBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(RevealBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -707,7 +707,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RevealBorderThicknessProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RevealBorderThickness", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(RevealBorderThickness), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ListViewItemPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/LoopingSelector.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/LoopingSelector.cs
@@ -109,7 +109,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemHeight", typeof(int), 
+			nameof(ItemHeight), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.LoopingSelector), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(ItemTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.LoopingSelector), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -125,7 +125,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemWidth", typeof(int), 
+			nameof(ItemWidth), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.LoopingSelector), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -133,7 +133,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Items", typeof(global::System.Collections.Generic.IList<object>), 
+			nameof(Items), typeof(global::System.Collections.Generic.IList<object>), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.LoopingSelector), 
 			new FrameworkPropertyMetadata(default(global::System.Collections.Generic.IList<object>)));
 		#endif
@@ -141,7 +141,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedIndex", typeof(int), 
+			nameof(SelectedIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.LoopingSelector), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -149,7 +149,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedItemProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedItem", typeof(object), 
+			nameof(SelectedItem), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.LoopingSelector), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -157,7 +157,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ShouldLoopProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ShouldLoop", typeof(bool), 
+			nameof(ShouldLoop), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.LoopingSelector), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/MenuFlyoutItemTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/MenuFlyoutItemTemplateSettings.cs
@@ -2,5 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class MenuFlyoutItemTemplateSettings : global::Windows.UI.Xaml.DependencyObject
+	{
+		// Skipping already declared property KeyboardAcceleratorTextMinWidth
+		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.MenuFlyoutItemTemplateSettings.KeyboardAcceleratorTextMinWidth.get
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/MenuFlyoutPresenterTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/MenuFlyoutPresenterTemplateSettings.cs
@@ -2,5 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class MenuFlyoutPresenterTemplateSettings : global::Windows.UI.Xaml.DependencyObject
+	{
+		// Skipping already declared property FlyoutContentMinWidth
+		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.MenuFlyoutPresenterTemplateSettings.FlyoutContentMinWidth.get
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/PickerFlyoutBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/PickerFlyoutBase.cs
@@ -2,10 +2,10 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
-	public partial class PickerFlyoutBase : global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase
+	public  partial class PickerFlyoutBase : global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase
 	{
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
@@ -15,13 +15,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.PickerFlyoutBase), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
-		#if NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		protected PickerFlyoutBase() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Primitives.PickerFlyoutBase", "PickerFlyoutBase.PickerFlyoutBase()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.PickerFlyoutBase.PickerFlyoutBase()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.PickerFlyoutBase.PickerFlyoutBase()
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/PivotPanel.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/PivotPanel.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class PivotPanel : global::Windows.UI.Xaml.Controls.Panel,global::Windows.UI.Xaml.Controls.Primitives.IScrollSnapPointsInfo
@@ -27,13 +27,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public PivotPanel() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Primitives.PivotPanel", "PivotPanel.PivotPanel()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.PivotPanel.PivotPanel()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.PivotPanel.PivotPanel()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.PivotPanel.AreHorizontalSnapPointsRegular.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.PivotPanel.AreVerticalSnapPointsRegular.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/Popup.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/Popup.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || false || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Popup : global::Windows.UI.Xaml.FrameworkElement
@@ -109,7 +109,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ChildProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Child", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(Child), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.Popup), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ChildTransitionsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ChildTransitions", typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
+			nameof(ChildTransitions), typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.Popup), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.TransitionCollection)));
 		#endif
@@ -125,7 +125,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalOffset", typeof(double), 
+			nameof(HorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.Popup), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -133,7 +133,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsLightDismissEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsLightDismissEnabled", typeof(bool), 
+			nameof(IsLightDismissEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.Popup), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -141,7 +141,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsOpenProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsOpen", typeof(bool), 
+			nameof(IsOpen), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.Popup), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -149,7 +149,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalOffset", typeof(double), 
+			nameof(VerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.Popup), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -157,11 +157,11 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
+			nameof(LightDismissOverlayMode), typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.Popup), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || false || __MACOS__
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public Popup() : base()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ProgressRingTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ProgressRingTemplateSettings.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ProgressRingTemplateSettings : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/RepeatButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/RepeatButton.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DelayProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Delay", typeof(int), 
+			nameof(Delay), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.RepeatButton), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IntervalProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Interval", typeof(int), 
+			nameof(Interval), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.RepeatButton), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ScrollBar.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ScrollBar.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IndicatorModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IndicatorMode", typeof(global::Windows.UI.Xaml.Controls.Primitives.ScrollingIndicatorMode), 
+			nameof(IndicatorMode), typeof(global::Windows.UI.Xaml.Controls.Primitives.ScrollingIndicatorMode), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ScrollBar), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.ScrollingIndicatorMode)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OrientationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Orientation", typeof(global::Windows.UI.Xaml.Controls.Orientation), 
+			nameof(Orientation), typeof(global::Windows.UI.Xaml.Controls.Orientation), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ScrollBar), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Orientation)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ViewportSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ViewportSize", typeof(double), 
+			nameof(ViewportSize), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ScrollBar), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/Selector.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/Selector.cs
@@ -7,6 +7,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 	#endif
 	public  partial class Selector : global::Windows.UI.Xaml.Controls.ItemsControl
 	{
+		// Skipping already declared property SelectedValuePath
+		// Skipping already declared property SelectedValue
 		// Skipping already declared property SelectedItem
 		// Skipping already declared property SelectedIndex
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
@@ -27,12 +29,14 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsSynchronizedWithCurrentItemProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsSynchronizedWithCurrentItem", typeof(bool?), 
+			nameof(IsSynchronizedWithCurrentItem), typeof(bool?), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.Selector), 
 			new FrameworkPropertyMetadata(default(bool?)));
 		#endif
 		// Skipping already declared property SelectedIndexProperty
 		// Skipping already declared property SelectedItemProperty
+		// Skipping already declared property SelectedValuePathProperty
+		// Skipping already declared property SelectedValueProperty
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.Selector.SelectedIndex.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.Selector.SelectedIndex.set
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.Selector.SelectedItem.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/SettingsFlyoutTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/SettingsFlyoutTemplateSettings.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || false || NET461 || __WASM__ || false
+	#if __ANDROID__ || false || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SettingsFlyoutTemplateSettings : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ToggleButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ToggleButton.cs
@@ -27,7 +27,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsThreeStateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsThreeState", typeof(bool), 
+			nameof(IsThreeState), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.ToggleButton), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ToolTipTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ToolTipTemplateSettings.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ToolTipTemplateSettings : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AppBarButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AppBarButton.cs
@@ -115,7 +115,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IconProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Icon", typeof(global::Windows.UI.Xaml.Controls.IconElement), 
+			nameof(Icon), typeof(global::Windows.UI.Xaml.Controls.IconElement), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.IconElement)));
 		#endif
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsCompactProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsCompact", typeof(bool), 
+			nameof(IsCompact), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarButton), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -131,7 +131,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LabelProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Label", typeof(string), 
+			nameof(Label), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarButton), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -139,7 +139,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DynamicOverflowOrderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DynamicOverflowOrder", typeof(int), 
+			nameof(DynamicOverflowOrder), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarButton), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -147,7 +147,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsInOverflowProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsInOverflow", typeof(bool), 
+			nameof(IsInOverflow), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarButton), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -155,7 +155,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LabelPositionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LabelPosition", typeof(global::Windows.UI.Xaml.Controls.CommandBarLabelPosition), 
+			nameof(LabelPosition), typeof(global::Windows.UI.Xaml.Controls.CommandBarLabelPosition), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.CommandBarLabelPosition)));
 		#endif
@@ -163,7 +163,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyboardAcceleratorTextOverrideProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyboardAcceleratorTextOverride", typeof(string), 
+			nameof(KeyboardAcceleratorTextOverride), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarButton), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AppBarElementContainer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AppBarElementContainer.cs
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DynamicOverflowOrderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DynamicOverflowOrder", typeof(int), 
+			nameof(DynamicOverflowOrder), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarElementContainer), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -57,7 +57,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsCompactProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsCompact", typeof(bool), 
+			nameof(IsCompact), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarElementContainer), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -65,7 +65,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsInOverflowProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsInOverflow", typeof(bool), 
+			nameof(IsInOverflow), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarElementContainer), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AppBarToggleButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AppBarToggleButton.cs
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyboardAcceleratorTextOverrideProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyboardAcceleratorTextOverride", typeof(string), 
+			nameof(KeyboardAcceleratorTextOverride), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.AppBarToggleButton), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBox.cs
@@ -59,7 +59,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
+			nameof(LightDismissOverlayMode), typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
@@ -67,7 +67,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Description", typeof(object), 
+			nameof(Description), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/BitmapIconSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/BitmapIconSource.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ShowAsMonochromeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ShowAsMonochrome", typeof(bool), 
+			nameof(ShowAsMonochrome), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.BitmapIconSource), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty UriSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"UriSource", typeof(global::System.Uri), 
+			nameof(UriSource), typeof(global::System.Uri), 
 			typeof(global::Windows.UI.Xaml.Controls.BitmapIconSource), 
 			new FrameworkPropertyMetadata(default(global::System.Uri)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Border.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Border.cs
@@ -52,7 +52,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BackgroundSizingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BackgroundSizing", typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
+			nameof(BackgroundSizing), typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
 			typeof(global::Windows.UI.Xaml.Controls.Border), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.BackgroundSizing)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/CalendarDatePicker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/CalendarDatePicker.cs
@@ -263,7 +263,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CalendarIdentifierProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CalendarIdentifier", typeof(string), 
+			nameof(CalendarIdentifier), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -271,7 +271,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CalendarViewStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CalendarViewStyle", typeof(global::Windows.UI.Xaml.Style), 
+			nameof(CalendarViewStyle), typeof(global::Windows.UI.Xaml.Style), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Style)));
 		#endif
@@ -279,7 +279,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DateFormatProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DateFormat", typeof(string), 
+			nameof(DateFormat), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -287,7 +287,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Date", typeof(global::System.DateTimeOffset?), 
+			nameof(Date), typeof(global::System.DateTimeOffset?), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(global::System.DateTimeOffset?)));
 		#endif
@@ -295,7 +295,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DayOfWeekFormatProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DayOfWeekFormat", typeof(string), 
+			nameof(DayOfWeekFormat), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -303,7 +303,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisplayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DisplayMode", typeof(global::Windows.UI.Xaml.Controls.CalendarViewDisplayMode), 
+			nameof(DisplayMode), typeof(global::Windows.UI.Xaml.Controls.CalendarViewDisplayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.CalendarViewDisplayMode)));
 		#endif
@@ -311,7 +311,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FirstDayOfWeekProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FirstDayOfWeek", typeof(global::Windows.Globalization.DayOfWeek), 
+			nameof(FirstDayOfWeek), typeof(global::Windows.Globalization.DayOfWeek), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.Globalization.DayOfWeek)));
 		#endif
@@ -319,7 +319,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Header", typeof(object), 
+			nameof(Header), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -327,7 +327,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(HeaderTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -335,7 +335,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsCalendarOpenProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsCalendarOpen", typeof(bool), 
+			nameof(IsCalendarOpen), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -343,7 +343,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsGroupLabelVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsGroupLabelVisible", typeof(bool), 
+			nameof(IsGroupLabelVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -351,7 +351,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsOutOfScopeEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsOutOfScopeEnabled", typeof(bool), 
+			nameof(IsOutOfScopeEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -359,7 +359,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTodayHighlightedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTodayHighlighted", typeof(bool), 
+			nameof(IsTodayHighlighted), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -367,7 +367,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxDateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxDate", typeof(global::System.DateTimeOffset), 
+			nameof(MaxDate), typeof(global::System.DateTimeOffset), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(global::System.DateTimeOffset)));
 		#endif
@@ -375,7 +375,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinDateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinDate", typeof(global::System.DateTimeOffset), 
+			nameof(MinDate), typeof(global::System.DateTimeOffset), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(global::System.DateTimeOffset)));
 		#endif
@@ -383,7 +383,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaceholderText", typeof(string), 
+			nameof(PlaceholderText), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -391,7 +391,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
+			nameof(LightDismissOverlayMode), typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
@@ -399,7 +399,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Description", typeof(object), 
+			nameof(Description), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarDatePicker), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/CalendarView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/CalendarView.cs
@@ -717,7 +717,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BlackoutForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BlackoutForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(BlackoutForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -725,7 +725,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CalendarIdentifierProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CalendarIdentifier", typeof(string), 
+			nameof(CalendarIdentifier), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -733,7 +733,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CalendarItemBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CalendarItemBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(CalendarItemBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -741,7 +741,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CalendarItemBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CalendarItemBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(CalendarItemBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -749,7 +749,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CalendarItemBorderThicknessProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CalendarItemBorderThickness", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(CalendarItemBorderThickness), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -757,7 +757,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CalendarItemForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CalendarItemForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(CalendarItemForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -765,7 +765,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CalendarViewDayItemStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CalendarViewDayItemStyle", typeof(global::Windows.UI.Xaml.Style), 
+			nameof(CalendarViewDayItemStyle), typeof(global::Windows.UI.Xaml.Style), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Style)));
 		#endif
@@ -773,7 +773,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DayItemFontFamilyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DayItemFontFamily", typeof(global::Windows.UI.Xaml.Media.FontFamily), 
+			nameof(DayItemFontFamily), typeof(global::Windows.UI.Xaml.Media.FontFamily), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FontFamily)));
 		#endif
@@ -781,7 +781,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DayItemFontSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DayItemFontSize", typeof(double), 
+			nameof(DayItemFontSize), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -789,7 +789,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DayItemFontStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DayItemFontStyle", typeof(global::Windows.UI.Text.FontStyle), 
+			nameof(DayItemFontStyle), typeof(global::Windows.UI.Text.FontStyle), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStyle)));
 		#endif
@@ -797,7 +797,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DayItemFontWeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DayItemFontWeight", typeof(global::Windows.UI.Text.FontWeight), 
+			nameof(DayItemFontWeight), typeof(global::Windows.UI.Text.FontWeight), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontWeight)));
 		#endif
@@ -805,7 +805,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DayOfWeekFormatProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DayOfWeekFormat", typeof(string), 
+			nameof(DayOfWeekFormat), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -813,7 +813,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisplayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DisplayMode", typeof(global::Windows.UI.Xaml.Controls.CalendarViewDisplayMode), 
+			nameof(DisplayMode), typeof(global::Windows.UI.Xaml.Controls.CalendarViewDisplayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.CalendarViewDisplayMode)));
 		#endif
@@ -821,7 +821,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FirstDayOfWeekProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FirstDayOfWeek", typeof(global::Windows.Globalization.DayOfWeek), 
+			nameof(FirstDayOfWeek), typeof(global::Windows.Globalization.DayOfWeek), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.Globalization.DayOfWeek)));
 		#endif
@@ -829,7 +829,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FirstOfMonthLabelFontFamilyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FirstOfMonthLabelFontFamily", typeof(global::Windows.UI.Xaml.Media.FontFamily), 
+			nameof(FirstOfMonthLabelFontFamily), typeof(global::Windows.UI.Xaml.Media.FontFamily), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FontFamily)));
 		#endif
@@ -837,7 +837,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FirstOfMonthLabelFontSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FirstOfMonthLabelFontSize", typeof(double), 
+			nameof(FirstOfMonthLabelFontSize), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -845,7 +845,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FirstOfMonthLabelFontStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FirstOfMonthLabelFontStyle", typeof(global::Windows.UI.Text.FontStyle), 
+			nameof(FirstOfMonthLabelFontStyle), typeof(global::Windows.UI.Text.FontStyle), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStyle)));
 		#endif
@@ -853,7 +853,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FirstOfMonthLabelFontWeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FirstOfMonthLabelFontWeight", typeof(global::Windows.UI.Text.FontWeight), 
+			nameof(FirstOfMonthLabelFontWeight), typeof(global::Windows.UI.Text.FontWeight), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontWeight)));
 		#endif
@@ -861,7 +861,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FirstOfYearDecadeLabelFontFamilyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FirstOfYearDecadeLabelFontFamily", typeof(global::Windows.UI.Xaml.Media.FontFamily), 
+			nameof(FirstOfYearDecadeLabelFontFamily), typeof(global::Windows.UI.Xaml.Media.FontFamily), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FontFamily)));
 		#endif
@@ -869,7 +869,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FirstOfYearDecadeLabelFontSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FirstOfYearDecadeLabelFontSize", typeof(double), 
+			nameof(FirstOfYearDecadeLabelFontSize), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -877,7 +877,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FirstOfYearDecadeLabelFontStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FirstOfYearDecadeLabelFontStyle", typeof(global::Windows.UI.Text.FontStyle), 
+			nameof(FirstOfYearDecadeLabelFontStyle), typeof(global::Windows.UI.Text.FontStyle), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStyle)));
 		#endif
@@ -885,7 +885,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FirstOfYearDecadeLabelFontWeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FirstOfYearDecadeLabelFontWeight", typeof(global::Windows.UI.Text.FontWeight), 
+			nameof(FirstOfYearDecadeLabelFontWeight), typeof(global::Windows.UI.Text.FontWeight), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontWeight)));
 		#endif
@@ -893,7 +893,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(FocusBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -901,7 +901,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalDayItemAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalDayItemAlignment", typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
+			nameof(HorizontalDayItemAlignment), typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.HorizontalAlignment)));
 		#endif
@@ -909,7 +909,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalFirstOfMonthLabelAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalFirstOfMonthLabelAlignment", typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
+			nameof(HorizontalFirstOfMonthLabelAlignment), typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.HorizontalAlignment)));
 		#endif
@@ -917,7 +917,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HoverBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HoverBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(HoverBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -925,7 +925,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsGroupLabelVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsGroupLabelVisible", typeof(bool), 
+			nameof(IsGroupLabelVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -933,7 +933,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsOutOfScopeEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsOutOfScopeEnabled", typeof(bool), 
+			nameof(IsOutOfScopeEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -941,7 +941,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTodayHighlightedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTodayHighlighted", typeof(bool), 
+			nameof(IsTodayHighlighted), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -949,7 +949,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxDateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxDate", typeof(global::System.DateTimeOffset), 
+			nameof(MaxDate), typeof(global::System.DateTimeOffset), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::System.DateTimeOffset)));
 		#endif
@@ -957,7 +957,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinDateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinDate", typeof(global::System.DateTimeOffset), 
+			nameof(MinDate), typeof(global::System.DateTimeOffset), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::System.DateTimeOffset)));
 		#endif
@@ -965,7 +965,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MonthYearItemFontFamilyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MonthYearItemFontFamily", typeof(global::Windows.UI.Xaml.Media.FontFamily), 
+			nameof(MonthYearItemFontFamily), typeof(global::Windows.UI.Xaml.Media.FontFamily), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FontFamily)));
 		#endif
@@ -973,7 +973,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MonthYearItemFontSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MonthYearItemFontSize", typeof(double), 
+			nameof(MonthYearItemFontSize), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -981,7 +981,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MonthYearItemFontStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MonthYearItemFontStyle", typeof(global::Windows.UI.Text.FontStyle), 
+			nameof(MonthYearItemFontStyle), typeof(global::Windows.UI.Text.FontStyle), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStyle)));
 		#endif
@@ -989,7 +989,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MonthYearItemFontWeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MonthYearItemFontWeight", typeof(global::Windows.UI.Text.FontWeight), 
+			nameof(MonthYearItemFontWeight), typeof(global::Windows.UI.Text.FontWeight), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontWeight)));
 		#endif
@@ -997,7 +997,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty NumberOfWeeksInViewProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"NumberOfWeeksInView", typeof(int), 
+			nameof(NumberOfWeeksInView), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -1005,7 +1005,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OutOfScopeBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OutOfScopeBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(OutOfScopeBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -1013,7 +1013,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OutOfScopeForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OutOfScopeForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(OutOfScopeForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -1021,7 +1021,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PressedBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PressedBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(PressedBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -1029,7 +1029,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PressedForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PressedForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(PressedForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -1037,7 +1037,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -1045,7 +1045,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedDatesProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedDates", typeof(global::System.Collections.Generic.IList<global::System.DateTimeOffset>), 
+			nameof(SelectedDates), typeof(global::System.Collections.Generic.IList<global::System.DateTimeOffset>), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::System.Collections.Generic.IList<global::System.DateTimeOffset>)));
 		#endif
@@ -1053,7 +1053,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -1061,7 +1061,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedHoverBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedHoverBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedHoverBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -1069,7 +1069,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedPressedBorderBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedPressedBorderBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedPressedBorderBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -1077,7 +1077,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionMode", typeof(global::Windows.UI.Xaml.Controls.CalendarViewSelectionMode), 
+			nameof(SelectionMode), typeof(global::Windows.UI.Xaml.Controls.CalendarViewSelectionMode), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.CalendarViewSelectionMode)));
 		#endif
@@ -1085,7 +1085,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TemplateSettingsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TemplateSettings", typeof(global::Windows.UI.Xaml.Controls.Primitives.CalendarViewTemplateSettings), 
+			nameof(TemplateSettings), typeof(global::Windows.UI.Xaml.Controls.Primitives.CalendarViewTemplateSettings), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.CalendarViewTemplateSettings)));
 		#endif
@@ -1093,7 +1093,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TodayFontWeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TodayFontWeight", typeof(global::Windows.UI.Text.FontWeight), 
+			nameof(TodayFontWeight), typeof(global::Windows.UI.Text.FontWeight), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontWeight)));
 		#endif
@@ -1101,7 +1101,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TodayForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TodayForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(TodayForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -1109,7 +1109,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalDayItemAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalDayItemAlignment", typeof(global::Windows.UI.Xaml.VerticalAlignment), 
+			nameof(VerticalDayItemAlignment), typeof(global::Windows.UI.Xaml.VerticalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.VerticalAlignment)));
 		#endif
@@ -1117,7 +1117,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalFirstOfMonthLabelAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalFirstOfMonthLabelAlignment", typeof(global::Windows.UI.Xaml.VerticalAlignment), 
+			nameof(VerticalFirstOfMonthLabelAlignment), typeof(global::Windows.UI.Xaml.VerticalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.VerticalAlignment)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/CalendarViewDayItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/CalendarViewDayItem.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Date", typeof(global::System.DateTimeOffset), 
+			nameof(Date), typeof(global::System.DateTimeOffset), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarViewDayItem), 
 			new FrameworkPropertyMetadata(default(global::System.DateTimeOffset)));
 		#endif
@@ -43,7 +43,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsBlackoutProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsBlackout", typeof(bool), 
+			nameof(IsBlackout), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.CalendarViewDayItem), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/CaptureElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/CaptureElement.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Source", typeof(global::Windows.Media.Capture.MediaCapture), 
+			nameof(Source), typeof(global::Windows.Media.Capture.MediaCapture), 
 			typeof(global::Windows.UI.Xaml.Controls.CaptureElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.Media.Capture.MediaCapture)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Stretch", typeof(global::Windows.UI.Xaml.Media.Stretch), 
+			nameof(Stretch), typeof(global::Windows.UI.Xaml.Media.Stretch), 
 			typeof(global::Windows.UI.Xaml.Controls.CaptureElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Stretch)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ColorPicker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ColorPicker.cs
@@ -277,7 +277,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Color", typeof(global::Windows.UI.Color), 
+			nameof(Color), typeof(global::Windows.UI.Color), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color)));
 		#endif
@@ -285,7 +285,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ColorSpectrumComponentsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ColorSpectrumComponents", typeof(global::Windows.UI.Xaml.Controls.ColorSpectrumComponents), 
+			nameof(ColorSpectrumComponents), typeof(global::Windows.UI.Xaml.Controls.ColorSpectrumComponents), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ColorSpectrumComponents)));
 		#endif
@@ -293,7 +293,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ColorSpectrumShapeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ColorSpectrumShape", typeof(global::Windows.UI.Xaml.Controls.ColorSpectrumShape), 
+			nameof(ColorSpectrumShape), typeof(global::Windows.UI.Xaml.Controls.ColorSpectrumShape), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ColorSpectrumShape)));
 		#endif
@@ -301,7 +301,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsAlphaEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsAlphaEnabled", typeof(bool), 
+			nameof(IsAlphaEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -309,7 +309,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsAlphaSliderVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsAlphaSliderVisible", typeof(bool), 
+			nameof(IsAlphaSliderVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -317,7 +317,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsAlphaTextInputVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsAlphaTextInputVisible", typeof(bool), 
+			nameof(IsAlphaTextInputVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -325,7 +325,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsColorChannelTextInputVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsColorChannelTextInputVisible", typeof(bool), 
+			nameof(IsColorChannelTextInputVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -333,7 +333,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsColorPreviewVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsColorPreviewVisible", typeof(bool), 
+			nameof(IsColorPreviewVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -341,7 +341,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsColorSliderVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsColorSliderVisible", typeof(bool), 
+			nameof(IsColorSliderVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -349,7 +349,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsColorSpectrumVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsColorSpectrumVisible", typeof(bool), 
+			nameof(IsColorSpectrumVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -357,7 +357,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsHexInputVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsHexInputVisible", typeof(bool), 
+			nameof(IsHexInputVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -365,7 +365,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsMoreButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsMoreButtonVisible", typeof(bool), 
+			nameof(IsMoreButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -373,7 +373,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxHueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxHue", typeof(int), 
+			nameof(MaxHue), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -381,7 +381,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxSaturationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxSaturation", typeof(int), 
+			nameof(MaxSaturation), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -389,7 +389,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxValueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxValue", typeof(int), 
+			nameof(MaxValue), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -397,7 +397,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinHueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinHue", typeof(int), 
+			nameof(MinHue), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -405,7 +405,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinSaturationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinSaturation", typeof(int), 
+			nameof(MinSaturation), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -413,7 +413,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinValueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinValue", typeof(int), 
+			nameof(MinValue), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -421,7 +421,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PreviousColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PreviousColor", typeof(global::Windows.UI.Color?), 
+			nameof(PreviousColor), typeof(global::Windows.UI.Color?), 
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color?)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ColumnDefinition.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ColumnDefinition.cs
@@ -8,6 +8,8 @@ namespace Windows.UI.Xaml.Controls
 	public  partial class ColumnDefinition : global::Windows.UI.Xaml.DependencyObject
 	{
 		// Skipping already declared property Width
+		// Skipping already declared property MinWidth
+		// Skipping already declared property MaxWidth
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  double ActualWidth
@@ -18,6 +20,8 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
+		// Skipping already declared property MaxWidthProperty
+		// Skipping already declared property MinWidthProperty
 		// Skipping already declared property WidthProperty
 		// Skipping already declared method Windows.UI.Xaml.Controls.ColumnDefinition.ColumnDefinition()
 		// Forced skipping of method Windows.UI.Xaml.Controls.ColumnDefinition.ColumnDefinition()

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ComboBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ComboBox.cs
@@ -164,7 +164,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextSearchEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextSearchEnabled", typeof(bool), 
+			nameof(IsTextSearchEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -172,7 +172,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
+			nameof(LightDismissOverlayMode), typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
@@ -180,7 +180,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionChangedTriggerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionChangedTrigger", typeof(global::Windows.UI.Xaml.Controls.ComboBoxSelectionChangedTrigger), 
+			nameof(SelectionChangedTrigger), typeof(global::Windows.UI.Xaml.Controls.ComboBoxSelectionChangedTrigger), 
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ComboBoxSelectionChangedTrigger)));
 		#endif
@@ -188,7 +188,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaceholderForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(PlaceholderForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -196,7 +196,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Description", typeof(object), 
+			nameof(Description), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -204,7 +204,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsEditableProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsEditable", typeof(bool), 
+			nameof(IsEditable), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -212,7 +212,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextBoxStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextBoxStyle", typeof(global::Windows.UI.Xaml.Style), 
+			nameof(TextBoxStyle), typeof(global::Windows.UI.Xaml.Style), 
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Style)));
 		#endif
@@ -220,7 +220,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Text", typeof(string), 
+			nameof(Text), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialog.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialog.cs
@@ -2,8 +2,123 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
 	public  partial class ContentDialog : global::Windows.UI.Xaml.Controls.ContentControl
 	{
-
+		// Skipping already declared property TitleTemplate
+		// Skipping already declared property Title
+		// Skipping already declared property SecondaryButtonText
+		// Skipping already declared property SecondaryButtonCommandParameter
+		// Skipping already declared property SecondaryButtonCommand
+		// Skipping already declared property PrimaryButtonText
+		// Skipping already declared property PrimaryButtonCommandParameter
+		// Skipping already declared property PrimaryButtonCommand
+		// Skipping already declared property IsSecondaryButtonEnabled
+		// Skipping already declared property IsPrimaryButtonEnabled
+		// Skipping already declared property FullSizeDesired
+		// Skipping already declared property SecondaryButtonStyle
+		// Skipping already declared property PrimaryButtonStyle
+		// Skipping already declared property DefaultButton
+		// Skipping already declared property CloseButtonText
+		// Skipping already declared property CloseButtonStyle
+		// Skipping already declared property CloseButtonCommandParameter
+		// Skipping already declared property CloseButtonCommand
+		// Skipping already declared property FullSizeDesiredProperty
+		// Skipping already declared property IsPrimaryButtonEnabledProperty
+		// Skipping already declared property IsSecondaryButtonEnabledProperty
+		// Skipping already declared property PrimaryButtonCommandParameterProperty
+		// Skipping already declared property PrimaryButtonCommandProperty
+		// Skipping already declared property PrimaryButtonTextProperty
+		// Skipping already declared property SecondaryButtonCommandParameterProperty
+		// Skipping already declared property SecondaryButtonCommandProperty
+		// Skipping already declared property SecondaryButtonTextProperty
+		// Skipping already declared property TitleProperty
+		// Skipping already declared property TitleTemplateProperty
+		// Skipping already declared property CloseButtonCommandParameterProperty
+		// Skipping already declared property CloseButtonCommandProperty
+		// Skipping already declared property CloseButtonStyleProperty
+		// Skipping already declared property CloseButtonTextProperty
+		// Skipping already declared property DefaultButtonProperty
+		// Skipping already declared property PrimaryButtonStyleProperty
+		// Skipping already declared property SecondaryButtonStyleProperty
+		// Skipping already declared method Windows.UI.Xaml.Controls.ContentDialog.ContentDialog()
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.ContentDialog()
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.Title.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.Title.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.TitleTemplate.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.TitleTemplate.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.FullSizeDesired.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.FullSizeDesired.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonText.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonText.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonText.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonText.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonCommand.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonCommand.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonCommand.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonCommand.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonCommandParameter.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonCommandParameter.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonCommandParameter.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonCommandParameter.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.IsPrimaryButtonEnabled.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.IsPrimaryButtonEnabled.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.IsSecondaryButtonEnabled.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.IsSecondaryButtonEnabled.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.Closing.add
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.Closing.remove
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.Closed.add
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.Closed.remove
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.Opened.add
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.Opened.remove
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonClick.add
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonClick.remove
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonClick.add
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonClick.remove
+		// Skipping already declared method Windows.UI.Xaml.Controls.ContentDialog.Hide()
+		// Skipping already declared method Windows.UI.Xaml.Controls.ContentDialog.ShowAsync()
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonText.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonText.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonCommand.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonCommand.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonCommandParameter.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonCommandParameter.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonStyle.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonStyle.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonStyle.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonStyle.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonStyle.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonStyle.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.DefaultButton.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.DefaultButton.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonClick.add
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonClick.remove
+		// Skipping already declared method Windows.UI.Xaml.Controls.ContentDialog.ShowAsync(Windows.UI.Xaml.Controls.ContentDialogPlacement)
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonTextProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonCommandProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonCommandParameterProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonStyleProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonStyleProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.CloseButtonStyleProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.DefaultButtonProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.TitleProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.TitleTemplateProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.FullSizeDesiredProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonTextProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonTextProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonCommandProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonCommandProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonCommandParameterProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonCommandParameterProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.IsPrimaryButtonEnabledProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialog.IsSecondaryButtonEnabledProperty.get
+		// Skipping already declared event Windows.UI.Xaml.Controls.ContentDialog.Closed
+		// Skipping already declared event Windows.UI.Xaml.Controls.ContentDialog.Closing
+		// Skipping already declared event Windows.UI.Xaml.Controls.ContentDialog.Opened
+		// Skipping already declared event Windows.UI.Xaml.Controls.ContentDialog.PrimaryButtonClick
+		// Skipping already declared event Windows.UI.Xaml.Controls.ContentDialog.SecondaryButtonClick
+		// Skipping already declared event Windows.UI.Xaml.Controls.ContentDialog.CloseButtonClick
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogButton.cs
@@ -2,5 +2,16 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum ContentDialogButton 
+	{
+		// Skipping already declared field Windows.UI.Xaml.Controls.ContentDialogButton.None
+		// Skipping already declared field Windows.UI.Xaml.Controls.ContentDialogButton.Primary
+		// Skipping already declared field Windows.UI.Xaml.Controls.ContentDialogButton.Secondary
+		// Skipping already declared field Windows.UI.Xaml.Controls.ContentDialogButton.Close
+	}
+	#endif
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogButtonClickDeferral.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogButtonClickDeferral.cs
@@ -2,5 +2,11 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class ContentDialogButtonClickDeferral 
+	{
+		// Skipping already declared method Windows.UI.Xaml.Controls.ContentDialogButtonClickDeferral.Complete()
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogButtonClickEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogButtonClickEventArgs.cs
@@ -2,5 +2,14 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class ContentDialogButtonClickEventArgs 
+	{
+		// Skipping already declared property Cancel
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialogButtonClickEventArgs.Cancel.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialogButtonClickEventArgs.Cancel.set
+		// Skipping already declared method Windows.UI.Xaml.Controls.ContentDialogButtonClickEventArgs.GetDeferral()
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogClosedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogClosedEventArgs.cs
@@ -2,5 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class ContentDialogClosedEventArgs 
+	{
+		// Skipping already declared property Result
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialogClosedEventArgs.Result.get
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogClosingDeferral.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogClosingDeferral.cs
@@ -2,5 +2,11 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class ContentDialogClosingDeferral 
+	{
+		// Skipping already declared method Windows.UI.Xaml.Controls.ContentDialogClosingDeferral.Complete()
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogClosingEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogClosingEventArgs.cs
@@ -2,5 +2,16 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class ContentDialogClosingEventArgs 
+	{
+		// Skipping already declared property Cancel
+		// Skipping already declared property Result
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialogClosingEventArgs.Result.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialogClosingEventArgs.Cancel.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.ContentDialogClosingEventArgs.Cancel.set
+		// Skipping already declared method Windows.UI.Xaml.Controls.ContentDialogClosingEventArgs.GetDeferral()
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogOpenedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogOpenedEventArgs.cs
@@ -2,5 +2,10 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class ContentDialogOpenedEventArgs 
+	{
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogPlacement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogPlacement.cs
@@ -2,5 +2,14 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum ContentDialogPlacement 
+	{
+		// Skipping already declared field Windows.UI.Xaml.Controls.ContentDialogPlacement.Popup
+		// Skipping already declared field Windows.UI.Xaml.Controls.ContentDialogPlacement.InPlace
+	}
+	#endif
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogResult.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentDialogResult.cs
@@ -2,5 +2,15 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public   enum ContentDialogResult 
+	{
+		// Skipping already declared field Windows.UI.Xaml.Controls.ContentDialogResult.None
+		// Skipping already declared field Windows.UI.Xaml.Controls.ContentDialogResult.Primary
+		// Skipping already declared field Windows.UI.Xaml.Controls.ContentDialogResult.Secondary
+	}
+	#endif
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ContentPresenter.cs
@@ -155,7 +155,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CharacterSpacingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CharacterSpacing", typeof(int), 
+			nameof(CharacterSpacing), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.ContentPresenter), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -169,7 +169,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontStretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontStretch", typeof(global::Windows.UI.Text.FontStretch), 
+			nameof(FontStretch), typeof(global::Windows.UI.Text.FontStretch), 
 			typeof(global::Windows.UI.Xaml.Controls.ContentPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStretch)));
 		#endif
@@ -180,7 +180,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OpticalMarginAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OpticalMarginAlignment", typeof(global::Windows.UI.Xaml.OpticalMarginAlignment), 
+			nameof(OpticalMarginAlignment), typeof(global::Windows.UI.Xaml.OpticalMarginAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.ContentPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.OpticalMarginAlignment)));
 		#endif
@@ -188,7 +188,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextLineBoundsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextLineBounds", typeof(global::Windows.UI.Xaml.TextLineBounds), 
+			nameof(TextLineBounds), typeof(global::Windows.UI.Xaml.TextLineBounds), 
 			typeof(global::Windows.UI.Xaml.Controls.ContentPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextLineBounds)));
 		#endif
@@ -196,7 +196,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextScaleFactorEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextScaleFactorEnabled", typeof(bool), 
+			nameof(IsTextScaleFactorEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ContentPresenter), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -209,7 +209,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LineHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LineHeight", typeof(double), 
+			nameof(LineHeight), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ContentPresenter), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -217,7 +217,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LineStackingStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LineStackingStrategy", typeof(global::Windows.UI.Xaml.LineStackingStrategy), 
+			nameof(LineStackingStrategy), typeof(global::Windows.UI.Xaml.LineStackingStrategy), 
 			typeof(global::Windows.UI.Xaml.Controls.ContentPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.LineStackingStrategy)));
 		#endif
@@ -229,7 +229,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BackgroundSizingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BackgroundSizing", typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
+			nameof(BackgroundSizing), typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
 			typeof(global::Windows.UI.Xaml.Controls.ContentPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.BackgroundSizing)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Control.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Control.cs
@@ -269,7 +269,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontStretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontStretch", typeof(global::Windows.UI.Text.FontStretch), 
+			nameof(FontStretch), typeof(global::Windows.UI.Text.FontStretch), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStretch)));
 		#endif
@@ -281,7 +281,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsEnabled", typeof(bool), 
+			nameof(IsEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -291,7 +291,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TabIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TabIndex", typeof(int), 
+			nameof(TabIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -299,7 +299,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TabNavigationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TabNavigation", typeof(global::Windows.UI.Xaml.Input.KeyboardNavigationMode), 
+			nameof(TabNavigation), typeof(global::Windows.UI.Xaml.Input.KeyboardNavigationMode), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.KeyboardNavigationMode)));
 		#endif
@@ -311,7 +311,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CharacterSpacingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CharacterSpacing", typeof(int), 
+			nameof(CharacterSpacing), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -319,7 +319,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DefaultStyleKeyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DefaultStyleKey", typeof(object), 
+			nameof(DefaultStyleKey), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -327,7 +327,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextScaleFactorEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextScaleFactorEnabled", typeof(bool), 
+			nameof(IsTextScaleFactorEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -343,7 +343,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty UseSystemFocusVisualsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"UseSystemFocusVisuals", typeof(bool), 
+			nameof(UseSystemFocusVisuals), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -351,7 +351,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ElementSoundModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ElementSoundMode", typeof(global::Windows.UI.Xaml.ElementSoundMode), 
+			nameof(ElementSoundMode), typeof(global::Windows.UI.Xaml.ElementSoundMode), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.ElementSoundMode)));
 		#endif
@@ -359,7 +359,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFocusEngagedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFocusEngaged", typeof(bool), 
+			nameof(IsFocusEngaged), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -367,7 +367,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFocusEngagementEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFocusEngagementEnabled", typeof(bool), 
+			nameof(IsFocusEngagementEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -375,7 +375,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RequiresPointerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RequiresPointer", typeof(global::Windows.UI.Xaml.Controls.RequiresPointer), 
+			nameof(RequiresPointer), typeof(global::Windows.UI.Xaml.Controls.RequiresPointer), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.RequiresPointer)));
 		#endif
@@ -383,7 +383,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusDownProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusDown", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusDown), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -391,7 +391,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusLeftProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusLeft", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusLeft), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -399,7 +399,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusRightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusRight", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusRight), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -407,7 +407,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusUpProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusUp", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusUp), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -415,7 +415,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DefaultStyleResourceUriProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DefaultStyleResourceUri", typeof(global::System.Uri), 
+			nameof(DefaultStyleResourceUri), typeof(global::System.Uri), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::System.Uri)));
 		#endif
@@ -431,7 +431,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CornerRadiusProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CornerRadius", typeof(global::Windows.UI.Xaml.CornerRadius), 
+			nameof(CornerRadius), typeof(global::Windows.UI.Xaml.CornerRadius), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.CornerRadius)));
 		#endif
@@ -439,7 +439,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BackgroundSizingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BackgroundSizing", typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
+			nameof(BackgroundSizing), typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
 			typeof(global::Windows.UI.Xaml.Controls.Control), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.BackgroundSizing)));
 		#endif
@@ -531,13 +531,7 @@ namespace Windows.UI.Xaml.Controls
 		// Skipping already declared method Windows.UI.Xaml.Controls.Control.OnPointerMoved(Windows.UI.Xaml.Input.PointerRoutedEventArgs)
 		// Skipping already declared method Windows.UI.Xaml.Controls.Control.OnPointerReleased(Windows.UI.Xaml.Input.PointerRoutedEventArgs)
 		// Skipping already declared method Windows.UI.Xaml.Controls.Control.OnPointerExited(Windows.UI.Xaml.Input.PointerRoutedEventArgs)
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected virtual void OnPointerCaptureLost( global::Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnPointerCaptureLost(PointerRoutedEventArgs e)");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Control.OnPointerCaptureLost(Windows.UI.Xaml.Input.PointerRoutedEventArgs)
 		// Skipping already declared method Windows.UI.Xaml.Controls.Control.OnPointerCanceled(Windows.UI.Xaml.Input.PointerRoutedEventArgs)
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
@@ -546,20 +540,8 @@ namespace Windows.UI.Xaml.Controls
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnPointerWheelChanged(PointerRoutedEventArgs e)");
 		}
 		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected virtual void OnTapped( global::Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnTapped(TappedRoutedEventArgs e)");
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected virtual void OnDoubleTapped( global::Windows.UI.Xaml.Input.DoubleTappedRoutedEventArgs e)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnDoubleTapped(DoubleTappedRoutedEventArgs e)");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Control.OnTapped(Windows.UI.Xaml.Input.TappedRoutedEventArgs)
+		// Skipping already declared method Windows.UI.Xaml.Controls.Control.OnDoubleTapped(Windows.UI.Xaml.Input.DoubleTappedRoutedEventArgs)
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		protected virtual void OnHolding( global::Windows.UI.Xaml.Input.HoldingRoutedEventArgs e)
@@ -609,14 +591,14 @@ namespace Windows.UI.Xaml.Controls
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnManipulationCompleted(ManipulationCompletedRoutedEventArgs e)");
 		}
 		#endif
-		#if false || false || false || false || false
+		#if false || false || NET461 || false || false
 		[global::Uno.NotImplemented]
 		protected virtual void OnKeyUp( global::Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnKeyUp(KeyRoutedEventArgs e)");
 		}
 		#endif
-		#if false || false || false || false || false
+		#if false || false || NET461 || false || false
 		[global::Uno.NotImplemented]
 		protected virtual void OnKeyDown( global::Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePickedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePickedEventArgs.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class DatePickedEventArgs : global::Windows.UI.Xaml.DependencyObject
@@ -27,7 +27,13 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.DatePickedEventArgs.DatePickedEventArgs()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public DatePickedEventArgs() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.DatePickedEventArgs", "DatePickedEventArgs.DatePickedEventArgs()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.DatePickedEventArgs.DatePickedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.DatePickedEventArgs.OldDate.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.DatePickedEventArgs.NewDate.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePicker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePicker.cs
@@ -143,7 +143,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CalendarIdentifierProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CalendarIdentifier", typeof(string), 
+			nameof(CalendarIdentifier), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePicker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -152,7 +152,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DayFormatProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DayFormat", typeof(string), 
+			nameof(DayFormat), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePicker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -161,7 +161,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Header", typeof(object), 
+			nameof(Header), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePicker), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -169,7 +169,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(HeaderTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -179,7 +179,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MonthFormatProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MonthFormat", typeof(string), 
+			nameof(MonthFormat), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePicker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -188,7 +188,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OrientationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Orientation", typeof(global::Windows.UI.Xaml.Controls.Orientation), 
+			nameof(Orientation), typeof(global::Windows.UI.Xaml.Controls.Orientation), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Orientation)));
 		#endif
@@ -196,7 +196,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty YearFormatProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"YearFormat", typeof(string), 
+			nameof(YearFormat), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePicker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -205,7 +205,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
+			nameof(LightDismissOverlayMode), typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
@@ -213,7 +213,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedDateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedDate", typeof(global::System.DateTimeOffset?), 
+			nameof(SelectedDate), typeof(global::System.DateTimeOffset?), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePicker), 
 			new FrameworkPropertyMetadata(default(global::System.DateTimeOffset?)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePickerFlyout.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePickerFlyout.cs
@@ -73,7 +73,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CalendarIdentifierProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CalendarIdentifier", typeof(string), 
+			nameof(CalendarIdentifier), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePickerFlyout), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -87,7 +87,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DayFormatProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DayFormat", typeof(string), 
+			nameof(DayFormat), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePickerFlyout), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -95,7 +95,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MonthFormatProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MonthFormat", typeof(string), 
+			nameof(MonthFormat), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePickerFlyout), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty YearFormatProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"YearFormat", typeof(string), 
+			nameof(YearFormat), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePickerFlyout), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePickerFlyoutItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePickerFlyoutItem.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class DatePickerFlyoutItem : global::Windows.UI.Xaml.DependencyObject,global::Windows.UI.Xaml.Data.ICustomPropertyProvider
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PrimaryTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PrimaryText", typeof(string), 
+			nameof(PrimaryText), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePickerFlyoutItem), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -57,7 +57,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SecondaryTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SecondaryText", typeof(string), 
+			nameof(SecondaryText), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.DatePickerFlyoutItem), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/FontIcon.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/FontIcon.cs
@@ -60,7 +60,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontWeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontWeight", typeof(global::Windows.UI.Text.FontWeight), 
+			nameof(FontWeight), typeof(global::Windows.UI.Text.FontWeight), 
 			typeof(global::Windows.UI.Xaml.Controls.FontIcon), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontWeight)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextScaleFactorEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextScaleFactorEnabled", typeof(bool), 
+			nameof(IsTextScaleFactorEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.FontIcon), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -77,7 +77,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MirroredWhenRightToLeftProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MirroredWhenRightToLeft", typeof(bool), 
+			nameof(MirroredWhenRightToLeft), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.FontIcon), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/FontIconSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/FontIconSource.cs
@@ -109,7 +109,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontFamilyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontFamily", typeof(global::Windows.UI.Xaml.Media.FontFamily), 
+			nameof(FontFamily), typeof(global::Windows.UI.Xaml.Media.FontFamily), 
 			typeof(global::Windows.UI.Xaml.Controls.FontIconSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FontFamily)));
 		#endif
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontSize", typeof(double), 
+			nameof(FontSize), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.FontIconSource), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -125,7 +125,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontStyle", typeof(global::Windows.UI.Text.FontStyle), 
+			nameof(FontStyle), typeof(global::Windows.UI.Text.FontStyle), 
 			typeof(global::Windows.UI.Xaml.Controls.FontIconSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStyle)));
 		#endif
@@ -133,7 +133,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontWeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontWeight", typeof(global::Windows.UI.Text.FontWeight), 
+			nameof(FontWeight), typeof(global::Windows.UI.Text.FontWeight), 
 			typeof(global::Windows.UI.Xaml.Controls.FontIconSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontWeight)));
 		#endif
@@ -141,7 +141,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GlyphProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Glyph", typeof(string), 
+			nameof(Glyph), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.FontIconSource), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -149,7 +149,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextScaleFactorEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextScaleFactorEnabled", typeof(bool), 
+			nameof(IsTextScaleFactorEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.FontIconSource), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -157,7 +157,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MirroredWhenRightToLeftProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MirroredWhenRightToLeft", typeof(bool), 
+			nameof(MirroredWhenRightToLeft), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.FontIconSource), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Frame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Frame.cs
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsNavigationStackEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsNavigationStackEnabled", typeof(bool), 
+			nameof(IsNavigationStackEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Frame), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Grid.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Grid.cs
@@ -67,7 +67,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ColumnSpacingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ColumnSpacing", typeof(double), 
+			nameof(ColumnSpacing), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Grid), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RowSpacingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RowSpacing", typeof(double), 
+			nameof(RowSpacing), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.Grid), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -83,7 +83,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BackgroundSizingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BackgroundSizing", typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
+			nameof(BackgroundSizing), typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
 			typeof(global::Windows.UI.Xaml.Controls.Grid), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.BackgroundSizing)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/HandwritingView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/HandwritingView.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AreCandidatesEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AreCandidatesEnabled", typeof(bool), 
+			nameof(AreCandidatesEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.HandwritingView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -71,7 +71,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsOpenProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsOpen", typeof(bool), 
+			nameof(IsOpen), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.HandwritingView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -79,7 +79,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlacementAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlacementAlignment", typeof(global::Windows.UI.Xaml.Controls.HandwritingPanelPlacementAlignment), 
+			nameof(PlacementAlignment), typeof(global::Windows.UI.Xaml.Controls.HandwritingPanelPlacementAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.HandwritingView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.HandwritingPanelPlacementAlignment)));
 		#endif
@@ -87,7 +87,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlacementTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlacementTarget", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(PlacementTarget), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.HandwritingView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Hub.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Hub.cs
@@ -139,7 +139,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DefaultSectionIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DefaultSectionIndex", typeof(int), 
+			nameof(DefaultSectionIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.Hub), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -147,7 +147,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Header", typeof(object), 
+			nameof(Header), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.Hub), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -155,7 +155,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(HeaderTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.Hub), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -163,7 +163,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsActiveViewProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsActiveView", typeof(bool), 
+			nameof(IsActiveView), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Hub), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -171,7 +171,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsZoomedInViewProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsZoomedInView", typeof(bool), 
+			nameof(IsZoomedInView), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Hub), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -179,7 +179,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OrientationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Orientation", typeof(global::Windows.UI.Xaml.Controls.Orientation), 
+			nameof(Orientation), typeof(global::Windows.UI.Xaml.Controls.Orientation), 
 			typeof(global::Windows.UI.Xaml.Controls.Hub), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Orientation)));
 		#endif
@@ -187,7 +187,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SemanticZoomOwnerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SemanticZoomOwner", typeof(global::Windows.UI.Xaml.Controls.SemanticZoom), 
+			nameof(SemanticZoomOwner), typeof(global::Windows.UI.Xaml.Controls.SemanticZoom), 
 			typeof(global::Windows.UI.Xaml.Controls.Hub), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SemanticZoom)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/HubSection.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/HubSection.cs
@@ -67,7 +67,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(ContentTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.HubSection), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Header", typeof(object), 
+			nameof(Header), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.HubSection), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -83,7 +83,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(HeaderTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.HubSection), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsHeaderInteractiveProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsHeaderInteractive", typeof(bool), 
+			nameof(IsHeaderInteractive), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.HubSection), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/IconSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/IconSource.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class IconSource : global::Windows.UI.Xaml.DependencyObject
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Foreground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Foreground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.IconSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/IconSourceElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/IconSourceElement.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IconSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IconSource", typeof(global::Windows.UI.Xaml.Controls.IconSource), 
+			nameof(IconSource), typeof(global::Windows.UI.Xaml.Controls.IconSource), 
 			typeof(global::Windows.UI.Xaml.Controls.IconSourceElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.IconSource)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Image.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Image.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty NineGridProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"NineGrid", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(NineGrid), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.Image), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -71,7 +71,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlayToSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlayToSource", typeof(global::Windows.Media.PlayTo.PlayToSource), 
+			nameof(PlayToSource), typeof(global::Windows.Media.PlayTo.PlayToSource), 
 			typeof(global::Windows.UI.Xaml.Controls.Image), 
 			new FrameworkPropertyMetadata(default(global::Windows.Media.PlayTo.PlayToSource)));
 		#endif
@@ -79,7 +79,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Source", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(Source), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.Image), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif
@@ -87,7 +87,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Stretch", typeof(global::Windows.UI.Xaml.Media.Stretch), 
+			nameof(Stretch), typeof(global::Windows.UI.Xaml.Media.Stretch), 
 			typeof(global::Windows.UI.Xaml.Controls.Image), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Stretch)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbar.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbar.cs
@@ -129,7 +129,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ActiveToolProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ActiveTool", typeof(global::Windows.UI.Xaml.Controls.InkToolbarToolButton), 
+			nameof(ActiveTool), typeof(global::Windows.UI.Xaml.Controls.InkToolbarToolButton), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbar), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.InkToolbarToolButton)));
 		#endif
@@ -137,7 +137,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ChildrenProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Children", typeof(global::Windows.UI.Xaml.DependencyObjectCollection), 
+			nameof(Children), typeof(global::Windows.UI.Xaml.DependencyObjectCollection), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbar), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObjectCollection)));
 		#endif
@@ -145,7 +145,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty InitialControlsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"InitialControls", typeof(global::Windows.UI.Xaml.Controls.InkToolbarInitialControls), 
+			nameof(InitialControls), typeof(global::Windows.UI.Xaml.Controls.InkToolbarInitialControls), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbar), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.InkToolbarInitialControls)));
 		#endif
@@ -153,7 +153,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty InkDrawingAttributesProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"InkDrawingAttributes", typeof(global::Windows.UI.Input.Inking.InkDrawingAttributes), 
+			nameof(InkDrawingAttributes), typeof(global::Windows.UI.Input.Inking.InkDrawingAttributes), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbar), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Input.Inking.InkDrawingAttributes)));
 		#endif
@@ -161,7 +161,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsRulerButtonCheckedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsRulerButtonChecked", typeof(bool), 
+			nameof(IsRulerButtonChecked), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbar), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -169,7 +169,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetInkCanvasProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetInkCanvas", typeof(global::Windows.UI.Xaml.Controls.InkCanvas), 
+			nameof(TargetInkCanvas), typeof(global::Windows.UI.Xaml.Controls.InkCanvas), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbar), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.InkCanvas)));
 		#endif
@@ -177,7 +177,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ButtonFlyoutPlacementProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ButtonFlyoutPlacement", typeof(global::Windows.UI.Xaml.Controls.InkToolbarButtonFlyoutPlacement), 
+			nameof(ButtonFlyoutPlacement), typeof(global::Windows.UI.Xaml.Controls.InkToolbarButtonFlyoutPlacement), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbar), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.InkToolbarButtonFlyoutPlacement)));
 		#endif
@@ -185,7 +185,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsStencilButtonCheckedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsStencilButtonChecked", typeof(bool), 
+			nameof(IsStencilButtonChecked), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbar), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -193,7 +193,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OrientationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Orientation", typeof(global::Windows.UI.Xaml.Controls.Orientation), 
+			nameof(Orientation), typeof(global::Windows.UI.Xaml.Controls.Orientation), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbar), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Orientation)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarCustomPen.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarCustomPen.cs
@@ -2,12 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class InkToolbarCustomPen : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared method Windows.UI.Xaml.Controls.InkToolbarCustomPen.InkToolbarCustomPen()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		protected InkToolbarCustomPen() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.InkToolbarCustomPen", "InkToolbarCustomPen.InkToolbarCustomPen()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.InkToolbarCustomPen.InkToolbarCustomPen()
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarCustomPenButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarCustomPenButton.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ConfigurationContentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ConfigurationContent", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(ConfigurationContent), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarCustomPenButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CustomPenProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CustomPen", typeof(global::Windows.UI.Xaml.Controls.InkToolbarCustomPen), 
+			nameof(CustomPen), typeof(global::Windows.UI.Xaml.Controls.InkToolbarCustomPen), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarCustomPenButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.InkToolbarCustomPen)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarCustomToolButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarCustomToolButton.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ConfigurationContentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ConfigurationContent", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(ConfigurationContent), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarCustomToolButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarEraserButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarEraserButton.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsClearAllVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsClearAllVisible", typeof(bool), 
+			nameof(IsClearAllVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarEraserButton), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarFlyoutItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarFlyoutItem.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsCheckedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsChecked", typeof(bool), 
+			nameof(IsChecked), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarFlyoutItem), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KindProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Kind", typeof(global::Windows.UI.Xaml.Controls.InkToolbarFlyoutItemKind), 
+			nameof(Kind), typeof(global::Windows.UI.Xaml.Controls.InkToolbarFlyoutItemKind), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarFlyoutItem), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.InkToolbarFlyoutItemKind)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarMenuButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarMenuButton.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsExtensionGlyphShownProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsExtensionGlyphShown", typeof(bool), 
+			nameof(IsExtensionGlyphShown), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarMenuButton), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarPenButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarPenButton.cs
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxStrokeWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxStrokeWidth", typeof(double), 
+			nameof(MaxStrokeWidth), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarPenButton), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -99,7 +99,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinStrokeWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinStrokeWidth", typeof(double), 
+			nameof(MinStrokeWidth), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarPenButton), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -107,7 +107,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PaletteProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Palette", typeof(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Media.Brush>), 
+			nameof(Palette), typeof(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Media.Brush>), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarPenButton), 
 			new FrameworkPropertyMetadata(default(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Media.Brush>)));
 		#endif
@@ -115,7 +115,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedBrushIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedBrushIndex", typeof(int), 
+			nameof(SelectedBrushIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarPenButton), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(SelectedBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarPenButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -131,7 +131,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedStrokeWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedStrokeWidth", typeof(double), 
+			nameof(SelectedStrokeWidth), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarPenButton), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarPenConfigurationControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarPenConfigurationControl.cs
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PenButtonProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PenButton", typeof(global::Windows.UI.Xaml.Controls.InkToolbarPenButton), 
+			nameof(PenButton), typeof(global::Windows.UI.Xaml.Controls.InkToolbarPenButton), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarPenConfigurationControl), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.InkToolbarPenButton)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarRulerButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarRulerButton.cs
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RulerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Ruler", typeof(global::Windows.UI.Input.Inking.InkPresenterRuler), 
+			nameof(Ruler), typeof(global::Windows.UI.Input.Inking.InkPresenterRuler), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarRulerButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Input.Inking.InkPresenterRuler)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarStencilButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarStencilButton.cs
@@ -73,7 +73,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsProtractorItemVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsProtractorItemVisible", typeof(bool), 
+			nameof(IsProtractorItemVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarStencilButton), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsRulerItemVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsRulerItemVisible", typeof(bool), 
+			nameof(IsRulerItemVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarStencilButton), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -89,7 +89,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ProtractorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Protractor", typeof(global::Windows.UI.Input.Inking.InkPresenterProtractor), 
+			nameof(Protractor), typeof(global::Windows.UI.Input.Inking.InkPresenterProtractor), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarStencilButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Input.Inking.InkPresenterProtractor)));
 		#endif
@@ -97,7 +97,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RulerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Ruler", typeof(global::Windows.UI.Input.Inking.InkPresenterRuler), 
+			nameof(Ruler), typeof(global::Windows.UI.Input.Inking.InkPresenterRuler), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarStencilButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Input.Inking.InkPresenterRuler)));
 		#endif
@@ -105,7 +105,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedStencilProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedStencil", typeof(global::Windows.UI.Xaml.Controls.InkToolbarStencilKind), 
+			nameof(SelectedStencil), typeof(global::Windows.UI.Xaml.Controls.InkToolbarStencilKind), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarStencilButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.InkToolbarStencilKind)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarToolButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarToolButton.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsExtensionGlyphShownProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsExtensionGlyphShown", typeof(bool), 
+			nameof(IsExtensionGlyphShown), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.InkToolbarToolButton), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsControl.cs
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GroupStyleSelectorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GroupStyleSelector", typeof(global::Windows.UI.Xaml.Controls.GroupStyleSelector), 
+			nameof(GroupStyleSelector), typeof(global::Windows.UI.Xaml.Controls.GroupStyleSelector), 
 			typeof(global::Windows.UI.Xaml.Controls.ItemsControl), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.GroupStyleSelector)));
 		#endif
@@ -72,7 +72,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemContainerTransitionsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemContainerTransitions", typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
+			nameof(ItemContainerTransitions), typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
 			typeof(global::Windows.UI.Xaml.Controls.ItemsControl), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.TransitionCollection)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsPickedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsPickedEventArgs.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ItemsPickedEventArgs : global::Windows.UI.Xaml.DependencyObject
@@ -27,7 +27,13 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.ItemsPickedEventArgs.ItemsPickedEventArgs()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public ItemsPickedEventArgs() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.ItemsPickedEventArgs", "ItemsPickedEventArgs.ItemsPickedEventArgs()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.ItemsPickedEventArgs.ItemsPickedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.ItemsPickedEventArgs.AddedItems.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.ItemsPickedEventArgs.RemovedItems.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsPresenter.cs
@@ -98,7 +98,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Header", typeof(object), 
+			nameof(Header), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.ItemsPresenter), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -106,7 +106,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(HeaderTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.ItemsPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -114,7 +114,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderTransitionsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderTransitions", typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
+			nameof(HeaderTransitions), typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
 			typeof(global::Windows.UI.Xaml.Controls.ItemsPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.TransitionCollection)));
 		#endif
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FooterProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Footer", typeof(object), 
+			nameof(Footer), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.ItemsPresenter), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -131,7 +131,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FooterTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FooterTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(FooterTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.ItemsPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -139,7 +139,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FooterTransitionsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FooterTransitions", typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
+			nameof(FooterTransitions), typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
 			typeof(global::Windows.UI.Xaml.Controls.ItemsPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.TransitionCollection)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsStackPanel.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsStackPanel.cs
@@ -93,7 +93,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CacheLengthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CacheLength", typeof(double), 
+			nameof(CacheLength), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ItemsStackPanel), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsWrapGrid.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsWrapGrid.cs
@@ -82,7 +82,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CacheLengthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CacheLength", typeof(double), 
+			nameof(CacheLength), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ItemsWrapGrid), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ListBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ListBox.cs
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionMode", typeof(global::Windows.UI.Xaml.Controls.SelectionMode), 
+			nameof(SelectionMode), typeof(global::Windows.UI.Xaml.Controls.SelectionMode), 
 			typeof(global::Windows.UI.Xaml.Controls.ListBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SelectionMode)));
 		#endif
@@ -57,7 +57,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SingleSelectionFollowsFocusProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SingleSelectionFollowsFocus", typeof(bool), 
+			nameof(SingleSelectionFollowsFocus), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ListBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ListPickerFlyout.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ListPickerFlyout.cs
@@ -133,7 +133,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisplayMemberPathProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DisplayMemberPath", typeof(string), 
+			nameof(DisplayMemberPath), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.ListPickerFlyout), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -141,7 +141,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(ItemTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.ListPickerFlyout), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -149,7 +149,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemsSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemsSource", typeof(object), 
+			nameof(ItemsSource), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.ListPickerFlyout), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -157,7 +157,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedIndex", typeof(int), 
+			nameof(SelectedIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.ListPickerFlyout), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -165,7 +165,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedItemProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedItem", typeof(object), 
+			nameof(SelectedItem), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.ListPickerFlyout), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -173,7 +173,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedValuePathProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedValuePath", typeof(string), 
+			nameof(SelectedValuePath), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.ListPickerFlyout), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -181,7 +181,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedValueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedValue", typeof(object), 
+			nameof(SelectedValue), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.ListPickerFlyout), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -189,7 +189,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionMode", typeof(global::Windows.UI.Xaml.Controls.ListPickerFlyoutSelectionMode), 
+			nameof(SelectionMode), typeof(global::Windows.UI.Xaml.Controls.ListPickerFlyoutSelectionMode), 
 			typeof(global::Windows.UI.Xaml.Controls.ListPickerFlyout), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ListPickerFlyoutSelectionMode)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ListViewBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ListViewBase.cs
@@ -199,7 +199,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanDragItemsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanDragItems", typeof(bool), 
+			nameof(CanDragItems), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -207,7 +207,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanReorderItemsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanReorderItems", typeof(bool), 
+			nameof(CanReorderItems), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -218,7 +218,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderTransitionsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderTransitions", typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
+			nameof(HeaderTransitions), typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.TransitionCollection)));
 		#endif
@@ -228,7 +228,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsActiveViewProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsActiveView", typeof(bool), 
+			nameof(IsActiveView), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -237,7 +237,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsSwipeEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsSwipeEnabled", typeof(bool), 
+			nameof(IsSwipeEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -245,7 +245,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsZoomedInViewProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsZoomedInView", typeof(bool), 
+			nameof(IsZoomedInView), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -254,7 +254,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SemanticZoomOwnerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SemanticZoomOwner", typeof(global::Windows.UI.Xaml.Controls.SemanticZoom), 
+			nameof(SemanticZoomOwner), typeof(global::Windows.UI.Xaml.Controls.SemanticZoom), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SemanticZoom)));
 		#endif
@@ -264,7 +264,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FooterTransitionsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FooterTransitions", typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
+			nameof(FooterTransitions), typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.TransitionCollection)));
 		#endif
@@ -272,7 +272,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ShowsScrollingPlaceholdersProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ShowsScrollingPlaceholders", typeof(bool), 
+			nameof(ShowsScrollingPlaceholders), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -280,7 +280,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ReorderModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ReorderMode", typeof(global::Windows.UI.Xaml.Controls.ListViewReorderMode), 
+			nameof(ReorderMode), typeof(global::Windows.UI.Xaml.Controls.ListViewReorderMode), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ListViewReorderMode)));
 		#endif
@@ -288,7 +288,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsMultiSelectCheckBoxEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsMultiSelectCheckBoxEnabled", typeof(bool), 
+			nameof(IsMultiSelectCheckBoxEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -296,7 +296,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SingleSelectionFollowsFocusProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SingleSelectionFollowsFocus", typeof(bool), 
+			nameof(SingleSelectionFollowsFocus), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaElement.cs
@@ -489,7 +489,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DownloadProgressOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DownloadProgressOffset", typeof(double), 
+			nameof(DownloadProgressOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -497,7 +497,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Source", typeof(global::System.Uri), 
+			nameof(Source), typeof(global::System.Uri), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::System.Uri)));
 		#endif
@@ -505,7 +505,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty Stereo3DVideoPackingModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Stereo3DVideoPackingMode", typeof(global::Windows.UI.Xaml.Media.Stereo3DVideoPackingMode), 
+			nameof(Stereo3DVideoPackingMode), typeof(global::Windows.UI.Xaml.Media.Stereo3DVideoPackingMode), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Stereo3DVideoPackingMode)));
 		#endif
@@ -513,7 +513,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty Stereo3DVideoRenderModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Stereo3DVideoRenderMode", typeof(global::Windows.UI.Xaml.Media.Stereo3DVideoRenderMode), 
+			nameof(Stereo3DVideoRenderMode), typeof(global::Windows.UI.Xaml.Media.Stereo3DVideoRenderMode), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Stereo3DVideoRenderMode)));
 		#endif
@@ -521,7 +521,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ActualStereo3DVideoPackingModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ActualStereo3DVideoPackingMode", typeof(global::Windows.UI.Xaml.Media.Stereo3DVideoPackingMode), 
+			nameof(ActualStereo3DVideoPackingMode), typeof(global::Windows.UI.Xaml.Media.Stereo3DVideoPackingMode), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Stereo3DVideoPackingMode)));
 		#endif
@@ -529,7 +529,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AspectRatioHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AspectRatioHeight", typeof(int), 
+			nameof(AspectRatioHeight), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -537,7 +537,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AspectRatioWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AspectRatioWidth", typeof(int), 
+			nameof(AspectRatioWidth), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -545,7 +545,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AudioCategoryProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AudioCategory", typeof(global::Windows.UI.Xaml.Media.AudioCategory), 
+			nameof(AudioCategory), typeof(global::Windows.UI.Xaml.Media.AudioCategory), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.AudioCategory)));
 		#endif
@@ -553,7 +553,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AudioDeviceTypeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AudioDeviceType", typeof(global::Windows.UI.Xaml.Media.AudioDeviceType), 
+			nameof(AudioDeviceType), typeof(global::Windows.UI.Xaml.Media.AudioDeviceType), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.AudioDeviceType)));
 		#endif
@@ -561,7 +561,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AudioStreamCountProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AudioStreamCount", typeof(int), 
+			nameof(AudioStreamCount), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -569,7 +569,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AudioStreamIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AudioStreamIndex", typeof(int?), 
+			nameof(AudioStreamIndex), typeof(int?), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(int?)));
 		#endif
@@ -577,7 +577,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AutoPlayProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AutoPlay", typeof(bool), 
+			nameof(AutoPlay), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -585,7 +585,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BalanceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Balance", typeof(double), 
+			nameof(Balance), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -593,7 +593,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BufferingProgressProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BufferingProgress", typeof(double), 
+			nameof(BufferingProgress), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -601,7 +601,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanPauseProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanPause", typeof(bool), 
+			nameof(CanPause), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -609,7 +609,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanSeekProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanSeek", typeof(bool), 
+			nameof(CanSeek), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -617,7 +617,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CurrentStateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CurrentState", typeof(global::Windows.UI.Xaml.Media.MediaElementState), 
+			nameof(CurrentState), typeof(global::Windows.UI.Xaml.Media.MediaElementState), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.MediaElementState)));
 		#endif
@@ -625,7 +625,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DefaultPlaybackRateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DefaultPlaybackRate", typeof(double), 
+			nameof(DefaultPlaybackRate), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -633,7 +633,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VolumeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Volume", typeof(double), 
+			nameof(Volume), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -641,7 +641,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DownloadProgressProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DownloadProgress", typeof(double), 
+			nameof(DownloadProgress), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -649,7 +649,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsAudioOnlyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsAudioOnly", typeof(bool), 
+			nameof(IsAudioOnly), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -657,7 +657,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsLoopingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsLooping", typeof(bool), 
+			nameof(IsLooping), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -665,7 +665,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsMutedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsMuted", typeof(bool), 
+			nameof(IsMuted), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -673,7 +673,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsStereo3DVideoProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsStereo3DVideo", typeof(bool), 
+			nameof(IsStereo3DVideo), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -681,7 +681,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty NaturalDurationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"NaturalDuration", typeof(global::Windows.UI.Xaml.Duration), 
+			nameof(NaturalDuration), typeof(global::Windows.UI.Xaml.Duration), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Duration)));
 		#endif
@@ -689,7 +689,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty NaturalVideoHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"NaturalVideoHeight", typeof(int), 
+			nameof(NaturalVideoHeight), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -697,7 +697,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty NaturalVideoWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"NaturalVideoWidth", typeof(int), 
+			nameof(NaturalVideoWidth), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -705,7 +705,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlayToSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlayToSource", typeof(global::Windows.Media.PlayTo.PlayToSource), 
+			nameof(PlayToSource), typeof(global::Windows.Media.PlayTo.PlayToSource), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.Media.PlayTo.PlayToSource)));
 		#endif
@@ -713,7 +713,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaybackRateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaybackRate", typeof(double), 
+			nameof(PlaybackRate), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -721,7 +721,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PositionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Position", typeof(global::System.TimeSpan), 
+			nameof(Position), typeof(global::System.TimeSpan), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::System.TimeSpan)));
 		#endif
@@ -729,7 +729,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PosterSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PosterSource", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(PosterSource), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif
@@ -737,7 +737,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ProtectionManagerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ProtectionManager", typeof(global::Windows.Media.Protection.MediaProtectionManager), 
+			nameof(ProtectionManager), typeof(global::Windows.Media.Protection.MediaProtectionManager), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.Media.Protection.MediaProtectionManager)));
 		#endif
@@ -745,7 +745,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RealTimePlaybackProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RealTimePlayback", typeof(bool), 
+			nameof(RealTimePlayback), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -753,7 +753,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFullWindowProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFullWindow", typeof(bool), 
+			nameof(IsFullWindow), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -761,7 +761,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlayToPreferredSourceUriProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlayToPreferredSourceUri", typeof(global::System.Uri), 
+			nameof(PlayToPreferredSourceUri), typeof(global::System.Uri), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::System.Uri)));
 		#endif
@@ -769,7 +769,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Stretch", typeof(global::Windows.UI.Xaml.Media.Stretch), 
+			nameof(Stretch), typeof(global::Windows.UI.Xaml.Media.Stretch), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Stretch)));
 		#endif
@@ -777,7 +777,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AreTransportControlsEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AreTransportControlsEnabled", typeof(bool), 
+			nameof(AreTransportControlsEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaPlayerElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaPlayerElement.cs
@@ -119,7 +119,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AreTransportControlsEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AreTransportControlsEnabled", typeof(bool), 
+			nameof(AreTransportControlsEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -127,7 +127,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AutoPlayProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AutoPlay", typeof(bool), 
+			nameof(AutoPlay), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -135,7 +135,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFullWindowProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFullWindow", typeof(bool), 
+			nameof(IsFullWindow), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -143,7 +143,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MediaPlayerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MediaPlayer", typeof(global::Windows.Media.Playback.MediaPlayer), 
+			nameof(MediaPlayer), typeof(global::Windows.Media.Playback.MediaPlayer), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.Media.Playback.MediaPlayer)));
 		#endif
@@ -151,7 +151,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PosterSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PosterSource", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(PosterSource), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Source", typeof(global::Windows.Media.Playback.IMediaPlaybackSource), 
+			nameof(Source), typeof(global::Windows.Media.Playback.IMediaPlaybackSource), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.Media.Playback.IMediaPlaybackSource)));
 		#endif
@@ -167,7 +167,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Stretch", typeof(global::Windows.UI.Xaml.Media.Stretch), 
+			nameof(Stretch), typeof(global::Windows.UI.Xaml.Media.Stretch), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Stretch)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaPlayerPresenter.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFullWindowProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFullWindow", typeof(bool), 
+			nameof(IsFullWindow), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerPresenter), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MediaPlayerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MediaPlayer", typeof(global::Windows.Media.Playback.MediaPlayer), 
+			nameof(MediaPlayer), typeof(global::Windows.Media.Playback.MediaPlayer), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.Media.Playback.MediaPlayer)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Stretch", typeof(global::Windows.UI.Xaml.Media.Stretch), 
+			nameof(Stretch), typeof(global::Windows.UI.Xaml.Media.Stretch), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Stretch)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaTransportControls.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaTransportControls.cs
@@ -417,7 +417,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsCompactProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsCompact", typeof(bool), 
+			nameof(IsCompact), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -425,7 +425,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFastForwardButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFastForwardButtonVisible", typeof(bool), 
+			nameof(IsFastForwardButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -433,7 +433,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFastForwardEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFastForwardEnabled", typeof(bool), 
+			nameof(IsFastForwardEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -441,7 +441,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFastRewindButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFastRewindButtonVisible", typeof(bool), 
+			nameof(IsFastRewindButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -449,7 +449,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFastRewindEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFastRewindEnabled", typeof(bool), 
+			nameof(IsFastRewindEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -457,7 +457,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFullWindowButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFullWindowButtonVisible", typeof(bool), 
+			nameof(IsFullWindowButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -465,7 +465,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsFullWindowEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsFullWindowEnabled", typeof(bool), 
+			nameof(IsFullWindowEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -473,7 +473,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsPlaybackRateButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsPlaybackRateButtonVisible", typeof(bool), 
+			nameof(IsPlaybackRateButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -481,7 +481,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsPlaybackRateEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsPlaybackRateEnabled", typeof(bool), 
+			nameof(IsPlaybackRateEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -489,7 +489,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsSeekBarVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsSeekBarVisible", typeof(bool), 
+			nameof(IsSeekBarVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -497,7 +497,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsSeekEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsSeekEnabled", typeof(bool), 
+			nameof(IsSeekEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -505,7 +505,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsStopButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsStopButtonVisible", typeof(bool), 
+			nameof(IsStopButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -513,7 +513,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsStopEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsStopEnabled", typeof(bool), 
+			nameof(IsStopEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -521,7 +521,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsVolumeButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsVolumeButtonVisible", typeof(bool), 
+			nameof(IsVolumeButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -529,7 +529,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsVolumeEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsVolumeEnabled", typeof(bool), 
+			nameof(IsVolumeEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -537,7 +537,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsZoomButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsZoomButtonVisible", typeof(bool), 
+			nameof(IsZoomButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -545,7 +545,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsZoomEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsZoomEnabled", typeof(bool), 
+			nameof(IsZoomEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -553,7 +553,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FastPlayFallbackBehaviourProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FastPlayFallbackBehaviour", typeof(global::Windows.UI.Xaml.Media.FastPlayFallbackBehaviour), 
+			nameof(FastPlayFallbackBehaviour), typeof(global::Windows.UI.Xaml.Media.FastPlayFallbackBehaviour), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FastPlayFallbackBehaviour)));
 		#endif
@@ -561,7 +561,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsNextTrackButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsNextTrackButtonVisible", typeof(bool), 
+			nameof(IsNextTrackButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -569,7 +569,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsPreviousTrackButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsPreviousTrackButtonVisible", typeof(bool), 
+			nameof(IsPreviousTrackButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -577,7 +577,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsSkipBackwardButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsSkipBackwardButtonVisible", typeof(bool), 
+			nameof(IsSkipBackwardButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -585,7 +585,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsSkipBackwardEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsSkipBackwardEnabled", typeof(bool), 
+			nameof(IsSkipBackwardEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -593,7 +593,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsSkipForwardButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsSkipForwardButtonVisible", typeof(bool), 
+			nameof(IsSkipForwardButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -601,7 +601,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsSkipForwardEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsSkipForwardEnabled", typeof(bool), 
+			nameof(IsSkipForwardEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -609,7 +609,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsRepeatButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsRepeatButtonVisible", typeof(bool), 
+			nameof(IsRepeatButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -617,7 +617,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsRepeatEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsRepeatEnabled", typeof(bool), 
+			nameof(IsRepeatEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -625,7 +625,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ShowAndHideAutomaticallyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ShowAndHideAutomatically", typeof(bool), 
+			nameof(ShowAndHideAutomatically), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -633,7 +633,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsCompactOverlayButtonVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsCompactOverlayButtonVisible", typeof(bool), 
+			nameof(IsCompactOverlayButtonVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -641,7 +641,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsCompactOverlayEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsCompactOverlayEnabled", typeof(bool), 
+			nameof(IsCompactOverlayEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.MediaTransportControls), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuBar.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuBar.cs
@@ -2,4 +2,16 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class MenuBar : global::Windows.UI.Xaml.Controls.Control
+	{
+		// Skipping already declared property Items
+		// Skipping already declared property ItemsProperty
+		// Skipping already declared method Windows.UI.Xaml.Controls.MenuBar.MenuBar()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuBar.MenuBar()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuBar.Items.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuBar.ItemsProperty.get
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuBarItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuBarItem.cs
@@ -2,5 +2,21 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class MenuBarItem : global::Windows.UI.Xaml.Controls.Control
+	{
+		// Skipping already declared property Title
+		// Skipping already declared property Items
+		// Skipping already declared property ItemsProperty
+		// Skipping already declared property TitleProperty
+		// Skipping already declared method Windows.UI.Xaml.Controls.MenuBarItem.MenuBarItem()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuBarItem.MenuBarItem()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuBarItem.Title.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuBarItem.Title.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuBarItem.Items.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuBarItem.TitleProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuBarItem.ItemsProperty.get
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuBarItemFlyout.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuBarItemFlyout.cs
@@ -2,5 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class MenuBarItemFlyout : global::Windows.UI.Xaml.Controls.MenuFlyout
+	{
+		// Skipping already declared method Windows.UI.Xaml.Controls.MenuBarItemFlyout.MenuBarItemFlyout()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuBarItemFlyout.MenuBarItemFlyout()
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuFlyout.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuFlyout.cs
@@ -7,5 +7,15 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class MenuFlyout 
 	{
+		// Skipping already declared property MenuFlyoutPresenterStyle
+		// Skipping already declared property Items
+		// Skipping already declared property MenuFlyoutPresenterStyleProperty
+		// Skipping already declared method Windows.UI.Xaml.Controls.MenuFlyout.MenuFlyout()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyout.MenuFlyout()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyout.Items.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyout.MenuFlyoutPresenterStyle.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyout.MenuFlyoutPresenterStyle.set
+		// Skipping already declared method Windows.UI.Xaml.Controls.MenuFlyout.ShowAt(Windows.UI.Xaml.UIElement, Windows.Foundation.Point)
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyout.MenuFlyoutPresenterStyleProperty.get
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuFlyoutItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuFlyoutItem.cs
@@ -38,6 +38,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
+		// Skipping already declared property TemplateSettings
 		// Skipping already declared property CommandParameterProperty
 		// Skipping already declared property CommandProperty
 		// Skipping already declared property TextProperty
@@ -45,7 +46,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IconProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Icon", typeof(global::Windows.UI.Xaml.Controls.IconElement), 
+			nameof(Icon), typeof(global::Windows.UI.Xaml.Controls.IconElement), 
 			typeof(global::Windows.UI.Xaml.Controls.MenuFlyoutItem), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.IconElement)));
 		#endif
@@ -53,7 +54,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyboardAcceleratorTextOverrideProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyboardAcceleratorTextOverride", typeof(string), 
+			nameof(KeyboardAcceleratorTextOverride), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.MenuFlyoutItem), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -77,6 +78,6 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutItem.TextProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutItem.CommandProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutItem.CommandParameterProperty.get
-
+		// Skipping already declared event Windows.UI.Xaml.Controls.MenuFlyoutItem.Click
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuFlyoutPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuFlyoutPresenter.cs
@@ -2,5 +2,14 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class MenuFlyoutPresenter : global::Windows.UI.Xaml.Controls.ItemsControl
+	{
+		// Skipping already declared property TemplateSettings
+		// Skipping already declared method Windows.UI.Xaml.Controls.MenuFlyoutPresenter.MenuFlyoutPresenter()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutPresenter.MenuFlyoutPresenter()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutPresenter.TemplateSettings.get
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuFlyoutSubItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuFlyoutSubItem.cs
@@ -2,5 +2,24 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class MenuFlyoutSubItem : global::Windows.UI.Xaml.Controls.MenuFlyoutItemBase
+	{
+		// Skipping already declared property Text
+		// Skipping already declared property Items
+		// Skipping already declared property Icon
+		// Skipping already declared property TextProperty
+		// Skipping already declared property IconProperty
+		// Skipping already declared method Windows.UI.Xaml.Controls.MenuFlyoutSubItem.MenuFlyoutSubItem()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutSubItem.MenuFlyoutSubItem()
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutSubItem.Items.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutSubItem.Text.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutSubItem.Text.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutSubItem.Icon.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutSubItem.Icon.set
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutSubItem.IconProperty.get
+		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutSubItem.TextProperty.get
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ParallaxView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ParallaxView.cs
@@ -207,7 +207,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ChildProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Child", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(Child), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif
@@ -215,7 +215,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalShiftProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalShift", typeof(double), 
+			nameof(HorizontalShift), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -223,7 +223,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalSourceEndOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalSourceEndOffset", typeof(double), 
+			nameof(HorizontalSourceEndOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -231,7 +231,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalSourceOffsetKindProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalSourceOffsetKind", typeof(global::Windows.UI.Xaml.Controls.ParallaxSourceOffsetKind), 
+			nameof(HorizontalSourceOffsetKind), typeof(global::Windows.UI.Xaml.Controls.ParallaxSourceOffsetKind), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ParallaxSourceOffsetKind)));
 		#endif
@@ -239,7 +239,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalSourceStartOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalSourceStartOffset", typeof(double), 
+			nameof(HorizontalSourceStartOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -247,7 +247,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsHorizontalShiftClampedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsHorizontalShiftClamped", typeof(bool), 
+			nameof(IsHorizontalShiftClamped), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -255,7 +255,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsVerticalShiftClampedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsVerticalShiftClamped", typeof(bool), 
+			nameof(IsVerticalShiftClamped), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -263,7 +263,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxHorizontalShiftRatioProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxHorizontalShiftRatio", typeof(double), 
+			nameof(MaxHorizontalShiftRatio), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -271,7 +271,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxVerticalShiftRatioProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxVerticalShiftRatio", typeof(double), 
+			nameof(MaxVerticalShiftRatio), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -279,7 +279,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Source", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(Source), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif
@@ -287,7 +287,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalShiftProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalShift", typeof(double), 
+			nameof(VerticalShift), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -295,7 +295,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalSourceEndOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalSourceEndOffset", typeof(double), 
+			nameof(VerticalSourceEndOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -303,7 +303,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalSourceOffsetKindProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalSourceOffsetKind", typeof(global::Windows.UI.Xaml.Controls.ParallaxSourceOffsetKind), 
+			nameof(VerticalSourceOffsetKind), typeof(global::Windows.UI.Xaml.Controls.ParallaxSourceOffsetKind), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ParallaxSourceOffsetKind)));
 		#endif
@@ -311,7 +311,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalSourceStartOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalSourceStartOffset", typeof(double), 
+			nameof(VerticalSourceStartOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ParallaxView), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
@@ -139,7 +139,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsPasswordRevealButtonEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsPasswordRevealButtonEnabled", typeof(bool), 
+			nameof(IsPasswordRevealButtonEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -148,7 +148,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PasswordCharProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PasswordChar", typeof(string), 
+			nameof(PasswordChar), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -160,7 +160,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PreventKeyboardDisplayOnProgrammaticFocusProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PreventKeyboardDisplayOnProgrammaticFocus", typeof(bool), 
+			nameof(PreventKeyboardDisplayOnProgrammaticFocus), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -168,7 +168,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionHighlightColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionHighlightColor", typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
+			nameof(SelectionHighlightColor), typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.SolidColorBrush)));
 		#endif
@@ -177,7 +177,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PasswordRevealModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PasswordRevealMode", typeof(global::Windows.UI.Xaml.Controls.PasswordRevealMode), 
+			nameof(PasswordRevealMode), typeof(global::Windows.UI.Xaml.Controls.PasswordRevealMode), 
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.PasswordRevealMode)));
 		#endif
@@ -185,7 +185,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextReadingOrderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextReadingOrder", typeof(global::Windows.UI.Xaml.TextReadingOrder), 
+			nameof(TextReadingOrder), typeof(global::Windows.UI.Xaml.TextReadingOrder), 
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextReadingOrder)));
 		#endif
@@ -193,7 +193,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanPasteClipboardContentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanPasteClipboardContent", typeof(bool), 
+			nameof(CanPasteClipboardContent), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -201,7 +201,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Description", typeof(object), 
+			nameof(Description), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -209,7 +209,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionFlyoutProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionFlyout", typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
+			nameof(SelectionFlyout), typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PathIconSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PathIconSource.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DataProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Data", typeof(global::Windows.UI.Xaml.Media.Geometry), 
+			nameof(Data), typeof(global::Windows.UI.Xaml.Media.Geometry), 
 			typeof(global::Windows.UI.Xaml.Controls.PathIconSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Geometry)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PersonPicture.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PersonPicture.cs
@@ -151,7 +151,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BadgeGlyphProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BadgeGlyph", typeof(string), 
+			nameof(BadgeGlyph), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.PersonPicture), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BadgeImageSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BadgeImageSource", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(BadgeImageSource), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.PersonPicture), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif
@@ -167,7 +167,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BadgeNumberProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BadgeNumber", typeof(int), 
+			nameof(BadgeNumber), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.PersonPicture), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -175,7 +175,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BadgeTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BadgeText", typeof(string), 
+			nameof(BadgeText), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.PersonPicture), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -183,7 +183,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContactProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Contact", typeof(global::Windows.ApplicationModel.Contacts.Contact), 
+			nameof(Contact), typeof(global::Windows.ApplicationModel.Contacts.Contact), 
 			typeof(global::Windows.UI.Xaml.Controls.PersonPicture), 
 			new FrameworkPropertyMetadata(default(global::Windows.ApplicationModel.Contacts.Contact)));
 		#endif
@@ -191,7 +191,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisplayNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DisplayName", typeof(string), 
+			nameof(DisplayName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.PersonPicture), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -199,7 +199,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty InitialsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Initials", typeof(string), 
+			nameof(Initials), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.PersonPicture), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -207,7 +207,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsGroupProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsGroup", typeof(bool), 
+			nameof(IsGroup), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.PersonPicture), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -215,7 +215,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PreferSmallImageProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PreferSmallImage", typeof(bool), 
+			nameof(PreferSmallImage), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.PersonPicture), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -223,7 +223,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ProfilePictureProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ProfilePicture", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(ProfilePicture), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.PersonPicture), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PickerConfirmedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PickerConfirmedEventArgs.cs
@@ -2,12 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class PickerConfirmedEventArgs : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared method Windows.UI.Xaml.Controls.PickerConfirmedEventArgs.PickerConfirmedEventArgs()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public PickerConfirmedEventArgs() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.PickerConfirmedEventArgs", "PickerConfirmedEventArgs.PickerConfirmedEventArgs()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.PickerConfirmedEventArgs.PickerConfirmedEventArgs()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PickerFlyout.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PickerFlyout.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ConfirmationButtonsVisibleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ConfirmationButtonsVisible", typeof(bool), 
+			nameof(ConfirmationButtonsVisible), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.PickerFlyout), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Content", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(Content), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.PickerFlyout), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Pivot.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Pivot.cs
@@ -80,7 +80,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderFocusVisualPlacementProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderFocusVisualPlacement", typeof(global::Windows.UI.Xaml.Controls.PivotHeaderFocusVisualPlacement), 
+			nameof(HeaderFocusVisualPlacement), typeof(global::Windows.UI.Xaml.Controls.PivotHeaderFocusVisualPlacement), 
 			typeof(global::Windows.UI.Xaml.Controls.Pivot), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.PivotHeaderFocusVisualPlacement)));
 		#endif
@@ -88,7 +88,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsHeaderItemsCarouselEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsHeaderItemsCarouselEnabled", typeof(bool), 
+			nameof(IsHeaderItemsCarouselEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.Pivot), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ProgressRing.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ProgressRing.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsActiveProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsActive", typeof(bool), 
+			nameof(IsActive), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ProgressRing), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingControl.cs
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CaptionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Caption", typeof(string), 
+			nameof(Caption), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingControl), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -131,7 +131,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty InitialSetValueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"InitialSetValue", typeof(int), 
+			nameof(InitialSetValue), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingControl), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -139,7 +139,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsClearEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsClearEnabled", typeof(bool), 
+			nameof(IsClearEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingControl), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -147,7 +147,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsReadOnlyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsReadOnly", typeof(bool), 
+			nameof(IsReadOnly), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingControl), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -155,7 +155,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemInfoProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemInfo", typeof(global::Windows.UI.Xaml.Controls.RatingItemInfo), 
+			nameof(ItemInfo), typeof(global::Windows.UI.Xaml.Controls.RatingItemInfo), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingControl), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.RatingItemInfo)));
 		#endif
@@ -163,7 +163,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxRatingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxRating", typeof(int), 
+			nameof(MaxRating), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingControl), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -171,7 +171,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderValueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaceholderValue", typeof(double), 
+			nameof(PlaceholderValue), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingControl), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -179,7 +179,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ValueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Value", typeof(double), 
+			nameof(Value), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingControl), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingItemFontInfo.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingItemFontInfo.cs
@@ -95,7 +95,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisabledGlyphProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DisabledGlyph", typeof(string), 
+			nameof(DisabledGlyph), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemFontInfo), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GlyphProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Glyph", typeof(string), 
+			nameof(Glyph), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemFontInfo), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -111,7 +111,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderGlyphProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaceholderGlyph", typeof(string), 
+			nameof(PlaceholderGlyph), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemFontInfo), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -119,7 +119,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PointerOverGlyphProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PointerOverGlyph", typeof(string), 
+			nameof(PointerOverGlyph), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemFontInfo), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -127,7 +127,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PointerOverPlaceholderGlyphProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PointerOverPlaceholderGlyph", typeof(string), 
+			nameof(PointerOverPlaceholderGlyph), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemFontInfo), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -135,7 +135,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty UnsetGlyphProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"UnsetGlyph", typeof(string), 
+			nameof(UnsetGlyph), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemFontInfo), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingItemImageInfo.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingItemImageInfo.cs
@@ -95,7 +95,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisabledImageProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DisabledImage", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(DisabledImage), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemImageInfo), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ImageProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Image", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(Image), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemImageInfo), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif
@@ -111,7 +111,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderImageProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaceholderImage", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(PlaceholderImage), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemImageInfo), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif
@@ -119,7 +119,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PointerOverImageProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PointerOverImage", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(PointerOverImage), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemImageInfo), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif
@@ -127,7 +127,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PointerOverPlaceholderImageProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PointerOverPlaceholderImage", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(PointerOverPlaceholderImage), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemImageInfo), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif
@@ -135,7 +135,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty UnsetImageProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"UnsetImage", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(UnsetImage), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.RatingItemImageInfo), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingItemInfo.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingItemInfo.cs
@@ -2,12 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class RatingItemInfo : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared method Windows.UI.Xaml.Controls.RatingItemInfo.RatingItemInfo()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public RatingItemInfo() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.RatingItemInfo", "RatingItemInfo.RatingItemInfo()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.RatingItemInfo.RatingItemInfo()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RefreshContainer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RefreshContainer.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PullDirectionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PullDirection", typeof(global::Windows.UI.Xaml.Controls.RefreshPullDirection), 
+			nameof(PullDirection), typeof(global::Windows.UI.Xaml.Controls.RefreshPullDirection), 
 			typeof(global::Windows.UI.Xaml.Controls.RefreshContainer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.RefreshPullDirection)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VisualizerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Visualizer", typeof(global::Windows.UI.Xaml.Controls.RefreshVisualizer), 
+			nameof(Visualizer), typeof(global::Windows.UI.Xaml.Controls.RefreshVisualizer), 
 			typeof(global::Windows.UI.Xaml.Controls.RefreshContainer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.RefreshVisualizer)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RefreshVisualizer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RefreshVisualizer.cs
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Content", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(Content), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.RefreshVisualizer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif
@@ -62,7 +62,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OrientationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Orientation", typeof(global::Windows.UI.Xaml.Controls.RefreshVisualizerOrientation), 
+			nameof(Orientation), typeof(global::Windows.UI.Xaml.Controls.RefreshVisualizerOrientation), 
 			typeof(global::Windows.UI.Xaml.Controls.RefreshVisualizer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.RefreshVisualizerOrientation)));
 		#endif
@@ -70,7 +70,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"State", typeof(global::Windows.UI.Xaml.Controls.RefreshVisualizerState), 
+			nameof(State), typeof(global::Windows.UI.Xaml.Controls.RefreshVisualizerState), 
 			typeof(global::Windows.UI.Xaml.Controls.RefreshVisualizer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.RefreshVisualizerState)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RelativePanel.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RelativePanel.cs
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BackgroundSizingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BackgroundSizing", typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
+			nameof(BackgroundSizing), typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
 			typeof(global::Windows.UI.Xaml.Controls.RelativePanel), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.BackgroundSizing)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RichEditBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RichEditBox.cs
@@ -433,7 +433,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AcceptsReturnProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AcceptsReturn", typeof(bool), 
+			nameof(AcceptsReturn), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -441,7 +441,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty InputScopeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"InputScope", typeof(global::Windows.UI.Xaml.Input.InputScope), 
+			nameof(InputScope), typeof(global::Windows.UI.Xaml.Input.InputScope), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.InputScope)));
 		#endif
@@ -449,7 +449,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsReadOnlyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsReadOnly", typeof(bool), 
+			nameof(IsReadOnly), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -457,7 +457,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsSpellCheckEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsSpellCheckEnabled", typeof(bool), 
+			nameof(IsSpellCheckEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -465,7 +465,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextPredictionEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextPredictionEnabled", typeof(bool), 
+			nameof(IsTextPredictionEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -473,7 +473,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextAlignment", typeof(global::Windows.UI.Xaml.TextAlignment), 
+			nameof(TextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
 		#endif
@@ -481,7 +481,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextWrappingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextWrapping", typeof(global::Windows.UI.Xaml.TextWrapping), 
+			nameof(TextWrapping), typeof(global::Windows.UI.Xaml.TextWrapping), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextWrapping)));
 		#endif
@@ -489,7 +489,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Header", typeof(object), 
+			nameof(Header), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -497,7 +497,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(HeaderTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -505,7 +505,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsColorFontEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsColorFontEnabled", typeof(bool), 
+			nameof(IsColorFontEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -513,7 +513,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaceholderText", typeof(string), 
+			nameof(PlaceholderText), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -521,7 +521,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PreventKeyboardDisplayOnProgrammaticFocusProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PreventKeyboardDisplayOnProgrammaticFocus", typeof(bool), 
+			nameof(PreventKeyboardDisplayOnProgrammaticFocus), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -529,7 +529,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionHighlightColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionHighlightColor", typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
+			nameof(SelectionHighlightColor), typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.SolidColorBrush)));
 		#endif
@@ -537,7 +537,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DesiredCandidateWindowAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DesiredCandidateWindowAlignment", typeof(global::Windows.UI.Xaml.Controls.CandidateWindowAlignment), 
+			nameof(DesiredCandidateWindowAlignment), typeof(global::Windows.UI.Xaml.Controls.CandidateWindowAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.CandidateWindowAlignment)));
 		#endif
@@ -545,7 +545,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextReadingOrderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextReadingOrder", typeof(global::Windows.UI.Xaml.TextReadingOrder), 
+			nameof(TextReadingOrder), typeof(global::Windows.UI.Xaml.TextReadingOrder), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextReadingOrder)));
 		#endif
@@ -553,7 +553,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ClipboardCopyFormatProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ClipboardCopyFormat", typeof(global::Windows.UI.Xaml.Controls.RichEditClipboardFormat), 
+			nameof(ClipboardCopyFormat), typeof(global::Windows.UI.Xaml.Controls.RichEditClipboardFormat), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.RichEditClipboardFormat)));
 		#endif
@@ -561,7 +561,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxLengthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxLength", typeof(int), 
+			nameof(MaxLength), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -569,7 +569,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionHighlightColorWhenNotFocusedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionHighlightColorWhenNotFocused", typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
+			nameof(SelectionHighlightColorWhenNotFocused), typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.SolidColorBrush)));
 		#endif
@@ -577,7 +577,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CharacterCasingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CharacterCasing", typeof(global::Windows.UI.Xaml.Controls.CharacterCasing), 
+			nameof(CharacterCasing), typeof(global::Windows.UI.Xaml.Controls.CharacterCasing), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.CharacterCasing)));
 		#endif
@@ -585,7 +585,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DisabledFormattingAcceleratorsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DisabledFormattingAccelerators", typeof(global::Windows.UI.Xaml.Controls.DisabledFormattingAccelerators), 
+			nameof(DisabledFormattingAccelerators), typeof(global::Windows.UI.Xaml.Controls.DisabledFormattingAccelerators), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.DisabledFormattingAccelerators)));
 		#endif
@@ -593,7 +593,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalTextAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalTextAlignment", typeof(global::Windows.UI.Xaml.TextAlignment), 
+			nameof(HorizontalTextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
 		#endif
@@ -601,7 +601,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentLinkBackgroundColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentLinkBackgroundColor", typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
+			nameof(ContentLinkBackgroundColor), typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.SolidColorBrush)));
 		#endif
@@ -609,7 +609,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentLinkForegroundColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentLinkForegroundColor", typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
+			nameof(ContentLinkForegroundColor), typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.SolidColorBrush)));
 		#endif
@@ -617,7 +617,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentLinkProvidersProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentLinkProviders", typeof(global::Windows.UI.Xaml.Documents.ContentLinkProviderCollection), 
+			nameof(ContentLinkProviders), typeof(global::Windows.UI.Xaml.Documents.ContentLinkProviderCollection), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Documents.ContentLinkProviderCollection)));
 		#endif
@@ -625,7 +625,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HandwritingViewProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HandwritingView", typeof(global::Windows.UI.Xaml.Controls.HandwritingView), 
+			nameof(HandwritingView), typeof(global::Windows.UI.Xaml.Controls.HandwritingView), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.HandwritingView)));
 		#endif
@@ -633,7 +633,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsHandwritingViewEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsHandwritingViewEnabled", typeof(bool), 
+			nameof(IsHandwritingViewEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -641,7 +641,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Description", typeof(object), 
+			nameof(Description), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -649,7 +649,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ProofingMenuFlyoutProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ProofingMenuFlyout", typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
+			nameof(ProofingMenuFlyout), typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif
@@ -657,7 +657,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionFlyoutProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionFlyout", typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
+			nameof(SelectionFlyout), typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			typeof(global::Windows.UI.Xaml.Controls.RichEditBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RichTextBlock.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RichTextBlock.cs
@@ -466,7 +466,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CharacterSpacingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CharacterSpacing", typeof(int), 
+			nameof(CharacterSpacing), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -474,7 +474,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontFamilyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontFamily", typeof(global::Windows.UI.Xaml.Media.FontFamily), 
+			nameof(FontFamily), typeof(global::Windows.UI.Xaml.Media.FontFamily), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FontFamily)));
 		#endif
@@ -482,7 +482,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontSize", typeof(double), 
+			nameof(FontSize), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -490,7 +490,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontStretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontStretch", typeof(global::Windows.UI.Text.FontStretch), 
+			nameof(FontStretch), typeof(global::Windows.UI.Text.FontStretch), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStretch)));
 		#endif
@@ -498,7 +498,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontStyle", typeof(global::Windows.UI.Text.FontStyle), 
+			nameof(FontStyle), typeof(global::Windows.UI.Text.FontStyle), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStyle)));
 		#endif
@@ -506,7 +506,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontWeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontWeight", typeof(global::Windows.UI.Text.FontWeight), 
+			nameof(FontWeight), typeof(global::Windows.UI.Text.FontWeight), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontWeight)));
 		#endif
@@ -514,7 +514,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Foreground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Foreground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -522,7 +522,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HasOverflowContentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HasOverflowContent", typeof(bool), 
+			nameof(HasOverflowContent), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -530,7 +530,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextSelectionEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextSelectionEnabled", typeof(bool), 
+			nameof(IsTextSelectionEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -538,7 +538,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LineHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LineHeight", typeof(double), 
+			nameof(LineHeight), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -546,7 +546,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LineStackingStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LineStackingStrategy", typeof(global::Windows.UI.Xaml.LineStackingStrategy), 
+			nameof(LineStackingStrategy), typeof(global::Windows.UI.Xaml.LineStackingStrategy), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.LineStackingStrategy)));
 		#endif
@@ -554,7 +554,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OverflowContentTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OverflowContentTarget", typeof(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow), 
+			nameof(OverflowContentTarget), typeof(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow)));
 		#endif
@@ -562,7 +562,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PaddingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Padding", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(Padding), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -570,7 +570,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedText", typeof(string), 
+			nameof(SelectedText), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -578,7 +578,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextAlignment", typeof(global::Windows.UI.Xaml.TextAlignment), 
+			nameof(TextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
 		#endif
@@ -586,7 +586,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextIndentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextIndent", typeof(double), 
+			nameof(TextIndent), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -594,7 +594,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextTrimmingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextTrimming", typeof(global::Windows.UI.Xaml.TextTrimming), 
+			nameof(TextTrimming), typeof(global::Windows.UI.Xaml.TextTrimming), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextTrimming)));
 		#endif
@@ -602,7 +602,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextWrappingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextWrapping", typeof(global::Windows.UI.Xaml.TextWrapping), 
+			nameof(TextWrapping), typeof(global::Windows.UI.Xaml.TextWrapping), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextWrapping)));
 		#endif
@@ -610,7 +610,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsColorFontEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsColorFontEnabled", typeof(bool), 
+			nameof(IsColorFontEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -618,7 +618,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxLinesProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxLines", typeof(int), 
+			nameof(MaxLines), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -626,7 +626,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OpticalMarginAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OpticalMarginAlignment", typeof(global::Windows.UI.Xaml.OpticalMarginAlignment), 
+			nameof(OpticalMarginAlignment), typeof(global::Windows.UI.Xaml.OpticalMarginAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.OpticalMarginAlignment)));
 		#endif
@@ -634,7 +634,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionHighlightColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionHighlightColor", typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
+			nameof(SelectionHighlightColor), typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.SolidColorBrush)));
 		#endif
@@ -642,7 +642,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextLineBoundsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextLineBounds", typeof(global::Windows.UI.Xaml.TextLineBounds), 
+			nameof(TextLineBounds), typeof(global::Windows.UI.Xaml.TextLineBounds), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextLineBounds)));
 		#endif
@@ -650,7 +650,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextReadingOrderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextReadingOrder", typeof(global::Windows.UI.Xaml.TextReadingOrder), 
+			nameof(TextReadingOrder), typeof(global::Windows.UI.Xaml.TextReadingOrder), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextReadingOrder)));
 		#endif
@@ -658,7 +658,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextScaleFactorEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextScaleFactorEnabled", typeof(bool), 
+			nameof(IsTextScaleFactorEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -666,7 +666,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextDecorationsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextDecorations", typeof(global::Windows.UI.Text.TextDecorations), 
+			nameof(TextDecorations), typeof(global::Windows.UI.Text.TextDecorations), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.TextDecorations)));
 		#endif
@@ -674,7 +674,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalTextAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalTextAlignment", typeof(global::Windows.UI.Xaml.TextAlignment), 
+			nameof(HorizontalTextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
 		#endif
@@ -682,7 +682,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextTrimmedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextTrimmed", typeof(bool), 
+			nameof(IsTextTrimmed), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -690,7 +690,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionFlyoutProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionFlyout", typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
+			nameof(SelectionFlyout), typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RichTextBlockOverflow.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RichTextBlockOverflow.cs
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HasOverflowContentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HasOverflowContent", typeof(bool), 
+			nameof(HasOverflowContent), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -121,7 +121,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OverflowContentTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OverflowContentTarget", typeof(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow), 
+			nameof(OverflowContentTarget), typeof(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow)));
 		#endif
@@ -129,7 +129,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PaddingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Padding", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(Padding), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -137,7 +137,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxLinesProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxLines", typeof(int), 
+			nameof(MaxLines), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -145,7 +145,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextTrimmedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextTrimmed", typeof(bool), 
+			nameof(IsTextTrimmed), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.RichTextBlockOverflow), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RowDefinition.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RowDefinition.cs
@@ -7,6 +7,8 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class RowDefinition : global::Windows.UI.Xaml.DependencyObject
 	{
+		// Skipping already declared property MinHeight
+		// Skipping already declared property MaxHeight
 		// Skipping already declared property Height
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
@@ -19,6 +21,8 @@ namespace Windows.UI.Xaml.Controls
 		}
 		#endif
 		// Skipping already declared property HeightProperty
+		// Skipping already declared property MaxHeightProperty
+		// Skipping already declared property MinHeightProperty
 		// Skipping already declared method Windows.UI.Xaml.Controls.RowDefinition.RowDefinition()
 		// Forced skipping of method Windows.UI.Xaml.Controls.RowDefinition.RowDefinition()
 		// Forced skipping of method Windows.UI.Xaml.Controls.RowDefinition.Height.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ScrollContentPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ScrollContentPresenter.cs
@@ -141,7 +141,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanContentRenderOutsideBoundsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanContentRenderOutsideBounds", typeof(bool), 
+			nameof(CanContentRenderOutsideBounds), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollContentPresenter), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -149,7 +149,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SizesContentToTemplatedParentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SizesContentToTemplatedParent", typeof(bool), 
+			nameof(SizesContentToTemplatedParent), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollContentPresenter), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ScrollViewer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ScrollViewer.cs
@@ -327,7 +327,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ZoomSnapPointsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ZoomSnapPoints", typeof(global::System.Collections.Generic.IList<float>), 
+			nameof(ZoomSnapPoints), typeof(global::System.Collections.Generic.IList<float>), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(global::System.Collections.Generic.IList<float>)));
 		#endif
@@ -336,7 +336,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ComputedHorizontalScrollBarVisibilityProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ComputedHorizontalScrollBarVisibility", typeof(global::Windows.UI.Xaml.Visibility), 
+			nameof(ComputedHorizontalScrollBarVisibility), typeof(global::Windows.UI.Xaml.Visibility), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Visibility)));
 		#endif
@@ -344,7 +344,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ComputedVerticalScrollBarVisibilityProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ComputedVerticalScrollBarVisibility", typeof(global::Windows.UI.Xaml.Visibility), 
+			nameof(ComputedVerticalScrollBarVisibility), typeof(global::Windows.UI.Xaml.Visibility), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Visibility)));
 		#endif
@@ -354,7 +354,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalOffset", typeof(double), 
+			nameof(HorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -390,7 +390,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ZoomSnapPointsTypeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ZoomSnapPointsType", typeof(global::Windows.UI.Xaml.Controls.SnapPointsType), 
+			nameof(ZoomSnapPointsType), typeof(global::Windows.UI.Xaml.Controls.SnapPointsType), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SnapPointsType)));
 		#endif
@@ -434,7 +434,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalOffset", typeof(double), 
+			nameof(VerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -445,7 +445,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LeftHeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LeftHeader", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(LeftHeader), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif
@@ -453,7 +453,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TopHeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TopHeader", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(TopHeader), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif
@@ -461,7 +461,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TopLeftHeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TopLeftHeader", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(TopLeftHeader), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif
@@ -469,7 +469,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalAnchorRatioProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalAnchorRatio", typeof(double), 
+			nameof(HorizontalAnchorRatio), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -477,7 +477,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ReduceViewportForCoreInputViewOcclusionsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ReduceViewportForCoreInputViewOcclusions", typeof(bool), 
+			nameof(ReduceViewportForCoreInputViewOcclusions), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -485,7 +485,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalAnchorRatioProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalAnchorRatio", typeof(double), 
+			nameof(VerticalAnchorRatio), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ScrollViewer), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SearchBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SearchBox.cs
@@ -95,7 +95,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ChooseSuggestionOnEnterProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ChooseSuggestionOnEnter", typeof(bool), 
+			nameof(ChooseSuggestionOnEnter), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.SearchBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusOnKeyboardInputProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusOnKeyboardInput", typeof(bool), 
+			nameof(FocusOnKeyboardInput), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.SearchBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -111,7 +111,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaceholderText", typeof(string), 
+			nameof(PlaceholderText), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.SearchBox), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -119,7 +119,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty QueryTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"QueryText", typeof(string), 
+			nameof(QueryText), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.SearchBox), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -127,7 +127,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SearchHistoryContextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SearchHistoryContext", typeof(string), 
+			nameof(SearchHistoryContext), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.SearchBox), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -135,7 +135,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SearchHistoryEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SearchHistoryEnabled", typeof(bool), 
+			nameof(SearchHistoryEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.SearchBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SemanticZoom.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SemanticZoom.cs
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanChangeViewsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanChangeViews", typeof(bool), 
+			nameof(CanChangeViews), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.SemanticZoom), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -89,7 +89,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsZoomOutButtonEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsZoomOutButtonEnabled", typeof(bool), 
+			nameof(IsZoomOutButtonEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.SemanticZoom), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -97,7 +97,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsZoomedInViewActiveProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsZoomedInViewActive", typeof(bool), 
+			nameof(IsZoomedInViewActive), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.SemanticZoom), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -105,7 +105,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ZoomedInViewProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ZoomedInView", typeof(global::Windows.UI.Xaml.Controls.ISemanticZoomInformation), 
+			nameof(ZoomedInView), typeof(global::Windows.UI.Xaml.Controls.ISemanticZoomInformation), 
 			typeof(global::Windows.UI.Xaml.Controls.SemanticZoom), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ISemanticZoomInformation)));
 		#endif
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ZoomedOutViewProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ZoomedOutView", typeof(global::Windows.UI.Xaml.Controls.ISemanticZoomInformation), 
+			nameof(ZoomedOutView), typeof(global::Windows.UI.Xaml.Controls.ISemanticZoomInformation), 
 			typeof(global::Windows.UI.Xaml.Controls.SemanticZoom), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ISemanticZoomInformation)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SettingsFlyout.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SettingsFlyout.cs
@@ -77,7 +77,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderBackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderBackground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(HeaderBackground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.SettingsFlyout), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -85,7 +85,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(HeaderForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.SettingsFlyout), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -93,7 +93,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IconSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IconSource", typeof(global::Windows.UI.Xaml.Media.ImageSource), 
+			nameof(IconSource), typeof(global::Windows.UI.Xaml.Media.ImageSource), 
 			typeof(global::Windows.UI.Xaml.Controls.SettingsFlyout), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ImageSource)));
 		#endif
@@ -101,7 +101,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TitleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Title", typeof(string), 
+			nameof(Title), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.SettingsFlyout), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SplitButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SplitButton.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CommandParameterProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CommandParameter", typeof(object), 
+			nameof(CommandParameter), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.SplitButton), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CommandProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Command", typeof(global::System.Windows.Input.ICommand), 
+			nameof(Command), typeof(global::System.Windows.Input.ICommand), 
 			typeof(global::Windows.UI.Xaml.Controls.SplitButton), 
 			new FrameworkPropertyMetadata(default(global::System.Windows.Input.ICommand)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FlyoutProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Flyout", typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
+			nameof(Flyout), typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			typeof(global::Windows.UI.Xaml.Controls.SplitButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SplitView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SplitView.cs
@@ -43,7 +43,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
+			nameof(LightDismissOverlayMode), typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.SplitView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/StackPanel.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/StackPanel.cs
@@ -65,7 +65,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AreScrollSnapPointsRegularProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AreScrollSnapPointsRegular", typeof(bool), 
+			nameof(AreScrollSnapPointsRegular), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.StackPanel), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -79,7 +79,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BackgroundSizingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BackgroundSizing", typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
+			nameof(BackgroundSizing), typeof(global::Windows.UI.Xaml.Controls.BackgroundSizing), 
 			typeof(global::Windows.UI.Xaml.Controls.StackPanel), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.BackgroundSizing)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwapChainPanel.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwapChainPanel.cs
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CompositionScaleXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CompositionScaleX", typeof(float), 
+			nameof(CompositionScaleX), typeof(float), 
 			typeof(global::Windows.UI.Xaml.Controls.SwapChainPanel), 
 			new FrameworkPropertyMetadata(default(float)));
 		#endif
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CompositionScaleYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CompositionScaleY", typeof(float), 
+			nameof(CompositionScaleY), typeof(float), 
 			typeof(global::Windows.UI.Xaml.Controls.SwapChainPanel), 
 			new FrameworkPropertyMetadata(default(float)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwipeControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwipeControl.cs
@@ -67,7 +67,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BottomItemsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BottomItems", typeof(global::Windows.UI.Xaml.Controls.SwipeItems), 
+			nameof(BottomItems), typeof(global::Windows.UI.Xaml.Controls.SwipeItems), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeControl), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SwipeItems)));
 		#endif
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LeftItemsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LeftItems", typeof(global::Windows.UI.Xaml.Controls.SwipeItems), 
+			nameof(LeftItems), typeof(global::Windows.UI.Xaml.Controls.SwipeItems), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeControl), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SwipeItems)));
 		#endif
@@ -83,7 +83,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RightItemsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RightItems", typeof(global::Windows.UI.Xaml.Controls.SwipeItems), 
+			nameof(RightItems), typeof(global::Windows.UI.Xaml.Controls.SwipeItems), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeControl), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SwipeItems)));
 		#endif
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TopItemsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TopItems", typeof(global::Windows.UI.Xaml.Controls.SwipeItems), 
+			nameof(TopItems), typeof(global::Windows.UI.Xaml.Controls.SwipeItems), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeControl), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SwipeItems)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwipeItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwipeItem.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SwipeItem : global::Windows.UI.Xaml.DependencyObject
@@ -109,7 +109,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Background", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Background), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeItem), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BehaviorOnInvokedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BehaviorOnInvoked", typeof(global::Windows.UI.Xaml.Controls.SwipeBehaviorOnInvoked), 
+			nameof(BehaviorOnInvoked), typeof(global::Windows.UI.Xaml.Controls.SwipeBehaviorOnInvoked), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeItem), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SwipeBehaviorOnInvoked)));
 		#endif
@@ -125,7 +125,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CommandParameterProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CommandParameter", typeof(object), 
+			nameof(CommandParameter), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeItem), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -133,7 +133,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CommandProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Command", typeof(global::System.Windows.Input.ICommand), 
+			nameof(Command), typeof(global::System.Windows.Input.ICommand), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeItem), 
 			new FrameworkPropertyMetadata(default(global::System.Windows.Input.ICommand)));
 		#endif
@@ -141,7 +141,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Foreground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Foreground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeItem), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -149,7 +149,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IconSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IconSource", typeof(global::Windows.UI.Xaml.Controls.IconSource), 
+			nameof(IconSource), typeof(global::Windows.UI.Xaml.Controls.IconSource), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeItem), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.IconSource)));
 		#endif
@@ -157,11 +157,17 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Text", typeof(string), 
+			nameof(Text), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeItem), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.SwipeItem.SwipeItem()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public SwipeItem() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.SwipeItem", "SwipeItem.SwipeItem()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItem.SwipeItem()
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItem.Text.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItem.Text.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwipeItems.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwipeItems.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SwipeItems : global::Windows.UI.Xaml.DependencyObject,global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Controls.SwipeItem>,global::System.Collections.Generic.IEnumerable<global::Windows.UI.Xaml.Controls.SwipeItem>
@@ -35,11 +35,17 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Mode", typeof(global::Windows.UI.Xaml.Controls.SwipeMode), 
+			nameof(Mode), typeof(global::Windows.UI.Xaml.Controls.SwipeMode), 
 			typeof(global::Windows.UI.Xaml.Controls.SwipeItems), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SwipeMode)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.SwipeItems.SwipeItems()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public SwipeItems() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.SwipeItems", "SwipeItems.SwipeItems()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItems.SwipeItems()
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItems.Mode.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItems.Mode.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SymbolIcon.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SymbolIcon.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SymbolProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Symbol", typeof(global::Windows.UI.Xaml.Controls.Symbol), 
+			nameof(Symbol), typeof(global::Windows.UI.Xaml.Controls.Symbol), 
 			typeof(global::Windows.UI.Xaml.Controls.SymbolIcon), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Symbol)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SymbolIconSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SymbolIconSource.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SymbolProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Symbol", typeof(global::Windows.UI.Xaml.Controls.Symbol), 
+			nameof(Symbol), typeof(global::Windows.UI.Xaml.Controls.Symbol), 
 			typeof(global::Windows.UI.Xaml.Controls.SymbolIconSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Symbol)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBlock.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBlock.cs
@@ -429,7 +429,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CharacterSpacingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CharacterSpacing", typeof(int), 
+			nameof(CharacterSpacing), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -437,7 +437,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontFamilyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontFamily", typeof(global::Windows.UI.Xaml.Media.FontFamily), 
+			nameof(FontFamily), typeof(global::Windows.UI.Xaml.Media.FontFamily), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FontFamily)));
 		#endif
@@ -445,7 +445,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontSize", typeof(double), 
+			nameof(FontSize), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -453,7 +453,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontStretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontStretch", typeof(global::Windows.UI.Text.FontStretch), 
+			nameof(FontStretch), typeof(global::Windows.UI.Text.FontStretch), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStretch)));
 		#endif
@@ -461,7 +461,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontStyle", typeof(global::Windows.UI.Text.FontStyle), 
+			nameof(FontStyle), typeof(global::Windows.UI.Text.FontStyle), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStyle)));
 		#endif
@@ -469,7 +469,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontWeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontWeight", typeof(global::Windows.UI.Text.FontWeight), 
+			nameof(FontWeight), typeof(global::Windows.UI.Text.FontWeight), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontWeight)));
 		#endif
@@ -477,7 +477,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Foreground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Foreground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -485,7 +485,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextSelectionEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextSelectionEnabled", typeof(bool), 
+			nameof(IsTextSelectionEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -493,7 +493,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LineHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LineHeight", typeof(double), 
+			nameof(LineHeight), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -501,7 +501,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LineStackingStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LineStackingStrategy", typeof(global::Windows.UI.Xaml.LineStackingStrategy), 
+			nameof(LineStackingStrategy), typeof(global::Windows.UI.Xaml.LineStackingStrategy), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.LineStackingStrategy)));
 		#endif
@@ -509,7 +509,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PaddingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Padding", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(Padding), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -517,7 +517,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedText", typeof(string), 
+			nameof(SelectedText), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -525,7 +525,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextAlignment", typeof(global::Windows.UI.Xaml.TextAlignment), 
+			nameof(TextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
 		#endif
@@ -533,7 +533,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Text", typeof(string), 
+			nameof(Text), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -541,7 +541,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextTrimmingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextTrimming", typeof(global::Windows.UI.Xaml.TextTrimming), 
+			nameof(TextTrimming), typeof(global::Windows.UI.Xaml.TextTrimming), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextTrimming)));
 		#endif
@@ -549,7 +549,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextWrappingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextWrapping", typeof(global::Windows.UI.Xaml.TextWrapping), 
+			nameof(TextWrapping), typeof(global::Windows.UI.Xaml.TextWrapping), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextWrapping)));
 		#endif
@@ -557,7 +557,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsColorFontEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsColorFontEnabled", typeof(bool), 
+			nameof(IsColorFontEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -565,7 +565,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxLinesProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxLines", typeof(int), 
+			nameof(MaxLines), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -573,7 +573,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OpticalMarginAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OpticalMarginAlignment", typeof(global::Windows.UI.Xaml.OpticalMarginAlignment), 
+			nameof(OpticalMarginAlignment), typeof(global::Windows.UI.Xaml.OpticalMarginAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.OpticalMarginAlignment)));
 		#endif
@@ -581,7 +581,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionHighlightColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionHighlightColor", typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
+			nameof(SelectionHighlightColor), typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.SolidColorBrush)));
 		#endif
@@ -589,7 +589,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextLineBoundsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextLineBounds", typeof(global::Windows.UI.Xaml.TextLineBounds), 
+			nameof(TextLineBounds), typeof(global::Windows.UI.Xaml.TextLineBounds), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextLineBounds)));
 		#endif
@@ -597,7 +597,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextReadingOrderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextReadingOrder", typeof(global::Windows.UI.Xaml.TextReadingOrder), 
+			nameof(TextReadingOrder), typeof(global::Windows.UI.Xaml.TextReadingOrder), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextReadingOrder)));
 		#endif
@@ -605,7 +605,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextScaleFactorEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextScaleFactorEnabled", typeof(bool), 
+			nameof(IsTextScaleFactorEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -614,7 +614,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalTextAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalTextAlignment", typeof(global::Windows.UI.Xaml.TextAlignment), 
+			nameof(HorizontalTextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
 		#endif
@@ -622,7 +622,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextTrimmedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextTrimmed", typeof(bool), 
+			nameof(IsTextTrimmed), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -630,7 +630,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionFlyoutProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionFlyout", typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
+			nameof(SelectionFlyout), typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -298,7 +298,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionHighlightColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionHighlightColor", typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
+			nameof(SelectionHighlightColor), typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.SolidColorBrush)));
 		#endif
@@ -306,7 +306,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PreventKeyboardDisplayOnProgrammaticFocusProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PreventKeyboardDisplayOnProgrammaticFocus", typeof(bool), 
+			nameof(PreventKeyboardDisplayOnProgrammaticFocus), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -315,7 +315,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsColorFontEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsColorFontEnabled", typeof(bool), 
+			nameof(IsColorFontEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -323,7 +323,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DesiredCandidateWindowAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DesiredCandidateWindowAlignment", typeof(global::Windows.UI.Xaml.Controls.CandidateWindowAlignment), 
+			nameof(DesiredCandidateWindowAlignment), typeof(global::Windows.UI.Xaml.Controls.CandidateWindowAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.CandidateWindowAlignment)));
 		#endif
@@ -331,7 +331,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextReadingOrderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextReadingOrder", typeof(global::Windows.UI.Xaml.TextReadingOrder), 
+			nameof(TextReadingOrder), typeof(global::Windows.UI.Xaml.TextReadingOrder), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextReadingOrder)));
 		#endif
@@ -339,7 +339,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionHighlightColorWhenNotFocusedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionHighlightColorWhenNotFocused", typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
+			nameof(SelectionHighlightColorWhenNotFocused), typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.SolidColorBrush)));
 		#endif
@@ -347,7 +347,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlaceholderForeground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(PlaceholderForeground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -355,7 +355,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalTextAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalTextAlignment", typeof(global::Windows.UI.Xaml.TextAlignment), 
+			nameof(HorizontalTextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
 		#endif
@@ -363,7 +363,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CharacterCasingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CharacterCasing", typeof(global::Windows.UI.Xaml.Controls.CharacterCasing), 
+			nameof(CharacterCasing), typeof(global::Windows.UI.Xaml.Controls.CharacterCasing), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.CharacterCasing)));
 		#endif
@@ -371,7 +371,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsHandwritingViewEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsHandwritingViewEnabled", typeof(bool), 
+			nameof(IsHandwritingViewEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -379,7 +379,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HandwritingViewProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HandwritingView", typeof(global::Windows.UI.Xaml.Controls.HandwritingView), 
+			nameof(HandwritingView), typeof(global::Windows.UI.Xaml.Controls.HandwritingView), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.HandwritingView)));
 		#endif
@@ -387,7 +387,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionFlyoutProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionFlyout", typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
+			nameof(SelectionFlyout), typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif
@@ -395,7 +395,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ProofingMenuFlyoutProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ProofingMenuFlyout", typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
+			nameof(ProofingMenuFlyout), typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif
@@ -403,7 +403,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Description", typeof(object), 
+			nameof(Description), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -411,7 +411,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanUndoProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanUndo", typeof(bool), 
+			nameof(CanUndo), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -419,7 +419,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanRedoProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanRedo", typeof(bool), 
+			nameof(CanRedo), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -427,7 +427,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanPasteClipboardContentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanPasteClipboardContent", typeof(bool), 
+			nameof(CanPasteClipboardContent), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -667,24 +667,9 @@ namespace Windows.UI.Xaml.Controls
 				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "event TypedEventHandler<TextBox, CandidateWindowBoundsChangedEventArgs> TextBox.CandidateWindowBoundsChanged");
 			}
 		}
-#endif
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.Controls.TextBox, global::Windows.UI.Xaml.Controls.TextBoxTextChangingEventArgs> TextChanging
-		{
-			[global::Uno.NotImplemented]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "event TypedEventHandler<TextBox, TextBoxTextChangingEventArgs> TextBox.TextChanging");
-			}
-			[global::Uno.NotImplemented]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "event TypedEventHandler<TextBox, TextBoxTextChangingEventArgs> TextBox.TextChanging");
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#endif
+		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.TextChanging
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.Controls.TextBox, global::Windows.UI.Xaml.Controls.TextCompositionChangedEventArgs> TextCompositionChanged
 		{
@@ -731,24 +716,9 @@ namespace Windows.UI.Xaml.Controls
 				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "event TypedEventHandler<TextBox, TextCompositionStartedEventArgs> TextBox.TextCompositionStarted");
 			}
 		}
-#endif
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.Controls.TextBox, global::Windows.UI.Xaml.Controls.TextBoxBeforeTextChangingEventArgs> BeforeTextChanging
-		{
-			[global::Uno.NotImplemented]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "event TypedEventHandler<TextBox, TextBoxBeforeTextChangingEventArgs> TextBox.BeforeTextChanging");
-			}
-			[global::Uno.NotImplemented]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "event TypedEventHandler<TextBox, TextBoxBeforeTextChangingEventArgs> TextBox.BeforeTextChanging");
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#endif
+		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.BeforeTextChanging
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.Controls.TextBox, global::Windows.UI.Xaml.Controls.TextControlCopyingToClipboardEventArgs> CopyingToClipboard
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBoxBeforeTextChangingEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBoxBeforeTextChangingEventArgs.cs
@@ -2,35 +2,13 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-#if false || false || false || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
-#endif
-	public partial class TextBoxBeforeTextChangingEventArgs 
+	#endif
+	public  partial class TextBoxBeforeTextChangingEventArgs 
 	{
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  bool Cancel
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool TextBoxBeforeTextChangingEventArgs.Cancel is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBoxBeforeTextChangingEventArgs", "bool TextBoxBeforeTextChangingEventArgs.Cancel");
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string NewText
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string TextBoxBeforeTextChangingEventArgs.NewText is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property Cancel
+		// Skipping already declared property NewText
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBoxBeforeTextChangingEventArgs.NewText.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBoxBeforeTextChangingEventArgs.Cancel.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBoxBeforeTextChangingEventArgs.Cancel.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBoxTextChangingEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBoxTextChangingEventArgs.cs
@@ -7,16 +7,7 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class TextBoxTextChangingEventArgs 
 	{
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  bool IsContentChanging
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool TextBoxTextChangingEventArgs.IsContentChanging is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property IsContentChanging
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBoxTextChangingEventArgs.IsContentChanging.get
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePickedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePickedEventArgs.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TimePickedEventArgs : global::Windows.UI.Xaml.DependencyObject
@@ -27,7 +27,13 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.TimePickedEventArgs.TimePickedEventArgs()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public TimePickedEventArgs() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TimePickedEventArgs", "TimePickedEventArgs.TimePickedEventArgs()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.TimePickedEventArgs.TimePickedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TimePickedEventArgs.OldTime.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.TimePickedEventArgs.NewTime.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePicker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePicker.cs
@@ -97,7 +97,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Header", typeof(object), 
+			nameof(Header), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -105,7 +105,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HeaderTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(HeaderTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinuteIncrementProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinuteIncrement", typeof(int), 
+			nameof(MinuteIncrement), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -121,7 +121,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TimeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Time", typeof(global::System.TimeSpan), 
+			nameof(Time), typeof(global::System.TimeSpan), 
 			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
 			new FrameworkPropertyMetadata(default(global::System.TimeSpan)));
 		#endif
@@ -129,7 +129,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
+			nameof(LightDismissOverlayMode), typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
@@ -137,7 +137,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedTimeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedTime", typeof(global::System.TimeSpan?), 
+			nameof(SelectedTime), typeof(global::System.TimeSpan?), 
 			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
 			new FrameworkPropertyMetadata(default(global::System.TimeSpan?)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePickerFlyout.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePickerFlyout.cs
@@ -7,6 +7,11 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class TimePickerFlyout 
 	{
+		// Skipping already declared property Time
+		// Skipping already declared property MinuteIncrement
+		// Skipping already declared property ClockIdentifier
+		// Skipping already declared property ClockIdentifierProperty
+		// Skipping already declared property MinuteIncrementProperty
 		// Skipping already declared property TimeProperty
 		// Skipping already declared method Windows.UI.Xaml.Controls.TimePickerFlyout.TimePickerFlyout()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TimePickerFlyout.TimePickerFlyout()

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSwitch.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSwitch.cs
@@ -41,6 +41,7 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSwitch.TemplateSettings.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSwitch.Toggled.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSwitch.Toggled.remove
+		// Skipping already declared method Windows.UI.Xaml.Controls.ToggleSwitch.OnToggled()
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		protected virtual void OnOnContentChanged( object oldContent,  object newContent)

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToolTip.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToolTip.cs
@@ -105,7 +105,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalOffset", typeof(double), 
+			nameof(HorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ToolTip), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsOpenProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsOpen", typeof(bool), 
+			nameof(IsOpen), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ToolTip), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -121,7 +121,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlacementProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Placement", typeof(global::Windows.UI.Xaml.Controls.Primitives.PlacementMode), 
+			nameof(Placement), typeof(global::Windows.UI.Xaml.Controls.Primitives.PlacementMode), 
 			typeof(global::Windows.UI.Xaml.Controls.ToolTip), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.PlacementMode)));
 		#endif
@@ -129,7 +129,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlacementTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlacementTarget", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(PlacementTarget), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Controls.ToolTip), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif
@@ -137,7 +137,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalOffset", typeof(double), 
+			nameof(VerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.ToolTip), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -145,7 +145,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlacementRectProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PlacementRect", typeof(global::Windows.Foundation.Rect?), 
+			nameof(PlacementRect), typeof(global::Windows.Foundation.Rect?), 
 			typeof(global::Windows.UI.Xaml.Controls.ToolTip), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Rect?)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeView.cs
@@ -157,7 +157,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectionMode", typeof(global::Windows.UI.Xaml.Controls.TreeViewSelectionMode), 
+			nameof(SelectionMode), typeof(global::Windows.UI.Xaml.Controls.TreeViewSelectionMode), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.TreeViewSelectionMode)));
 		#endif
@@ -165,7 +165,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanDragItemsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanDragItems", typeof(bool), 
+			nameof(CanDragItems), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -173,7 +173,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanReorderItemsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanReorderItems", typeof(bool), 
+			nameof(CanReorderItems), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -181,7 +181,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemContainerStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemContainerStyle", typeof(global::Windows.UI.Xaml.Style), 
+			nameof(ItemContainerStyle), typeof(global::Windows.UI.Xaml.Style), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Style)));
 		#endif
@@ -189,7 +189,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemContainerStyleSelectorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemContainerStyleSelector", typeof(global::Windows.UI.Xaml.Controls.StyleSelector), 
+			nameof(ItemContainerStyleSelector), typeof(global::Windows.UI.Xaml.Controls.StyleSelector), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.StyleSelector)));
 		#endif
@@ -197,7 +197,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemContainerTransitionsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemContainerTransitions", typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
+			nameof(ItemContainerTransitions), typeof(global::Windows.UI.Xaml.Media.Animation.TransitionCollection), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.TransitionCollection)));
 		#endif
@@ -205,7 +205,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemTemplateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
+			nameof(ItemTemplate), typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
 		#endif
@@ -213,7 +213,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemTemplateSelectorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemTemplateSelector", typeof(global::Windows.UI.Xaml.Controls.DataTemplateSelector), 
+			nameof(ItemTemplateSelector), typeof(global::Windows.UI.Xaml.Controls.DataTemplateSelector), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.DataTemplateSelector)));
 		#endif
@@ -221,7 +221,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemsSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemsSource", typeof(object), 
+			nameof(ItemsSource), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeViewItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeViewItem.cs
@@ -133,7 +133,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CollapsedGlyphProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CollapsedGlyph", typeof(string), 
+			nameof(CollapsedGlyph), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItem), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -141,7 +141,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ExpandedGlyphProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ExpandedGlyph", typeof(string), 
+			nameof(ExpandedGlyph), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItem), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -149,7 +149,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GlyphBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GlyphBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(GlyphBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItem), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -157,7 +157,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GlyphOpacityProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GlyphOpacity", typeof(double), 
+			nameof(GlyphOpacity), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItem), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -165,7 +165,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GlyphSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GlyphSize", typeof(double), 
+			nameof(GlyphSize), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItem), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -173,7 +173,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsExpandedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsExpanded", typeof(bool), 
+			nameof(IsExpanded), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItem), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -181,7 +181,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TreeViewItemTemplateSettingsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TreeViewItemTemplateSettings", typeof(global::Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings), 
+			nameof(TreeViewItemTemplateSettings), typeof(global::Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItem), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings)));
 		#endif
@@ -189,7 +189,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HasUnrealizedChildrenProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HasUnrealizedChildren", typeof(bool), 
+			nameof(HasUnrealizedChildren), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItem), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -197,7 +197,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemsSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemsSource", typeof(object), 
+			nameof(ItemsSource), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItem), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeViewItemTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeViewItemTemplateSettings.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TreeViewItemTemplateSettings : global::Windows.UI.Xaml.DependencyObject
@@ -51,7 +51,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CollapsedGlyphVisibilityProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CollapsedGlyphVisibility", typeof(global::Windows.UI.Xaml.Visibility), 
+			nameof(CollapsedGlyphVisibility), typeof(global::Windows.UI.Xaml.Visibility), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Visibility)));
 		#endif
@@ -59,7 +59,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DragItemsCountProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DragItemsCount", typeof(int), 
+			nameof(DragItemsCount), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -67,7 +67,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ExpandedGlyphVisibilityProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ExpandedGlyphVisibility", typeof(global::Windows.UI.Xaml.Visibility), 
+			nameof(ExpandedGlyphVisibility), typeof(global::Windows.UI.Xaml.Visibility), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Visibility)));
 		#endif
@@ -75,11 +75,17 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IndentationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Indentation", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(Indentation), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings.TreeViewItemTemplateSettings()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public TreeViewItemTemplateSettings() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings", "TreeViewItemTemplateSettings.TreeViewItemTemplateSettings()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings.TreeViewItemTemplateSettings()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings.ExpandedGlyphVisibility.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings.CollapsedGlyphVisibility.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeViewNode.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeViewNode.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TreeViewNode : global::Windows.UI.Xaml.DependencyObject
@@ -93,7 +93,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Content", typeof(object), 
+			nameof(Content), typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewNode), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -101,7 +101,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DepthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Depth", typeof(int), 
+			nameof(Depth), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewNode), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -109,7 +109,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HasChildrenProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HasChildren", typeof(bool), 
+			nameof(HasChildren), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewNode), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -117,11 +117,17 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsExpandedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsExpanded", typeof(bool), 
+			nameof(IsExpanded), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewNode), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Controls.TreeViewNode.TreeViewNode()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public TreeViewNode() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TreeViewNode", "TreeViewNode.TreeViewNode()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewNode.TreeViewNode()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewNode.Content.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewNode.Content.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/VariableSizedWrapGrid.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/VariableSizedWrapGrid.cs
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalChildrenAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalChildrenAlignment", typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
+			nameof(HorizontalChildrenAlignment), typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.VariableSizedWrapGrid), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.HorizontalAlignment)));
 		#endif
@@ -111,7 +111,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemHeight", typeof(double), 
+			nameof(ItemHeight), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.VariableSizedWrapGrid), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -119,7 +119,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemWidth", typeof(double), 
+			nameof(ItemWidth), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.VariableSizedWrapGrid), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -127,7 +127,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaximumRowsOrColumnsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaximumRowsOrColumns", typeof(int), 
+			nameof(MaximumRowsOrColumns), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.VariableSizedWrapGrid), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -135,7 +135,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OrientationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Orientation", typeof(global::Windows.UI.Xaml.Controls.Orientation), 
+			nameof(Orientation), typeof(global::Windows.UI.Xaml.Controls.Orientation), 
 			typeof(global::Windows.UI.Xaml.Controls.VariableSizedWrapGrid), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Orientation)));
 		#endif
@@ -151,7 +151,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalChildrenAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalChildrenAlignment", typeof(global::Windows.UI.Xaml.VerticalAlignment), 
+			nameof(VerticalChildrenAlignment), typeof(global::Windows.UI.Xaml.VerticalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.VariableSizedWrapGrid), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.VerticalAlignment)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Viewbox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Viewbox.cs
@@ -7,7 +7,11 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class Viewbox : global::Windows.UI.Xaml.FrameworkElement
 	{
-
+		// Skipping already declared property StretchDirection
+		// Skipping already declared property Stretch
+		// Skipping already declared property Child
+		// Skipping already declared property StretchDirectionProperty
+		// Skipping already declared property StretchProperty
 		// Skipping already declared method Windows.UI.Xaml.Controls.Viewbox.Viewbox()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Viewbox.Viewbox()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Viewbox.Child.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/VirtualizingStackPanel.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/VirtualizingStackPanel.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AreScrollSnapPointsRegularProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AreScrollSnapPointsRegular", typeof(bool), 
+			nameof(AreScrollSnapPointsRegular), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.VirtualizingStackPanel), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -55,7 +55,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OrientationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Orientation", typeof(global::Windows.UI.Xaml.Controls.Orientation), 
+			nameof(Orientation), typeof(global::Windows.UI.Xaml.Controls.Orientation), 
 			typeof(global::Windows.UI.Xaml.Controls.VirtualizingStackPanel), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Orientation)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WebView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WebView.cs
@@ -133,7 +133,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AllowedScriptNotifyUrisProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AllowedScriptNotifyUris", typeof(global::System.Collections.Generic.IList<global::System.Uri>), 
+			nameof(AllowedScriptNotifyUris), typeof(global::System.Collections.Generic.IList<global::System.Uri>), 
 			typeof(global::Windows.UI.Xaml.Controls.WebView), 
 			new FrameworkPropertyMetadata(default(global::System.Collections.Generic.IList<global::System.Uri>)));
 		#endif
@@ -151,7 +151,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DataTransferPackageProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DataTransferPackage", typeof(global::Windows.ApplicationModel.DataTransfer.DataPackage), 
+			nameof(DataTransferPackage), typeof(global::Windows.ApplicationModel.DataTransfer.DataPackage), 
 			typeof(global::Windows.UI.Xaml.Controls.WebView), 
 			new FrameworkPropertyMetadata(default(global::Windows.ApplicationModel.DataTransfer.DataPackage)));
 		#endif
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Source", typeof(global::System.Uri), 
+			nameof(Source), typeof(global::System.Uri), 
 			typeof(global::Windows.UI.Xaml.Controls.WebView), 
 			new FrameworkPropertyMetadata(default(global::System.Uri)));
 		#endif
@@ -167,7 +167,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanGoBackProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanGoBack", typeof(bool), 
+			nameof(CanGoBack), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.WebView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -175,7 +175,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanGoForwardProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanGoForward", typeof(bool), 
+			nameof(CanGoForward), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.WebView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -183,7 +183,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DefaultBackgroundColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DefaultBackgroundColor", typeof(global::Windows.UI.Color), 
+			nameof(DefaultBackgroundColor), typeof(global::Windows.UI.Color), 
 			typeof(global::Windows.UI.Xaml.Controls.WebView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color)));
 		#endif
@@ -191,7 +191,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DocumentTitleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DocumentTitle", typeof(string), 
+			nameof(DocumentTitle), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.WebView), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -199,7 +199,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContainsFullScreenElementProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContainsFullScreenElement", typeof(bool), 
+			nameof(ContainsFullScreenElement), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.WebView), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WebViewBrush.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WebViewBrush.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SourceNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SourceName", typeof(string), 
+			nameof(SourceName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.WebViewBrush), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WrapGrid.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WrapGrid.cs
@@ -95,7 +95,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalChildrenAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalChildrenAlignment", typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
+			nameof(HorizontalChildrenAlignment), typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.WrapGrid), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.HorizontalAlignment)));
 		#endif
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemHeight", typeof(double), 
+			nameof(ItemHeight), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.WrapGrid), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -111,7 +111,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ItemWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemWidth", typeof(double), 
+			nameof(ItemWidth), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.WrapGrid), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -119,7 +119,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaximumRowsOrColumnsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaximumRowsOrColumns", typeof(int), 
+			nameof(MaximumRowsOrColumns), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Controls.WrapGrid), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -127,7 +127,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OrientationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Orientation", typeof(global::Windows.UI.Xaml.Controls.Orientation), 
+			nameof(Orientation), typeof(global::Windows.UI.Xaml.Controls.Orientation), 
 			typeof(global::Windows.UI.Xaml.Controls.WrapGrid), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Orientation)));
 		#endif
@@ -135,7 +135,7 @@ namespace Windows.UI.Xaml.Controls
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalChildrenAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalChildrenAlignment", typeof(global::Windows.UI.Xaml.VerticalAlignment), 
+			nameof(VerticalChildrenAlignment), typeof(global::Windows.UI.Xaml.VerticalAlignment), 
 			typeof(global::Windows.UI.Xaml.Controls.WrapGrid), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.VerticalAlignment)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Data/BindingExpression.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Data/BindingExpression.cs
@@ -20,6 +20,6 @@ namespace Windows.UI.Xaml.Data
 		// Skipping already declared property ParentBinding
 		// Forced skipping of method Windows.UI.Xaml.Data.BindingExpression.DataItem.get
 		// Forced skipping of method Windows.UI.Xaml.Data.BindingExpression.ParentBinding.get
-		// Skipping already declared property UpdateSource()
+		// Skipping already declared method Windows.UI.Xaml.Data.BindingExpression.UpdateSource()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Data/CollectionViewSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Data/CollectionViewSource.cs
@@ -7,6 +7,14 @@ namespace Windows.UI.Xaml.Data
 	#endif
 	public  partial class CollectionViewSource : global::Windows.UI.Xaml.DependencyObject
 	{
+		// Skipping already declared property Source
+		// Skipping already declared property ItemsPath
+		// Skipping already declared property IsSourceGrouped
+		// Skipping already declared property View
+		// Skipping already declared property IsSourceGroupedProperty
+		// Skipping already declared property ItemsPathProperty
+		// Skipping already declared property SourceProperty
+		// Skipping already declared property ViewProperty
 		// Skipping already declared method Windows.UI.Xaml.Data.CollectionViewSource.CollectionViewSource()
 		// Forced skipping of method Windows.UI.Xaml.Data.CollectionViewSource.CollectionViewSource()
 		// Forced skipping of method Windows.UI.Xaml.Data.CollectionViewSource.Source.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/Block.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/Block.cs
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LineHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LineHeight", typeof(double), 
+			nameof(LineHeight), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Documents.Block), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -89,7 +89,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LineStackingStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LineStackingStrategy", typeof(global::Windows.UI.Xaml.LineStackingStrategy), 
+			nameof(LineStackingStrategy), typeof(global::Windows.UI.Xaml.LineStackingStrategy), 
 			typeof(global::Windows.UI.Xaml.Documents.Block), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.LineStackingStrategy)));
 		#endif
@@ -97,7 +97,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MarginProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Margin", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(Margin), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.Documents.Block), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -105,7 +105,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TextAlignment", typeof(global::Windows.UI.Xaml.TextAlignment), 
+			nameof(TextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
 			typeof(global::Windows.UI.Xaml.Documents.Block), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
 		#endif
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalTextAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalTextAlignment", typeof(global::Windows.UI.Xaml.TextAlignment), 
+			nameof(HorizontalTextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
 			typeof(global::Windows.UI.Xaml.Documents.Block), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/ContentLink.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/ContentLink.cs
@@ -217,7 +217,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Background", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Background), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -225,7 +225,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CursorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Cursor", typeof(global::Windows.UI.Core.CoreCursorType), 
+			nameof(Cursor), typeof(global::Windows.UI.Core.CoreCursorType), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Core.CoreCursorType)));
 		#endif
@@ -233,7 +233,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ElementSoundModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ElementSoundMode", typeof(global::Windows.UI.Xaml.ElementSoundMode), 
+			nameof(ElementSoundMode), typeof(global::Windows.UI.Xaml.ElementSoundMode), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.ElementSoundMode)));
 		#endif
@@ -241,7 +241,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusStateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusState", typeof(global::Windows.UI.Xaml.FocusState), 
+			nameof(FocusState), typeof(global::Windows.UI.Xaml.FocusState), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.FocusState)));
 		#endif
@@ -249,7 +249,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTabStopProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTabStop", typeof(bool), 
+			nameof(IsTabStop), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -257,7 +257,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TabIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TabIndex", typeof(int), 
+			nameof(TabIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -265,7 +265,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusDownNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusDownNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusDownNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -273,7 +273,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusDownProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusDown", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusDown), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -281,7 +281,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusLeftNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusLeftNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusLeftNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -289,7 +289,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusLeftProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusLeft", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusLeft), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -297,7 +297,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusRightNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusRightNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusRightNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -305,7 +305,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusRightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusRight", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusRight), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -313,7 +313,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusUpNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusUpNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusUpNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -321,7 +321,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusUpProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusUp", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusUp), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Documents.ContentLink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/ContentLinkProvider.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/ContentLinkProvider.cs
@@ -2,12 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Documents
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ContentLinkProvider : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared method Windows.UI.Xaml.Documents.ContentLinkProvider.ContentLinkProvider()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		protected ContentLinkProvider() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Documents.ContentLinkProvider", "ContentLinkProvider.ContentLinkProvider()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Documents.ContentLinkProvider.ContentLinkProvider()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/Glyphs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/Glyphs.cs
@@ -151,7 +151,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FillProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Fill", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Fill), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Documents.Glyphs), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontRenderingEmSizeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontRenderingEmSize", typeof(double), 
+			nameof(FontRenderingEmSize), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Documents.Glyphs), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -167,7 +167,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontUriProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontUri", typeof(global::System.Uri), 
+			nameof(FontUri), typeof(global::System.Uri), 
 			typeof(global::Windows.UI.Xaml.Documents.Glyphs), 
 			new FrameworkPropertyMetadata(default(global::System.Uri)));
 		#endif
@@ -175,7 +175,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IndicesProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Indices", typeof(string), 
+			nameof(Indices), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Documents.Glyphs), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -183,7 +183,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OriginXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OriginX", typeof(double), 
+			nameof(OriginX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Documents.Glyphs), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -191,7 +191,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OriginYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OriginY", typeof(double), 
+			nameof(OriginY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Documents.Glyphs), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -199,7 +199,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StyleSimulationsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StyleSimulations", typeof(global::Windows.UI.Xaml.Media.StyleSimulations), 
+			nameof(StyleSimulations), typeof(global::Windows.UI.Xaml.Media.StyleSimulations), 
 			typeof(global::Windows.UI.Xaml.Documents.Glyphs), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.StyleSimulations)));
 		#endif
@@ -207,7 +207,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty UnicodeStringProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"UnicodeString", typeof(string), 
+			nameof(UnicodeString), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Documents.Glyphs), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -215,7 +215,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ColorFontPaletteIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ColorFontPaletteIndex", typeof(int), 
+			nameof(ColorFontPaletteIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Documents.Glyphs), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -223,7 +223,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsColorFontEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsColorFontEnabled", typeof(bool), 
+			nameof(IsColorFontEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Documents.Glyphs), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/Hyperlink.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/Hyperlink.cs
@@ -179,7 +179,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ElementSoundModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ElementSoundMode", typeof(global::Windows.UI.Xaml.ElementSoundMode), 
+			nameof(ElementSoundMode), typeof(global::Windows.UI.Xaml.ElementSoundMode), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.ElementSoundMode)));
 		#endif
@@ -187,7 +187,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusDownProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusDown", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusDown), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -195,7 +195,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusLeftProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusLeft", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusLeft), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -203,7 +203,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusRightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusRight", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusRight), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -211,7 +211,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusUpProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusUp", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(XYFocusUp), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -219,7 +219,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusStateProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusState", typeof(global::Windows.UI.Xaml.FocusState), 
+			nameof(FocusState), typeof(global::Windows.UI.Xaml.FocusState), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.FocusState)));
 		#endif
@@ -227,7 +227,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusDownNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusDownNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusDownNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -235,7 +235,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusLeftNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusLeftNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusLeftNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -243,7 +243,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusRightNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusRightNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusRightNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -251,7 +251,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusUpNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusUpNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusUpNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -259,7 +259,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTabStopProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTabStop", typeof(bool), 
+			nameof(IsTabStop), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -267,7 +267,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TabIndexProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TabIndex", typeof(int), 
+			nameof(TabIndex), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Documents.Hyperlink), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/Run.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/Run.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FlowDirectionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FlowDirection", typeof(global::Windows.UI.Xaml.FlowDirection), 
+			nameof(FlowDirection), typeof(global::Windows.UI.Xaml.FlowDirection), 
 			typeof(global::Windows.UI.Xaml.Documents.Run), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.FlowDirection)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/TextElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/TextElement.cs
@@ -216,7 +216,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontStretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FontStretch", typeof(global::Windows.UI.Text.FontStretch), 
+			nameof(FontStretch), typeof(global::Windows.UI.Text.FontStretch), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStretch)));
 		#endif
@@ -227,7 +227,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LanguageProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Language", typeof(string), 
+			nameof(Language), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -235,7 +235,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextScaleFactorEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTextScaleFactorEnabled", typeof(bool), 
+			nameof(IsTextScaleFactorEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -243,7 +243,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AccessKeyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AccessKey", typeof(string), 
+			nameof(AccessKey), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -251,7 +251,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AllowFocusOnInteractionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AllowFocusOnInteraction", typeof(bool), 
+			nameof(AllowFocusOnInteraction), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -259,7 +259,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ExitDisplayModeOnAccessKeyInvokedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ExitDisplayModeOnAccessKeyInvoked", typeof(bool), 
+			nameof(ExitDisplayModeOnAccessKeyInvoked), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -267,7 +267,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AccessKeyScopeOwnerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AccessKeyScopeOwner", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(AccessKeyScopeOwner), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -275,7 +275,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsAccessKeyScopeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsAccessKeyScope", typeof(bool), 
+			nameof(IsAccessKeyScope), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -283,7 +283,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyTipHorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyTipHorizontalOffset", typeof(double), 
+			nameof(KeyTipHorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -291,7 +291,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyTipPlacementModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyTipPlacementMode", typeof(global::Windows.UI.Xaml.Input.KeyTipPlacementMode), 
+			nameof(KeyTipPlacementMode), typeof(global::Windows.UI.Xaml.Input.KeyTipPlacementMode), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.KeyTipPlacementMode)));
 		#endif
@@ -299,7 +299,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyTipVerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyTipVerticalOffset", typeof(double), 
+			nameof(KeyTipVerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Documents.TextElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/TextHighlighter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/TextHighlighter.cs
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BackgroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Background", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Background), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Documents.TextHighlighter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -57,7 +57,7 @@ namespace Windows.UI.Xaml.Documents
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ForegroundProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Foreground", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(Foreground), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.Documents.TextHighlighter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/TextHighlighterBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/TextHighlighterBase.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Documents
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TextHighlighterBase : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/KeyboardAccelerator.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/KeyboardAccelerator.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class KeyboardAccelerator : global::Windows.UI.Xaml.DependencyObject
@@ -67,7 +67,7 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsEnabled", typeof(bool), 
+			nameof(IsEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Input.KeyboardAccelerator), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Key", typeof(global::Windows.System.VirtualKey), 
+			nameof(Key), typeof(global::Windows.System.VirtualKey), 
 			typeof(global::Windows.UI.Xaml.Input.KeyboardAccelerator), 
 			new FrameworkPropertyMetadata(default(global::Windows.System.VirtualKey)));
 		#endif
@@ -83,7 +83,7 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ModifiersProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Modifiers", typeof(global::Windows.System.VirtualKeyModifiers), 
+			nameof(Modifiers), typeof(global::Windows.System.VirtualKeyModifiers), 
 			typeof(global::Windows.UI.Xaml.Input.KeyboardAccelerator), 
 			new FrameworkPropertyMetadata(default(global::Windows.System.VirtualKeyModifiers)));
 		#endif
@@ -91,11 +91,17 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ScopeOwnerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ScopeOwner", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(ScopeOwner), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Input.KeyboardAccelerator), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Input.KeyboardAccelerator.KeyboardAccelerator()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public KeyboardAccelerator() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Input.KeyboardAccelerator", "KeyboardAccelerator.KeyboardAccelerator()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Input.KeyboardAccelerator.KeyboardAccelerator()
 		// Forced skipping of method Windows.UI.Xaml.Input.KeyboardAccelerator.Key.get
 		// Forced skipping of method Windows.UI.Xaml.Input.KeyboardAccelerator.Key.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/PointerRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/PointerRoutedEventArgs.cs
@@ -11,13 +11,12 @@ namespace Windows.UI.Xaml.Input
 		// Skipping already declared property KeyModifiers
 		// Skipping already declared property Pointer
 		// Skipping already declared property IsGenerated
-
 		// Forced skipping of method Windows.UI.Xaml.Input.PointerRoutedEventArgs.Pointer.get
 		// Forced skipping of method Windows.UI.Xaml.Input.PointerRoutedEventArgs.KeyModifiers.get
 		// Forced skipping of method Windows.UI.Xaml.Input.PointerRoutedEventArgs.Handled.get
 		// Forced skipping of method Windows.UI.Xaml.Input.PointerRoutedEventArgs.Handled.set
 		// Skipping already declared method Windows.UI.Xaml.Input.PointerRoutedEventArgs.GetCurrentPoint(Windows.UI.Xaml.UIElement)
-#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::System.Collections.Generic.IList<global::Windows.UI.Input.PointerPoint> GetIntermediatePoints( global::Windows.UI.Xaml.UIElement relativeTo)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/StandardUICommand.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/StandardUICommand.cs
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KindProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Kind", typeof(global::Windows.UI.Xaml.Input.StandardUICommandKind), 
+			nameof(Kind), typeof(global::Windows.UI.Xaml.Input.StandardUICommandKind), 
 			typeof(global::Windows.UI.Xaml.Input.StandardUICommand), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.StandardUICommandKind)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/XamlUICommand.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/XamlUICommand.cs
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AccessKeyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AccessKey", typeof(string), 
+			nameof(AccessKey), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Input.XamlUICommand), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -99,7 +99,7 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CommandProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Command", typeof(global::System.Windows.Input.ICommand), 
+			nameof(Command), typeof(global::System.Windows.Input.ICommand), 
 			typeof(global::Windows.UI.Xaml.Input.XamlUICommand), 
 			new FrameworkPropertyMetadata(default(global::System.Windows.Input.ICommand)));
 		#endif
@@ -107,7 +107,7 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Description", typeof(string), 
+			nameof(Description), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Input.XamlUICommand), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -115,7 +115,7 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IconSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IconSource", typeof(global::Windows.UI.Xaml.Controls.IconSource), 
+			nameof(IconSource), typeof(global::Windows.UI.Xaml.Controls.IconSource), 
 			typeof(global::Windows.UI.Xaml.Input.XamlUICommand), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.IconSource)));
 		#endif
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyboardAcceleratorsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyboardAccelerators", typeof(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Input.KeyboardAccelerator>), 
+			nameof(KeyboardAccelerators), typeof(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Input.KeyboardAccelerator>), 
 			typeof(global::Windows.UI.Xaml.Input.XamlUICommand), 
 			new FrameworkPropertyMetadata(default(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Input.KeyboardAccelerator>)));
 		#endif
@@ -131,7 +131,7 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LabelProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Label", typeof(string), 
+			nameof(Label), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Input.XamlUICommand), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/BeginStoryboard.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/BeginStoryboard.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StoryboardProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Storyboard", typeof(global::Windows.UI.Xaml.Media.Animation.Storyboard), 
+			nameof(Storyboard), typeof(global::Windows.UI.Xaml.Media.Animation.Storyboard), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.BeginStoryboard), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.Storyboard)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/BounceEase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/BounceEase.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BouncesProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Bounces", typeof(int), 
+			nameof(Bounces), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.BounceEase), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BouncinessProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Bounciness", typeof(double), 
+			nameof(Bounciness), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.BounceEase), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorAnimation.cs
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ByProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"By", typeof(global::Windows.UI.Color?), 
+			nameof(By), typeof(global::Windows.UI.Color?), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ColorAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color?)));
 		#endif
@@ -89,7 +89,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EasingFunctionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EasingFunction", typeof(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase), 
+			nameof(EasingFunction), typeof(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ColorAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase)));
 		#endif
@@ -97,7 +97,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EnableDependentAnimationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EnableDependentAnimation", typeof(bool), 
+			nameof(EnableDependentAnimation), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ColorAnimation), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -105,7 +105,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FromProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"From", typeof(global::Windows.UI.Color?), 
+			nameof(From), typeof(global::Windows.UI.Color?), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ColorAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color?)));
 		#endif
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ToProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"To", typeof(global::Windows.UI.Color?), 
+			nameof(To), typeof(global::Windows.UI.Color?), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ColorAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color?)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorAnimationUsingKeyFrames.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EnableDependentAnimationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EnableDependentAnimation", typeof(bool), 
+			nameof(EnableDependentAnimation), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ColorAnimationUsingKeyFrames), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorKeyFrame.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ColorKeyFrame : global::Windows.UI.Xaml.DependencyObject
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyTimeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyTime", typeof(global::Windows.UI.Xaml.Media.Animation.KeyTime), 
+			nameof(KeyTime), typeof(global::Windows.UI.Xaml.Media.Animation.KeyTime), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ColorKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.KeyTime)));
 		#endif
@@ -47,11 +47,17 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ValueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Value", typeof(global::Windows.UI.Color), 
+			nameof(Value), typeof(global::Windows.UI.Color), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ColorKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.ColorKeyFrame()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		protected ColorKeyFrame() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Animation.ColorKeyFrame", "ColorKeyFrame.ColorKeyFrame()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.ColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.Value.get
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.Value.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ContentThemeTransition.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ContentThemeTransition.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalOffset", typeof(double), 
+			nameof(HorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ContentThemeTransition), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalOffset", typeof(double), 
+			nameof(VerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ContentThemeTransition), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ContinuumNavigationTransitionInfo.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ContinuumNavigationTransitionInfo.cs
@@ -33,7 +33,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ExitElementProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ExitElement", typeof(global::Windows.UI.Xaml.UIElement), 
+			nameof(ExitElement), typeof(global::Windows.UI.Xaml.UIElement), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ContinuumNavigationTransitionInfo), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DragItemThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DragItemThemeAnimation.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DragItemThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DragOverThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DragOverThemeAnimation.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DirectionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Direction", typeof(global::Windows.UI.Xaml.Controls.Primitives.AnimationDirection), 
+			nameof(Direction), typeof(global::Windows.UI.Xaml.Controls.Primitives.AnimationDirection), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DragOverThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.AnimationDirection)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DragOverThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ToOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ToOffset", typeof(double), 
+			nameof(ToOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DragOverThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DrillInThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DrillInThemeAnimation.cs
@@ -67,7 +67,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EntranceTargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EntranceTargetName", typeof(string), 
+			nameof(EntranceTargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DrillInThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EntranceTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EntranceTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(EntranceTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DrillInThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -83,7 +83,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ExitTargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ExitTargetName", typeof(string), 
+			nameof(ExitTargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DrillInThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ExitTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ExitTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(ExitTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DrillInThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DrillOutThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DrillOutThemeAnimation.cs
@@ -67,7 +67,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EntranceTargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EntranceTargetName", typeof(string), 
+			nameof(EntranceTargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DrillOutThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EntranceTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EntranceTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(EntranceTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DrillOutThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -83,7 +83,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ExitTargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ExitTargetName", typeof(string), 
+			nameof(ExitTargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DrillOutThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ExitTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ExitTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(ExitTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DrillOutThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DropTargetItemThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DropTargetItemThemeAnimation.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.DropTargetItemThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/EasingColorKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/EasingColorKeyFrame.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EasingFunctionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EasingFunction", typeof(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase), 
+			nameof(EasingFunction), typeof(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.EasingColorKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/EasingPointKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/EasingPointKeyFrame.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EasingFunctionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EasingFunction", typeof(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase), 
+			nameof(EasingFunction), typeof(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.EasingPointKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/EdgeUIThemeTransition.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/EdgeUIThemeTransition.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EdgeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Edge", typeof(global::Windows.UI.Xaml.Controls.Primitives.EdgeTransitionLocation), 
+			nameof(Edge), typeof(global::Windows.UI.Xaml.Controls.Primitives.EdgeTransitionLocation), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.EdgeUIThemeTransition), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.EdgeTransitionLocation)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ElasticEase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ElasticEase.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OscillationsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Oscillations", typeof(int), 
+			nameof(Oscillations), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ElasticEase), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SpringinessProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Springiness", typeof(double), 
+			nameof(Springiness), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ElasticEase), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/FadeInThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/FadeInThemeAnimation.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.FadeInThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/FadeOutThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/FadeOutThemeAnimation.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.FadeOutThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/NavigationThemeTransition.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/NavigationThemeTransition.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DefaultNavigationTransitionInfoProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DefaultNavigationTransitionInfo", typeof(global::Windows.UI.Xaml.Media.Animation.NavigationTransitionInfo), 
+			nameof(DefaultNavigationTransitionInfo), typeof(global::Windows.UI.Xaml.Media.Animation.NavigationTransitionInfo), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.NavigationThemeTransition), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.NavigationTransitionInfo)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ObjectAnimationUsingKeyFrames.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EnableDependentAnimationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EnableDependentAnimation", typeof(bool), 
+			nameof(EnableDependentAnimation), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.ObjectAnimationUsingKeyFrames), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PaneThemeTransition.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PaneThemeTransition.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EdgeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Edge", typeof(global::Windows.UI.Xaml.Controls.Primitives.EdgeTransitionLocation), 
+			nameof(Edge), typeof(global::Windows.UI.Xaml.Controls.Primitives.EdgeTransitionLocation), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PaneThemeTransition), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.EdgeTransitionLocation)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointAnimation.cs
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ByProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"By", typeof(global::Windows.Foundation.Point?), 
+			nameof(By), typeof(global::Windows.Foundation.Point?), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point?)));
 		#endif
@@ -89,7 +89,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EasingFunctionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EasingFunction", typeof(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase), 
+			nameof(EasingFunction), typeof(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase)));
 		#endif
@@ -97,7 +97,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EnableDependentAnimationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EnableDependentAnimation", typeof(bool), 
+			nameof(EnableDependentAnimation), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointAnimation), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -105,7 +105,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FromProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"From", typeof(global::Windows.Foundation.Point?), 
+			nameof(From), typeof(global::Windows.Foundation.Point?), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point?)));
 		#endif
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ToProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"To", typeof(global::Windows.Foundation.Point?), 
+			nameof(To), typeof(global::Windows.Foundation.Point?), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point?)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointAnimationUsingKeyFrames.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EnableDependentAnimationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EnableDependentAnimation", typeof(bool), 
+			nameof(EnableDependentAnimation), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointAnimationUsingKeyFrames), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointKeyFrame.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class PointKeyFrame : global::Windows.UI.Xaml.DependencyObject
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyTimeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyTime", typeof(global::Windows.UI.Xaml.Media.Animation.KeyTime), 
+			nameof(KeyTime), typeof(global::Windows.UI.Xaml.Media.Animation.KeyTime), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.KeyTime)));
 		#endif
@@ -47,11 +47,17 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ValueProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Value", typeof(global::Windows.Foundation.Point), 
+			nameof(Value), typeof(global::Windows.Foundation.Point), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Media.Animation.PointKeyFrame.PointKeyFrame()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		protected PointKeyFrame() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Animation.PointKeyFrame", "PointKeyFrame.PointKeyFrame()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.PointKeyFrame.PointKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.PointKeyFrame.Value.get
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.PointKeyFrame.Value.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointerDownThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointerDownThemeAnimation.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointerDownThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointerUpThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointerUpThemeAnimation.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointerUpThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PopInThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PopInThemeAnimation.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FromHorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FromHorizontalOffset", typeof(double), 
+			nameof(FromHorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PopInThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FromVerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FromVerticalOffset", typeof(double), 
+			nameof(FromVerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PopInThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PopInThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PopOutThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PopOutThemeAnimation.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PopOutThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PopupThemeTransition.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PopupThemeTransition.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FromHorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FromHorizontalOffset", typeof(double), 
+			nameof(FromHorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PopupThemeTransition), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FromVerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FromVerticalOffset", typeof(double), 
+			nameof(FromVerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.PopupThemeTransition), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/RepositionThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/RepositionThemeAnimation.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FromHorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FromHorizontalOffset", typeof(double), 
+			nameof(FromHorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.RepositionThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FromVerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FromVerticalOffset", typeof(double), 
+			nameof(FromVerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.RepositionThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.RepositionThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/RepositionThemeTransition.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/RepositionThemeTransition.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsStaggeringEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsStaggeringEnabled", typeof(bool), 
+			nameof(IsStaggeringEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.RepositionThemeTransition), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SlideNavigationTransitionInfo.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SlideNavigationTransitionInfo.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EffectProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Effect", typeof(global::Windows.UI.Xaml.Media.Animation.SlideNavigationTransitionEffect), 
+			nameof(Effect), typeof(global::Windows.UI.Xaml.Media.Animation.SlideNavigationTransitionEffect), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SlideNavigationTransitionInfo), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.SlideNavigationTransitionEffect)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SplineColorKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SplineColorKeyFrame.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeySplineProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeySpline", typeof(global::Windows.UI.Xaml.Media.Animation.KeySpline), 
+			nameof(KeySpline), typeof(global::Windows.UI.Xaml.Media.Animation.KeySpline), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplineColorKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.KeySpline)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SplinePointKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SplinePointKeyFrame.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeySplineProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeySpline", typeof(global::Windows.UI.Xaml.Media.Animation.KeySpline), 
+			nameof(KeySpline), typeof(global::Windows.UI.Xaml.Media.Animation.KeySpline), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplinePointKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.KeySpline)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SplitCloseThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SplitCloseThemeAnimation.cs
@@ -165,7 +165,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ClosedLengthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ClosedLength", typeof(double), 
+			nameof(ClosedLength), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -173,7 +173,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ClosedTargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ClosedTargetName", typeof(string), 
+			nameof(ClosedTargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -181,7 +181,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ClosedTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ClosedTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(ClosedTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -189,7 +189,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentTargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentTargetName", typeof(string), 
+			nameof(ContentTargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -197,7 +197,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(ContentTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -205,7 +205,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentTranslationDirectionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentTranslationDirection", typeof(global::Windows.UI.Xaml.Controls.Primitives.AnimationDirection), 
+			nameof(ContentTranslationDirection), typeof(global::Windows.UI.Xaml.Controls.Primitives.AnimationDirection), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.AnimationDirection)));
 		#endif
@@ -213,7 +213,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentTranslationOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentTranslationOffset", typeof(double), 
+			nameof(ContentTranslationOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -221,7 +221,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OffsetFromCenterProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OffsetFromCenter", typeof(double), 
+			nameof(OffsetFromCenter), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -229,7 +229,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OpenedLengthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OpenedLength", typeof(double), 
+			nameof(OpenedLength), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -237,7 +237,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OpenedTargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OpenedTargetName", typeof(string), 
+			nameof(OpenedTargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -245,7 +245,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OpenedTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OpenedTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(OpenedTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitCloseThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SplitOpenThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SplitOpenThemeAnimation.cs
@@ -165,7 +165,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ClosedLengthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ClosedLength", typeof(double), 
+			nameof(ClosedLength), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -173,7 +173,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ClosedTargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ClosedTargetName", typeof(string), 
+			nameof(ClosedTargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -181,7 +181,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ClosedTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ClosedTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(ClosedTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -189,7 +189,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentTargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentTargetName", typeof(string), 
+			nameof(ContentTargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -197,7 +197,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(ContentTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -205,7 +205,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentTranslationDirectionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentTranslationDirection", typeof(global::Windows.UI.Xaml.Controls.Primitives.AnimationDirection), 
+			nameof(ContentTranslationDirection), typeof(global::Windows.UI.Xaml.Controls.Primitives.AnimationDirection), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.AnimationDirection)));
 		#endif
@@ -213,7 +213,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContentTranslationOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContentTranslationOffset", typeof(double), 
+			nameof(ContentTranslationOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -221,7 +221,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OffsetFromCenterProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OffsetFromCenter", typeof(double), 
+			nameof(OffsetFromCenter), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -229,7 +229,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OpenedLengthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OpenedLength", typeof(double), 
+			nameof(OpenedLength), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -237,7 +237,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OpenedTargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OpenedTargetName", typeof(string), 
+			nameof(OpenedTargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -245,7 +245,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OpenedTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OpenedTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(OpenedTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplitOpenThemeAnimation), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SwipeBackThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SwipeBackThemeAnimation.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FromHorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FromHorizontalOffset", typeof(double), 
+			nameof(FromHorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SwipeBackThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FromVerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FromVerticalOffset", typeof(double), 
+			nameof(FromVerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SwipeBackThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SwipeBackThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SwipeHintThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SwipeHintThemeAnimation.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetNameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetName", typeof(string), 
+			nameof(TargetName), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SwipeHintThemeAnimation), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ToHorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ToHorizontalOffset", typeof(double), 
+			nameof(ToHorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SwipeHintThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ToVerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ToVerticalOffset", typeof(double), 
+			nameof(ToVerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.SwipeHintThemeAnimation), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/Timeline.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/Timeline.cs
@@ -57,7 +57,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AutoReverseProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AutoReverse", typeof(bool), 
+			nameof(AutoReverse), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.Timeline), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SpeedRatioProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SpeedRatio", typeof(double), 
+			nameof(SpeedRatio), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Animation.Timeline), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Imaging/BitmapImage.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Imaging/BitmapImage.cs
@@ -55,7 +55,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AutoPlayProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AutoPlay", typeof(bool), 
+			nameof(AutoPlay), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.Imaging.BitmapImage), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsAnimatedBitmapProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsAnimatedBitmap", typeof(bool), 
+			nameof(IsAnimatedBitmap), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.Imaging.BitmapImage), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -71,7 +71,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsPlayingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsPlaying", typeof(bool), 
+			nameof(IsPlaying), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.Imaging.BitmapImage), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Imaging/RenderTargetBitmap.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Imaging/RenderTargetBitmap.cs
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PixelHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PixelHeight", typeof(int), 
+			nameof(PixelHeight), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PixelWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"PixelWidth", typeof(int), 
+			nameof(PixelWidth), typeof(int), 
 			typeof(global::Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Imaging/SvgImageSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Imaging/SvgImageSource.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RasterizePixelHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RasterizePixelHeight", typeof(double), 
+			nameof(RasterizePixelHeight), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Imaging.SvgImageSource), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RasterizePixelWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RasterizePixelWidth", typeof(double), 
+			nameof(RasterizePixelWidth), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Imaging.SvgImageSource), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty UriSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"UriSource", typeof(global::System.Uri), 
+			nameof(UriSource), typeof(global::System.Uri), 
 			typeof(global::Windows.UI.Xaml.Media.Imaging.SvgImageSource), 
 			new FrameworkPropertyMetadata(default(global::System.Uri)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Media3D/CompositeTransform3D.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Media3D/CompositeTransform3D.cs
@@ -179,7 +179,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CenterXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CenterX", typeof(double), 
+			nameof(CenterX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -187,7 +187,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CenterYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CenterY", typeof(double), 
+			nameof(CenterY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -195,7 +195,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CenterZProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CenterZ", typeof(double), 
+			nameof(CenterZ), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -203,7 +203,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RotationXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RotationX", typeof(double), 
+			nameof(RotationX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -211,7 +211,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RotationYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RotationY", typeof(double), 
+			nameof(RotationY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -219,7 +219,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RotationZProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RotationZ", typeof(double), 
+			nameof(RotationZ), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -227,7 +227,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ScaleXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ScaleX", typeof(double), 
+			nameof(ScaleX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -235,7 +235,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ScaleYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ScaleY", typeof(double), 
+			nameof(ScaleY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -243,7 +243,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ScaleZProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ScaleZ", typeof(double), 
+			nameof(ScaleZ), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -251,7 +251,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TranslateXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TranslateX", typeof(double), 
+			nameof(TranslateX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -259,7 +259,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TranslateYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TranslateY", typeof(double), 
+			nameof(TranslateY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -267,7 +267,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TranslateZProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TranslateZ", typeof(double), 
+			nameof(TranslateZ), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.CompositeTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Media3D/PerspectiveTransform3D.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Media3D/PerspectiveTransform3D.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DepthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Depth", typeof(double), 
+			nameof(Depth), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.PerspectiveTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OffsetXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OffsetX", typeof(double), 
+			nameof(OffsetX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.PerspectiveTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OffsetYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"OffsetY", typeof(double), 
+			nameof(OffsetY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.Media3D.PerspectiveTransform3D), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Media3D/Transform3D.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Media3D/Transform3D.cs
@@ -2,12 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Media3D
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Transform3D : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared method Windows.UI.Xaml.Media.Media3D.Transform3D.Transform3D()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		protected Transform3D() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Media3D.Transform3D", "Transform3D.Transform3D()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Media.Media3D.Transform3D.Transform3D()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/AcrylicBrush.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/AcrylicBrush.cs
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AlwaysUseFallbackProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AlwaysUseFallback", typeof(bool), 
+			nameof(AlwaysUseFallback), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.AcrylicBrush), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -89,7 +89,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty BackgroundSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"BackgroundSource", typeof(global::Windows.UI.Xaml.Media.AcrylicBackgroundSource), 
+			nameof(BackgroundSource), typeof(global::Windows.UI.Xaml.Media.AcrylicBackgroundSource), 
 			typeof(global::Windows.UI.Xaml.Media.AcrylicBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.AcrylicBackgroundSource)));
 		#endif
@@ -97,7 +97,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TintColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TintColor", typeof(global::Windows.UI.Color), 
+			nameof(TintColor), typeof(global::Windows.UI.Color), 
 			typeof(global::Windows.UI.Xaml.Media.AcrylicBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color)));
 		#endif
@@ -105,7 +105,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TintOpacityProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TintOpacity", typeof(double), 
+			nameof(TintOpacity), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.AcrylicBrush), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TintTransitionDurationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TintTransitionDuration", typeof(global::System.TimeSpan), 
+			nameof(TintTransitionDuration), typeof(global::System.TimeSpan), 
 			typeof(global::Windows.UI.Xaml.Media.AcrylicBrush), 
 			new FrameworkPropertyMetadata(default(global::System.TimeSpan)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/Brush.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/Brush.cs
@@ -29,7 +29,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TransformProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Transform", typeof(global::Windows.UI.Xaml.Media.Transform), 
+			nameof(Transform), typeof(global::Windows.UI.Xaml.Media.Transform), 
 			typeof(global::Windows.UI.Xaml.Media.Brush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Transform)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/CacheMode.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/CacheMode.cs
@@ -2,12 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CacheMode : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared method Windows.UI.Xaml.Media.CacheMode.CacheMode()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		protected CacheMode() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.CacheMode", "CacheMode.CacheMode()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Media.CacheMode.CacheMode()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/EllipseGeometry.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/EllipseGeometry.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CenterProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Center", typeof(global::Windows.Foundation.Point), 
+			nameof(Center), typeof(global::Windows.Foundation.Point), 
 			typeof(global::Windows.UI.Xaml.Media.EllipseGeometry), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RadiusXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RadiusX", typeof(double), 
+			nameof(RadiusX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.EllipseGeometry), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RadiusYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RadiusY", typeof(double), 
+			nameof(RadiusY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.EllipseGeometry), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/GradientBrush.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/GradientBrush.cs
@@ -67,7 +67,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ColorInterpolationModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ColorInterpolationMode", typeof(global::Windows.UI.Xaml.Media.ColorInterpolationMode), 
+			nameof(ColorInterpolationMode), typeof(global::Windows.UI.Xaml.Media.ColorInterpolationMode), 
 			typeof(global::Windows.UI.Xaml.Media.GradientBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ColorInterpolationMode)));
 		#endif
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GradientStopsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GradientStops", typeof(global::Windows.UI.Xaml.Media.GradientStopCollection), 
+			nameof(GradientStops), typeof(global::Windows.UI.Xaml.Media.GradientStopCollection), 
 			typeof(global::Windows.UI.Xaml.Media.GradientBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.GradientStopCollection)));
 		#endif
@@ -83,7 +83,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MappingModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MappingMode", typeof(global::Windows.UI.Xaml.Media.BrushMappingMode), 
+			nameof(MappingMode), typeof(global::Windows.UI.Xaml.Media.BrushMappingMode), 
 			typeof(global::Windows.UI.Xaml.Media.GradientBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.BrushMappingMode)));
 		#endif
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SpreadMethodProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"SpreadMethod", typeof(global::Windows.UI.Xaml.Media.GradientSpreadMethod), 
+			nameof(SpreadMethod), typeof(global::Windows.UI.Xaml.Media.GradientSpreadMethod), 
 			typeof(global::Windows.UI.Xaml.Media.GradientBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.GradientSpreadMethod)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/LineGeometry.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/LineGeometry.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty EndPointProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"EndPoint", typeof(global::Windows.Foundation.Point), 
+			nameof(EndPoint), typeof(global::Windows.Foundation.Point), 
 			typeof(global::Windows.UI.Xaml.Media.LineGeometry), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StartPointProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StartPoint", typeof(global::Windows.Foundation.Point), 
+			nameof(StartPoint), typeof(global::Windows.Foundation.Point), 
 			typeof(global::Windows.UI.Xaml.Media.LineGeometry), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/Matrix3DProjection.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/Matrix3DProjection.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ProjectionMatrixProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ProjectionMatrix", typeof(global::Windows.UI.Xaml.Media.Media3D.Matrix3D), 
+			nameof(ProjectionMatrix), typeof(global::Windows.UI.Xaml.Media.Media3D.Matrix3D), 
 			typeof(global::Windows.UI.Xaml.Media.Matrix3DProjection), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Media3D.Matrix3D)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/PlaneProjection.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/PlaneProjection.cs
@@ -189,7 +189,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CenterOfRotationXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CenterOfRotationX", typeof(double), 
+			nameof(CenterOfRotationX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -197,7 +197,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CenterOfRotationYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CenterOfRotationY", typeof(double), 
+			nameof(CenterOfRotationY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -205,7 +205,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CenterOfRotationZProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CenterOfRotationZ", typeof(double), 
+			nameof(CenterOfRotationZ), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -213,7 +213,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GlobalOffsetXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GlobalOffsetX", typeof(double), 
+			nameof(GlobalOffsetX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -221,7 +221,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GlobalOffsetYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GlobalOffsetY", typeof(double), 
+			nameof(GlobalOffsetY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -229,7 +229,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty GlobalOffsetZProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"GlobalOffsetZ", typeof(double), 
+			nameof(GlobalOffsetZ), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -237,7 +237,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LocalOffsetXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LocalOffsetX", typeof(double), 
+			nameof(LocalOffsetX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -245,7 +245,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LocalOffsetYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LocalOffsetY", typeof(double), 
+			nameof(LocalOffsetY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -253,7 +253,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LocalOffsetZProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"LocalOffsetZ", typeof(double), 
+			nameof(LocalOffsetZ), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -261,7 +261,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ProjectionMatrixProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ProjectionMatrix", typeof(global::Windows.UI.Xaml.Media.Media3D.Matrix3D), 
+			nameof(ProjectionMatrix), typeof(global::Windows.UI.Xaml.Media.Media3D.Matrix3D), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Media3D.Matrix3D)));
 		#endif
@@ -269,7 +269,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RotationXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RotationX", typeof(double), 
+			nameof(RotationX), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -277,7 +277,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RotationYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RotationY", typeof(double), 
+			nameof(RotationY), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -285,7 +285,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RotationZProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RotationZ", typeof(double), 
+			nameof(RotationZ), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Media.PlaneProjection), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/Projection.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/Projection.cs
@@ -2,12 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Projection : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared method Windows.UI.Xaml.Media.Projection.Projection()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		protected Projection() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Projection", "Projection.Projection()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Media.Projection.Projection()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/RevealBrush.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/RevealBrush.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AlwaysUseFallbackProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AlwaysUseFallback", typeof(bool), 
+			nameof(AlwaysUseFallback), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Media.RevealBrush), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Color", typeof(global::Windows.UI.Color), 
+			nameof(Color), typeof(global::Windows.UI.Color), 
 			typeof(global::Windows.UI.Xaml.Media.RevealBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color)));
 		#endif
@@ -77,7 +77,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TargetThemeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TargetTheme", typeof(global::Windows.UI.Xaml.ApplicationTheme), 
+			nameof(TargetTheme), typeof(global::Windows.UI.Xaml.ApplicationTheme), 
 			typeof(global::Windows.UI.Xaml.Media.RevealBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.ApplicationTheme)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/TileBrush.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/TileBrush.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AlignmentXProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AlignmentX", typeof(global::Windows.UI.Xaml.Media.AlignmentX), 
+			nameof(AlignmentX), typeof(global::Windows.UI.Xaml.Media.AlignmentX), 
 			typeof(global::Windows.UI.Xaml.Media.TileBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.AlignmentX)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AlignmentYProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AlignmentY", typeof(global::Windows.UI.Xaml.Media.AlignmentY), 
+			nameof(AlignmentY), typeof(global::Windows.UI.Xaml.Media.AlignmentY), 
 			typeof(global::Windows.UI.Xaml.Media.TileBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.AlignmentY)));
 		#endif
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StretchProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Stretch", typeof(global::Windows.UI.Xaml.Media.Stretch), 
+			nameof(Stretch), typeof(global::Windows.UI.Xaml.Media.Stretch), 
 			typeof(global::Windows.UI.Xaml.Media.TileBrush), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Stretch)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/TimelineMarker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/TimelineMarker.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TimelineMarker : global::Windows.UI.Xaml.DependencyObject
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Text", typeof(string), 
+			nameof(Text), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.TimelineMarker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TimeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Time", typeof(global::System.TimeSpan), 
+			nameof(Time), typeof(global::System.TimeSpan), 
 			typeof(global::Windows.UI.Xaml.Media.TimelineMarker), 
 			new FrameworkPropertyMetadata(default(global::System.TimeSpan)));
 		#endif
@@ -69,11 +69,17 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TypeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Type", typeof(string), 
+			nameof(Type), typeof(string), 
 			typeof(global::Windows.UI.Xaml.Media.TimelineMarker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Media.TimelineMarker.TimelineMarker()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public TimelineMarker() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.TimelineMarker", "TimelineMarker.TimelineMarker()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Media.TimelineMarker.TimelineMarker()
 		// Forced skipping of method Windows.UI.Xaml.Media.TimelineMarker.Time.get
 		// Forced skipping of method Windows.UI.Xaml.Media.TimelineMarker.Time.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/XamlCompositionBrushBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/XamlCompositionBrushBase.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Media
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FallbackColorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FallbackColor", typeof(global::Windows.UI.Color), 
+			nameof(FallbackColor), typeof(global::Windows.UI.Color), 
 			typeof(global::Windows.UI.Xaml.Media.XamlCompositionBrushBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/XamlLight.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/XamlLight.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class XamlLight : global::Windows.UI.Xaml.DependencyObject
@@ -21,7 +21,13 @@ namespace Windows.UI.Xaml.Media
 			}
 		}
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Media.XamlLight.XamlLight()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public XamlLight() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.XamlLight", "XamlLight.XamlLight()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Media.XamlLight.XamlLight()
 		// Forced skipping of method Windows.UI.Xaml.Media.XamlLight.CompositionLight.get
 		// Forced skipping of method Windows.UI.Xaml.Media.XamlLight.CompositionLight.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Printing/PrintDocument.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Printing/PrintDocument.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Printing
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class PrintDocument : global::Windows.UI.Xaml.DependencyObject
@@ -21,11 +21,17 @@ namespace Windows.UI.Xaml.Printing
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty DocumentSourceProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"DocumentSource", typeof(global::Windows.Graphics.Printing.IPrintDocumentSource), 
+			nameof(DocumentSource), typeof(global::Windows.Graphics.Printing.IPrintDocumentSource), 
 			typeof(global::Windows.UI.Xaml.Printing.PrintDocument), 
 			new FrameworkPropertyMetadata(default(global::Windows.Graphics.Printing.IPrintDocumentSource)));
 		#endif
-		// Skipping already declared method Windows.UI.Xaml.Printing.PrintDocument.PrintDocument()
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public PrintDocument() : base()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Printing.PrintDocument", "PrintDocument.PrintDocument()");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.Printing.PrintDocument.PrintDocument()
 		// Forced skipping of method Windows.UI.Xaml.Printing.PrintDocument.DocumentSource.get
 		// Forced skipping of method Windows.UI.Xaml.Printing.PrintDocument.Paginate.add

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Shapes/Polygon.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Shapes/Polygon.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Shapes
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FillRuleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FillRule", typeof(global::Windows.UI.Xaml.Media.FillRule), 
+			nameof(FillRule), typeof(global::Windows.UI.Xaml.Media.FillRule), 
 			typeof(global::Windows.UI.Xaml.Shapes.Polygon), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FillRule)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Shapes/Polyline.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Shapes/Polyline.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Shapes
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FillRuleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FillRule", typeof(global::Windows.UI.Xaml.Media.FillRule), 
+			nameof(FillRule), typeof(global::Windows.UI.Xaml.Media.FillRule), 
 			typeof(global::Windows.UI.Xaml.Shapes.Polyline), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FillRule)));
 		#endif
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Shapes
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PointsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Points", typeof(global::Windows.UI.Xaml.Media.PointCollection), 
+			nameof(Points), typeof(global::Windows.UI.Xaml.Media.PointCollection), 
 			typeof(global::Windows.UI.Xaml.Shapes.Polyline), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.PointCollection)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Shapes/Shape.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Shapes/Shape.cs
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Shapes
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StrokeDashCapProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StrokeDashCap", typeof(global::Windows.UI.Xaml.Media.PenLineCap), 
+			nameof(StrokeDashCap), typeof(global::Windows.UI.Xaml.Media.PenLineCap), 
 			typeof(global::Windows.UI.Xaml.Shapes.Shape), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.PenLineCap)));
 		#endif
@@ -121,7 +121,7 @@ namespace Windows.UI.Xaml.Shapes
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StrokeDashOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StrokeDashOffset", typeof(double), 
+			nameof(StrokeDashOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Shapes.Shape), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -129,7 +129,7 @@ namespace Windows.UI.Xaml.Shapes
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StrokeEndLineCapProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StrokeEndLineCap", typeof(global::Windows.UI.Xaml.Media.PenLineCap), 
+			nameof(StrokeEndLineCap), typeof(global::Windows.UI.Xaml.Media.PenLineCap), 
 			typeof(global::Windows.UI.Xaml.Shapes.Shape), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.PenLineCap)));
 		#endif
@@ -137,7 +137,7 @@ namespace Windows.UI.Xaml.Shapes
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StrokeLineJoinProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StrokeLineJoin", typeof(global::Windows.UI.Xaml.Media.PenLineJoin), 
+			nameof(StrokeLineJoin), typeof(global::Windows.UI.Xaml.Media.PenLineJoin), 
 			typeof(global::Windows.UI.Xaml.Shapes.Shape), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.PenLineJoin)));
 		#endif
@@ -145,7 +145,7 @@ namespace Windows.UI.Xaml.Shapes
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StrokeMiterLimitProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StrokeMiterLimit", typeof(double), 
+			nameof(StrokeMiterLimit), typeof(double), 
 			typeof(global::Windows.UI.Xaml.Shapes.Shape), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -154,7 +154,7 @@ namespace Windows.UI.Xaml.Shapes
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty StrokeStartLineCapProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"StrokeStartLineCap", typeof(global::Windows.UI.Xaml.Media.PenLineCap), 
+			nameof(StrokeStartLineCap), typeof(global::Windows.UI.Xaml.Media.PenLineCap), 
 			typeof(global::Windows.UI.Xaml.Shapes.Shape), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.PenLineCap)));
 		#endif

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/Application.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/Application.cs
@@ -121,6 +121,7 @@ namespace Windows.UI.Xaml
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Application", "void Application.OnCachedFileUpdaterActivated(CachedFileUpdaterActivatedEventArgs args)");
 		}
 		#endif
+		// Skipping already declared method Windows.UI.Xaml.Application.OnWindowCreated(Windows.UI.Xaml.WindowCreatedEventArgs)
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		protected virtual void OnBackgroundActivated( global::Windows.ApplicationModel.Activation.BackgroundActivatedEventArgs args)

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FlowDirection.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FlowDirection.cs
@@ -2,18 +2,14 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml
 {
-	#if false 
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum FlowDirection 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		LeftToRight,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		RightToLeft,
-		#endif
+		// Skipping already declared field Windows.UI.Xaml.FlowDirection.LeftToRight
+		// Skipping already declared field Windows.UI.Xaml.FlowDirection.RightToLeft
 	}
 	#endif
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
@@ -178,26 +178,8 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  double ActualHeight
-		{
-			get
-			{
-				return (double)this.GetValue(ActualHeightProperty);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  double ActualWidth
-		{
-			get
-			{
-				return (double)this.GetValue(ActualWidthProperty);
-			}
-		}
-		#endif
+		// Skipping already declared property ActualHeight
+		// Skipping already declared property ActualWidth
 		#if false || false || NET461 || false || false
 		[global::Uno.NotImplemented]
 		public  global::System.Uri BaseUri
@@ -346,7 +328,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ActualHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ActualHeight", typeof(double), 
+			nameof(ActualHeight), typeof(double), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -354,7 +336,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ActualWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ActualWidth", typeof(double), 
+			nameof(ActualWidth), typeof(double), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -362,7 +344,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FlowDirectionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FlowDirection", typeof(global::Windows.UI.Xaml.FlowDirection), 
+			nameof(FlowDirection), typeof(global::Windows.UI.Xaml.FlowDirection), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.FlowDirection)));
 		#endif
@@ -370,7 +352,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Height", typeof(double), 
+			nameof(Height), typeof(double), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -378,7 +360,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HorizontalAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HorizontalAlignment", typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
+			nameof(HorizontalAlignment), typeof(global::Windows.UI.Xaml.HorizontalAlignment), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.HorizontalAlignment)));
 		#endif
@@ -386,7 +368,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LanguageProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Language", typeof(string), 
+			nameof(Language), typeof(string), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -394,7 +376,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MarginProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Margin", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(Margin), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -402,7 +384,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxHeight", typeof(double), 
+			nameof(MaxHeight), typeof(double), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -410,7 +392,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MaxWidth", typeof(double), 
+			nameof(MaxWidth), typeof(double), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -418,7 +400,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinHeight", typeof(double), 
+			nameof(MinHeight), typeof(double), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -426,7 +408,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MinWidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"MinWidth", typeof(double), 
+			nameof(MinWidth), typeof(double), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -434,7 +416,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty NameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Name", typeof(string), 
+			nameof(Name), typeof(string), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -443,7 +425,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TagProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Tag", typeof(object), 
+			nameof(Tag), typeof(object), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
@@ -451,7 +433,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty VerticalAlignmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"VerticalAlignment", typeof(global::Windows.UI.Xaml.VerticalAlignment), 
+			nameof(VerticalAlignment), typeof(global::Windows.UI.Xaml.VerticalAlignment), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.VerticalAlignment)));
 		#endif
@@ -459,7 +441,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty WidthProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Width", typeof(double), 
+			nameof(Width), typeof(double), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -467,7 +449,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty RequestedThemeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"RequestedTheme", typeof(global::Windows.UI.Xaml.ElementTheme), 
+			nameof(RequestedTheme), typeof(global::Windows.UI.Xaml.ElementTheme), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.ElementTheme)));
 		#endif
@@ -475,7 +457,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AllowFocusOnInteractionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AllowFocusOnInteraction", typeof(bool), 
+			nameof(AllowFocusOnInteraction), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -483,7 +465,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AllowFocusWhenDisabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AllowFocusWhenDisabled", typeof(bool), 
+			nameof(AllowFocusWhenDisabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -491,7 +473,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusVisualMarginProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusVisualMargin", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(FocusVisualMargin), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -499,7 +481,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusVisualPrimaryBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusVisualPrimaryBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(FocusVisualPrimaryBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -507,7 +489,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusVisualPrimaryThicknessProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusVisualPrimaryThickness", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(FocusVisualPrimaryThickness), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -515,7 +497,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusVisualSecondaryBrushProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusVisualSecondaryBrush", typeof(global::Windows.UI.Xaml.Media.Brush), 
+			nameof(FocusVisualSecondaryBrush), typeof(global::Windows.UI.Xaml.Media.Brush), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
@@ -523,7 +505,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FocusVisualSecondaryThicknessProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"FocusVisualSecondaryThickness", typeof(global::Windows.UI.Xaml.Thickness), 
+			nameof(FocusVisualSecondaryThickness), typeof(global::Windows.UI.Xaml.Thickness), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
@@ -531,7 +513,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ActualThemeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ActualTheme", typeof(global::Windows.UI.Xaml.ElementTheme), 
+			nameof(ActualTheme), typeof(global::Windows.UI.Xaml.ElementTheme), 
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.ElementTheme)));
 		#endif
@@ -583,12 +565,24 @@ namespace Windows.UI.Xaml
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.LayoutUpdated.add
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.LayoutUpdated.remove
 		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.FindName(string)
-		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.SetBinding(Windows.UI.Xaml.DependencyProperty, Windows.UI.Xaml.Data.BindingBase)
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  void SetBinding( global::Windows.UI.Xaml.DependencyProperty dp,  global::Windows.UI.Xaml.Data.BindingBase binding)
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "void FrameworkElement.SetBinding(DependencyProperty dp, BindingBase binding)");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.RequestedTheme.get
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.RequestedTheme.set
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.DataContextChanged.add
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.DataContextChanged.remove
-		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.GetBindingExpression(Windows.UI.Xaml.DependencyProperty)
+		#if false || false || NET461 || __WASM__ || __MACOS__
+		[global::Uno.NotImplemented]
+		public  global::Windows.UI.Xaml.Data.BindingExpression GetBindingExpression( global::Windows.UI.Xaml.DependencyProperty dp)
+		{
+			throw new global::System.NotImplementedException("The member BindingExpression FrameworkElement.GetBindingExpression(DependencyProperty dp) is not implemented in Uno.");
+		}
+		#endif
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.Loading.add
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.Loading.remove
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.AllowFocusOnInteraction.get
@@ -621,6 +615,7 @@ namespace Windows.UI.Xaml
 		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.MeasureOverride(Windows.Foundation.Size)
 		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.ArrangeOverride(Windows.Foundation.Size)
 		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.OnApplyTemplate()
+		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.GoToElementStateCore(string, bool)
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.ActualThemeProperty.get
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
@@ -654,38 +649,8 @@ namespace Windows.UI.Xaml
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.DataContextProperty.get
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.StyleProperty.get
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.FlowDirectionProperty.get
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  event global::System.EventHandler<object> LayoutUpdated
-		{
-			[global::Uno.NotImplemented]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event EventHandler<object> FrameworkElement.LayoutUpdated");
-			}
-			[global::Uno.NotImplemented]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event EventHandler<object> FrameworkElement.LayoutUpdated");
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  event global::Windows.UI.Xaml.RoutedEventHandler Loaded
-		{
-			[global::Uno.NotImplemented]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event RoutedEventHandler FrameworkElement.Loaded");
-			}
-			[global::Uno.NotImplemented]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event RoutedEventHandler FrameworkElement.Loaded");
-			}
-		}
-		#endif
+		// Skipping already declared event Windows.UI.Xaml.FrameworkElement.LayoutUpdated
+		// Skipping already declared event Windows.UI.Xaml.FrameworkElement.Loaded
 		#if false || false || NET461 || false || false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.UI.Xaml.SizeChangedEventHandler SizeChanged
@@ -702,39 +667,24 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if false || false || false || false || false
+		// Skipping already declared event Windows.UI.Xaml.FrameworkElement.Unloaded
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
-		public  event global::Windows.UI.Xaml.RoutedEventHandler Unloaded
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.FrameworkElement, global::Windows.UI.Xaml.DataContextChangedEventArgs> DataContextChanged
 		{
 			[global::Uno.NotImplemented]
 			add
 			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event RoutedEventHandler FrameworkElement.Unloaded");
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event TypedEventHandler<FrameworkElement, DataContextChangedEventArgs> FrameworkElement.DataContextChanged");
 			}
 			[global::Uno.NotImplemented]
 			remove
 			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event RoutedEventHandler FrameworkElement.Unloaded");
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event TypedEventHandler<FrameworkElement, DataContextChangedEventArgs> FrameworkElement.DataContextChanged");
 			}
 		}
 		#endif
-		// Skipping already declared event Windows.UI.Xaml.FrameworkElement.DataContextChanged
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.FrameworkElement, object> Loading
-		{
-			[global::Uno.NotImplemented]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event TypedEventHandler<FrameworkElement, object> FrameworkElement.Loading");
-			}
-			[global::Uno.NotImplemented]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event TypedEventHandler<FrameworkElement, object> FrameworkElement.Loading");
-			}
-		}
-		#endif
+		// Skipping already declared event Windows.UI.Xaml.FrameworkElement.Loading
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.FrameworkElement, object> ActualThemeChanged

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/RectHelper.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/RectHelper.cs
@@ -2,112 +2,25 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml
 {
-#if false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
-#endif
-	public partial class RectHelper
+	#endif
+	public  partial class RectHelper 
 	{
-#if false
-		[global::Uno.NotImplemented]
-		public static global::Windows.Foundation.Rect Empty
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member Rect RectHelper.Empty is not implemented in Uno.");
-			}
-		}
-#endif
+		// Skipping already declared property Empty
 		// Forced skipping of method Windows.UI.Xaml.RectHelper.Empty.get
-#if false
-		[global::Uno.NotImplemented]
-		public static global::Windows.Foundation.Rect FromCoordinatesAndDimensions( float x,  float y,  float width,  float height)
-		{
-			throw new global::System.NotImplementedException("The member Rect RectHelper.FromCoordinatesAndDimensions(float x, float y, float width, float height) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static global::Windows.Foundation.Rect FromPoints( global::Windows.Foundation.Point point1,  global::Windows.Foundation.Point point2)
-		{
-			throw new global::System.NotImplementedException("The member Rect RectHelper.FromPoints(Point point1, Point point2) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static global::Windows.Foundation.Rect FromLocationAndSize( global::Windows.Foundation.Point location,  global::Windows.Foundation.Size size)
-		{
-			throw new global::System.NotImplementedException("The member Rect RectHelper.FromLocationAndSize(Point location, Size size) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static bool GetIsEmpty( global::Windows.Foundation.Rect target)
-		{
-			throw new global::System.NotImplementedException("The member bool RectHelper.GetIsEmpty(Rect target) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static float GetBottom( global::Windows.Foundation.Rect target)
-		{
-			throw new global::System.NotImplementedException("The member float RectHelper.GetBottom(Rect target) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static float GetLeft( global::Windows.Foundation.Rect target)
-		{
-			throw new global::System.NotImplementedException("The member float RectHelper.GetLeft(Rect target) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static float GetRight( global::Windows.Foundation.Rect target)
-		{
-			throw new global::System.NotImplementedException("The member float RectHelper.GetRight(Rect target) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static float GetTop( global::Windows.Foundation.Rect target)
-		{
-			throw new global::System.NotImplementedException("The member float RectHelper.GetTop(Rect target) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static bool Contains( global::Windows.Foundation.Rect target,  global::Windows.Foundation.Point point)
-		{
-			throw new global::System.NotImplementedException("The member bool RectHelper.Contains(Rect target, Point point) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static bool Equals( global::Windows.Foundation.Rect target,  global::Windows.Foundation.Rect value)
-		{
-			throw new global::System.NotImplementedException("The member bool RectHelper.Equals(Rect target, Rect value) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static global::Windows.Foundation.Rect Intersect( global::Windows.Foundation.Rect target,  global::Windows.Foundation.Rect rect)
-		{
-			throw new global::System.NotImplementedException("The member Rect RectHelper.Intersect(Rect target, Rect rect) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static global::Windows.Foundation.Rect Union( global::Windows.Foundation.Rect target,  global::Windows.Foundation.Point point)
-		{
-			throw new global::System.NotImplementedException("The member Rect RectHelper.Union(Rect target, Point point) is not implemented in Uno.");
-		}
-#endif
-#if false
-		[global::Uno.NotImplemented]
-		public static global::Windows.Foundation.Rect Union( global::Windows.Foundation.Rect target,  global::Windows.Foundation.Rect rect)
-		{
-			throw new global::System.NotImplementedException("The member Rect RectHelper.Union(Rect target, Rect rect) is not implemented in Uno.");
-		}
-#endif
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.FromCoordinatesAndDimensions(float, float, float, float)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.FromPoints(Windows.Foundation.Point, Windows.Foundation.Point)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.FromLocationAndSize(Windows.Foundation.Point, Windows.Foundation.Size)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.GetIsEmpty(Windows.Foundation.Rect)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.GetBottom(Windows.Foundation.Rect)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.GetLeft(Windows.Foundation.Rect)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.GetRight(Windows.Foundation.Rect)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.GetTop(Windows.Foundation.Rect)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.Contains(Windows.Foundation.Rect, Windows.Foundation.Point)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.Equals(Windows.Foundation.Rect, Windows.Foundation.Rect)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.Intersect(Windows.Foundation.Rect, Windows.Foundation.Rect)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.Union(Windows.Foundation.Rect, Windows.Foundation.Point)
+		// Skipping already declared method Windows.UI.Xaml.RectHelper.Union(Windows.Foundation.Rect, Windows.Foundation.Rect)
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/TriggerAction.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/TriggerAction.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TriggerAction : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/TriggerBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/TriggerBase.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TriggerBase : global::Windows.UI.Xaml.DependencyObject

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
@@ -610,7 +610,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsDoubleTapEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsDoubleTapEnabled", typeof(bool), 
+			nameof(IsDoubleTapEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -618,7 +618,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsHoldingEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsHoldingEnabled", typeof(bool), 
+			nameof(IsHoldingEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -626,10 +626,12 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsRightTapEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsRightTapEnabled", typeof(bool), 
+			nameof(IsRightTapEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
+		// Skipping already declared property KeyDownEvent
+		// Skipping already declared property KeyUpEvent
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.RoutedEvent ManipulationCompletedEvent
@@ -654,7 +656,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTapEnabledProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsTapEnabled", typeof(bool), 
+			nameof(IsTapEnabled), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -672,7 +674,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ManipulationModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ManipulationMode", typeof(global::Windows.UI.Xaml.Input.ManipulationModes), 
+			nameof(ManipulationMode), typeof(global::Windows.UI.Xaml.Input.ManipulationModes), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.ManipulationModes)));
 		#endif
@@ -696,9 +698,15 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
+		// Skipping already declared property PointerCanceledEvent
+		// Skipping already declared property PointerCaptureLostEvent
+		// Skipping already declared property PointerCapturesProperty
+		// Skipping already declared property PointerEnteredEvent
+		// Skipping already declared property PointerExitedEvent
+		// Skipping already declared property PointerMovedEvent
+		// Skipping already declared property PointerPressedEvent
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
-		// Skipping already declared property PointerCapturesProperty
 		public static global::Windows.UI.Xaml.RoutedEvent PointerWheelChangedEvent
 		{
 			get
@@ -711,7 +719,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ProjectionProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Projection", typeof(global::Windows.UI.Xaml.Media.Projection), 
+			nameof(Projection), typeof(global::Windows.UI.Xaml.Media.Projection), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Projection)));
 		#endif
@@ -735,11 +743,12 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
+		// Skipping already declared property TappedEvent
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty UseLayoutRoundingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"UseLayoutRounding", typeof(bool), 
+			nameof(UseLayoutRounding), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -747,7 +756,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AllowDropProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AllowDrop", typeof(bool), 
+			nameof(AllowDrop), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -755,11 +764,13 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CacheModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CacheMode", typeof(global::Windows.UI.Xaml.Media.CacheMode), 
+			nameof(CacheMode), typeof(global::Windows.UI.Xaml.Media.CacheMode), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.CacheMode)));
 		#endif
 		// Skipping already declared property ClipProperty
+		// Skipping already declared property DoubleTappedEvent
+		// Skipping already declared property PointerReleasedEvent
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.RoutedEvent DragLeaveEvent
@@ -794,7 +805,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CompositeModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CompositeMode", typeof(global::Windows.UI.Xaml.Media.ElementCompositeMode), 
+			nameof(CompositeMode), typeof(global::Windows.UI.Xaml.Media.ElementCompositeMode), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.ElementCompositeMode)));
 		#endif
@@ -802,7 +813,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanDragProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanDrag", typeof(bool), 
+			nameof(CanDrag), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -810,7 +821,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty Transform3DProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Transform3D", typeof(global::Windows.UI.Xaml.Media.Media3D.Transform3D), 
+			nameof(Transform3D), typeof(global::Windows.UI.Xaml.Media.Media3D.Transform3D), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Media3D.Transform3D)));
 		#endif
@@ -818,7 +829,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AccessKeyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AccessKey", typeof(string), 
+			nameof(AccessKey), typeof(string), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
@@ -826,7 +837,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AccessKeyScopeOwnerProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"AccessKeyScopeOwner", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(AccessKeyScopeOwner), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -834,7 +845,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ContextFlyoutProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ContextFlyout", typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
+			nameof(ContextFlyout), typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif
@@ -842,7 +853,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsAccessKeyScopeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsAccessKeyScope", typeof(bool), 
+			nameof(IsAccessKeyScope), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -850,7 +861,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ExitDisplayModeOnAccessKeyInvokedProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"ExitDisplayModeOnAccessKeyInvoked", typeof(bool), 
+			nameof(ExitDisplayModeOnAccessKeyInvoked), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -858,7 +869,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TabFocusNavigationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"TabFocusNavigation", typeof(global::Windows.UI.Xaml.Input.KeyboardNavigationMode), 
+			nameof(TabFocusNavigation), typeof(global::Windows.UI.Xaml.Input.KeyboardNavigationMode), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.KeyboardNavigationMode)));
 		#endif
@@ -866,7 +877,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HighContrastAdjustmentProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"HighContrastAdjustment", typeof(global::Windows.UI.Xaml.ElementHighContrastAdjustment), 
+			nameof(HighContrastAdjustment), typeof(global::Windows.UI.Xaml.ElementHighContrastAdjustment), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.ElementHighContrastAdjustment)));
 		#endif
@@ -874,7 +885,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyTipHorizontalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyTipHorizontalOffset", typeof(double), 
+			nameof(KeyTipHorizontalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -882,7 +893,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyTipPlacementModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyTipPlacementMode", typeof(global::Windows.UI.Xaml.Input.KeyTipPlacementMode), 
+			nameof(KeyTipPlacementMode), typeof(global::Windows.UI.Xaml.Input.KeyTipPlacementMode), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.KeyTipPlacementMode)));
 		#endif
@@ -890,7 +901,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyTipVerticalOffsetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyTipVerticalOffset", typeof(double), 
+			nameof(KeyTipVerticalOffset), typeof(double), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
@@ -898,7 +909,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightsProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"Lights", typeof(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Media.XamlLight>), 
+			nameof(Lights), typeof(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Media.XamlLight>), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Media.XamlLight>)));
 		#endif
@@ -906,7 +917,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusDownNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusDownNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusDownNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -914,7 +925,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusKeyboardNavigationProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusKeyboardNavigation", typeof(global::Windows.UI.Xaml.Input.XYFocusKeyboardNavigationMode), 
+			nameof(XYFocusKeyboardNavigation), typeof(global::Windows.UI.Xaml.Input.XYFocusKeyboardNavigationMode), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusKeyboardNavigationMode)));
 		#endif
@@ -922,7 +933,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusLeftNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusLeftNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusLeftNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -930,7 +941,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusRightNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusRightNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusRightNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -938,7 +949,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty XYFocusUpNavigationStrategyProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"XYFocusUpNavigationStrategy", typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
+			nameof(XYFocusUpNavigationStrategy), typeof(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.XYFocusNavigationStrategy)));
 		#endif
@@ -1026,7 +1037,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyTipTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyTipTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(KeyTipTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -1034,7 +1045,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyboardAcceleratorPlacementModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyboardAcceleratorPlacementMode", typeof(global::Windows.UI.Xaml.Input.KeyboardAcceleratorPlacementMode), 
+			nameof(KeyboardAcceleratorPlacementMode), typeof(global::Windows.UI.Xaml.Input.KeyboardAcceleratorPlacementMode), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.KeyboardAcceleratorPlacementMode)));
 		#endif
@@ -1042,7 +1053,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty KeyboardAcceleratorPlacementTargetProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"KeyboardAcceleratorPlacementTarget", typeof(global::Windows.UI.Xaml.DependencyObject), 
+			nameof(KeyboardAcceleratorPlacementTarget), typeof(global::Windows.UI.Xaml.DependencyObject), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
@@ -1050,7 +1061,7 @@ namespace Windows.UI.Xaml
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty CanBeScrollAnchorProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
-			"CanBeScrollAnchor", typeof(bool), 
+			nameof(CanBeScrollAnchor), typeof(bool), 
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
@@ -1144,6 +1155,8 @@ namespace Windows.UI.Xaml
 		// Skipping already declared method Windows.UI.Xaml.UIElement.CapturePointer(Windows.UI.Xaml.Input.Pointer)
 		// Skipping already declared method Windows.UI.Xaml.UIElement.ReleasePointerCapture(Windows.UI.Xaml.Input.Pointer)
 		// Skipping already declared method Windows.UI.Xaml.UIElement.ReleasePointerCaptures()
+		// Skipping already declared method Windows.UI.Xaml.UIElement.AddHandler(Windows.UI.Xaml.RoutedEvent, object, bool)
+		// Skipping already declared method Windows.UI.Xaml.UIElement.RemoveHandler(Windows.UI.Xaml.RoutedEvent, object)
 		#if false || false || NET461 || false || false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.Media.GeneralTransform TransformToVisual( global::Windows.UI.Xaml.UIElement visual)
@@ -1523,6 +1536,8 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
+		// Skipping already declared event Windows.UI.Xaml.UIElement.KeyDown
+		// Skipping already declared event Windows.UI.Xaml.UIElement.KeyUp
 		// Skipping already declared event Windows.UI.Xaml.UIElement.LostFocus
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Globalization/Calendar.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Globalization/Calendar.cs
@@ -1,855 +1,148 @@
-#if false
 #pragma warning disable 108 // new keyword hiding
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Globalization
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Calendar 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int Year
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.Year is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "int Calendar.Year");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int Second
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.Second is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "int Calendar.Second");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int Period
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.Period is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "int Calendar.Period");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int Nanosecond
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.Nanosecond is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "int Calendar.Nanosecond");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int Month
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.Month is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "int Calendar.Month");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int Minute
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.Minute is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "int Calendar.Minute");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string NumeralSystem
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string Calendar.NumeralSystem is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "string Calendar.NumeralSystem");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int Era
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.Era is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "int Calendar.Era");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int Hour
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.Hour is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "int Calendar.Hour");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int Day
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.Day is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "int Calendar.Day");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int FirstSecondInThisMinute
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.FirstSecondInThisMinute is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int FirstYearInThisEra
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.FirstYearInThisEra is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  bool IsDaylightSavingTime
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool Calendar.IsDaylightSavingTime is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  global::System.Collections.Generic.IReadOnlyList<string> Languages
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member IReadOnlyList<string> Calendar.Languages is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int LastDayInThisMonth
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.LastDayInThisMonth is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int LastEra
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.LastEra is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int LastHourInThisPeriod
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.LastHourInThisPeriod is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int LastMinuteInThisHour
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.LastMinuteInThisHour is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int LastMonthInThisYear
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.LastMonthInThisYear is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int LastSecondInThisMinute
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.LastSecondInThisMinute is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int LastYearInThisEra
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.LastYearInThisEra is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  global::Windows.Globalization.DayOfWeek DayOfWeek
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member DayOfWeek Calendar.DayOfWeek is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int FirstDayInThisMonth
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.FirstDayInThisMonth is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int LastPeriodInThisDay
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.LastPeriodInThisDay is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int FirstEra
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.FirstEra is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int NumberOfDaysInThisMonth
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.NumberOfDaysInThisMonth is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int NumberOfEras
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.NumberOfEras is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int NumberOfHoursInThisPeriod
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.NumberOfHoursInThisPeriod is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int NumberOfMinutesInThisHour
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.NumberOfMinutesInThisHour is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int FirstHourInThisPeriod
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.FirstHourInThisPeriod is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int NumberOfMonthsInThisYear
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.NumberOfMonthsInThisYear is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int NumberOfPeriodsInThisDay
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.NumberOfPeriodsInThisDay is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int NumberOfSecondsInThisMinute
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.NumberOfSecondsInThisMinute is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int NumberOfYearsInThisEra
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.NumberOfYearsInThisEra is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int FirstMinuteInThisHour
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.FirstMinuteInThisHour is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string ResolvedLanguage
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string Calendar.ResolvedLanguage is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int FirstMonthInThisYear
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.FirstMonthInThisYear is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int FirstPeriodInThisDay
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int Calendar.FirstPeriodInThisDay is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public Calendar( global::System.Collections.Generic.IEnumerable<string> languages,  string calendar,  string clock,  string timeZoneId) 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "Calendar.Calendar(IEnumerable<string> languages, string calendar, string clock, string timeZoneId)");
-		}
-		#endif
+		// Skipping already declared property Year
+		// Skipping already declared property Second
+		// Skipping already declared property Period
+		// Skipping already declared property Nanosecond
+		// Skipping already declared property Month
+		// Skipping already declared property Minute
+		// Skipping already declared property NumeralSystem
+		// Skipping already declared property Era
+		// Skipping already declared property Hour
+		// Skipping already declared property Day
+		// Skipping already declared property FirstSecondInThisMinute
+		// Skipping already declared property FirstYearInThisEra
+		// Skipping already declared property IsDaylightSavingTime
+		// Skipping already declared property Languages
+		// Skipping already declared property LastDayInThisMonth
+		// Skipping already declared property LastEra
+		// Skipping already declared property LastHourInThisPeriod
+		// Skipping already declared property LastMinuteInThisHour
+		// Skipping already declared property LastMonthInThisYear
+		// Skipping already declared property LastSecondInThisMinute
+		// Skipping already declared property LastYearInThisEra
+		// Skipping already declared property DayOfWeek
+		// Skipping already declared property FirstDayInThisMonth
+		// Skipping already declared property LastPeriodInThisDay
+		// Skipping already declared property FirstEra
+		// Skipping already declared property NumberOfDaysInThisMonth
+		// Skipping already declared property NumberOfEras
+		// Skipping already declared property NumberOfHoursInThisPeriod
+		// Skipping already declared property NumberOfMinutesInThisHour
+		// Skipping already declared property FirstHourInThisPeriod
+		// Skipping already declared property NumberOfMonthsInThisYear
+		// Skipping already declared property NumberOfPeriodsInThisDay
+		// Skipping already declared property NumberOfSecondsInThisMinute
+		// Skipping already declared property NumberOfYearsInThisEra
+		// Skipping already declared property FirstMinuteInThisHour
+		// Skipping already declared property ResolvedLanguage
+		// Skipping already declared property FirstMonthInThisYear
+		// Skipping already declared property FirstPeriodInThisDay
+		// Skipping already declared method Windows.Globalization.Calendar.Calendar(System.Collections.Generic.IEnumerable<string>, string, string, string)
 		// Forced skipping of method Windows.Globalization.Calendar.Calendar(System.Collections.Generic.IEnumerable<string>, string, string, string)
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public Calendar( global::System.Collections.Generic.IEnumerable<string> languages) 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "Calendar.Calendar(IEnumerable<string> languages)");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.Calendar(System.Collections.Generic.IEnumerable<string>)
 		// Forced skipping of method Windows.Globalization.Calendar.Calendar(System.Collections.Generic.IEnumerable<string>)
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public Calendar( global::System.Collections.Generic.IEnumerable<string> languages,  string calendar,  string clock) 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "Calendar.Calendar(IEnumerable<string> languages, string calendar, string clock)");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.Calendar(System.Collections.Generic.IEnumerable<string>, string, string)
 		// Forced skipping of method Windows.Globalization.Calendar.Calendar(System.Collections.Generic.IEnumerable<string>, string, string)
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public Calendar() 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "Calendar.Calendar()");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.Calendar()
 		// Forced skipping of method Windows.Globalization.Calendar.Calendar()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  global::Windows.Globalization.Calendar Clone()
-		{
-			throw new global::System.NotImplementedException("The member Calendar Calendar.Clone() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void SetToMin()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.SetToMin()");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void SetToMax()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.SetToMax()");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.Clone()
+		// Skipping already declared method Windows.Globalization.Calendar.SetToMin()
+		// Skipping already declared method Windows.Globalization.Calendar.SetToMax()
 		// Forced skipping of method Windows.Globalization.Calendar.Languages.get
 		// Forced skipping of method Windows.Globalization.Calendar.NumeralSystem.get
 		// Forced skipping of method Windows.Globalization.Calendar.NumeralSystem.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string GetCalendarSystem()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.GetCalendarSystem() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void ChangeCalendarSystem( string value)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.ChangeCalendarSystem(string value)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string GetClock()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.GetClock() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void ChangeClock( string value)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.ChangeClock(string value)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  global::System.DateTimeOffset GetDateTime()
-		{
-			throw new global::System.NotImplementedException("The member DateTimeOffset Calendar.GetDateTime() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void SetDateTime( global::System.DateTimeOffset value)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.SetDateTime(DateTimeOffset value)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void SetToNow()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.SetToNow()");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.GetCalendarSystem()
+		// Skipping already declared method Windows.Globalization.Calendar.ChangeCalendarSystem(string)
+		// Skipping already declared method Windows.Globalization.Calendar.GetClock()
+		// Skipping already declared method Windows.Globalization.Calendar.ChangeClock(string)
+		// Skipping already declared method Windows.Globalization.Calendar.GetDateTime()
+		// Skipping already declared method Windows.Globalization.Calendar.SetDateTime(System.DateTimeOffset)
+		// Skipping already declared method Windows.Globalization.Calendar.SetToNow()
 		// Forced skipping of method Windows.Globalization.Calendar.FirstEra.get
 		// Forced skipping of method Windows.Globalization.Calendar.LastEra.get
 		// Forced skipping of method Windows.Globalization.Calendar.NumberOfEras.get
 		// Forced skipping of method Windows.Globalization.Calendar.Era.get
 		// Forced skipping of method Windows.Globalization.Calendar.Era.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void AddEras( int eras)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.AddEras(int eras)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string EraAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.EraAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string EraAsString( int idealLength)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.EraAsString(int idealLength) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.AddEras(int)
+		// Skipping already declared method Windows.Globalization.Calendar.EraAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.EraAsString(int)
 		// Forced skipping of method Windows.Globalization.Calendar.FirstYearInThisEra.get
 		// Forced skipping of method Windows.Globalization.Calendar.LastYearInThisEra.get
 		// Forced skipping of method Windows.Globalization.Calendar.NumberOfYearsInThisEra.get
 		// Forced skipping of method Windows.Globalization.Calendar.Year.get
 		// Forced skipping of method Windows.Globalization.Calendar.Year.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void AddYears( int years)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.AddYears(int years)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string YearAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.YearAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string YearAsTruncatedString( int remainingDigits)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.YearAsTruncatedString(int remainingDigits) is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string YearAsPaddedString( int minDigits)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.YearAsPaddedString(int minDigits) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.AddYears(int)
+		// Skipping already declared method Windows.Globalization.Calendar.YearAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.YearAsTruncatedString(int)
+		// Skipping already declared method Windows.Globalization.Calendar.YearAsPaddedString(int)
 		// Forced skipping of method Windows.Globalization.Calendar.FirstMonthInThisYear.get
 		// Forced skipping of method Windows.Globalization.Calendar.LastMonthInThisYear.get
 		// Forced skipping of method Windows.Globalization.Calendar.NumberOfMonthsInThisYear.get
 		// Forced skipping of method Windows.Globalization.Calendar.Month.get
 		// Forced skipping of method Windows.Globalization.Calendar.Month.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void AddMonths( int months)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.AddMonths(int months)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string MonthAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.MonthAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string MonthAsString( int idealLength)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.MonthAsString(int idealLength) is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string MonthAsSoloString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.MonthAsSoloString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string MonthAsSoloString( int idealLength)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.MonthAsSoloString(int idealLength) is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string MonthAsNumericString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.MonthAsNumericString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string MonthAsPaddedNumericString( int minDigits)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.MonthAsPaddedNumericString(int minDigits) is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void AddWeeks( int weeks)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.AddWeeks(int weeks)");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.AddMonths(int)
+		// Skipping already declared method Windows.Globalization.Calendar.MonthAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.MonthAsString(int)
+		// Skipping already declared method Windows.Globalization.Calendar.MonthAsSoloString()
+		// Skipping already declared method Windows.Globalization.Calendar.MonthAsSoloString(int)
+		// Skipping already declared method Windows.Globalization.Calendar.MonthAsNumericString()
+		// Skipping already declared method Windows.Globalization.Calendar.MonthAsPaddedNumericString(int)
+		// Skipping already declared method Windows.Globalization.Calendar.AddWeeks(int)
 		// Forced skipping of method Windows.Globalization.Calendar.FirstDayInThisMonth.get
 		// Forced skipping of method Windows.Globalization.Calendar.LastDayInThisMonth.get
 		// Forced skipping of method Windows.Globalization.Calendar.NumberOfDaysInThisMonth.get
 		// Forced skipping of method Windows.Globalization.Calendar.Day.get
 		// Forced skipping of method Windows.Globalization.Calendar.Day.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void AddDays( int days)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.AddDays(int days)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string DayAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.DayAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string DayAsPaddedString( int minDigits)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.DayAsPaddedString(int minDigits) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.AddDays(int)
+		// Skipping already declared method Windows.Globalization.Calendar.DayAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.DayAsPaddedString(int)
 		// Forced skipping of method Windows.Globalization.Calendar.DayOfWeek.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string DayOfWeekAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.DayOfWeekAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string DayOfWeekAsString( int idealLength)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.DayOfWeekAsString(int idealLength) is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string DayOfWeekAsSoloString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.DayOfWeekAsSoloString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string DayOfWeekAsSoloString( int idealLength)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.DayOfWeekAsSoloString(int idealLength) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.DayOfWeekAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.DayOfWeekAsString(int)
+		// Skipping already declared method Windows.Globalization.Calendar.DayOfWeekAsSoloString()
+		// Skipping already declared method Windows.Globalization.Calendar.DayOfWeekAsSoloString(int)
 		// Forced skipping of method Windows.Globalization.Calendar.FirstPeriodInThisDay.get
 		// Forced skipping of method Windows.Globalization.Calendar.LastPeriodInThisDay.get
 		// Forced skipping of method Windows.Globalization.Calendar.NumberOfPeriodsInThisDay.get
 		// Forced skipping of method Windows.Globalization.Calendar.Period.get
 		// Forced skipping of method Windows.Globalization.Calendar.Period.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void AddPeriods( int periods)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.AddPeriods(int periods)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string PeriodAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.PeriodAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string PeriodAsString( int idealLength)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.PeriodAsString(int idealLength) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.AddPeriods(int)
+		// Skipping already declared method Windows.Globalization.Calendar.PeriodAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.PeriodAsString(int)
 		// Forced skipping of method Windows.Globalization.Calendar.FirstHourInThisPeriod.get
 		// Forced skipping of method Windows.Globalization.Calendar.LastHourInThisPeriod.get
 		// Forced skipping of method Windows.Globalization.Calendar.NumberOfHoursInThisPeriod.get
 		// Forced skipping of method Windows.Globalization.Calendar.Hour.get
 		// Forced skipping of method Windows.Globalization.Calendar.Hour.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void AddHours( int hours)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.AddHours(int hours)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string HourAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.HourAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string HourAsPaddedString( int minDigits)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.HourAsPaddedString(int minDigits) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.AddHours(int)
+		// Skipping already declared method Windows.Globalization.Calendar.HourAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.HourAsPaddedString(int)
 		// Forced skipping of method Windows.Globalization.Calendar.Minute.get
 		// Forced skipping of method Windows.Globalization.Calendar.Minute.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void AddMinutes( int minutes)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.AddMinutes(int minutes)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string MinuteAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.MinuteAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string MinuteAsPaddedString( int minDigits)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.MinuteAsPaddedString(int minDigits) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.AddMinutes(int)
+		// Skipping already declared method Windows.Globalization.Calendar.MinuteAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.MinuteAsPaddedString(int)
 		// Forced skipping of method Windows.Globalization.Calendar.Second.get
 		// Forced skipping of method Windows.Globalization.Calendar.Second.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void AddSeconds( int seconds)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.AddSeconds(int seconds)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string SecondAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.SecondAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string SecondAsPaddedString( int minDigits)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.SecondAsPaddedString(int minDigits) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.AddSeconds(int)
+		// Skipping already declared method Windows.Globalization.Calendar.SecondAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.SecondAsPaddedString(int)
 		// Forced skipping of method Windows.Globalization.Calendar.Nanosecond.get
 		// Forced skipping of method Windows.Globalization.Calendar.Nanosecond.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void AddNanoseconds( int nanoseconds)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.AddNanoseconds(int nanoseconds)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string NanosecondAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.NanosecondAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string NanosecondAsPaddedString( int minDigits)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.NanosecondAsPaddedString(int minDigits) is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int Compare( global::Windows.Globalization.Calendar other)
-		{
-			throw new global::System.NotImplementedException("The member int Calendar.Compare(Calendar other) is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  int CompareDateTime( global::System.DateTimeOffset other)
-		{
-			throw new global::System.NotImplementedException("The member int Calendar.CompareDateTime(DateTimeOffset other) is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void CopyTo( global::Windows.Globalization.Calendar other)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.CopyTo(Calendar other)");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.AddNanoseconds(int)
+		// Skipping already declared method Windows.Globalization.Calendar.NanosecondAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.NanosecondAsPaddedString(int)
+		// Skipping already declared method Windows.Globalization.Calendar.Compare(Windows.Globalization.Calendar)
+		// Skipping already declared method Windows.Globalization.Calendar.CompareDateTime(System.DateTimeOffset)
+		// Skipping already declared method Windows.Globalization.Calendar.CopyTo(Windows.Globalization.Calendar)
 		// Forced skipping of method Windows.Globalization.Calendar.FirstMinuteInThisHour.get
 		// Forced skipping of method Windows.Globalization.Calendar.LastMinuteInThisHour.get
 		// Forced skipping of method Windows.Globalization.Calendar.NumberOfMinutesInThisHour.get
@@ -858,34 +151,9 @@ namespace Windows.Globalization
 		// Forced skipping of method Windows.Globalization.Calendar.NumberOfSecondsInThisMinute.get
 		// Forced skipping of method Windows.Globalization.Calendar.ResolvedLanguage.get
 		// Forced skipping of method Windows.Globalization.Calendar.IsDaylightSavingTime.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string GetTimeZone()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.GetTimeZone() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void ChangeTimeZone( string timeZoneId)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Globalization.Calendar", "void Calendar.ChangeTimeZone(string timeZoneId)");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string TimeZoneAsString()
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.TimeZoneAsString() is not implemented in Uno.");
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string TimeZoneAsString( int idealLength)
-		{
-			throw new global::System.NotImplementedException("The member string Calendar.TimeZoneAsString(int idealLength) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.Globalization.Calendar.GetTimeZone()
+		// Skipping already declared method Windows.Globalization.Calendar.ChangeTimeZone(string)
+		// Skipping already declared method Windows.Globalization.Calendar.TimeZoneAsString()
+		// Skipping already declared method Windows.Globalization.Calendar.TimeZoneAsString(int)
 	}
 }
-#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Globalization/CalendarIdentifiers.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Globalization/CalendarIdentifiers.cs
@@ -1,163 +1,27 @@
-#if false
 #pragma warning disable 108 // new keyword hiding
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Globalization
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CalendarIdentifiers 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string Julian
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.Julian is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string Gregorian
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.Gregorian is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string Hebrew
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.Hebrew is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string Hijri
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.Hijri is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string Japanese
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.Japanese is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string Korean
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.Korean is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string Taiwan
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.Taiwan is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string Thai
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.Thai is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string UmAlQura
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.UmAlQura is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string Persian
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.Persian is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string ChineseLunar
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.ChineseLunar is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string VietnameseLunar
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.VietnameseLunar is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string TaiwanLunar
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.TaiwanLunar is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string KoreanLunar
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.KoreanLunar is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string JapaneseLunar
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string CalendarIdentifiers.JapaneseLunar is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property Julian
+		// Skipping already declared property Gregorian
+		// Skipping already declared property Hebrew
+		// Skipping already declared property Hijri
+		// Skipping already declared property Japanese
+		// Skipping already declared property Korean
+		// Skipping already declared property Taiwan
+		// Skipping already declared property Thai
+		// Skipping already declared property UmAlQura
+		// Skipping already declared property Persian
+		// Skipping already declared property ChineseLunar
+		// Skipping already declared property VietnameseLunar
+		// Skipping already declared property TaiwanLunar
+		// Skipping already declared property KoreanLunar
+		// Skipping already declared property JapaneseLunar
 		// Forced skipping of method Windows.Globalization.CalendarIdentifiers.ChineseLunar.get
 		// Forced skipping of method Windows.Globalization.CalendarIdentifiers.JapaneseLunar.get
 		// Forced skipping of method Windows.Globalization.CalendarIdentifiers.KoreanLunar.get
@@ -175,4 +39,3 @@ namespace Windows.Globalization
 		// Forced skipping of method Windows.Globalization.CalendarIdentifiers.UmAlQura.get
 	}
 }
-#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Globalization/DayOfWeek.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Globalization/DayOfWeek.cs
@@ -1,36 +1,20 @@
-#if false
 #pragma warning disable 108 // new keyword hiding
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Globalization
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum DayOfWeek 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Sunday,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Monday,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Tuesday,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Wednesday,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Thursday,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Friday,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Saturday,
-		#endif
+		// Skipping already declared field Windows.Globalization.DayOfWeek.Sunday
+		// Skipping already declared field Windows.Globalization.DayOfWeek.Monday
+		// Skipping already declared field Windows.Globalization.DayOfWeek.Tuesday
+		// Skipping already declared field Windows.Globalization.DayOfWeek.Wednesday
+		// Skipping already declared field Windows.Globalization.DayOfWeek.Thursday
+		// Skipping already declared field Windows.Globalization.DayOfWeek.Friday
+		// Skipping already declared field Windows.Globalization.DayOfWeek.Saturday
 	}
 	#endif
 }
-#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackItem.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Media.Playback
 {
-	#if NET461 || __WASM__ || __MACOS__
+	#if false || false || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MediaPlaybackItem : global::Windows.Media.Playback.IMediaPlaybackSource
@@ -17,7 +17,7 @@ namespace Windows.Media.Playback
 			}
 		}
 		#endif
-		#if NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Media.Core.MediaSource Source
 		{
@@ -145,7 +145,7 @@ namespace Windows.Media.Playback
 		}
 		#endif
 		// Forced skipping of method Windows.Media.Playback.MediaPlaybackItem.MediaPlaybackItem(Windows.Media.Core.MediaSource, System.TimeSpan, System.TimeSpan)
-		#if NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public MediaPlaybackItem( global::Windows.Media.Core.MediaSource source) 
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackList.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackList.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Media.Playback
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MediaPlaybackList : global::Windows.Media.Playback.IMediaPlaybackSource
@@ -55,7 +55,7 @@ namespace Windows.Media.Playback
 			}
 		}
 		#endif
-		#if NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Collections.IObservableVector<global::Windows.Media.Playback.MediaPlaybackItem> Items
 		{
@@ -117,7 +117,7 @@ namespace Windows.Media.Playback
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public MediaPlaybackList() 
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Security.Credentials/PasswordCredential.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Security.Credentials/PasswordCredential.cs
@@ -2,53 +2,14 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Security.Credentials
 {
-	#if false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class PasswordCredential 
 	{
-		#if false
-		[global::Uno.NotImplemented]
-		public  string UserName
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string PasswordCredential.UserName is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Security.Credentials.PasswordCredential", "string PasswordCredential.UserName");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented]
-		public  string Resource
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string PasswordCredential.Resource is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Security.Credentials.PasswordCredential", "string PasswordCredential.Resource");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented]
-		public  string Password
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string PasswordCredential.Password is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Security.Credentials.PasswordCredential", "string PasswordCredential.Password");
-			}
-		}
-		#endif
+		// Skipping already declared property UserName
+		// Skipping already declared property Resource
+		// Skipping already declared property Password
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Collections.IPropertySet Properties
@@ -59,21 +20,9 @@ namespace Windows.Security.Credentials
 			}
 		}
 		#endif
-		#if false
-		[global::Uno.NotImplemented]
-		public PasswordCredential( string resource,  string userName,  string password) 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Security.Credentials.PasswordCredential", "PasswordCredential.PasswordCredential(string resource, string userName, string password)");
-		}
-		#endif
+		// Skipping already declared method Windows.Security.Credentials.PasswordCredential.PasswordCredential(string, string, string)
 		// Forced skipping of method Windows.Security.Credentials.PasswordCredential.PasswordCredential(string, string, string)
-		#if false
-		[global::Uno.NotImplemented]
-		public PasswordCredential() 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Security.Credentials.PasswordCredential", "PasswordCredential.PasswordCredential()");
-		}
-		#endif
+		// Skipping already declared method Windows.Security.Credentials.PasswordCredential.PasswordCredential()
 		// Forced skipping of method Windows.Security.Credentials.PasswordCredential.PasswordCredential()
 		// Forced skipping of method Windows.Security.Credentials.PasswordCredential.Resource.get
 		// Forced skipping of method Windows.Security.Credentials.PasswordCredential.Resource.set
@@ -81,13 +30,7 @@ namespace Windows.Security.Credentials
 		// Forced skipping of method Windows.Security.Credentials.PasswordCredential.UserName.set
 		// Forced skipping of method Windows.Security.Credentials.PasswordCredential.Password.get
 		// Forced skipping of method Windows.Security.Credentials.PasswordCredential.Password.set
-		#if false
-		[global::Uno.NotImplemented]
-		public  void RetrievePassword()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Security.Credentials.PasswordCredential", "void PasswordCredential.RetrievePassword()");
-		}
-		#endif
+		// Skipping already declared method Windows.Security.Credentials.PasswordCredential.RetrievePassword()
 		// Forced skipping of method Windows.Security.Credentials.PasswordCredential.Properties.get
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Security.Credentials/PasswordVault.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Security.Credentials/PasswordVault.cs
@@ -2,60 +2,18 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Security.Credentials
 {
-	#if false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class PasswordVault 
 	{
-		#if false 
-		[global::Uno.NotImplemented]
-		public PasswordVault() 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Security.Credentials.PasswordVault", "PasswordVault.PasswordVault()");
-		}
-		#endif
+		// Skipping already declared method Windows.Security.Credentials.PasswordVault.PasswordVault()
 		// Forced skipping of method Windows.Security.Credentials.PasswordVault.PasswordVault()
-		#if false
-		[global::Uno.NotImplemented]
-		public  void Add( global::Windows.Security.Credentials.PasswordCredential credential)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Security.Credentials.PasswordVault", "void PasswordVault.Add(PasswordCredential credential)");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented]
-		public  void Remove( global::Windows.Security.Credentials.PasswordCredential credential)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Security.Credentials.PasswordVault", "void PasswordVault.Remove(PasswordCredential credential)");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented]
-		public  global::Windows.Security.Credentials.PasswordCredential Retrieve( string resource,  string userName)
-		{
-			throw new global::System.NotImplementedException("The member PasswordCredential PasswordVault.Retrieve(string resource, string userName) is not implemented in Uno.");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented]
-		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Security.Credentials.PasswordCredential> FindAllByResource( string resource)
-		{
-			throw new global::System.NotImplementedException("The member IReadOnlyList<PasswordCredential> PasswordVault.FindAllByResource(string resource) is not implemented in Uno.");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented]
-		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Security.Credentials.PasswordCredential> FindAllByUserName( string userName)
-		{
-			throw new global::System.NotImplementedException("The member IReadOnlyList<PasswordCredential> PasswordVault.FindAllByUserName(string userName) is not implemented in Uno.");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented]
-		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Security.Credentials.PasswordCredential> RetrieveAll()
-		{
-			throw new global::System.NotImplementedException("The member IReadOnlyList<PasswordCredential> PasswordVault.RetrieveAll() is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.Security.Credentials.PasswordVault.Add(Windows.Security.Credentials.PasswordCredential)
+		// Skipping already declared method Windows.Security.Credentials.PasswordVault.Remove(Windows.Security.Credentials.PasswordCredential)
+		// Skipping already declared method Windows.Security.Credentials.PasswordVault.Retrieve(string, string)
+		// Skipping already declared method Windows.Security.Credentials.PasswordVault.FindAllByResource(string)
+		// Skipping already declared method Windows.Security.Credentials.PasswordVault.FindAllByUserName(string)
+		// Skipping already declared method Windows.Security.Credentials.PasswordVault.RetrieveAll()
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/ApplicationData.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/ApplicationData.cs
@@ -108,7 +108,7 @@ namespace Windows.Storage
 		}
 		#endif
 		// Forced skipping of method Windows.Storage.ApplicationData.Version.get
-		#if false || false || NET461 || false || false
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction SetVersionAsync( uint desiredVersion,  global::Windows.Storage.ApplicationDataSetVersionHandler handler)
 		{
@@ -122,7 +122,7 @@ namespace Windows.Storage
 			throw new global::System.NotImplementedException("The member IAsyncAction ApplicationData.ClearAsync() is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || false || false
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction ClearAsync( global::Windows.Storage.ApplicationDataLocality locality)
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreDispatcher.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreDispatcher.cs
@@ -23,7 +23,7 @@ namespace Windows.UI.Core
 		}
 		#endif
 		// Forced skipping of method Windows.UI.Core.CoreDispatcher.HasThreadAccess.get
-		#if __ANDROID__ || __IOS__ || false || __WASM__ || __MACOS__
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  void ProcessEvents( global::Windows.UI.Core.CoreProcessEventsOption options)
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreVirtualKeyStates.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreVirtualKeyStates.cs
@@ -2,21 +2,15 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Core
 {
-	#if false
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum CoreVirtualKeyStates 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		None,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Down,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Locked,
-		#endif
+		// Skipping already declared field Windows.UI.Core.CoreVirtualKeyStates.None
+		// Skipping already declared field Windows.UI.Core.CoreVirtualKeyStates.Down
+		// Skipping already declared field Windows.UI.Core.CoreVirtualKeyStates.Locked
 	}
 	#endif
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreWindow.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreWindow.cs
@@ -150,20 +150,8 @@ namespace Windows.UI.Core
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Core.CoreWindow", "void CoreWindow.Close()");
 		}
 		#endif
-		#if false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Core.CoreVirtualKeyStates GetAsyncKeyState( global::Windows.System.VirtualKey virtualKey)
-		{
-			throw new global::System.NotImplementedException("The member CoreVirtualKeyStates CoreWindow.GetAsyncKeyState(VirtualKey virtualKey) is not implemented in Uno.");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Core.CoreVirtualKeyStates GetKeyState( global::Windows.System.VirtualKey virtualKey)
-		{
-			throw new global::System.NotImplementedException("The member CoreVirtualKeyStates CoreWindow.GetKeyState(VirtualKey virtualKey) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Core.CoreWindow.GetAsyncKeyState(Windows.System.VirtualKey)
+		// Skipping already declared method Windows.UI.Core.CoreWindow.GetKeyState(Windows.System.VirtualKey)
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  void ReleasePointerCapture()

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -1157,7 +1157,15 @@ namespace Uno.UWPSyncGenerator
 
 								b.AppendLineInvariant($"Windows.UI.Xaml.DependencyProperty.Register{attachedModifier}(");
 
-								b.AppendLineInvariant($"\tnameof({propertyName}), typeof({propertyDisplayType}), ");
+								if (getAttached == null)
+								{
+									b.AppendLineInvariant($"\tnameof({propertyName}), typeof({propertyDisplayType}), ");
+								}
+								else
+								{
+									b.AppendLineInvariant($"\t\"{propertyName}\", typeof({propertyDisplayType}), ");
+								}
+
 								b.AppendLineInvariant($"\ttypeof({property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}), ");
 								b.AppendLineInvariant($"\tnew FrameworkPropertyMetadata(default({propertyDisplayType})));");
 							}

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -1163,6 +1163,7 @@ namespace Uno.UWPSyncGenerator
 								}
 								else
 								{
+									//attached properties do not have a corresponding property
 									b.AppendLineInvariant($"\t\"{propertyName}\", typeof({propertyDisplayType}), ");
 								}
 

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -1157,7 +1157,7 @@ namespace Uno.UWPSyncGenerator
 
 								b.AppendLineInvariant($"Windows.UI.Xaml.DependencyProperty.Register{attachedModifier}(");
 
-								b.AppendLineInvariant($"\tnameof({propertyName})\", typeof({propertyDisplayType}), ");
+								b.AppendLineInvariant($"\tnameof({propertyName}), typeof({propertyDisplayType}), ");
 								b.AppendLineInvariant($"\ttypeof({property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}), ");
 								b.AppendLineInvariant($"\tnew FrameworkPropertyMetadata(default({propertyDisplayType})));");
 							}


### PR DESCRIPTION
GitHub Issue (If applicable): #1275 


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Dependency properties are not correctly generated.

Also generated files differ from what the tool generates currently, so there is always a lot of changes even when user makes small change.


## What is the new behavior?

Generator bugs fixed, generated files aligned with latest generated code from the tool.

After running `UWPSyncGenerator` in this PR, tool should make 0 changes.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
