### PR TITLE
Fix Index is Greater than the items available from a VirtualizePanelAdaptater for WASM

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -69,6 +69,7 @@
 * Projects targeting Android 9 must now use Xamarin.GooglePlayServices.* 71.1600.0
 
 ### Bug fixes
+* [#1531](https://github.com/unoplatform/uno/pull/1531)Fix an issue with VirtualizePanelAdaptater by adding a cache where the ItemSources lenght change and created a OutOfRangeException
 * [WASM] #1518 Fix Navigation Issue Where SystemNavigationManager.enable() is called twice and clear the stack history
 * [#1278](https://github.com/unoplatform/uno/pull/1278) the XAML sourcegenerator now always uses the fully qualified type name to prevent type conflicts.
 * [#1392](https://github.com/unoplatform/uno/pull/1392) Resolved exceptions while changing cursor color on Android P.

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
@@ -70,5 +70,16 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 				_app.Screenshot($"ListView_ItemPanel_HotSwap - {buttonName}");
 			}
 		}
+
+		[Test]
+		[AutoRetry]
+		public void ListView_VirtualizePanelAdaptaterCache()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ListView.ListView_VirtualizePanelAdaptaterCache");
+
+			var result = _app.Query(e => e.Text("Success"));
+
+			_app.Screenshot($"ListView_VirtualizePanelAdaptaterCache");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -297,6 +297,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_VirtualizePanelAdaptaterIdCache.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\RotatedListView_WithRotatedItems.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2590,6 +2594,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ItemsPanel_HotSwap.xaml.cs">
       <DependentUpon>ListView_ItemsPanel_HotSwap.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_VirtualizePanelAdaptaterIdCache.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\RotatedListView_WithRotatedItems.xaml.cs">
       <DependentUpon>RotatedListView_WithRotatedItems.xaml</DependentUpon>
     </Compile>
@@ -4460,6 +4465,12 @@
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\TextOnlyToolTipSample.xaml.cs">
       <DependentUpon>TextOnlyToolTipSample.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_VirtualizePanelAdaptaterIdCache.xaml.cs">
+      <DependentUpon>ListView_VirtualizePanelAdaptaterIdCache.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ItemDataContext.xaml.cs">
+      <DependentUpon>ComboBox_ItemDataContext.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_VirtualizePanelAdaptaterIdCache.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_VirtualizePanelAdaptaterIdCache.xaml
@@ -1,0 +1,34 @@
+﻿<UserControl
+    x:Class="SamplesApp.Windows_UI_Xaml_Controls.ListView.ListView_VirtualizePanelAdaptaterIdCache"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ListView"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock x:Name="TextResult" />
+		<Button x:Name="MyButton" Content="Change ItemSource"></Button>
+		<ListView Height="300"
+				  Width="230"
+				  Background="Gray"
+				  x:Name="MyListView"
+				  ItemsSource="{Binding LotsOfNumbers}">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<Border Height="25"
+							Width="50"
+							BorderBrush="Blue"
+							BorderThickness="1">
+						<TextBlock Text="{Binding}"
+								   VerticalAlignment="Center"
+								   FontSize="10" />
+					</Border>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_VirtualizePanelAdaptaterIdCache.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_VirtualizePanelAdaptaterIdCache.xaml.cs
@@ -1,0 +1,44 @@
+﻿using Uno;
+using Uno.UI.Samples.Controls;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Sample.Views.Helper;
+using System;
+using System.Collections.Generic;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfo("ListView", "ListView_VirtualizePanelAdaptaterCache", description: "Demonstrates the Id Items Cache When ItemSource Lenght change")]
+	public sealed partial class ListView_VirtualizePanelAdaptaterIdCache : UserControl
+	{
+		public List<int> LotsOfNumbers { get; } = Enumerable.Range(0, 500).ToList();
+
+		public ListView_VirtualizePanelAdaptaterIdCache()
+		{
+			this.InitializeComponent();
+			MyListView.ItemsSource = LotsOfNumbers;
+			MyButton.Click += (sender, e) =>
+			{
+				UpdateItemSource();
+			};
+		}
+
+		private void UpdateItemSource()
+		{
+			try
+			{
+				LotsOfNumbers.RemoveRange(10, 20);
+				MyListView.ItemsSource = LotsOfNumbers;
+				TextResult.Text = "Success";
+			}
+			catch (Exception ex)
+			{
+				TextResult.Text = "ItemSource Update Fails " + ex.Message;
+			}
+		}
+
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.wasm.cs
@@ -452,7 +452,7 @@ namespace Windows.UI.Xaml.Controls
 			ClearLines();
 
 			UpdateCompleted();
-
+			Generator.ClearIdCache();
 			OwnerPanel?.InvalidateMeasure();
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://github.com/unoplatform/private/issues/60
## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In WASM the index is superior to the VirtualizePanelAdaptater Item causing a OutofRangeException.
https://gist.github.com/ghuntley/90eb1a9af59c5be87a43df33323e059b

## What is the new behavior?
Verify if the Index is not bigger than the list's length
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
