### PR TITLE
Fix the labeling issues with Android, iOS and WASM

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,14 +13,14 @@ area/automation:
 area/android:
   - src/Uno.UI.BindingHelper.Android/*
   - src/Uno.UI.BindingHelper.Android/**/*
-  - ./**/*.Android.cs
-  - ./**/*.android.cs
-  - ./**/*.droid.cs
+  - '**/*.Android.cs'
+  - '**/*.android.cs'
+  - '**/*.droid.cs'
 
 area/build:
   - build/*
   - build/**/*
-  - ./**/*.yml
+  - '**/*.yml'
   - src/Uno.UI.AssemblyComparer/*
   - src/Uno.UI.AssemblyComparer/**/*
   - src/Uno.UI.TestComparer/*
@@ -37,13 +37,13 @@ kind/documentation:
   - README.*
   - docs/*
   - docs/**/*
-  - ./**/*.md
-  - ./**/*.MD
-  - ./**/*.txt
+  - '**/*.md'
+  - '**/*.MD'
+  - '**/*.txt'
 
 area/ios:
-  - ./**/*.iOS.cs
-  - ./**/*.ios.cs
+  - '**/*.iOS.cs'
+  - '**/*.ios.cs'
 
 area/solution-templates:
   - src/SolutionTemplate/*
@@ -52,7 +52,8 @@ area/solution-templates:
   - src/UnoItemTemplate/**/*
 
 area/wasm:
-  - ./**/*.wasm.cs
-  - ./**/*.WASM.cs
+  - '**/*.wasm.cs'
+  - '**/*.WASM.cs'
   - src/Uno.UI.Wasm/*
   - src/Uno.UI.Wasm/**/*
+  


### PR DESCRIPTION
GitHub Issue: #1788

## PR Type

- Bugfix
- Build or CI related changes
- Project automation


## What is the current behavior?

As of now, some of the rules that should enforce automatic assignment of Android, iOS, WASM, build and documentation labels to pull requests are not working. See #1787 


## What is the new behavior?

With my fixes, all of the automatic labeling rules work as intended, except on hidden files and folders. From my tests, it looks like the [labeler](https://github.com/actions/labeler) doesn't parse them unless they're specifically mentioned, so if it's important to include hidden folders I can add specific rules for them. I also see from the `.gitignore` that only the `.github` folder is not ignored, so if you wanted I could also add specific rules for that one only (just tell me the desired behavior).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
