### PR TITLE
Fail fast on *nix script errors

### DIFF
--- a/.azure-devops-wasm-uitests.yml
+++ b/.azure-devops-wasm-uitests.yml
@@ -72,7 +72,8 @@ jobs:
         downloadPath: '$(build.sourcesdirectory)/build'
 
   - bash: |
-      set -e
+      set -euo pipefail
+      IFS=$'\n\t'
       cd $(build.sourcesdirectory)/build/wasm-uitest-binaries/site
       python server.py &
       cd $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Wasm.UITests

--- a/.azure-devops-wasm-uitests.yml
+++ b/.azure-devops-wasm-uitests.yml
@@ -18,9 +18,13 @@ jobs:
   - bash: |
       source /emsdk/emsdk_env.sh
       msbuild /r /p:Configuration=Release src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj /p:UnoSourceGeneratorUseGenerationHost=true /p:UnoSourceGeneratorUseGenerationController=false
-      msbuild /r /p:Configuration=Release src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
 
     displayName: 'Build sample app'
+
+  - bash: |
+      msbuild /r /p:Configuration=Release src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+
+    displayName: 'Build Tests'
 
   - task: CopyFiles@2
     displayName: 'Publish Wasm Site'
@@ -68,6 +72,7 @@ jobs:
         downloadPath: '$(build.sourcesdirectory)/build'
 
   - bash: |
+      set -e
       cd $(build.sourcesdirectory)/build/wasm-uitest-binaries/site
       python server.py &
       cd $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Wasm.UITests

--- a/build/android-uitest-run.sh
+++ b/build/android-uitest-run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 export BUILDCONFIGURATION=Release
 

--- a/build/android-uitest-run.sh
+++ b/build/android-uitest-run.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+
 export BUILDCONFIGURATION=Release
 
 cd $BUILD_SOURCESDIRECTORY/build

--- a/build/run-automated-uitests.sh
+++ b/build/run-automated-uitests.sh
@@ -1,5 +1,6 @@
 ﻿#!/bin/bash
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 cd $BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries
 

--- a/build/run-automated-uitests.sh
+++ b/build/run-automated-uitests.sh
@@ -1,4 +1,5 @@
 ﻿#!/bin/bash
+set -e
 
 cd $BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?

Build errors happening on *nixes are not reported properly

## What is the new behavior?

Build fails early at the proper location.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
