### PR TITLE
[UITest][Android] Adjust tests to allow for auto retry on failure

### DIFF
--- a/.azure-devops-wasm-uitests.yml
+++ b/.azure-devops-wasm-uitests.yml
@@ -114,8 +114,8 @@ jobs:
         downloadPath: '$(build.sourcesdirectory)/build'
 
   - bash: |
-      sudo chmod +x $(build.sourcesdirectory)/build/run-automated-uitests.sh
-      sudo $(build.sourcesdirectory)/build/run-automated-uitests.sh
+      chmod +x $(build.sourcesdirectory)/build/run-automated-uitests.sh
+      $(build.sourcesdirectory)/build/run-automated-uitests.sh
 
     env:
       BUILD_SOURCESDIRECTORY: "$(build.sourcesdirectory)"

--- a/.azure-devops-wasm-uitests.yml
+++ b/.azure-devops-wasm-uitests.yml
@@ -114,8 +114,8 @@ jobs:
         downloadPath: '$(build.sourcesdirectory)/build'
 
   - bash: |
-      chmod +x $(build.sourcesdirectory)/build/run-automated-uitests.sh
-      $(build.sourcesdirectory)/build/run-automated-uitests.sh
+      sudo chmod +x $(build.sourcesdirectory)/build/run-automated-uitests.sh
+      sudo $(build.sourcesdirectory)/build/run-automated-uitests.sh
 
     env:
       BUILD_SOURCESDIRECTORY: "$(build.sourcesdirectory)"

--- a/build/android-uitest-run.sh
+++ b/build/android-uitest-run.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+export BUILDCONFIGURATION=Release
+
+cd $BUILD_SOURCESDIRECTORY/build
+
+# uncomment the following lines to override the installed Xamarin.Android SDK
+# wget -nv https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-d16-2/49/Azure/processDownloadRequest/xamarin-android/xamarin-android/bin/BuildRelease/Xamarin.Android.Sdk-OSS-9.4.0.59_d16-2_6d9b105.pkg
+# sudo installer -verbose -pkg Xamarin.Android.Sdk-OSS-9.4.0.59_d16-2_6d9b105.pkg -target /
 
 # Install AVD files
 echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-28;google_apis;x86'
@@ -16,8 +23,8 @@ nohup $ANDROID_HOME/emulator/emulator -avd xamarin_android_emulator -skin 1280x8
 export IsUiAutomationMappingEnabled=true
 
 # build the sample and tests, while the emulator is starting
-msbuild /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
-msbuild /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+msbuild /r /p:Configuration=$BUILDCONFIGURATION $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+msbuild /r /p:Configuration=$BUILDCONFIGURATION $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
 
 # Wait for the emulator to finish booting
 chmod +x $BUILD_SOURCESDIRECTORY/build/android-uitest-wait-systemui.sh
@@ -29,7 +36,7 @@ echo "Emulator started"
 
 export UNO_UITEST_SCREENSHOT_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/android
 export UNO_UITEST_PLATFORM=Android
-export UNO_UITEST_ANDROIDAPK_PATH=$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/bin/Release/uno.platform.unosampleapp.apk
+export UNO_UITEST_ANDROIDAPK_PATH=$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/bin/$BUILDCONFIGURATION/uno.platform.unosampleapp.apk
 
 cd $BUILD_SOURCESDIRECTORY/build
 
@@ -37,6 +44,7 @@ mono nuget/NuGet.exe install NUnit.ConsoleRunner -Version 3.10.0
 
 mkdir -p $UNO_UITEST_SCREENSHOT_PATH
 
-mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/net47/SamplesApp.UITests.dll
+mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/$BUILDCONFIGURATION/net47/SamplesApp.UITests.dll
 
 $ANDROID_HOME/platform-tools/adb shell logcat -d > $BUILD_ARTIFACTSTAGINGDIRECTORY/android-device-log.txt
+cp $UNO_UITEST_ANDROIDAPK_PATH $BUILD_ARTIFACTSTAGINGDIRECTORY

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -7,6 +7,12 @@
     <WriteLinesToFile File="$(AndroidResgenFile)" Lines="// Empty Content from uno.ui Directory.Build.targets." />
   </Target>
 
