### PR TITLE
Add support for AutomationProperties.AutomationId

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -72,6 +72,7 @@
 * Add support for `IObservableVector<T>` in `ItemsControl`
 * [#1559] [#1167] Wasm: make the IsEnabled property inheritable.
 * Full support of pointer events cf. [routed events documentation](../articles/features/routed-events.md)
+* Adds the support for `AutomationProperties.AutomationId`
 
 ### Breaking changes
 

--- a/doc/articles/features/working-with-accessibility.md
+++ b/doc/articles/features/working-with-accessibility.md
@@ -12,6 +12,7 @@ Uno.UI implements a subset of UWP's UI Automation APIs, to make your application
 
 Read [this guide](https://docs.microsoft.com/en-us/windows/uwp/design/accessibility/basic-accessibility-information) to learn how to use the `AutomationProperties` supported by Uno.UI:
 
+- `AutomationProperties.AutomationId`
 - `AutomationProperties.Name`
 - `AutomationProperties.LabeledBy`
 - `AutomationProperties.AccessibilityView`
@@ -46,6 +47,19 @@ Here's how to disable it
 // App's constructor (App.xaml.cs) 
 Uno.UI.FeatureConfiguration.Font.IgnoreTextScaleFactor= true; 
 ```
+
+## AutomationId
+The `AutomationProperties.AutomationId` attached property can be used by UI Testing frameworks to find visual elements.
+
+To avoid performance issues, this property only has an effect when the `IsUiAutomationMappingEnabled` msbuild property is set, or `Uno.UI.FrameworkElementHelper.IsUiAutomationMappingEnabled` is set to true.
+
+Setting this property does the following:
+- On iOS, it sets the [`UIView.AccessibilityIdentifier`](https://developer.apple.com/documentation/uikit/uiaccessibilityidentification/1623132-accessibilityidentifier) property
+- On Android, it sets the [`View.ContentDescription`](https://developer.android.com/reference/android/view/View.html#setContentDescription(java.lang.CharSequence)) property
+- On Android, it sets the [`View.ContentDescription`](https://developer.android.com/reference/android/view/View.html#setContentDescription(java.lang.CharSequence)) property
+- On WebAssembly, it sets the `xamlautomationid` property on the HTML element.
+
+This property is generally used alongside [Uno.UITest](https://github.com/unoplatform/Uno.UITest) to create UI Tests, and is particularly useful to select items using databound identifiers.
 
 ## Known issues
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -26,10 +26,10 @@
     <PackageReference Update="Microsoft.TypeScript.MSBuild" Version="3.1.5" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Update="Uno.UITest" Version="1.0.0-dev.80" />
-    <PackageReference Update="Uno.UITest.Selenium" Version="1.0.0-dev.80" />
-    <PackageReference Update="Uno.UITest.Xamarin" Version="1.0.0-dev.80" />
-    <PackageReference Update="Uno.UITest.Helpers" Version="1.0.0-dev.80" />
+    <PackageReference Update="Uno.UITest" Version="1.0.0-dev.92" />
+    <PackageReference Update="Uno.UITest.Selenium" Version="1.0.0-dev.92" />
+    <PackageReference Update="Uno.UITest.Xamarin" Version="1.0.0-dev.92" />
+    <PackageReference Update="Uno.UITest.Helpers" Version="1.0.0-dev.92" />
   </ItemGroup>
 
 </Project>

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Automation/AutomationId_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Automation/AutomationId_Tests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+using Query = System.Func<Uno.UITest.IAppQuery, Uno.UITest.IAppQuery>;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Automation
+{
+	public class AutomationId_Tests : SampleControlUITestBase
+	{
+		[Test]
+		public void TestSimple()
+		{
+			Run("UITests.Shared.Windows_UI.Xaml_Automation.AutomationProperties_AutomationId");
+
+			Query result = q => q.Marked("result");
+			_app.WaitForElement(result);
+
+			for (int i = 1; i < 4; i++)
+			{
+				var itemName = $"Item{i:00}";
+				_app.WaitForElement(itemName);
+				_app.Tap(itemName);
+				_app.WaitForDependencyPropertyValue(result, "Text", $"Item {i:00}");
+			}
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -11,6 +11,8 @@
 		
 		<!-- https://github.com/unoplatform/uno/issues/61 -->
 		<UnoSkipUserControlsInVisualTree>false</UnoSkipUserControlsInVisualTree>
+		
+		<IsUiAutomationMappingEnabled>true</IsUiAutomationMappingEnabled>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -89,6 +89,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI.Xaml_Automation\AutomationProperties_AutomationId.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI.Xaml_Automation\AutomationProperties_Name.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2577,11 +2581,11 @@
       <DependentUpon>BarometerTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\GyrometerTests.xaml.cs">
-	    <DependentUpon>GyrometerTests.xaml</DependentUpon>
-    </Compile>    
+      <DependentUpon>GyrometerTests.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\GeolocatorTests.xaml.cs">
-	    <DependentUpon>GeolocatorTests.xaml</DependentUpon>
-	</Compile>
+      <DependentUpon>GeolocatorTests.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\GeopositionDisplayControl.xaml.cs">
       <DependentUpon>GeopositionDisplayControl.xaml</DependentUpon>
     </Compile>
@@ -2605,6 +2609,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_System\Power\PowerManager.xaml.cs">
       <DependentUpon>PowerManager.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI.Xaml_Automation\AutomationProperties_AutomationId.xaml.cs">
+      <DependentUpon>AutomationProperties_AutomationId.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI.Xaml_Automation\AutomationProperties_Name.xaml.cs">
       <DependentUpon>AutomationProperties_Name.xaml</DependentUpon>
@@ -4495,9 +4502,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Windows_Devices\GeolocatorTests.xaml.cs">
       <DependentUpon>GeolocatorTests.xaml</DependentUpon>
     </Compile>
-	<Compile Update="$(MSBuildThisFileDirectory)Windows_Devices\GyrometerTests.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_Devices\GyrometerTests.xaml.cs">
       <DependentUpon>GyrometerTests.xaml</DependentUpon>
-	</Compile>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_MinYear.xaml.cs">
       <DependentUpon>DatePickerFlyout_MinYear.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/AutomationProperties_AutomationId.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/AutomationProperties_AutomationId.xaml
@@ -1,0 +1,33 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI.Xaml_Automation.AutomationProperties_AutomationId"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI.Xaml_Automation"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="auto"/>
+			<RowDefinition Height="*"/>
+		</Grid.RowDefinitions>
+		<TextBlock x:Name="result"/>
+		<ListView x:Name="myList" Grid.Row="1">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<StackPanel AutomationProperties.AutomationId="{Binding AutomationId}">
+						<TextBlock>
+							<Run Text="Text: " />
+							<Run Text="{Binding Text}"/>
+							<Run Text="AutomationId: " />
+							<Run Text="{Binding AutomationId}"/>
+						</TextBlock>
+					</StackPanel>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/AutomationProperties_AutomationId.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI.Xaml_Automation/AutomationProperties_AutomationId.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI.Xaml_Automation
+{
+	[SampleControlInfo("Automation", nameof(AutomationProperties_AutomationId))]
+	public sealed partial class AutomationProperties_AutomationId : UserControl
+    {
+        public AutomationProperties_AutomationId()
+        {
+            this.InitializeComponent();
+
+			myList.ItemsSource = new[] {
+				new MyItem { AutomationId = "Item01", Text = "Item 01" },
+				new MyItem { AutomationId = "Item02", Text = "Item 02" },
+				new MyItem { AutomationId = "Item03", Text = "Item 03" },
+			};
+
+			myList.SelectionChanged += (s, e) =>
+			{
+				if (myList.SelectedItem is MyItem item)
+				{
+					result.Text = item.Text;
+				}
+				else
+				{
+					result.Text = "Clicked item is not of type MyItem";
+				}
+			};
+		}
+    }
+
+	[Bindable]
+	public class MyItem
+	{
+		public string Text { get; set; }
+		public string AutomationId { get; set; }
+	}
+}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -27,7 +27,7 @@ namespace Uno.UI
 
 #if __WASM__
 			/// <summary>
-			/// Enable the assignation of the "XamlName" and "xuid" attributes on DOM elements created
+			/// Enable the assignation of the "xamlname", "xuid" and "xamlautomationid" attributes on DOM elements created
 			/// from the XAML visual tree. This enables tools such as Puppeteer to select elements
 			/// in the DOM for automation purposes.
 			/// </summary>

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation/AutomationProperties.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation/AutomationProperties.cs
@@ -25,14 +25,6 @@ namespace Windows.UI.Xaml.Automation
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty AutomationIdProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.RegisterAttached(
-			"AutomationId", typeof(string), 
-			typeof(global::Windows.UI.Xaml.Automation.AutomationProperties), 
-			new FrameworkPropertyMetadata(default(string)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HelpTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.RegisterAttached(
 			"HelpText", typeof(string), 
@@ -435,21 +427,6 @@ namespace Windows.UI.Xaml.Automation
 		public static void SetAccessKey( global::Windows.UI.Xaml.DependencyObject element,  string value)
 		{
 			element.SetValue(AccessKeyProperty, value);
-		}
-		#endif
-		// Forced skipping of method Windows.UI.Xaml.Automation.AutomationProperties.AutomationIdProperty.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static string GetAutomationId( global::Windows.UI.Xaml.DependencyObject element)
-		{
-			return (string)element.GetValue(AutomationIdProperty);
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static void SetAutomationId( global::Windows.UI.Xaml.DependencyObject element,  string value)
-		{
-			element.SetValue(AutomationIdProperty, value);
 		}
 		#endif
 		// Forced skipping of method Windows.UI.Xaml.Automation.AutomationProperties.HelpTextProperty.get

--- a/src/Uno.UI/UI/Xaml/Automation/AutomationProperties.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/AutomationProperties.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Uno.UI;
 using Windows.UI.Xaml.Automation.Peers;
 
 namespace Windows.UI.Xaml.Automation
@@ -112,6 +113,50 @@ namespace Windows.UI.Xaml.Automation
 				new FrameworkPropertyMetadata(default(IList<DependencyObject>)) // TODO: Empty list?
 			);
 
+		#endregion
+
+		#region AutomationId
+
+		public static DependencyProperty AutomationIdProperty { get; } =
+		DependencyProperty.RegisterAttached(
+			name: "AutomationId",
+			propertyType: typeof(string),
+			ownerType: typeof(AutomationProperties),
+			typeMetadata: new FrameworkPropertyMetadata(
+				defaultValue: "",
+				propertyChangedCallback: OnAutomationIdChanged)
+		);
+
+		private static void OnAutomationIdChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+#if __IOS__
+			if (FrameworkElementHelper.IsUiAutomationMappingEnabled && dependencyObject is UIKit.UIView view)
+			{
+				view.AccessibilityIdentifier = (string)args.NewValue;
+			}
+#elif __MACOS__
+			if (FrameworkElementHelper.IsUiAutomationMappingEnabled && dependencyObject is AppKit.NSView view)
+			{
+				view.AccessibilityIdentifier = (string)args.NewValue;
+			}
+#elif __ANDROID__
+			if(FrameworkElementHelper.IsUiAutomationMappingEnabled && dependencyObject is Android.Views.View view)
+			{
+				view.ContentDescription = (string)args.NewValue;
+			}
+#elif __WASM__
+			if (FrameworkElementHelper.IsUiAutomationMappingEnabled && dependencyObject is UIElement uiElement)
+			{
+				uiElement.SetAttribute("xamlautomationid", (string)args.NewValue);
+			}
+#endif
+		}
+
+		public static string GetAutomationId(DependencyObject element)
+			=> (string)element.GetValue(AutomationIdProperty);
+
+		public static void SetAutomationId(DependencyObject element, string value)
+			=> element.SetValue(AutomationIdProperty, value);
 		#endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/FrameworkElementHelper.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElementHelper.cs
@@ -31,6 +31,8 @@ namespace Uno.UI
 		/// When true (normally because the IsUiAutomationMappingEnabled build property is set), setting the <see cref="Name"/> property
 		/// programmatically will also set the appropriate test identifier for Android/iOS. Disabled by default because it may interfere
 		/// with accessibility features in non-testing scenarios.
+		/// On WebAssembly, settings this property also enables the ability for <see cref="Windows.UI.Xaml.Automation.AutomationProperties.AutomationIdProperty"/>
+		/// to be applied to the visual tree elements.
 		/// </summary>
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool IsUiAutomationMappingEnabled { get; set; } = false;

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -480,7 +480,7 @@ namespace <#= mixin.NamespaceName #>
 		private void OnNameChanged(string oldValue, string newValue) {
 			if (FrameworkElementHelper.IsUiAutomationMappingEnabled)
 			{
-				ContentDescription = newValue;
+				Windows.UI.Xaml.Automation.AutomationProperties.SetAutomationId(this, newValue);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -235,7 +235,7 @@ namespace <#= mixin.NamespaceName #>
 		private void OnNameChanged(string oldValue, string newValue) {
 			if (FrameworkElementHelper.IsUiAutomationMappingEnabled)
 			{
-				AccessibilityIdentifier = newValue;
+				Windows.UI.Xaml.Automation.AutomationProperties.SetAutomationId(this, newValue);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
@@ -223,8 +223,17 @@ namespace <#= mixin.NamespaceName #>
 				"Name",
 				typeof(string),
 				typeof(<#= mixin.ClassName #>),
-				new PropertyMetadata("")
+				new PropertyMetadata("",
+					(s, e) => (s as <#= mixin.ClassName #>).OnNameChanged((string)e.OldValue, (string)e.NewValue)
+				)
 		);
+
+		private void OnNameChanged(string oldValue, string newValue) {
+			if (FrameworkElementHelper.IsUiAutomationMappingEnabled)
+			{
+				Windows.UI.Xaml.Automation.AutomationProperties.SetAutomationId(this, newValue);
+			}
+		}
 
 		public virtual string Name
 		{

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+    <add key="platform.uno dev" value="https://uno-platform.pkgs.visualstudio.com/Uno%20Platform/_packaging/unoplatformdev/nuget/v3/index.json" />
     <add key="Solution Packages" value="PackageCache" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Fixes #1798

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

- Adds the support for `AutomationProperties.AutomationId` and related Uno.UITest support for it.
- Updates to latest Uno.UITest which updates to latest Xamarin.UITest and will tentatively fix Android UI Tests instabilities. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)