### PR TITLE
Adjust screenshots names for automated tests

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
@@ -72,6 +73,27 @@ namespace SamplesApp.UITests
 			Helpers.App = _app;
 		}
 
+		public void TakeScreenshot(string stepName)
+		{
+			var title = $"{TestContext.CurrentContext.Test.Name}_{stepName}"
+				.Replace(" ", "_")
+				.Replace(".", "_");
+
+			var fileInfo = _app.Screenshot(title);
+
+			var fileNameWithoutExt = Path.GetFileNameWithoutExtension(fileInfo.Name);
+			if (fileNameWithoutExt != title)
+			{
+				var destFileName = Path.Combine(Path.GetDirectoryName(fileInfo.FullName), fileNameWithoutExt + "." + Path.GetExtension(fileInfo.Name));
+				if (File.Exists(destFileName))
+				{
+					File.Delete(destFileName);
+				}
+
+				File.Move(fileInfo.FullName, destFileName);
+			}
+		}
+
 		private static void ValidateAutoRetry()
 		{
 			var testType = Type.GetType(TestContext.CurrentContext.Test.ClassName);
@@ -125,7 +147,7 @@ namespace SamplesApp.UITests
 				return bool.TryParse(result, out var testDone) && testDone;
 			});
 
-			_app.Screenshot(metadataName.Replace(".", "_"));
+			TakeScreenshot(metadataName.Replace(".", "_"));
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
@@ -42,72 +42,72 @@ namespace SamplesApp.UITests
 				// Setting focus on normalTextBox
 				_app.Tap(normalTextBox);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 0 - Focus on normalTextBox ");
+				TakeScreenshot("0 - Focus on normalTextBox ");
 
 				// Removing focus on normalTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 0 - Remove Focus on normalTextBox");
+				TakeScreenshot("0 - Remove Focus on normalTextBox");
 			}
 
 			{
 				// Setting focus on normalTextBox
 				_app.Tap(filledTextBox);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 1 - Focus on filledTextBox");
+				TakeScreenshot("1 - Focus on filledTextBox");
 
 				// Removing focus on normalTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 1 - Remove Focus on filledTextBox");
+				TakeScreenshot("1 - Remove Focus on filledTextBox");
 			}
 
 			{
 				// Setting focus on placeholderTextTextBox
 				_app.Tap(placeholderTextTextBox);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 2 - Focus on placeholderTextTextBox");
+				TakeScreenshot("2 - Focus on placeholderTextTextBox");
 
 				// Removing focus on placeholderTextTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 2 - Remove Focus on placeholderTextTextBox");
+				TakeScreenshot("2 - Remove Focus on placeholderTextTextBox");
 			}
 
 			{
 				// Setting focus on disabledTextBox
 				_app.Tap(disabledTextBox);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 3 - Focus on disabledTextBox");
+				TakeScreenshot("3 - Focus on disabledTextBox");
 
 				// Removing focus on disabledTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 3 - Remove Focus on disabledTextBox");
+				TakeScreenshot("3 - Remove Focus on disabledTextBox");
 			}
 
 			{
 				// Setting focus on multilineTextBox
 				_app.Tap(multilineTextBox);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 4 - Focus on multilineTextBox");
+				TakeScreenshot("4 - Focus on multilineTextBox");
 
 				// Removing focus on multilineTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 4 - Remove Focus on multilineTextBox");
+				TakeScreenshot("4 - Remove Focus on multilineTextBox");
 			}
 
 			{
 				// Setting focus on numberTextBox
 				_app.Tap(numberTextBox);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 5 - Focus on numberTextBox");
+				TakeScreenshot("5 - Focus on numberTextBox");
 
 				// Removing focus on numberTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("Inside ScrollViewer - 5 - Remove Focus on numberTextBox");
+				TakeScreenshot("5 - Remove Focus on numberTextBox");
 			}
 		}
 
@@ -138,72 +138,72 @@ namespace SamplesApp.UITests
 				// Setting focus on normalTextBox
 				_app.Tap(normalTextBox);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 0 - Focus on normalTextBox");
+				TakeScreenshot("0 - Focus on normalTextBox");
 
 				// Removing focus on normalTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 0 - Remove Focus on normalTextBox");
+				TakeScreenshot("0 - Remove Focus on normalTextBox");
 			}
 
 			{
 				// Setting focus on normalTextBox
 				_app.Tap(filledTextBox);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 1 - Focus on filledTextBox");
+				TakeScreenshot("1 - Focus on filledTextBox");
 
 				// Removing focus on normalTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 1 - Remove Focus on filledTextBox");
+				TakeScreenshot("1 - Remove Focus on filledTextBox");
 			}
 
 			{
 				// Setting focus on placeholderTextTextBox
 				_app.Tap(placeholderTextTextBox);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 2 - Focus on placeholderTextTextBox");
+				TakeScreenshot("2 - Focus on placeholderTextTextBox");
 
 				// Removing focus on placeholderTextTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 2 - Remove Focus on placeholderTextTextBox");
+				TakeScreenshot("2 - Remove Focus on placeholderTextTextBox");
 			}
 
 			{
 				// Setting focus on disabledTextBox
 				_app.Tap(disabledTextBox);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 3 - Focus on disabledTextBox");
+				TakeScreenshot("3 - Focus on disabledTextBox");
 
 				// Removing focus on disabledTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 3 - Remove Focus on disabledTextBox");
+				TakeScreenshot("3 - Remove Focus on disabledTextBox");
 			}
 
 			{
 				// Setting focus on multilineTextBox
 				_app.Tap(multilineTextBox);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 4 - Focus on multilineTextBox");
+				TakeScreenshot("4 - Focus on multilineTextBox");
 
 				// Removing focus on multilineTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 4 - Remove Focus on multilineTextBox");
+				TakeScreenshot("4 - Remove Focus on multilineTextBox");
 			}
 
 			{
 				// Setting focus on numberTextBox
 				_app.Tap(numberTextBox);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 5 - Focus on numberTextBox");
+				TakeScreenshot("5 - Focus on numberTextBox");
 
 				// Removing focus on numberTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				_app.Screenshot("No ScrollViewer - 5 - Remove Focus on numberTextBox");
+				TakeScreenshot("5 - Remove Focus on numberTextBox");
 			}
 		}
 
@@ -394,7 +394,7 @@ namespace SamplesApp.UITests
 
 			_app.WaitForElement(singleTextBox);
 
-			var f = _app.Screenshot("initial");
+			TakeScreenshot("initial");
 
 			singleTextBox.Tap();
 			_app.Wait(2);
@@ -407,7 +407,7 @@ namespace SamplesApp.UITests
 			_app.Wait(3);
 			_app.Back();
 
-			var t = _app.Screenshot("final");
+			TakeScreenshot("final");
 			_app.Wait(2);
 
 			// TODO do not rely on GDI to do the image comparison


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Android UI Tests file names are not useful, now renamed to test names.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
