### PR TITLE
Support for Launcher.QueryUriSupportAsync API

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## Next version
 ### Features
+* Support for `Launcher.QueryUriSupportAsync` method on Android and iOS
 * [#1493](https://github.com/unoplatform/uno/pull/1493) - Implemented the `Windows.Input.PointerUpdateKind` Enum.
 *  [#1428](https://github.com/unoplatform/uno/issues/1428) - Add support for horizontal progressbars to `BindableProgressBar` on Android.
 * Add support for `Windows.Devices.Sensors.Magnetometer` APIs on iOS, Android and WASM

--- a/doc/articles/features/windows-system.md
+++ b/doc/articles/features/windows-system.md
@@ -1,0 +1,7 @@
+# Uno Support for Windows.System APIs
+
+## `Launcher`
+
+`LaunchUriAsync` is supported on iOS, Android and WASM.
+
+`QueryUriSupportAsync` is supported on iOS and Android and the implementation does not respect the  `LaunchQuerySupportType` parameter yet.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_Launcher.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_Launcher.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__ || __IOS__ || __UWP__
+﻿#if __ANDROID__ || __IOS__ || NETFX_CORE
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_Launcher.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_Launcher.cs
@@ -1,0 +1,37 @@
+﻿#if __ANDROID__ || __IOS__ || __UWP__
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.System;
+using Windows.UI.StartScreen;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_StartScreen
+{
+	[TestClass]
+	public class Given_Launcher
+	{
+		[TestMethod]
+		public async Task When_Valid_Uri_Is_Queried()
+		{
+			var result = await Launcher.QueryUriSupportAsync(
+				new Uri("https://platform.uno"),
+				LaunchQuerySupportType.Uri);
+
+			Assert.AreEqual(LaunchQuerySupportStatus.Available, result);
+		}
+
+		[TestMethod]
+		public async Task When_Unsupported_Uri_Is_Queried()
+		{
+			var result = await Launcher.QueryUriSupportAsync(
+				new Uri("thisschemedefinitelydoesnotexist://helloworld"),
+				LaunchQuerySupportType.Uri);
+
+			Assert.AreEqual(LaunchQuerySupportStatus.NotSupported, result);
+		}
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_StartScreen/Given_JumpListItem.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_StartScreen/Given_JumpListItem.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__ || __IOS__ || __UWP__
+﻿#if __ANDROID__ || __IOS__ || NETFX_CORE
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System/LaunchQuerySupportStatus.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System/LaunchQuerySupportStatus.cs
@@ -2,25 +2,25 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || NET461 || __WASM__ || __MACOS__
+	#if false || false || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum LaunchQuerySupportStatus 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		Available,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		AppNotInstalled,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		AppUnavailable,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		NotSupported,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		Unknown,
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System/LaunchQuerySupportType.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System/LaunchQuerySupportType.cs
@@ -2,16 +2,16 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || NET461 || __WASM__ || __MACOS__
+	#if false || false || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum LaunchQuerySupportType 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		Uri,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		UriForResults,
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System/Launcher.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System/Launcher.cs
@@ -148,7 +148,7 @@ namespace Windows.System
 			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> Launcher.LaunchUriAsync(Uri uri, LauncherOptions options, ValueSet inputData) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.System.LaunchQuerySupportStatus> QueryUriSupportAsync( global::System.Uri uri,  global::Windows.System.LaunchQuerySupportType launchQuerySupportType)
 		{

--- a/src/Uno.UWP/System/LaunchQuerySupportStatus.cs
+++ b/src/Uno.UWP/System/LaunchQuerySupportStatus.cs
@@ -1,4 +1,4 @@
-﻿#if __MOBILE__
+﻿#if __ANDROID__ || __IOS__
 namespace Windows.System
 {
 	public enum LaunchQuerySupportStatus

--- a/src/Uno.UWP/System/LaunchQuerySupportStatus.cs
+++ b/src/Uno.UWP/System/LaunchQuerySupportStatus.cs
@@ -1,0 +1,13 @@
+﻿#if __MOBILE__
+namespace Windows.System
+{
+	public enum LaunchQuerySupportStatus
+	{
+		Available,
+		AppNotInstalled,
+		AppUnavailable,
+		NotSupported,
+		Unknown,
+	}
+}
+#endif

--- a/src/Uno.UWP/System/LaunchQuerySupportType.cs
+++ b/src/Uno.UWP/System/LaunchQuerySupportType.cs
@@ -1,4 +1,4 @@
-﻿#if __MOBILE__
+﻿#if __ANDROID__ || __IOS__
 namespace Windows.System
 {
 	public enum LaunchQuerySupportType

--- a/src/Uno.UWP/System/LaunchQuerySupportType.cs
+++ b/src/Uno.UWP/System/LaunchQuerySupportType.cs
@@ -1,0 +1,10 @@
+﻿#if __MOBILE__
+namespace Windows.System
+{
+	public enum LaunchQuerySupportType
+	{
+		Uri,
+		UriForResults,
+	}
+}
+#endif

--- a/src/Uno.UWP/System/Launcher.cs
+++ b/src/Uno.UWP/System/Launcher.cs
@@ -1,17 +1,16 @@
 ﻿#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Uno.Extensions;
 using Uno.Logging;
-using Windows.ApplicationModel;
 using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.Foundation.Metadata;
-using Windows.UI.Core;
 using Microsoft.Extensions.Logging;
+using System.Linq;
+#if __ANDROID__
+using Android.Content;
+using Android.Content.PM;
+#endif
 
 namespace Windows.System
 {
@@ -24,9 +23,15 @@ namespace Windows.System
 #if __IOS__
 				return UIKit.UIApplication.SharedApplication.OpenUrl(new global::Foundation.NSUrl(uri.OriginalString));
 #elif __ANDROID__
-				var androidUri = global::Android.Net.Uri.Parse(uri.OriginalString);
-				var intent = new global::Android.Content.Intent(global::Android.Content.Intent.ActionView, androidUri);
+				var androidUri = Android.Net.Uri.Parse(uri.OriginalString);
+				var intent = new Intent(Intent.ActionView, androidUri);
 
+				if ( Uno.UI.ContextHelper.Current == null)
+				{
+					throw new InvalidOperationException(
+						"LaunchUriAsync was called too early in application lifetime. " +
+						"App context needs to be initialized");
+				}
 				((Android.App.Activity)Uno.UI.ContextHelper.Current).StartActivity(intent);
 
 				return true;
@@ -34,6 +39,47 @@ namespace Windows.System
 				var command = $"Uno.UI.WindowManager.current.open(\"{uri.OriginalString}\");";
 				var result = Uno.Foundation.WebAssemblyRuntime.InvokeJS(command);
 				return result == "True";
+#else
+				throw new NotImplementedException();
+#endif
+			}
+			catch (Exception exception)
+			{
+				if (typeof(Launcher).Log().IsEnabled(LogLevel.Error))
+				{
+					typeof(Launcher).Log().Error($"Failed to {nameof(LaunchUriAsync)}.", exception);
+				}
+
+				return false;
+			}
+		}
+
+		public static IAsyncOperation<LaunchQuerySupportStatus> QueryUriSupportAsync(
+			Uri uri,
+			LaunchQuerySupportType launchQuerySupportType)
+		{
+			try
+			{
+#if __IOS__
+				
+#elif __ANDROID__
+				var androidUri = Android.Net.Uri.Parse(uri.OriginalString);
+				var intent = new Intent(Intent.ActionView, androidUri);
+
+				if (Uno.UI.ContextHelper.Current == null)
+				{
+					throw new InvalidOperationException(
+						"LaunchUriAsync was called too early in application lifetime. " +
+						"App context needs to be initialized");
+				}
+
+				var manager = Uno.UI.ContextHelper.Current.PackageManager;
+				var supportedResolvedInfos = manager.QueryIntentActivities(
+					intent,
+					PackageInfoFlags.MatchDefaultOnly);
+				var result = supportedResolvedInfos.Any() ?
+					LaunchQuerySupportStatus.Available : LaunchQuerySupportStatus.NotSupported;
+				return Task.FromResult(result).AsAsyncOperation();
 #else
 				throw new NotImplementedException();
 #endif

--- a/src/Uno.UWP/System/Launcher.cs
+++ b/src/Uno.UWP/System/Launcher.cs
@@ -7,9 +7,13 @@ using Uno.Logging;
 using Windows.Foundation;
 using Microsoft.Extensions.Logging;
 using System.Linq;
+using UIKit;
 #if __ANDROID__
 using Android.Content;
 using Android.Content.PM;
+#endif
+#if __IOS__
+using AppleUrl = global::Foundation.NSUrl;
 #endif
 
 namespace Windows.System
@@ -21,7 +25,8 @@ namespace Windows.System
 			try
 			{
 #if __IOS__
-				return UIKit.UIApplication.SharedApplication.OpenUrl(new global::Foundation.NSUrl(uri.OriginalString));
+				return UIKit.UIApplication.SharedApplication.OpenUrl(
+					new AppleUrl(uri.OriginalString));
 #elif __ANDROID__
 				var androidUri = Android.Net.Uri.Parse(uri.OriginalString);
 				var intent = new Intent(Intent.ActionView, androidUri);
@@ -54,45 +59,36 @@ namespace Windows.System
 			}
 		}
 
+#if __MOBILE__
 		public static IAsyncOperation<LaunchQuerySupportStatus> QueryUriSupportAsync(
 			Uri uri,
 			LaunchQuerySupportType launchQuerySupportType)
 		{
-			try
-			{
 #if __IOS__
-				
+			var canOpenUri = UIApplication.SharedApplication.CanOpenUrl(
+				new AppleUrl(uri.OriginalString));
 #elif __ANDROID__
-				var androidUri = Android.Net.Uri.Parse(uri.OriginalString);
-				var intent = new Intent(Intent.ActionView, androidUri);
+			var androidUri = Android.Net.Uri.Parse(uri.OriginalString);
+			var intent = new Intent(Intent.ActionView, androidUri);
 
-				if (Uno.UI.ContextHelper.Current == null)
-				{
-					throw new InvalidOperationException(
-						"LaunchUriAsync was called too early in application lifetime. " +
-						"App context needs to be initialized");
-				}
-
-				var manager = Uno.UI.ContextHelper.Current.PackageManager;
-				var supportedResolvedInfos = manager.QueryIntentActivities(
-					intent,
-					PackageInfoFlags.MatchDefaultOnly);
-				var result = supportedResolvedInfos.Any() ?
-					LaunchQuerySupportStatus.Available : LaunchQuerySupportStatus.NotSupported;
-				return Task.FromResult(result).AsAsyncOperation();
-#else
-				throw new NotImplementedException();
-#endif
-			}
-			catch (Exception exception)
+			if (Uno.UI.ContextHelper.Current == null)
 			{
-				if (typeof(Launcher).Log().IsEnabled(LogLevel.Error))
-				{
-					typeof(Launcher).Log().Error($"Failed to {nameof(LaunchUriAsync)}.", exception);
-				}
-
-				return false;
+				throw new InvalidOperationException(
+					"LaunchUriAsync was called too early in application lifetime. " +
+					"App context needs to be initialized");
 			}
+
+			var manager = Uno.UI.ContextHelper.Current.PackageManager;
+			var supportedResolvedInfos = manager.QueryIntentActivities(
+				intent,
+				PackageInfoFlags.MatchDefaultOnly);
+			var canOpenUri = supportedResolvedInfos.Any();
+#endif
+			var supportStatus = canOpenUri ?
+				LaunchQuerySupportStatus.Available : LaunchQuerySupportStatus.NotSupported;
+
+			return Task.FromResult(supportStatus).AsAsyncOperation();			
 		}
+#endif
 	}
 }

--- a/src/Uno.UWP/System/Launcher.cs
+++ b/src/Uno.UWP/System/Launcher.cs
@@ -7,12 +7,12 @@ using Uno.Logging;
 using Windows.Foundation;
 using Microsoft.Extensions.Logging;
 using System.Linq;
-using UIKit;
 #if __ANDROID__
 using Android.Content;
 using Android.Content.PM;
 #endif
 #if __IOS__
+using UIKit;
 using AppleUrl = global::Foundation.NSUrl;
 #endif
 
@@ -59,7 +59,7 @@ namespace Windows.System
 			}
 		}
 
-#if __MOBILE__
+#if __ANDROID__ || __IOS__
 		public static IAsyncOperation<LaunchQuerySupportStatus> QueryUriSupportAsync(
 			Uri uri,
 			LaunchQuerySupportType launchQuerySupportType)


### PR DESCRIPTION
GitHub Issue (If applicable): #1511 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

API not supported

## What is the new behavior?

API supported on iOS and Android. WASM does not support such check at this moment.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)