### PR TITLE
Prevent PivotPanel from returning "infinite" as desired height

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/PivotPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/PivotPanel.cs
@@ -30,19 +30,28 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				// Here we are bypassing the infinite width provided by the ScrollViewer of the Pivot's template
 				// and instead we are constraining the items to have the same width of the parent pivot so can be panned properly.
 
-				availableSize = new Size(Math.Min(availableSize.Width, scroll.ViewportMeasureSize.Width), availableSize.Height);
+				availableSize = new Size(
+					Math.Min(availableSize.Width, scroll.ViewportMeasureSize.Width),
+					availableSize.Height);
 			}
 
 			// Note: Here we should X-stack the items to allow the ScrollViewer to do its job
 			//		 however currently the Pivot is only changing the Visibility of the items,
 			//		 so we only have to Z-stack items and return the 'availableSize' (which actually disable the 'scroll' ScrollViewer)
 
-			foreach (var child in Children)
+			var maxHeight = 0d;
+			foreach (UIElement child in Children)
 			{
 				MeasureElement(child, availableSize);
+				if(child.DesiredSize.Height > maxHeight)
+				{
+					maxHeight = child.DesiredSize.Height;
+				}
 			}
-			
-			return availableSize;
+
+			return availableSize.Height > maxHeight
+				? new Size(availableSize.Width, maxHeight)
+				: availableSize;
 		}
 
 		/// <inheritdoc />


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## Bugfix
`PivotPanel` were returning the `availablesize`'s `Height` as desired height, which is invalid when the available size is infinite.

This was causing a crash.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
