### PR TITLE
feat: Check launch URL for fragments if no querystring exists

### DIFF
--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -204,18 +204,34 @@ namespace Uno.UI {
 			* 
 			*/
 		static findLaunchArguments(): string {
-			if (typeof URLSearchParams === "function") {
-				return new URLSearchParams(window.location.search).toString();
-			}
-			else {
-				const queryIndex = document.location.search.indexOf('?');
+			/*
+			* Concatenate the query/search with any url fragments into one string
+			*/
+			const searchAndHash = window.location.search + window.location.hash;
+			
+			/*
+			* Look for the presence of ? for the querystring, if found return
+			* everything after it, which will include a fragment if also present
+			* since fragments always proceed querystring params if they exist
+			*/
+			const queryIndex = document.location.search.indexOf('?');
 
-				if (queryIndex !== -1) {
-					return document.location.search.substring(queryIndex + 1);
+			if (queryIndex !== -1) {
+				return document.location.search.substring(queryIndex + 1);
+			} else {
+				/*
+				* Fall back to trying a url fragment if no querystring args were found
+				* since there may still be a url fragment we want to include
+				*/
+				const fragmentIndex = document.location.search.indexOf('#');
+					
+				if (fragmentIndex !== -1) {
+					return document.location.search.substring(fragmentIndex + 1);
 				}
-
-				return "";
 			}
+
+			// Return probably an empty string
+			return searchAndHash;
 		}
 
 		/**


### PR DESCRIPTION
Querystrings were already being checked for and passed along to the launch event args, however in some cases we might want to use fragments instead. The best use case I can think of is that they don't get sent to from the client in web requests, and they don't participate in redirects.  Anyway, I think it's a simple case that would be useful to include.

GitHub Issue (If applicable): # N/A

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

URL Fragments are ignored if there is no querystring (`?`) before the fragment start (`#`) and don't get passed to the launch event args.


## What is the new behavior?

If there's no querystring (`?`) in the url, the url is checked for a fragment (`#`) and captures it to pass to the launch event args.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

