### PR TITLE
Fixed problem with ButtonBase.Click on Android

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -56,6 +56,7 @@
 * [Android/iOS] Fixed Arc command in paths
 * Changing the `DataContext` of an element to a new value were pushing the properties default
   value on data bound properties before setting the new value.
+* [Android] `.Click` on a `ButtonBase` were not raising events properly
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -209,6 +209,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_BeforeTextChanging.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2460,6 +2464,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\PhaseBinding.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\PhaseBinding_Large.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\PhaseBinding_StartOne.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_BeforeTextChanging.xaml.cs">
       <DependentUpon>TextBox_BeforeTextChanging.xaml</DependentUpon>
     </Compile>
@@ -4224,6 +4229,9 @@
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button_With_CanExecute_Changing.xaml.cs">
       <DependentUpon>Simple_Button_With_CanExecute_Changing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Button_Events.xaml.cs">
+      <DependentUpon>Button_Events.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events.xaml
@@ -1,0 +1,138 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Button.Button_Events"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.Button"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+	    <Grid.ColumnDefinitions>
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="*" />
+	    </Grid.ColumnDefinitions>
+
+	    <Grid.RowDefinitions>
+			<RowDefinition Height="Auto" MinHeight="40" />
+			<RowDefinition Height="Auto" MinHeight="40" />
+			<RowDefinition Height="Auto" MinHeight="40" />
+			<RowDefinition Height="Auto" MinHeight="40" />
+			<RowDefinition Height="Auto" MinHeight="40" />
+			<RowDefinition Height="Auto" MinHeight="40" />
+			<RowDefinition Height="Auto" MinHeight="40" />
+			<RowDefinition Height="Auto" MinHeight="40" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+	    </Grid.RowDefinitions>
+
+	    <TextBlock FontWeight="Bold" Grid.Column="2">Count</TextBlock>
+
+	    <TextBlock FontWeight="Bold" Grid.Row="1">Tapped</TextBlock>
+		<Button x:Name="btnTapped"
+				Grid.Row="1"
+				Grid.Column="1">ON TAP</Button>
+	    <TextBlock x:Name="btnTappedCount" Grid.Row="1" Grid.Column="2">0</TextBlock>
+		<TextBlock Grid.Row="1" Grid.Column="3" TextWrapping="WrapWholeWords">
+			On UWP, TAP will be raised when the pointer is both pressed and released over the button
+			and the pointer didn't moved significantly while being pressed.
+		</TextBlock>
+
+	    <TextBlock FontWeight="Bold" Grid.Row="2">Double Tapped</TextBlock>
+	    <Button x:Name="btnDoubleTapped"
+	            Grid.Row="2"
+	            Grid.Column="1">ON DOUBLE TAP</Button>
+	    <TextBlock x:Name="btnDoubleTappedCount" Grid.Row="2" Grid.Column="2">0</TextBlock>
+	    <TextBlock Grid.Row="2" Grid.Column="3" TextWrapping="WrapWholeWords">
+		    On UWP, DOUBLE TAP will be raised on the PRESSED right after a single TAP on the same control.
+	    </TextBlock>
+
+	    <TextBlock FontWeight="Bold" Grid.Row="3">Clicked</TextBlock>
+		<Button x:Name="btnClick"
+				Grid.Row="3"
+				Grid.Column="1">ON CLICK</Button>
+	    <TextBlock x:Name="btnClickCount" Grid.Row="3" Grid.Column="2">0</TextBlock>
+	    <TextBlock Grid.Row="3" Grid.Column="3" TextWrapping="WrapWholeWords">
+		    On UWP, CLICKED will be raised when the pointer is both pressed and released
+			over the button. The pointer can go anywhere while pressed, as soon it's pressed and
+			released over the control.
+	    </TextBlock>
+
+	    <TextBlock FontWeight="Bold" Grid.Row="4">Pointer Pressed</TextBlock>
+		<Button x:Name="btnPointerPressed"
+				Grid.Row="4"
+				Grid.Column="1">ON PRESS</Button>
+		<TextBlock x:Name="btnPointerPressedCount" Grid.Row="4" Grid.Column="2">0</TextBlock>
+	    <TextBlock Grid.Row="4" Grid.Column="3" TextWrapping="WrapWholeWords">
+		    On UWP, PRESSED is never raised from a button.
+	    </TextBlock>
+
+	    <TextBlock FontWeight="Bold" Grid.Row="5">Pointer Released</TextBlock>
+		<Button x:Name="btnPointerReleased"
+				Grid.Row="5"
+				Grid.Column="1">ON RELEASE</Button>
+	    <TextBlock x:Name="btnPointerReleasedCount" Grid.Row="5" Grid.Column="2">0</TextBlock>
+	    <TextBlock Grid.Row="5" Grid.Column="3" TextWrapping="WrapWholeWords">
+		    On UWP, RELEASE is never raised from a button.
+	    </TextBlock>
+
+	    <TextBlock FontWeight="Bold" Grid.Row="6">Pointer Entered</TextBlock>
+	    <Button x:Name="btnPointerEntered"
+	            Grid.Row="6"
+	            Grid.Column="1">ON ENTERED</Button>
+	    <TextBlock x:Name="btnPointerEnteredCount" Grid.Row="6" Grid.Column="2">0</TextBlock>
+	    <TextBlock Grid.Row="6" Grid.Column="3" TextWrapping="WrapWholeWords">
+		    On UWP, ENTERED is raised when the button is entering the button zone.
+	    </TextBlock>
+
+	    <TextBlock FontWeight="Bold" Grid.Row="7">Pointer Leaved</TextBlock>
+	    <Button x:Name="btnPointerExited"
+	            Grid.Row="7"
+	            Grid.Column="1">ON LEAVED</Button>
+	    <TextBlock x:Name="btnPointerExitedCount" Grid.Row="7" Grid.Column="2">0</TextBlock>
+	    <TextBlock Grid.Row="7" Grid.Column="3" TextWrapping="WrapWholeWords">
+		    On UWP, LEAVED is raised when the button is leaving the button zone.
+	    </TextBlock>
+
+		<Border Background="BlueViolet"
+		        Opacity="0.5"
+		        Width="15"
+		        Margin="20,0,0,0"
+				HorizontalAlignment="Left"
+		        IsHitTestVisible="False"
+		        Grid.Column="1"
+				Grid.Row="1"
+		        Grid.RowSpan="8"/>
+
+		<Border Background="Gold"
+		        Opacity="0.5"
+		        Width="15"
+		        Margin="35,0,0,0"
+		        HorizontalAlignment="Left"
+		        IsHitTestVisible="True"
+		        Grid.Column="1"
+		        Grid.Row="1"
+		        Grid.RowSpan="7"/>
+
+		<Border Background="Gold"
+		        Opacity="0.5"
+		        Margin="35,0,0,0"
+		        HorizontalAlignment="Stretch"
+		        Grid.Column="1"
+		        Grid.Row="8"/>
+
+		<Border Background="BlueViolet"
+		        Opacity="0.5"
+		        Margin="20,0,0,0"
+		        HorizontalAlignment="Stretch"
+		        Grid.Column="1"
+		        Grid.Row="9"/>
+
+		<TextBlock Grid.Row="8" Grid.Column="2" Grid.ColumnSpan="2">Hit test visible (pointer doesn't pass through)</TextBlock>
+		<TextBlock Grid.Row="9" Grid.Column="2" Grid.ColumnSpan="2">Hit test NOT visible (pointer pass through)</TextBlock>
+
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events.xaml.cs
@@ -1,0 +1,30 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
+{
+	[SampleControlInfo("Button", "Button_Events")]
+	public sealed partial class Button_Events : Page
+	{
+		private int _btnTappedCount;
+		private int _btnDoubleTappedCount;
+		private int _btnClickCount;
+		private int _btnPointerPressedCount;
+		private int _btnPointerReleasedCount;
+		private int _btnPointerEnteredCount;
+		private int _btnPointerExitedCount;
+
+		public Button_Events()
+		{
+			this.InitializeComponent();
+
+			btnTapped.Tapped += (snd, evt) => btnTappedCount.Text = (++_btnTappedCount).ToString();
+			btnDoubleTapped.DoubleTapped += (snd, evt) => btnDoubleTappedCount.Text = (++_btnDoubleTappedCount).ToString();
+			btnClick.Click += (snd, evt) => btnClickCount.Text = (++_btnClickCount).ToString();
+			btnPointerPressed.PointerPressed += (snd, evt) => btnPointerPressedCount.Text = (++_btnPointerPressedCount).ToString();
+			btnPointerReleased.PointerReleased += (snd, evt) => btnPointerReleasedCount.Text = (++_btnPointerReleasedCount).ToString();
+			btnPointerEntered.PointerEntered += (snd, evt) => btnPointerEnteredCount.Text = (++_btnPointerEnteredCount).ToString();
+			btnPointerExited.PointerExited += (snd, evt) => btnPointerExitedCount.Text = (++_btnPointerExitedCount).ToString();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Overlapped_Buttons.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Overlapped_Buttons.xaml
@@ -93,14 +93,23 @@
 			<TextBlock x:Name="msgs" FontSize="8" />
 		</Border>
 
-		<uno:StarStackPanel Sizes="Auto,*" Grid.Row="2" Grid.ColumnSpan="5">
-			<Button Tapped="ClearMsgs">CLEAR</Button>
-			<TextBlock>
-				layer1 clicks: <Run x:Name="l1Clicks" FontWeight="Bold" />,
-				layer1_inner clicks: <Run x:Name="l1innerClicks" FontWeight="Bold" />,
-				layer2 clicks: <Run x:Name="l2Clicks" FontWeight="Bold" />,
-				layer3 clicks: <Run x:Name="l3Clicks" FontWeight="Bold" />
-			</TextBlock>
+		<Button Tapped="ClearMsgs" Grid.Row="2" Grid.ColumnSpan="5">CLEAR</Button>
+
+		<uno:StarStackPanel
+			Sizes="Auto"
+			Orientation="Horizontal"
+			Grid.Row="0"
+			Grid.ColumnSpan="5"
+			IsHitTestVisible="False"
+			VerticalAlignment="Bottom">
+			<TextBlock>layer1 clicks:</TextBlock>
+			<TextBlock x:Name="l1Clicks" FontWeight="Bold"/>
+			<TextBlock>, layer1_inner clicks:</TextBlock>
+			<TextBlock x:Name="l1innerClicks" FontWeight="Bold"/>
+			<TextBlock>, layer2 clicks:</TextBlock>
+			<TextBlock x:Name="l2Clicks" FontWeight="Bold"/>
+			<TextBlock>, layer3 clicks:</TextBlock>
+			<TextBlock x:Name="l3Clicks" FontWeight="Bold"/>
 		</uno:StarStackPanel>
 
 	</Grid>

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.Android.cs
@@ -13,6 +13,12 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		private readonly SerialDisposable _touchSubscription = new SerialDisposable();
 		private readonly SerialDisposable _isEnabledSubscription = new SerialDisposable();
 
+		partial void PartialInitializeProperties()
+		{
+			// need the Tapped event to be registered for "Click" to work properly
+			Tapped += (snd, evt) => { };
+		}
+
 		protected override void OnLoaded()
 		{
 			base.OnLoaded();
@@ -115,6 +121,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				// Finally check for templated ContentControl root
 				?? TemplatedRoot as View
 				;
-		}		
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #1315

# Bugfix

## What is the current behavior?
On Android, using `ButtonBase.Click` were not working properly:
it was required to register to event `.Tapped` for the click to work properly.

## What is the new behavior?
`.Tapped` requirement removed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
