### PR TITLE
automation: automatically merge PR's from the allcontributors r…

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,4 @@
 pull_request_rules:
-  - name: automatic deletion of pull-request branches after merge
-    conditions: []
-    actions:
-      # Takes no options, see <https://doc.mergify.io/examples.html#deleting-merged-branch>
-      delete_head_branch: {}
 
   - name: automatic strict merge when CI passes, has 2 reviews, no requests for change and is labeled 'ready-to-merge' unless labelled 'do-not-merge/breaking-change' or 'do-not-merge/work-in-progress'
     conditions:
@@ -36,3 +31,10 @@ pull_request_rules:
         # https://doc.mergify.io/strict-workflow.html
         # https://doc.mergify.io/actions.html#label
         strict: smart
+
+  - name: automatic merge for allcontributors pull requests
+    conditions:
+      - author=allcontributors[bot]
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?

- Project automation

## What is the current behavior?

Spending too much time waiting for all-contributors pull-requests to the README to pass. If multiple PR's are open at the same time then there's merge conflicts which is a time suck.

## What is the new behavior?

Automatically merge pull-requests from all-contributors.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)



## Other information

Tested in the mergify simulator against https://github.com/unoplatform/uno/pull/1760