### PR TITLE
Windows.UI.Xaml.Application.Current.Resources.MergedDictionaries public API contract does not match UWP

### DIFF
--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -22,7 +22,7 @@ namespace Windows.UI.Xaml
 			set;
 		}
 
-		public ResourceDictionary[] MergedDictionaries => Array.Empty<ResourceDictionary>();
+		public IList<ResourceDictionary> MergedDictionaries => Array.Empty<ResourceDictionary>();
 
 		public IDictionary<object, object> ThemeDictionaries { get; } = new Dictionary<object, object>();
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Uno's implementation of `Windows.UI.Xaml.Application.Current.Resources.MergedDictionaries` differs to the UWP contract.

Uno: `public ResourceDictionary[] MergedDictionaries`
UWP: `public IList<ResourceDictionary> MergedDictionaries`

![image](https://user-images.githubusercontent.com/127353/61855472-7a1d1600-af03-11e9-8be9-7a561126172b.png)

https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.resourcedictionary.mergeddictionaries

## What is the new behavior?

Changed Uno's implementation to match UWP.

Previously `MergedDictionaries.Add(new ResourceDictionary());` did not work. Now it does.

See https://github.com/xamarin/Xamarin.Forms/blob/f74c6846dfef1843fd2c02c9936fac8d0ac0be77/Xamarin.Forms.Platform.UAP/Platform.cs#L74 as an example of 3rd party code that was expects basic collection operators that `IList` provides.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

I went through the history of ResourceDictionary and couldn't identify where this change was introduced. Maybe it was a mistake, maybe it isn't. Discuss below :)