### PR TITLE
Added CSS pseudo property to remove cross button from Edge input fields

### DIFF
--- a/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
@@ -143,3 +143,7 @@ body {
 textarea {
   resize: none;
 }
+
+::-ms-clear {
+  display: none;
+}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/1569

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

On Edge browser additional X (clear) button is visible

## What is the new behavior?

Additional X button is no longer visible


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ x] Associated with an issue (GitHub or internal)
