### PR TITLE
Fix Navigation Issue Where SystemNavigationManager.enable() is called twice

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -67,6 +67,7 @@
 * Projects targeting Android 9 must now use Xamarin.GooglePlayServices.* 71.1600.0
 
 ### Bug fixes
+* [WASM] #1518 Fix Navigation Issue Where SystemNavigationManager.enable() is called twice and clear the stack history
 * [#1278](https://github.com/unoplatform/uno/pull/1278) the XAML sourcegenerator now always uses the fully qualified type name to prevent type conflicts.
 * [#1392](https://github.com/unoplatform/uno/pull/1392) Resolved exceptions while changing cursor color on Android P.
 * [#1383](https://github.com/unoplatform/uno/pull/1383) resolve Android compilation errors related to Assets filenames: "Invali`d file name: It must contain only"

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -2156,7 +2156,7 @@ var Windows;
                         }
                         else if (evt.state === 1) {
                             // The manager is disabled, but the user requested to navigate forward to our dummy entry,
-                            // but we prefer to keep this dummy entry in teh forward stack (is more prompt to be cleared by the browser,
+                            // but we prefer to keep this dummy entry in the forward stack (is more prompt to be cleared by the browser,
                             // and as it's less commonly used it should be less annoying for the user)
                             window.history.back();
                         }
@@ -2169,6 +2169,9 @@ var Windows;
                     return this._current;
                 }
                 enable() {
+                    if (this._isEnabled) {
+                        return;
+                    }
                     // Clear the back stack, so the only items will be ours (and we won't have any remaining forward item)
                     this.clearStack();
                     window.history.pushState(1, document.title, null);
@@ -2176,6 +2179,9 @@ var Windows;
                     this._isEnabled = true;
                 }
                 disable() {
+                    if (!this._isEnabled) {
+                        return;
+                    }
                     // Disable the handler, then clear the history
                     // Note: As a side effect, the forward button will be enabled :(
                     this._isEnabled = false;

--- a/src/Uno.UI.Wasm/ts/Windows/UI.Core/SystemNavigationManager.ts
+++ b/src/Uno.UI.Wasm/ts/Windows/UI.Core/SystemNavigationManager.ts
@@ -27,7 +27,7 @@
 					dispatchBackRequest();
 				} else if (evt.state === 1) {
 					// The manager is disabled, but the user requested to navigate forward to our dummy entry,
-					// but we prefer to keep this dummy entry in teh forward stack (is more prompt to be cleared by the browser,
+					// but we prefer to keep this dummy entry in the forward stack (is more prompt to be cleared by the browser,
 					// and as it's less commonly used it should be less annoying for the user)
 					window.history.back();
 				}
@@ -35,6 +35,10 @@
 		}
 
 		public enable(): void {
+			if (this._isEnabled) {
+				return;
+			}
+
 			// Clear the back stack, so the only items will be ours (and we won't have any remaining forward item)
 			this.clearStack();
 			window.history.pushState(1, document.title, null);
@@ -44,6 +48,9 @@
 		}
 
 		public disable(): void {
+			if (!this._isEnabled) {
+				return;
+			}
 
 			// Disable the handler, then clear the history
 			// Note: As a side effect, the forward button will be enabled :(

--- a/src/Uno.UWP/UI/Core/SystemNavigationManager.cs
+++ b/src/Uno.UWP/UI/Core/SystemNavigationManager.cs
@@ -31,6 +31,11 @@ namespace Windows.UI.Core
 			get => _appViewBackButtonVisibility;
 			set
 			{
+				if (_appViewBackButtonVisibility == value)
+				{
+					return;
+				}
+
 				_appViewBackButtonVisibility = value;
 				AppViewBackButtonVisibilityChanged?.Invoke(this, _appViewBackButtonVisibility);
 				OnAppViewBackButtonVisibility(value);


### PR DESCRIPTION
Fix Issue Where SystemNavigationManager.enable() is called two time during navigation.uring navigation.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://github.com/unoplatform/private/issues/60
## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
During navigation request, the 
SystemNavigationManager.enable() is called two time, this raises SystemNavigationManager.GetForCurrentView().BackRequested, this may cause the app to lose their navigation stack.

## What is the new behavior?
SystemNavigationManager.enable() will be hit only if SystemNavigationManager.Disable() has been hit first for the new page in the stack.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
