### PR TITLE
Added partial initialization hookup

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/NativeCtor/NativeCtorsGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/NativeCtor/NativeCtorsGenerator.cs
@@ -44,7 +44,10 @@ namespace {0}
 	partial class {1}
 	{{
 #if {2}
-		public {3}() {{ }}
+		public {3}()
+		{{
+			OnInitialized();
+		}}
 #endif
 
 #if __ANDROID__
@@ -55,7 +58,10 @@ namespace {0}
 		/// Used by the Xamarin Runtime to materialize native 
 		/// objects that may have been collected in the managed world.
 		/// </remarks>
-		public {3}(IntPtr javaReference, global::Android.Runtime.JniHandleOwnership transfer) : base (javaReference, transfer) {{ }}
+		public {3}(IntPtr javaReference, global::Android.Runtime.JniHandleOwnership transfer) : base (javaReference, transfer)
+	    {{
+			OnInitialized();
+		}}
 #endif
 #if __IOS__
 		/// <summary>
@@ -65,9 +71,14 @@ namespace {0}
 		/// Used by the Xamarin Runtime to materialize native 
 		/// objects that may have been collected in the managed world.
 		/// </remarks>
-		public {3}(IntPtr handle) : base (handle) {{ }}
+		public {3}(IntPtr handle) : base (handle)
+		{{
+			OnInitialized();
+		}}
 #endif
 	}}
+
+	partial void OnInitialized();
 }}
 ";
 


### PR DESCRIPTION
GitHub Issue (If applicable): #1385

## PR Type

Feature

## What is the current behavior?

Adds hookup to UI controls' initialization process


## What is the new behavior?

Adds a partial `OnInitialization` method that's called from all platforms' constructors, to enable a unified initialization hookup.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)