### PR TITLE
Provide a better error-message on page-navigation-errors

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -81,6 +81,7 @@
 * Flyout that are than anchor but fit in page were defaulting to full placement.
 * [iOS]Fixed DatePickerFlyout & TimePickerFlyout not being placed at the bottom
 * [Android] Animated content is cut off/glitchy when RenderTransform translation is applied (#1333)
+* [#1409](https://github.com/unoplatform/uno/pull/1413) Provide a better error-message on Page-Navigation-Errors
 
 ## Release 1.45.0
 ### Features

--- a/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml.cs
@@ -89,7 +89,7 @@ namespace $ext_safeprojectname$
 		/// <param name="e">Details about the navigation failure</param>
 		void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
 		{
-			throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
+			throw new Exception($"Failed to load {e.SourcePageType.FullName}: {e.Exception}");
 		}
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): #1409

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix

## What is the current behavior?
When navigation to a page fails (OnNavigationFailed) an exception is thrown with the name of the page that failed to load. The actual reason why the exception is thrown is swallowed. This behavior hides root causes and makes troubleshooting new applications harder, especially on the WebAssembly head.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
The error message includes the root-cause of the error by providing it's exception-message.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): 
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
