### PR TITLE
Add missing assets link in dotnet new template

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
@@ -38,7 +38,7 @@
 		<!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-		<PackageReference Include="Uno.Xamarin.Forms.Platform" Version="4.1.0-uno.93" />
+		<PackageReference Include="Uno.Xamarin.Forms.Platform" Version="4.1.0-uno.104" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.302" />
 		<DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.0-dev.302" />
 	</ItemGroup>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoQuickStart.Wasm/UnoQuickStart.Wasm.csproj
@@ -11,6 +11,7 @@
 
 	<ItemGroup>
 		<Content Include="..\UnoQuickStart.UWP\Assets\*.png" Link="Assets\%(FileName)%(Extension)" />
+		<Content Include="..\UnoQuickStart.UWP\*.png" Link="%(FileName)%(Extension)" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Some assets are not linked properly in `dotnet new` 

## What is the new behavior?
Assets are now properly linked.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
