### PR TITLE
IOS BugFix Datepicker min and max year get reset to fallbacknull value

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -140,6 +140,7 @@
 * Adjust the Stretch mode of `BitmapIcon` content
 * Fix invalid Image size constraint
 * [Android] MenuFlyout was misplaced if view was in a hierarchy with a RenderTransform
+* [IOS] DatePickerFlyout min and max year were resetting to FallbackNullValue
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -70,5 +70,43 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 
 			_app.Screenshot("DatePicker - Flyout");
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)] // Android is disabled https://github.com/unoplatform/uno/issues/1634
+		public void DatePickerFlyout_MinYearProperlySets()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePicker_SampleContent");
+
+			_app.WaitForElement(_app.Marked("theDatePicker"));
+
+			var theDatePicker = _app.Marked("theDatePicker");
+			var datePickerFlyout = theDatePicker.Child;
+
+			// Open flyout
+			theDatePicker.Tap();
+
+			//Assert
+			Assert.AreEqual(datePickerFlyout.GetDependencyPropertyValue("MinYear").ToString(), theDatePicker.GetDependencyPropertyValue("MinYear").ToString());
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)] // Android is disabled https://github.com/unoplatform/uno/issues/1634
+		public void DatePickerFlyout_MaxYearProperlySets()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePicker_SampleContent");
+
+			_app.WaitForElement(_app.Marked("theDatePicker"));
+
+			var theDatePicker = _app.Marked("theDatePicker");
+			var datePickerFlyout = theDatePicker.Child;
+
+			// Open flyout
+			theDatePicker.Tap();
+
+			//Assert
+			Assert.AreEqual(datePickerFlyout.GetDependencyPropertyValue("MaxYear").ToString(), theDatePicker.GetDependencyPropertyValue("MaxYear").ToString());
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -317,6 +317,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_MinYear.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_ImageSource_PixelSize.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2663,6 +2667,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentPresenter\ContentPresenter_Padding.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentPresenter\ContentPresenter_Template.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentPresenter\ContentPresenter_TextProperties.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_MinYear.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_ImageSource_PixelSize.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ChangeView.xaml.cs">
       <DependentUpon>ListView_ChangeView.xaml</DependentUpon>
@@ -4563,6 +4568,9 @@
     </Compile>
 	<Compile Update="$(MSBuildThisFileDirectory)Windows_Devices\GyrometerTests.xaml.cs">
       <DependentUpon>GyrometerTests.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\P\uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_MinYear.xaml.cs">
