### PR TITLE
Fix MaxLength handling on Android and WASM

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -60,6 +60,7 @@
 * [Android] `.Click` on a `ButtonBase` were not raising events properly
 * TemplateReuse not called when dataContext is set
 * [WASM] #1167 Apply `IsEnabled` correctly to `TextBox` (inner `TextBoxView` is now correctly disabled)
+* [Android/WASM] Fix MaxLength not respected or overwriting text
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
@@ -293,6 +293,24 @@ namespace SamplesApp.UITests
 
 		[Test]
 		[AutoRetry]
+		public void TextBox_MaxLength()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_MaxLength");
+
+			const string Entered = "123456789";
+			const string Final = "12345";
+
+			var textBox = TypeInto("MaxLengthTextBox", Entered, Final);
+
+			Assert.AreEqual(Final, GetText(textBox));
+
+			_app.ClearText();
+
+			Assert.AreEqual("", GetText(textBox));
+		}
+
+		[Test]
+		[AutoRetry]
 		public void TextBox_TextChanging_Capitalize()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_TextChanging");

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -225,6 +225,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_MaxLength.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_TextChanging.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2487,6 +2491,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Disabled.xaml.cs">
       <DependentUpon>TextBox_Disabled.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_MaxLength.xaml.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_TextChanging.xaml.cs">
       <DependentUpon>TextBox_TextChanging.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_MaxLength.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_MaxLength.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_MaxLength"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBox x:Name="MaxLengthTextBox"
+				 PlaceholderText="This TextBox can't contain more than 5 characters"
+				 IsSpellCheckEnabled="False"
+				 MaxLength="5"
+				 Margin="5" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_MaxLength.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_MaxLength.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
+{
+	[SampleControlInfo("TextBox", "TextBox_MaxLength")]
+	public sealed partial class TextBox_MaxLength : UserControl
+	{
+		public TextBox_MaxLength()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -338,27 +338,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		partial void OnMaxLengthChangedPartial(DependencyPropertyChangedEventArgs e)
-		{
-			if (_textBoxView != null)
-			{
-				if (e.NewValue != null)
-				{
-					var maxValue = (int)e.NewValue;
-
-					if (maxValue != 0)
-					{
-						_textBoxView.SetFilters(new IInputFilter[] { new InputFilterLengthFilter(maxValue) });
-					}
-					else
-					{
-						// Remove length filter
-						_textBoxView.SetFilters(new IInputFilter[0]);
-					}
-				}
-			}
-		}
-
 		partial void OnAcceptsReturnChangedPartial(DependencyPropertyChangedEventArgs e)
 		{
 			var acceptsReturn = (bool)e.NewValue;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -253,6 +253,11 @@ namespace Windows.UI.Xaml.Controls
 				return ""; //Pushing null to the binding resets the text. (Setting null to the Text property directly throws an exception.)
 			}
 
+			if (MaxLength > 0 && baseString.Length > MaxLength)
+			{
+				return DependencyProperty.UnsetValue;
+			}
+
 			var args = new TextBoxBeforeTextChangingEventArgs(baseString);
 			BeforeTextChanging?.Invoke(this, args);
 			if (args.Cancel)


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

**On Android**:
- After MaxLength is reached, text gets overwritten by subsequent characters. For example, if MaxLength=5, typing '123456' will result in '62345'.
- After MaxLength is reached, the BeforeTextChanging event is still called for subsequent characters. This is not the case on UWP.

**On WASM**: The MaxLength property is not respected.

## What is the new behavior?

**On Android and WASM**:
- The user is prevented from typing more text when MaxLength is reached.
- After MaxLength is reached, the BeforeTextChanging event is not triggered for subsequent characters (like on UWP).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

https://nventive.visualstudio.com/Umbrella/_workitems/edit/158910