### PR TITLE
fixed RecyclerView.State desync

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -104,6 +104,7 @@
   - Using a `ThemeResource` on the wrong property type shouldn't raise compile-time error (to align with UWP)
 * Fix layout bug in Image control.
 * [#1387] `ComboBox`: Fix DataContext was propagated to `<ContentPresenter>` when there was no selected item, causing strange display behavior.
+* #1354 fixed Recycler.State desync issue
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
@@ -1,11 +1,11 @@
-﻿using NUnit.Framework;
-using SamplesApp.UITests.TestFramework;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
@@ -21,9 +21,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			Run("SamplesApp.Windows_UI_Xaml_Controls.ListView.RotatedListView_WithRotatedItems");
 
 			//Rotated ListView items can't be properly tests until https://github.com/xamarin/Xamarin.Forms/issues/2496 is fixed.
-     }
-      
-    [Test]
+		}
+
+		[Test]
 		[AutoRetry]
 		public void ListView_ListViewVariableItemHeightLong_InitializesTest()
 		{
@@ -49,6 +49,26 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 			// Assert initial state
 			Assert.IsNotNull(theListView.GetDependencyPropertyValue("DataContext"));
+		}
+
+		[Test]
+		[ActivePlatforms(Platform.Android)]
+		public void ListView_ItemPanel_HotSwapTest()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ListView.ListView_ItemsPanel_HotSwap");
+
+			_app.WaitForElement("SampleListView");
+			TabWaitAndThenScreenshot("SwapHorizontalStackPanelButton");
+			TabWaitAndThenScreenshot("UpdateItemsSourceButton");
+			TabWaitAndThenScreenshot("SwapVerticalItemsStackPanelButton");
+			TabWaitAndThenScreenshot("UpdateItemsSourceButton");
+
+			void TabWaitAndThenScreenshot(string buttonName)
+			{
+				_app.Marked(buttonName).Tap();
+				_app.Wait(TimeSpan.FromSeconds(2));
+				_app.Screenshot($"ListView_ItemPanel_HotSwap - {buttonName}");
+			}
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -285,6 +285,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ItemsPanel_HotSwap.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\RotatedListView_WithRotatedItems.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2568,6 +2572,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentPresenter\ContentPresenter_TextProperties.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ChangeView.xaml.cs">
       <DependentUpon>ListView_ChangeView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ItemsPanel_HotSwap.xaml.cs">
+      <DependentUpon>ListView_ItemsPanel_HotSwap.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\RotatedListView_WithRotatedItems.xaml.cs">
       <DependentUpon>RotatedListView_WithRotatedItems.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ItemsPanel_HotSwap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ItemsPanel_HotSwap.xaml
@@ -1,0 +1,49 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ListView.ListView_ItemsPanel_HotSwap"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ListView"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:xamarin="http://uno.ui/xamarin"
+			 mc:Ignorable="d xamarin">
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<ScrollViewer Grid.Row="1">
+			<ListView x:Name="SampleListView">
+				<ListView.ItemTemplate>
+					<DataTemplate>
+						<TextBlock HorizontalAlignment="Center"
+								   VerticalAlignment="Center"
+								   Text="{Binding}" />
+					</DataTemplate>
+				</ListView.ItemTemplate>
+				<ListView.ItemsPanel>
+					<ItemsPanelTemplate>
+						<ItemsStackPanel />
+					</ItemsPanelTemplate>
+				</ListView.ItemsPanel>
+			</ListView>
+		</ScrollViewer>
+
+		<StackPanel Grid.Row="2">
+			<xamarin:Button Content="StackPanel Horizontal"
+							Tag="StackPanel Orientation='Horizontal'"
+							Click="SwapPanelButton_Click" />
+			<Button Content="ItemsStackPanel Vertical"
+					Tag="ItemsStackPanel Orientation='Vertical'"
+					Click="SwapPanelButton_Click" />
+			<win:Button Content="VirtualizingStackPanel Horizontal"
+						Tag="VirtualizingStackPanel Orientation='Horizontal'"
+						Click="SwapPanelButton_Click" />
+
+			<Button Content="Update ItemsSource"
+					Click="UpdateItemsSourceButton_Click" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ItemsPanel_HotSwap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ItemsPanel_HotSwap.xaml
@@ -32,17 +32,22 @@
 		</ScrollViewer>
 
 		<StackPanel Grid.Row="2">
