### PR TITLE
Fix WASM ScrollViewer offsets parsing

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -5,6 +5,7 @@ using Windows.UI.Xaml.Data;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using Uno.Disposables;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -75,6 +76,11 @@ namespace Windows.UI.Xaml.Controls
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{
 				this.Log().LogDebug($"{HtmlId}: {offsetSize} / {clientSize} / {e.GetCurrentPoint()}");
+			}
+
+			if (!hasVerticalScroll && !hasHorizontalScroll)
+			{
+				return;
 			}
 
 			// The events coming from the scrollbars are bubbled up
@@ -203,9 +209,18 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnScroll(object sender, EventArgs args)
 		{
-			int.TryParse(GetProperty("scrollLeft"), out var horizontalOffset);
-			int.TryParse(GetProperty("scrollTop"), out var verticalOffset);
-			
+			var left = GetProperty("scrollLeft");
+			var top = GetProperty("scrollTop");
+
+			if (!double.TryParse(left, NumberStyles.Number, CultureInfo.InvariantCulture, out var horizontalOffset))
+			{
+				horizontalOffset = 0;
+			}
+			if (!double.TryParse(top, NumberStyles.Number, CultureInfo.InvariantCulture, out var verticalOffset))
+			{
+				verticalOffset = 0;
+			}
+
 			(TemplatedParent as ScrollViewer)?.OnScrollInternal(
 				horizontalOffset,
 				verticalOffset,


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/234

## BugFix
ScrollViewer offsets

## What is the current behavior?
Offsets are parssed as `int` but we often get a `double` so parsing fails and if fallbacks to 0, leading the managed `ScrollViewer` believe that offset are at 0 while the native is much lower.

## What is the new behavior?
Parsing works :)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ _Tests are in the ['iosTouches' feature branch](https://github.com/unoplatform/uno/pull/1256)_
- [ ] ~~[Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~ _Tests are in the ['iosTouches' feature branch](https://github.com/unoplatform/uno/pull/1256)_
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
