### PR TITLE
Added support for custom MarkupExtensions

### DIFF
--- a/.azure-devops-android-tests.yml
+++ b/.azure-devops-android-tests.yml
@@ -24,8 +24,7 @@ jobs:
     env:
       BUILD_SOURCESDIRECTORY: "$(build.sourcesdirectory)"
       BUILD_ARTIFACTSTAGINGDIRECTORY: "$(build.artifactstagingdirectory)"
-
-
+ 
   - task: PublishTestResults@2
     condition: always()
     inputs:

--- a/doc/articles/supported-features.md
+++ b/doc/articles/supported-features.md
@@ -120,6 +120,7 @@
 - XAML Behaviors
 - AttachedProperty Binding
 - AttachedProperty Styling
+- Custom `MarkupExtension` support
 - Brightness Control
 - Native and Custom dialogs
 - Support for StateTriggers

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2596,6 +2596,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Localization\Localization_Implicit.xaml.cs">
       <DependentUpon>Localization_Implicit.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\MarkupExtensionTests\Entity.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\MarkupExtensionTests\InverseBool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Properties\DataContextProperty.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\StyleTests\Style_Inline.xaml.cs">
       <DependentUpon>Style_Inline.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2528,7 +2528,7 @@
       <DependentUpon>BarometerTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\GyrometerTests.xaml.cs">
-	    <DependentUpon>GyrometerTests.xaml</DependentUpon>
+      <DependentUpon>GyrometerTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\MagnetometerTests.xaml.cs">
       <DependentUpon>MagnetometerTests.xaml</DependentUpon>
@@ -2598,6 +2598,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\MarkupExtensionTests\Entity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\MarkupExtensionTests\InverseBool.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\MarkupExtensionTests\MarkupExtensionBehaviors.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Properties\DataContextProperty.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\StyleTests\Style_Inline.xaml.cs">
       <DependentUpon>Style_Inline.xaml</DependentUpon>
@@ -4575,7 +4576,7 @@
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ItemDataContext.xaml.cs">
       <DependentUpon>ComboBox_ItemDataContext.xaml</DependentUpon>
     </Compile>
-	<Compile Update="$(MSBuildThisFileDirectory)Windows_Devices\GyrometerTests.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_Devices\GyrometerTests.xaml.cs">
       <DependentUpon>GyrometerTests.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\P\uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_MinYear.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/Entity.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/Entity.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Markup;
