### PR TITLE
Add handler for DateSet event

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.Android.cs
@@ -41,6 +41,7 @@ namespace Windows.UI.Xaml.Controls
             _dialog.DatePicker.MaxDate = maxYearCalendar.TimeInMillis;
 
 			_dialog.DismissEvent += OnDismiss;
+			_dialog.DateSet += OnDateSet;
             _dialog.Show();
         }
 


### PR DESCRIPTION
Seems like method OnDateSet is not referenced. And, when using DatePicker, there is no change in DatePicker.Date after changing date.

GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?
- Bugfix [probably]

## What is the current behavior?
When DatePicker is used to change date, no DateChanged is fired, and Date member is not changed.

## What is the new behavior?
Date member should be changed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
Sorry, not - too little memory on my PC to build Uno.

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information

Internal Issue (If applicable):
