### PR TITLE
housekeeping: automatically label pull-requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,58 @@
+# https://github.com/actions/labeler
+
+area/automation:
+  - src/SamplesApp/*
+  - src/SamplesApp/**/*
+  - src/Uno.UI.Tests/*
+  - src/Uno.UI.Tests/**/*
+  - src/Uno.UI.Tests.Performance/*
+  - src/Uno.UI.Tests.Performance/**/*
+  - src/Uno.UI.Wasm.Tests/*
+  - src/Uno.UI.Wasm.Tests/**/*
+
+area/android:
+  - src/Uno.UI.BindingHelper.Android/*
+  - src/Uno.UI.BindingHelper.Android/**/*
+  - ./**/*.Android.cs
+  - ./**/*.android.cs
+  - ./**/*.droid.cs
+
+area/build:
+  - build/*
+  - build/**/*
+  - ./**/*.yml
+  - src/Uno.UI.AssemblyComparer/*
+  - src/Uno.UI.AssemblyComparer/**/*
+  - src/Uno.UI.TestComparer/*
+  - src/Uno.UI.TestComparer/**/*
+
+area/code-generation:
+  - src/SourceGenerators/*
+  - src/SourceGenerators/**/*
+
+area/community:
+  - .all-contributorsrc
+
+kind/documentation:
+  - README.*
+  - docs/*
+  - docs/**/*
+  - ./**/*.md
+  - ./**/*.MD
+  - ./**/*.txt
+
+area/ios:
+  - ./**/*.iOS.cs
+  - ./**/*.ios.cs
+
+area/solution-templates:
+  - src/SolutionTemplate/*
+  - src/SolutionTemplate/**/*
+  - src/UnoItemTemplate/*
+  - src/UnoItemTemplate/**/*
+
+area/wasm:
+  - ./**/*.wasm.cs
+  - ./**/*.WASM.cs
+  - src/Uno.UI.Wasm/*
+  - src/Uno.UI.Wasm/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?

- Project automation

## What is the current behavior?

I'm spending too much time labeling pull-requests by hand and at times they don't get labelled if I'm traveling or on leave.

## What is the new behavior?

Automatically label pull-requests based off filenames 

![](https://media.giphy.com/media/YTbZzCkRQCEJa/giphy.gif)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)


## Other information

See https://github.com/actions/labeler to learn more.