### PR TITLE
ThemeResource bugfixes

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -53,6 +53,7 @@
 * Add support for `CoreApplication.MainView` and `CoreApplication.Views`
 * Add support for resolution of merged and theme resources from `ResourceDictionary` in code
 * `ToolTip` & `ToolTipService` are now implemented.
+* [#1352](https://github.com/unoplatform/uno/issues/1352) Add support for `ThemeResource`s with different types (eg: mixing `SolidColorBrush` and `LinearGradientBrush`)
 
 ### Breaking changes
 * `TextBox` no longer raises TextChanged when its template is applied, in line with UWP.
@@ -98,6 +99,9 @@
 * Fix NRE when using custom `Pivot` templates.
 * [Android] ScrollViewer were no more clipping the scrollable area.
 * `ComboBox`'s ControlTemplate was requiring a binding to _TemplatedParent_ for the `x:Name="ContentPresenter"` control. Now aligned with UWP by making this binding in the control itself.
+* [#1352](https://github.com/unoplatform/uno/issues/1352) `ThemeResource` bugfixes:
+  - `StaticResource` not working inside `ResourceDictionary.ThemeDictionaries`
+  - Using a `ThemeResource` on the wrong property type shouldn't raise compile-time error (to align with UWP)
 
 ## Release 1.45.0
 ### Features

--- a/src/SourceGenerators/XamlGenerationTests/ThemeResourcesTest.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/ThemeResourcesTest.xaml
@@ -12,15 +12,24 @@
 				<ResourceDictionary x:Key="Dark">
 					<SolidColorBrush x:Key="LocalColor" Color="Blue" />
 					<SolidColorBrush x:Key="LocalThemeColor" Color="Green" />
+					<StaticResource x:Key="StaticResourceWithForwardReference" ResourceKey="SystemBaseHighColor" />
+					<SolidColorBrush x:Key="BrushThatHasMultipleThemeTypes" Color="Gray" />
 				</ResourceDictionary>
 
 				<ResourceDictionary x:Key="Light">
 					<SolidColorBrush x:Key="LocalColor" Color="Yellow" />
 					<SolidColorBrush x:Key="LocalThemeColor" Color="Red" />
+					<StaticResource x:Key="StaticResourceWithForwardReference" ResourceKey="SystemBaseLowColor" />
+					<LinearGradientBrush x:Key="BrushThatHasMultipleThemeTypes" StartPoint="0,0" EndPoint="1,0.5">
+						<GradientStop Offset="0.0" Color="Black" />
+						<GradientStop Offset="1.0" Color="White" />
+					</LinearGradientBrush>
 				</ResourceDictionary>
 			</ResourceDictionary.ThemeDictionaries>
 
 			<SolidColorBrush x:Key="LocalColor" Color="Brown" />
+			<!-- While this isnt a correct usage, ThemeResource doesnt fail at compile-time on uwp, nor does it crash the app. -->
+			<SolidColorBrush x:Key="BrushThatUsesAnotherBrushAsColor" Color="{ThemeResource LocalColor}" />
 		</ResourceDictionary>
 	</Page.Resources>
 
@@ -36,5 +45,6 @@
 		<Rectangle Fill="{StaticResource LocalColor}" Stroke="{ThemeResource LocalThemeColor}" />
 		<Rectangle Fill="{ThemeResource LocalColor}" Stroke="{StaticResource LocalThemeColor}" />
 
+		<TextBlock Background="{ThemeResource StaticResourceWithForwardReference}" />
 	</Grid>
 </Page>


### PR DESCRIPTION
GitHub Issue (If applicable): #1352

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
- `StaticResource` not working inside `ResourceDictionary.ThemeDictionaries`
- Using a `ThemeResource` on the wrong property type should fails silently (no-crash, but the property is cleared). In uno, we are trying to resolve this statically during compile-time.
- The current implementation of `ThemeDictionaries` fail to support themed resources with different types (eg: mixing `SolidColorBrush` and `LinearGradientBrush`)

## What is the new behavior?
Fixed the above issues.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)