### PR TITLE
#1430 Surface multiple iOS constructors 

### DIFF
--- a/src/Uno.UI/Controls/BindableSearchBar.iOS.cs
+++ b/src/Uno.UI/Controls/BindableSearchBar.iOS.cs
@@ -9,6 +9,8 @@ using Uno.UI.DataBinding;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 using Uno.Client;
+using CoreGraphics;
+
 #if XAMARIN_IOS_UNIFIED
 using Foundation;
 using UIKit;
@@ -25,7 +27,7 @@ namespace Uno.UI.Controls
 		private static readonly TimeSpan _defaultTextChangedMinDelay = TimeSpan.FromMilliseconds(250);
 		private const bool _defaultIsAutoLostFocusEnabled = true;
 
-		private readonly SerialDisposable _textChangedSubscription;
+		private readonly SerialDisposable _textChangedSubscription = new SerialDisposable();
 
 		private ICommand _submitCommand;
 		private TimeSpan _textUpdateMinDelay = _defaultTextChangedMinDelay;
@@ -33,8 +35,37 @@ namespace Uno.UI.Controls
 
 		public BindableSearchBar()
 		{
+			Initialize();
+		}
+
+		public BindableSearchBar(CGRect frame)
+			: base(frame)
+		{
+			Initialize();
+		}
+
+		public BindableSearchBar(NSCoder coder)
+			: base(coder)
+		{
+			Initialize();
+		}
+
+		public BindableSearchBar(NSObjectFlag t)
+			: base(t)
+		{
+			Initialize();
+		}
+
+		public BindableSearchBar(IntPtr handle)
+			: base(handle)
+		{
+			Initialize();
+		}
+
+
+		private void Initialize()
+		{
 			InitializeBinder();
-			_textChangedSubscription = new SerialDisposable();
 
 			UpdateTextChangedSubscription();
 			SearchButtonClicked += SubmitQuery;

--- a/src/Uno.UI/Controls/BindableUIActivityIndicatorView.iOS.cs
+++ b/src/Uno.UI/Controls/BindableUIActivityIndicatorView.iOS.cs
@@ -1,16 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Windows.UI.Xaml;
-using CoreGraphics;
-
-#if XAMARIN_IOS_UNIFIED
 using Foundation;
 using UIKit;
-#elif XAMARIN_IOS
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
+using Windows.UI.Xaml;
+using CoreGraphics;
 
 namespace Uno.UI.Views.Controls
 {

--- a/src/Uno.UI/Controls/BindableUIActivityIndicatorView.iOS.cs
+++ b/src/Uno.UI/Controls/BindableUIActivityIndicatorView.iOS.cs
@@ -1,15 +1,46 @@
-﻿using Foundation;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using UIKit;
 using Windows.UI.Xaml;
+using CoreGraphics;
+
+#if XAMARIN_IOS_UNIFIED
+using Foundation;
+using UIKit;
+#elif XAMARIN_IOS
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+#endif
 
 namespace Uno.UI.Views.Controls
 {
 	public partial class BindableUIActivityIndicatorView : UIActivityIndicatorView, DependencyObject
 	{
 		public BindableUIActivityIndicatorView()
+		{
+			InitializeBinder();
+		}
+
+		public BindableUIActivityIndicatorView(CGRect frame)
+			: base(frame)
+		{
+			InitializeBinder();
+		}
+
+		public BindableUIActivityIndicatorView(NSCoder coder)
+			: base(coder)
+		{
+			InitializeBinder();
+		}
+
+		public BindableUIActivityIndicatorView(NSObjectFlag t)
+			: base(t)
+		{
+			InitializeBinder();
+		}
+
+		public BindableUIActivityIndicatorView(IntPtr handle)
+			: base(handle)
 		{
 			InitializeBinder();
 		}

--- a/src/Uno.UI/Controls/BindableUIButton.iOS.cs
+++ b/src/Uno.UI/Controls/BindableUIButton.iOS.cs
@@ -40,6 +40,18 @@ namespace Uno.UI.Views.Controls
 			InitializeBinder();
 		}
 
+		public BindableUIButton(NSCoder coder)
+			: base(coder)
+		{
+			InitializeBinder();
+		}
+
+		public BindableUIButton(NSObjectFlag t)
+			: base(t)
+		{
+			InitializeBinder();
+		}
+
 		string _text;
 
 		public string Text

--- a/src/Uno.UI/Controls/BindableUISlider.iOS.cs
+++ b/src/Uno.UI/Controls/BindableUISlider.iOS.cs
@@ -2,16 +2,10 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
-using Windows.UI.Xaml;
-using CoreGraphics;
-
-#if XAMARIN_IOS_UNIFIED
 using Foundation;
 using UIKit;
-#elif XAMARIN_IOS
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
+using Windows.UI.Xaml;
+using CoreGraphics;
 
 namespace Uno.UI.Controls
 {

--- a/src/Uno.UI/Controls/BindableUISlider.iOS.cs
+++ b/src/Uno.UI/Controls/BindableUISlider.iOS.cs
@@ -2,32 +2,69 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
-using UIKit;
 using Windows.UI.Xaml;
+using CoreGraphics;
+
+#if XAMARIN_IOS_UNIFIED
+using Foundation;
+using UIKit;
+#elif XAMARIN_IOS
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+#endif
 
 namespace Uno.UI.Controls
 {
-    public partial class BindableUISlider : UISlider, DependencyObject, INotifyPropertyChanged
-    {
-        public BindableUISlider()
-        {
-            this.ValueChanged += (s, e) =>
-            {
-                SetBindingValue(Value, nameof(Value));
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
-            };
-        }
+	public partial class BindableUISlider : UISlider, DependencyObject, INotifyPropertyChanged
+	{
+		public BindableUISlider()
+		{
+			Initialize();
+		}
 
-        public override float Value
-        {
-            get { return base.Value; }
-            set
-            {
-                base.Value = value;
-                
-            }
-        }
+		public BindableUISlider(CGRect frame)
+			: base(frame)
+		{
+			Initialize();
+		}
 
-        public event PropertyChangedEventHandler PropertyChanged;
-    }
+		public BindableUISlider(NSCoder coder)
+			: base(coder)
+		{
+			Initialize();
+		}
+
+		public BindableUISlider(NSObjectFlag t)
+			: base(t)
+		{
+			Initialize();
+		}
+
+		public BindableUISlider(IntPtr handle)
+			: base(handle)
+		{
+			Initialize();
+		}
+
+		private void Initialize()
+		{
+			this.ValueChanged += (s, e) =>
+			{
+				SetBindingValue(Value, nameof(Value));
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Value)));
+			};
+		}
+
+		public override float Value
+		{
+			get { return base.Value; }
+			set
+			{
+				base.Value = value;
+
+			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+	}
 }

--- a/src/Uno.UI/Controls/BindableUIView.iOS.cs
+++ b/src/Uno.UI/Controls/BindableUIView.iOS.cs
@@ -80,6 +80,18 @@ namespace Uno.UI.Controls
 			Initialize();
 		}
 
+		public BindableUIView(NSCoder coder)
+			: base(coder)
+		{
+			Initialize();
+		}
+
+		public BindableUIView(NSObjectFlag t)
+			: base(t)
+		{
+			Initialize();
+		}
+
 		private void Initialize()
 		{
 			InitializeBinder();

--- a/src/Uno.UI/Controls/RootViewController.iOS.cs
+++ b/src/Uno.UI/Controls/RootViewController.iOS.cs
@@ -2,18 +2,12 @@
 using System.Collections.Generic;
 using System.Text;
 using Windows.Graphics.Display;
+using Foundation;
+using UIKit;
 using Windows.UI.Xaml.Media;
 using Uno.Extensions;
 using Windows.Devices.Sensors;
 using CoreGraphics;
-
-#if XAMARIN_IOS_UNIFIED
-using Foundation;
-using UIKit;
-#elif XAMARIN_IOS
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace Uno.UI.Controls
 {

--- a/src/Uno.UI/Controls/RootViewController.iOS.cs
+++ b/src/Uno.UI/Controls/RootViewController.iOS.cs
@@ -2,10 +2,18 @@
 using System.Collections.Generic;
 using System.Text;
 using Windows.Graphics.Display;
-using UIKit;
 using Windows.UI.Xaml.Media;
 using Uno.Extensions;
 using Windows.Devices.Sensors;
+using CoreGraphics;
+
+#if XAMARIN_IOS_UNIFIED
+using Foundation;
+using UIKit;
+#elif XAMARIN_IOS
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+#endif
 
 namespace Uno.UI.Controls
 {
@@ -14,6 +22,35 @@ namespace Uno.UI.Controls
 		internal event Action VisibleBoundsChanged;
 
 		public RootViewController()
+		{
+			Initialize();
+		}
+
+		public RootViewController(UIViewController rootViewController)
+			: base(rootViewController)
+		{
+			Initialize();
+		}
+
+		public RootViewController(NSObjectFlag t)
+			: base(t)
+		{
+			Initialize();
+		}
+
+		public RootViewController(NSCoder coder)
+			: base(coder)
+		{
+			Initialize();
+		}
+
+		public RootViewController(IntPtr handle)
+			: base(handle)
+		{
+			Initialize();
+		}
+
+		private void Initialize()
 		{
 			// Dismiss on device rotation: this reproduces the windows behavior
 			UIApplication.Notifications

--- a/src/Uno.UI/Controls/UnoNavigationBar.iOS.cs
+++ b/src/Uno.UI/Controls/UnoNavigationBar.iOS.cs
@@ -3,14 +3,8 @@ using System.Collections.Generic;
 using System.Text;
 using CoreGraphics;
 using Windows.UI.Xaml;
-
-#if XAMARIN_IOS_UNIFIED
 using Foundation;
 using UIKit;
-#elif XAMARIN_IOS
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
-#endif
 
 namespace Uno.UI.Controls
 {

--- a/src/Uno.UI/Controls/UnoNavigationBar.iOS.cs
+++ b/src/Uno.UI/Controls/UnoNavigationBar.iOS.cs
@@ -2,13 +2,50 @@
 using System.Collections.Generic;
 using System.Text;
 using CoreGraphics;
+using Windows.UI.Xaml;
+
+#if XAMARIN_IOS_UNIFIED
+using Foundation;
 using UIKit;
+#elif XAMARIN_IOS
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+#endif
 
 namespace Uno.UI.Controls
 {
-	public partial class UnoNavigationBar : UINavigationBar
+	public partial class UnoNavigationBar : UINavigationBar, DependencyObject
 	{
 		internal event Action SizeChanged;
+
+		public UnoNavigationBar()
+		{
+			InitializeBinder();
+		}
+
+		public UnoNavigationBar(CGRect frame)
+			: base(frame)
+		{
+			InitializeBinder();
+		}
+
+		public UnoNavigationBar(NSCoder coder)
+			: base(coder)
+		{
+			InitializeBinder();
+		}
+
+		public UnoNavigationBar(NSObjectFlag t)
+			: base(t)
+		{
+			InitializeBinder();
+		}
+
+		public UnoNavigationBar(IntPtr handle)
+			: base(handle)
+		{
+			InitializeBinder();
+		}
 
 		public override CGRect Frame
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #1430

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Multiple UIKit controls constructors are currently unsupported

## What is the new behavior?

Now possible to utilize additional available base constructors such as:
```csharp
     public RootViewController(UIViewController rootViewController)
		: base(rootViewController)
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Other information

Successfully built against target framework xamarinios10

## For which Platform:
- [X] iOS
- [ ] Android
- [ ] WebAssembly
- [ ] Windows