+      <DependentUpon>DatePickerFlyout_MinYear.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_MinYear.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_MinYear.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePickerFlyout_MinYear"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.DatePicker"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<!--  DatePicker is broken: https://github.com/unoplatform/uno/issues/188  -->
+		<!--  Using a Button with DatePickerFlyout to simulate a DatePicker  -->
+		<Button x:Name="TestDatePickerFlyoutButton"
+				Content="Open DatePickerFlyout">
+			<Button.Flyout>
+				<DatePickerFlyout x:Name="TestDatePickerFlyout"
+								  MinYear="{Binding Date}"
+								  Date="{Binding Date}"/>
+			</Button.Flyout>
+		</Button>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_MinYear.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_MinYear.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.Models;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.DatePicker
+{
+	[SampleControlInfo("Date Picker", nameof(DatePickerFlyout_MinYear), typeof(DatePickerViewModel))]
+	public sealed partial class DatePickerFlyout_MinYear : UserControl
+	{
+		public DatePickerFlyout_MinYear()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePicker_SampleContent.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePicker_SampleContent.xaml
@@ -1,20 +1,21 @@
-﻿<UserControl
-    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePicker_SampleContent"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    d:DesignHeight="300"
-    d:DesignWidth="400">
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePicker_SampleContent"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
 
-    <Grid>
+	<Grid>
 		<Grid Background="White">
-					<DatePicker x:Name="theDatePicker"
-								Margin="15,10"
-								HorizontalAlignment="Center"
-								VerticalAlignment="Top">
-					</DatePicker>
-				</Grid>
-    </Grid>
+			<DatePicker x:Name="theDatePicker"
+						Margin="15,10"
+						MinYear="{Binding Date}"
+						Date="{Binding Date}"
+						HorizontalAlignment="Center"
+						VerticalAlignment="Top">
+			</DatePicker>
+		</Grid>
+	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePicker_SampleContent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePicker_SampleContent.xaml.cs
@@ -1,11 +1,12 @@
 ﻿using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml.Controls;
+using UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.Models;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.DatePicker
 {
-	[SampleControlInfo("DatePicker", "DatePicker_SampleContent")]
+	[SampleControlInfo("DatePicker", "DatePicker_SampleContent", typeof(DatePickerViewModel))]
 	public sealed partial class DatePicker_SampleContent : UserControl
     {
         public DatePicker_SampleContent()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/Models/DatePickerViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/Models/DatePickerViewModel.cs
@@ -9,13 +9,13 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.Models
 	[Bindable]
 	public class DatePickerViewModel : ViewModelBase
 	{
-		private DateTime _date = DateTime.Now.Date;
+		private DateTimeOffset _date = DateTime.Now;
 
 		public DatePickerViewModel(CoreDispatcher dispatcher) : base(dispatcher)
 		{
 		}
 
-		public DateTime Date
+		public DateTimeOffset Date
 		{
 			get => _date;
 			set
@@ -25,6 +25,6 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.Models
 			}
 		}
 
-		public ICommand SetToCurrentDate => GetOrCreateCommand(() => Date = DateTime.Now.Date);
+		public ICommand SetToCurrentDate => GetOrCreateCommand(() => Date = DateTime.Now);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.iOS.cs
@@ -52,7 +52,12 @@ namespace Windows.UI.Xaml.Controls
 
 			_isInitialized = true;
 
-			Content = new DatePickerSelector();
+			Content = new DatePickerSelector()
+			{
+				MinYear = MinYear,
+				MaxYear = MaxYear
+			};
+
 			BindToContent("MinYear");
 			BindToContent("MaxYear");
 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -67,10 +67,17 @@ namespace Windows.UI.Xaml.Controls
 			// Animate to cover up the small delay in setting the date when the flyout is opened
 			var animated = !UIDevice.CurrentDevice.CheckSystemVersion(10, 0);
 
-			_picker?.SetDate(
-				DateTime.SpecifyKind(newDate.DateTime, DateTimeKind.Local).ToNSDate(),
-				animated: animated
-			);
+			if (newDate < MinYear || newDate > MaxYear)
+			{
+				Date = oldDate;
+			}
+			else
+			{
+				_picker?.SetDate(
+					DateTime.SpecifyKind(newDate.DateTime, DateTimeKind.Local).ToNSDate(),
+					animated: animated
+				);
+			}
 		}
 
 		partial void OnMinYearChangedPartialNative(DateTimeOffset oldMinYear, DateTimeOffset newMinYear)

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -1802,6 +1802,181 @@
 	<xamarin:Style TargetType="GridViewItem"
 				   BasedOn="{StaticResource GridViewItemExpanded}" />
 
+	<!--Default style for DatePicker -->
+	<Style TargetType="DatePicker">
+		<ios:Setter Property="FlyoutPlacement"
+					Value="Full" />
+		<Setter Property="Orientation"
+				Value="Horizontal" />
+		<Setter Property="IsTabStop"
+				Value="False" />
+		<Setter Property="FontSize"
+				Value="17" />
+		<Setter Property="Foreground"
+				Value="Red" />
+		<Setter Property="Background"
+				Value="Transparent" />
+		<Setter Property="HorizontalAlignment"
+				Value="Center" />
+		<Setter Property="VerticalAlignment"
+				Value="Center" />
+		<Setter Property="Padding"
+				Value="0" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="DatePicker">
+					<StackPanel x:Name="LayoutRoot">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="Disabled">
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter"
+																	   Storyboard.TargetProperty="Foreground">
+											<DiscreteObjectKeyFrame KeyTime="0"
+																	Value="Black" />
+										</ObjectAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+						<ContentPresenter x:Name="HeaderContentPresenter"
+										  x:DeferLoadStrategy="Lazy"
+										  Visibility="Collapsed"
+										  Content="{TemplateBinding Header}"
+										  ContentTemplate="{TemplateBinding HeaderTemplate}"
+										  Margin="0,0,0,8"
+										  Background="{TemplateBinding Background}"
+										  Foreground="{StaticResource Color02Brush}"
+										  AutomationProperties.AccessibilityView="Raw" />
+						<Button x:Name="FlyoutButton"
+								Style="{StaticResource DatePickerFlyoutButtonStyle}"
+								Foreground="{TemplateBinding Foreground}"
+								Background="{TemplateBinding Background}"
+								BorderThickness="{TemplateBinding BorderThickness}"
+								BorderBrush="{TemplateBinding BorderBrush}"
+								IsEnabled="{TemplateBinding IsEnabled}"
+								MinHeight="{TemplateBinding MinHeight}"
+								Margin="0"
+								Padding="0"
+								HorizontalAlignment="Stretch"
+								HorizontalContentAlignment="Stretch"
+								VerticalAlignment="Stretch"
+								VerticalContentAlignment="Stretch">
+							<StackPanel Orientation="Horizontal"
+										HorizontalAlignment="Center">
+								<!--MONTH / DAY-->
+								<TextBlock Text="{Binding Date, RelativeSource={RelativeSource TemplatedParent}}" />
+
+								<!--SEPERATOR-->
+								<xamarin:Rectangle Width="1"
+												   Fill="#FFFFFFFF"
+												   Margin="20,0" />
+								<win:TextBlock Text="|"
+											   Foreground="Black"
+											   Margin="20,0" />
+
+								<!--TIME-->
+								<TextBlock Text="{Binding Date, RelativeSource={RelativeSource TemplatedParent}}" />
+
+								<!--SEPERATOR-->
+								<xamarin:Rectangle Width="1"
+												   Fill="#FFFFFFFF"
+												   Margin="20,0" />
+								<win:TextBlock Text="|"
+											   Foreground="Black"
+											   Margin="20,0" />
+
+								<!--PERIOD-->
+								<TextBlock Text="{Binding Date, RelativeSource={RelativeSource TemplatedParent}}" />
+
+							</StackPanel>
+						</Button>
+					</StackPanel>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<!--Default style for DatePickerFlyout buttons -->
+	<Style x:Key="DatePickerFlyoutButtonStyle"
+		   TargetType="Button">
+		<Setter Property="UseSystemFocusVisuals"
+				Value="False" />
+		<Setter Property="FontSize"
+				Value="16" />
+		<Setter Property="Foreground"
+				Value="Red" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Button">
+					<Grid Background="{TemplateBinding Background}"
+						  x:Name="Root">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="PointerOver">
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																	   Storyboard.TargetProperty="BorderBrush">
+											<DiscreteObjectKeyFrame KeyTime="0"
+																	Value="White" />
+										</ObjectAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																	   Storyboard.TargetProperty="Opacity">
+											<DiscreteObjectKeyFrame KeyTime="0"
+																	Value="0.7" />
+										</ObjectAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Disabled">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="Root"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="0"
+														 To="0.3" />
+									</Storyboard>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="FocusStates">
+								<VisualState x:Name="Focused">
+
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																	   Storyboard.TargetProperty="Background">
+											<DiscreteObjectKeyFrame KeyTime="0"
+																	Value="Grey" />
+										</ObjectAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Unfocused" />
+								<VisualState x:Name="PointerFocused" />
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<ContentPresenter x:Name="ContentPresenter"
+										  Background="{TemplateBinding Background}"
+										  Content="{TemplateBinding Content}"
+										  Foreground="{TemplateBinding Foreground}"
+										  BorderThickness="{TemplateBinding BorderThickness}"
+										  BorderBrush="{TemplateBinding BorderBrush}"
+										  HorizontalContentAlignment="Stretch"
+										  VerticalContentAlignment="Stretch"
+										  Margin="0"
+										  Padding="0"
+										  VerticalAlignment="Center"
+										  HorizontalAlignment="Stretch"
+										  AutomationProperties.AccessibilityView="Raw" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
 		<!--Default style for TimePickerSelector - Xamarin-only control internal to TimePickerFlyout-->
 	<xamarin:Style TargetType="TimePickerSelector">
 		<ios:Setter Property="Template">


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://github.com/unoplatform/private/issues/75

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
-->

## What is the current behavior?
ios datepicker min and max year get reset to fallbacknull value


## What is the new behavior?
ios datepicker min and max year values function properly


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

