### PR TITLE
Fix for UWPSyncGenerator issues

### DIFF
--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -1157,7 +1157,15 @@ namespace Uno.UWPSyncGenerator
 
 								b.AppendLineInvariant($"Windows.UI.Xaml.DependencyProperty.Register{attachedModifier}(");
 
-								b.AppendLineInvariant($"\tnameof({propertyName}), typeof({propertyDisplayType}), ");
+								if (getAttached == null)
+								{
+									b.AppendLineInvariant($"\tnameof({propertyName}), typeof({propertyDisplayType}), ");
+								}
+								else
+								{
+									b.AppendLineInvariant($"\t\"{propertyName}\", typeof({propertyDisplayType}), ");
+								}
+
 								b.AppendLineInvariant($"\ttypeof({property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}), ");
 								b.AppendLineInvariant($"\tnew FrameworkPropertyMetadata(default({propertyDisplayType})));");
 							}

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -1163,6 +1163,7 @@ namespace Uno.UWPSyncGenerator
 								}
 								else
 								{
+									//attached properties do not have a corresponding property
 									b.AppendLineInvariant($"\t\"{propertyName}\", typeof({propertyDisplayType}), ");
 								}
 

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -1157,7 +1157,7 @@ namespace Uno.UWPSyncGenerator
 
 								b.AppendLineInvariant($"Windows.UI.Xaml.DependencyProperty.Register{attachedModifier}(");
 
-								b.AppendLineInvariant($"\tnameof({propertyName})\", typeof({propertyDisplayType}), ");
+								b.AppendLineInvariant($"\tnameof({propertyName}), typeof({propertyDisplayType}), ");
 								b.AppendLineInvariant($"\ttypeof({property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}), ");
 								b.AppendLineInvariant($"\tnew FrameworkPropertyMetadata(default({propertyDisplayType})));");
 							}


### PR DESCRIPTION
GitHub Issue (If applicable): #1275 


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

**Cherry-picked the UWPSyncGenerator fixes from #1279**

Dependency properties are not correctly generated.

Also generated files differ from what the tool generates currently, so there is always a lot of changes even when user makes small change.


## What is the new behavior?

Generator bugs fixed, generated files aligned with latest generated code from the tool.

After running `UWPSyncGenerator` in this PR, tool should make 0 changes.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
