### PR TITLE
[Android] Fix glitchy animations inside list with transformed ancestor

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -127,6 +127,7 @@
 * #1557 Fix local DataContext on ContentDialog is overwritten
 * [WASM] Fix display for multiple popups (eg ComboBox inside of ContentDialog)
 * [Android] Fix invalid ImageBrush stack overflow with delayed image reuse
+* [Android] Fix glitchy animations inside ListView with transformed ancestor.
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2261,6 +2261,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\List_With_Transformed_Ancestor.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Polygon_With_RotateTransform.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3655,6 +3659,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Image_With_RotateTransform.xaml.cs">
       <DependentUpon>Image_With_RotateTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\List_With_Transformed_Ancestor.xaml.cs">
+      <DependentUpon>List_With_Transformed_Ancestor.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Polygon_With_RotateTransform.xaml.cs">
       <DependentUpon>Polygon_With_RotateTransform.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/List_With_Transformed_Ancestor.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/List_With_Transformed_Ancestor.xaml
@@ -1,0 +1,39 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Media.Transform.List_With_Transformed_Ancestor"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Media.Transform"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid Margin="30">
+		<Grid.RenderTransform>
+			<TranslateTransform Y="20" />
+		</Grid.RenderTransform>
+		<ListView ItemsSource="012345678"
+				  Width="300">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<Border Background="Green"
+							Width="250"
+							Height="40">
+						<Border Background="White"
+								HorizontalAlignment="Stretch"
+								PointerPressed="Border_PointerPressed"
+								PointerMoved="Border_PointerMoved"
+								PointerReleased="Border_PointerReleased"
+								PointerCanceled="Border_PointerCanceled">
+							<Border.RenderTransform>
+								<TranslateTransform />
+							</Border.RenderTransform>
+							<TextBlock Text="{Binding}" />
+						</Border>
+					</Border>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/List_With_Transformed_Ancestor.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/List_With_Transformed_Ancestor.xaml.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "List_With_Transformed_Ancestor", description: "Items can be swiped. This shouldn't cause visual 'tearing' on Android.")]
+	public sealed partial class List_With_Transformed_Ancestor : UserControl
+	{
+		public List_With_Transformed_Ancestor()
+		{
+			this.InitializeComponent();
+		}
+
+		Point _initialPoint;
+		bool _isPressed;
+		private void Border_PointerMoved(object sender, PointerRoutedEventArgs e)
+		{
+			if (!_isPressed)
+			{
+				return;
+			}
+			var currentPoint = e.GetCurrentPoint(null).Position;
+			var offset = currentPoint.X - _initialPoint.X;
+			SetHorizontalTransform(sender as Border, offset);
+		}
+
+		private void Border_PointerPressed(object sender, PointerRoutedEventArgs e)
+		{
+			_isPressed = true;
+			_initialPoint = e.GetCurrentPoint(null).Position;
+		}
+
+		private void SetHorizontalTransform(Border border, double x)
+		{
+			(border.RenderTransform as TranslateTransform).X = x;
+		}
+
+		private void Border_PointerReleased(object sender, PointerRoutedEventArgs e)
+		{
+			_isPressed = false;
+			SetHorizontalTransform(sender as Border, 0);
+		}
+
+		private void Border_PointerCanceled(object sender, PointerRoutedEventArgs e)
+		{
+			_isPressed = false;
+			SetHorizontalTransform(sender as Border, 0);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.Android.cs
@@ -68,6 +68,9 @@ namespace Windows.UI.Xaml.Controls
 			MotionEventSplittingEnabled = false;
 
 			_shouldRecalibrateFlingVelocity = (int)Android.OS.Build.VERSION.SdkInt >= 28; // Android.OS.BuildVersionCodes.P
+
+			// // This is required for animations not to be cut off by transformed ancestor views. (#1333)
+			SetClipChildren(false);
 		}
 
 		partial void InitializeSnapHelper();


### PR DESCRIPTION
Setting ClipChildren to false ensures animation is still updated correctly outside of its pre-transform bounds.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://github.com/unoplatform/private/issues/35
https://github.com/unoplatform/private/issues/38