### PR TITLE
TextBox - reset Text when pushing null to bound value

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -37,6 +37,7 @@
 * `TextBox` no longer raises TextChanged when its template is applied, in line with UWP.
 * `TextBox.TextChanged` is now called asynchronously after the UI is updated, in line with UWP. For most uses `TextChanging` should be preferred.
 * [Android] `TextBox.IsSpellCheckEnabled = false` is now enforced in a way that may cause issues in certain use cases (see https://stackoverflow.com/a/5188119/1902058). The old behavior can be restored by setting `ShouldForceDisableSpellCheck = false`, per `TextBox`.
+* `TextBox.Text = null` will now throw an exception, as on UWP. Pushing `null` via a binding is still valid.
 
 ### Bug fixes
 * #1276 retrieving non-existent setting via indexer should not throw and  `ApplicationDataContainer` allowed clearing value by calling `Add(null)` which was not consistent with UWP.

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/TextBoxTests/Given_TextBox.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/TextBoxTests/Given_TextBox.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
 
 namespace Uno.UI.Tests.TextBoxTests
 {
@@ -40,15 +44,43 @@ namespace Uno.UI.Tests.TextBoxTests
 			textBox.Text = "Rhubarb";
 			Assert.AreEqual("Rhubarb", textBox.Text);
 			Assert.AreEqual(1, callbackCount);
-
-#if NETFX_CORE
+			
 			Assert.ThrowsException<ArgumentNullException>(() => textBox.Text = null);
-#else
-			textBox.Text = null;
-#endif
-			;
+
 			Assert.AreEqual("Rhubarb", textBox.Text);
 			Assert.AreEqual(1, callbackCount);
+		}
+
+		[TestMethod]
+		public void When_Binding_Set_Null()
+		{
+			var textBox = new TextBox();
+			var source = new MySource() { SourceText = "Spinach" };
+
+			textBox.DataContext = source;
+			textBox.SetBinding(TextBox.TextProperty, new Binding() { Path = new PropertyPath("SourceText") });
+
+			Assert.AreEqual("Spinach", textBox.Text);
+
+			source.SourceText = null;
+
+			Assert.AreEqual("", textBox.Text);
+		}
+
+		[TestMethod]
+		public void When_Binding_Set_Non_String()
+		{
+			var textBox = new TextBox();
+			var source = new MySource() { SourceInt = 12 };
+
+			textBox.DataContext = source;
+			textBox.SetBinding(TextBox.TextProperty, new Binding() { Path = new PropertyPath("SourceInt") });
+
+			Assert.AreEqual("12", textBox.Text);
+
+			source.SourceInt = 19;
+
+			Assert.AreEqual("19", textBox.Text);
 		}
 
 		[TestMethod]
@@ -79,6 +111,44 @@ namespace Uno.UI.Tests.TextBoxTests
 
 			textBox.Text = "Chirimoya";
 			Assert.AreEqual(2, beforeTextChangingCount);
+		}
+
+		public class MySource : INotifyPropertyChanged
+		{
+			private string _sourceText;
+
+			public string SourceText
+			{
+				get => _sourceText;
+				set
+				{
+					if (_sourceText != value)
+					{
+						_sourceText = value;
+						OnPropertyChanged(); 
+					}
+				}
+			}
+
+			private int _sourceInt;
+
+			public int SourceInt
+			{
+				get => _sourceInt;
+				set
+				{
+					if (_sourceInt != value)
+					{
+						_sourceInt = value;
+						OnPropertyChanged();
+					}
+				}
+			}
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+				=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -153,7 +153,14 @@ namespace Windows.UI.Xaml.Controls
 		public string Text
 		{
 			get { return (string)this.GetValue(TextProperty); }
-			set { this.SetValue(TextProperty, value); }
+			set {
+				if (value == null)
+				{
+					throw new ArgumentNullException();
+				}
+
+				this.SetValue(TextProperty, value);
+			}
 		}
 
 		public static readonly DependencyProperty TextProperty =
@@ -243,7 +250,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (!(baseValue is string baseString))
 			{
-				return DependencyProperty.UnsetValue; //TODO: UWP throws ArgumentNullException, in principle we should do the same. 
+				return ""; //Pushing null to the binding resets the text. (Setting null to the Text property directly throws an exception.)
 			}
 
 			var args = new TextBoxBeforeTextChangingEventArgs(baseString);


### PR DESCRIPTION
Fix regression where a null pushed to Text via binding was being ignored, rather than clearing the Text.

GitHub Issue (If applicable): fixes #1302 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

 - Bugfix
<!-- Please uncomment one ore more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
