### PR TITLE
added a sample DoubleAnimation clipping issue

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -97,6 +97,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clip\DoubleAnimationClipping.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DeferLoadStrategy\DeferLoadStrategyWithTemplateBinding.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2520,6 +2524,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clip\ButtonWithClippingAndOffset.xaml.cs">
       <DependentUpon>ButtonWithClippingAndOffset.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clip\DoubleAnimationClipping.xaml.cs">
+      <DependentUpon>DoubleAnimationClipping.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DeferLoadStrategy\DeferLoadStrategyViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DeferLoadStrategy\DeferLoadStrategyWithTemplateBinding.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clip/DoubleAnimationClipping.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clip/DoubleAnimationClipping.xaml
@@ -1,0 +1,61 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml.Clip.DoubleAnimationClipping"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml.Clip"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<ContentControl x:Name="MainContent">
+		<ContentControl.Template>
+			<ControlTemplate>
+				<Grid x:Name="RootGrid"
+					  Background="LightGray">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="*" />
+						<RowDefinition Height="Auto" />
+					</Grid.RowDefinitions>
+					<VisualStateManager.VisualStateGroups>
+						<VisualStateGroup x:Name="ReadyStates">
+							<VisualState x:Name="Ready">
+								<Storyboard>
+									<DoubleAnimation Storyboard.TargetName="WebView"
+													 Storyboard.TargetProperty="Opacity"
+													 Duration="0:0:0.5"
+													 To="1" />
+								</Storyboard>
+							</VisualState>
+							<VisualState x:Name="NotReady">
+								<Storyboard>
+									<DoubleAnimation Storyboard.TargetName="WebView"
+													 Storyboard.TargetProperty="Opacity"
+													 Duration="0:0:0.5"
+													 To="0" />
+								</Storyboard>
+							</VisualState>
+						</VisualStateGroup>
+					</VisualStateManager.VisualStateGroups>
+
+					<CommandBar Grid.Row="0"
+								Content="Title"
+								Background="Aqua" />
+					<Border Grid.Row="1"
+							Margin="16"
+							Padding="8,12"
+							Background="Gray">
+						<WebView x:Name="WebView" />
+					</Border>
+					<StackPanel Grid.Row="2">
+						<Button Content="GOTO Ready"
+								Click="GotoReadyState" />
+						<Button Content="GOTO NotReady"
+								Click="GotoNotReadyState" />
+					</StackPanel>
+				</Grid>
+			</ControlTemplate>
+		</ContentControl.Template>
+	</ContentControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clip/DoubleAnimationClipping.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clip/DoubleAnimationClipping.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Sample.Views.Helper;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml.Clip
+{
+
+	[SampleControlInfo("Clip", nameof(DoubleAnimationClipping), description: "[Android]When going to `Ready` state the WebView expand to full screen and cover other control when it shouldn't be.")]
+	public sealed partial class DoubleAnimationClipping : UserControl
+	{
+		private static readonly Random random = new Random();
+
+		public DoubleAnimationClipping()
+		{
+			this.InitializeComponent();
+		}
+
+		private void GotoReadyState(object sender, RoutedEventArgs e)
+		{
+			//var rootGrid = MainContent.FindFirstChild<Grid>(x => x.Name == "RootGrid");
+			var webView = MainContent.FindFirstChild<WebView>(x => x.Name == "WebView");
+
+			var colors = "Blue,Pink,Yellow,Lime".Split(',');
+			var color = colors[random.Next(colors.Length)];
+
+			webView.NavigateToString($@"
+				<html>
+					<body style='background: {color};' />
+				</html>
+			");
+			VisualStateManager.GoToState(MainContent, "Ready", true);
+		}
+
+		private void GotoNotReadyState(object sender, RoutedEventArgs e) => VisualStateManager.GoToState(MainContent, "NotReady", true);
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #1599

## PR Type
What kind of change does this PR introduce?
- Other... Please describe: new sample

## What is the current behavior?
## What is the new behavior?
Added a new sample to illustrate the clipping issue with `DoubleAnimation`.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] ~~[Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)

## Other information
This is an regression from: https://github.com/unoplatform/uno/pull/1373

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/160360
https://nventive.visualstudio.com/Umbrella/_workitems/edit/161730
