### PR TITLE
Surface all ProgressBar constructors

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## Next version
 ### Features
+*  [#1428](https://github.com/unoplatform/uno/issues/1428) - Add support for horizontal progressbars to `BindableProgressBar` on Android.
 * Add support for `Windows.Devices.Sensors.Magnetometer` APIs on iOS, Android and WASM
    * `ReadingChanged`
    * `ReportInterval`

--- a/src/Uno.UI/Controls/BindableProgressBar.Android.cs
+++ b/src/Uno.UI/Controls/BindableProgressBar.Android.cs
@@ -1,4 +1,5 @@
-﻿using Android.Widget;
+﻿using Android.Util;
+using Android.Widget;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -8,8 +9,36 @@ namespace Uno.UI.Controls
 {
 	public partial class BindableProgressBar : ProgressBar, DependencyObject
 	{
-		public BindableProgressBar() 
-			: base(ContextHelper.Current)
+		public BindableProgressBar()
+			: base(Uno.UI.ContextHelper.Current)
+		{
+		}
+
+		public BindableProgressBar(Android.Content.Context context)
+			: base(context)
+		{
+			Initialize(context, null);
+		}
+
+		public BindableProgressBar(Android.Content.Context context, IAttributeSet attrs)
+			: base(context, attrs)
+		{
+			Initialize(context, attrs);
+		}
+
+		public BindableProgressBar(Android.Content.Context context, IAttributeSet attrs, int defstyleAttr)
+			: base(context, attrs, defStyleAttr: defstyleAttr)
+		{
+			Initialize(context, attrs);
+		}
+
+		public BindableProgressBar(Android.Content.Context context, IAttributeSet attrs, int defstyleAttr, int defStyleRes)
+			: base(context, attrs, defstyleAttr, defStyleRes)
+		{
+			Initialize(context, attrs);
+		}
+
+		private void Initialize(Android.Content.Context context, IAttributeSet attrs)
 		{
 			InitializeBinder();
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/1428

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

See https://github.com/unoplatform/uno/issues/1428

## What is the new behavior?

This is now possible:

```csharp
public partial class NativeProgressControl : BindableProgressBar
{
    public NativeProgressControl() : base(ContextHelper.Current, null, Android.Resource.Attribute.ProgressBarStyleHorizontal)
    {
        Indeterminate = false;
    }
```

Thus allowing result based progress bars:

![image](https://user-images.githubusercontent.com/127353/63677071-95937d80-c82f-11e9-9e80-25a28ed5e873.png)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information