### PR TITLE
Fix layouting bug in Image for Android and iOS

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -102,6 +102,7 @@
 * [#1352](https://github.com/unoplatform/uno/issues/1352) `ThemeResource` bugfixes:
   - `StaticResource` not working inside `ResourceDictionary.ThemeDictionaries`
   - Using a `ThemeResource` on the wrong property type shouldn't raise compile-time error (to align with UWP)
+* Fix layout bug in Image control.
 
 ## Release 1.45.0
 ### Features

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
@@ -344,7 +344,7 @@ namespace Windows.UI.Xaml.Controls
 					}
 				}
 
-				if (sourceSize.Width > availableSize.Width || sourceSize.Height > availableSize.Height)
+				if (sourceSize.Width > availableSize.Width || sourceSize.Height > availableSize.Height || (hasKnownWidth && hasKnownHeight))
 				{
 					var knownWidth = ImageControl.GetKnownWidth(availableSize.Width, sourceSize.Width);
 					var knownHeight = ImageControl.GetKnownHeight(availableSize.Height, sourceSize.Height);


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Image using Stretch=Uniform in a vertical "Auto" context doesn't stretch properly.
i.e. the image takes it's native size rather than stretching.

## What is the new behavior?
Image using Stretch=Uniform in a vertical "Auto" context now stretches properly.
i.e. the image behaves like UWP.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/160805
