### PR TITLE
Fix to flyoutpresenter(area around flyout) not dismissing flyout on tap

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -141,6 +141,7 @@
 * Fix invalid Image size constraint
 * [Android] MenuFlyout was misplaced if view was in a hierarchy with a RenderTransform
 * [IOS] DatePickerFlyout min and max year were resetting to FallbackNullValue
+* DatePickerFlyoutPresenter not dismissing flyout on tap
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -108,5 +108,30 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			//Assert
 			Assert.AreEqual(datePickerFlyout.GetDependencyPropertyValue("MaxYear").ToString(), theDatePicker.GetDependencyPropertyValue("MaxYear").ToString());
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)] // Android is disabled https://github.com/unoplatform/uno/issues/1634
+		public void DatePicker_TappingPresenterDismissesFlyout()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePicker_SampleContent");
+
+			_app.WaitForElement(_app.Marked("theDatePicker"));
+
+			var theDatePicker = _app.Marked("theDatePicker");
+			var datePickerFlyout = theDatePicker.Child;
+
+			// Open flyout
+			theDatePicker.Tap();
+
+			//Assert
+			Assert.Equals("True", datePickerFlyout.GetDependencyPropertyValue("IsOpened").ToString());
+
+			// Open flyout
+			theDatePicker.Tap();
+
+			//Assert
+			Assert.Equals("False", datePickerFlyout.GetDependencyPropertyValue("IsOpened").ToString());
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPresenter.cs
@@ -8,36 +8,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 		}
 
-		protected override void OnPointerPressed(PointerRoutedEventArgs args)
-		{
-			// All pointer-related should be "eaten" to prevent closing
-			// the flyout when a tap is done in its content
-			args.Handled = true;
-		}
-
-		protected override void OnPointerReleased(PointerRoutedEventArgs args)
-		{
-			// All pointer-related should be "eaten" to prevent closing
-			// the flyout when a tap is done in its content
-			args.Handled = true;
-		}
-
-		protected override void OnTapped(TappedRoutedEventArgs args)
-		{
-			// All pointer-related should be "eaten" to prevent closing
-			// the flyout when a tap is done in its content
-			args.Handled = true;
-		}
-
-		protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs args)
-		{
-			// All pointer-related should be "eaten" to prevent closing
-			// the flyout when a tap is done in its content
-			args.Handled = true;
-		}
-
 		protected override bool CanCreateTemplateWithoutParent { get; } = true;
 
-		internal override bool IsViewHit() => true;
+		internal override bool IsViewHit() => false;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Style/Generic/DatePickerSelector.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/DatePickerSelector.xaml
@@ -16,6 +16,7 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="DatePickerSelector">
 					<Border Background="White"
+							VerticalAlignment="Bottom"
 							Margin="5"
 							CornerRadius="10">
 						<native:UIDatePicker/>

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -1977,6 +1977,52 @@
 		</Setter>
 	</Style>
 
+	<!-- IOS Default style for DatePickerFlyoutPresenter -->
+	<ios:Style TargetType="DatePickerFlyoutPresenter">
+		<Setter Property="RequestedTheme"
+				Value="Dark" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Center" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalAlignment"
+				Value="Stretch" />
+		<Setter Property="IsTabStop"
+				Value="False" />
+		<Setter Property="Background"
+				Value="#FF808080" />
+		<Setter Property="BorderThickness"
+				Value="0" />
+		<Setter Property="Padding"
+				Value="10" />
+		<Setter Property="MinWidth"
+				Value="50" />
+		<Setter Property="MinHeight"
+				Value="30" />
+		<!--To take up full background-->
+        <Setter Property="Width"
+                Value="5000"/>
+        <Setter Property="Height"
+                Value="10000"/>
+        <Setter Property="ScrollViewer.HorizontalScrollMode"
+				Value="Auto" />
+		<win:Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+					Value="Auto" />
+		<Setter Property="ScrollViewer.VerticalScrollMode"
+				Value="Auto" />
+		<win:Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+					Value="Auto" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="DatePickerFlyoutPresenter">
+					<ContentPresenter Content="{TemplateBinding Content}" />
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</ios:Style>
+
 		<!--Default style for TimePickerSelector - Xamarin-only control internal to TimePickerFlyout-->
 	<xamarin:Style TargetType="TimePickerSelector">
 		<ios:Setter Property="Template">


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://github.com/unoplatform/private/issues/76

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Fix to flyoutpresenter(area around flyout) not dismissing flyout on tap


## What is the new behavior?

Dismisses flyout on tap


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
~~- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
~~- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
