### PR TITLE
fixed FormatException in DependencyPropertyDescriptor

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDescriptor.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDescriptor.cs
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml
 					{
 						if (typeof(DependencyPropertyDescriptor).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 						{
-							typeof(DependencyPropertyDescriptor).Log().DebugFormat("The property path [{0}] is not formatted properly (must only access one property)");
+							typeof(DependencyPropertyDescriptor).Log().DebugFormat($"The property path [{propertyPath}] is not formatted properly (must only access one property)");
 						}
 					}
 				}
@@ -83,7 +83,7 @@ namespace Windows.UI.Xaml
 				{
 					if (typeof(DependencyPropertyDescriptor).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 					{
-						typeof(DependencyPropertyDescriptor).Log().DebugFormat("The property path [{0}] is not formatted properly (must have exactly one ':')");
+						typeof(DependencyPropertyDescriptor).Log().DebugFormat($"The property path [{propertyPath}] is not formatted properly (must have exactly one ':')");
 					}
 				}
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
`FormatException` is thrown in `DependencyPropertyDescriptor.Parse`.

## What is the new behavior?
No exception.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information
```
Uno.UI.DataBinding.BindingPropertyHelper:
      GetValueGetter(Windows.UI.Xaml.UnsetValue, Models:PaneState) [Reflection]
Exception:

System.FormatException: Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
```