### PR TITLE
Add support of Manipulation events

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -439,9 +439,6 @@
 					fullName="System.Void Windows.UI.Xaml.Input.KeyRoutedEventArgs..ctor()"
 					reason="Not part of the UWP API."/>
 				<Member 
-					fullName="System.Void Windows.UI.Xaml.Controls.SelectionChangedEventArgs..ctor(System.Collections.Generic.IList`1&lt;System.Object&gt; removedItems, System.Collections.Generic.IList`1&lt;System.Object&gt; addedItems)"
-					reason="Not part of the UWP API."/>
-				<Member 
 					fullName="System.Void Windows.UI.Xaml.Controls.Primitives.RangeBaseValueChangedEventArgs..ctor()"
 					reason="Not part of the UWP API."/>
 				<Member 

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -447,6 +447,48 @@
 				<Member 
 					fullName="System.Void Windows.Devices.Geolocation.StatusChangedEventArgs..ctor()"
 					readson="Constructor is not public in UWP" />
+				<Member 
+					fullName="System.Void Windows.UI.Input.ManipulationStartedEventArgs..ctor()"
+					reason="Not part of the UWP API." />
+				<Member 
+					fullName="System.Void Windows.UI.Input.ManipulationUpdatedEventArgs..ctor()"
+					reason="Not part of the UWP API." />
+				<Member 
+					fullName="System.Void Windows.UI.Input.ManipulationInertiaStartingEventArgs..ctor()"
+					reason="Not part of the UWP API." />
+				<Member 
+					fullName="System.Void Windows.UI.Input.ManipulationCompletedEventArgs..ctor()"
+					reason="Not part of the UWP API." />
+				<Member 
+					fullName="System.Boolean Windows.UI.Xaml.Input.ManipulationStartingRoutedEventArgs.get_Handled()"
+					reason="Get/set methods removed as not part of the UWP API but property still present" />
+				<Member 
+					fullName="System.Void Windows.UI.Xaml.Input.ManipulationStartingRoutedEventArgs.set_Handled(System.Boolean value)"
+					reason="Get/set methods removed as not part of the UWP API but property still present" />
+				<Member 
+					fullName="System.Boolean Windows.UI.Xaml.Input.ManipulationStartedRoutedEventArgs.get_Handled()"
+					reason="Get/set methods removed as not part of the UWP API but property still present" />
+				<Member 
+					fullName="System.Void Windows.UI.Xaml.Input.ManipulationStartedRoutedEventArgs.set_Handled(System.Boolean value)"
+					reason="Get/set methods removed as not part of the UWP API but property still present" />
+				<Member 
+					fullName="System.Boolean Windows.UI.Xaml.Input.ManipulationDeltaRoutedEventArgs.get_Handled()"
+					reason="Get/set methods removed as not part of the UWP API but property still present" />
+				<Member 
+					fullName="System.Void Windows.UI.Xaml.Input.ManipulationDeltaRoutedEventArgs.set_Handled(System.Boolean value)"
+					reason="Get/set methods removed as not part of the UWP API but property still present" />
+				<Member 
+					fullName="System.Boolean Windows.UI.Xaml.Input.ManipulationInertiaStartingRoutedEventArgs.get_Handled()"
+					reason="Get/set methods removed as not part of the UWP API but property still present" />
+				<Member 
+					fullName="System.Void Windows.UI.Xaml.Input.ManipulationInertiaStartingRoutedEventArgs.set_Handled(System.Boolean value)"
+					reason="Get/set methods removed as not part of the UWP API but property still present" />
+				<Member 
+					fullName="System.Boolean Windows.UI.Xaml.Input.ManipulationCompletedRoutedEventArgs.get_Handled()"
+					reason="Get/set methods removed as not part of the UWP API but property still present" />
+				<Member 
+					fullName="System.Void Windows.UI.Xaml.Input.ManipulationCompletedRoutedEventArgs.set_Handled(System.Boolean value)"
+					reason="Get/set methods removed as not part of the UWP API but property still present" />
 			</Methods>
 			
 			<Fields>

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/EventSequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/EventSequence_Tests.cs
@@ -21,6 +21,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			=> RunSequence("Click");
 
 		[Test]
+		public void TestTranslatedTap()
+			=> RunSequence("TranslatedTap", TranslateOverElement);
+
+		[Test]
+		public void TestTranslatedClick()
+			=> RunSequence("TranslatedClick", TranslateOverElement);
+
+		[Test]
 		public void TestHyperlink()
 			=> RunSequence("Hyperlink", TapSomewhereInElement);
 
@@ -29,6 +37,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			=> RunSequence("ListView", TapSomewhereInElement);
 
 		private readonly Action<QueryEx> TapElement = element => element.Tap();
+		private void TranslateOverElement(QueryEx element)
+		{
+			var rect = _app.WaitForElement(element).Single().Rect;
+			_app.DragCoordinates(rect.X + 2, rect.Y + 2, rect.Right - 2, rect.Bottom - 2);
+		}
 		private void TapSomewhereInElement(QueryEx element)
 		{
 			var rect = _app.WaitForElement(element).Single().Rect;

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -4496,9 +4496,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ItemDataContext.xaml.cs">
       <DependentUpon>ComboBox_ItemDataContext.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\Geolocator.xaml.cs">
-      <DependentUpon>Geolocator.xaml</DependentUpon>
-    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_MinYear.xaml.cs">
       <DependentUpon>DatePickerFlyout_MinYear.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -4496,14 +4496,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ItemDataContext.xaml.cs">
       <DependentUpon>ComboBox_ItemDataContext.xaml</DependentUpon>
     </Compile>
-    <Compile Update="$(MSBuildThisFileDirectory)Windows_Devices\Geolocator.xaml.cs">
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\Geolocator.xaml.cs">
       <DependentUpon>Geolocator.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="$(MSBuildThisFileDirectory)Windows_Devices\GeolocatorTests.xaml.cs">
-      <DependentUpon>GeolocatorTests.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="$(MSBuildThisFileDirectory)Windows_Devices\GyrometerTests.xaml.cs">
-      <DependentUpon>GyrometerTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_MinYear.xaml.cs">
       <DependentUpon>DatePickerFlyout_MinYear.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml
@@ -40,7 +40,29 @@
 			</StackPanel>
 
 			<StackPanel Orientation="Horizontal">
-				<Border Background="#FFFF41" Width="100" Height="100">
+				<Border x:Name="TestTranslatedTapTarget" Background="#FFFF41" Width="100" Height="100" ManipulationMode="All">
+					<TextBlock Text="UIElement.tr-Tapped" />
+				</Border>
+				<StackPanel>
+					<Button x:Name="TestTranslatedTapReset" Content="Reset" Click="ResetTranslatedTapTest" />
+					<Button x:Name="TestTranslatedTapValidate" Content="Validate" Click="ValidateTranslatedTapTest" />
+					<TextBlock x:Name="TestTranslatedTapResult" Text="** no result **" />
+				</StackPanel>
+			</StackPanel>
+
+			<StackPanel Orientation="Horizontal">
+				<Button x:Name="TestTranslatedClickTarget" Background="#008018" Width="100" Height="100" ManipulationMode="All">
+					<TextBlock Text="Button.tr-Click" />
+				</Button>
+				<StackPanel>
+					<Button x:Name="TestTranslatedClickReset" Content="Reset" Click="ResetTranslatedClickTest" />
+					<Button x:Name="TestTranslatedClickValidate" Content="Validate" Click="ValidateTranslatedClickTest" />
+					<TextBlock x:Name="TestTranslatedClickResult" Text="** no result **" />
+				</StackPanel>
+			</StackPanel>
+
+			<StackPanel Orientation="Horizontal">
+				<Border Background="#0000F9" Width="100" Height="100">
 					<TextBlock x:Name="TestHyperlinkTarget" TextWrapping="Wrap">
 						<Hyperlink x:Name="TestHyperlinkInner"><Run Text="Hyperlink.Click" /></Hyperlink><Run Text=" event" />.
 					</TextBlock>
@@ -53,7 +75,7 @@
 			</StackPanel>
 
 			<StackPanel Orientation="Horizontal">
-				<Border Background="#008018" Width="100" Height="100">
+				<Border Background="#86007D" Width="100" Height="100">
 					<ListView x:Name="TestListViewTarget" ItemsSource="0123456789" IsItemClickEnabled="True" />
 				</Border>
 				<StackPanel>

--- a/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
@@ -9,6 +9,7 @@ using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.UI.Input;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Point = Windows.Foundation.Point;
 using static Uno.UI.Tests.Windows_UI_Input.GestureRecognizerTestExtensions;
@@ -186,11 +187,823 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 			taps.Should().BeEquivalentTo(Tap(25, 25));
 		}
