### PR TITLE
housekeeping: adjusted github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -30,18 +30,23 @@ Nuget Package:
 Package Version(s):
 
 Affected platform(s):
+
 - [ ] iOS
 - [ ] Android
 - [ ] WebAssembly
+- [ ] WebAssembly renderers for Xamarin.Forms
 - [ ] Windows
 - [ ] Build tasks
+- [ ] Solution Templates
 
-Visual Studio
+Visual Studio:
+
 - [ ] 2017 (version: )
 - [ ] 2019 (version: )
 - [ ] for Mac (version: )
 
-Relevant plugins
+Relevant plugins:
+
 - [ ] Resharper (version: )
 
 ## Anything else we need to know?

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -15,7 +15,10 @@ labels: kind/enhancement, triage/untriaged
 - [ ] iOS
 - [ ] Android
 - [ ] WebAssembly
+- [ ] WebAssembly renderers for Xamarin.Forms
 - [ ] Windows
+- [ ] Build tasks
+- [ ] Solution Templates
 
 ## Anything else we need to know?
 

--- a/.github/ISSUE_TEMPLATE/samples-request.md
+++ b/.github/ISSUE_TEMPLATE/samples-request.md
@@ -15,7 +15,9 @@ labels: kind/contributor-experience, kind/documentation, triage/untriaged
 - [ ] iOS
 - [ ] Android
 - [ ] WebAssembly
+- [ ] WebAssembly renderers for Xamarin.Forms
 - [ ] Windows
+
 
 ## Anything else we need to know?
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Other... Please describe:

Adjusts GitHub -> New Issue templates.

## What is the new behavior?

- Added Xamarin.Forms
- Standardized platforms across issue types

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)


## Other information