-			<xamarin:Button Content="StackPanel Horizontal"
+			<xamarin:Button x:Name="SwapHorizontalStackPanelButton"
+							Content="Horizontal StackPanel"
 							Tag="StackPanel Orientation='Horizontal'"
 							Click="SwapPanelButton_Click" />
-			<Button Content="ItemsStackPanel Vertical"
+			<Button x:Name="SwapVerticalItemsStackPanelButton"
+					Content="Vertical ItemsStackPanel"
 					Tag="ItemsStackPanel Orientation='Vertical'"
 					Click="SwapPanelButton_Click" />
-			<win:Button Content="VirtualizingStackPanel Horizontal"
+			<win:Button x:Name="SwapHorizontalVirtualizingStackPanelButton"
+						Content="Horizontal VirtualizingStackPanel"
 						Tag="VirtualizingStackPanel Orientation='Horizontal'"
 						Click="SwapPanelButton_Click" />
 
-			<Button Content="Update ItemsSource"
+			<Button x:Name="UpdateItemsSourceButton"
+					Margin="0,10,0,0"
+					Content="Update ItemsSource"
 					Click="UpdateItemsSourceButton_Click" />
 		</StackPanel>
 	</Grid>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ItemsPanel_HotSwap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ItemsPanel_HotSwap.xaml.cs