+
+		[TestMethod]
+		public void Manipulation_Begin()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var result = new ManipulationRecorder(sut);
+			var step = GestureRecognizer.MinManipulationDeltaTranslateX;
+
+			sut.ProcessDownEvent(25, 25);
+			sut.ProcessMoveEvent(25 + 1, 25); // Ignored
+			sut.ProcessMoveEvent(25 + step, 25);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().At(25 + step, 25).WithCumulative(step, 0)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Begin_MultiPointer()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, 25, id: 1);
+			sut.ProcessDownEvent(25, 25, id: 2);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started()
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Begin_WithAnotherDevice()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, 25, id: 1);
+			sut.ProcessDownEvent(25, 25, id: 2, device: PointerDeviceType.Pen);
+
+			result.ShouldBe(
+				v => v.Starting()
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Delta()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var result = new ManipulationRecorder(sut);
+			var step = GestureRecognizer.MinManipulationDeltaTranslateX + 1;
+
+			sut.ProcessDownEvent(25, 25);
+			sut.ProcessMoveEvent(25 + 1, 25);
+			sut.ProcessMoveEvent(25 + step, 25);
+			sut.ProcessMoveEvent(25 + step * 2, 25);
+			sut.ProcessMoveEvent(25 + step * 2 + 1, 25);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().At(25 + step, 25).WithCumulative(step, 0),
+				v => v.Delta().At(25 + step * 2, 25).WithDelta(step, 0).WithCumulative(step * 2, 0)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_End()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var result = new ManipulationRecorder(sut);
+			var step = GestureRecognizer.MinManipulationDeltaTranslateX + 1;
+
+			sut.ProcessDownEvent(25, 25);
+			sut.ProcessMoveEvent(25 + step, 25);
+			sut.ProcessUpEvent(25 + step + 1, 25);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().At(25 + step, 25).WithCumulative(step, 0),
+				v => v.End().At(25 + step + 1, 25).WithCumulative(step + 1, 0)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_End_2()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var result = new ManipulationRecorder(sut);
+			var step = GestureRecognizer.MinManipulationDeltaTranslateX + 1;
+
+			sut.ProcessDownEvent(25, 25);
+			sut.ProcessMoveEvent(25 + step, 25);
+			sut.ProcessMoveEvent(25 + step * 2, 25);
+			sut.ProcessMoveEvent(25 + step * 2 + 1, 25);
+			sut.ProcessUpEvent(25 + step * 2 + 2, 25);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().At(25 + step, 25).WithCumulative(step, 0),
+				v => v.Delta().At(25 + step * 2, 25).WithDelta(step, 0).WithCumulative(step * 2, 0),
+				v => v.End().At(25 + step * 2 + 2, 25).WithCumulative(step * 2 + 2, 0)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_TranslateXOnly()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationTranslateX };
+			var result = new ManipulationRecorder(sut);
+			var stepX = GestureRecognizer.MinManipulationDeltaTranslateX + 1;
+			var stepY = GestureRecognizer.MinManipulationDeltaTranslateY + 1;
+
+			sut.ProcessDownEvent(25, 25);
+			sut.ProcessMoveEvent(25, 25 + stepY); // Invalid move that should NOT cause the started
+			sut.ProcessMoveEvent(25 + stepX, 25 + stepY); // Valid move that should cause a started ... but without Y
+			sut.ProcessMoveEvent(25 + stepX, 25 + stepY * 2); // Invalid move that should also be muted
+			sut.ProcessMoveEvent(25 + stepX * 2, 25 + stepY * 2); // Invalid move that should also be muted
+			sut.ProcessUpEvent(25 + stepX * 2 + 1, 25 + stepY * 2 + 1);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().At(25 + stepX, 25 + stepY).WithCumulative(stepX, 0),
+				v => v.Delta().At(25 + stepX * 2, 25 + stepY * 2).WithDelta(stepX, 0).WithCumulative(stepX * 2, 0),
+				v => v.End().At(25 + stepX * 2 + 1, 25 + stepY * 2 + 1).WithCumulative(stepX * 2 + 1, 0)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_TranslateYOnly()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationTranslateY };
+			var result = new ManipulationRecorder(sut);
+			var stepX = GestureRecognizer.MinManipulationDeltaTranslateX + 1;
+			var stepY = GestureRecognizer.MinManipulationDeltaTranslateY + 1;
+
+			sut.ProcessDownEvent(25, 25);
+			sut.ProcessMoveEvent(25 + stepX, 25); // Invalid move that should NOT cause the started
+			sut.ProcessMoveEvent(25 + stepX, 25 + stepY); // Valid move that should cause a started ... but without Y
+			sut.ProcessMoveEvent(25 + stepX * 2, 25 + stepY); // Invalid move that should also be muted
+			sut.ProcessMoveEvent(25 + stepX * 2, 25 + stepY * 2); // Invalid move that should also be muted
+			sut.ProcessUpEvent(25 + stepX * 2 + 1, 25 + stepY * 2 + 1);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().At(25 + stepX, 25 + stepY).WithCumulative(0, stepY),
+				v => v.Delta().At(25 + stepX * 2, 25 + stepY * 2).WithDelta(0, stepY).WithCumulative(0, stepY * 2),
+				v => v.End().At(25 + stepX * 2 + 1, 25 + stepY * 2 + 1).WithCumulative(0, stepX * 2 + 1)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_TranslateXOnly_Negative()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationTranslateX };
+			var result = new ManipulationRecorder(sut);
+			var stepX = GestureRecognizer.MinManipulationDeltaTranslateX + 1;
+			var stepY = GestureRecognizer.MinManipulationDeltaTranslateY + 1;
+
+			sut.ProcessDownEvent(25, 25);
+			sut.ProcessMoveEvent(25, 25 + stepY); // Invalid move that should NOT cause the started
+			sut.ProcessMoveEvent(25 - stepX, 25 - stepY); // Valid move that should cause a started ... but without Y
+			sut.ProcessMoveEvent(25 - stepX, 25 - stepY * 2); // Invalid move that should also be muted
+			sut.ProcessMoveEvent(25 - stepX * 2, 25 - stepY * 2); // Invalid move that should also be muted
+			sut.ProcessUpEvent(25 - stepX * 2 - 1, 25 - stepY * 2 - 1);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().At(25 - stepX, 25 - stepY).WithCumulative(-stepX, 0),
+				v => v.Delta().At(25 - stepX * 2, 25 - stepY * 2).WithDelta(-stepX, 0).WithCumulative(-stepX * 2, 0),
+				v => v.End().At(25 - stepX * 2 - 1, 25 - stepY * 2 - 1).WithCumulative(-stepX * 2 - 1, 0)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_TranslateYOnly_Negative()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationTranslateY };
+			var result = new ManipulationRecorder(sut);
+			var stepX = GestureRecognizer.MinManipulationDeltaTranslateX + 1;
+			var stepY = GestureRecognizer.MinManipulationDeltaTranslateY + 1;
+
+			sut.ProcessDownEvent(25, 25);
+			sut.ProcessMoveEvent(25 - stepX, 25); // Invalid move that should NOT cause the started
+			sut.ProcessMoveEvent(25 - stepX, 25 - stepY); // Valid move that should cause a started ... but without Y
+			sut.ProcessMoveEvent(25 - stepX * 2, 25 - stepY); // Invalid move that should also be muted
+			sut.ProcessMoveEvent(25 - stepX * 2, 25 - stepY * 2); // Invalid move that should also be muted
+			sut.ProcessUpEvent(25 - stepX * 2 - 1, 25 - stepY * 2 - 1);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().At(25 - stepX, 25 - stepY).WithCumulative(0, -stepY),
+				v => v.Delta().At(25 - stepX * 2, 25 - stepY * 2).WithDelta(0, -stepY).WithCumulative(0, -stepY * 2),
+				v => v.End().At(25 - stepX * 2 - 1, 25 - stepY * 2 - 1).WithCumulative(0, -stepX * 2 - 1)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Translate_MultiTouch()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationTranslateX | GestureSettings.ManipulationTranslateY };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(0, 0, id: 1);
+
+			sut.ProcessDownEvent(50, 50, id: 2);
+			sut.ProcessMoveEvent(200, 200, id: 2);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().At(25, 25).WithCumulative(),
+				v => v.Delta().At(100, 100).WithDelta(tX: 75, tY: 75).WithCumulative(tX: 75, tY: 75)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Translate_MultiTouch_Negative()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationTranslateX | GestureSettings.ManipulationTranslateY };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(0, 0, id: 1);
+
+			sut.ProcessDownEvent(200, 200, id: 2);
+			sut.ProcessMoveEvent(50, 50, id: 2);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().At(100, 100).WithCumulative(),
+				v => v.Delta().At(25, 25).WithDelta(tX: -75, tY: -75).WithCumulative(tX: -75, tY: -75)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_RotateOnly_Trigonometric_InFirstQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, -25, id: 1);
+
+			sut.ProcessDownEvent(50, -25, id: 2); // Angle = 0
+			sut.ProcessMoveEvent(50, -50, id: 2); // Angle = -Pi/4
+			sut.ProcessMoveEvent(25, -50, id: 2); // Angle = -Pi/2
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
+				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 270)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_RotateOnly_Trigonometric_InSecondQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(-25, -25, id: 1);
+
+			sut.ProcessDownEvent(-25, -50, id: 2); // Angle = 0
+			sut.ProcessMoveEvent(-50, -50, id: 2); // Angle = -Pi/4
+			sut.ProcessMoveEvent(-50, -25, id: 2); // Angle = -Pi/2
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
+				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 270)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_RotateOnly_Trigonometric_InThirdQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(-25, 25, id: 1);
+
+			sut.ProcessDownEvent(-50, 25, id: 2); // Angle = 0
+			sut.ProcessMoveEvent(-50, 50, id: 2); // Angle = -Pi/4
+			sut.ProcessMoveEvent(-25, 50, id: 2); // Angle = -Pi/2
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
+				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 270)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_RotateOnly_Trigonometric_InForthQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, 25, id: 1);
+
+			sut.ProcessDownEvent(25, 50, id: 2); // Angle = 0
+			sut.ProcessMoveEvent(50, 50, id: 2); // Angle = -Pi/4
+			sut.ProcessMoveEvent(50, 25, id: 2); // Angle = -Pi/2
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
+				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 270)
+			);
+		}
+
+
+		[TestMethod]
+		public void Manipulation_RotateOnly_AntiTrigonometric_InFirstQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, -25, id: 1);
+
+			sut.ProcessDownEvent(25, -50, id: 2); // Angle = 0
+			sut.ProcessMoveEvent(50, -50, id: 2); // Angle = -Pi/4
+			sut.ProcessMoveEvent(50, -25, id: 2); // Angle = -Pi/2
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 90)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_RotateOnly_AntiTrigonometric_InSecondQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(-25, -25, id: 1);
+
+			sut.ProcessDownEvent(-50, -25, id: 2); // Angle = 0
+			sut.ProcessMoveEvent(-50, -50, id: 2); // Angle = -Pi/4
+			sut.ProcessMoveEvent(-25, -50, id: 2); // Angle = -Pi/2
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 90)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_RotateOnly_AntiTrigonometric_InThirdQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(-25, 25, id: 1);
+
+			sut.ProcessDownEvent(-25, 50, id: 2); // Angle = 0
+			sut.ProcessMoveEvent(-50, 50, id: 2); // Angle = -Pi/4
+			sut.ProcessMoveEvent(-50, 25, id: 2); // Angle = -Pi/2
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 90)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_RotateOnly_AntiTrigonometric_InForthQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, 25, id: 1);
+
+			sut.ProcessDownEvent(50, 25, id: 2); // Angle = 0
+			sut.ProcessMoveEvent(50, 50, id: 2); // Angle = -Pi/4
+			sut.ProcessMoveEvent(25, 50, id: 2); // Angle = -Pi/2
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 90)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_ScaleOnly()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationScale };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, 25, id: 1);
+
+			sut.ProcessDownEvent(50, 25, id: 2);
+			sut.ProcessMoveEvent(100, 25, id: 2);
+			sut.ProcessMoveEvent(150, 25, id: 2);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().WithCumulative(scale: 1),
+				v => v.Delta().WithDelta(scale: 3, exp: 50).WithCumulative(scale: 3, exp: 50),
+				v => v.Delta().WithDelta(scale: 5F/3F, exp: 50).WithCumulative(scale: 5, exp: 100)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_ScaleOnly_Negative()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationScale };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, 25, id: 1);
+
+			sut.ProcessDownEvent(150, 25, id: 2);
+			sut.ProcessMoveEvent(100, 25, id: 2);
+			sut.ProcessMoveEvent(75, 25, id: 2);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Starting(),
+				v => v.Started().WithCumulative(scale: 1),
+				v => v.Delta().WithDelta(scale: .6F, exp: -50).WithCumulative(scale: .6F, exp: -50),
+				v => v.Delta().WithDelta(scale: 2F/3F, exp: -25).WithCumulative(scale: .4F, exp: -75)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Mixed()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(50, 50, id: 1); // 1.
+			sut.ProcessDownEvent(50, 200, id: 2); // 2. & 3.
+
+			sut.ProcessMoveEvent(200, 200, id: 2); // 4.
+			sut.ProcessMoveEvent(50, 200, id: 1); // 5.
+
+			sut.ProcessMoveEvent(200, 50, id: 2); // 6.
+			sut.ProcessMoveEvent(200, 200, id: 1); // 7.
+
+			sut.ProcessMoveEvent(50, 50, id: 2); // 8.
+			sut.ProcessMoveEvent(200, 50, id: 1); // 9.
+
+			sut.ProcessMoveEvent(50, 200, id: 2); // 10.
+			sut.ProcessMoveEvent(50, 50, id: 1); // 11.
+
+			// At same point (0 proof ?)
+			sut.ProcessMoveEvent(50, 50, id: 2); // 12.
+
+			var s = (float)Math.Sqrt(2);
+			var e = (float)((Math.Sqrt(2) - 1) * 150);
+
+			result.ShouldBe(
+				v => v.Starting(), // 1.
+				v => v.Starting(), // 2.
+
+				// 3.
+				v => v.Started()
+					.At(50, 125)
+					.WithCumulative(),
+
+				// 4.
+				v => v.Delta()
+					.At(125, 125)
+					.WithDelta(tX: 75, tY: 0, angle: 315, scale: s, exp: e)
+					.WithCumulative(tX: 75, tY: 0, angle: 315, scale: s, exp: e),
+
+				// 5.
+				v => v.Delta()
+					.At(125, 200)
+					.WithDelta(tX: 0, tY: 75, angle: 315, scale: 1/s, exp: -e)
+					.WithCumulative(tX: 75, tY: 75, angle: 270, scale: 1, exp: 0),
+
+				// 6.
+				v => v.Delta()
+					.At(125, 125)
+					.WithDelta(tX: 0, tY: -75, angle: 315, scale: s, exp: e)
+					.WithCumulative(tX: 75, tY: 0, angle: 225, scale: s, exp: e),
+
+				// 7.
+				v => v.Delta()
+					.At(200, 125)
+					.WithDelta(tX: 75, tY: 0, angle: 315, scale: 1 / s, exp: -e)
+					.WithCumulative(tX: 150, tY: 0, angle: 180, scale: 1, exp: 0),
+
+				// 8.
+				v => v.Delta()
+					.At(125, 125)
+					.WithDelta(tX: -75, tY: 0, angle: 315, scale: s, exp: e)
+					.WithCumulative(tX: 75, tY: 0, angle: 135, scale: s, exp: e),
+
+				// 9.
+				v => v.Delta()
+					.At(125, 50)
+					.WithDelta(tX: 0, tY: -75, angle: 315, scale: 1 / s, exp: -e)
+					.WithCumulative(tX: 75, tY: -75, angle: 90, scale: 1, exp: 0),
+
+				// 10.
+				v => v.Delta()
+					.At(125, 125)
+					.WithDelta(tX: 0, tY: 75, angle: 315, scale: s, exp: e)
+					.WithCumulative(tX: 75, tY: 0, angle: 45, scale: s, exp: e),
+
+				// 11.
+				v => v.Delta()
+					.At(50, 125)
+					.WithDelta(tX: -75, tY: 0, angle: 315, scale: 1 / s, exp: -e)
+					.WithCumulative(tX: 0, tY: 0, angle: 0, scale: 1, exp: 0),
+
+				// 12.
+				v => v.Delta()
+					.At(50, 50)
+					.WithDelta(tX: 0, tY: -75, angle: 90 /* ??? */, scale: 0, exp: -150F)
+					.WithCumulative(tX: 0, tY: -75, angle: 90 /* ??? */, scale: 0, exp: -150F)
+			);
+		}
+	}
+
+	internal class ManipulationRecorder
+	{
+		private readonly GestureRecognizer _recognizer;
+
+		private List<(GestureRecognizer snd, object args)> _result = new List<(GestureRecognizer, object)>();
+
+		public ManipulationRecorder(GestureRecognizer recognizer)
+		{
+			_recognizer = recognizer;
+			recognizer.ManipulationStarting += (snd, e) => _result.Add((snd, e));
+			recognizer.ManipulationStarted += (snd, e) => _result.Add((snd, e));
+			recognizer.ManipulationUpdated += (snd, e) => _result.Add((snd, e));
+			recognizer.ManipulationCompleted += (snd, e) => _result.Add((snd, e));
+		}
+
+		public void ShouldBe(params Func<EmptyValidator, Validator>[] expected)
+		{
+			if (expected.Length != _result.Count)
+			{
+				throw new AssertionFailedException(
+					$"Not the same number of events. Expected: {expected.Length} actual: {_result.Count}"
+					+ $"\r\nExpected: \r\n\t{string.Join("\r\n\t", expected.Select((e, i) => $"[{i+1:D3}] + {e(Validator.Empty)}"))}"
+					+ $"\r\nActual: \r\n\t{string.Join("\r\n\t", _result.Select((r, i) => $"[{i+1:D3}] + {r.args.GetType().Name}"))}");
+			}
+
+			for (var i = 0; i < expected.Length; i++)
+			{
+				var config = expected[i];
+				var actual = _result[i];
+
+				if (actual.snd != _recognizer)
+				{
+					throw new AssertionFailedException($"args {i + 1} of {expected.Length}: sender is not the sut.");
+				}
+
+				config(Validator.Empty).Assert(actual.args, $"args {i + 1} of {expected.Length}");
+			}
+		}
+
+		public abstract class Validator
+		{
+			public static EmptyValidator Empty { get; } = new EmptyValidator();
+
+			internal abstract void Assert(object args, string identifier);
+		}
+
+		public abstract class Validator<TArgs> : Validator
+		{
+			private string _pendingAssertIdentifier;
+			private List<(string name, object expected, object actual)> _pendingAssertResult;
+
+			internal override void Assert(object args, string identifier)
+			{
+				try
+				{
+					_pendingAssertIdentifier = identifier;
+					if (!(args is TArgs t))
+					{
+						Failed($"is not of the expected type: {typeof(TArgs).Name}");
+						return;
+					}
+
+					_pendingAssertResult = new List<(string, object, object)>();
+
+					Assert(t);
+
+					if (_pendingAssertResult.Any())
+					{
+						Failed("has some unexpected values: \r\n" + string.Join("\r\n", _pendingAssertResult.Select(r => $"\t{r.name} (expected: {r.expected} / actual: {r.actual})")));
+					}
+				}
+				catch (Exception e) when (!(e is AssertionFailedException))
+				{
+					throw new AssertionFailedException($"{identifier} validation failed: {e.Message}");
+				}
+				finally
+				{
+					_pendingAssertResult = null;
+				}
+			}
+
+			protected abstract void Assert(TArgs args);
+
+			protected void Failed(string reason)
+				=> throw new AssertionFailedException($"{_pendingAssertIdentifier} {reason}");
+
+			protected void AreEquals(string name, Point? expected, Point actual)
+			{
+				if (expected.HasValue && expected.Value != actual)
+					_pendingAssertResult.Add((name, expected.Value, actual));
+			}
+
+			protected void AreEquals(string name, bool? expected, bool actual)
+			{
+				if (expected.HasValue && expected.Value != actual)
+					_pendingAssertResult.Add((name, expected.Value, actual));
+			}
+
+			protected void AreEquals(string name, ManipulationDelta? expected, ManipulationDelta actual)
+			{
+				if (!expected.HasValue)
+				{
+					return;
+				}
+
+				var e = expected.Value;
+
+				if (e.Translation.X != actual.Translation.X)
+					_pendingAssertResult.Add((name + ".Translation.X", expected.Value.Translation.X, actual.Translation.X));
+
+				if (e.Translation.Y != actual.Translation.Y)
+					_pendingAssertResult.Add((name + ".Translation.Y", expected.Value.Translation.Y, actual.Translation.Y));
+
+				if (e.Rotation != actual.Rotation)
+					_pendingAssertResult.Add((name + ".Rotation", expected.Value.Rotation, actual.Rotation));
+
+				if (e.Scale != actual.Scale)
+					_pendingAssertResult.Add((name + ".Scale", expected.Value.Scale, actual.Scale));
+
+				if (e.Expansion != actual.Expansion)
+					_pendingAssertResult.Add((name + ".Expansion", expected.Value.Expansion, actual.Expansion));
+			}
+
+			/// <inheritdoc />
+			public override string ToString()
+				=> typeof(TArgs).Name;
+		}
+
+		public class EmptyValidator : Validator
+		{
+			public StartingValidator Starting() => new StartingValidator();
+			public StartedValidator Started() => new StartedValidator();
+			public DeltaValidator Delta() => new DeltaValidator();
+			public EndValidator End() => new EndValidator();
+
+			internal override void Assert(object args, string identifier)
+				=> throw new AssertionFailedException($"Expected of {identifier} is not configured");
+		}
+
+		public class StartingValidator : Validator<EventArgs>
+		{
+			protected override void Assert(EventArgs args)
+			{
+			}
+		}
+
+		public class StartedValidator : Validator<ManipulationStartedEventArgs>
+		{
+			private Point? _position;
+			private ManipulationDelta? _cumulative;
+
+			public StartedValidator()
+			{
+			}
+
+			public StartedValidator At(double x, double y)
+			{
+				_position = new Point(x, y);
+				return this;
+			}
+
+			public StartedValidator WithCumulative(double tX = 0, double tY = 0, float angle = 0, float scale = 1, float exp = 0)
+			{
+				_cumulative = new ManipulationDelta
+				{
+					Translation = new Point(tX, tY),
+					Rotation = angle,
+					Scale = scale,
+					Expansion = exp,
+				};
+				return this;
+			}
+
+			protected override void Assert(ManipulationStartedEventArgs args)
+			{
+				AreEquals(nameof(args.Position), _position, args.Position);
+				AreEquals(nameof(args.Cumulative), _cumulative, args.Cumulative);
+			}
+		}
+
+		public class DeltaValidator : Validator<ManipulationUpdatedEventArgs>
+		{
+			private Point? _position;
+			private ManipulationDelta? _delta;
+			private ManipulationDelta? _cumulative;
+			private bool? _isInertial;
+
+			public DeltaValidator At(double x, double y)
+			{
+				_position = new Point(x, y);
+				return this;
+			}
+
+			public DeltaValidator WithDelta(double tX = 0, double tY = 0, float angle = 0, float scale = 1, float exp = 0)
+			{
+				_delta = new ManipulationDelta
+				{
+					Translation = new Point(tX, tY),
+					Rotation = angle,
+					Scale = scale,
+					Expansion = exp,
+				};
+				return this;
+			}
+
+			public DeltaValidator WithCumulative(double tX = 0, double tY = 0, float angle = 0, float scale = 1, float exp = 0)
+			{
+				_cumulative = new ManipulationDelta
+				{
+					Translation = new Point(tX, tY),
+					Rotation = angle,
+					Scale = scale,
+					Expansion = exp,
+				};
+				return this;
+			}
+
+			public DeltaValidator IsNotInertial() => IsInertial(false);
+			public DeltaValidator IsInertial(bool isInertial = true)
+			{
+				_isInertial = isInertial;
+				return this;
+			}
+
+			protected override void Assert(ManipulationUpdatedEventArgs args)
+			{
+				AreEquals(nameof(args.Position), _position, args.Position);
+				AreEquals(nameof(args.Delta), _delta, args.Delta);
+				AreEquals(nameof(args.Cumulative), _cumulative, args.Cumulative);
+				AreEquals(nameof(args.IsInertial), _isInertial, args.IsInertial);
+			}
+		}
+
+		public class EndValidator : Validator<ManipulationCompletedEventArgs>
+		{
+			private Point? _position;
+			private ManipulationDelta? _cumulative;
+			private bool? _isInertial;
+
+			public EndValidator At(double x, double y)
+			{
+				_position = new Point(x, y);
+				return this;
+			}
+
+			public EndValidator WithCumulative(double tX = 0, double tY = 0, float angle = 0, float scale = 1, float exp = 0)
+			{
+				_cumulative = new ManipulationDelta
+				{
+					Translation = new Point(tX, tY),
+					Rotation = angle,
+					Scale = scale,
+					Expansion = exp,
+				};
+				return this;
+			}
+
+			public EndValidator IsNotInertial() => IsInertial(false);
+			public EndValidator IsInertial(bool isInertial = true)
+			{
+				_isInertial = isInertial;
+				return this;
+			}
+
+			protected override void Assert(ManipulationCompletedEventArgs args)
+			{
+				AreEquals(nameof(args.Position), _position, args.Position);
+				AreEquals(nameof(args.Cumulative), _cumulative, args.Cumulative);
+				AreEquals(nameof(args.IsInertial), _isInertial, args.IsInertial);
+			}
+		}
 	}
 
 	internal static class GestureRecognizerTestExtensions
 	{
-		private static long _pointerId = 0;
+		private static long _frameId = 0;
 
 		public static PointerPoint GetPoint(
 			double x,
@@ -201,8 +1014,9 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			bool? isInContact = true,
 			PointerPointProperties properties = null)
 		{
-			id = id ?? (uint)Interlocked.Increment(ref _pointerId);
-			ts = ts ?? (ulong)id;
+			var frameId = (uint)Interlocked.Increment(ref _frameId);
+			id = id ?? 1;
+			ts = ts ?? frameId;
 			var pointer = new PointerDevice(device ?? PointerDeviceType.Mouse);
 			var location = new Windows.Foundation.Point(x, y);
 			properties = properties ?? new PointerPointProperties
@@ -212,7 +1026,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 				IsLeftButtonPressed = true,
 			};
 
-			return new PointerPoint(id.Value, ts.Value, pointer, (uint)pointer.PointerDeviceType, location, location, isInContact.GetValueOrDefault(), properties);
+			return new PointerPoint(frameId, ts.Value, pointer, id.Value, location, location, isInContact.GetValueOrDefault(), properties);
 		}
 
 		public static TappedEventArgs Tap(double x, double y, uint tapCount = 1, PointerDeviceType? device = null)

--- a/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
@@ -216,7 +216,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 			result.ShouldBe(
 				v => v.Starting(),
-				v => v.Starting(),
 				v => v.Started()
 			);
 		}
@@ -399,7 +398,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 			result.ShouldBe(
 				v => v.Starting(),
-				v => v.Starting(),
 				v => v.Started().At(25, 25).WithCumulative(),
 				v => v.Delta().At(100, 100).WithDelta(tX: 75, tY: 75).WithCumulative(tX: 75, tY: 75)
 			);
