### PR TITLE
Errors setting some properties on root of XAML file

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -63,6 +63,8 @@
 * TemplateReuse not called when dataContext is set
 * [WASM] #1167 Apply `IsEnabled` correctly to `TextBox` (inner `TextBoxView` is now correctly disabled)
 * [Android/WASM] Fix MaxLength not respected or overwriting text
+* Settings collection-based properties on root node in XAML were leading to C# compilation errors
+* Properties on root node in XAML were not applied when there was no content (sub-elements)
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -129,6 +129,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Properties\DataContextProperty.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\StyleTests\Style_Inline.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2442,6 +2446,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Localization\Localization_Implicit.xaml.cs">
       <DependentUpon>Localization_Implicit.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Properties\DataContextProperty.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\StyleTests\Style_Inline.xaml.cs">
       <DependentUpon>Style_Inline.xaml</DependentUpon>
     </Compile>
@@ -4259,6 +4264,9 @@
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button_With_CanExecute_Changing.xaml.cs">
       <DependentUpon>Simple_Button_With_CanExecute_Changing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml\Properties\DataContextProperty.xaml.cs">
+      <DependentUpon>DataContextProperty.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Button_Events.xaml.cs">
       <DependentUpon>Button_Events.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Properties/DataContextProperty.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Properties/DataContextProperty.xaml
@@ -1,0 +1,15 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml.Properties.DataContextProperty"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.DataContext>
+		<x:String>YES It's working!</x:String>
+	</Page.DataContext>
+
+	<Page.Content>
+		<TextBlock>Is it working: <Run Text="{Binding}" /></TextBlock>
+	</Page.Content>
+
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Properties/DataContextProperty.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Properties/DataContextProperty.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml.Properties
+{
+	[SampleControlInfo("XAML", "DataContextProperty")]
+	public sealed partial class DataContextProperty : Page
+	{
+		public DataContextProperty()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3194,7 +3194,19 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								var isInitializableCollection = IsInitializableCollection(member.Member);
 								var isInlineCollection = IsInlineCollection(member.Member, nonBindingObjects);
 
-								if (isInitializableCollection || isInlineCollection)
+								if (isInlineCollection && closureName != null)
+								{
+									foreach (var child in nonBindingObjects)
+									{
+										writer.AppendLineInvariant($"{fullValueSetter}.Add(");
+										using (writer.Indent())
+										{
+											BuildChild(writer, member, child);
+										}
+										writer.AppendLineInvariant(");");
+									}
+								}
+								else if (isInitializableCollection || isInlineCollection)
 								{
 									using (writer.BlockInvariant($"{fullValueSetter} = "))
 									{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -419,37 +419,34 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			writer.AppendLineInvariant("NameScope.SetNameScope(this, nameScope);");
 
 			RegisterResources(topLevelControl);
-			var hasContent = BuildProperties(writer, topLevelControl, isInline: false, returnsContent: isDirectUserControlChild);
+			BuildProperties(writer, topLevelControl, isInline: false, returnsContent: isDirectUserControlChild);
 
 			writer.AppendLineInvariant(";");
 
-			if (hasContent)
+			writer.AppendLineInvariant("");
+			writer.AppendLineInvariant(isDirectUserControlChild ? "content" : "this");
+
+			string closure;
+
+			using (var blockWriter = CreateApplyBlock(writer, null, out closure))
 			{
-				writer.AppendLineInvariant("");
-				writer.AppendLineInvariant(isDirectUserControlChild ? "content" : "this");
+				blockWriter.AppendLineInvariant(
+					"// Source {0} (Line {1}:{2})",
+					_fileDefinition.FilePath,
+					topLevelControl.LineNumber,
+					topLevelControl.LinePosition
+				);
 
-				string closure;
-
-				using (var blockWriter = CreateApplyBlock(writer, null, out closure))
-				{
-					blockWriter.AppendLineInvariant(
-						"// Source {0} (Line {1}:{2})",
-						_fileDefinition.FilePath,
-						topLevelControl.LineNumber,
-						topLevelControl.LinePosition
-					);
-
-					BuildLiteralProperties(blockWriter, topLevelControl, closure);
-				}
-
-				if (IsFrameworkElement(topLevelControl.Type))
-				{
-					BuildExtendedProperties(writer, topLevelControl, isDirectUserControlChild, useGenericApply: true);
-				}
-
-				writer.AppendLineInvariant(";");
+				BuildLiteralProperties(blockWriter, topLevelControl, closure);
 			}
 
+			if (IsFrameworkElement(topLevelControl.Type))
+			{
+				BuildExtendedProperties(writer, topLevelControl, isDirectUserControlChild, useGenericApply: true);
+			}
+
+			writer.AppendLineInvariant(";");
+			
 			writer.AppendLineInvariant("OnInitializeCompleted();");
 			writer.AppendLineInvariant("InitializeXamlOwner();");
 		}

--- a/src/SourceGenerators/XamlGenerationTests/Grid.Test.AsRoot.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/Grid.Test.AsRoot.xaml
@@ -1,0 +1,16 @@
+﻿<Grid
+	x:Class="XamlGenerationTests.Shared.GridAsRoot"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"> 
+
+	<Grid.ColumnDefinitions>
+		<ColumnDefinition />
+	</Grid.ColumnDefinitions>
+
+	<Grid >
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition />
+		</Grid.ColumnDefinitions>
+	</Grid>
+
+</Grid>


### PR DESCRIPTION
GitHub Issue (If applicable): #718

# Bugfix

## Description of the bug
Setting a collection-based property on the root of a XAML file like this
were leading to c# compilation errors:
```xml
<Grid
	x:Class="XamlGenerationTests.Shared.GridAsRoot"
	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"> 
	<Grid.ColumnDefinitions>
		<ColumnDefinition />
	</Grid.ColumnDefinitions>
</Grid>
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
