### PR TITLE
ComboBox: Fix DataContext Inheritance on ContentPresenter when no selected item.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -103,6 +103,7 @@
   - `StaticResource` not working inside `ResourceDictionary.ThemeDictionaries`
   - Using a `ThemeResource` on the wrong property type shouldn't raise compile-time error (to align with UWP)
 * Fix layout bug in Image control.
+* [#1387] `ComboBox`: Fix DataContext was propagated to `<ContentPresenter>` when there was no selected item, causing strange display behavior.
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.ContentControl.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.ContentControl.cs
@@ -21,9 +21,9 @@ namespace SamplesApp.UITests
 
 
 			var tb1 = _app.Marked("innerText");
-			Assert.AreEqual("ContentPresenter:  SampleControl.Presentation.SampleChooserViewModel", tb1.GetDependencyPropertyValue("Text").ToString());
+			Assert.AreEqual("ContentPresenter:  DataContext", tb1.GetDependencyPropertyValue("Text").ToString());
 			var tb2 = _app.Marked("innerText2");
-			Assert.AreEqual("ContentControl:  SampleControl.Presentation.SampleChooserViewModel", tb2.GetDependencyPropertyValue("Text").ToString());
+			Assert.AreEqual("ContentControl:  DataContext", tb2.GetDependencyPropertyValue("Text").ToString());
 
 			_app.Tap(c => c.Text("Click me"));
 

--- a/src/SamplesApp/UITests.Shared/Resources/StaticResource/StaticResource_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Resources/StaticResource/StaticResource_Simple.xaml.cs
@@ -27,6 +27,8 @@ namespace UITests.Shared.Resources.StaticResource
 			Application.Current.Resources["HelloConverter"] = new HelloConverter();
 
 			this.InitializeComponent();
+
+			DataContext = new object();
 		}
 
 		private class HelloConverter : IValueConverter

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -221,6 +221,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ItemDataContext.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentControlTestsControl\ContentControl_NoTemplateDataContext.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2539,6 +2543,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\PhaseBinding.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\PhaseBinding_Large.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\PhaseBinding_StartOne.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ItemDataContext.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentControlTestsControl\ContentControl_Changing_ContentTemplate.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentControlTestsControl\ContentControl_DefaultText.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentControlTestsControl\ContentControl_FindName.xaml.cs" />
@@ -4434,6 +4439,9 @@
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\TextOnlyToolTipSample.xaml.cs">
       <DependentUpon>TextOnlyToolTipSample.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ComboBox\ComboBox_ItemDataContext.xaml.cs">
+      <DependentUpon>ComboBox_ItemDataContext.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DisplayMemberPath.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DisplayMemberPath.xaml
@@ -8,12 +8,23 @@
 	d:DesignHeight="300"
 	d:DesignWidth="400">
 
-  <StackPanel>
+	<StackPanel>
 
-	<TextBlock Text="You should see First, Second, Third, ..." />
-	<ComboBox ItemsSource="{Binding}"
-			  DisplayMemberPath="Name" />
+		<TextBlock Text="You should see First, Second, Third, ..." />
+		<ComboBox x:Name="comboBox"
+				  ItemsSource="{Binding}"
+				  DisplayMemberPath="Name" />
 