+
+namespace UITests.Shared.Windows_UI_Xaml.MarkupExtension
+{
+	[MarkupExtensionReturnType(ReturnType = typeof(EntityObject))]
+	public class Entity : Windows.UI.Xaml.Markup.MarkupExtension
+	{
+		public string TextValue { get; set; }
+
+		public int IntValue { get; set; }
+
+		protected override object ProvideValue()
+		{
+			return new EntityObject()
+			{
+				StringProperty = TextValue,
+				IntProperty = IntValue
+			};
+		}
+	}
+
+	public class EntityObject
+	{
+		public string StringProperty { get; set; } = string.Empty;
+
+		public int IntProperty { get; set; }
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/InverseBool.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/InverseBool.cs
@@ -14,12 +14,12 @@ namespace UITests.Shared.Windows_UI_Xaml.MarkupExtension
 
 		public object Convert(object value, Type targetType, object parameter, string language)
 		{
-			return !(bool)value;
+			return !(bool)(value ?? false);
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, string language)
 		{
-			return !(bool)value;
+			return !(bool)(value ?? false);
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/InverseBool.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/InverseBool.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Markup;
+
+namespace UITests.Shared.Windows_UI_Xaml.MarkupExtension
+{
+	[MarkupExtensionReturnType(ReturnType = typeof(IValueConverter))]
+	public class InverseBool : Windows.UI.Xaml.Markup.MarkupExtension, IValueConverter
+	{
+		protected override object ProvideValue() => this;
+
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			return !(bool)value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language)
+		{
+			return !(bool)value;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/MarkupExtension.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/MarkupExtension.xaml
@@ -4,6 +4,7 @@
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:ex="using:UITests.Shared.Windows_UI_Xaml.MarkupExtension"
+			 xmlns:beh="using:UITests.Shared.Windows_UI_Xaml.MarkupExtensionTests.Behaviors"
 			 mc:Ignorable="d"
 			 d:DesignHeight="300"
 			 d:DesignWidth="400">
@@ -15,24 +16,25 @@
 		<DataTemplate x:Key="MarkupDataTemplate"
 					  x:DataType="ex:EntityObject">
 			<StackPanel>
-				<TextBlock Text="{x:Bind StringProperty, Mode=OneWay}" />
-				<TextBlock Text="{x:Bind IntProperty, Mode=OneWay}" />
+				<TextBlock Text="{x:Bind StringProperty, Mode=OneWay}" FontSize="16" />
+				<TextBlock Text="{x:Bind IntProperty, Mode=OneWay}" FontSize="16" />
 
 				<!-- Make a markup extension inside a DataTemplate generates correctly -->
-				<TextBlock Text="{ex:Simple TextValue={StaticResource ResourceString2}}" />
+				<TextBlock Text="{ex:Simple TextValue={StaticResource ResourceString2}}" FontSize="16" />
 			</StackPanel>
 		</DataTemplate>
 	</UserControl.Resources>
 
 	<Grid>
 		<StackPanel Margin="8,0">
-			<TextBlock Text="Here's a simple use of a custom Markup Extension"
+			<TextBlock Text="Simple use of a custom Markup Extension"
 					   Foreground="Green" />
+			
 			<TextBlock Text="{ex:Simple TextValue='Just a simple ...'}"
 					   FontSize="16"
 					   Margin="0,0,0,40" />
 
-			<TextBlock Text="Here's a custom Markup Extension that sets a DataContext on the StackPanel"
+			<TextBlock Text="Custom Markup Extension that sets a DataContext on the StackPanel"
 					   TextWrapping="Wrap"
 					   Foreground="Green" />
 
@@ -44,7 +46,7 @@
 						   FontSize="16" />
 			</StackPanel>
 
-			<TextBlock Text="Here's a custom Markup Extension that is also used as a Converter"
+			<TextBlock Text="Custom Markup Extension that is also used as a Converter"
 					   Foreground="Green" />
 
 			<StackPanel x:Name="StackContainer"
@@ -57,11 +59,24 @@
 						   FontSize="16" />
 			</StackPanel>
 
-			<TextBlock Text="Here's a custom Markup Extension using a StaticResource:"
+			<TextBlock Text="Custom Markup Extension using a StaticResource"
 					   Foreground="Green" />
 
 			<ContentControl Content="{ex:Entity TextValue={StaticResource ResourceString1}, IntValue=123}"
-							ContentTemplate="{StaticResource MarkupDataTemplate}" />
+							ContentTemplate="{StaticResource MarkupDataTemplate}"
+							Margin="0,0,0,40"/>
+
+			<TextBlock Text="Attached Property using a custom Markup Extension"
+					   Foreground="Green" />
+
+			<TextBlock beh:MarkupExtensionBehaviors.CustomText="{ex:Simple TextValue='I am an Attached Property using a ...'}"
+					   FontSize="16" />
+
+			<TextBlock Text="Attached Property using a custom Markup Extension (with converter)"
+					   Foreground="Green" />
+
+			<TextBlock beh:MarkupExtensionBehaviors.CustomText="{Binding IsTapEnabled, ElementName=StackContainer, Converter={ex:InverseBool}}"
+					   FontSize="16" />
 		</StackPanel>
 	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/MarkupExtension.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/MarkupExtension.xaml
@@ -4,37 +4,64 @@
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:ex="using:UITests.Shared.Windows_UI_Xaml.MarkupExtension"
-			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 xmlns:ios="http://uno.ui/ios"
-			 xmlns:android="http://uno.ui/android"
-			 xmlns:wasm="http://uno.ui/wasm"
-			 mc:Ignorable="d ios android wasm"
+			 mc:Ignorable="d"
 			 d:DesignHeight="300"
 			 d:DesignWidth="400">
-	
+
 	<UserControl.Resources>
-		<Style x:Key="UnsupportedTextStyle"
-			   TargetType="TextBlock">
-			<Setter Property="Foreground"
-					Value="Red" />
-			<Setter Property="FontSize"
-					Value="16" />
-			<Setter Property="FontWeight"
-					Value="Bold" />
-			<Setter Property="Text"
-					Value="Feature not yet supported" />
-		</Style>
+		<x:String x:Key="ResourceString1">I'm a StaticResource, look for 123 below me...</x:String>
+		<x:String x:Key="ResourceString2">...and from within a DataTemplate I'm a custom ...</x:String>
+		
+		<DataTemplate x:Key="MarkupDataTemplate"
+					  x:DataType="ex:EntityObject">
+			<StackPanel>
+				<TextBlock Text="{x:Bind StringProperty, Mode=OneWay}" />
+				<TextBlock Text="{x:Bind IntProperty, Mode=OneWay}" />
+
+				<!-- Make a markup extension inside a DataTemplate generates correctly -->
+				<TextBlock Text="{ex:Simple TextValue={StaticResource ResourceString2}}" />
+			</StackPanel>
+		</DataTemplate>
 	</UserControl.Resources>
-	
+
 	<Grid>
-		<StackPanel>
+		<StackPanel Margin="8,0">
 			<TextBlock Text="Here's a simple use of a custom Markup Extension"
 					   Foreground="Green" />
-			<win:TextBlock Text="{ex:Simple TextValue='Just a simple ...'}"
-						   FontSize="20" />
-			<ios:TextBlock Style="{StaticResource UnsupportedTextStyle}" />
-			<android:TextBlock Style="{StaticResource UnsupportedTextStyle}" />
-			<wasm:TextBlock Style="{StaticResource UnsupportedTextStyle}" />
+			<TextBlock Text="{ex:Simple TextValue='Just a simple ...'}"
+					   FontSize="16"
+					   Margin="0,0,0,40" />
+
+			<TextBlock Text="Here's a custom Markup Extension that sets a DataContext on the StackPanel"
+					   TextWrapping="Wrap"
+					   Foreground="Green" />
+
+			<StackPanel DataContext="{ex:Entity TextValue='We should see the number 100 below:', IntValue=100}"
+						Margin="0,0,0,40">
+				<TextBlock Text="{Binding StringProperty}"
+						   FontSize="16" />
+				<TextBlock Text="{Binding IntProperty}"
+						   FontSize="16" />
+			</StackPanel>
+
+			<TextBlock Text="Here's a custom Markup Extension that is also used as a Converter"
+					   Foreground="Green" />
+
+			<StackPanel x:Name="StackContainer"
+						IsTapEnabled="False"
+						Margin="0,0,0,40">
+				<TextBlock Text="This StackPanel has IsTapEnabled='False', let's inverse it below:"
+						   FontSize="16"
+						   TextWrapping="Wrap" />
+				<TextBlock Text="{Binding IsTapEnabled, ElementName=StackContainer, Converter={ex:InverseBool}}"
+						   FontSize="16" />
+			</StackPanel>
+
+			<TextBlock Text="Here's a custom Markup Extension using a StaticResource:"
+					   Foreground="Green" />
+
+			<ContentControl Content="{ex:Entity TextValue={StaticResource ResourceString1}, IntValue=123}"
+							ContentTemplate="{StaticResource MarkupDataTemplate}" />
 		</StackPanel>
 	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/MarkupExtensionBehaviors.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/MarkupExtensionTests/MarkupExtensionBehaviors.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml.MarkupExtensionTests.Behaviors
+{
+	public static class MarkupExtensionBehaviors
+	{
+		public static string GetCustomText(TextBlock obj) => (string)obj.GetValue(CustomTextProperty);
+
+		public static void SetCustomText(TextBlock obj, string value) => obj.SetValue(CustomTextProperty, value);
+
+		public static readonly DependencyProperty CustomTextProperty =
+			DependencyProperty.RegisterAttached(
+				"CustomText",
+				typeof(string),
+				typeof(MarkupExtensionBehaviors),
+				new PropertyMetadata(string.Empty, OnCustomTextChanged));
+
+		private static void OnCustomTextChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			if (dependencyObject is TextBlock tb)
+			{
+				tb.Text = GetCustomText(tb);
+			}
+		}
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/RoslynMetadataHelper.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/RoslynMetadataHelper.cs
@@ -239,5 +239,31 @@ namespace Uno.Roslyn
 		public INamedTypeSymbol GetGenericType(string name = "T") =>  Compilation.CreateErrorTypeSymbol(null, name, 0);
 
 		public IArrayTypeSymbol GetArray(ITypeSymbol type) => Compilation.CreateArrayTypeSymbol(type);
+
+		public IEnumerable<INamedTypeSymbol> GetAllTypesDerivingFrom(INamedTypeSymbol baseType)
+		{
+			return GetTypesDerivingFrom(Compilation.GlobalNamespace);
+
+			IEnumerable<INamedTypeSymbol> GetTypesDerivingFrom(INamespaceSymbol ns)
+			{
+				foreach (var member in ns.GetMembers())
+				{
+					if (member is INamespaceSymbol nsInner)
+					{
+						foreach (var t in GetTypesDerivingFrom(nsInner))
+						{
+							yield return t;
+						}
+					}
+					else if (member is INamedTypeSymbol type)
+					{
+						if (((INamedTypeSymbol)member).Is(baseType))
+						{
+							yield return type;
+						}
+					}
+				}
+			}
+		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/RoslynMetadataHelper.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/RoslynMetadataHelper.cs
@@ -22,6 +22,7 @@ namespace Uno.Roslyn
 		private readonly Dictionary<string, INamedTypeSymbol> _legacyTypes;
 		private readonly Func<string, ITypeSymbol[]> _findTypesByName;
 		private readonly Func<string, ITypeSymbol> _findTypeByFullName;
+		private readonly Func<INamedTypeSymbol, IEnumerable<INamedTypeSymbol>> _getAllDerivingTypes;
 		private readonly Dictionary<string, INamedTypeSymbol> _additionalTypesMap;
 
 		public Compilation Compilation { get; }
@@ -36,7 +37,8 @@ namespace Uno.Roslyn
 			_findTypeByFullName = Funcs.Create<string, ITypeSymbol>(SourceFindTypeByFullName).AsLockedMemoized();
 			_additionalTypes = additionalTypes ?? new string[0];
 			_legacyTypes = BuildLegacyTypes(legacyTypes);
-			_project = roslynProject;
+			_getAllDerivingTypes = Funcs.Create<INamedTypeSymbol, IEnumerable<INamedTypeSymbol>>(GetAllDerivingTypes).AsLockedMemoized();
+			 _project = roslynProject;
 			_nullableSymbol = Compilation.GetTypeByMetadataName("System.Nullable`1");
 		}
 
@@ -241,6 +243,11 @@ namespace Uno.Roslyn
 		public IArrayTypeSymbol GetArray(ITypeSymbol type) => Compilation.CreateArrayTypeSymbol(type);
 
 		public IEnumerable<INamedTypeSymbol> GetAllTypesDerivingFrom(INamedTypeSymbol baseType)
+		{
+			return _getAllDerivingTypes(baseType);
+		}
+
+		private IEnumerable<INamedTypeSymbol> GetAllDerivingTypes(INamedTypeSymbol baseType)
 		{
 			return GetTypesDerivingFrom(Compilation.GlobalNamespace);
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
@@ -65,9 +65,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			public const string Style = BaseXamlNamespace + ".Style";
 			public const string ElementStub = BaseXamlNamespace + ".ElementStub";
 			public const string ContentPresenter = Namespaces.Controls + ".ContentPresenter";
+			public const string Markup = BaseXamlNamespace + ".Markup";
 
 			// Attributes
-			public const string ContentPropertyAttribute = BaseXamlNamespace + ".Markup.ContentPropertyAttribute";
+			public const string ContentPropertyAttribute = Markup + ".ContentPropertyAttribute";
 
 			// Text
 			public const string FontWeight = Namespaces.Text + ".FontWeight";
@@ -103,10 +104,15 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			public const string Panel = Namespaces.Controls + ".Panel";
 			public const string Button = Namespaces.Controls + ".Button";
 			public const string TextBox = Namespaces.Controls + ".TextBox";
-			
+
 			// Documents
 			public const string Run = Namespaces.Documents + ".Run";
 			public const string Span = Namespaces.Documents + ".Span";
+
+			// MarkupExtension
+			public const string MarkupExtension = Markup + ".MarkupExtension";
+			public const string IMarkupExtensionOverrides = Markup + ".IMarkupExtensionOverrides";
+			public const string MarkupExtensionReturnTypeAttribute = Markup + ".MarkupExtensionReturnTypeAttribute";
 		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2044,7 +2044,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						}
 						else if (HasCustomMarkupExtension(member))
 						{
-							BuildCustomMarkupExtensionPropertyValue(writer, member, closureName + ".");
+							if (IsAttachedProperty(member) && FindPropertyType(member.Member) != null)
+							{
+								BuildSetAttachedProperty(writer, closureName, member, objectUid, isCustomMarkupExtension: true);
+							}
+							else
+							{
+								BuildCustomMarkupExtensionPropertyValue(writer, member, closureName + ".");
+							}
 						}
 						else if (member.Objects.Any())
 						{
@@ -2253,7 +2260,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								{
 									if (FindPropertyType(member.Member) != null)
 									{
-										BuildSetAttachedProperty(writer, closureName, member, objectUid);
+										BuildSetAttachedProperty(writer, closureName, member, objectUid, isCustomMarkupExtension: false);
 									}
 									else if (eventSymbol != null)
 									{
@@ -2444,13 +2451,17 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				name.Equals("AlignVerticalCenterWith");
 		}
 
-		private void BuildSetAttachedProperty(IIndentedStringBuilder writer, string closureName, XamlMemberDefinition member, string objectUid)
+		private void BuildSetAttachedProperty(IIndentedStringBuilder writer, string closureName, XamlMemberDefinition member, string objectUid, bool isCustomMarkupExtension)
 		{
+			var literalValue = isCustomMarkupExtension
+					? GetCustomMarkupExtensionValue(member)
+					: BuildLiteralValue(member, owner: member, objectUid: objectUid);
+
 			writer.AppendLineInvariant(
 				"{0}.Set{1}({3}, {2});",
 				GetGlobalizedTypeName(FindType(member.Member.DeclaringType).SelectOrDefault(t => t.ToDisplayString(), member.Member.DeclaringType.Name)),
 				member.Member.Name,
-				BuildLiteralValue(member, owner: member, objectUid: objectUid),
+				literalValue,
 				closureName
 			);
 		}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1390,7 +1390,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 
 			// Determine if the type is a custom markup extension
-			return _markupExtensionTypes.Any(ns => ns.Name.Equals(xamlType.Name, StringComparison.OrdinalIgnoreCase));
+			return _markupExtensionTypes.Any(ns => ns.Name.Equals(xamlType.Name, StringComparison.InvariantCulture));
 		}
 
 		private XamlMemberDefinition FindMember(XamlObjectDefinition xamlObjectDefinition, string memberName)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3165,7 +3165,16 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					return $"new RelativeSource(RelativeSourceMode.{resourceName})";
 				}
 
-				return "Unsupported";
+				// If type specified in the binding was not found, log and return an error message
+				if (!string.IsNullOrEmpty(bindingType?.Type?.Name ?? string.Empty))
+				{
+					var message = $"#Error // {bindingType.Type.Name} could not be found.";
+					this.Log().Error(message);
+
+					return message;
+				}
+
+				return "#Error";
 			}
 			else
 			{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1389,8 +1389,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				return false;
 			}
 
+			// Adjustment for Uno.Xaml parser which returns the namespace in the name
+			var xamlTypeName = xamlType.Name.Contains(':') ? xamlType.Name.Split(':').LastOrDefault() : xamlType.Name;
+
 			// Determine if the type is a custom markup extension
-			return _markupExtensionTypes.Any(ns => ns.Name.Equals(xamlType.Name, StringComparison.InvariantCulture));
+			return _markupExtensionTypes.Any(ns => ns.Name.Equals(xamlTypeName, StringComparison.InvariantCulture));
 		}
 
 		private XamlMemberDefinition FindMember(XamlObjectDefinition xamlObjectDefinition, string memberName)

--- a/src/SourceGenerators/XamlGenerationTests/CustomMarkupExtensions.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/CustomMarkupExtensions.xaml
@@ -46,6 +46,12 @@
 
 			<ContentPresenter Content="{ext:ComplexMarkup String='MyString', Number=100}"
 							  ContentTemplate="{StaticResource TestDataTemplate}" />
+
+			<!-- Make sure markup extension works in an attached property -->
+			<TextBlock ext:MarkupExtensionTestBehavior.CustomText="{ext:TestMarkup String1='Just a test string...'}" />
+
+			<!-- Make sure markup extension works in an attached property using a binding and converter -->
+			<TextBlock ext:MarkupExtensionTestBehavior.CustomText="{Binding IsRightTapEnabled, ElementName=RootGrid, Converter={ext:InverseBoolMarkup}}" />
 		</StackPanel>
 	</Grid>
 </UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/CustomMarkupExtensions.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/CustomMarkupExtensions.xaml
@@ -1,0 +1,51 @@
+﻿<UserControl x:Class="XamlGenerationTests.Shared.CustomMarkupExtensions"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:ext="clr-namespace:XamlGenerationTests.Shared.MarkupExtensions"
+			 mc:Ignorable="d">
+
+	<UserControl.Resources>
+		<ext:InverseBoolMarkup x:Key="Inverse" />
+
+		<x:String x:Key="ResourceTest">Resource String</x:String>
+
+		<!-- Make sure x:DataType generates correctly -->
+		<DataTemplate x:Key="TestDataTemplate"
+					  x:DataType="local:ComplexObject">
+			<StackPanel Orientation="Horizontal"
+						Spacing="8">
+				<!-- Make sure x:Bind generates correctly -->
+				<TextBlock Text="{x:Bind StringProp, Mode=OneWay}" />
+				<TextBlock Text="{x:Bind IntProp, Mode=OneWay}" />
+
+				<!-- Make a markup extension inside a DataTemplate generates correctly -->
+				<TextBlock Text="{ext:TestMarkup String1='TemplateString1', String2={StaticResource ResourceTest}, Number=999}" />
+			</StackPanel>
+		</DataTemplate>
+	</UserControl.Resources>
+
+	<!-- Make sure x:Name generates correctly -->
+	<Grid x:Name="RootGrid"
+		  IsRightTapEnabled="False"
+		  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+		<StackPanel>
+			<!-- Make sure x:Null generates correctly -->
+			<!-- Make an attached behavior generates correctly -->
+			<Border Background="{x:Null}">
+				<TextBlock Text="{ext:TestMarkup String1='1st', String2={StaticResource ResourceTest}, Number=55}"
+						   ext:AttachedTest.IsAttached="True" />
+			</Border>
+
+			<!-- Make regular markup extension converters generate correctly -->
+			<TextBlock Text="{Binding IsRightTapEnabled, Converter={ext:InverseBoolMarkup}, ElementName=RootGrid}" />
+
+			<!-- Make sure regular bindings and regular converters still generate correctly -->
+			<TextBlock Text="{Binding IsRightTapEnabled, Converter={StaticResource Inverse}, ElementName=RootGrid}" />
+
+			<ContentPresenter Content="{ext:ComplexMarkup String='MyString', Number=100}"
+							  ContentTemplate="{StaticResource TestDataTemplate}" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/CustomMarkupExtensions.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/CustomMarkupExtensions.xaml.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Markup;
+
+namespace XamlGenerationTests.Shared
+{
+	public partial class CustomMarkupExtensions : UserControl
+	{
+		public CustomMarkupExtensions()
+		{
+			this.InitializeComponent();
+		}
+	}
+}
+
+namespace XamlGenerationTests.Shared.MarkupExtensions
+{
+	public class TestObject
+	{
+		public string StringProp { get; set; }
+
+		public int IntProp { get; set; }
+
+		public bool BoolProp { get; set; }
+	}
+
+	public class TestConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			return value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language)
+		{
+			throw new NotSupportedException();
+		}
+	}
+
+	public static class AttachedTest
+	{
+		public static bool GetIsAttached(DependencyObject obj) => (bool)obj.GetValue(IsAttachedProperty);
+
+		public static void SetIsAttached(DependencyObject obj, bool value) => obj.SetValue(IsAttachedProperty, value);
+
+		public static readonly DependencyProperty IsAttachedProperty =
+			DependencyProperty.RegisterAttached(
+				"IsAttached",
+				typeof(bool),
+				typeof(AttachedTest),
+				new PropertyMetadata(false));
+	}
+
+	[MarkupExtensionReturnType(ReturnType = typeof(string))]
+	public class TestMarkup : MarkupExtension
+	{
+		public string String1 { get; set; }
+
+		public string String2 { get; set; }
+
+		public int Number { get; set; }
+
+		protected override object ProvideValue()
+		{
+			return $"{String1} AND {String2} THEN #{Number}";
+		}
+	}
+
+	[MarkupExtensionReturnType(ReturnType = typeof(IValueConverter))]
+	public class InverseBoolMarkup : MarkupExtension, IValueConverter
+	{
+		protected override object ProvideValue() => this;
+
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			return !(bool)value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language)
+		{
+			return !(bool)value;
+		}
+	}
+
+	[MarkupExtensionReturnType(ReturnType = typeof(TestObject))]
+	public class ComplexMarkup : MarkupExtension
+	{
+		public string String { get; set; }
+
+		public int Number { get; set; }
+
+		public bool Boolean { get; set; }
+
+		protected override object ProvideValue()
+		{
+			return new TestObject()
+			{
+				StringProp = String,
+				IntProp = Number
+			};
+		}
+	}
+}

--- a/src/SourceGenerators/XamlGenerationTests/CustomMarkupExtensions.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/CustomMarkupExtensions.xaml.cs
@@ -64,7 +64,7 @@ namespace XamlGenerationTests.Shared.MarkupExtensions
 
 		protected override object ProvideValue()
 		{
-			return $"{String1} AND {String2} THEN #{Number}";
+			return $"{String1 ?? string.Empty} AND {String2 ?? string.Empty} THEN #{Number}";
 		}
 	}
 
