### PR TITLE
Dismissible popup various fixes

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -57,6 +57,7 @@
 * Relax DependencyProperty owner validation for non-FrameworkElement
 * `ToolTip` & `ToolTipService` are now implemented.
 * [#1352](https://github.com/unoplatform/uno/issues/1352) Add support for `ThemeResource`s with different types (eg: mixing `SolidColorBrush` and `LinearGradientBrush`)
+* `Popup` & `ComboBox` (and other controls using `Popup`) were not behaving properly when `IsLightDismissable` were set to `true`.
 
 ### Breaking changes
 * `TextBox` no longer raises TextChanged when its template is applied, in line with UWP.

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
+{
+	public class UnoSamples_Popup_Simple_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry()]
+		public void DismissiblePopup()
+		{
+			Run("Uno.UI.Samples.Content.UITests.Popup.Popup_Simple");
+
+			_app.WaitForElement(_app.Marked("sampleContent"));
+
+			_app.Wait(0.15f);
+
+			var toggleButton = _app.Marked("TogglePopup");
+
+			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", "False");
+
+			toggleButton.Tap();
+
+			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", "True");
+
+			var popupContent = _app.Marked("popupContent");
+
+			_app.WaitForElement(popupContent);
+
+			popupContent.Tap();
+
+			_app.Wait(0.25f);
+
+			_app.WaitForElement(popupContent); // should remain opened
+
+			var screenRect = _app.Marked("sampleContent").FirstResult().Rect;
+
+			_app.TapCoordinates(10, screenRect.Bottom - 10); // click elsewhere on the page
+
+			for (var i = 0; i < 5; i++)
+			{
+				if (_app.Marked("popupContent").FirstResult() == null)
+				{
+					return; // dismissed!
+				}
+
+				_app.Wait(i * 0.15f);
+			}
+
+			Assert.Fail("Popup not dismissed.");
+		}
+
+		[Test]
+		[AutoRetry()]
+		public void NonDismissiblePopup()
+		{
+			Run("Uno.UI.Samples.Content.UITests.Popup.Popup_Simple");
+
+			_app.WaitForElement(_app.Marked("sampleContent"));
+
+			_app.Wait(0.15f);
+
+			var toggleButton = _app.Marked("TogglePopup2");
+
+			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", "False");
+
+			toggleButton.Tap();
+
+			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", "True");
+
+			var popupContent = _app.Marked("popupContent2");
+
+			_app.WaitForElement(popupContent);
+
+			popupContent.Tap();
+
+			_app.Wait(0.25f);
+
+			_app.WaitForElement(popupContent); // should remain opened
+
+			var screenRect = _app.Marked("sampleContent").FirstResult().Rect;
+
+			_app.TapCoordinates(10, screenRect.Bottom - 10); // click elsewhere on the page
+
+			_app.Wait(0.25f);
+
+			_app.WaitForElement(popupContent); // should remain opened
+
+			_app.Wait(0.25f);
+
+			toggleButton.Tap(); // should dismiss here
+
+			for (var i = 0; i < 5; i++)
+			{
+				if (_app.Marked("popupContent2").FirstResult() == null)
+				{
+					return; // dismissed!
+				}
+
+				_app.Wait(i * 0.15f);
+			}
+
+			Assert.Fail("Popup not dismissed.");
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
@@ -24,11 +24,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 
 			var toggleButton = _app.Marked("TogglePopup");
 
-			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", "False");
+			var v = toggleButton.GetDependencyPropertyValue("IsChecked");
+
+
+
+			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", false);
 
 			toggleButton.Tap();
 
-			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", "True");
+			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", true);
 
 			var popupContent = _app.Marked("popupContent");
 
@@ -69,11 +73,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 
 			var toggleButton = _app.Marked("TogglePopup2");
 
-			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", "False");
+			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", false);
 
 			toggleButton.Tap();
 
-			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", "True");
+			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", true);
 
 			var popupContent = _app.Marked("popupContent2");
 
@@ -107,7 +111,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 				_app.Wait(i * 0.15f);
 			}
 
-			Assert.Fail("Popup not dismissed.");
+			Assert.Fail("Popup not dismissed."); // this feature is known to fail on Android
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Simple.xaml
@@ -8,58 +8,70 @@
 	xmlns:ios="http://nventive.com/ios"
 	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:android="http://nventive.com/android"
+	xmlns:toolTip="using:UITests.Shared.Windows_UI_Xaml_Controls.ToolTip"
 	mc:Ignorable="d ios android"
 	d:DesignHeight="2000"
 	d:DesignWidth="400">
 
-	<controls:SampleControl SampleDescription="Description for sample of Popup_Simple">
-		<controls:SampleControl.SampleContent>
-			<DataTemplate>
-				<StackPanel>
-					<!-- Insert your code sample here -->
-					<TextBlock Text="This Toggle Button should open a Dismissible Popup" />
-					<ToggleButton x:Name="TogglePopup">TOGGLE OPEN/CLOSE</ToggleButton>
-					<Popup IsOpen="{Binding IsChecked, ElementName=TogglePopup, Mode=TwoWay}"
-						    HorizontalOffset="200"
-						   VerticalOffset="200"
-						   IsLightDismissEnabled="True">
-						<Popup.Child>
-							<Border Height="100"
-									Width="150"
-									Background="Red">
-								<TextBlock Text="Clicking here shouldn't dismiss the Popup!" TextWrapping="WrapWholeWords" Foreground="White" />
-							</Border>
-						</Popup.Child>
-					</Popup>
-					<TextBlock Text="This Toggle Button should open a NON-Dismissible Popup" />
-					<ToggleButton x:Name="TogglePopup2">TOGGLE OPEN/CLOSE</ToggleButton>
-					<Popup IsOpen="{Binding IsChecked, ElementName=TogglePopup2}"
-						   HorizontalOffset="300"
-						   VerticalOffset="300"
-						   IsLightDismissEnabled="False">
-						<Popup.Child>
-							<Border Height="100"
-									Width="150"
-									Background="Orange">
-								<TextBlock Text="Test" />
-							</Border>
-						</Popup.Child>
-					</Popup>
-					<TextBlock Text="This Toggle Button should open a Popup without fixed height" />
-					<ToggleButton x:Name="TogglePopup3">TOGGLE OPEN/CLOSE</ToggleButton>
-					<Popup IsOpen="{Binding IsChecked, ElementName=TogglePopup3, Mode=TwoWay}"
-						    HorizontalOffset="400"
-						   VerticalOffset="400"
-						   IsLightDismissEnabled="True">
-						<Popup.Child>
-							<Border Width="150"
-									Background="Blue">
-								<TextBlock Text="Test" Foreground="White" />
-							</Border>
-						</Popup.Child>
-					</Popup>
-				</StackPanel>
-			</DataTemplate>
-		</controls:SampleControl.SampleContent>
-	</controls:SampleControl>
+	<Grid x:Name="sampleContent">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<StackPanel>
+			<!-- Insert your code sample here -->
+			<TextBlock Text="This Toggle Button should open a Dismissible Popup" />
+			<ToggleButton x:Name="TogglePopup">TOGGLE OPEN/CLOSE</ToggleButton>
+			<Popup IsOpen="{Binding IsChecked, ElementName=TogglePopup, Mode=TwoWay}"
+			       HorizontalOffset="40"
+				   VerticalOffset="100"
+				   IsLightDismissEnabled="True"
+			       x:Name="popup">
+				<Popup.Child>
+					<Border Height="230"
+							Width="350"
+							Background="Red"
+							x:Name="popupContent">
+						<TextBlock>Clicking here shouldn't close the popup.</TextBlock>
+					</Border>
+				</Popup.Child>
+			</Popup>
+			<TextBlock Text="This Toggle Button should open a NON-Dismissible Popup" />
+			<ToggleButton x:Name="TogglePopup2">TOGGLE OPEN/CLOSE</ToggleButton>
+			<Popup IsOpen="{Binding IsChecked, ElementName=TogglePopup2, Mode=TwoWay}"
+				   HorizontalOffset="300"
+				   VerticalOffset="100"
+				   IsLightDismissEnabled="False">
+				<Popup.Child>
+					<StackPanel Height="100"
+							Width="150"
+							Background="Orange"
+							x:Name="popupContent2">
+						<TextBlock Text="Test" />
+						<ToggleButton IsChecked="{Binding IsChecked, ElementName=TogglePopup2, Mode=TwoWay}">X</ToggleButton>
+					</StackPanel>
+				</Popup.Child>
+			</Popup>
+			<TextBlock Text="This Toggle Button should open a dismissible Popup without fixed height" />
+			<ToggleButton x:Name="TogglePopup3">TOGGLE OPEN/CLOSE</ToggleButton>
+			<Popup IsOpen="{Binding IsChecked, ElementName=TogglePopup3, Mode=TwoWay}"
+				    HorizontalOffset="200"
+				   VerticalOffset="-50"
+				   IsLightDismissEnabled="True">
+				<Popup.Child>
+					<Border Width="150"
+							Background="Blue"
+							x:Name="popupContent3">
+						<TextBlock Text="Test" Foreground="White" />
+					</Border>
+				</Popup.Child>
+			</Popup>
+		</StackPanel>
+
+		<ScrollViewer Grid.Row="1">
+			<TextBlock x:Name="output" />
+		</ScrollViewer>
+	</Grid>
+
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Simple.xaml.cs
@@ -1,14 +1,53 @@
+using Windows.UI.Xaml;
 using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 
 namespace Uno.UI.Samples.Content.UITests.Popup
 {
-	[SampleControlInfo("Popup", "Popup_Simple")]
+	[SampleControlInfo("Popup", "Popup_Simple", description: "Description for sample of Popup_Simple")]
 	public sealed partial class Popup_Simple : UserControl
 	{
 		public Popup_Simple()
 		{
 			this.InitializeComponent();
+
+			Register(popup);
+			Register(sampleContent);
+
+			popupContent.Loaded += RegisterContent;
 		}
+
+		private void RegisterContent(object sender, RoutedEventArgs e)
+		{
+			var ctl = sender as FrameworkElement;
+			while(ctl != null)
+			{
+				Register(ctl);
+				Write($"{ctl}-registered, IsHitTestVisible={ctl.IsHitTestVisible}");
+				ctl = ctl.Parent as FrameworkElement;
+			}
+
+			popupContent.Loaded -= RegisterContent;
+		}
+
+		private void Register(FrameworkElement control)
+		{
+			void OnPressed(object sender, PointerRoutedEventArgs e)
+			{
+				Write($"{sender}-pressed {e.GetCurrentPoint(this).Position}");
+			}
+
+			void OnReleased(object sender, PointerRoutedEventArgs e)
+			{
+				Write($"{sender}-released {e.GetCurrentPoint(this).Position}");
+			}
+
+			control.PointerPressed += OnPressed;
+			control.PointerPressed += OnReleased;
+		}
+
+
+		private void Write(string msg) => output.Text += msg + "\n";
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Android.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Text;
 using static Android.Views.View;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -56,6 +57,8 @@ namespace Windows.UI.Xaml.Controls
 				newPanel.PointerPressed += Panel_PointerPressed;
 			}
 			_popupWindow.ContentView = newPanel;
+
+			UpdatePopupPanelDismissibleBackground(IsLightDismissEnabled);
 		}
 
 		private void OnPopupDismissed(object sender, EventArgs e)
@@ -73,7 +76,10 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else
 			{
-				_popupWindow.Dismiss();
+				if(_popupWindow.IsShowing)
+				{
+					_popupWindow.Dismiss();
+				}
 				PopupPanel.Visibility = Visibility.Collapsed;
 			}
 		}
