### PR TITLE
Add support of Invalidate on WriteableBitmap

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/AppInitializer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/AppInitializer.cs
@@ -94,6 +94,7 @@ namespace SamplesApp.UITests
 					.ScreenShotsPath(TestContext.CurrentContext.TestDirectory)
 #if DEBUG
 					.Headless(false)
+					.SeleniumArgument("--remote-debugging-port=9222")
 #endif
 					.StartApp();
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
+{
+	[TestFixture]
+	public partial class UnoSamples_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Android, Platform.Browser)]
+		public void WriteableBitmap_Invalidate()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ImageTests.ImageSourceWriteableBitmapInvalidate");
+
+			// Request to render
+			var button = _app.Marked("_update");
+			_app.WaitForElement(button);
+			button.Tap();
+
+			// Take screenshot
+			_app.Screenshot("WriteableBitmap_Invalidate - Result");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1189,6 +1189,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\ImageSourceWriteableBitmapInvalidate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\Slider_Transformed.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4472,5 +4476,10 @@
     <Folder Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ChatBox\" />
     <Folder Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\Models\" />
     <Folder Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\Model\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\ImageSourceWriteableBitmapInvalidate.xaml.cs">
+      <DependentUpon>ImageSourceWriteableBitmapInvalidate.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceWriteableBitmapInvalidate.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceWriteableBitmapInvalidate.xaml
@@ -1,0 +1,28 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ImageTests.ImageSourceWriteableBitmapInvalidate"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ImageTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+		<Button
+			x:Name="_update"
+			Content="Update writeable image source"
+			Click="UpdateSource" />
+
+		<TextBlock
+			TextWrapping="Wrap"
+			Text="When you click on the button, the writable bitmap (set as source of the image in the orange square bellow) is updated and invalidated. This test makes sure that it appears properly without updating the source on the Image control itself." />
+
+		<Border BorderBrush="Orange"
+				BorderThickness="3"
+				Width="206"
+				Height="206">
+			<Image x:Name="_image" />
+		</Border>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceWriteableBitmapInvalidate.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceWriteableBitmapInvalidate.xaml.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Windows.Storage.Streams;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Imaging;
+using Uno.UI.Samples.Controls;
+
+#if NETFX_CORE
+using System.Runtime.InteropServices.WindowsRuntime;
+#endif
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ImageTests
+{
+	[SampleControlInfo(category: "Image", controlName: nameof(ImageSourceWriteableBitmapInvalidate))]
+	public sealed partial class ImageSourceWriteableBitmapInvalidate : Page
+	{
+		private WriteableBitmap _bitmap;
+
+		public ImageSourceWriteableBitmapInvalidate()
+		{
+			this.InitializeComponent();
+
+			_bitmap = new WriteableBitmap(200, 200);
+			_image.Source = _bitmap;
+		}
+
+		private void UpdateSource(object sender, RoutedEventArgs e)
+		{
+#if NETFX_CORE
+			using (var data = _bitmap.PixelBuffer.AsStream())
+			{
+				// Half of the image in green, alpha 100% (bgra buffer)
+				var pixel = new byte[] {0, 255, 0, 255};
+				for (var i = 1; i < data.Length / 2; i += 4)
+				{
+					data.Write(pixel, 0, 4);
+				}
+				data.Flush();
+			}
+#else
+			if (_bitmap.PixelBuffer is InMemoryBuffer buffer
+				&& buffer.GetType().GetProperty("Data", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(buffer) is byte[] data)
+			{
+				// Half of the image in green, alpha 100% (bgra buffer)
+				for (var i = 1; i < data.Length / 2; i += 2)
+				{
+					data[i] = byte.MaxValue;
+				}
+			}
+#endif
+
+			// This request to the image to redraw the buffer
+			_bitmap.Invalidate();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
@@ -130,17 +130,31 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnSourceChanged(ImageSource oldValue, ImageSource newValue)
 		{
-			_sourceDisposable.Disposable =
-				Source?.RegisterDisposablePropertyChangedCallback(
-					BitmapImage.UriSourceProperty, (o, e) =>
-					{
-						if (!object.Equals(e.OldValue, e.NewValue))
+			if (newValue is WriteableBitmap wb)
+			{
+				wb.Invalidated += OnInvalidated;
+				_sourceDisposable.Disposable = Disposable.Create(() => wb.Invalidated -= OnInvalidated);
+
+				void OnInvalidated(object sdn, EventArgs args)
+				{
+					_openedImage = null;
+					TryOpenImage();
+				}
+			}
+			else
+			{
+				_sourceDisposable.Disposable =
+					Source?.RegisterDisposablePropertyChangedCallback(
+						BitmapImage.UriSourceProperty, (o, e) =>
 						{
-							_openedImage = null;
-							TryOpenImage(); 
+							if (!object.Equals(e.OldValue, e.NewValue))
+							{
+								_openedImage = null;
+								TryOpenImage();
+							}
 						}
-					}
-				);
+					);
+			}
 
 			TryOpenImage();
 		}

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.cs
@@ -1,3 +1,4 @@
+using System;
 using Windows.Foundation;
 using Windows.Storage.Streams;
 
@@ -5,6 +6,8 @@ namespace Windows.UI.Xaml.Media.Imaging
 {
 	public partial class WriteableBitmap : global::Windows.UI.Xaml.Media.Imaging.BitmapSource
 	{
+		internal event EventHandler Invalidated;
+
 		public global::Windows.Storage.Streams.IBuffer PixelBuffer { get; private set; }
 
 		public WriteableBitmap(int pixelWidth, int pixelHeight) : base()
@@ -17,7 +20,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 		public void Invalidate()
 		{
-
+			Invalidated?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #https://github.com/unoplatform/uno/issues/1490

## Feature/Bug fix
Add support of WriteableBitmap.Invalidate

## What is the current behavior?
WriteableBitmap.Invalidate does nothing

## What is the new behavior?
WriteableBitmap.Invalidate works

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