@@ -417,7 +415,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			sut.ProcessMoveEvent(50, 50, id: 2);
 
 			result.ShouldBe(
-				v => v.Starting(),
 				v => v.Starting(),
 				v => v.Started().At(100, 100).WithCumulative(),
 				v => v.Delta().At(25, 25).WithDelta(tX: -75, tY: -75).WithCumulative(tX: -75, tY: -75)
@@ -437,7 +434,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			sut.ProcessMoveEvent(25, -50, id: 2); // Angle = -Pi/2
 
 			result.ShouldBe(
-				v => v.Starting(),
 				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
 				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
@@ -459,7 +455,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 			result.ShouldBe(
 				v => v.Starting(),
-				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
 				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
 				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 270)
@@ -480,7 +475,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 			result.ShouldBe(
 				v => v.Starting(),
-				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
 				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
 				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 270)
@@ -500,7 +494,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			sut.ProcessMoveEvent(50, 25, id: 2); // Angle = -Pi/2
 
 			result.ShouldBe(
-				v => v.Starting(),
 				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
 				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
@@ -523,7 +516,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 			result.ShouldBe(
 				v => v.Starting(),
-				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
 				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
 				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 90)
@@ -543,7 +535,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			sut.ProcessMoveEvent(-25, -50, id: 2); // Angle = -Pi/2
 
 			result.ShouldBe(
-				v => v.Starting(),
 				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
 				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
@@ -565,7 +556,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 			result.ShouldBe(
 				v => v.Starting(),
-				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
 				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
 				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 90)
@@ -585,7 +575,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			sut.ProcessMoveEvent(25, 50, id: 2); // Angle = -Pi/2
 
 			result.ShouldBe(
-				v => v.Starting(),
 				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
 				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
@@ -607,7 +596,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 			result.ShouldBe(
 				v => v.Starting(),
-				v => v.Starting(),
 				v => v.Started().WithCumulative(scale: 1),
 				v => v.Delta().WithDelta(scale: 3, exp: 50).WithCumulative(scale: 3, exp: 50),
 				v => v.Delta().WithDelta(scale: 5F/3F, exp: 50).WithCumulative(scale: 5, exp: 100)
@@ -628,7 +616,6 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 			result.ShouldBe(
 				v => v.Starting(),
-				v => v.Starting(),
 				v => v.Started().WithCumulative(scale: 1),
 				v => v.Delta().WithDelta(scale: .6F, exp: -50).WithCumulative(scale: .6F, exp: -50),
 				v => v.Delta().WithDelta(scale: 2F/3F, exp: -25).WithCumulative(scale: .4F, exp: -75)
@@ -642,84 +629,83 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			var result = new ManipulationRecorder(sut);
 
 			sut.ProcessDownEvent(50, 50, id: 1); // 1.
-			sut.ProcessDownEvent(50, 200, id: 2); // 2. & 3.
+			sut.ProcessDownEvent(50, 200, id: 2); // 2.
 
-			sut.ProcessMoveEvent(200, 200, id: 2); // 4.
-			sut.ProcessMoveEvent(50, 200, id: 1); // 5.
+			sut.ProcessMoveEvent(200, 200, id: 2); // 3.
+			sut.ProcessMoveEvent(50, 200, id: 1); // 4.
 
-			sut.ProcessMoveEvent(200, 50, id: 2); // 6.
-			sut.ProcessMoveEvent(200, 200, id: 1); // 7.
+			sut.ProcessMoveEvent(200, 50, id: 2); // 5.
+			sut.ProcessMoveEvent(200, 200, id: 1); // 6.
 
-			sut.ProcessMoveEvent(50, 50, id: 2); // 8.
-			sut.ProcessMoveEvent(200, 50, id: 1); // 9.
+			sut.ProcessMoveEvent(50, 50, id: 2); // 7.
+			sut.ProcessMoveEvent(200, 50, id: 1); // 8.
 
-			sut.ProcessMoveEvent(50, 200, id: 2); // 10.
-			sut.ProcessMoveEvent(50, 50, id: 1); // 11.
+			sut.ProcessMoveEvent(50, 200, id: 2); // 9.
+			sut.ProcessMoveEvent(50, 50, id: 1); // 10.
 
 			// At same point (0 proof ?)
-			sut.ProcessMoveEvent(50, 50, id: 2); // 12.
+			sut.ProcessMoveEvent(50, 50, id: 2); // 11.
 
 			var s = (float)Math.Sqrt(2);
 			var e = (float)((Math.Sqrt(2) - 1) * 150);
 
 			result.ShouldBe(
 				v => v.Starting(), // 1.
-				v => v.Starting(), // 2.
 
-				// 3.
+				// 2.
 				v => v.Started()
 					.At(50, 125)
 					.WithCumulative(),
 
-				// 4.
+				// 3.
 				v => v.Delta()
 					.At(125, 125)
 					.WithDelta(tX: 75, tY: 0, angle: 315, scale: s, exp: e)
 					.WithCumulative(tX: 75, tY: 0, angle: 315, scale: s, exp: e),
 
-				// 5.
+				// 4.
 				v => v.Delta()
 					.At(125, 200)
 					.WithDelta(tX: 0, tY: 75, angle: 315, scale: 1/s, exp: -e)
 					.WithCumulative(tX: 75, tY: 75, angle: 270, scale: 1, exp: 0),
 
-				// 6.
+				// 5.
 				v => v.Delta()
 					.At(125, 125)
 					.WithDelta(tX: 0, tY: -75, angle: 315, scale: s, exp: e)
 					.WithCumulative(tX: 75, tY: 0, angle: 225, scale: s, exp: e),
 
-				// 7.
+				// 6.
 				v => v.Delta()
 					.At(200, 125)
 					.WithDelta(tX: 75, tY: 0, angle: 315, scale: 1 / s, exp: -e)
 					.WithCumulative(tX: 150, tY: 0, angle: 180, scale: 1, exp: 0),
 
-				// 8.
+				// 7.
 				v => v.Delta()
 					.At(125, 125)
 					.WithDelta(tX: -75, tY: 0, angle: 315, scale: s, exp: e)
 					.WithCumulative(tX: 75, tY: 0, angle: 135, scale: s, exp: e),
 
-				// 9.
+				// 8.
 				v => v.Delta()
 					.At(125, 50)
 					.WithDelta(tX: 0, tY: -75, angle: 315, scale: 1 / s, exp: -e)
 					.WithCumulative(tX: 75, tY: -75, angle: 90, scale: 1, exp: 0),
 
-				// 10.
+				// 9.
 				v => v.Delta()
 					.At(125, 125)
 					.WithDelta(tX: 0, tY: 75, angle: 315, scale: s, exp: e)
 					.WithCumulative(tX: 75, tY: 0, angle: 45, scale: s, exp: e),
 
-				// 11.
+				// 10.
 				v => v.Delta()
 					.At(50, 125)
 					.WithDelta(tX: -75, tY: 0, angle: 315, scale: 1 / s, exp: -e)
 					.WithCumulative(tX: 0, tY: 0, angle: 0, scale: 1, exp: 0),
 
-				// 12.
+				// 11.
 				v => v.Delta()
 					.At(50, 50)
 					.WithDelta(tX: 0, tY: -75, angle: 90 /* ??? */, scale: 0, exp: -150F)
@@ -867,9 +853,9 @@ namespace Uno.UI.Tests.Windows_UI_Input
 				=> throw new AssertionFailedException($"Expected of {identifier} is not configured");
 		}
 
-		public class StartingValidator : Validator<EventArgs>
+		public class StartingValidator : Validator<ManipulationStartingEventArgs>
 		{
-			protected override void Assert(EventArgs args)
+			protected override void Assert(ManipulationStartingEventArgs args)
 			{
 			}
 		}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Control.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Control.cs
@@ -574,35 +574,35 @@ namespace Windows.UI.Xaml.Controls
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnRightTapped(RightTappedRoutedEventArgs e)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		protected virtual void OnManipulationStarting( global::Windows.UI.Xaml.Input.ManipulationStartingRoutedEventArgs e)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnManipulationStarting(ManipulationStartingRoutedEventArgs e)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		protected virtual void OnManipulationInertiaStarting( global::Windows.UI.Xaml.Input.ManipulationInertiaStartingRoutedEventArgs e)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnManipulationInertiaStarting(ManipulationInertiaStartingRoutedEventArgs e)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		protected virtual void OnManipulationStarted( global::Windows.UI.Xaml.Input.ManipulationStartedRoutedEventArgs e)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnManipulationStarted(ManipulationStartedRoutedEventArgs e)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		protected virtual void OnManipulationDelta( global::Windows.UI.Xaml.Input.ManipulationDeltaRoutedEventArgs e)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnManipulationDelta(ManipulationDeltaRoutedEventArgs e)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		protected virtual void OnManipulationCompleted( global::Windows.UI.Xaml.Input.ManipulationCompletedRoutedEventArgs e)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationCompletedEventHandler.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationCompletedEventHandler.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	public delegate void ManipulationCompletedEventHandler(object @sender, global::Windows.UI.Xaml.Input.ManipulationCompletedRoutedEventArgs @e);
 	#endif
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationCompletedRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationCompletedRoutedEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ManipulationCompletedRoutedEventArgs : global::Windows.UI.Xaml.RoutedEventArgs
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  bool Handled
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.UIElement Container
 		{
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Cumulative
 		{
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  bool IsInertial
 		{
@@ -51,7 +51,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Input.PointerDeviceType PointerDeviceType
 		{
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Point Position
 		{
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public ManipulationCompletedRoutedEventArgs() : base()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationDeltaRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationDeltaRoutedEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ManipulationDeltaRoutedEventArgs : global::Windows.UI.Xaml.RoutedEventArgs
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  bool Handled
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.UIElement Container
 		{
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Cumulative
 		{
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Delta
 		{
@@ -51,7 +51,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  bool IsInertial
 		{
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Input.PointerDeviceType PointerDeviceType
 		{
@@ -71,7 +71,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Point Position
 		{
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public ManipulationDeltaRoutedEventArgs() : base()
 		{
@@ -108,7 +108,7 @@ namespace Windows.UI.Xaml.Input
 		// Forced skipping of method Windows.UI.Xaml.Input.ManipulationDeltaRoutedEventArgs.Handled.get
 		// Forced skipping of method Windows.UI.Xaml.Input.ManipulationDeltaRoutedEventArgs.Handled.set
 		// Forced skipping of method Windows.UI.Xaml.Input.ManipulationDeltaRoutedEventArgs.PointerDeviceType.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  void Complete()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationInertiaStartingRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationInertiaStartingRoutedEventArgs.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  bool Handled
 		{
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.UIElement Container
 		{
@@ -73,7 +73,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Cumulative
 		{
@@ -83,7 +83,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Delta
 		{
@@ -93,7 +93,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Input.PointerDeviceType PointerDeviceType
 		{
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public ManipulationInertiaStartingRoutedEventArgs() : base()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationStartedRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationStartedRoutedEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ManipulationStartedRoutedEventArgs : global::Windows.UI.Xaml.RoutedEventArgs
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  bool Handled
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.UIElement Container
 		{
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Cumulative
 		{
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Input.PointerDeviceType PointerDeviceType
 		{
@@ -51,7 +51,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Point Position
 		{
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public ManipulationStartedRoutedEventArgs() : base()
 		{
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml.Input
 		// Forced skipping of method Windows.UI.Xaml.Input.ManipulationStartedRoutedEventArgs.Handled.set
 		// Forced skipping of method Windows.UI.Xaml.Input.ManipulationStartedRoutedEventArgs.PointerDeviceType.get
 		// Forced skipping of method Windows.UI.Xaml.Input.ManipulationStartedRoutedEventArgs.Cumulative.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  void Complete()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationStartingRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationStartingRoutedEventArgs.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ManipulationStartingRoutedEventArgs : global::Windows.UI.Xaml.RoutedEventArgs
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.Input.ManipulationModes Mode
 		{
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  bool Handled
 		{
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.UIElement Container
 		{
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public ManipulationStartingRoutedEventArgs() : base()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
@@ -1524,7 +1524,7 @@ namespace Windows.UI.Xaml
 		}
 		#endif
 		// Skipping already declared event Windows.UI.Xaml.UIElement.LostFocus
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.UI.Xaml.Input.ManipulationCompletedEventHandler ManipulationCompleted
 		{
@@ -1540,7 +1540,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.UI.Xaml.Input.ManipulationDeltaEventHandler ManipulationDelta
 		{
@@ -1556,7 +1556,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.UI.Xaml.Input.ManipulationInertiaStartingEventHandler ManipulationInertiaStarting
 		{
@@ -1572,7 +1572,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.UI.Xaml.Input.ManipulationStartedEventHandler ManipulationStarted
 		{
@@ -1588,7 +1588,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.UI.Xaml.Input.ManipulationStartingEventHandler ManipulationStarting
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
@@ -630,7 +630,7 @@ namespace Windows.UI.Xaml
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.RoutedEvent ManipulationCompletedEvent
 		{
@@ -640,7 +640,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.RoutedEvent ManipulationDeltaEvent
 		{
@@ -658,7 +658,7 @@ namespace Windows.UI.Xaml
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.RoutedEvent ManipulationInertiaStartingEvent
 		{
@@ -676,7 +676,7 @@ namespace Windows.UI.Xaml
 			typeof(global::Windows.UI.Xaml.UIElement), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Input.ManipulationModes)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.RoutedEvent ManipulationStartedEvent
 		{
@@ -686,7 +686,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.RoutedEvent ManipulationStartingEvent
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -165,67 +165,92 @@ namespace Windows.UI.Xaml.Controls
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.PointerPressed))
 			{
-				PointerPressed += OnPointerPressed;
+				PointerPressed += OnPointerPressedHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.PointerReleased))
 			{
-				PointerReleased += OnPointerReleased;
+				PointerReleased += OnPointerReleasedHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.PointerMoved))
 			{
-				PointerMoved += OnPointerMoved;
+				PointerMoved += OnPointerMovedHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.PointerEntered))
 			{
-				PointerEntered += OnPointerEntered;
+				PointerEntered += OnPointerEnteredHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.PointerExited))
 			{
-				PointerExited += OnPointerExited;
+				PointerExited += OnPointerExitedHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.PointerCanceled))
 			{
-				PointerCanceled += OnPointerCanceled;
+				PointerCanceled += OnPointerCanceledHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.PointerCaptureLost))
 			{
-				PointerCaptureLost += OnPointerCaptureLost;
+				PointerCaptureLost += OnPointerCaptureLostHandler;
+			}
+
+			if (implementedEvents.HasFlag(RoutedEventFlag.ManipulationStarting))
+			{
+				ManipulationStarting += OnManipulationStartingHandler;
+			}
+
+			if (implementedEvents.HasFlag(RoutedEventFlag.ManipulationStarted))
+			{
+				ManipulationStarted += OnManipulationStartedHandler;
+			}
+
+			if (implementedEvents.HasFlag(RoutedEventFlag.ManipulationDelta))
+			{
+				ManipulationDelta += OnManipulationDeltaHandler;
+			}
+
+			if (implementedEvents.HasFlag(RoutedEventFlag.ManipulationInertiaStarting))
+			{
+				ManipulationInertiaStarting += OnManipulationInertiaStartingHandler;
+			}
+
+			if (implementedEvents.HasFlag(RoutedEventFlag.ManipulationCompleted))
+			{
+				ManipulationCompleted += OnManipulationCompletedHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.Tapped))
 			{
-				Tapped += OnTapped;
+				Tapped += OnTappedHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.DoubleTapped))
 			{
-				DoubleTapped += OnDoubleTapped;
+				DoubleTapped += OnDoubleTappedHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.KeyDown))
 			{
-				KeyDown += OnKeyDown;
+				KeyDown += OnKeyDownHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.KeyUp))
 			{
-				KeyUp += OnKeyUp;
+				KeyUp += OnKeyUpHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.GotFocus))
 			{
-				GotFocus += OnGotFocus;
+				GotFocus += OnGotFocusHandler;
 			}
 
 			if (implementedEvents.HasFlag(RoutedEventFlag.LostFocus))
 			{
-				LostFocus += OnLostFocus;
+				LostFocus += OnLostFocusHandler;
 			}
 		}
 
@@ -724,6 +749,11 @@ namespace Windows.UI.Xaml.Controls
 		protected virtual void OnPointerMoved(PointerRoutedEventArgs args) { }
 		protected virtual void OnPointerCanceled(PointerRoutedEventArgs args) { }
 		protected virtual void OnPointerCaptureLost(PointerRoutedEventArgs args) { }
+		protected virtual void OnManipulationStarting(ManipulationStartingRoutedEventArgs e) { }
+		protected virtual void OnManipulationStarted(ManipulationStartedRoutedEventArgs e) { }
+		protected virtual void OnManipulationDelta(ManipulationDeltaRoutedEventArgs e) { }
+		protected virtual void OnManipulationInertiaStarting(ManipulationInertiaStartingRoutedEventArgs e) { }
+		protected virtual void OnManipulationCompleted(ManipulationCompletedRoutedEventArgs e) { }
 		protected virtual void OnTapped(TappedRoutedEventArgs e) { }
 		protected virtual void OnDoubleTapped(DoubleTappedRoutedEventArgs e) { }
 		protected virtual void OnKeyDown(KeyRoutedEventArgs args) { }
@@ -731,71 +761,59 @@ namespace Windows.UI.Xaml.Controls
 		protected virtual void OnGotFocus(RoutedEventArgs e) { }
 		protected virtual void OnLostFocus(RoutedEventArgs e) { }
 
+		private static readonly PointerEventHandler OnPointerPressedHandler =
+			(object sender, PointerRoutedEventArgs args) => ((Control)sender).OnPointerPressed(args);
 
-		private void OnPointerPressed(object sender, PointerRoutedEventArgs args)
-		{
-			OnPointerPressed(args);
-		}
+		private static readonly PointerEventHandler OnPointerReleasedHandler =
+			(object sender, PointerRoutedEventArgs args) => ((Control)sender).OnPointerReleased(args);
 
-		private void OnPointerReleased(object sender, PointerRoutedEventArgs args)
-		{
-			OnPointerReleased(args);
-		}
+		private static readonly PointerEventHandler OnPointerEnteredHandler =
+			(object sender, PointerRoutedEventArgs args) => ((Control)sender).OnPointerEntered(args);
 
-		private void OnPointerEntered(object sender, PointerRoutedEventArgs args)
-		{
-			OnPointerEntered(args);
-		}
+		private static readonly PointerEventHandler OnPointerExitedHandler =
+			(object sender, PointerRoutedEventArgs args) => ((Control)sender).OnPointerExited(args);
 
-		private void OnPointerExited(object sender, PointerRoutedEventArgs args)
-		{
-			OnPointerExited(args);
-		}
+		private static readonly PointerEventHandler OnPointerMovedHandler =
+			(object sender, PointerRoutedEventArgs args) => ((Control)sender).OnPointerMoved(args);
 
-		private void OnPointerMoved(object sender, PointerRoutedEventArgs args)
-		{
-			OnPointerMoved(args);
-		}
+		private static readonly PointerEventHandler OnPointerCanceledHandler =
+			(object sender, PointerRoutedEventArgs args) => ((Control)sender).OnPointerCanceled(args);
 
-		private void OnPointerCanceled(object sender, PointerRoutedEventArgs args)
-		{
-			OnPointerCanceled(args);
-		}
+		private static readonly PointerEventHandler OnPointerCaptureLostHandler =
+			(object sender, PointerRoutedEventArgs args) => ((Control)sender).OnPointerCaptureLost(args);
 
-		private void OnPointerCaptureLost(object sender, PointerRoutedEventArgs args)
-		{
-			OnPointerCaptureLost(args);
-		}
+		private static readonly ManipulationStartingEventHandler OnManipulationStartingHandler =
+			(object sender, ManipulationStartingRoutedEventArgs args) => ((Control)sender).OnManipulationStarting(args);
 
-		private void OnTapped(object sender, TappedRoutedEventArgs args)
-		{
-			OnTapped(args);
-		}
+		private static readonly ManipulationStartedEventHandler OnManipulationStartedHandler =
+			(object sender, ManipulationStartedRoutedEventArgs args) => ((Control)sender).OnManipulationStarted(args);
 
-		private void OnDoubleTapped(object sender, DoubleTappedRoutedEventArgs args)
-		{
-			OnDoubleTapped(args);
-		}
+		private static readonly ManipulationDeltaEventHandler OnManipulationDeltaHandler =
+			(object sender, ManipulationDeltaRoutedEventArgs args) => ((Control)sender).OnManipulationDelta(args);
 
-		private void OnKeyDown(object sender, KeyRoutedEventArgs args)
-		{
-			OnKeyDown(args);
-		}
+		private static readonly ManipulationInertiaStartingEventHandler OnManipulationInertiaStartingHandler =
+			(object sender, ManipulationInertiaStartingRoutedEventArgs args) => ((Control)sender).OnManipulationInertiaStarting(args);
 
-		private void OnKeyUp(object sender, KeyRoutedEventArgs args)
-		{
-			OnKeyUp(args);
-		}
+		private static readonly ManipulationCompletedEventHandler OnManipulationCompletedHandler =
+			(object sender, ManipulationCompletedRoutedEventArgs args) => ((Control)sender).OnManipulationCompleted(args);
 
-		private void OnGotFocus(object sender, RoutedEventArgs args)
-		{
-			OnGotFocus(args);
-		}
+		private static readonly TappedEventHandler OnTappedHandler =
+			(object sender, TappedRoutedEventArgs args) => ((Control)sender).OnTapped(args);
 
-		private void OnLostFocus(object sender, RoutedEventArgs args)
-		{
-			OnLostFocus(args);
-		}
+		private static readonly DoubleTappedEventHandler OnDoubleTappedHandler =
+			(object sender, DoubleTappedRoutedEventArgs args) => ((Control)sender).OnDoubleTapped(args);
+
+		private static readonly KeyEventHandler OnKeyDownHandler =
+			(object sender, KeyRoutedEventArgs args) => ((Control)sender).OnKeyDown(args);
+
+		private static readonly KeyEventHandler OnKeyUpHandler =
+			(object sender, KeyRoutedEventArgs args) => ((Control)sender).OnKeyUp(args);
+
+		private static readonly RoutedEventHandler OnGotFocusHandler =
+			(object sender, RoutedEventArgs args) => ((Control)sender).OnGotFocus(args);
+
+		private static readonly RoutedEventHandler OnLostFocusHandler =
+			(object sender, RoutedEventArgs args) => ((Control)sender).OnLostFocus(args);
 
 		private static readonly Dictionary<Type, RoutedEventFlag> ImplementedRoutedEvents
 			= new Dictionary<Type, RoutedEventFlag>();
@@ -825,67 +843,92 @@ namespace Windows.UI.Xaml.Controls
 			var keyArgs = new[] { typeof(KeyRoutedEventArgs) };
 			var routedArgs = new[] { typeof(RoutedEventArgs) };
 
-			if (GetIsEventOverrideImplemented(type, "OnPointerPressed", pointerArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnPointerPressed), pointerArgs))
 			{
 				result |= RoutedEventFlag.PointerPressed;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnPointerReleased", pointerArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnPointerReleased), pointerArgs))
 			{
 				result |= RoutedEventFlag.PointerReleased;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnPointerEntered", pointerArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnPointerEntered), pointerArgs))
 			{
 				result |= RoutedEventFlag.PointerEntered;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnPointerExited", pointerArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnPointerExited), pointerArgs))
 			{
 				result |= RoutedEventFlag.PointerExited;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnPointerMoved", pointerArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnPointerMoved), pointerArgs))
 			{
 				result |= RoutedEventFlag.PointerMoved;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnPointerCanceled", pointerArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnPointerCanceled), pointerArgs))
 			{
 				result |= RoutedEventFlag.PointerCanceled;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnPointerCaptureLost", pointerArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnPointerCaptureLost), pointerArgs))
 			{
 				result |= RoutedEventFlag.PointerCaptureLost;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnTapped", tappedArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnManipulationStarting), pointerArgs))
+			{
+				result |= RoutedEventFlag.ManipulationStarting;
+			}
+
+			if (GetIsEventOverrideImplemented(type, nameof(OnManipulationStarted), pointerArgs))
+			{
+				result |= RoutedEventFlag.ManipulationStarted;
+			}
+
+			if (GetIsEventOverrideImplemented(type, nameof(OnManipulationDelta), pointerArgs))
+			{
+				result |= RoutedEventFlag.ManipulationDelta;
+			}
+
+			if (GetIsEventOverrideImplemented(type, nameof(OnManipulationInertiaStarting), pointerArgs))
+			{
+				result |= RoutedEventFlag.ManipulationInertiaStarting;
+			}
+
+			if (GetIsEventOverrideImplemented(type, nameof(OnManipulationCompleted), pointerArgs))
+			{
+				result |= RoutedEventFlag.ManipulationCompleted;
+			}
+
+			if (GetIsEventOverrideImplemented(type, nameof(OnTapped), tappedArgs))
 			{
 				result |= RoutedEventFlag.Tapped;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnDoubleTapped", doubleTappedArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnDoubleTapped), doubleTappedArgs))
 			{
 				result |= RoutedEventFlag.DoubleTapped;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnKeyDown", keyArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnKeyDown), keyArgs))
 			{
 				result |= RoutedEventFlag.KeyDown;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnKeyUp", keyArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnKeyUp), keyArgs))
 			{
 				result |= RoutedEventFlag.KeyUp;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnLostFocus", routedArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnLostFocus), routedArgs))
 			{
 				result |= RoutedEventFlag.LostFocus;
 			}
 
-			if (GetIsEventOverrideImplemented(type, "OnGotFocus", routedArgs))
+			if (GetIsEventOverrideImplemented(type, nameof(OnGotFocus), routedArgs))
 			{
 				result |= RoutedEventFlag.GotFocus;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ISelector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ISelector.cs
@@ -26,7 +26,13 @@ namespace Windows.UI.Xaml.Controls
 	//
 	public partial class SelectionChangedEventArgs : RoutedEventArgs
 	{
-		public SelectionChangedEventArgs(object originalSource, IList<object> removedItems, IList<object> addedItems)
+		public SelectionChangedEventArgs(IList<object> removedItems, IList<object> addedItems)
+		{
+			RemovedItems = removedItems;
+			AddedItems = addedItems;
+		}
+
+		internal SelectionChangedEventArgs(object originalSource, IList<object> removedItems, IList<object> addedItems)
 			: base(originalSource)
 		{
 			RemovedItems = removedItems;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Android.cs
@@ -13,7 +13,7 @@ using System.Text;
 using System.Drawing;
 using Uno.UI;
 using Microsoft.Extensions.Logging;
-using static Uno.UI.MathEx;
+using static Uno.Extensions.MathEx;
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Input/DoubleTappedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/DoubleTappedRoutedEventArgs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Windows.Devices.Input;
 using Windows.Foundation;
+using Windows.UI.Input;
 using Uno.UI.Xaml.Input;
 
 namespace Windows.UI.Xaml.Input
@@ -11,16 +12,13 @@ namespace Windows.UI.Xaml.Input
 	{
 		private readonly Point _position;
 
-		public DoubleTappedRoutedEventArgs() 
-			: this(null, PointerDeviceType.Mouse, new Point())
-		{
-		}
+		public DoubleTappedRoutedEventArgs() { }
 
-		internal DoubleTappedRoutedEventArgs(object originalSource, PointerDeviceType pointerType, Point position)
+		internal DoubleTappedRoutedEventArgs(object originalSource, TappedEventArgs args)
 			: base(originalSource)
 		{
-			PointerDeviceType = pointerType;
-			_position = position;
+			PointerDeviceType = args.PointerDeviceType;
+			_position = args.Position;
 		}
 
 		public Point GetPosition()
@@ -30,7 +28,7 @@ namespace Windows.UI.Xaml.Input
 
 		public PointerDeviceType PointerDeviceType { get; internal set; }
 
-		public global::Windows.Foundation.Point GetPosition(global::Windows.UI.Xaml.UIElement relativeTo)
+		public Point GetPosition(UIElement relativeTo)
 		{
 			if (relativeTo == null)
 			{

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedEventHandler.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedEventHandler.cs
@@ -1,0 +1,4 @@
+namespace Windows.UI.Xaml.Input
+{
+	public delegate void ManipulationCompletedEventHandler(object @sender, ManipulationCompletedRoutedEventArgs @e);
+}

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedRoutedEventArgs.cs
@@ -1,0 +1,40 @@
+using Windows.Devices.Input;
+using Windows.Foundation;
+using Windows.UI.Input;
+using Uno.UI.Xaml.Input;
+
+namespace Windows.UI.Xaml.Input
+{
+	public partial class ManipulationCompletedRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
+	{
+		public ManipulationCompletedRoutedEventArgs() { }
+
+		internal ManipulationCompletedRoutedEventArgs(
+			object originalSource,
+			UIElement container,
+			PointerDeviceType pointerDeviceType,
+			Point position,
+			ManipulationDelta cumulative,
+			bool isInertial)
+			: base(originalSource)
+		{
+			Container = container;
+			PointerDeviceType = pointerDeviceType;
+			Position = position;
+			Cumulative = cumulative;
+			IsInertial = isInertial;
+		}
+
+		public bool Handled { get; set; }
+
+		public UIElement Container { get; }
+
+		public PointerDeviceType PointerDeviceType { get; }
+
+		public Point Position { get; }
+
+		public ManipulationDelta Cumulative { get; }
+
+		public bool IsInertial { get; }
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaEventHandler.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaEventHandler.cs
@@ -1,8 +1,4 @@
-#pragma warning disable 108 // new keyword hiding
-#pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if false
 	public delegate void ManipulationDeltaEventHandler(object @sender, global::Windows.UI.Xaml.Input.ManipulationDeltaRoutedEventArgs @e);
-	#endif
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
@@ -7,24 +7,22 @@ namespace Windows.UI.Xaml.Input
 {
 	public partial class ManipulationDeltaRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
 	{
+		private readonly GestureRecognizer _recognizer;
+
 		public ManipulationDeltaRoutedEventArgs() { }
 
-		internal ManipulationDeltaRoutedEventArgs(
-			object originalSource,
-			UIElement container,
-			PointerDeviceType pointerDeviceType,
-			Point position,
-			ManipulationDelta delta,
-			ManipulationDelta cumulative,
-			bool isInertial)
-			: base(originalSource)
+		internal ManipulationDeltaRoutedEventArgs(UIElement container, GestureRecognizer recognizer, ManipulationUpdatedEventArgs args)
+			: base(container)
 		{
 			Container = container;
-			PointerDeviceType = pointerDeviceType;
-			Position = position;
-			Delta = delta;
-			Cumulative = cumulative;
-			IsInertial = isInertial;
+
+			_recognizer = recognizer;
+
+			PointerDeviceType = args.PointerDeviceType;
+			Position = args.Position;
+			Delta = args.Delta;
+			Cumulative = args.Cumulative;
+			IsInertial = args.IsInertial;
 		}
 
 		public bool Handled { get; set; }
@@ -37,7 +35,6 @@ namespace Windows.UI.Xaml.Input
 		public bool IsInertial { get; }
 
 		public void Complete()
-		{
-		}
+			=> _recognizer?.CompleteGesture();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
@@ -1,0 +1,43 @@
+using Windows.Devices.Input;
+using Windows.Foundation;
+using Windows.UI.Input;
+using Uno.UI.Xaml.Input;
+
+namespace Windows.UI.Xaml.Input
+{
+	public partial class ManipulationDeltaRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
+	{
+		public ManipulationDeltaRoutedEventArgs() { }
+
+		internal ManipulationDeltaRoutedEventArgs(
+			object originalSource,
+			UIElement container,
+			PointerDeviceType pointerDeviceType,
+			Point position,
+			ManipulationDelta delta,
+			ManipulationDelta cumulative,
+			bool isInertial)
+			: base(originalSource)
+		{
+			Container = container;
+			PointerDeviceType = pointerDeviceType;
+			Position = position;
+			Delta = delta;
+			Cumulative = cumulative;
+			IsInertial = isInertial;
+		}
+
+		public bool Handled { get; set; }
+
+		public UIElement Container { get; }
+		public PointerDeviceType PointerDeviceType { get; }
+		public Point Position { get; }
+		public ManipulationDelta Delta { get; }
+		public ManipulationDelta Cumulative { get; }
+		public bool IsInertial { get; }
+
+		public void Complete()
+		{
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationInertiaStartingEventHandler.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationInertiaStartingEventHandler.cs
@@ -1,8 +1,4 @@
-#pragma warning disable 108 // new keyword hiding
-#pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if false
 	public delegate void ManipulationInertiaStartingEventHandler(object @sender, global::Windows.UI.Xaml.Input.ManipulationInertiaStartingRoutedEventArgs @e);
-	#endif
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationInertiaStartingRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationInertiaStartingRoutedEventArgs.cs
@@ -1,22 +1,21 @@
 using Windows.Devices.Input;
-using Windows.Foundation;
 using Windows.UI.Input;
 using Uno.UI.Xaml.Input;
 
 namespace Windows.UI.Xaml.Input
 {
-	public partial class ManipulationCompletedRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
+	public  partial class ManipulationInertiaStartingRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
 	{
-		public ManipulationCompletedRoutedEventArgs() { }
+		public ManipulationInertiaStartingRoutedEventArgs() { }
 
-		internal ManipulationCompletedRoutedEventArgs(UIElement container, ManipulationCompletedEventArgs args)
+		internal ManipulationInertiaStartingRoutedEventArgs(UIElement container, ManipulationInertiaStartingEventArgs args)
 			: base(container)
 		{
 			Container = container;
+
 			PointerDeviceType = args.PointerDeviceType;
-			Position = args.Position;
+			Delta = args.Delta;
 			Cumulative = args.Cumulative;
-			IsInertial = args.IsInertial;
 		}
 
 		public bool Handled { get; set; }
@@ -24,8 +23,7 @@ namespace Windows.UI.Xaml.Input
 		public UIElement Container { get; }
 
 		public PointerDeviceType PointerDeviceType { get; }
-		public Point Position { get; }
+		public ManipulationDelta Delta { get; }
 		public ManipulationDelta Cumulative { get; }
-		public bool IsInertial { get; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationModes.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationModes.cs
@@ -1,6 +1,8 @@
 using System;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
+using Microsoft.Extensions.Logging;
+using Uno.Logging;
 
 namespace Windows.UI.Xaml.Input
 {
@@ -12,10 +14,8 @@ namespace Windows.UI.Xaml.Input
 		/// <summary>Do not present graphic interaction with manipulation events.</summary>
 		None = 0U,
 		/// <summary>Permit manipulation actions that translate the target on the X axis.</summary>
-		[global::Uno.NotImplemented]
 		TranslateX = 1U,
 		/// <summary>Permit manipulation actions that translate the target on the Y axis.</summary>
-		[global::Uno.NotImplemented]
 		TranslateY = 2U,
 		/// <summary>Permit manipulation actions that translate the target on the X axis but using a rails mode.</summary>
 		[global::Uno.NotImplemented]
@@ -24,10 +24,8 @@ namespace Windows.UI.Xaml.Input
 		[global::Uno.NotImplemented]
 		TranslateRailsY = 8U,
 		/// <summary>Permit manipulation actions that rotate the target.</summary>
-		[global::Uno.NotImplemented]
 		Rotate = 16U,
 		/// <summary>Permit manipulation actions that scale the target.</summary>
-		[global::Uno.NotImplemented]
 		Scale = 32U,
 		/// <summary>Apply inertia to translate actions.</summary>
 		[global::Uno.NotImplemented]
@@ -46,8 +44,27 @@ namespace Windows.UI.Xaml.Input
 
 	internal static class ManipulationModesExtensions
 	{
+		private const ManipulationModes _unsupported =
+			ManipulationModes.TranslateRailsX
+			| ManipulationModes.TranslateRailsY
+			| ManipulationModes.TranslateInertia
+			| ManipulationModes.RotateInertia
+			| ManipulationModes.ScaleInertia;
+
 		public static bool IsSupported(this ManipulationModes mode)
-			=> mode == ManipulationModes.None
-				|| mode >= ManipulationModes.All;
+			=> mode == ManipulationModes.All
+			|| (mode & _unsupported) == 0;
+
+		public static void LogIfNotSupported(this ManipulationModes mode, ILogger log)
+		{
+			if (!mode.IsSupported() && log.IsEnabled(LogLevel.Information))
+			{
+				log.Warn(
+					$"The ManipulationMode '{mode}' is not supported by Uno. "
+					+ "Only 'None', 'All', 'System', 'TranslateX', 'TranslateY', 'Rotate', and 'Scale' are supported. "
+					+ "Any other mode will not cause any issue, but the corresponding but no manipulation event will be generated form them. "
+					+ "Note that with Uno the 'All' and 'System' are handled the same way.");
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationModes.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationModes.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Input
 				log.Warn(
 					$"The ManipulationMode '{mode}' is not supported by Uno. "
 					+ "Only 'None', 'All', 'System', 'TranslateX', 'TranslateY', 'Rotate', and 'Scale' are supported. "
-					+ "Any other mode will not cause any issue, but the corresponding but no manipulation event will be generated form them. "
+					+ "Using any other mode will not cause an error, but the corresponding manipulation event will not be generated. "
 					+ "Note that with Uno the 'All' and 'System' are handled the same way.");
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationModes.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationModes.cs
@@ -1,6 +1,7 @@
 using System;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
+using Windows.UI.Input;
 using Microsoft.Extensions.Logging;
 using Uno.Logging;
 
@@ -65,6 +66,60 @@ namespace Windows.UI.Xaml.Input
 					+ "Any other mode will not cause any issue, but the corresponding but no manipulation event will be generated form them. "
 					+ "Note that with Uno the 'All' and 'System' are handled the same way.");
 			}
+		}
+
+		/// <summary>
+		/// Converts the given <see cref="ManipulationModes"/> to a <see cref="GestureSettings"/>. cf. remarks.
+		/// </summary>
+		/// <remarks>
+		/// The returned <see cref="GestureSettings"/> will contains only manipulation related flags
+		/// as defined in <see cref="GestureSettingsHelper.Manipulations"/>
+		/// </remarks>
+		/// <param name="mode">The manipulation mode to convert</param>
+		/// <returns>The gesture settings with the corresponding manipulation flags set.</returns>
+		public static GestureSettings ToGestureSettings(this ManipulationModes mode)
+		{
+			var settings = default(GestureSettings);
+			if (mode.HasFlag(ManipulationModes.TranslateX))
+			{
+				settings |= GestureSettings.ManipulationTranslateX;
+			}
+			if (mode.HasFlag(ManipulationModes.TranslateY))
+			{
+				settings |= GestureSettings.ManipulationTranslateY;
+			}
+			if (mode.HasFlag(ManipulationModes.TranslateRailsX))
+			{
+				settings |= GestureSettings.ManipulationTranslateRailsX;
+			}
+			if (mode.HasFlag(ManipulationModes.TranslateRailsY))
+			{
+				settings |= GestureSettings.ManipulationTranslateRailsY;
+			}
+			if (mode.HasFlag(ManipulationModes.TranslateInertia))
+			{
+				settings |= GestureSettings.ManipulationTranslateInertia;
+			}
+			if (mode.HasFlag(ManipulationModes.Rotate))
+			{
+				settings |= GestureSettings.ManipulationRotate;
+			}
+			if (mode.HasFlag(ManipulationModes.RotateInertia))
+			{
+				settings |= GestureSettings.ManipulationRotateInertia;
+			}
+			if (mode.HasFlag(ManipulationModes.Scale))
+			{
+				settings |= GestureSettings.ManipulationScale;
+			}
+			if (mode.HasFlag(ManipulationModes.ScaleInertia))
+			{
+				settings |= GestureSettings.ManipulationScaleInertia;
+			}
+
+			// Note: ManipulationMultipleFingerPanning is not supported by ManipulationModes enumeration
+
+			return settings;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartedEventHandler.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartedEventHandler.cs
@@ -1,8 +1,4 @@
-#pragma warning disable 108 // new keyword hiding
-#pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if false
 	public delegate void ManipulationStartedEventHandler(object @sender, global::Windows.UI.Xaml.Input.ManipulationStartedRoutedEventArgs @e);
-	#endif
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartedRoutedEventArgs.cs
@@ -7,32 +7,32 @@ namespace Windows.UI.Xaml.Input
 {
 	public partial class ManipulationStartedRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
 	{
+		private readonly GestureRecognizer _recognizer;
+
 		public ManipulationStartedRoutedEventArgs() { }
 
-		internal ManipulationStartedRoutedEventArgs(
-			object originalSource,
-			UIElement container,
-			PointerDeviceType pointerDeviceType,
-			Point position,
-			ManipulationDelta cumulative)
-			: base(originalSource)
+		internal ManipulationStartedRoutedEventArgs(UIElement container, GestureRecognizer recognizer, ManipulationStartedEventArgs args)
+			: base(container)
 		{
 			Container = container;
-			PointerDeviceType = pointerDeviceType;
-			Position = position;
-			Cumulative = cumulative;
+
+			_recognizer = recognizer;
+
+			PointerDeviceType = args.PointerDeviceType;
+			Position = args.Position;
+			Cumulative = args.Cumulative;
 		}
 
 
 		public bool Handled { get; set; }
 
 		public UIElement Container { get; }
+
 		public PointerDeviceType PointerDeviceType { get; }
 		public Point Position { get; }
 		public ManipulationDelta Cumulative { get; }
 
 		public void Complete()
-		{
-		}
+			=> _recognizer?.CompleteGesture();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartedRoutedEventArgs.cs
@@ -1,0 +1,38 @@
+using Windows.Devices.Input;
+using Windows.Foundation;
+using Windows.UI.Input;
+using Uno.UI.Xaml.Input;
+
+namespace Windows.UI.Xaml.Input
+{
+	public partial class ManipulationStartedRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
+	{
+		public ManipulationStartedRoutedEventArgs() { }
+
+		internal ManipulationStartedRoutedEventArgs(
+			object originalSource,
+			UIElement container,
+			PointerDeviceType pointerDeviceType,
+			Point position,
+			ManipulationDelta cumulative)
+			: base(originalSource)
+		{
+			Container = container;
+			PointerDeviceType = pointerDeviceType;
+			Position = position;
+			Cumulative = cumulative;
+		}
+
+
+		public bool Handled { get; set; }
+
+		public UIElement Container { get; }
+		public PointerDeviceType PointerDeviceType { get; }
+		public Point Position { get; }
+		public ManipulationDelta Cumulative { get; }
+
+		public void Complete()
+		{
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartingEventHandler.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartingEventHandler.cs
@@ -1,8 +1,4 @@
-#pragma warning disable 108 // new keyword hiding
-#pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if false
 	public delegate void ManipulationStartingEventHandler(object @sender, global::Windows.UI.Xaml.Input.ManipulationStartingRoutedEventArgs @e);
-	#endif
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartingRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartingRoutedEventArgs.cs
@@ -1,3 +1,4 @@
+using Windows.UI.Input;
 using Uno.UI.Xaml.Input;
 
 namespace Windows.UI.Xaml.Input
@@ -6,14 +7,11 @@ namespace Windows.UI.Xaml.Input
 	{
 		public ManipulationStartingRoutedEventArgs() { }
 
-		internal ManipulationStartingRoutedEventArgs(
-			object originalSource,
-			UIElement container,
-			ManipulationModes mode)
-			: base(originalSource)
+		internal ManipulationStartingRoutedEventArgs(UIElement container)
+			: base(container)
 		{
 			Container = container;
-			Mode = mode;
+			Mode = container.ManipulationMode;
 		}
 
 		public bool Handled { get; set; }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartingRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartingRoutedEventArgs.cs
@@ -1,0 +1,24 @@
+using Uno.UI.Xaml.Input;
+
+namespace Windows.UI.Xaml.Input
+{
+	public partial class ManipulationStartingRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
+	{
+		public ManipulationStartingRoutedEventArgs() { }
+
+		internal ManipulationStartingRoutedEventArgs(
+			object originalSource,
+			UIElement container,
+			ManipulationModes mode)
+			: base(originalSource)
+		{
+			Container = container;
+			Mode = mode;
+		}
+
+		public bool Handled { get; set; }
+
+		public UIElement Container { get; set; }
+		public ManipulationModes Mode { get; set; }
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartingRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartingRoutedEventArgs.cs
@@ -5,18 +5,38 @@ namespace Windows.UI.Xaml.Input
 {
 	public partial class ManipulationStartingRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
 	{
+		private readonly ManipulationStartingEventArgs _args;
+		private ManipulationModes _mode;
+
 		public ManipulationStartingRoutedEventArgs() { }
 
-		internal ManipulationStartingRoutedEventArgs(UIElement container)
+		internal ManipulationStartingRoutedEventArgs(UIElement container, ManipulationStartingEventArgs args)
 			: base(container)
 		{
 			Container = container;
-			Mode = container.ManipulationMode;
+
+			_args = args;
+
+			// We should convert back the enum from the args.Settings, but its the same value of the container.ManipulationMode
+			// so we use the easiest path!
+			_mode = container.ManipulationMode; 
 		}
 
 		public bool Handled { get; set; }
 
 		public UIElement Container { get; set; }
-		public ManipulationModes Mode { get; set; }
+
+		public ManipulationModes Mode
+		{
+			get => _mode;
+			set
+			{
+				_mode = value;
+				if (_args != null)
+				{
+					_args.Settings = value.ToGestureSettings();
+				}
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/TappedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/TappedRoutedEventArgs.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Windows.Devices.Input;
+using Windows.UI.Input;
 using Uno.UI.Xaml.Input;
 
 namespace Windows.UI.Xaml.Input
@@ -11,16 +12,13 @@ namespace Windows.UI.Xaml.Input
 	{
 		private readonly Point _position;
 
-		public TappedRoutedEventArgs() 
-			: this(null, PointerDeviceType.Mouse, new Point())
-		{
-		}
+		public TappedRoutedEventArgs() { }
 		
-		internal TappedRoutedEventArgs(object originalSource, PointerDeviceType pointerType, Point position)
+		internal TappedRoutedEventArgs(object originalSource, TappedEventArgs args)
 			: base(originalSource)
 		{
-			PointerDeviceType = pointerType;
-			_position = position;
+			_position = args.Position;
+			PointerDeviceType = args.PointerDeviceType;
 		}
 
 		public bool Handled { get; set; }
@@ -29,7 +27,7 @@ namespace Windows.UI.Xaml.Input
 
 		public PointerDeviceType PointerDeviceType { get; internal set; }
 
-		public global::Windows.Foundation.Point GetPosition(global::Windows.UI.Xaml.UIElement relativeTo)
+		public Point GetPosition(UIElement relativeTo)
 		{
 			if(relativeTo == null)
 			{

--- a/src/Uno.UI/UI/Xaml/Media/SkewTransform.cs
+++ b/src/Uno.UI/UI/Xaml/Media/SkewTransform.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
 using Windows.Foundation;
+using Uno.Extensions;
 using Uno.UI;
 
 namespace Windows.UI.Xaml.Media

--- a/src/Uno.UI/UI/Xaml/RoutedEvent.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEvent.cs
@@ -20,9 +20,10 @@ namespace Windows.UI.Xaml
 			Name = name;
 
 			IsPointerEvent = flag.IsPointerEvent();
-			IsGestureEvent = flag.IsGestureEvent();
 			IsKeyEvent = flag.IsKeyEvent();
 			IsFocusEvent = flag.IsFocusEvent();
+			IsManipulationEvent = flag.IsManipulationEvent();
+			IsGestureEvent = flag.IsGestureEvent();
 		}
 
 		internal string Name { get; }
@@ -30,8 +31,9 @@ namespace Windows.UI.Xaml
 		internal RoutedEventFlag Flag { get; }
 
 		internal bool IsPointerEvent { get; }
-		internal bool IsGestureEvent { get; }
 		internal bool IsKeyEvent { get; }
 		internal bool IsFocusEvent { get; }
+		internal bool IsManipulationEvent { get; }
+		internal bool IsGestureEvent { get; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/RoutedEventFlag.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEventFlag.cs
@@ -10,30 +10,62 @@ namespace Uno.UI.Xaml
 		None = 0,
 
 		// Pointers
-		PointerPressed = 1 << 0,
-		PointerReleased = 1 << 1,
-		PointerEntered = 1 << 2,
-		PointerExited = 1 << 3,
-		PointerMoved = 1 << 4,
-		PointerCanceled = 1 << 5,
-		PointerCaptureLost = 1 << 6,
+		PointerPressed = 1UL << 0,
+		PointerReleased = 1UL << 1,
+		PointerEntered = 1UL << 2,
+		PointerExited = 1UL << 3,
+		PointerMoved = 1UL << 4,
+		PointerCanceled = 1UL << 5,
+		PointerCaptureLost = 1UL << 6,
+		// PointerWheelChanged = 1UL << 7, => Reserved for future usage
 
-		// Gestures
-		Tapped = 1 << 7,
-		DoubleTapped = 1 << 8,
-
-		// Key
-		KeyDown = 1 << 9,
-		KeyUp = 1 << 10,
+		// Keyboard
+		// PreviewKeyDown = 1UL << 12 => Reserved for future usage
+		KeyDown = 1UL << 13,
+		// PreviewKeyUp = 1 >> 14, => Reserved for future usage
+		KeyUp = 1UL << 15,
+		// CharacterReceived = 1UL << 16,
+		// ProcessKeyboardAccelerators = 1UL << 17, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
+		// AccessKeyInvoked = 1UL << 18, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
+		// AccessKeyDisplayRequested = 1UL << 19, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
+		// AccessKeyDisplayDismissed = 1UL << 20, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
 
 		// Focus
-		GotFocus = 1 << 11,
-		LostFocus = 1 << 12,
+		// GettingFocus = 1UL << 24, => Reserved for future usage
+		GotFocus = 1UL << 25,
+		// LosingFocus = 1UL << 26, => Reserved for future usage
+		LostFocus = 1UL << 27,
+		// NoFocusCandidateFound = 1UL << 28, => Reserved for future usage
+		// BringIntoViewRequested = 1UL << 29, => Reserved for future usage 
+
+		// Drag and drop
+		// DragEnter = 1UL << 32, => Reserved for future usage
+		// DragLeave = 1UL << 33, => Reserved for future usage
+		// DragOver = 1UL << 34, => Reserved for future usage
+		// Drop = 1UL << 35, => Reserved for future usage 
+		// DropCompleted = 1UL << 36, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
+
+		// Manipulations
+		ManipulationStarting = 1UL << 40,
+		ManipulationStarted = 1UL << 41,
+		ManipulationDelta = 1UL << 42,
+		ManipulationInertiaStarting = 1UL << 43,
+		ManipulationCompleted = 1UL << 44,
+
+		// Gestures
+		Tapped = 1UL << 48,
+		DoubleTapped = 1UL << 49,
+		// RightTapped = 1UL << 50, => Reserved for future usage 
+		// Holding = 1UL << 51, => Reserved for future usage 
+
+		// Context menu
+		// ContextRequested = 1UL << 61, => Reserved for future usage 
+		// ContextCanceled  = 1UL << 62, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
 	}
 
 	internal static class RoutedEventFlagExtensions
 	{
-		private const RoutedEventFlag _isPointer = // 0b0000_0000_0111_1111
+		private const RoutedEventFlag _isPointer = // 0b0000_0000_0000_0000___0000_0000_0000_0000___0000_0000_0000_0000___0000_0000_1111_1111
 			  RoutedEventFlag.PointerPressed
 			| RoutedEventFlag.PointerReleased
 			| RoutedEventFlag.PointerEntered
@@ -41,26 +73,41 @@ namespace Uno.UI.Xaml
 			| RoutedEventFlag.PointerMoved
 			| RoutedEventFlag.PointerCanceled
 			| RoutedEventFlag.PointerCaptureLost;
+			//| RoutedEventFlag.PointerWheelChanged;
 
-		private const RoutedEventFlag _isGesture = // 0b0000_0001_1000_0000
-			  RoutedEventFlag.Tapped
-			| RoutedEventFlag.DoubleTapped;
-
-		private const RoutedEventFlag _isKey = // 0b0000_0110_0000_0000
+		private const RoutedEventFlag _isKey = // 0b0000_0000_0000_0000___0000_0000_0000_0000___0000_0000_0001_1111___1111_0000_0000_0000
 			  RoutedEventFlag.KeyDown
 			| RoutedEventFlag.KeyUp;
 
-		private const RoutedEventFlag _isFocus = // 0b0001_1000_0000_0000
+		private const RoutedEventFlag _isFocus = // 0b0000_0000_0000_0000___0000_0000_0000_0000___0011_1111_0000_0000___0000_0000_0000_0000
 			  RoutedEventFlag.GotFocus
 			| RoutedEventFlag.LostFocus;
+
+		private const RoutedEventFlag _isDragAndDrop = (RoutedEventFlag)0b0000_0000_0000_0000___0000_0000_0001_1111___0000_0000_0000_0000___0000_0000_0000_0000;
+			//  RoutedEventFlag.DragEnter
+			//| RoutedEventFlag.DragLeave
+			//| RoutedEventFlag.DragOver
+			//| RoutedEventFlag.Drop
+			//| RoutedEventFlag.DropCompleted;
+
+		private const RoutedEventFlag _isManipulation = // 0b0000_0000_0000_0000___0001_1111_0000_0000___0000_0000_0000_0000___0000_0000_0000_0000
+			  RoutedEventFlag.ManipulationStarting
+			| RoutedEventFlag.ManipulationStarted
+			| RoutedEventFlag.ManipulationDelta
+			| RoutedEventFlag.ManipulationInertiaStarting
+			| RoutedEventFlag.ManipulationCompleted;
+
+		private const RoutedEventFlag _isGesture = // 0b0000_0000_0001_1111___0000_0000_0000_0000___0000_0000_0000_0000___0000_0000_0000_0000
+			  RoutedEventFlag.Tapped
+			| RoutedEventFlag.DoubleTapped;
+
+		private const RoutedEventFlag _isContextMenu = (RoutedEventFlag)0b0011_0000_0000_0000___0000_0000_0000_0000___0000_0000_0000_0000___0000_0000_0000_0000;
+			//   RoutedEventFlag.ContextRequested
+			// | RoutedEventFlag.ContextCanceled;
 
 		[Pure]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsPointerEvent(this RoutedEventFlag flag) => (flag & _isPointer) != 0;
-
-		[Pure]
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static bool IsGestureEvent(this RoutedEventFlag flag) => (flag & _isGesture) != 0;
 
 		[Pure]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -69,5 +116,21 @@ namespace Uno.UI.Xaml
 		[Pure]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool IsFocusEvent(this RoutedEventFlag flag) => (flag & _isFocus) != 0;
+
+		[Pure]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsDragAndDropEvent(this RoutedEventFlag flag) => (flag & _isDragAndDrop) != 0;
+
+		[Pure]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsManipulationEvent(this RoutedEventFlag flag) => (flag & _isManipulation) != 0;
+
+		[Pure]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsGestureEvent(this RoutedEventFlag flag) => (flag & _isGesture) != 0;
+
+		[Pure]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsContextEvent(this RoutedEventFlag flag) => (flag & _isContextMenu) != 0;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/RoutedEventFlag.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEventFlag.cs
@@ -25,10 +25,10 @@ namespace Uno.UI.Xaml
 		// PreviewKeyUp = 1 >> 14, => Reserved for future usage
 		KeyUp = 1UL << 15,
 		// CharacterReceived = 1UL << 16,
-		// ProcessKeyboardAccelerators = 1UL << 17, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
-		// AccessKeyInvoked = 1UL << 18, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
-		// AccessKeyDisplayRequested = 1UL << 19, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
-		// AccessKeyDisplayDismissed = 1UL << 20, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
+		// ProcessKeyboardAccelerators = 1UL << 17, => Reserved for future use (even if it is not an actual standard RoutedEvent)
+		// AccessKeyInvoked = 1UL << 18, => Reserved for future use (even if it is not an actual standard RoutedEvent)
+		// AccessKeyDisplayRequested = 1UL << 19, => Reserved for future use (even if it is not an actual standard RoutedEvent)
+		// AccessKeyDisplayDismissed = 1UL << 20, => Reserved for future use (even if it is not an actual standard RoutedEvent)
 
 		// Focus
 		// GettingFocus = 1UL << 24, => Reserved for future usage
@@ -43,7 +43,7 @@ namespace Uno.UI.Xaml
 		// DragLeave = 1UL << 33, => Reserved for future usage
 		// DragOver = 1UL << 34, => Reserved for future usage
 		// Drop = 1UL << 35, => Reserved for future usage 
-		// DropCompleted = 1UL << 36, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
+		// DropCompleted = 1UL << 36, => Reserved for future use (even if it is not an actual standard RoutedEvent)
 
 		// Manipulations
 		ManipulationStarting = 1UL << 40,
@@ -60,7 +60,7 @@ namespace Uno.UI.Xaml
 
 		// Context menu
 		// ContextRequested = 1UL << 61, => Reserved for future usage 
-		// ContextCanceled  = 1UL << 62, => Reserved for future usage (even if the is actually not a standard RoutedEvent)
+		// ContextCanceled  = 1UL << 62, => Reserved for future use (even if it is not an actual standard RoutedEvent)
 	}
 
 	internal static class RoutedEventFlagExtensions

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -250,18 +250,6 @@ namespace Windows.UI.Xaml
 			|| CountHandler(ManipulationInertiaStartingEvent) != 0
 			|| CountHandler(ManipulationCompletedEvent) != 0;
 
-		private GestureSettings _manipulations =
-			  GestureSettings.ManipulationTranslateX
-			| GestureSettings.ManipulationTranslateY
-			| GestureSettings.ManipulationTranslateRailsX
-			| GestureSettings.ManipulationTranslateRailsY
-			| GestureSettings.ManipulationTranslateInertia
-			| GestureSettings.ManipulationRotate
-			| GestureSettings.ManipulationRotateInertia
-			| GestureSettings.ManipulationScale
-			| GestureSettings.ManipulationScaleInertia
-			| GestureSettings.ManipulationMultipleFingerPanning; // Not supported by ManipulationMode
-
 		private void UpdateManipulations(ManipulationModes mode, bool hasManipulationHandler)
 		{
 			if (!hasManipulationHandler || mode == ManipulationModes.None || mode == ManipulationModes.System)
@@ -272,12 +260,12 @@ namespace Windows.UI.Xaml
 				}
 				else
 				{
-					_gestures.Value.GestureSettings &= ~_manipulations;
+					_gestures.Value.GestureSettings &= ~GestureSettingsHelper.Manipulations;
 					return;
 				}
 			}
 
-			var settings = _gestures.Value.GestureSettings & ~_manipulations;
+			var settings = _gestures.Value.GestureSettings & ~GestureSettingsHelper.Manipulations;
 			if (mode.HasFlag(ManipulationModes.TranslateX))
 			{
 				settings |= GestureSettings.ManipulationTranslateX;

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -67,15 +67,9 @@ namespace Windows.UI.Xaml
 				var oldMode = (ManipulationModes)args.OldValue;
 				var newMode = (ManipulationModes)args.NewValue;
 
-				if (!newMode.IsSupported()
-					&& snd.Log().IsEnabled(LogLevel.Warning))
-				{
-					snd.Log().Warn(
-						$"The ManipulationMode '{newMode}' is not supported by Uno. "
-						+ "Only 'None', 'All' and 'System' are supported, setting any other mode will be handled as 'All'. "
-						+ "Note that with Uno the 'All' and 'System' are handled the same way.");
-				}
+				newMode.LogIfNotSupported(elt.Log());
 
+				elt.UpdateManipulations(newMode, elt.HasManipulationHandler);
 				elt.OnManipulationModeChanged(oldMode, newMode);
 			}
 		}
@@ -263,8 +257,6 @@ namespace Windows.UI.Xaml
 				UpdateManipulations(default(ManipulationModes), hasManipulationHandler: false);
 			}
 		}
-
-		// TODO: OnManipulationChanged
 
 		private bool HasManipulationHandler =>
 			   CountHandler(ManipulationStartingEvent) != 0

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -176,10 +176,10 @@ namespace Windows.UI.Xaml
 		// Note: For the manipulation and gesture event args, the original source has to be the element that raise the event
 		//		 As those events are bubbling in managed only, the original source will be right one for all.
 
-		private static readonly TypedEventHandler<GestureRecognizer, EventArgs> OnRecognizerManipulationStarting = (sender, args) =>
+		private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartingEventArgs> OnRecognizerManipulationStarting = (sender, args) =>
 		{
 			var that = (UIElement)sender.Owner;
-			that.SafeRaiseEvent(ManipulationStartingEvent, new ManipulationStartingRoutedEventArgs(that));
+			that.SafeRaiseEvent(ManipulationStartingEvent, new ManipulationStartingRoutedEventArgs(that, args));
 		};
 
 		private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> OnRecognizerManipulationStarted = (sender,  args) =>
@@ -280,43 +280,9 @@ namespace Windows.UI.Xaml
 				}
 			}
 
-			var settings = _gestures.Value.GestureSettings & ~GestureSettingsHelper.Manipulations;
-			if (mode.HasFlag(ManipulationModes.TranslateX))
-			{
-				settings |= GestureSettings.ManipulationTranslateX;
-			}
-			if (mode.HasFlag(ManipulationModes.TranslateY))
-			{
-				settings |= GestureSettings.ManipulationTranslateY;
-			}
-			if (mode.HasFlag(ManipulationModes.TranslateRailsX))
-			{
-				settings |= GestureSettings.ManipulationTranslateRailsX;
-			}
-			if (mode.HasFlag(ManipulationModes.TranslateRailsY))
-			{
-				settings |= GestureSettings.ManipulationTranslateRailsY;
-			}
-			if (mode.HasFlag(ManipulationModes.TranslateInertia))
-			{
-				settings |= GestureSettings.ManipulationTranslateInertia;
-			}
-			if (mode.HasFlag(ManipulationModes.Rotate))
-			{
-				settings |= GestureSettings.ManipulationRotate;
-			}
-			if (mode.HasFlag(ManipulationModes.RotateInertia))
-			{
-				settings |= GestureSettings.ManipulationRotateInertia;
-			}
-			if (mode.HasFlag(ManipulationModes.Scale))
-			{
-				settings |= GestureSettings.ManipulationScale;
-			}
-			if (mode.HasFlag(ManipulationModes.ScaleInertia))
-			{
-				settings |= GestureSettings.ManipulationScaleInertia;
-			}
+			var settings = _gestures.Value.GestureSettings;
+			settings &= ~GestureSettingsHelper.Manipulations; // Remove all configured manipulation flags
+			settings |= mode.ToGestureSettings(); // Then set them back from the mode
 
 			_gestures.Value.GestureSettings = settings;
 		}

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -91,6 +91,16 @@ namespace Windows.UI.Xaml
 
 		public static RoutedEvent PointerCaptureLostEvent { get; } = new RoutedEvent(RoutedEventFlag.PointerCaptureLost);
 
+		public static RoutedEvent ManipulationStartingEvent { get; } = new RoutedEvent(RoutedEventFlag.ManipulationStarting);
+
+		public static RoutedEvent ManipulationStartedEvent { get; } = new RoutedEvent(RoutedEventFlag.ManipulationStarted);
+
+		public static RoutedEvent ManipulationDeltaEvent { get; } = new RoutedEvent(RoutedEventFlag.ManipulationDelta);
+
+		public static RoutedEvent ManipulationInertiaStartingEvent { get; } = new RoutedEvent(RoutedEventFlag.ManipulationInertiaStarting);
+
+		public static RoutedEvent ManipulationCompletedEvent { get; } = new RoutedEvent(RoutedEventFlag.ManipulationCompleted);
+
 		public static RoutedEvent TappedEvent { get; } = new RoutedEvent(RoutedEventFlag.Tapped);
 
 		public static RoutedEvent DoubleTappedEvent { get; } = new RoutedEvent(RoutedEventFlag.DoubleTapped);
@@ -323,10 +333,6 @@ namespace Windows.UI.Xaml
 			{
 				AddPointerHandler(routedEvent, handlersCount, handler, handledEventsToo);
 			}
-			else if (routedEvent.IsGestureEvent)
-			{
-				AddGestureHandler(routedEvent, handlersCount, handler, handledEventsToo);
-			}
 			else if (routedEvent.IsKeyEvent)
 			{
 				AddKeyHandler(routedEvent, handlersCount, handler, handledEventsToo);
@@ -335,12 +341,21 @@ namespace Windows.UI.Xaml
 			{
 				AddFocusHandler(routedEvent, handlersCount, handler, handledEventsToo);
 			}
+			else if (routedEvent.IsManipulationEvent)
+			{
+				AddManipulationHandler(routedEvent, handlersCount, handler, handledEventsToo);
+			}
+			else if (routedEvent.IsGestureEvent)
+			{
+				AddGestureHandler(routedEvent, handlersCount, handler, handledEventsToo);
+			}
 		}
 
 		partial void AddPointerHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo);
-		partial void AddGestureHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo);
 		partial void AddKeyHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo);
 		partial void AddFocusHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo);
+		partial void AddManipulationHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo);
+		partial void AddGestureHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo);
 
 		public void RemoveHandler(RoutedEvent routedEvent, object handler)
 		{
@@ -372,10 +387,6 @@ namespace Windows.UI.Xaml
 			{
 				RemovePointerHandler(routedEvent, remainingHandlersCount, handler);
 			}
-			else if (routedEvent.IsGestureEvent)
-			{
-				RemoveGestureHandler(routedEvent, remainingHandlersCount, handler);
-			}
 			else if (routedEvent.IsKeyEvent)
 			{
 				RemoveKeyHandler(routedEvent, remainingHandlersCount, handler);
@@ -384,12 +395,26 @@ namespace Windows.UI.Xaml
 			{
 				RemoveFocusHandler(routedEvent, remainingHandlersCount, handler);
 			}
+			else if (routedEvent.IsManipulationEvent)
+			{
+				RemoveManipulationHandler(routedEvent, remainingHandlersCount, handler);
+			}
+			else if (routedEvent.IsGestureEvent)
+			{
+				RemoveGestureHandler(routedEvent, remainingHandlersCount, handler);
+			}
 		}
 
 		partial void RemovePointerHandler(RoutedEvent routedEvent, int remainingHandlersCount, object handler);
-		partial void RemoveGestureHandler(RoutedEvent routedEvent, int remainingHandlersCount, object handler);
 		partial void RemoveKeyHandler(RoutedEvent routedEvent, int remainingHandlersCount, object handler);
 		partial void RemoveFocusHandler(RoutedEvent routedEvent, int remainingHandlersCount, object handler);
+		partial void RemoveManipulationHandler(RoutedEvent routedEvent, int remainingHandlersCount, object handler);
+		partial void RemoveGestureHandler(RoutedEvent routedEvent, int remainingHandlersCount, object handler);
+
+		private int CountHandler(RoutedEvent routedEvent)
+			=> _eventHandlerStore.TryGetValue(routedEvent, out var handlers)
+				? handlers.Count
+				: 0;
 
 		private void UpdateSubscribedToHandledEventsToo()
 		{

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -213,13 +213,11 @@ namespace Windows.UI.Xaml
 			remove => RemoveHandler(GotFocusEvent, value);
 		}
 
-#pragma warning disable 67 // Unused member
 		public event PointerEventHandler PointerCanceled
 		{
 			add => AddHandler(PointerCanceledEvent, value, false);
 			remove => RemoveHandler(PointerCanceledEvent, value);
 		}
-#pragma warning restore 67 // Unused member
 
 		public event PointerEventHandler PointerCaptureLost
 		{
@@ -255,6 +253,36 @@ namespace Windows.UI.Xaml
 		{
 			add => AddHandler(PointerReleasedEvent, value, false);
 			remove => RemoveHandler(PointerReleasedEvent, value);
+		}
+
+		public event ManipulationStartingEventHandler ManipulationStarting
+		{
+			add => AddHandler(ManipulationStartingEvent, value, false);
+			remove => RemoveHandler(ManipulationStartingEvent, value);
+		}
+
+		public event ManipulationStartedEventHandler ManipulationStarted
+		{
+			add => AddHandler(ManipulationStartedEvent, value, false);
+			remove => RemoveHandler(ManipulationStartedEvent, value);
+		}
+
+		public event ManipulationDeltaEventHandler ManipulationDelta
+		{
+			add => AddHandler(ManipulationDeltaEvent, value, false);
+			remove => RemoveHandler(ManipulationDeltaEvent, value);
+		}
+
+		public event ManipulationInertiaStartingEventHandler ManipulationInertiaStarting
+		{
+			add => AddHandler(ManipulationInertiaStartingEvent, value, false);
+			remove => RemoveHandler(ManipulationInertiaStartingEvent, value);
+		}
+
+		public event ManipulationCompletedEventHandler ManipulationCompleted
+		{
+			add => AddHandler(ManipulationCompletedEvent, value, false);
+			remove => RemoveHandler(ManipulationCompletedEvent, value);
 		}
 
 		public event TappedEventHandler Tapped
@@ -583,6 +611,21 @@ namespace Windows.UI.Xaml
 					break;
 				case KeyEventHandler keyEventHandler:
 					keyEventHandler(this, (KeyRoutedEventArgs)args);
+					break;
+				case ManipulationStartingEventHandler manipStarting:
+					manipStarting(this, (ManipulationStartingRoutedEventArgs)args);
+					break;
+				case ManipulationStartedEventHandler manipStarted:
+					manipStarted(this, (ManipulationStartedRoutedEventArgs)args);
+					break;
+				case ManipulationDeltaEventHandler manipDelta:	
+					manipDelta(this, (ManipulationDeltaRoutedEventArgs)args);
+					break;
+				case ManipulationInertiaStartingEventHandler manipInertia:
+					manipInertia(this, (ManipulationInertiaStartingRoutedEventArgs)args);
+					break;
+				case ManipulationCompletedEventHandler manipCompleted:
+					manipCompleted(this, (ManipulationCompletedRoutedEventArgs)args);
 					break;
 			}
 		}

--- a/src/Uno.UWP/Extensions/MathEx.cs
+++ b/src/Uno.UWP/Extensions/MathEx.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
-namespace Uno.UI
+namespace Uno.Extensions
 {
 	internal static class MathEx
 	{

--- a/src/Uno.UWP/Extensions/MathEx.cs
+++ b/src/Uno.UWP/Extensions/MathEx.cs
@@ -43,13 +43,21 @@ namespace Uno.Extensions
 		/// Converts an angle in degree into radians
 		/// </summary>
 		public static double ToRadians(double angleDegree) 
-			=> (Math.PI / 180.0) * angleDegree;
+			=> angleDegree * Math.PI / 180.0;
 
 		/// <summary>
 		/// Converts an angle in radians into degrees
 		/// </summary>
 		public static double ToDegree(double angleRadian)
-			=> angleRadian / (Math.PI / 180.0);
+			=> angleRadian * 180.0 / Math.PI;
+
+		/// <summary>
+		/// Converts an angle in radians into degrees normalized in the [0, 360[ range.
+		/// </summary>
+		public static double ToDegreeNormalized(double angleRadian)
+			=> angleRadian >= 0
+				? ToDegree(angleRadian) % 360
+				: 360 + ToDegree(angleRadian) % 360;
 
 		/// <summary>
 		/// Tests if two values are equal to within the specified error.

--- a/src/Uno.UWP/Extensions/Vector2Extensions.cs
+++ b/src/Uno.UWP/Extensions/Vector2Extensions.cs
@@ -6,13 +6,20 @@ using Windows.Foundation;
 
 namespace Uno.Extensions
 {
-    public static class Vector2Extensions
-    {
+	public static class Vector2Extensions
+	{
 		/// <summary>
 		/// Converts a <see cref="Vector2"/> to a <see cref="Point"/>.
 		/// </summary>
 		/// <param name="v">The <see cref="Vector2"/> to convert</param>
 		/// <returns>A <see cref="Point"/></returns>
 		public static Point ToPoint(this Vector2 v) => new Point(v.X, v.Y);
+
+		/// <summary>
+		/// Converts a <see cref="Point"/> to a <see cref="Vector2"/>.
+		/// </summary>
+		/// <param name="p">The <see cref="Point"/> to convert</param>
+		/// <returns>A <see cref="Vector2"/></returns>
+		public static Vector2 ToVector(this Point p) => new Vector2((float)p.X, (float)p.Y);
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/GestureRecognizer.cs
@@ -403,7 +403,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Input.GestureRecognizer, global::Windows.UI.Input.ManipulationCompletedEventArgs> ManipulationCompleted
 		{
@@ -419,7 +419,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Input.GestureRecognizer, global::Windows.UI.Input.ManipulationInertiaStartingEventArgs> ManipulationInertiaStarting
 		{
@@ -435,7 +435,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Input.GestureRecognizer, global::Windows.UI.Input.ManipulationStartedEventArgs> ManipulationStarted
 		{
@@ -451,7 +451,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Input.GestureRecognizer, global::Windows.UI.Input.ManipulationUpdatedEventArgs> ManipulationUpdated
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationCompletedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationCompletedEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ManipulationCompletedEventArgs 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Cumulative
 		{
@@ -17,7 +17,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Input.PointerDeviceType PointerDeviceType
 		{
@@ -27,7 +27,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Point Position
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationDelta.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationDelta.cs
@@ -2,22 +2,22 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial struct ManipulationDelta 
 	{
 		// Forced skipping of method Windows.UI.Input.ManipulationDelta.ManipulationDelta()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		public  global::Windows.Foundation.Point Translation;
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		public  float Scale;
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		public  float Rotation;
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		public  float Expansion;
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationInertiaStartingEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationInertiaStartingEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ManipulationInertiaStartingEventArgs 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Cumulative
 		{
@@ -17,7 +17,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Delta
 		{
@@ -27,7 +27,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Input.PointerDeviceType PointerDeviceType
 		{
@@ -37,7 +37,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Point Position
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationStartedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationStartedEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ManipulationStartedEventArgs 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Cumulative
 		{
@@ -17,7 +17,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Input.PointerDeviceType PointerDeviceType
 		{
@@ -27,7 +27,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Point Position
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationUpdatedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationUpdatedEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ManipulationUpdatedEventArgs 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Cumulative
 		{
@@ -17,7 +17,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.ManipulationDelta Delta
 		{
@@ -27,7 +27,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Input.PointerDeviceType PointerDeviceType
 		{
@@ -37,7 +37,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Point Position
 		{

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Windows.Devices.Input;
+using Windows.Foundation;
+using Uno.Extensions;
+
+namespace Windows.UI.Input
+{
+	public partial class GestureRecognizer
+	{
+		private class Manipulation
+		{
+			private enum ManipulationStates
+			{
+				Starting = 1,
+				Started = 2,
+				// Inertia = 3
+				Completed = 4,
+			}
+
+			private readonly GestureRecognizer _recognizer;
+			private readonly PointerDeviceType _deviceType;
+			private readonly GestureSettings _settings;
+
+			private ManipulationStates _state = ManipulationStates.Starting;
+			private Points _origins;
+			private Points _lastPublished;
+			private Points _currents;
+
+			public Manipulation(GestureRecognizer recognizer, PointerPoint pointer1)
+			{
+				_recognizer = recognizer;
+				_settings = recognizer._gestureSettings;
+				_deviceType = pointer1.PointerDevice.PointerDeviceType;
+
+				_origins = _lastPublished = _currents = pointer1;
+
+				_recognizer.ManipulationStarting?.Invoke(_recognizer, EventArgs.Empty);
+			}
+
+			public void Add(PointerPoint point)
+			{
+				if (_state == ManipulationStates.Completed
+					|| point.PointerDevice.PointerDeviceType != _deviceType
+					|| _currents.HasPointer2)
+				{
+					return;
+				}
+
+				_origins.SetPointer2(point);
+				_lastPublished.SetPointer2(point);
+				_currents.SetPointer2(point);
+
+				// As weird it is, it's how UWP behaves: Starting is raised for each pointer
+				_recognizer.ManipulationStarting?.Invoke(_recognizer, EventArgs.Empty);
+
+				// We force to start the manipulation (or update it) a second pointer is pressed
+				NotifyUpdate(forceUpdate: true);
+			}
+
+			public void Update(IList<PointerPoint> updated)
+			{
+				if (_state == ManipulationStates.Completed)
+				{
+					return;
+				}
+
+				var hasUpdate = false;
+				foreach (var point in updated)
+				{
+					hasUpdate |= TryUpdate(point);
+				}
+
+				if (hasUpdate)
+				{
+					NotifyUpdate();
+				}
+			}
+
+			public void Remove(PointerPoint removed)
+			{
+				if (TryUpdate(removed))
+				{
+					// For now we complete the Manipulation as soon as a pointer was removed ...
+					// not checked the UWP behavior for that!
+					Complete();
+				}
+			}
+
+			public void Complete()
+			{
+				// If the manipulation was not started, we just abort the manipulation without any event
+				switch (_state)
+				{
+					case ManipulationStates.Started:
+						_state = ManipulationStates.Completed;
+
+						_recognizer.ManipulationCompleted?.Invoke(
+							_recognizer,
+							new ManipulationCompletedEventArgs(_deviceType, _currents.Center, GetDelta(), isInertial: false));
+						break;
+
+					default:
+						_state = ManipulationStates.Completed;
+						break;
+				}
+
+				// Self scavenge our self from the _recognizer ... yes it's a bit, but it's  the safer and easier way.
+				if (_recognizer._manipulation == this)
+				{
+					_recognizer._manipulation = null;
+				}
+			}
+
+			private bool TryUpdate(PointerPoint point)
+			{
+				if (_deviceType != point.PointerDevice.PointerDeviceType)
+				{
+					return false;
+				}
+
+				return _currents.TryUpdate(point);
+			}
+
+			private void NotifyUpdate(bool forceUpdate = false)
+			{
+				// Note: Make sure to update the _manipulationLast before raising the event, so if an exception is raised
+				//		 or if the manipulation is Completed, the Complete event args can use the updated _manipulationLast.
+
+				switch (_state)
+				{
+					case ManipulationStates.Starting:
+						var cumulative = GetDelta();
+						if (forceUpdate || IsSignificant(cumulative))
+						{
+							_state = ManipulationStates.Started;
+							_lastPublished = _currents;
+
+							_recognizer.ManipulationStarted?.Invoke(
+								_recognizer,
+								new ManipulationStartedEventArgs(_deviceType, _currents.Center, cumulative));
+						}
+
+						break;
+
+					case ManipulationStates.Started when _recognizer.ManipulationUpdated == null:
+						_lastPublished = _currents;
+						break;
+
+					case ManipulationStates.Started:
+						// Even if Scale and Angle are expected to be default when we add a pointer (i.e. forceUpdate == true),
+						// the 'delta' and 'cumulative' might still contains some TranslateX|Y compared to the previous Pointer1 location.
+						var delta = GetDelta(_lastPublished);
+						if (forceUpdate || IsSignificant(delta))
+						{
+							_lastPublished = _currents;
+
+							_recognizer.ManipulationUpdated.Invoke(
+								_recognizer,
+								new ManipulationUpdatedEventArgs(_deviceType, _currents.Center, delta, GetDelta(), isInertial: false));
+						}
+						break;
+				}
+			}
+
+			private ManipulationDelta GetDelta() => GetDelta(_origins);
+			private ManipulationDelta GetDelta(Points from)
+			{
+				var isTranslateXEnabled = (_settings & (GestureSettings.ManipulationTranslateX | GestureSettings.ManipulationTranslateRailsX)) != 0;
+				var isTranslateYEnabled = (_settings & (GestureSettings.ManipulationTranslateY | GestureSettings.ManipulationTranslateRailsY)) != 0;
+				var translateX = isTranslateXEnabled ? _currents.Center.X - from.Center.X : 0;
+				var translateY = isTranslateYEnabled ? _currents.Center.Y - from.Center.Y : 0;
+
+				double rotate;
+				float scale, expansion;
+				if (!_currents.HasPointer2)
+				{
+					rotate = 0;
+					scale = 1;
+					expansion = 0;
+				}
+				else
+				{
+					var isRotateEnabled = (_settings & (GestureSettings.ManipulationRotate | GestureSettings.ManipulationRotateInertia)) != 0;
+					var isScaleEnabled = (_settings & (GestureSettings.ManipulationScale | GestureSettings.ManipulationScaleInertia)) != 0;
+
+					rotate = isRotateEnabled ? _currents.Angle - from.Angle : 0;
+					scale = isScaleEnabled ? _currents.Distance / from.Distance : 1;
+					expansion = isScaleEnabled ? _currents.Distance - from.Distance : 0;
+				}
+
+				return new ManipulationDelta
+				{
+					Translation = new Point(translateX, translateY),
+					Rotation = (float)MathEx.ToDegreeNormalized(rotate),
+					Scale = scale,
+					Expansion = expansion
+				};
+			}
+
+			private bool IsSignificant(ManipulationDelta delta)
+				=> Math.Abs(delta.Translation.X) >= MinManipulationDeltaTranslateX
+				|| Math.Abs(delta.Translation.Y) >= MinManipulationDeltaTranslateY
+				|| delta.Rotation >= MinManipulationDeltaRotate // We used the ToDegreeNormalized, no need to check for negative angles
+				|| Math.Abs(delta.Expansion) >= MinManipulationDeltaExpansion;
+
+			// WARNING: This struct is ** MUTABLE **
+			private struct Points
+			{
+				private PointerPoint _pointer1;
+				private PointerPoint _pointer2;
+
+				public Point Center;
+				public float Distance;
+				public double Angle;
+
+				public bool HasPointer2 => _pointer2 != null;
+
+				public Points(PointerPoint point)
+				{
+					_pointer1 = point;
+					_pointer2 = default;
+
+					Center = point.Position;
+					Distance = 0;
+					Angle = 0;
+				}
+
+				public void SetPointer2(PointerPoint point)
+				{
+					_pointer2 = point;
+					UpdateComputedValues();
+				}
+
+				public bool TryUpdate(PointerPoint point)
+				{
+					if (_pointer1.PointerId == point.PointerId)
+					{
+						_pointer1 = point;
+						UpdateComputedValues();
+
+						return true;
+					}
+					else if (_pointer2.PointerId == point.PointerId)
+					{
+						_pointer2 = point;
+						UpdateComputedValues();
+
+						return true;
+					}
+					else
+					{
+						return false;
+					}
+				}
+
+				private void UpdateComputedValues()
+				{
+					if (_pointer2 == null)
+					{
+						Center = _pointer1.Position;
+						Distance = 0;
+						Angle = 0;
+					}
+					else
+					{
+						var p1 = _pointer1.Position;
+						var p2 = _pointer2.Position;
+
+						Center = new Point((p1.X + p2.X) / 2, (p1.Y + p2.Y) / 2);
+						Distance = Vector2.Distance(p1.ToVector(), p2.ToVector());
+						Angle = Math.Atan2(p1.Y - p2.Y, p1.X - p2.X);
+					}
+				}
+
+				public static implicit operator Points(PointerPoint pointer1)
+					=> new Points(pointer1);
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
@@ -16,7 +16,7 @@ namespace Windows.UI.Input
 			{
 				Starting = 1,
 				Started = 2,
-				// Inertia = 3
+				// Inertia = 3 // Not supported yet
 				Completed = 4,
 			}
 
@@ -113,7 +113,8 @@ namespace Windows.UI.Input
 						break;
 				}
 
-				// Self scavenge our self from the _recognizer ... yes it's a bit, but it's  the safer and easier way.
+				// Self scavenge our self from the _recognizer ... yes it's a bit strange,
+				// but it's the safest and easiest way to avoid invalid state.
 				if (_recognizer._manipulation == this)
 				{
 					_recognizer._manipulation = null;

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -27,9 +27,20 @@ namespace Windows.UI.Input
 
 		public bool IsActive => _activePointers.Count > 0;
 
+		/// <summary>
+		/// This is the owner provided in the ctor. It might be `null` if none provided.
+		/// It's purpose it to allow usage of static event handlers.
+		/// </summary>
+		internal object Owner { get; }
+
 		public GestureRecognizer()
 		{
 			_log = this.Log();
+		}
+
+		internal GestureRecognizer(object owner)
+		{
+			Owner = owner;
 		}
 
 		public void ProcessDownEvent(PointerPoint value)
@@ -119,11 +130,11 @@ namespace Windows.UI.Input
 		}
 
 		#region Manipulations
-		internal event EventHandler ManipulationStarting; // This is not on the public API!
-		public event TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> ManipulationCompleted
-		public event TypedEventHandler<GestureRecognizer, ManipulationInertiaStartingEventArgs> ManipulationInertiaStarting
-		public event TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> ManipulationStarted
-		public event TypedEventHandler<GestureRecognizer, ManipulationUpdatedEventArgs> ManipulationUpdated
+		internal event TypedEventHandler<GestureRecognizer, EventArgs> ManipulationStarting; // This is not on the public API!
+		public event TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> ManipulationCompleted;
+		public event TypedEventHandler<GestureRecognizer, ManipulationInertiaStartingEventArgs> ManipulationInertiaStarting;
+		public event TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> ManipulationStarted;
+		public event TypedEventHandler<GestureRecognizer, ManipulationUpdatedEventArgs> ManipulationUpdated;
 
 		#endregion
 

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -211,37 +211,37 @@ namespace Windows.UI.Input
 			// Mouse
 			if (props.IsLeftButtonPressed)
 			{
-				identifier |= 1 << 32;
+				identifier |= 1L << 32;
 			}
 			if (props.IsMiddleButtonPressed)
 			{
-				identifier |= 1 << 33;
+				identifier |= 1L << 33;
 			}
 			if (props.IsRightButtonPressed)
 			{
-				identifier |= 1 << 34;
+				identifier |= 1L << 34;
 			}
 			if (props.IsHorizontalMouseWheel)
 			{
-				identifier |= 1 << 35;
+				identifier |= 1L << 35;
 			}
 			if (props.IsXButton1Pressed)
 			{
-				identifier |= 1 << 36;
+				identifier |= 1L << 36;
 			}
 			if (props.IsXButton2Pressed)
 			{
-				identifier |= 1 << 37;
+				identifier |= 1L << 37;
 			}
 
 			// Pen
 			if (props.IsBarrelButtonPressed)
 			{
-				identifier |= 1 << 38;
+				identifier |= 1L << 38;
 			}
 			if (props.IsEraser)
 			{
-				identifier |= 1 << 39;
+				identifier |= 1L << 39;
 			}
 
 			return identifier;

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -12,8 +12,18 @@ namespace Windows.UI.Input
 	{
 		private readonly ILogger _log;
 		private IDictionary<uint, List<PointerPoint>> _activePointers = new Dictionary<uint, List<PointerPoint>>();
+		private GestureSettings _gestureSettings;
+		private bool _isManipulationEnabled;
 
-		public GestureSettings GestureSettings { get; set; }
+		public GestureSettings GestureSettings
+		{
+			get => _gestureSettings;
+			set
+			{
+				_gestureSettings = value;
+				_isManipulationEnabled = (value & GestureSettingsHelper.Manipulations) != 0;
+			}
+		}
 
 		public bool IsActive => _activePointers.Count > 0;
 
@@ -32,7 +42,7 @@ namespace Windows.UI.Input
 				return;
 			}
 
-			_activePointers[value.PointerId] = new List<PointerPoint>(16) { value }; ;
+			_activePointers[value.PointerId] = new List<PointerPoint>(16) { value };
 		}
 
 		public void ProcessMoveEvents(IList<PointerPoint> value)
@@ -108,6 +118,15 @@ namespace Windows.UI.Input
 			}
 		}
 
+		#region Manipulations
+		internal event EventHandler ManipulationStarting; // This is not on the public API!
+		public event TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> ManipulationCompleted
+		public event TypedEventHandler<GestureRecognizer, ManipulationInertiaStartingEventArgs> ManipulationInertiaStarting
+		public event TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> ManipulationStarted
+		public event TypedEventHandler<GestureRecognizer, ManipulationUpdatedEventArgs> ManipulationUpdated
+
+		#endregion
+
 		#region Tap (includes DoubleTap)
 		internal const ulong MultiTapMaxDelayTicks = TimeSpan.TicksPerMillisecond * 1000;
 		internal const int TapMaxXDelta = 15;
@@ -119,7 +138,7 @@ namespace Windows.UI.Input
 
 		public bool CanBeDoubleTap(PointerPoint value)
 		{
-			if (!GestureSettings.HasFlag(GestureSettings.DoubleTap))
+			if (!_gestureSettings.HasFlag(GestureSettings.DoubleTap))
 			{
 				return false;
 			}

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -54,7 +54,17 @@ namespace Windows.UI.Input
 
 			_activePointers[value.PointerId] = new List<PointerPoint>(16) { value };
 
-			UpdateManipulationForPointerAdded(value);
+			if (_isManipulationEnabled)
+			{
+				if (_manipulation == null)
+				{
+					_manipulation = new Manipulation(this, value);
+				}
+				else
+				{
+					_manipulation.Add(value);
+				}
+			}
 		}
 
 		public void ProcessMoveEvents(IList<PointerPoint> value)
@@ -72,7 +82,7 @@ namespace Windows.UI.Input
 				}
 			}
 
-			UpdateManipulationForPointersUpdated();
+			_manipulation?.Update(value);
 		}
 		public void ProcessUpEvent(PointerPoint value)
 		{
@@ -90,7 +100,7 @@ namespace Windows.UI.Input
 
 				Recognize(points, pointerUp: value);
 
-				UpdateManipulationForPointerRemoved(value);
+				_manipulation?.Remove(value);
 			}
 			else if (_log.IsEnabled(LogLevel.Error))
 			{
@@ -118,7 +128,7 @@ namespace Windows.UI.Input
 				Recognize(points, pointerUp: null);
 			}
 
-			UpdateManipulationForCanceled();
+			_manipulation?.Complete();
 		}
 
 		private void Recognize(List<PointerPoint> points, PointerPoint pointerUp)
@@ -137,152 +147,21 @@ namespace Windows.UI.Input
 		}
 
 		#region Manipulations
-		internal const int MinManipulationDeltaTranslateX = 15;
-		internal const int MinManipulationDeltaTranslateY = 15;
+		internal const int MinManipulationDeltaTranslateX = 30;
+		internal const int MinManipulationDeltaTranslateY = 30;
+		internal const int MinManipulationDeltaRotate = 5; // Degrees
+		internal const double MinManipulationDeltaExpansion = 15;
 
 		internal event TypedEventHandler<GestureRecognizer, EventArgs> ManipulationStarting; // This is not on the public API!
 		public event TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> ManipulationCompleted;
-#pragma warning disable 67
+#pragma warning disable  // Event not raised: intertia is not supported yet
 		public event TypedEventHandler<GestureRecognizer, ManipulationInertiaStartingEventArgs> ManipulationInertiaStarting;
 #pragma warning restore 67
 		public event TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> ManipulationStarted;
 		public event TypedEventHandler<GestureRecognizer, ManipulationUpdatedEventArgs> ManipulationUpdated;
 
 		private bool _isManipulationEnabled;
-
-		private ManipulationStates _manipulationState = ManipulationStates.None;
-		private PointerPoint _manipulationOrigin;
-		private PointerPoint _manipulationLast;
-
-		private enum ManipulationStates
-		{
-			None = 0,
-			Starting = 1,
-			Started = 2,
-			// Inertia = 3
-		}
-
-		private void UpdateManipulationForPointerAdded(PointerPoint point)
-		{
-			if (_isManipulationEnabled && _manipulationState == ManipulationStates.None)
-			{
-				_manipulationOrigin = _manipulationLast = point;
-				_manipulationState = ManipulationStates.Starting;
-
-				ManipulationStarting?.Invoke(this, EventArgs.Empty);
-			}
-		}
-
-		private void UpdateManipulationForPointersUpdated()
-		{
-			if (!_isManipulationEnabled
-				|| _manipulationOrigin == null // The manipulation was not enabled when pointer went down
-				|| !_activePointers.TryGetValue(_manipulationOrigin.PointerId, out var points))
-			{
-				return;
-			}
-
-			var current = points.Last();
-			var delta = GetManipulationDelta(_manipulationLast, current);
-
-			if (!IsSignificant(delta))
-			{
-				return;
-			}
-
-			// Make sure to update the _manipulationLast before raising the event, so if an exception is raised
-			// or if the manipulation is Completed, the Complete event args can use the updated _manipulationLast.
-			_manipulationLast = current;
-
-			switch (_manipulationState)
-			{
-				case ManipulationStates.Starting:
-					_manipulationState = ManipulationStates.Started;
-
-					ManipulationStarted?.Invoke(this, new ManipulationStartedEventArgs(
-						_manipulationOrigin.PointerDevice.PointerDeviceType,
-						current.Position,
-						delta));
-					break;
-
-				case ManipulationStates.Started:
-					ManipulationUpdated?.Invoke(this, new ManipulationUpdatedEventArgs(
-						_manipulationOrigin.PointerDevice.PointerDeviceType,
-						current.Position,
-						delta,
-						GetManipulationDelta(_manipulationOrigin, current),
-						isInertial: false));
-					break;
-			}
-		}
-
-		private void UpdateManipulationForPointerRemoved(PointerPoint removed)
-		{
-			if (!_isManipulationEnabled
-				|| _manipulationOrigin == null // The manipulation was not enabled when pointer went down
-				|| _manipulationOrigin != removed)
-			{
-				return;
-			}
-
-			CompleteManipulation(removed);
-		}
-
-		private void UpdateManipulationForCanceled()
-		{
-			CompleteManipulation(_manipulationLast);
-		}
-
-		private void CompleteManipulation(PointerPoint current)
-		{
-			// If the manipulation was not started, we just abort the manipulation without any event
-			if (_manipulationState == ManipulationStates.Started)
-			{
-				ManipulationCompleted?.Invoke(this, new ManipulationCompletedEventArgs(
-					_manipulationOrigin.PointerDevice.PointerDeviceType,
-					current.Position,
-					GetManipulationDelta(_manipulationOrigin, current),
-					isInertial: false));
-			}
-
-			_manipulationOrigin = null;
-			_manipulationLast = null;
-			_manipulationState = ManipulationStates.None;
-		}
-
-		private ManipulationDelta GetManipulationDelta(PointerPoint origin, PointerPoint current)
-		{
-			var originPosition = origin.Position;
-			var currentPosition = current.Position;
-
-			var deltaX = Math.Abs(currentPosition.X - originPosition.X);
-			var deltaY = Math.Abs(currentPosition.Y - originPosition.Y);
-
-			return new ManipulationDelta
-			{
-				Translation = new Point(deltaX, deltaY),
-				Scale = 1,
-				Rotation = 0,
-				Expansion = 0,
-			};
-		}
-
-		internal bool IsSignificant(ManipulationDelta delta)
-		{
-			if ((_gestureSettings & (GestureSettings.ManipulationTranslateX | GestureSettings.ManipulationTranslateRailsX)) != 0
-				&& delta.Translation.X >= MinManipulationDeltaTranslateX)
-			{
-				return true;
-			}
-
-			if ((_gestureSettings & (GestureSettings.ManipulationTranslateY | GestureSettings.ManipulationTranslateRailsY)) != 0
-				&& delta.Translation.Y >= MinManipulationDeltaTranslateY)
-			{
-				return true;
-			}
-
-			return false;
-		}
+		private Manipulation _manipulation;
 		#endregion
 
 		#region Tap (includes DoubleTap)

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -152,7 +152,7 @@ namespace Windows.UI.Input
 		internal const int MinManipulationDeltaRotate = 5; // Degrees
 		internal const double MinManipulationDeltaExpansion = 15;
 
-		internal event TypedEventHandler<GestureRecognizer, EventArgs> ManipulationStarting; // This is not on the public API!
+		internal event TypedEventHandler<GestureRecognizer, ManipulationStartingEventArgs> ManipulationStarting; // This is not on the public API!
 		public event TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> ManipulationCompleted;
 #pragma warning disable  // Event not raised: intertia is not supported yet
 		public event TypedEventHandler<GestureRecognizer, ManipulationInertiaStartingEventArgs> ManipulationInertiaStarting;

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -38,6 +38,7 @@ namespace Windows.UI.Input
 		}
 
 		internal GestureRecognizer(object owner)
+			: this()
 		{
 			Owner = owner;
 		}
@@ -147,8 +148,8 @@ namespace Windows.UI.Input
 		}
 
 		#region Manipulations
-		internal const int MinManipulationDeltaTranslateX = 30;
-		internal const int MinManipulationDeltaTranslateY = 30;
+		internal const int MinManipulationDeltaTranslateX = 15;
+		internal const int MinManipulationDeltaTranslateY = 15;
 		internal const int MinManipulationDeltaRotate = 5; // Degrees
 		internal const double MinManipulationDeltaExpansion = 15;
 

--- a/src/Uno.UWP/UI/Input/GestureSettings.cs
+++ b/src/Uno.UWP/UI/Input/GestureSettings.cs
@@ -62,4 +62,38 @@ namespace Windows.UI.Input
 		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		[ContractVersion("Windows.Foundation.UniversalApiContract", 65536U)] ManipulationMultipleFingerPanning = 65536U,
 	}
+
+	internal static class GestureSettingsHelper
+	{
+		/// <summary>
+		/// A combination of all "manipulation" flags
+		/// </summary>
+		public const GestureSettings Manipulations =
+			  GestureSettings.ManipulationTranslateX
+			| GestureSettings.ManipulationTranslateY
+			| GestureSettings.ManipulationTranslateRailsX
+			| GestureSettings.ManipulationTranslateRailsY
+			| GestureSettings.ManipulationTranslateInertia
+			| GestureSettings.ManipulationRotate
+			| GestureSettings.ManipulationRotateInertia
+			| GestureSettings.ManipulationScale
+			| GestureSettings.ManipulationScaleInertia
+			| GestureSettings.ManipulationMultipleFingerPanning; // Not supported by ManipulationMode
+
+		/// <summary>
+		/// A combination of all "gesture" flags
+		/// </summary>
+		public const GestureSettings Gestures =
+			  GestureSettings.Tap
+			| GestureSettings.DoubleTap
+			| GestureSettings.Hold
+			| GestureSettings.HoldWithMouse
+			| GestureSettings.RightTap
+			| GestureSettings.CrossSlide;
+
+		/// <summary>
+		/// A combination of all "drag and drop" flags
+		/// </summary>
+		public const GestureSettings DragAndDrop = GestureSettings.Drag;
+	}
 }

--- a/src/Uno.UWP/UI/Input/GestureSettings.cs
+++ b/src/Uno.UWP/UI/Input/GestureSettings.cs
@@ -29,10 +29,8 @@ namespace Windows.UI.Input
 		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		Drag = 32U,
 		/// <summary>Enable support for the slide gesture through pointer input, on the horizontal axis. The ManipulationStarted, ManipulationUpdated, and ManipulationCompleted events are all raised during the course of this interaction.This gesture can be used for rearranging objects.</summary>
-		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		ManipulationTranslateX = 64U,
 		/// <summary>Enable support for the slide gesture through pointer input, on the vertical axis. The ManipulationStarted, ManipulationUpdated, and ManipulationCompleted events are all raised during the course of this interaction.This gesture can be used for rearranging objects.</summary>
-		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		ManipulationTranslateY = 128U,
 		/// <summary>Enable support for the slide gesture through pointer input, on the horizontal axis using rails (guides). The ManipulationStarted, ManipulationUpdated, and ManipulationCompleted events are all raised during the course of this interaction.This gesture can be used for rearranging objects.</summary>
 		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
@@ -41,10 +39,8 @@ namespace Windows.UI.Input
 		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		ManipulationTranslateRailsY = 512U,
 		/// <summary>Enable support for the rotation gesture through pointer input. The ManipulationStarted, ManipulationUpdated, and ManipulationCompleted events are all raised during the course of this interaction.</summary>
-		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		ManipulationRotate = 1024U,
 		/// <summary>Enable support for the pinch or stretch gesture through pointer input.These gestures can be used for optical or semantic zoom and resizing an object. The ManipulationStarted, ManipulationUpdated, and ManipulationCompleted events are all raised during the course of this interaction.</summary>
-		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		ManipulationScale = 2048U,
 		/// <summary>Enable support for translation inertia after the slide gesture (through pointer input) is complete. The ManipulationInertiaStarting event is raised if inertia is enabled.</summary>
 		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event

--- a/src/Uno.UWP/UI/Input/GestureSettings.cs
+++ b/src/Uno.UWP/UI/Input/GestureSettings.cs
@@ -56,7 +56,8 @@ namespace Windows.UI.Input
 		CrossSlide = 32768U,
 		/// <summary>Enable panning and disable zoom when two or more touch contacts are detected.Prevents unintentional zoom interactions when panning with multiple fingers.</summary>
 		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
-		[ContractVersion("Windows.Foundation.UniversalApiContract", 65536U)] ManipulationMultipleFingerPanning = 65536U,
+		[ContractVersion("Windows.Foundation.UniversalApiContract", 65536U)]
+		ManipulationMultipleFingerPanning = 65536U,
 	}
 
 	internal static class GestureSettingsHelper

--- a/src/Uno.UWP/UI/Input/ManipulationCompletedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationCompletedEventArgs.cs
@@ -1,0 +1,21 @@
+using Windows.Devices.Input;
+using Windows.Foundation;
+
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.UI.Input
+{
+	public partial class ManipulationCompletedEventArgs 
+	{
+		internal ManipulationCompletedEventArgs(PointerDeviceType pointerDeviceType, Point position, ManipulationDelta cumulative)
+		{
+			PointerDeviceType = pointerDeviceType;
+			Position = position;
+			Cumulative = cumulative;
+		}
+
+		public PointerDeviceType PointerDeviceType { get; }
+		public Point Position { get; }
+		public ManipulationDelta Cumulative { get; }
+	}
+}

--- a/src/Uno.UWP/UI/Input/ManipulationCompletedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationCompletedEventArgs.cs
@@ -7,15 +7,22 @@ namespace Windows.UI.Input
 {
 	public partial class ManipulationCompletedEventArgs 
 	{
-		internal ManipulationCompletedEventArgs(PointerDeviceType pointerDeviceType, Point position, ManipulationDelta cumulative)
+		internal ManipulationCompletedEventArgs(
+			PointerDeviceType pointerDeviceType,
+			Point position,
+			ManipulationDelta cumulative,
+			bool isInertial)
 		{
 			PointerDeviceType = pointerDeviceType;
 			Position = position;
 			Cumulative = cumulative;
+			IsInertial = isInertial;
 		}
 
 		public PointerDeviceType PointerDeviceType { get; }
 		public Point Position { get; }
 		public ManipulationDelta Cumulative { get; }
+
+		internal bool IsInertial { get; }
 	}
 }

--- a/src/Uno.UWP/UI/Input/ManipulationDelta.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationDelta.cs
@@ -4,18 +4,6 @@ namespace Windows.UI.Input
 {
 	public partial struct ManipulationDelta 
 	{
-		internal ManipulationDelta(
-			Point translation,
-			float scale,
-			float rotation,
-			float expansion)
-		{
-			Translation = translation;
-			Scale = scale;
-			Rotation = rotation;
-			Expansion = expansion;
-		}
-
 		public Point Translation;
 		public float Scale;
 		public float Rotation;

--- a/src/Uno.UWP/UI/Input/ManipulationDelta.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationDelta.cs
@@ -1,0 +1,24 @@
+using Windows.Foundation;
+
+namespace Windows.UI.Input
+{
+	public partial struct ManipulationDelta 
+	{
+		internal ManipulationDelta(
+			Point translation,
+			float scale,
+			float rotation,
+			float expansion)
+		{
+			Translation = translation;
+			Scale = scale;
+			Rotation = rotation;
+			Expansion = expansion;
+		}
+
+		public Point Translation;
+		public float Scale;
+		public float Rotation;
+		public float Expansion;
+	}
+}

--- a/src/Uno.UWP/UI/Input/ManipulationDelta.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationDelta.cs
@@ -1,4 +1,4 @@
-using Windows.Foundation;
+﻿using Windows.Foundation;
 
 namespace Windows.UI.Input
 {
@@ -8,5 +8,9 @@ namespace Windows.UI.Input
 		public float Scale;
 		public float Rotation;
 		public float Expansion;
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"x:{Translation.X:N0};y:{Translation.Y:N0};θ:{Rotation:F2};s:{Scale:F2};e:{Expansion:F2}";
 	}
 }

--- a/src/Uno.UWP/UI/Input/ManipulationInertiaStartingEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationInertiaStartingEventArgs.cs
@@ -1,0 +1,21 @@
+using Windows.Devices.Input;
+using Windows.Foundation;
+
+namespace Windows.UI.Input
+{
+	public partial class ManipulationInertiaStartingEventArgs 
+	{
+		internal ManipulationInertiaStartingEventArgs(PointerDeviceType pointerDeviceType, Point position, ManipulationDelta delta, ManipulationDelta cumulative)
+		{
+			PointerDeviceType = pointerDeviceType;
+			Position = position;
+			Delta = delta;
+			Cumulative = cumulative;
+		}
+
+		public PointerDeviceType PointerDeviceType { get; }
+		public Point Position { get; }
+		public ManipulationDelta Delta { get; }
+		public ManipulationDelta Cumulative { get; }
+	}
+}

--- a/src/Uno.UWP/UI/Input/ManipulationStartedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationStartedEventArgs.cs
@@ -1,0 +1,19 @@
+using Windows.Devices.Input;
+using Windows.Foundation;
+
+namespace Windows.UI.Input
+{
+	public partial class ManipulationStartedEventArgs 
+	{
+		internal ManipulationStartedEventArgs(PointerDeviceType pointerDeviceType, Point position, ManipulationDelta cumulative)
+		{
+			PointerDeviceType = pointerDeviceType;
+			Position = position;
+			Cumulative = cumulative;
+		}
+
+		public PointerDeviceType PointerDeviceType { get; }
+		public Point Position { get; }
+		public ManipulationDelta Cumulative { get; }
+	}
+}

--- a/src/Uno.UWP/UI/Input/ManipulationStartingEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationStartingEventArgs.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Linq;
+
+namespace Windows.UI.Input
+{
+	internal partial class ManipulationStartingEventArgs
+	{
+		// Be aware that this class is not part of the UWP contract
+
+		internal ManipulationStartingEventArgs(GestureSettings settings)
+		{
+			Settings = settings;
+		}
+
+		public GestureSettings Settings { get; set; }
+	}
+}

--- a/src/Uno.UWP/UI/Input/ManipulationUpdatedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationUpdatedEventArgs.cs
@@ -5,17 +5,25 @@ namespace Windows.UI.Input
 {
 	public  partial class ManipulationUpdatedEventArgs 
 	{
-		internal ManipulationUpdatedEventArgs(PointerDeviceType pointerDeviceType, Point position, ManipulationDelta delta, ManipulationDelta cumulative)
+		internal ManipulationUpdatedEventArgs(
+			PointerDeviceType pointerDeviceType,
+			Point position,
+			ManipulationDelta delta,
+			ManipulationDelta cumulative,
+			bool isInertial)
 		{
 			PointerDeviceType = pointerDeviceType;
 			Position = position;
 			Delta = delta;
 			Cumulative = cumulative;
+			IsInertial = isInertial;
 		}
 
 		public PointerDeviceType PointerDeviceType { get; }
 		public Point Position { get; }
 		public ManipulationDelta Delta { get; }
 		public ManipulationDelta Cumulative { get; }
+
+		internal bool IsInertial { get; }
 	}
 }

--- a/src/Uno.UWP/UI/Input/ManipulationUpdatedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationUpdatedEventArgs.cs
@@ -1,0 +1,21 @@
+using Windows.Devices.Input;
+using Windows.Foundation;
+
+namespace Windows.UI.Input
+{
+	public  partial class ManipulationUpdatedEventArgs 
+	{
+		internal ManipulationUpdatedEventArgs(PointerDeviceType pointerDeviceType, Point position, ManipulationDelta delta, ManipulationDelta cumulative)
+		{
+			PointerDeviceType = pointerDeviceType;
+			Position = position;
+			Delta = delta;
+			Cumulative = cumulative;
+		}
+
+		public PointerDeviceType PointerDeviceType { get; }
+		public Point Position { get; }
+		public ManipulationDelta Delta { get; }
+		public ManipulationDelta Cumulative { get; }
+	}
+}

--- a/src/Uno.UWP/UI/Input/TappedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/TappedEventArgs.cs
@@ -14,7 +14,7 @@ namespace Windows.UI.Input
 
 		public PointerDeviceType PointerDeviceType { get; }
 
-		public global::Windows.Foundation.Point Position { get; }
+		public Point Position { get; }
 
 		public uint TapCount { get; }
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): 
#221 
https://github.com/unoplatform/Uno.WindowsCommunityToolkit/issues/38

## Feature: 
- Feature

## What is the current behavior?
Manipulation events are not raised

## What is the new behavior?
`Manipulation<Starting|Started|Delta|Completed>` are raised according to the configured `ManipulationMode`

> The inertia is not supported yet, so the `ManipulationInertiaStarting` won't be raised.

## PR Checklist
- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