@@ -108,6 +114,26 @@ namespace Windows.UI.Xaml.Controls
 				_popupWindow.OutsideTouchable = false;
 
 				_popupWindow.SetBackgroundDrawable(null);
+			}
+
+			UpdatePopupPanelDismissibleBackground(newIsLightDismissEnabled);
+		}
+
+		private void UpdatePopupPanelDismissibleBackground(bool isLightDismiss)
+		{
+			var popupPanel = PopupPanel;
+			if (popupPanel == null)
+			{
+				return; // nothing to do
+			}
+
+			if (isLightDismiss)
+			{
+				PopupPanel.Background = new SolidColorBrush(Colors.Transparent);
+			}
+			else
+			{
+				PopupPanel.Background = null;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
@@ -157,7 +157,12 @@ namespace Windows.UI.Xaml.Controls
 				{
 					if (this.IsLightDismissEnabled)
 					{
+						PopupPanel.Background = new SolidColorBrush(Colors.Transparent);
 						PopupPanel.PointerPressed += OnPointerPressed;
+					}
+					else
+					{
+						PopupPanel.Background = null;
 					}
 				}
 				else

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -34,6 +34,12 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		internal IDynamicPopupLayouter CustomLayouter { get; set; }
 
+		protected override void OnUnloaded()
+		{
+			IsOpen = false;
+			base.OnUnloaded();
+		}
+
 		/// <inheritdoc />
 		protected override Size MeasureOverride(Size availableSize)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Windows.Foundation;
+using Windows.UI.Xaml.Input;
 using Uno.Extensions;
 using Uno.UI.DataBinding;
 using Windows.UI.Xaml.Media;
@@ -82,6 +83,23 @@ namespace Windows.UI.Xaml.Controls
 
 			UpdateDataContext();
 			UpdateTemplatedParent();
+
+			if (oldChild is FrameworkElement ocfe)
+			{
+				ocfe.PointerPressed -= HandlePointerEvent;
+				ocfe.PointerReleased -= HandlePointerEvent;
+			}
+
+			if (newChild is FrameworkElement ncfe)
+			{
+				ncfe.PointerPressed += HandlePointerEvent;
+				ncfe.PointerReleased += HandlePointerEvent;
+			}
+		}
+
+		private void HandlePointerEvent(object sender, PointerRoutedEventArgs e)
+		{
+			e.Handled = true;
 		}
 
 		protected internal override void OnDataContextChanged(DependencyPropertyChangedEventArgs e)
@@ -138,7 +156,6 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsLightDismissEnabledChangedPartial(bool oldIsLightDismissEnabled, bool newIsLightDismissEnabled)
 		{
-
 		}
 	}
 }


### PR DESCRIPTION
# Bugfix

## What is the new behavior?
* iOS & Android:
  * Clicking outside a _dismissible popup_ were not closing it.
* Wasm:
  * Clicking in the content of a _dismissible popup_ were dismissing it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Internal Issues
* <https://github.com/unoplatform/private/issues/51>
* <https://github.com/unoplatform/private/issues/57>