### PR TITLE
feature: enable wasm debugging by default

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Wasm/UnoQuickStart.Wasm.csproj
@@ -8,6 +8,13 @@
 		<NoWarn>NU1701</NoWarn>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
+		<MonoRuntimeDebuggerEnabled>true</MonoRuntimeDebuggerEnabled>
+		<DefineConstants>TRACE;DEBUG</DefineConstants>
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<Content Include="..\$ext_safeprojectname$.UWP\Assets\*.png" Link="Assets\%(FileName)%(Extension)" />
 	</ItemGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

People need to find the information and do things manually to enable debugging support.

## What is the new behavior?

Debugging support is enabled by default.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

Opening up pull-request for discussion. Is there any reason why this hasn't been enabled by default? Do we want to ship these specific defaults?