-  </StackPanel>
+		<TextBlock Text="Pick which field you want to see as DisplayMemberPath..." />
+		<StackPanel Orientation="Horizontal">
+			<ComboBox x:Name="selectMemberPath">
+				<ComboBoxItem>Id</ComboBoxItem>
+				<ComboBoxItem IsSelected="True">Name</ComboBoxItem>
+			</ComboBox>
+			<ComboBox x:Name="comboBox2"
+			          ItemsSource="{Binding}"
+			          DisplayMemberPath="{Binding SelectedValue.Content, ElementName=selectMemberPath}" />
+		</StackPanel>
+	</StackPanel>
 
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DisplayMemberPath.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DisplayMemberPath.xaml.cs
@@ -12,19 +12,27 @@ namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 
 			DataContext = new MyEntity[]
 			{
-				new MyEntity { Name = "First" },
-				new MyEntity { Name = "Second" },
-				new MyEntity { Name = "Third" },
-				new MyEntity { Name = "Fourth" },
-				new MyEntity { Name = "Fifth" },
-				new MyEntity { Name = "Sixth" },
-				new MyEntity { Name = "Seventh" },
+				new MyEntity("ID1", "First"),
+				new MyEntity("ID2", "Second"),
+				new MyEntity("ID3", "Third"),
+				new MyEntity("ID4", "Fourth"),
+				new MyEntity("ID5", "Fifth"),
+				new MyEntity("ID6", "Sixth"),
+				new MyEntity("ID7", "Seventh")
 			};
 		}
 
 		public class MyEntity
 		{
-			public string Name { get; set; }
+			public MyEntity(string id, string name)
+			{
+				Id = id;
+				Name = name;
+			}
+
+			public string Id { get; }
+
+			public string Name { get; }
 
 			// We're using DisplayMemberPath="Name", therefore we shouldn't see MyEntity.ToString().
 			public override string ToString() => "If you see this text, there's a bug.";

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemDataContext.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemDataContext.xaml
@@ -1,0 +1,21 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ComboBox.ComboBox_ItemDataContext"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ComboBox"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+		<TextBlock>
+			Control DataContext: <Run Text="{Binding}" />
+			<LineBreak />
+			DataContenxt.Value: <Run Text="{Binding Value}" />
+		</TextBlock>
+
+		<ComboBox ItemsSource="{Binding Items}" DisplayMemberPath="Value" />
+
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemDataContext.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemDataContext.xaml
@@ -12,7 +12,7 @@
 		<TextBlock>
 			Control DataContext: <Run Text="{Binding}" />
 			<LineBreak />
-			DataContenxt.Value: <Run Text="{Binding Value}" />
+			DataContext.Value: <Run Text="{Binding Value}" />
 		</TextBlock>
 
 		<ComboBox ItemsSource="{Binding Items}" DisplayMemberPath="Value" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemDataContext.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemDataContext.xaml.cs
@@ -1,0 +1,39 @@
+﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.Models;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", nameof(ComboBox_ItemDataContext))]
+	public sealed partial class ComboBox_ItemDataContext : Page
+	{
+		public ComboBox_ItemDataContext()
+		{
+			this.InitializeComponent();
+
+			DataContext= new ControlDataContext();
+		}
+
+		public class ControlDataContext
+		{
+			public DataContextItem[] Items { get; } =
+			{
+				new DataContextItem("Item A"),
+				new DataContextItem("Item B"),
+				new DataContextItem("Item C")
+			};
+
+			public string Value { get; } = "This value should NEVER be in the ComboBox";
+		}
+
+		public class DataContextItem
+		{
+			public DataContextItem(string value)
+			{
+				Value = value;
+			}
+
+			public string Value { get; }
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_Template.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_Template.xaml.cs
@@ -24,6 +24,8 @@ namespace Uno.UI.Samples.Content.UITests.ContentPresenter
         public ContentPresenter_Template()
         {
             this.InitializeComponent();
+
+            DataContext = nameof(DataContext);
         }
 
 		private void Button_Click(object sender, RoutedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -96,6 +96,24 @@ namespace Windows.UI.Xaml.Controls
 					{
 						RelativeSource = RelativeSource.TemplatedParent
 					});
+
+				_contentPresenter.DataContextChanged += (snd, evt) =>
+				{
+					// The ContentPresenter will automatically clear its local DataContext
+					// on first load.
+					//
+					// When there's no selection, this will cause this ContentPresenter to
+					// received the same DataContext as the ComboBox itself, which could
+					// lead to strange result or errors.
+					//
+					// See comments in ContentPresenter.ResetDataContextOnFirstLoad() method.
+					// Fixed in this PR: https://github.com/unoplatform/uno/pull/1465
+
+					if (evt.NewValue != null && SelectedItem == null)
+					{
+						_contentPresenter.DataContext = null; // Remove problematic inherited DataContext
+					}
+				};
 			}
 		}
 
@@ -177,13 +195,13 @@ namespace Windows.UI.Xaml.Controls
 				{
 					// On Windows, all interactions involving the HeaderContentPresenter don't seem to affect the ComboBox.
 					// For example, hovering/pressing doesn't trigger the PointOver/Pressed visual states. Tapping on it doesn't open the drop down.
-					// This is true even if the Background of the root of ComboBox's template (which contains the HeaderContentPresenter) is set. 
+					// This is true even if the Background of the root of ComboBox's template (which contains the HeaderContentPresenter) is set.
 					// Interaction with any other part of the control (including the root) triggers the corresponding visual states and actions.
 					// It doesn't seem like the HeaderContentPresenter consumes (Handled = true) events because they are properly routed to the ComboBox.
 
 					// My guess is that ComboBox checks whether the OriginalSource of Pointer events is a child of HeaderContentPresenter.
 
-					// Because routed events are not implemented yet, the easy workaround is to prevent HeaderContentPresenter from being hit. 
+					// Because routed events are not implemented yet, the easy workaround is to prevent HeaderContentPresenter from being hit.
 					// This only works if the background of the root of ComboBox's template is null (which is the case by default).
 					_headerContentPresenter.IsHitTestVisible = false;
 				}
@@ -324,7 +342,7 @@ namespace Windows.UI.Xaml.Controls
 			IsDropDownOpen = true;
 		}
 
-		// This is required by some apps trying to emulate the native iPhone look for ComboBox. 
+		// This is required by some apps trying to emulate the native iPhone look for ComboBox.
 		// The standard popup layouter works like on Windows, and doesn't stretch to take the full size of the screen.
 		public bool IsPopupFullscreen { get; set; } = false;
 
@@ -474,7 +492,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 					// On UWP, the popup always let 1 px free at the bottom
 					// Note: frame.Height is already at most visibleBounds.Height
-					frame.Y = visibleBounds.Height - frame.Height - 1; 
+					frame.Y = visibleBounds.Height - frame.Height - 1;
 				}
 
 				if (this.Log().IsEnabled(LogLevel.Debug))

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1319,7 +1319,7 @@ namespace Windows.UI.Xaml
 			var propertyMetadata = propertyDetails.Metadata;
 
 			// We can reuse the weak reference, otherwise capture the weak reference to this instance.
-			var instanceRef = _originalObjectRef != null ? _originalObjectRef : _thisWeakRef;
+			var instanceRef = _originalObjectRef ?? _thisWeakRef;
 
 			if (propertyMetadata is FrameworkPropertyMetadata frameworkPropertyMetadata)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #1387

# Bugfix

## What is the current behavior?
When using `DisplayMemberPath` on a `<ComboBox>`, the path is applied on the
_parent_ `DataContext` when there's no _selected item_.

## What is the new behavior?
The `DataContext` is not propagated anymore to children, even when there's no
_Selected Item_.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
