### PR TITLE
Update Xamarin.GooglePlayServices packages

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -34,12 +34,16 @@
 * Implement `TextBox.TextChanging` and `TextBox.BeforeTextChanging`. As on UWP, this allows the text to be intercepted and modified before the UI is updated. Previously on Android using the `TextChanged` event would lead to laggy response and dropped characters when typing rapidly; this is no longer the case with `TextChanging`.
 * [WASM] `ComboBox`'s dropdown list (`CarouselPanel`) is now virtualized (#1012)
 * Improve Screenshot comparer tool, CI test results now contain Screenshots compare data
+* Updated Xamarin.GooglePlayServices.* packages to 60.1142.1 for Target MonoAndroid80
+* Updated Xamarin.GooglePlayServices.* packages to 71.1600.0 for Target MonoAndroid90
 
 ### Breaking changes
 * `TextBox` no longer raises TextChanged when its template is applied, in line with UWP.
 * `TextBox.TextChanged` is now called asynchronously after the UI is updated, in line with UWP. For most uses `TextChanging` should be preferred.
 * [Android] `TextBox.IsSpellCheckEnabled = false` is now enforced in a way that may cause issues in certain use cases (see https://stackoverflow.com/a/5188119/1902058). The old behavior can be restored by setting `ShouldForceDisableSpellCheck = false`, per `TextBox`.
 * `TextBox.Text = null` will now throw an exception, as on UWP. Pushing `null` via a binding is still valid.
+* Projects targeting Android 8 must now use Xamarin.GooglePlayServices.* 60.1142.1 (60.1142.0 has been unlisted)
+* Projects targeting Android 9 must now use Xamarin.GooglePlayServices.* 71.1600.0
 
 ### Bug fixes
 * #1276 retrieving non-existent setting via indexer should not throw and  `ApplicationDataContainer` allowed clearing value by calling `Add(null)` which was not consistent with UWP.

--- a/src/Uno.UI.Maps/Uno.UI.Maps.csproj
+++ b/src/Uno.UI.Maps/Uno.UI.Maps.csproj
@@ -31,14 +31,14 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
-		<PackageReference Include="Xamarin.GooglePlayServices.Location" Version="60.1142.0" />
-		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="60.1142.0" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Location" Version="60.1142.1" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="60.1142.1" />
 		<PackageReference Include="Xamarin.Android.Support.v4" Version="26.1.0.1" PrivateAssets="none" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
-		<PackageReference Include="Xamarin.GooglePlayServices.Location" Version="60.1142.0" />
-		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="60.1142.0" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Location" Version="71.1600.0" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="71.1600.0" />
 		<PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" PrivateAssets="none" />
 	</ItemGroup>
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

Packages upgrade

-->

## What is the current behavior?
MonoAndroid uses outdated versions of Xamarin.GooglePlayServices packages


## What is the new behavior?

MonoAndroid uses latest stable versions of Xamarin.GooglePlayServices packages for both Android 8 and Android 9

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
~~- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~
~~- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
~~- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

Projects targeting Android 8 must now use Xamarin.GooglePlayServices.* 60.1142.1 (60.1142.0 has been unlisted)
 Projects targeting Android 9 must now use Xamarin.GooglePlayServices.* 71.1600.0

## Other information

Internal Issue (If applicable):
[159128](https://dev.azure.com/nventive/Umbrella/_workitems/edit/159128)
