### PR TITLE
fixed gitversion

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -8,13 +8,13 @@ branches:
     tag: dev
     regex: master
   beta:
-    regex: beta
+    regex: release/beta/
     tag: beta
     increment: none
     source-branches: ['master']
   stable:
-    regex: stable
-    tag: 
+    regex: release/stable/
+    tag: ''
     increment: none
     source-branches: ['master']
   dev:


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type
What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
`gitversion` calculates the version for `release/stable` branches as if they are "beta".

## What is the new behavior?
`gitversion` should now gives the correct version for each branch.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)

## Other information
Cherry-pick of https://github.com/unoplatform/uno/pull/1297 for https://github.com/unoplatform/uno/tree/release/stable/Batman
See: https://github.com/nventive/Uno.Core/pull/54

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/157372