+  <Target Name="AndroidResourceGenWorkaround_16_2"
+          AfterTargets="_UpdateAndroidResgen"
+          Condition="'$(AndroidUseIntermediateDesignerFile)'=='True' and !Exists($(_AndroidResourceDesignerFile))">
+    <WriteLinesToFile File="$(_AndroidResourceDesignerFile)" Lines="// Empty Content from uno.ui Directory.Build.targets." />
+  </Target>
+
   <ItemGroup>
     <PackageReference Update="Uno.SourceGenerationTasks" Version="1.31.0-dev.285" />
     <PackageReference Update="Uno.SourceGeneration" Version="1.31.0-dev.285" />

--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -43,7 +43,7 @@
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <BundleAssemblies>false</BundleAssemblies>
     <MandroidI18n />
-    <AndroidSupportedAbis />
+    <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/SamplesApp/SamplesApp.UITests/CommandBar/UnoSamples_Tests.CommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/CommandBar/UnoSamples_Tests.CommandBar.cs
@@ -14,6 +14,7 @@ namespace SamplesApp.UITests.CommandBar
 	public partial class UnoSamples_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		public void CommandBar_LongTitle_Validation()
 		{

--- a/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
@@ -13,6 +14,7 @@ namespace SamplesApp.UITests
 	public partial class RuntimeTests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void RunRuntimeTests()
 		{
 			Run("SamplesApp.Samples.UnitTests.UnitTestsPage");

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -25,8 +25,11 @@ namespace SamplesApp.UITests
 
 
 		[SetUp]
+		[AutoRetry]
 		public void BeforeEachTest()
 		{
+			ValidateAutoRetry();
+
 			// Check if the test needs to be ignore or not
 			// If nothing specified, it is considered as a global test
 			var platforms = GetActivePlatforms();
@@ -67,6 +70,16 @@ namespace SamplesApp.UITests
 			_app = AppInitializer.AttachToApp();
 
 			Helpers.App = _app;
+		}
+
+		private static void ValidateAutoRetry()
+		{
+			var testType = Type.GetType(TestContext.CurrentContext.Test.ClassName);
+			var methodInfo = testType?.GetMethod(TestContext.CurrentContext.Test.MethodName);
+			if (methodInfo?.GetCustomAttributes(typeof(AutoRetryAttribute), true).Length == 0 && false)
+			{
+				Assert.Fail($"The AutoRetryAttribute is not defined for this test");
+			}
 		}
 
 		private Platform[] GetActivePlatforms()

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -10,10 +10,10 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
-		<PackageReference Include="Uno.UITest" Version="1.0.0-dev.67" />
-		<PackageReference Include="Uno.UITest.Selenium" Version="1.0.0-dev.67" />
-		<PackageReference Include="Uno.UITest.Xamarin" Version="1.0.0-dev.67" />
-		<PackageReference Include="Uno.UITest.Helpers" Version="1.0.0-dev.67" />
+		<PackageReference Include="Uno.UITest" Version="1.0.0-dev.70" />
+		<PackageReference Include="Uno.UITest.Selenium" Version="1.0.0-dev.70" />
+		<PackageReference Include="Uno.UITest.Xamarin" Version="1.0.0-dev.70" />
+		<PackageReference Include="Uno.UITest.Helpers" Version="1.0.0-dev.70" />
 	</ItemGroup>
 
 </Project>

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/AppInitializer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/AppInitializer.cs
@@ -24,7 +24,8 @@ namespace SamplesApp.UITests
 				: null;
 
 		public static IApp AttachToApp()
-			=> StartApp(alreadyRunningApp: true);
+			// If the retry count is set, the test already failed. Retry the test with restarting the app.
+			=> StartApp(alreadyRunningApp: TestContext.CurrentContext.CurrentRepeatCount == 0);
 
 		private static IApp StartApp(bool alreadyRunningApp)
 		{
@@ -96,12 +97,13 @@ namespace SamplesApp.UITests
 
 		private static IApp CreateAndroidApp(bool alreadyRunningApp)
 		{
-#if DEBUG
-			// To set in case of Xamarin.UITest errors
-			//
-			Environment.SetEnvironmentVariable("ANDROID_HOME", @"C:\Program Files (x86)\Android\android-sdk");
-			Environment.SetEnvironmentVariable("JAVA_HOME", @"C:\Program Files\Android\Jdk\microsoft_dist_openjdk_1.8.0.25");
-#endif
+			if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ANDROID_HOME")))
+			{
+				// To set in case of Xamarin.UITest errors
+				//
+				Environment.SetEnvironmentVariable("ANDROID_HOME", @"C:\Program Files (x86)\Android\android-sdk");
+				Environment.SetEnvironmentVariable("JAVA_HOME", @"C:\Program Files\Android\Jdk\microsoft_dist_openjdk_1.8.0.25");
+			}
 
 			var androidConfig = Xamarin.UITest.ConfigureApp
 				.Android

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/AutoRetry.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/AutoRetry.cs
@@ -1,19 +1,101 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
 
 namespace SamplesApp.UITests.TestFramework
 {
 	/// <summary>
-	/// Tentative workaround for https://github.com/microsoft/appcenter/issues/723
+	/// Specifies that a test method should be rerun on failure up to the specified 
+	/// maximum number of times.
 	/// </summary>
-	public class AutoRetryAttribute : RetryAttribute
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+	public class AutoRetryAttribute : NUnitAttribute, IWrapSetUpTearDown
 	{
-		public AutoRetryAttribute() : base(3)
+		private readonly int _tryCount;
+
+		/// <summary>
+		/// Construct a <see cref="RetryAttribute" />
+		/// </summary>
+		/// <param name="tryCount">The maximum number of times the test should be run if it fails</param>
+		public AutoRetryAttribute(int tryCount = 2)
 		{
+			_tryCount = tryCount;
 		}
+
+		#region IRepeatTest Members
+
+		/// <summary>
+		/// Wrap a command and return the result.
+		/// </summary>
+		/// <param name="command">The command to be wrapped</param>
+		/// <returns>The wrapped command</returns>
+		public TestCommand Wrap(TestCommand command)
+		{
+			return new RetryCommand(command, _tryCount);
+		}
+
+		#endregion
+
+		#region Nested RetryCommand Class
+
+		/// <summary>
+		/// The test command for the <see cref="RetryAttribute"/>
+		/// </summary>
+		public class RetryCommand : DelegatingTestCommand
+		{
+			private readonly int _tryCount;
+
+			/// <summary>
+			/// Initializes a new instance of the <see cref="RetryCommand"/> class.
+			/// </summary>
+			/// <param name="innerCommand">The inner command.</param>
+			/// <param name="tryCount">The maximum number of repetitions</param>
+			public RetryCommand(TestCommand innerCommand, int tryCount)
+				: base(innerCommand)
+			{
+				_tryCount = tryCount;
+			}
+
+			/// <summary>
+			/// Runs the test, saving a TestResult in the supplied TestExecutionContext.
+			/// </summary>
+			/// <param name="context">The context in which the test should run.</param>
+			/// <returns>A TestResult</returns>
+			public override TestResult Execute(TestExecutionContext context)
+			{
+				int count = _tryCount;
+
+				while (count-- > 0)
+				{
+					try
+					{
+						context.CurrentResult = innerCommand.Execute(context);
+					}
+					// Commands are supposed to catch exceptions, but some don't
+					// and we want to look at restructuring the API in the future.
+					catch (Exception ex)
+					{
+						if (context.CurrentResult == null) context.CurrentResult = context.CurrentTest.MakeTestResult();
+						context.CurrentResult.RecordException(ex);
+					}
+
+					if (context.CurrentResult.ResultState != ResultState.Failure && context.CurrentResult.ResultState.Status != ResultState.Failure.Status)
+						break;
+
+					// Clear result for retry
+					if (count > 0)
+					{
+						context.CurrentResult = context.CurrentTest.MakeTestResult();
+						context.CurrentRepeatCount++; // increment Retry count for next iteration. will only happen if we are guaranteed another iteration
+					}
+				}
+
+				return context.CurrentResult;
+			}
+		}
+
+		#endregion
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
@@ -292,6 +292,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void TextBox_TextChanging_Capitalize()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_TextChanging");
@@ -308,6 +309,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void TextBox_TextChanging_Limit()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_TextChanging");
@@ -337,6 +339,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void TextBox_BeforeTextChanging()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_BeforeTextChanging");

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.StaticResource.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.StaticResource.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 using Xamarin.UITest;
@@ -14,6 +15,7 @@ namespace SamplesApp.UITests
 	partial class UnoSamples_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void StaticResource_XAML_Validation()
 		{
 			Run("UITests.Shared.Resources.StaticResource.StaticResource_Simple");
@@ -26,6 +28,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void StaticResource_CSharp_Validation()
 		{
 			Run("UITests.Shared.Resources.StaticResource.StaticResource_Simple");
@@ -38,6 +41,7 @@ namespace SamplesApp.UITests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void StaticResource_Converter_Validation()
 		{
 			Run("UITests.Shared.Resources.StaticResource.StaticResource_Simple");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
@@ -15,6 +15,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 	public partial class ComboBoxTests_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		[ActivePlatforms(Platform.iOS)]
 		public void ComboBoxTests_PickerDefaultValue()
 		{
@@ -27,6 +28,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void ComboBoxTests_Kidnapping()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ComboBox.ComboBox_ComboBoxItem_Selection");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -15,6 +15,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 	public partial class DatePickerTests_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		[ActivePlatforms(Platform.iOS, Platform.Android)]
 		public void DatePickerFlyout_HasDataContextTest()
 		{
@@ -34,6 +35,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		[ActivePlatforms(Platform.iOS)]
 		public void DatePickerFlyout_HasContentTest()
 		{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
@@ -15,6 +15,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 	public partial class ListViewTests_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		public void ListView_ListViewVariableItemHeightLong_InitializesTest()
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Controls.ListView.ListViewVariableItemHeightLong");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
@@ -94,6 +94,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		public void TimePickerFlyout_DoesntApplyDefaultTime()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TimePicker.Sample1");
@@ -109,6 +110,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		[ActivePlatforms(Platform.iOS, Platform.Android)]
 		public void TimePickerFlyout_HasDataContextTest()
 		{
@@ -128,6 +130,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		}
 
 		[Test]
+		[AutoRetry]
 		[ActivePlatforms(Platform.iOS)]
 		public void TimePickerFlyout_HasContentTest()
 		{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DragCoordinates_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DragCoordinates_Tests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers.Queries;
 using Query = System.Func<Uno.UITest.IAppQuery, Uno.UITest.IAppQuery>;
 using StringQuery = System.Func<Uno.UITest.IAppQuery, Uno.UITest.IAppTypedSelector<string>>;
@@ -13,7 +14,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 	public class DragCoordinates_Tests : SampleControlUITestBase
 	{
 		[Test]
-		[Ignore("https://github.com/unoplatform/uno/issues/1257")]
+		[ActivePlatforms(Platform.iOS, Platform.Browser)] // Android is disabled https://github.com/unoplatform/uno/issues/1257
 		public void DragBorder01()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Input.Pointers.DragCoordinates_Automated");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DragCoordinates_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DragCoordinates_Tests.cs
@@ -19,15 +19,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Input.Pointers.DragCoordinates_Automated");
 
-			Query testSelector = q => q.Text("DragCoordinates 01");
-
 			Query rootCanvas = q => q.Marked("rootCanvas");
 			Query myBorder = q => q.Marked("myBorder");
 			Query topValue = q => q.Marked("borderPositionTop");
 			Query leftValue = q => q.Marked("borderPositionLeft");
-
-			_app.WaitForElement(testSelector);
-			_app.Tap(testSelector);
 
 			_app.WaitForElement(rootCanvas);
 

--- a/src/Uno.UI-Android-only.slnf
+++ b/src/Uno.UI-Android-only.slnf
@@ -8,6 +8,7 @@
       "SamplesApp\\SamplesApp.UITests\\SamplesApp.UITests.csproj",
       "SamplesApp\\SamplesApp.UnitTests.Shared\\SamplesApp.UnitTests.Shared.shproj",
       "SamplesApp\\UITests.Shared\\UITests.Shared.shproj",
+      "SourceGenerators\\System.Xaml\\Uno.Xaml.csproj",
       "SourceGenerators\\Uno.UI.SourceGenerators\\Uno.UI.SourceGenerators.csproj",
       "SourceGenerators\\Uno.UI.Tasks\\Uno.UI.Tasks.csproj",
       "T4Generator\\T4Generator.csproj",


### PR DESCRIPTION
GitHub Issue (If applicable): Tentative fix for #1259

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Android tests fail randomly as the app crashes.

## What is the new behavior?
Android app should not crash anymore. The libmonosgen-2.0.so library is provided a local override that is coming from the binary from X.A: 9fa7775cbf9fed7d87253797f3f9c211dd94d228.

This is a tentative workaround for an unknown VS16.1 issue fixed in VS16.2 pre 4.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
