### PR TITLE
Static resources defined in App.xaml were not processed properly

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -83,6 +83,8 @@
 * Projects targeting Android 9 must now use Xamarin.GooglePlayServices.* 71.1600.0
 * [iOS] UIWebView is deprecated and replaced with WKWebView (ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of apps that use UIWebView APIs . See https://developer.apple.com/documentation/uikit/uiwebview for more information.)
 * [iOS] If you set the `ManipulationMode` to something else than `System` or `All`, the [DelaysContentTouches](https://developer.apple.com/documentation/uikit/uiscrollview/1619398-delayscontenttouches) is going to be disabled on all parent `ScrollViewer`
+* [#1237] Static resources defined in App.xaml were not processed and registered properly
+    > This change might break the compilation for projects that define duplicate resources in other globally accessible resource dictionaries. Adjustments to remove duplicate resources may be necessary.
 
 ### Bug fixes
 

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml
@@ -4,42 +4,64 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	RequestedTheme="Light">
 
-	<Application.Resources>
+  <Application.Resources>
+	<ResourceDictionary>
+	  <ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="HighContrast">
+		  <SolidColorBrush x:Key="GlobalThemeResource_Test01"
+						   Color="Red" />
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Default">
+		  <SolidColorBrush x:Key="GlobalThemeResource_Test01"
+						   Color="Gray" />
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Dark">
+		  <SolidColorBrush x:Key="GlobalThemeResource_Test01"
+						   Color="Blue" />
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Light">
+		  <SolidColorBrush x:Key="GlobalThemeResource_Test01"
+						   Color="Yellow" />
+		</ResourceDictionary>
+	  </ResourceDictionary.ThemeDictionaries>
 
-		<!-- ReSharper disable once InconsistentNaming -->
-		<SolidColorBrush x:Key="Pink_From_App_Xaml_Resources" Color="#FF54BA" />
+	  <SolidColorBrush x:Key="GlobalStaticResource_Test01"
+						Color="Purple" />
 
-		<Style x:Key="Style_Bold_From_App_Xaml_Resources" TargetType="TextBlock">
-			<Setter Property="FontWeight" Value="ExtraBold" />
-		</Style>
+	  <!-- ReSharper disable once InconsistentNaming -->
+	  <SolidColorBrush x:Key="Pink_From_App_Xaml_Resources" Color="#FF54BA" />
 
-		<Style x:Key="Style_Pink_From_App_Xaml_Resources" TargetType="TextBlock" BasedOn="{StaticResource Style_Bold_From_App_Xaml_Resources}">
-			<Setter Property="Foreground" Value="{StaticResource Pink_From_App_Xaml_Resources}" />
-		</Style>
+	  <Style x:Key="Style_Bold_From_App_Xaml_Resources" TargetType="TextBlock">
+		<Setter Property="FontWeight" Value="ExtraBold" />
+	  </Style>
 
-		<Style x:Key="CustomTextBox" TargetType="TextBox" >
-			<Setter Property="Template">
-				<Setter.Value>
-					<ControlTemplate TargetType="TextBox">
-						<Grid>
-							<Grid.Resources>
-								<Style x:Key="TestStyle" TargetType="Button">
-									<Setter Property="Template">
-										<Setter.Value>
-											<ControlTemplate TargetType="Button">
-												<Grid>
-													<TextBlock Text="Sample" />
-												</Grid>
-											</ControlTemplate>
-										</Setter.Value>
-									</Setter>
-								</Style>
-							</Grid.Resources>
-						</Grid>
-					</ControlTemplate>
-				</Setter.Value>
-			</Setter>
-		</Style>
+	  <Style x:Key="Style_Pink_From_App_Xaml_Resources" TargetType="TextBlock" BasedOn="{StaticResource Style_Bold_From_App_Xaml_Resources}">
+		<Setter Property="Foreground" Value="{StaticResource Pink_From_App_Xaml_Resources}" />
+	  </Style>
 
-	</Application.Resources>
+	  <Style x:Key="CustomTextBox" TargetType="TextBox" >
+		<Setter Property="Template">
+		  <Setter.Value>
+			<ControlTemplate TargetType="TextBox">
+			  <Grid>
+				<Grid.Resources>
+				  <Style x:Key="TestStyle" TargetType="Button">
+					<Setter Property="Template">
+					  <Setter.Value>
+						<ControlTemplate TargetType="Button">
+						  <Grid>
+							<TextBlock Text="Sample" />
+						  </Grid>
+						</ControlTemplate>
+					  </Setter.Value>
+					</Setter>
+				  </Style>
+				</Grid.Resources>
+			  </Grid>
+			</ControlTemplate>
+		  </Setter.Value>
+		</Setter>
+	  </Style>
+	</ResourceDictionary>
+  </Application.Resources>
 </Application>

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="FluentAssertions" Version="5.9.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
 		<PackageReference Include="NUnit" />
-		<PackageReference Include="NUnit3TestAdapter"/>
+		<PackageReference Include="NUnit3TestAdapter" />
 		<PackageReference Include="Uno.UITest" />
 		<PackageReference Include="Uno.UITest.Selenium" />
 		<PackageReference Include="Uno.UITest.Xamarin" />

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/AppXamlResourcesTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/AppXamlResourcesTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml
+{
+	[TestFixture]
+	public class AppXamlResourcesTests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void When_TransformToVisual()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml.ThemeResources.AppXamlDefinedResources");
+
+			_app.WaitForElement("Border01");
+
+			Assert.AreEqual("Should be Yellow: [Color: 000000FF;000000FF;000000FF;00000000]", _app.GetText("result01"));
+			Assert.AreEqual("Should be Purple: [Color: 000000FF;00000080;00000000;00000080]", _app.GetText("result02"));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -197,6 +197,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ThemeResources\AppXamlDefinedResources.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ThemeResources\BasicThemeResources.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2647,6 +2651,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\MarkupExtensionTests\MarkupExtensionBehaviors.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\StyleTests\Style_Inline.xaml.cs">
       <DependentUpon>Style_Inline.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ThemeResources\AppXamlDefinedResources.xaml.cs">
+      <DependentUpon>AppXamlDefinedResources.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\TouchEventsTests\ControlWithTouchEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\TouchEventsTests\TappedEventTest.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/AppXamlDefinedResources.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/AppXamlDefinedResources.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml.ThemeResources.AppXamlDefinedResources"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml.ThemeResources"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<StackPanel>
+			<Border x:Name="Border01" Width="100" Height="30" Background="{ThemeResource GlobalThemeResource_Test01}"/>
+			<TextBlock x:Name="result01">
+				<Run Text="Should be Yellow:"/>
+				<Run Text="{Binding Background.Color, ElementName=Border01}"/>
+			</TextBlock>
+			<Border x:Name="Border02" Width="100" Height="30" Background="{StaticResource GlobalStaticResource_Test01}"/>
+			<TextBlock x:Name="result02">
+				<Run Text="Should be Purple:"/>
+				<Run Text="{Binding Background.Color, ElementName=Border02}"/>
+			</TextBlock>
+		</StackPanel>
+    </Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/AppXamlDefinedResources.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/AppXamlDefinedResources.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml.ThemeResources
+{
+	[SampleControlInfo("XAML", controlName: nameof(AppXamlDefinedResources), description: "Validates the use of resources defined in App.xaml")]
+	public sealed partial class AppXamlDefinedResources : UserControl
+    {
+        public AppXamlDefinedResources()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #1237

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Static and Theme Resources defined in App.xaml, when defined in an inner `ResourceDictionary` are now discovered and registered properly.

Note that this PR might break the compilation for projects that define duplicate resources in other globally accessible resource dictionaries.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
