### PR TITLE
[Android] Fix invalid ImageBrush stack overflow with delayed im…

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -125,6 +125,7 @@
 * [Pivot] Add support for non PivotItem items
 * #1557 Fix local DataContext on ContentDialog is overwritten
 * [WASM] Fix display for multiple popups (eg ComboBox inside of ContentDialog)
+* [Android] Fix invalid ImageBrush stack overflow with delayed image reuse
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2061,6 +2061,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrush_SameWithDelay.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrush_StreamSource.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3494,6 +3498,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrushWithScaleTransform.xaml.cs">
       <DependentUpon>ImageBrushWithScaleTransform.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrush_SameWithDelay.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrush_StreamSource.xaml.cs">
       <DependentUpon>ImageBrush_StreamSource.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_SameWithDelay.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_SameWithDelay.xaml
@@ -1,0 +1,30 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Media.ImageBrushTests.ImageBrush_SameWithDelay"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Media.ImageBrushTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid>
+		<StackPanel>
+			<TextBlock Text="This should not crash the app, when the same URL is used twice with delays." />
+			<Ellipse Width="200"
+				 Height="200">
+				<Ellipse.Fill>
+					<ImageBrush x:Name="imageBrush" ImageSource="{Binding ImgSource}" Stretch="UniformToFill"/>
+				</Ellipse.Fill>
+			</Ellipse>
+
+			<Ellipse Width="200"
+				 Height="200">
+				<Ellipse.Fill>
+					<ImageBrush ImageSource="{Binding ImgSource2}" Stretch="UniformToFill"/>
+				</Ellipse.Fill>
+			</Ellipse>
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_SameWithDelay.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_SameWithDelay.xaml.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Media.ImageBrushTests
+{
+	[SampleControlInfo("ImageBrushTestControl", "ImageBrush_SameWithDelay")]
+	public sealed partial class ImageBrush_SameWithDelay : UserControl
+	{
+		BrushContext _ctx = new BrushContext();
+
+		public ImageBrush_SameWithDelay()
+		{
+			this.InitializeComponent();
+
+			DataContext = _ctx;
+
+			Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => _ctx.ImgSource = "https://lh5.ggpht.com/lxBMauupBiLIpgOgu5apeiX_YStXeHRLK1oneS4NfwwNt7fGDKMP0KpQIMwfjfL9GdHRVEavmg7gOrj5RYC4qwrjh3Y0jCWFDj83jzg");
+
+			imageBrush.ImageOpened += (s, e) => { 
+				_ctx.ImgSource2 = "https://lh5.ggpht.com/lxBMauupBiLIpgOgu5apeiX_YStXeHRLK1oneS4NfwwNt7fGDKMP0KpQIMwfjfL9GdHRVEavmg7gOrj5RYC4qwrjh3Y0jCWFDj83jzg";
+		   };
+		}
+	}
+
+	public class BrushContext : INotifyPropertyChanged
+	{
+		private string _imageSource;
+		private string _imageSource2;
+
+		public string ImgSource
+		{
+			get { return _imageSource; }
+			set
+			{
+				_imageSource = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ImgSource)));
+			}
+		}
+
+		public string ImgSource2
+		{
+			get { return _imageSource2; }
+			set
+			{
+				_imageSource2 = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ImgSource2)));
+			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
@@ -47,6 +47,8 @@ namespace Windows.UI.Xaml.Media
 			//TODO: should also check if Stretch has changed
 			if (_imageSourceChanged || !drawRect.Equals(_lastDrawRect))
 			{
+				_imageSourceChanged = false;
+
 				if (ImageSource != null)
 				{
 					RefreshImageAsync(drawRect);
@@ -55,7 +57,6 @@ namespace Windows.UI.Xaml.Media
 				{
 					_refreshPaint.Disposable = null;
 				}
-				_imageSourceChanged = false;
 				_lastDrawRect = drawRect;
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/Uno.WindowsCommunityToolkit/pull/59

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Using an `ImageBrush` on a shape may result in a stack overflow if the image has already been loaded.

## What is the new behavior?

Reusing a image does not crash the app.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
