### PR TITLE
fix: ApplicationData.Current.[LocalFolder|RoamingFolder] throws a NRE exception

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -91,6 +91,7 @@
 ### Bug fixes
 
 * [#1741](https://github.com/unoplatform/uno/issues/1741) On Android, `ApplicationData.Current.[LocalFolder|RoamingFolder]` can now be used in the ctor of App.xaml.cs
+    > This change introduces a new constructor in `Windows.UI.Xaml.NativeApplication` that requests a delegate. In the Visual Studio Templates for Uno Platform, the `Main.cs` for the Android, the constructor now provides `() => new App()` instead of `new App()`, you can do the same in your existing application. See [this file](https://github.com/unoplatform/uno/blob/master/src/SolutionTemplate/UnoSolutionTemplate/Droid/Main.cs) for an example.
 * [#1767] Invalid `this` keyword generated for `Storyboard.SetTarget`
 * [#1781] WASM Images are no longer draggable and selectable by default to match UWP
 * [#1771](https://github.com/unoplatform/uno/pull/1771) Fix ".Uno" in project names resulted in build errors.

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -1,4 +1,4 @@
-# Release notes
+﻿# Release notes
 
 ## Next version
 
@@ -89,6 +89,8 @@
     > This change might break the compilation for projects that define duplicate resources in other globally accessible resource dictionaries. Adjustments to remove duplicate resources may be necessary.
 
 ### Bug fixes
+
+* [#1741](https://github.com/unoplatform/uno/issues/1741) On Android, `ApplicationData.Current.[LocalFolder|RoamingFolder]` can now be used in the ctor of App.xaml.cs
 * [#1767] Invalid `this` keyword generated for `Storyboard.SetTarget`
 * [#1781] WASM Images are no longer draggable and selectable by default to match UWP
 * [#1771](https://github.com/unoplatform/uno/pull/1771) Fix ".Uno" in project names resulted in build errors.

--- a/src/SamplesApp/SamplesApp.Droid/Main.cs
+++ b/src/SamplesApp/SamplesApp.Droid/Main.cs
@@ -23,7 +23,7 @@ namespace SamplesApp.Droid
 	public class Application : Windows.UI.Xaml.NativeApplication
 	{
 		public Application(IntPtr javaReference, JniHandleOwnership transfer)
-			: base(new App(), javaReference, transfer)
+			: base(() => new App(), javaReference, transfer)
 		{
 			ConfigureUniversalImageLoader();
 		}

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -22,6 +22,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SamplesApp
 {
@@ -38,8 +39,31 @@ namespace SamplesApp
 		{
 			ConfigureFilters(LogExtensionPoint.AmbientLoggerFactory);
 
+			AssertIssue1790();
+
 			this.InitializeComponent();
 			this.Suspending += OnSuspending;
+
+		}
+
+		/// <summary>
+		/// Assert that ApplicationData.Current.[LocalFolder|RoamingFolder] is usable in the constructor of App.xaml.cs on all platforms.
+		/// </summary>
+		/// <seealso cref="https://github.com/unoplatform/uno/issues/1741"/>
+		public void AssertIssue1790()
+		{
+			void AssertIsUsable(Windows.Storage.ApplicationDataContainer container)
+			{
+				const string issue1790 = nameof(issue1790);
+
+				container.Values.Remove(issue1790);
+				container.Values.Add(issue1790, "ApplicationData.Current.[LocalFolder|RoamingFolder] is usable in the constructor of App.xaml.cs on this platform.");
+
+				Assert.IsTrue(container.Values.ContainsKey(issue1790));
+			}
+
+			AssertIsUsable(Windows.Storage.ApplicationData.Current.LocalSettings);
+			AssertIsUsable(Windows.Storage.ApplicationData.Current.RoamingSettings);
 		}
 
 		/// <summary>

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -137,7 +137,7 @@ namespace SamplesApp
 						{ "Windows", LogLevel.Warning },
 						// { "Uno.Foundation.WebAssemblyRuntime", LogLevel.Debug },
 						// { "Windows.UI.Xaml.Controls.PopupPanel", LogLevel.Debug },
-						
+
 						// Generic Xaml events
 						//{ "Windows.UI.Xaml", LogLevel.Debug },
 						// { "Windows.UI.Xaml.Shapes", LogLevel.Debug },
@@ -145,17 +145,17 @@ namespace SamplesApp
 						//{ "Windows.UI.Xaml.StateTriggerBase", LogLevel.Debug },
 						// { "Windows.UI.Xaml.UIElement", LogLevel.Debug },
 						// { "Windows.UI.Xaml.Controls.TextBlock", LogLevel.Debug },
-						   
+
 						// Layouter specific messages
 						// { "Windows.UI.Xaml.Controls", LogLevel.Debug },
 						//{ "Windows.UI.Xaml.Controls.Layouter", LogLevel.Debug },
 						//{ "Windows.UI.Xaml.Controls.Panel", LogLevel.Debug },
 						// { "Windows.Storage", LogLevel.Debug },
-						   
+
 						// Binding related messages
 						// { "Windows.UI.Xaml.Data", LogLevel.Debug },
 						// { "Windows.UI.Xaml.Data", LogLevel.Debug },
-						   
+
 						//  Binder memory references tracking
 						// { "ReferenceHolder", LogLevel.Debug },
 					}
@@ -201,8 +201,8 @@ namespace SamplesApp
 #endif
 
 #if HAS_UNO
-                            // Disable the TextBox caret for new instances
-                            Uno.UI.FeatureConfiguration.TextBox.HideCaret = true;
+							// Disable the TextBox caret for new instances
+							Uno.UI.FeatureConfiguration.TextBox.HideCaret = true;
 #endif
 
 							var t = SampleControl.Presentation.SampleChooserViewModel.Instance.SetSelectedSample(CancellationToken.None, metadataName);

--- a/src/SolutionTemplate/UnoSolutionTemplate/Droid/Main.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Droid/Main.cs
@@ -23,7 +23,7 @@ namespace $ext_safeprojectname$.Droid
 	public class Application : Windows.UI.Xaml.NativeApplication
 	{
 		public Application(IntPtr javaReference, JniHandleOwnership transfer)
-			: base(new App(), javaReference, transfer)
+			: base(() => new App(), javaReference, transfer)
 		{
 			ConfigureUniversalImageLoader();
 		}

--- a/src/Uno.UI/UI/Xaml/NativeApplication.cs
+++ b/src/Uno.UI/UI/Xaml/NativeApplication.cs
@@ -8,6 +8,9 @@ using Uno.UI.Services;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.StartScreen;
 using Android.Content;
+using Uno.Extensions;
+using Microsoft.Extensions.Logging;
+using System.ComponentModel;
 
 namespace Windows.UI.Xaml
 {
@@ -16,10 +19,32 @@ namespace Windows.UI.Xaml
 		private readonly Application _app;
 		private Intent _lastHandledIntent;
 
+		public delegate Windows.UI.Xaml.Application AppBuilder();
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public NativeApplication(Windows.UI.Xaml.Application app, IntPtr javaReference, Android.Runtime.JniHandleOwnership transfer)
+			: this(() => app, javaReference, transfer)
+		{
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().LogWarning(
+					"The constructor on Windows.UI.Xaml.NativeApplication uses an explicitly created Windows.UI.Xaml.Application instance. " +
+					"Instead, use the constructor that requires a Windows.UI.Xaml.NativeApplication.AppBuilder delegate.");
+			}
+		}
+
+		/// <summary>
+		/// Creates an android Application instance
+		/// </summary>
+		/// <param name="appBuilder">A <see cref="AppBuilder"/> delegate that provides an <see cref="Application"/> instance.</param>
+		public NativeApplication(AppBuilder appBuilder, IntPtr javaReference, Android.Runtime.JniHandleOwnership transfer)
 			: base(javaReference, transfer)
 		{
-			_app = app;
+			// Delay create the Windows.UI.Xaml.Application in order to get the
+			// Android.App.Application.Context to be populated properly. This enables
+			// APIs such as Windows.Storage.ApplicationData.Current.LocalSettings to function properly.
+			_app = appBuilder();
+
 			ResourceHelper.ResourcesService = new ResourcesService(this);
 		}
 

--- a/src/Uno.UWP/Storage/ApplicationData.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationData.Android.cs
@@ -4,22 +4,29 @@ using System.IO;
 
 namespace Windows.Storage
 {
-	partial class ApplicationData 
+	partial class ApplicationData
 	{
-		private static string GetLocalCacheFolder() 
-			=> Android.App.Application.Context.CacheDir.AbsolutePath;
+		private static string GetLocalCacheFolder()
+			=> GetAndroidAppContext().CacheDir.AbsolutePath;
 
 		private static string GetTemporaryFolder()
 			=> Path.GetTempPath();
 
-		private static string GetLocalFolder() 
-			=> Android.App.Application.Context.FilesDir.AbsolutePath;
+		private static string GetLocalFolder()
+			=> GetAndroidAppContext().FilesDir.AbsolutePath;
 
 		private static string GetRoamingFolder()
 			=> Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
 		private static string GetSharedLocalFolder()
 			=> Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+		internal static Android.Content.Context GetAndroidAppContext()
+			=> Android.App.Application.Context
+				?? throw new InvalidOperationException(
+					"The Android Application context is not yet available. " +
+					"You need to initialize Windows.UI.Xaml.NativeApplication using the constructor " +
+					"with the Windows.UI.Xaml.NativeApplication.AppBuilder delegate.");
 	}
 }
 #endif

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
@@ -26,7 +26,7 @@ namespace Windows.Storage
 
 			public SharedPreferencesPropertySet()
 			{
-				_preferences = PreferenceManager.GetDefaultSharedPreferences(ContextHelper.Current);
+				_preferences = PreferenceManager.GetDefaultSharedPreferences(Android.App.Application.Context);
 			}
 
 			public object this[string key]

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
@@ -33,12 +33,12 @@ namespace Windows.Storage
 			{
 				get
 				{
-					if(TryGetValue(key, out var value))
+					if (TryGetValue(key, out var value))
 					{
 						return value;
 					}
 
-					return null;					
+					return null;
 				}
 				set
 				{
@@ -86,7 +86,7 @@ namespace Windows.Storage
 					throw new ArgumentException("An item with the same key has already been added.");
 				}
 				if (value != null)
-				{					
+				{
 					_preferences
 						.Edit()
 						.PutString(key, DataTypeSerializer.Serialize(value))
@@ -105,7 +105,7 @@ namespace Windows.Storage
 					.Commit();
 			}
 
-			public bool Contains(KeyValuePair<string, object> item) 
+			public bool Contains(KeyValuePair<string, object> item)
 				=> throw new NotSupportedException();
 
 			public bool ContainsKey(string key)
@@ -131,7 +131,7 @@ namespace Windows.Storage
 
 			public bool TryGetValue(string key, out object value)
 			{
-				if(_preferences.All.TryGetValue(key, out var serializedValue))
+				if (_preferences.All.TryGetValue(key, out var serializedValue))
 				{
 					value = DataTypeSerializer.Deserialize(serializedValue?.ToString());
 					return true;

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
@@ -26,7 +26,7 @@ namespace Windows.Storage
 
 			public SharedPreferencesPropertySet()
 			{
-				_preferences = PreferenceManager.GetDefaultSharedPreferences(Android.App.Application.Context);
+				_preferences = PreferenceManager.GetDefaultSharedPreferences(ApplicationData.GetAndroidAppContext());
 			}
 
 			public object this[string key]


### PR DESCRIPTION
GitHub Issue (If applicable):

Fixes #1741
Fixes https://github.com/unoplatform/uno/issues/1879


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On Android, `ApplicationData.Current.[LocalFolder|RoamingFolder]` throws a NRE exception if accessed in the constructor of App.xaml.cs.

Digging into the current implementation on Android reveals:

https://github.com/unoplatform/uno/blob/master/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs#L29

Specifically there's a dependency on `ContextHelper.Current`:

```csharp
_preferences = PreferenceManager.GetDefaultSharedPreferences(ContextHelper.Current);
```

and `ContextHelper.Current` isn't populated until an activity is created:

```csharp
protected override void OnLaunched(LaunchActivatedEventArgs e)
{
    Console.WriteLine(ContextHelper.Current); // is the name of the current activity.
}
```

Here's `ContextHelper.Current` in the App.xaml.cs constructor:

```csharp
sealed partial class App : Application
{
    public App()
    {
        Console.WriteLine(ContextHelper.Current); // is null.
    }
}
```

## What is the new behavior?

The fix is to change the internals of Uno to use `Android.App.Application.Context` instead of `ContextHelper.Current` as the preference manager needs any context and the application context will do. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Outstanding Tasks

- [ ] Determine appropriate way to test this scenario to prevent regressions
- [x] Update release notes
