### PR TITLE
"Uri too long" after webView.NavigateToString

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
@@ -301,7 +301,10 @@ namespace Windows.UI.Xaml.Controls
 					IsSuccess = _webViewSuccess,
 					WebErrorStatus = _webErrorStatus
 				};
-				if(url != null && url != "") args.Uri = new Uri(url);
+				if(!string.IsNullOrEmpty(url))
+				{
+				    args.Uri = new Uri(url);
+				}
 
 				_webView.NavigationCompleted?.Invoke(_webView, args);
 				base.OnPageFinished(view, url);

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
@@ -299,9 +299,9 @@ namespace Windows.UI.Xaml.Controls
 				var args = new WebViewNavigationCompletedEventArgs()
 				{
 					IsSuccess = _webViewSuccess,
-					Uri = new Uri(url),
 					WebErrorStatus = _webErrorStatus
 				};
+				if(url != null && url != "") args.Uri = new Uri(url);
 
 				_webView.NavigationCompleted?.Invoke(_webView, args);
 				base.OnPageFinished(view, url);


### PR DESCRIPTION
GitHub Issue (If applicable): #1527

## PR Type
- Bugfix

## What is the current behavior?
After webView.NavigateToString, code fails with Invalid URI: The Uri string is too long

## What is the new behavior?
Should not fail.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X ] Tested code with current [supported SDKs](../README.md#supported)
Sorry, not - too little memory on my PC to build Uno (only 6 GB)

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information
