### PR TITLE
Fix changing cursor color in Android P

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
@@ -117,17 +117,27 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_prepared = true;
 
-				var textView = new TextView(context);
+				Java.Lang.Class textViewClass;
+				using (var textView = new TextView(context))
+					textViewClass = textView.Class;
 				var editText = new EditText(context);
 
-				_cursorDrawableResField = textView.Class.GetDeclaredField("mCursorDrawableRes");
+				_cursorDrawableResField = textViewClass.GetDeclaredField("mCursorDrawableRes");
 				_cursorDrawableResField.Accessible = true;
 
-				_editorField = textView.Class.GetDeclaredField("mEditor");
+				_editorField = textViewClass.GetDeclaredField("mEditor");
 				_editorField.Accessible = true;
 
-				_cursorDrawableField = _editorField.Get(editText).Class.GetDeclaredField("mCursorDrawable");
-				_cursorDrawableField.Accessible = true;
+				if (Build.VERSION.SdkInt < BuildVersionCodes.P)
+				{
+					_cursorDrawableField = _editorField.Get(editText).Class.GetDeclaredField("mCursorDrawable");
+					_cursorDrawableField.Accessible = true;
+				}
+				else // set differently in Android P (API 28) and higher
+				{
+					_cursorDrawableField = _editorField.Get(editText).Class.GetDeclaredField("mDrawableForCursor");
+					_cursorDrawableField.Accessible = true;
+				}
 			}
 
 			public static void SetCursorColor(EditText editText, Color color)
@@ -140,13 +150,22 @@ namespace Windows.UI.Xaml.Controls
 					}
 
 					var mCursorDrawableRes = _cursorDrawableResField.GetInt(editText);
-					var drawables = new Drawable[2];
-					drawables[0] = Android.Support.V4.Content.ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
-					drawables[1] = Android.Support.V4.Content.ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
-					drawables[0].SetColorFilter(color, PorterDuff.Mode.SrcIn);
-					drawables[1].SetColorFilter(color, PorterDuff.Mode.SrcIn);
 					var editor = _editorField.Get(editText);
-					_cursorDrawableField.Set(editor, drawables);
+					if (Build.VERSION.SdkInt < BuildVersionCodes.P)
+					{
+						var drawables = new Drawable[2];
+						drawables[0] = Android.Support.V4.Content.ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
+						drawables[1] = Android.Support.V4.Content.ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
+						drawables[0].SetColorFilter(color, PorterDuff.Mode.SrcIn);
+						drawables[1].SetColorFilter(color, PorterDuff.Mode.SrcIn);
+						_cursorDrawableField.Set(editor, drawables);
+					}
+					else
+					{
+						var drawable = Android.Support.V4.Content.ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
+						drawable.SetColorFilter(color, PorterDuff.Mode.SrcIn);
+						_cursorDrawableField.Set(editor, drawable);
+					}
 				}
 				catch (Exception)
 				{


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix

<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
When run on Android P it will throw a few exceptions, because there's no such field as "mCursorDrawable".
It throws java.lang.NoSuchFieldException and then NullReferenceException's (when we enable to stop the debugger on every C# exception in Visual Studio)
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
It should not throw, and the feature should work in Android P now.

The change is based on 
https://stackoverflow.com/a/52564925
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
