### PR TITLE
Fixed ApplicationDataContainer inconsistencies

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -38,6 +38,7 @@
 * [Android] `TextBox.IsSpellCheckEnabled = false` is now enforced in a way that may cause issues in certain use cases (see https://stackoverflow.com/a/5188119/1902058). The old behavior can be restored by setting `ShouldForceDisableSpellCheck = false`, per `TextBox`.
 
 ### Bug fixes
+* #1276 retrieving non-existent setting via indexer should not throw and  `ApplicationDataContainer` allowed clearing value by calling `Add(null)` which was not consistent with UWP.
 * [iOS] Area of view outside Clip rect now allows touch to pass through, this fixes NavigationView not allowing touches to children (#1018)
 * `ComboBox` drop down is now placed following a logic which is closer to UWP and it longer flickers when it appears (especilly on WASM)
 * #854 `BasedOn` on a `<Style>` in `App.Xaml` were not resolving properly

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationDataContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationDataContainer.cs
@@ -228,6 +228,17 @@ namespace Uno.UI.Samples.Tests.Windows_Storage
 		}
 
 		[TestMethod]
+		public void When_IndexerClearsSettingWithNull()
+		{
+			var SUT = ApplicationData.Current.LocalSettings;
+			var key = "test";
+			var value = "something";
+			SUT.Values.Add(key, value);
+			SUT.Values[key] = null;
+			Assert.IsFalse(SUT.Values.ContainsKey(key));
+		}
+
+		[TestMethod]
 		public void When_AddNullTriesToClearSetting()
 		{
 			var SUT = ApplicationData.Current.LocalSettings;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationDataContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationDataContainer.cs
@@ -228,16 +228,22 @@ namespace Uno.UI.Samples.Tests.Windows_Storage
 		}
 
 		[TestMethod]
-		public void When_AddNullClearsSetting()
+		public void When_AddNullTriesToClearSetting()
 		{
 			var SUT = ApplicationData.Current.LocalSettings;
 			var key = "test";
 			var value = "something";
-			var secondValue = "somethingElse";
 			SUT.Values.Add(key, value);
-			SUT.Values.Add(key, null);
-			SUT.Values.Add(key, secondValue);
-			Assert.AreEqual(secondValue, SUT.Values[key]);
+			Assert.ThrowsException<ArgumentException>(
+				() => SUT.Values.Add(key, null)); 
+		}
+
+		[TestMethod]
+        public void When_KeyDoesNotExist()
+		{
+			var SUT = ApplicationData.Current.LocalSettings;
+
+			Assert.IsNull(SUT.Values["ThisKeyDoesNotExist"]);
 		}
 	}
 }

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
@@ -38,7 +38,7 @@ namespace Windows.Storage
 						return value;
 					}
 
-					throw new InvalidOperationException();
+					return null;					
 				}
 				set
 				{
@@ -81,20 +81,16 @@ namespace Windows.Storage
 
 			public void Add(string key, object value)
 			{
-				if (value != null)
+				if (ContainsKey(key))
 				{
-					if (ContainsKey(key))
-					{
-						throw new ArgumentException("An item with the same key has already been added.");
-					}
+					throw new ArgumentException("An item with the same key has already been added.");
+				}
+				if (value != null)
+				{					
 					_preferences
 						.Edit()
 						.PutString(key, DataTypeSerializer.Serialize(value))
 						.Commit();
-				}
-				else
-				{
-					Remove(key);
 				}
 			}
 

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.iOS.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.iOS.cs
@@ -67,18 +67,14 @@ namespace Windows.Storage
 
 			public void Add(string key, object value)
 			{
-				if (value != null)
+				if (ContainsKey(key))
 				{
-					if (ContainsKey(key))
-					{
-						throw new ArgumentException("An item with the same key has already been added.");
-					}
+					throw new ArgumentException("An item with the same key has already been added.");
+				}
+				if (value != null)
+				{					
 					var nativeObject = NSObject.FromObject(DataTypeSerializer.Serialize(value));
 					NSUserDefaults.StandardUserDefaults.SetValueForKey(nativeObject, (NSString)key);
-				}
-				else
-				{
-					Remove(key);
 				}
 			}
 

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.wasm.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.wasm.cs
@@ -171,18 +171,14 @@ namespace Windows.Storage
 
 			public void Add(string key, object value)
 			{
-				if (value != null)
-				{
-					if (ContainsKey(key))
-					{
-						throw new ArgumentException("An item with the same key has already been added.");
-					}
+                if (ContainsKey(key))
+                {
+                    throw new ArgumentException("An item with the same key has already been added.");
+                }
+                if (value != null)
+				{				
 					_values.Add(key, DataTypeSerializer.Serialize(value));
 					WriteToFile();
-				}
-				else
-				{
-					Remove(key);
 				}
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #1276 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Reported problem in #1276, while investigating, found another inconsistency with UWP behavior.

## What is the new behavior?

Both problems now fixed and covered with unit tests


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
