### PR TITLE
Fix Android ListView crash when using ObservableCollection with Heade…

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -155,6 +155,7 @@
 * [Android] MenuFlyout was misplaced if view was in a hierarchy with a RenderTransform
 * Fix color refresh of `BitmapIcon` monochrome Foreground
 * [IOS] DatePickerFlyout min and max year were resetting to FallbackNullValue
+* [Android] Fix bug in `ListView` when using an `ObservableCollection` as its source and using `Header` and `Footer`.
 
 ## Release 1.45.0
 ### Features

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -1585,7 +1585,8 @@ namespace Windows.UI.Xaml.Controls
 				var headerIndex = GetHeaderViewIndex();
 				_previousHeaderExtent = GetChildExtentWithMargins(headerIndex);
 				// Rebind to apply changes, RecyclerView alone will recycle the view without rebinding.
-				recycler.BindViewToPosition(GetChildAt(headerIndex), headerIndex);
+				// Here we use position: 0 because the header is always at index 0 from the collection's perspective.
+				recycler.BindViewToPosition(GetChildAt(headerIndex), position: 0);
 				base.RemoveAndRecycleViewAt(headerIndex, recycler);
 				HeaderViewCount = 0;
 			}
@@ -1594,7 +1595,8 @@ namespace Windows.UI.Xaml.Controls
 			{
 				var footerIndex = GetFooterViewIndex();
 				// Rebind to apply changes, RecyclerView alone will recycle the view without rebinding.
-				recycler.BindViewToPosition(GetChildAt(footerIndex), footerIndex);
+				// Here we use position: 1 or 0 because the footer is always the first or second item (depending on the header's presence) from the collection's perspective.
+				recycler.BindViewToPosition(GetChildAt(footerIndex), XamlParent.ShouldShowHeader ? 1 : 0);
 				base.RemoveAndRecycleViewAt(footerIndex, recycler);
 				FooterViewCount = 0;
 			}


### PR DESCRIPTION
…r and Footer

## PR Type

- Bugfix

## What is the current behavior?

The Android `ListView` crashes when using a `ObservableCollection` as its source and using the `Header` and `Footer` features.

## What is the new behavior?

The Android `ListView` doesn't crash when using a `ObservableCollection` as its source and using the `Header` and `Footer` features.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/164045
