### PR TITLE
force itempresenter to load on TemplateParentChanged()

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -112,6 +112,7 @@
 * Fix layout bug in Image control.
 * [#1387] `ComboBox`: Fix DataContext was propagated to `<ContentPresenter>` when there was no selected item, causing strange display behavior.
 * #1354 fixed Recycler.State desync issue
+* [iOS(iPad)] `ComboBox` : the combobox wasn't fully expanding vertically on first opening.
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/SamplesApp.iOS/Info.plist
+++ b/src/SamplesApp/SamplesApp.iOS/Info.plist
@@ -10,8 +10,6 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
 	<key>MinimumOSVersion</key>
 	<string>9.0</string>
 	<key>UIDeviceFamily</key>

--- a/src/SamplesApp/SamplesApp.iOS/Info.plist
+++ b/src/SamplesApp/SamplesApp.iOS/Info.plist
@@ -10,6 +10,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
 	<key>MinimumOSVersion</key>
 	<string>9.0</string>
 	<key>UIDeviceFamily</key>

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ComboBoxTests/Given_ComboBox.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ComboBoxTests/Given_ComboBox.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml;
+using Uno.UI.Tests.App.Xaml;
+using System.Windows.Data;
+
+namespace Uno.UI.Tests.ComboBoxTests
+{
+	[TestClass]
+    public class Given_ComboBox
+    {
+		[TestMethod]
+		public void When_ComboBox_Is_First_Opening()
+		{
+			var itemsPresenter = new ItemsPresenter();
+
+			var popup = new PopupBase()
+			{
+				Child = itemsPresenter
+			};
+
+			var grid = new Grid()
+			{
+				Children =
+				{
+					popup.Name<PopupBase>("Popup"),
+					new Border().Name<Border>("PopupBorder")
+				}
+			};
+
+			var style = new Style(typeof(ComboBox))
+			{
+				Setters =  {
+					new Setter<ComboBox>("Template", t =>
+						t.Template = Funcs.Create(() => grid)
+					)
+				}
+			};
+
+			const int initialCount = 10;
+			var array = Enumerable.Range(0, initialCount).Select(i => i * 10).ToArray();
+			var source = new CollectionViewSource
+			{
+				Source = array
+			};
+
+			var view = source.View;
+
+			var comboBox = new ComboBox()
+			{
+				Style = style,
+				ItemsSource = view
+			};
+
+			comboBox.IsDropDownOpen = true;
+
+			Assert.IsNotNull(comboBox.InternalItemsPanelRoot);
+			Assert.IsNotNull(comboBox.ItemsPanelRoot);
+		}
+    }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -312,6 +312,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsDropDownOpenChangedPartial(bool oldIsDropDownOpen, bool newIsDropDownOpen)
 		{
+			// This method will load the itempresnter children
+			SetItemsPresenter(_popup.Child.FindFirstChild<ItemsPresenter>());
+
 			if (_popup != null)
 			{
 				_popup.IsOpen = newIsDropDownOpen;

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.net.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.net.cs
@@ -49,6 +49,11 @@ namespace Windows.UI.Xaml
 			return _children.FirstOrDefault();
 		}
 
+		public T FindFirstChild<T>()  where T : View
+		{
+			return _children.OfType<T>().FirstOrDefault<T>();
+		}
+
 		public virtual IEnumerable<View> GetChildren()
 		{
 			return _children;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

ItemPresenter doesn't load his children right away. Certain Control such as ComboBox (with popover) to not fully expand vertically.

## What is the new behavior?

ItemPresenter and his children are loaded on template changed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
Internal Issue (If applicable):
https://dev.azure.com/nventive/JeanCoutu/_sprints/backlog/JeanCoutu%20Team/JeanCoutu/4.16/%5B4.16%5D%20Sprint%200.1?workitem=160030