@@ -23,7 +23,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
 	[SampleControlInfo("ListView", nameof(ListView_ItemsPanel_HotSwap))]
 	public sealed partial class ListView_ItemsPanel_HotSwap : UserControl
 	{
-		private static readonly Random random = new Random();
+		private readonly Random random = new Random(312);
 
 		public ListView_ItemsPanel_HotSwap()
 		{
@@ -43,7 +43,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
 		private void UpdateItemsSourceButton_Click(object sender, RoutedEventArgs e)
 		{
 			var start = random.Next(-50, 50);
-			var count = random.Next(15, 255);
+			var count = random.Next(10, 20);
 
 			this.SampleListView.ItemsSource = Enumerable.Range(start, count).ToArray();
 		}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ItemsPanel_HotSwap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ItemsPanel_HotSwap.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Markup;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
+{
+
+	[SampleControlInfo("ListView", nameof(ListView_ItemsPanel_HotSwap))]
+	public sealed partial class ListView_ItemsPanel_HotSwap : UserControl
+	{
+		private static readonly Random random = new Random();
+
+		public ListView_ItemsPanel_HotSwap()
+		{
+			this.InitializeComponent();
+			this.SampleListView.ItemsSource = Enumerable.Range(3, 12).ToArray();
+		}
+
+		private void SwapPanelButton_Click(object sender, RoutedEventArgs e)
+		{
+			var button = (global::Windows.UI.Xaml.Controls.Button)sender;
+			var xaml = $"<ItemsPanelTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'><{button.Tag} /></ItemsPanelTemplate>"
+				.Replace('\'', '"');
+
+			this.SampleListView.ItemsPanel = (ItemsPanelTemplate)XamlReader.Load(xaml);
+		}
+
+		private void UpdateItemsSourceButton_Click(object sender, RoutedEventArgs e)
+		{
+			var start = random.Next(-50, 50);
+			var count = random.Next(15, 255);
+
+			this.SampleListView.ItemsSource = Enumerable.Range(start, count).ToArray();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -841,6 +841,11 @@ namespace Windows.UI.Xaml.Controls
 				ItemsPanelRoot?.Children.Clear();
 			}
 
+			if (InternalItemsPanelRoot != null)
+			{
+				CleanUpInternalItemsPanel(InternalItemsPanelRoot);
+			}
+
 			var itemsPanel = ItemsPanel?.LoadContent() ?? new StackPanel();
 			InternalItemsPanelRoot = ResolveInternalItemsPanel(itemsPanel);
 			ItemsPanelRoot = itemsPanel as Panel;
@@ -1275,5 +1280,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			return DataTemplateHelper.ResolveTemplate(ItemTemplate, ItemTemplateSelector, item, this);
 		}
+
+		internal protected virtual void CleanUpInternalItemsPanel(View panel) { }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Android.cs
@@ -22,11 +22,9 @@ namespace Windows.UI.Xaml.Controls
 		private readonly SerialDisposable _collectionChangedSubscription = new SerialDisposable();
 		private readonly SerialDisposable _headerFooterSubscription = new SerialDisposable();
 
-		private void InitializeNativePanel()
+		private void InitializeNativePanel(NativeListViewBase panel)
 		{
-			var adapter = new NativeListViewBaseAdapter();
-			adapter.Owner = NativePanel;
-			NativePanel.CurrentAdapter = adapter;
+			panel.CurrentAdapter = new NativeListViewBaseAdapter { Owner = panel };
 		}
 
 		private void AddItems(int firstItem, int count, int section)

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Android.cs
@@ -27,6 +27,17 @@ namespace Windows.UI.Xaml.Controls
 			panel.CurrentAdapter = new NativeListViewBaseAdapter { Owner = panel };
 		}
 
+		partial void CleanUpNativePanel(NativeListViewBase panel)
+		{
+			_headerFooterSubscription.Disposable = null;
+			panel.NativeLayout?.RemoveAllViews();
+			panel.ViewCache?.OnUnloaded();
+
+			panel.NativeLayout = null;
+			panel.SetViewCacheExtension(null);
+			panel.CurrentAdapter = null;
+		}
+
 		private void AddItems(int firstItem, int count, int section)
 		{
 			var unoIndex = IndexPath.FromRowSection(firstItem, section);

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOS.cs
@@ -40,19 +40,19 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private void InitializeNativePanel()
+		private void InitializeNativePanel(NativeListViewBase panel)
 		{
-			var source = new ListViewBaseSource(NativePanel);
-			NativePanel.Source = source;
-			NativePanel.NativeLayout.Source = new WeakReference<ListViewBaseSource>(NativePanel.Source);
+			var source = new ListViewBaseSource(panel);
+			panel.Source = source;
+			panel.NativeLayout.Source = new WeakReference<ListViewBaseSource>(panel.Source);
 
-			BindToPanel(nameof(ItemsSource));
+			BindToPanel(panel, nameof(ItemsSource));
 
-			NativePanel.AnimateScrollIntoView = AnimateScrollIntoView;
+			panel.AnimateScrollIntoView = AnimateScrollIntoView;
 
 			var disposables = new CompositeDisposable();
 
-			Action headerFooterCallback = () => NativePanel?.UpdateHeaderAndFooter();
+			Action headerFooterCallback = () => panel?.UpdateHeaderAndFooter();
 			RegisterCallback(HeaderProperty, headerFooterCallback).DisposeWith(disposables);
 			RegisterCallback(HeaderTemplateProperty, headerFooterCallback).DisposeWith(disposables);
 			RegisterCallback(FooterProperty, headerFooterCallback).DisposeWith(disposables);
@@ -64,9 +64,9 @@ namespace Windows.UI.Xaml.Controls
 		/// <summary>
 		/// Bind a property on the native collection panel to its equivalent on ListViewBase
 		/// </summary>
-		private void BindToPanel(string propertyName, BindingMode bindingMode = BindingMode.OneWay)
+		private void BindToPanel(NativeListViewBase panel, string propertyName, BindingMode bindingMode = BindingMode.OneWay)
 		{
-			NativePanel.Binding(propertyName, propertyName, this, bindingMode);
+			panel.Binding(propertyName, propertyName, this, bindingMode);
 		}
 
 		private IDisposable RegisterCallback(DependencyProperty property, Action callback)

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOS.cs
@@ -61,6 +61,13 @@ namespace Windows.UI.Xaml.Controls
 			_callbackSubscriptions.Disposable = disposables;
 		}
 
+		partial void CleanUpNativePanel(NativeListViewBase panel)
+		{
+			_callbackSubscriptions.Disposable = null;
+			panel.Source?.Dispose();
+			panel.Source = null;
+		}
+
 		/// <summary>
 		/// Bind a property on the native collection panel to its equivalent on ListViewBase
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOSAndroid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOSAndroid.cs
@@ -91,7 +91,17 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		protected internal override void CleanUpInternalItemsPanel(_View panel)
+		{
+			if (panel is NativeListViewBase nativePanel)
+			{
+				CleanUpNativePanel(nativePanel);
+			}
+		}
+
 		private void TryLoadMoreItems() => TryLoadMoreItems(NativePanel.NativeLayout.LastVisibleIndex);
+
+		partial void CleanUpNativePanel(NativeListViewBase panel);
 	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOSAndroid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOSAndroid.cs
@@ -43,10 +43,8 @@ namespace Windows.UI.Xaml.Controls
 			// NativePanel may not exist if we're using a non-virtualizing ItemsPanel.
 			if (NativePanel != null)
 			{
-				NativePanel.XamlParent = this;
 				// Propagate the DataContext manually, since ItemsPanelRoot isn't really part of the visual tree
 				ItemsPanelRoot.SetValue(DataContextProperty, DataContext, DependencyPropertyValuePrecedences.Inheritance);
-				InitializeNativePanel();
 
 				if (ScrollViewer?.Style?.Precedence == DependencyPropertyValuePrecedences.ImplicitStyle)
 				{
@@ -75,12 +73,16 @@ namespace Windows.UI.Xaml.Controls
 			var virtualizingPanel = itemsPanel as IVirtualizingPanel;
 			if (virtualizingPanel != null)
 			{
-				var internalPanel = new NativeListViewBase();
 				var layouter = virtualizingPanel.GetLayouter();
 				PrepareNativeLayout(layouter);
-				internalPanel.NativeLayout = layouter;
-				internalPanel.BindToEquivalentProperty(virtualizingPanel, "Background");
-				return internalPanel;
+
+				var panel = new NativeListViewBase();
+				panel.XamlParent = this;
+				panel.NativeLayout = layouter;
+				panel.BindToEquivalentProperty(virtualizingPanel, "Background");
+				InitializeNativePanel(panel);
+
+				return panel;
 			}
 			else
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #1354

## PR Type
- Bugfix

## What is the current behavior?
On android, when `ListView.ItemsPanel` changes, the newly created native panel doesn't have its adapter is initialized in time (or at all). This cause the `Recycler.State` to go out of sync with the actual items inside the list-view which results in an app crash.

## What is the new behavior?
No crash.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
This app crash at launch with:
```
Java.Lang.IllegalStateException: View with id -1: md53236df40a47f0df12473f710f43d224f.NativeListViewBase#onMeasure() did not set the measured dimension by calling setMeasuredDimension()
```
The real exception is actually swallowed by: `RaiseRecoverableUnhandledExceptionOrLog` in `VirtualizingPanelLayout.OnMeasure`:
```
		{System.IndexOutOfRangeException: Invalid item position (0). Item count:0
		at Uno.UI.Extensions.RecyclerExtensions.GetViewForPosition (Android.Support.V7.Widget.RecyclerView+Recycler recycler, System.Int32 position, Android.Support.V7.Widget.RecyclerView+State state) [0x00019] in D:\code\framework\uno\src\Uno.UI\Extensions\RecyclerExtensions.Android.cs:18 
		at Windows.UI.Xaml.Controls.ItemsStackPanelLayout.CreateLine (Windows.UI.Xaml.Controls.Primitives.GeneratorDirection direction, System.Int32 extentOffset, System.Int32 breadthOffset, System.Int32 availableBreadth, Android.Support.V7.Widget.RecyclerView+Recycler recycler, Android.Support.V7.Widget.RecyclerView+State state, Uno.UI.IndexPath nextVisibleItem, System.Boolean isNewGroup) [0x0000a] in D:\code\framework\uno\src\Uno.UI\UI\Xaml\Controls\ItemsStackPanel\ItemsStackPanelLayout.Android.cs:29 
		at Windows.UI.Xaml.Controls.VirtualizingPanelLayout.AddLine (Windows.UI.Xaml.Controls.Primitives.GeneratorDirection fillDirection, System.Int32 availableBreadth, Android.Support.V7.Widget.RecyclerView+Recycler recycler, Android.Support.V7.Widget.RecyclerView+State state, Uno.UI.IndexPath nextVisibleItem) [0x00009] in D:\code\framework\uno\src\Uno.UI\UI\Xaml\Controls\ListViewBase\VirtualizingPanelLayout.Android.cs:1230 
		at Windows.UI.Xaml.Controls.VirtualizingPanelLayout.TryCreateLine (Windows.UI.Xaml.Controls.Primitives.GeneratorDirection fillDirection, System.Int32 scrollOffset, System.Int32 availableExtent, System.Int32 availableBreadth, Android.Support.V7.Widget.RecyclerView+Recycler recycler, Android.Support.V7.Widget.RecyclerView+State state, Uno.UI.IndexPath nextVisibleItem) [0x0002e] in D:\code\framework\uno\src\Uno.UI\UI\Xaml\Controls\ListViewBase\VirtualizingPanelLayout.Android.cs:1197 
		at Windows.UI.Xaml.Controls.VirtualizingPanelLayout.FillLayout (Windows.UI.Xaml.Controls.Primitives.GeneratorDirection direction, System.Int32 scrollOffset, System.Int32 availableExtent, System.Int32 availableBreadth, Android.Support.V7.Widget.RecyclerView+Recycler recycler, Android.Support.V7.Widget.RecyclerView+State state) [0x00230] in D:\code\framework\uno\src\Uno.UI\UI\Xaml\Controls\ListViewBase\VirtualizingPanelLayout.Android.cs:1155 
		at Windows.UI.Xaml.Controls.VirtualizingPanelLayout.UpdateLayout (Windows.UI.Xaml.Controls.Primitives.GeneratorDirection direction, System.Int32 availableExtent, System.Int32 availableBreadth, Android.Support.V7.Widget.RecyclerView+Recycler recycler, Android.Support.V7.Widget.RecyclerView+State state, System.Boolean isMeasure) [0x00099] in D:\code\framework\uno\src\Uno.UI\UI\Xaml\Controls\ListViewBase\VirtualizingPanelLayout.Android.cs:1016 
		at Windows.UI.Xaml.Controls.VirtualizingPanelLayout.OnMeasure (Android.Support.V7.Widget.RecyclerView+Recycler recycler, Android.Support.V7.Widget.RecyclerView+State state, System.Int32 widthSpec, System.Int32 heightSpec) [0x00047] in D:\code\framework\uno\src\Uno.UI\UI\Xaml\Controls\ListViewBase\VirtualizingPanelLayout.Android.cs:384 }
```
While the exception is correct, it was based on an incorrect state. Because while `state.ItemCount` is 0, `XamlParent.ItemsSource` indicates that the `Count` is 3. The native panel's `CurrentAdapter` is also null during the time of `onMeasure`, which shows that it has not been initialized.

Internal Issue (If applicable): https://nventive.visualstudio.com/Umbrella/_workitems/edit/160911