### PR TITLE
docs: added links to examples of Uno.UI.RequestedCustomTheme

### DIFF
--- a/doc/articles/api-differences.md
+++ b/doc/articles/api-differences.md
@@ -61,3 +61,7 @@ You can do something similar - an even create totally custom themes - by using t
 * Themed dictionaries will fall back to `Application.Current.RequestedTheme` when they are not
   defining a resource for the custom theme.
 * You can put any string and create totally custom themes, but they won't be supported by UWP.
+
+Themes [are implemented](https://calculator.platform.uno?Theme=Pink) in the Uno port of the Windows 10 calculator. See [App.xaml.cs](https://github.com/unoplatform/calculator/blob/7772a593b541edd9809bc8946ee29d6a5b29e0ff/src/Calculator.Shared/App.xaml.cs#L79) and  [Styles.xaml](https://github.com/unoplatform/calculator/blob/7772a593b541edd9809bc8946ee29d6a5b29e0ff/src/Calculator.Shared/Styles.xaml).
+
+


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

No links to examples.

## What is the new behavior?

Links to implementation and wasm website to try it out.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)


