### PR TITLE
Enable increment of Patch for each commit in dev branch

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -5,9 +5,9 @@ continuous-delivery-fallback-tag: ""
 tag-prefix: '[vV]'
 branches:
   master:
-    increment: none
-    tag: dev
     regex: master
+    tag: dev
+    increment: patch
   beta:
     regex: release/beta/
     tag: beta
@@ -21,15 +21,17 @@ branches:
   dev:
     regex: dev/.*?/(.*?)
     tag: dev.{BranchName}
+    increment: none
     source-branches: ['master']
   projects:
-    tag: proj-{BranchName}
     regex: projects/(.*?)
+    tag: proj.{BranchName}
+    increment: none
     source-branches: ['master']
   feature:
-    tag: feature.{BranchName}
     regex: feature/(.*?)
+    tag: feature.{BranchName}
+    increment: none
     source-branches: ['master']
-
 ignore:
   sha: []


### PR DESCRIPTION
so feature branches will remain after the latest dev version in Nuget

GitHub Issue (If applicable): #1256 

## Build or CI related changes

## What is the current behavior?
* Major: Manually updated
* Minor: Manually updated
* Patch: Not used
==> Branches are ordered by nuget reverse-alphabetically based on the tag, so the feature branch versions are upper the dev version (as f > d)

## What is the new behavior?
* Major: Manually updated
* Minor: Manually updated
* Patch: Updated on each commit in dev branch
==> As the Patch number is incremented for each commit in dev, but not for feature branches, the dev versions should appear above the feature branch versions in nuget

## PR Checklist
Please check if your PR fulfills the following requirements:

- ~[ ] Tested code with current [supported SDKs](../README.md#supported)~
- ~[ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~
- ~[ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~
- ~[ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~
- [x] Contains **NO** breaking changes
- ~[ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)~
- [x] Associated with an issue (GitHub or internal)~