@@ -100,6 +100,28 @@ namespace XamlGenerationTests.Shared.MarkupExtensions
 				StringProp = String,
 				IntProp = Number
 			};
+		}
+	}
+
+	public static class MarkupExtensionTestBehavior
+	{
+		public static string GetCustomText(TextBlock obj) => (string)obj.GetValue(CustomTextProperty);
+
+		public static void SetCustomText(TextBlock obj, string value) => obj.SetValue(CustomTextProperty, value);
+
+		public static readonly DependencyProperty CustomTextProperty =
+			DependencyProperty.RegisterAttached(
+				"CustomText",
+				typeof(string),
+				typeof(MarkupExtensionTestBehavior),
+				new PropertyMetadata(string.Empty, OnCustomTextChanged));
+
+		private static void OnCustomTextChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			if (dependencyObject is TextBlock tb)
+			{
+				tb.Text = GetCustomText(tb);
+			}
 		}
 	}
 }

--- a/src/Uno.UI.Tests/App/Behaviors/AttachedPropertiesBehavior.cs
+++ b/src/Uno.UI.Tests/App/Behaviors/AttachedPropertiesBehavior.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.App.Behaviors
+{
+    public static class AttachedPropertiesBehavior
+    {
+		public static string GetCustomText(TextBlock obj) => (string)obj.GetValue(CustomTextProperty);
+
+		public static void SetCustomText(TextBlock obj, string value) => obj.SetValue(CustomTextProperty, value);
+
+		public static readonly DependencyProperty CustomTextProperty =
+			DependencyProperty.RegisterAttached(
+				"CustomText",
+				typeof(string),
+				typeof(AttachedPropertiesBehavior),
+				new PropertyMetadata(string.Empty, OnCustomTextChanged));
+
+		private static void OnCustomTextChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			if (dependencyObject is TextBlock tb)
+			{
+				tb.Text = GetCustomText(tb);
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml
@@ -2,6 +2,7 @@
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:ex="using:Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests"
+			 xmlns:beh="using:Uno.UI.Tests.App.Behaviors"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 mc:Ignorable="d">
@@ -29,6 +30,12 @@
 
 		<TextBlock x:Name="Text5"
 				   Text="{ex:SimpleMarkupExt TextValue={StaticResource ResourceString}}" />
+
+		<TextBlock x:Name="Text6"
+				   beh:AttachedPropertiesBehavior.CustomText="{ex:SimpleMarkupExt TextValue='String from attached property'}" />
+
+		<TextBlock x:Name="Text7"
+				   beh:AttachedPropertiesBehavior.CustomText="{Binding IsTapEnabled, ElementName=StackContainer, Converter={ex:InverseBoolMarkupExt}}" />
 	</StackPanel>
 
 </UserControl>

--- a/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml
@@ -1,0 +1,34 @@
+﻿<UserControl x:Class="Uno.UI.Tests.App.Xaml.Test_MarkupExtension"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:ex="using:Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d">
+
+	<UserControl.Resources>
+		<x:String x:Key="ResourceString">From a Resource String</x:String>
+	</UserControl.Resources>
+
+	<StackPanel>
+		<TextBlock x:Name="Text1"
+				   Text="{ex:SimpleMarkupExt TextValue='Just a simple ...'}" />
+
+		<StackPanel DataContext="{ex:EntityMarkupExt TextValue='We should see the number 100 below:', IntValue=100}">
+			<TextBlock x:Name="Text2"
+					   Text="{Binding StringProperty}" />
+			<TextBlock x:Name="Text3"
+					   Text="{Binding IntProperty}" />
+		</StackPanel>
+
+		<StackPanel x:Name="StackContainer"
+					IsTapEnabled="False">
+			<TextBlock x:Name="Text4"
+					   Text="{Binding IsTapEnabled, ElementName=StackContainer, Converter={ex:InverseBoolMarkupExt}}" />
+		</StackPanel>
+
+		<TextBlock x:Name="Text5"
+				   Text="{ex:SimpleMarkupExt TextValue={StaticResource ResourceString}}" />
+	</StackPanel>
+
+</UserControl>

--- a/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml.cs
+++ b/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml.cs
@@ -27,6 +27,8 @@ namespace Uno.UI.Tests.App.Xaml
 		public TextBlock TestText3 => Text3;
 		public TextBlock TestText4 => Text4;
 		public TextBlock TestText5 => Text5;
+		public TextBlock TestText6 => Text6;
+		public TextBlock TestText7 => Text7;
 
 		public Test_MarkupExtension()
         {

--- a/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml.cs
+++ b/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.App.Xaml
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class Test_MarkupExtension : UserControl
+    {
+		public TextBlock TestText1 => Text1;
+		public TextBlock TestText2 => Text2;
+		public TextBlock TestText3 => Text3;
+		public TextBlock TestText4 => Text4;
+		public TextBlock TestText5 => Text5;
+
+		public Test_MarkupExtension()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -102,6 +102,7 @@
 		<Page Include="App\App.xaml" />
 		<Page Include="App\Xaml\Test_Dictionary.xaml" />
 		<Page Include="App\Xaml\Test_Control.xaml" />
+		<Page Include="App\Xaml\Test_MarkupExtension.xaml" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
@@ -26,6 +26,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests
 			Assert.AreEqual("100", control.TestText3.Text);
 			Assert.AreEqual("True", control.TestText4.Text);
 			Assert.AreEqual("From a Resource String markup extension", control.TestText5.Text);
+			Assert.AreEqual("String from attached property", control.TestText6.Text);
+			Assert.AreEqual("True", control.TestText7.Text);
 		}
 	}
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Tests.App.Xaml;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Markup;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests
+{
+	[TestClass]
+	public class Given_MarkupExtension
+	{
+		[TestMethod]
+		public void When_ExtensionProvidesValues()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			var control = new Test_MarkupExtension();
+			app.HostView.Children.Add(control);
+
+			Assert.AreEqual("Just a simple ... markup extension", control.TestText1.Text);
+			Assert.AreEqual("We should see the number 100 below:", control.TestText2.Text);
+			Assert.AreEqual("100", control.TestText3.Text);
+			Assert.AreEqual("True", control.TestText4.Text);
+			Assert.AreEqual("From a Resource String markup extension", control.TestText5.Text);
+		}
+	}
+
+	[MarkupExtensionReturnType(ReturnType = typeof(string))]
+	public class SimpleMarkupExt : Windows.UI.Xaml.Markup.MarkupExtension
+	{
+		public string TextValue { get; set; }
+
+		protected override object ProvideValue()
+		{
+			return TextValue + " markup extension";
+		}
+	}
+
+	[MarkupExtensionReturnType(ReturnType = typeof(TestEntityObject))]
+	public class EntityMarkupExt : Windows.UI.Xaml.Markup.MarkupExtension
+	{
+		public string TextValue { get; set; }
+
+		public int IntValue { get; set; }
+
+		protected override object ProvideValue()
+		{
+			return new TestEntityObject()
+			{
+				StringProperty = TextValue,
+				IntProperty = IntValue
+			};
+		}
+	}
+
+	[MarkupExtensionReturnType(ReturnType = typeof(IValueConverter))]
+	public class InverseBoolMarkupExt : Windows.UI.Xaml.Markup.MarkupExtension, IValueConverter
+	{
+		protected override object ProvideValue() => this;
+
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			return !(bool)value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language)
+		{
+			return !(bool)value;
+		}
+	}
+
+	public class TestEntityObject
+	{
+		public string StringProperty { get; set; } = string.Empty;
+
+		public int IntProperty { get; set; }
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
@@ -26,7 +26,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests
 			Assert.AreEqual("100", control.TestText3.Text);
 			Assert.AreEqual("True", control.TestText4.Text);
 			Assert.AreEqual("From a Resource String markup extension", control.TestText5.Text);
-			Assert.AreEqual("String from attached property", control.TestText6.Text);
+			Assert.AreEqual("String from attached property markup extension", control.TestText6.Text);
 			Assert.AreEqual("True", control.TestText7.Text);
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Markup/IMarkupExtensionOverrides.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/IMarkupExtensionOverrides.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Windows.UI.Xaml.Markup
+{
+	public partial interface IMarkupExtensionOverrides
+	{
+		object ProvideValue();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Markup/MarkupExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/MarkupExtensions.cs
@@ -8,11 +8,9 @@ namespace Windows.UI.Xaml.Markup
 {
 	public partial class MarkupExtension : IMarkupExtensionOverrides
 	{
-#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		object IMarkupExtensionOverrides.ProvideValue()
 		{
 			return ProvideValue();
 		}
-#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Markup/MarkupExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/MarkupExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Windows.UI.Xaml.Markup
+{
+	public partial class MarkupExtension : IMarkupExtensionOverrides
+	{
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		//protected virtual object ProvideValue()
+		//{
+		//	return null;
+		//}
+
+		object IMarkupExtensionOverrides.ProvideValue()
+		{
+			return ProvideValue();
+		}
+#endif
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Markup/MarkupExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/MarkupExtensions.cs
@@ -9,11 +9,6 @@ namespace Windows.UI.Xaml.Markup
 	public partial class MarkupExtension : IMarkupExtensionOverrides
 	{
 #if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		//protected virtual object ProvideValue()
-		//{
-		//	return null;
-		//}
-
 		object IMarkupExtensionOverrides.ProvideValue()
 		{
 			return ProvideValue();


### PR DESCRIPTION
GitHub Issue (If applicable):
#39 

## PR Type

What kind of change does this PR introduce?
Feature

## What is the current behavior?

## What is the new behavior?

Added support for developers to use their own custom MarkupExtensions.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X ] Associated with an issue (GitHub or internal)


## Other information

Internal Issue (If applicable):
