### PR TITLE
Increased target and minimum versions of Windows to 10.0.17763.0

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/UWP/UnoQuickStart.Uwp.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UWP/UnoQuickStart.Uwp.csproj
@@ -24,8 +24,8 @@
 		<AssemblyName>$ext_safeprojectname$</AssemblyName>
 		<DefaultLanguage>en-US</DefaultLanguage>
 		<TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-		<TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-		<TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+		<TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
 		<FileAlignment>512</FileAlignment>
 		<ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
GitHub Issue (If applicable): #

fixes https://github.com/unoplatform/uno/issues/1614#issue-498932273

## PR Type

What kind of change does this PR introduce?
Update project configuration

## What is the current behavior?

Project target Windows version was 10.0.16299.0.


## What is the new behavior?

Project target Windows version is 10.0.17763.0.
