### PR TITLE
Correction to #if condition

### DIFF
--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -200,7 +200,7 @@ namespace Uno.UI
 			/// Defines the default font to be used when displaying symbols, such as in SymbolIcon.
 			/// </summary>
 			public static string SymbolsFont { get; set; } =
-#if !ANDROID
+#if !__ANDROID__
 			"Symbols";
 #else
 			"ms-appx:///Assets/Fonts/winjs-symbols.ttf#Symbols";


### PR DESCRIPTION
It solves #1332 (at least partially) - correct font used by SymbolIcon, used by AppBarButton, on Android.

GitHub Issue (If applicable): #1332

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Bad font is used on Android (Symbol).

## What is the new behavior?
Correct font is used.

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
Sorry, not - too little memory on my PC, but I created small project with AppBarButton with appriopriate font name and it works.
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Other information

Internal Issue (If applicable):
