### PR TITLE
[Android] Fix java NRE handing touch events on detached view

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -119,6 +119,7 @@
 * [iOS(iPad)] `ComboBox` : the combobox wasn't fully expanding vertically on first opening.
 * `Popup` & `ComboBox` (and other controls using `Popup`) were not behaving properly when `IsLightDismissable` were set to `true`.
 * [Wasm] Fix unloaded UIElements are made visible if measured and arranged
+* [Android] Fix java NRE handing touch events on detached view
 
 ## Release 1.45.0
 ### Features

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
@@ -951,14 +951,19 @@ public abstract class UnoViewGroup
 			return point;
 		}
 
-		// Non-UIElement view, walk the tree up to the next UIElement
-		// (and adjust coordinate for each layer to include its location, i.e. Top, Left, etc.)
-		final ViewParent parent = view.getParent();
-		if (parent instanceof View) {
-			// Not at root, walk upward
-			float[] coords = getTransformedTouchCoordinate(parent, e);
-			calculateTransformedPoint((View) view, coords);
-			return coords;
+		if(view != null) {
+			// The parent view may be null if the touched item is being removed
+			// from the tree while being touched.
+
+			// Non-UIElement view, walk the tree up to the next UIElement
+			// (and adjust coordinate for each layer to include its location, i.e. Top, Left, etc.)
+			final ViewParent parent = view.getParent();
+			if (parent instanceof View) {
+				// Not at root, walk upward
+				float[] coords = getTransformedTouchCoordinate(parent, e);
+				calculateTransformedPoint((View) view, coords);
+				return coords;
+			}
 		}
 
 		// We reached the top of the tree


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/Uno.WindowsCommunityToolkit/pull/59#issuecomment-533661254

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Touching an element in an `AutoSuggestBox` may crash the application.

## What is the new behavior?
The application does not crash.

This PR should be tested once unoplatform/Uno.UITest#19 is fixed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
