### PR TITLE
Update to VS2019, use C# 8.0

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,7 +15,7 @@ pr:
 resources:
   containers:
   - container: nv-bionic-wasm
-    image: nventive/wasm-build:1.5
+    image: unoplatform/wasm-build:2.0
 
 jobs:
 - template: build/ci/.azure-devops-windows.yml

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -17,12 +17,48 @@ resources:
   - container: nv-bionic-wasm
     image: unoplatform/wasm-build:2.0
 
+variables:
+  windowsVMImage: 'windows-2019'
+  linuxVMImage: 'ubuntu-16.04'
+  macOSVMImage: 'macOS-10.15'
+  xCodeRoot: '/Applications/Xcode_11.3.app'
+  XamarinSDKVersion: 6_6_0
+
 jobs:
 - template: build/ci/.azure-devops-windows.yml
+  parameters:
+    vmImage: '$(windowsVMImage)'
+
 - template: build/ci/.azure-devops-unit-tests.yml
+  parameters:
+    vmImage: '$(windowsVMImage)'
+
 - template: build/ci/.azure-devops-docs.yml
+  parameters:
+    vmImage: '$(windowsVMImage)'
+
 - template: build/ci/.azure-devops-wasm-uitests.yml
+  parameters:
+    vmImage: '$(linuxVMImage)'
+
 - template: build/ci/.azure-devops-macos.yml
+  parameters:
+    vmImage: '$(macOSVMImage)'
+    xCodeRoot: '$(xCodeRoot)'
+    XamarinSDKVersion: '$(XamarinSDKVersion)'
+
 - template: build/ci/.azure-devops-android-tests.yml
+  parameters:
+    vmImage: '$(macOSVMImage)'
+    xCodeRoot: '$(xCodeRoot)'
+    XamarinSDKVersion: '$(XamarinSDKVersion)'
+
 - template: build/ci/.azure-devops-ios-tests.yml
+  parameters:
+    vmImage: '$(macOSVMImage)'
+    xCodeRoot: '$(xCodeRoot)'
+    XamarinSDKVersion: '$(XamarinSDKVersion)'
+
 - template: build/ci/.azure-devops-screenshot-compare.yml
+  parameters:
+    vmImage: '$(windowsVMImage)'

--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -119,7 +119,7 @@
 
 		<MSBuild Properties="Configuration=Release;VisualStudioVersion=15.0;CopyDSYM=False;UnoSampleAppDisableAPKGeneration=True;InformationalVersion=$(GITVERSION_InformationalVersion);CI_Build=true;_IsCIBuild=true;PackageOutputPath=$(BUILD_ARTIFACTSTAGINGDIRECTORY)\vslatest;PackageVersion=$(GITVERSION_FullSemVer)"
              Projects="..\src\Uno.UI.sln"
-             Targets="Build"
+             Targets="Restore;Build"
              RebaseOutputs="false"
              BuildInParallel="true" />
 
@@ -127,14 +127,14 @@
 
 	<Target Name="BuildCImacOS">
 
-		<MSBuild Properties="Configuration=Release;VisualStudioVersion=15.0;CopyDSYM=False;InformationalVersion=$(GITVERSION_InformationalVersion);CI_Build=true;_IsCIBuild=true" Projects="..\src\Uno.UI-vs4mac.sln" Targets="Build" RebaseOutputs="false" BuildInParallel="true" />
+		<MSBuild Properties="Configuration=Release;InformationalVersion=$(GITVERSION_InformationalVersion);CI_Build=true;_IsCIBuild=true" Projects="..\src\Uno.UI-vs4mac.sln" Targets="Restore;Build" RebaseOutputs="false" BuildInParallel="true" />
 
 	</Target>
 
 	<Target Name="GenerateDoc">
 
 		<!-- Restore the nuget packages for the whole solution -->
-		<MSBuild Properties="Configuration=Release;VisualStudioVersion=15.0;CopyDSYM=False;InformationalVersion=$(GITVERSION_InformationalVersion);CI_Build=true;_IsCIBuild=true" Projects="..\src\Uno.UI.sln" Targets="Restore" RebaseOutputs="false" BuildInParallel="true" />
+		<MSBuild Properties="Configuration=Release;InformationalVersion=$(GITVERSION_InformationalVersion);CI_Build=true;_IsCIBuild=true" Projects="..\src\Uno.UI.sln" Targets="Restore" RebaseOutputs="false" BuildInParallel="true" />
 
 		<MSBuild Properties="Configuration=Release;VisualStudioVersion=15.0" Projects="..\src\Uno.UWPSyncGenerator\Uno.UWPSyncGenerator.csproj" Targets="Restore;Build" />
 		<Exec Command="..\src\Uno.UWPSyncGenerator\Bin\Release\net461\Uno.UWPSyncGenerator.exe &quot;doc&quot;" />

--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -117,7 +117,7 @@
 	<Target Name="BuildCI">
 		<Exec Command="npm i" WorkingDirectory="..\src\SamplesApp\SamplesApp.Wasm.UITests" />
 
-		<MSBuild Properties="Configuration=Release;VisualStudioVersion=15.0;CopyDSYM=False;UnoSampleAppDisableAPKGeneration=True;InformationalVersion=$(GITVERSION_InformationalVersion);CI_Build=true;_IsCIBuild=true;PackageOutputPath=$(BUILD_ARTIFACTSTAGINGDIRECTORY)\vslatest;PackageVersion=$(GITVERSION_FullSemVer)"
+		<MSBuild Properties="Configuration=Release;CopyDSYM=False;UnoSampleAppDisableAPKGeneration=True;InformationalVersion=$(GITVERSION_InformationalVersion);CI_Build=true;_IsCIBuild=true;PackageOutputPath=$(BUILD_ARTIFACTSTAGINGDIRECTORY)\vslatest;PackageVersion=$(GITVERSION_FullSemVer)"
              Projects="..\src\Uno.UI.sln"
              Targets="Restore;Build"
              RebaseOutputs="false"
@@ -136,7 +136,7 @@
 		<!-- Restore the nuget packages for the whole solution -->
 		<MSBuild Properties="Configuration=Release;InformationalVersion=$(GITVERSION_InformationalVersion);CI_Build=true;_IsCIBuild=true" Projects="..\src\Uno.UI.sln" Targets="Restore" RebaseOutputs="false" BuildInParallel="true" />
 
-		<MSBuild Properties="Configuration=Release;VisualStudioVersion=15.0" Projects="..\src\Uno.UWPSyncGenerator\Uno.UWPSyncGenerator.csproj" Targets="Restore;Build" />
+		<MSBuild Properties="Configuration=Release" Projects="..\src\Uno.UWPSyncGenerator\Uno.UWPSyncGenerator.csproj" Targets="Restore;Build" />
 		<Exec Command="..\src\Uno.UWPSyncGenerator\Bin\Release\net461\Uno.UWPSyncGenerator.exe &quot;doc&quot;" />
 		<Exec Command="$(Pkgdocfx_console)\tools\docfx.exe ..\doc\docfx.json -o $(OutputDir)\doc" />
 	</Target>

--- a/build/Uno.UI.Lottie.nuspec
+++ b/build/Uno.UI.Lottie.nuspec
@@ -47,7 +47,6 @@
   <files>
 	<file src="..\src\AddIns\Uno.UI.Lottie\bin\Release\netstandard2.0\Uno.UI.Lottie.dll" target="lib\netstandard2.0" />
 	<file src="..\src\AddIns\Uno.UI.Lottie\bin\Release\xamarinios10\Uno.UI.Lottie.dll" target="lib\xamarinios10" />
-	<file src="..\src\AddIns\Uno.UI.Lottie\bin\Release\MonoAndroid80\Uno.UI.Lottie.dll" target="lib\MonoAndroid80" />
 	<file src="..\src\AddIns\Uno.UI.Lottie\bin\Release\MonoAndroid90\Uno.UI.Lottie.dll" target="lib\MonoAndroid90" />
   </files>
 </package>

--- a/build/Uno.UI.RemoteControl.nuspec
+++ b/build/Uno.UI.RemoteControl.nuspec
@@ -15,12 +15,6 @@
     <repository type="git" url="https://github.com/unoplatform/uno.git" />
 
     <dependencies>
-      <!-- Android 8.0 -->
-      <group targetFramework="MonoAndroid80">
-        <dependency id="Uno.UI" version="1.29.0-dev.93" />
-
-        <dependency id="Newtonsoft.Json" version="12.0.2" />
-      </group>
 
       <!-- Android 9.0 -->
       <group targetFramework="MonoAndroid90">
@@ -80,9 +74,6 @@
     <!-- Remote Control -->
     <file src="..\src\Uno.UI.RemoteControl\bin\Release\netstandard2.0\Uno.UI.RemoteControl.dll" target="lib\netstandard2.0" />
     <file src="..\src\Uno.UI.RemoteControl\bin\Release\netstandard2.0\Uno.UI.RemoteControl.pdb" target="lib\netstandard2.0" />
-    
-    <file src="..\src\Uno.UI.RemoteControl\bin\Release\MonoAndroid80\Uno.UI.RemoteControl.dll" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI.RemoteControl\bin\Release\MonoAndroid80\Uno.UI.RemoteControl.pdb" target="lib\MonoAndroid80" />
     
     <file src="..\src\Uno.UI.RemoteControl\bin\Release\MonoAndroid90\Uno.UI.RemoteControl.dll" target="lib\MonoAndroid90" />
     <file src="..\src\Uno.UI.RemoteControl\bin\Release\MonoAndroid90\Uno.UI.RemoteControl.pdb" target="lib\MonoAndroid90" />

--- a/build/Uno.UI.nuspec
+++ b/build/Uno.UI.nuspec
@@ -16,16 +16,6 @@
 
     <dependencies>
 
-      <!-- Android 8.0 -->
-      <group targetFramework="MonoAndroid80">
-        <dependency id="Xamarin.Android.Support.v4" version="26.1.0.1" />
-        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="26.1.0.1" />
-        <dependency id="Xamarin.Android.Support.v7.RecyclerView" version="26.1.0.1" />
-        <dependency id="Uno.SourceGenerationTasks" version="1.32.0-dev.297" />
-        <dependency id="Uno.Core" version="1.29.0-dev.93" />
-        <dependency id="Uno.Core.Build" version="1.29.0-dev.93" />
-      </group>
-
       <!-- Android 9.0 -->
       <group targetFramework="MonoAndroid90">
         <dependency id="Xamarin.Android.Support.v4" version="28.0.0.1" />
@@ -134,19 +124,6 @@
     <file src="..\src\Uno.UI.Toolkit\bin\Release\xamarinios10\Uno.UI.Toolkit.pdb" target="lib\xamarinios10" />
     <file src="..\src\Uno.UI.Toolkit\bin\Release\netstandard2.0\Uno.UI.Toolkit.dll" target="lib\netstandard2.0" />
     <file src="..\src\Uno.UI.Toolkit\bin\Release\netstandard2.0\Uno.UI.Toolkit.pdb" target="lib\netstandard2.0" />
-
-    <!-- Android 8.0 -->
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.dll" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.pdb" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.Foundation.dll" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.Foundation.pdb" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.UI.BindingHelper.Android.dll" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.UI.BindingHelper.Android.pdb" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.UI.dll" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.UI.pdb" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.Xaml.dll" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.Xaml.pdb" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI\Bin\Release\monoandroid80\*.xml" target="lib\MonoAndroid80" />
 
     <!-- Android 9.0 -->
     <file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.dll" target="lib\MonoAndroid90" />

--- a/build/Uno.UI.nuspec
+++ b/build/Uno.UI.nuspec
@@ -116,8 +116,6 @@
     <!-- Uno.UI.Toolkit -->
     <file src="..\src\Uno.UI.Toolkit\bin\Release\uap10.0.17763\Uno.UI.Toolkit.dll" target="lib\UAP" />
     <file src="..\src\Uno.UI.Toolkit\bin\Release\uap10.0.17763\Uno.UI.Toolkit.pdb" target="lib\UAP" />
-    <file src="..\src\Uno.UI.Toolkit\bin\Release\MonoAndroid80\Uno.UI.Toolkit.dll" target="lib\MonoAndroid80" />
-    <file src="..\src\Uno.UI.Toolkit\bin\Release\MonoAndroid80\Uno.UI.Toolkit.pdb" target="lib\MonoAndroid80" />
     <file src="..\src\Uno.UI.Toolkit\bin\Release\MonoAndroid90\Uno.UI.Toolkit.dll" target="lib\MonoAndroid90" />
     <file src="..\src\Uno.UI.Toolkit\bin\Release\MonoAndroid90\Uno.UI.Toolkit.pdb" target="lib\MonoAndroid90" />
     <file src="..\src\Uno.UI.Toolkit\bin\Release\xamarinios10\Uno.UI.Toolkit.dll" target="lib\xamarinios10" />

--- a/build/ci/.azure-devops-android-tests.yml
+++ b/build/ci/.azure-devops-android-tests.yml
@@ -1,9 +1,14 @@
+parameters:
+  vmImage: ''
+  xCodeRoot: ''
+  XamarinSDKVersion: ''
+
 jobs:
 
 - job: Android_Build_For_Tests
 
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: ${{ parameters.vmImage }}
 
   variables:
     CI_Build: true
@@ -20,8 +25,10 @@ jobs:
     parameters:
       nugetPackages: $(NUGET_PACKAGES)
 
-  - bash: /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0"
-    displayName: Select Xamarin Version
+  - template: templates/ios-build-select-version.yml
+    parameters:
+      xCodeRoot: ${{ parameters.xCodeRoot }}
+      XamarinSDKVersion: ${{ parameters.XamarinSDKVersion }}
 
   - bash: |
       $(build.sourcesdirectory)/build/android-uitest-build.sh
@@ -48,7 +55,7 @@ jobs:
     NUGET_PACKAGES: $(Agent.WorkFolder)/.nuget
 
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: ${{ parameters.vmImage }}
 
   strategy:
     matrix:
@@ -75,8 +82,10 @@ jobs:
 
   - template: templates/optimize-roslyn-mono.yml
 
-  - bash: /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_18_1"
-    displayName: Select Xamarin Version
+  - template: templates/ios-build-select-version.yml
+    parameters:
+      xCodeRoot: ${{ parameters.xCodeRoot }}
+      XamarinSDKVersion: ${{ parameters.XamarinSDKVersion }}
 
   - bash: |
       $(build.sourcesdirectory)/build/android-uitest-run.sh

--- a/build/ci/.azure-devops-android-tests.yml
+++ b/build/ci/.azure-devops-android-tests.yml
@@ -20,7 +20,7 @@ jobs:
     parameters:
       nugetPackages: $(NUGET_PACKAGES)
 
-  - bash: /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_18_1"
+  - bash: /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0"
     displayName: Select Xamarin Version
 
   - bash: |

--- a/build/ci/.azure-devops-docs.yml
+++ b/build/ci/.azure-devops-docs.yml
@@ -5,7 +5,7 @@ jobs:
 - job: Documentation
 
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
 
   variables:
     CombinedConfiguration: Release|Any CPU

--- a/build/ci/.azure-devops-docs.yml
+++ b/build/ci/.azure-devops-docs.yml
@@ -1,11 +1,11 @@
 parameters:
-  pool: ''
+  vmImage: ''
 
 jobs:
 - job: Documentation
 
   pool:
-    vmImage: 'windows-2019'
+    vmImage: ${{ parameters.vmImage }}
 
   variables:
     CombinedConfiguration: Release|Any CPU

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -1,7 +1,7 @@
 parameters:
-  vmImage: 'macOS-10.14'
-  xCodeRoot: '/Applications/Xcode_10.3.app'
-  XamarinSDKVersion: 5_18_1
+  vmImage: ''
+  xCodeRoot: ''
+  XamarinSDKVersion: ''
 
 jobs:
 - job: iOS_Build

--- a/build/ci/.azure-devops-macos.yml
+++ b/build/ci/.azure-devops-macos.yml
@@ -21,7 +21,7 @@ jobs:
     parameters:
       nugetPackages: $(NUGET_PACKAGES)
 
-  - bash: /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_18_1"
+  - bash: /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0"
     displayName: Select Xamarin Version
     
   - bash: /bin/bash -c "echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${XCODE_ROOT};sudo xcode-select --switch ${XCODE_ROOT}/Contents/Developer"

--- a/build/ci/.azure-devops-macos.yml
+++ b/build/ci/.azure-devops-macos.yml
@@ -1,3 +1,8 @@
+parameters:
+  vmImage: ''
+  xCodeRoot: ''
+  XamarinSDKVersion: ''
+
 jobs:
 
 - job: macOS
@@ -9,7 +14,7 @@ jobs:
     XCODE_ROOT: /Applications/Xcode_10.3.app
 
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: ${{ parameters.vmImage }}
 
   steps:
   - checkout: self
@@ -21,11 +26,10 @@ jobs:
     parameters:
       nugetPackages: $(NUGET_PACKAGES)
 
-  - bash: /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0"
-    displayName: Select Xamarin Version
-    
-  - bash: /bin/bash -c "echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'${XCODE_ROOT};sudo xcode-select --switch ${XCODE_ROOT}/Contents/Developer"
-    displayName: Select Xcode
+  - template: templates/ios-build-select-version.yml
+    parameters:
+      xCodeRoot: ${{ parameters.xCodeRoot }}
+      XamarinSDKVersion: ${{ parameters.XamarinSDKVersion }}
 
   - task: NuGetToolInstaller@0
     inputs:

--- a/build/ci/.azure-devops-screenshot-compare.yml
+++ b/build/ci/.azure-devops-screenshot-compare.yml
@@ -1,3 +1,6 @@
+parameters:
+  vmImage: ''
+
 jobs:
 
 - job: UITests_Screenshots_Compare
@@ -9,7 +12,7 @@ jobs:
   condition: succeededOrFailed()
 
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: ${{ parameters.vmImage }}
 
   variables:
     COMPARE_WORKDIR: $(Build.SourcesDirectory)\snapshot-compare

--- a/build/ci/.azure-devops-unit-tests.yml
+++ b/build/ci/.azure-devops-unit-tests.yml
@@ -1,12 +1,12 @@
 parameters:
-  pool: ''
+  vmImage: ''
 
 jobs:
 - job: Unit_Tests
   timeoutInMinutes: 90
 
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: ${{ parameters.vmImage }}
 
   variables:
     CombinedConfiguration: Release|Any CPU

--- a/build/ci/.azure-devops-wasm-uitests.yml
+++ b/build/ci/.azure-devops-wasm-uitests.yml
@@ -1,12 +1,12 @@
 parameters:
-  pool: ''
+  vmImage: ''
 
 jobs:
 - job: Wasm_UITests_Build
   container: nv-bionic-wasm
 
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: ${{ parameters.vmImage }}
 
   variables:
     NUGET_PACKAGES: $(build.sourcesdirectory)/.nuget

--- a/build/ci/.azure-devops-windows.yml
+++ b/build/ci/.azure-devops-windows.yml
@@ -1,12 +1,12 @@
 parameters:
-  pool: ''
+  vmImage: ''
 
 jobs:
 - job: VS_Latest
   timeoutInMinutes: 90
 
   pool:
-    vmImage: 'windows-2019'
+    vmImage: ${{ parameters.vmImage }}
 
   variables:
     CombinedConfiguration: Release|Any CPU

--- a/build/ci/.azure-devops-windows.yml
+++ b/build/ci/.azure-devops-windows.yml
@@ -6,7 +6,7 @@ jobs:
   timeoutInMinutes: 90
 
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
 
   variables:
     CombinedConfiguration: Release|Any CPU

--- a/doc/ReleaseNotes/LegacyReleaseNotes.md
+++ b/doc/ReleaseNotes/LegacyReleaseNotes.md
@@ -2,10 +2,26 @@
 
 ### Features
 
-- Added new `ElevatedView` in the `Uno.Toolkit` to provide elevation & rounded corners on all platforms
-  (not supported on Windows yet, because Uno needs to target framework `10.0.18362.0`)
 - [Android] Support for `Application.Current.Exit`
 - Support for `Windows.Storage.FileProperties.BasicProperties.DateModified`
+
+### Breaking changes
+- Uno is now built using VS2019 16.4, and does not support building applications with Visual Studio 2017.
+  Linker errors may occur such as:
+  ```
+  Java.Interop.Tools.Diagnostics.XamarinAndroidException: error XA2006: Could not resolve reference to 'System.Collections.Generic.Queue`1'
+  (defined in assembly 'Uno.UI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null') with scope 'mscorlib, Version=2.0.5.0,
+  Culture=neutral, PublicKeyToken=7cec85d7bea7798e'.
+  ```
+
+### Bug fixes
+- 
+
+## Release 2.1
+
+### Features
+- Added new `ElevatedView` in the `Uno.Toolkit` to provide elevation & rounded corners on all platforms
+  (not supported on Windows yet, because Uno needs to target framework `10.0.18362.0`)
 - Added CornerRadius support to more default styles to match UWP (for list of updated styles see PR [#2713])
 - Support for `FontIcon` on macOS
 - Support for `PhoneCallManager.ShowPhoneCallUI` on macOS

--- a/doc/articles/get-started.md
+++ b/doc/articles/get-started.md
@@ -3,7 +3,7 @@
 This guide will walk you through the set-up process for building cross-platform apps with Uno.
 
 ## Prerequisites
-* [**Visual Studio 2017 15.5 or later**](https://visualstudio.microsoft.com/), with:
+* [**Visual Studio 2019 16.3 or later**](https://visualstudio.microsoft.com/), with:
     * **Universal Windows Platform** workload installed.
 
     ![visual-studio-installer-uwp](Assets/quick-start/vs-install-uwp.png)

--- a/doc/articles/uno-development/debugging-uno-ui.md
+++ b/doc/articles/uno-development/debugging-uno-ui.md
@@ -3,7 +3,7 @@
 ## Building Uno.UI
 
 Prerequisites:
-- Visual Studio 2017 (15.8 or later) or 2019 (Preview 2 or later)
+- Visual Studio 2019 (16.3 or later)
     - `Mobile Development with .NET` (Xamarin) development
     - `Visual Studio extensions development` (for the VSIX projects)
     - `ASP.NET and Web Development`

--- a/doc/articles/using-uno-ui.md
+++ b/doc/articles/using-uno-ui.md
@@ -2,7 +2,7 @@
 
 ## Pre-requisites
 
-* [**Visual Studio 2017 15.5 or later**](https://visualstudio.microsoft.com/), with :
+* [**Visual Studio 2019 16.3 or later**](https://visualstudio.microsoft.com/), with :
 	* Xamarin component, with the iOS Remote Simulator installed
 	* A working Mac with Visual Studio for Mac, XCode 8.2 or later installed
 	* The google Android x86 emulators

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -15,7 +15,7 @@ branches:
     mode: ContinuousDeployment
     tag: 'PullRequest'
     tag-number-pattern: '[/-](?<number>\d+)[-/]'
-    increment: none
+    increment: Inherit
 
   beta:
     mode: ContinuousDeployment
@@ -39,14 +39,14 @@ branches:
     increment: none
 
   projects:
-    tag: ^proj-{BranchName}
-    regex: projects/(.*?)
+    tag: proj-{BranchName}
+    regex: ^projects/(.*?)
     source-branches: ['master']
     increment: none
 
   feature:
-    tag: ^feature.{BranchName}
-    regex: feature/(.*?)
+    tag: feature.{BranchName}
+    regex: ^feature/(.*?)
     source-branches: ['master']
     increment: none
 

--- a/src/AddIns/Uno.UI.Lottie/Uno.UI.Lottie.csproj
+++ b/src/AddIns/Uno.UI.Lottie/Uno.UI.Lottie.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>xamarinmac20;MonoAndroid90;xamarinios10;net461;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>xamarinmac20;MonoAndroid80;MonoAndroid90;xamarinios10;net461;netstandard2.0</TargetFrameworksCI>
+		<TargetFrameworksCI>xamarinmac20;MonoAndroid90;xamarinios10;net461;netstandard2.0</TargetFrameworksCI>
 		<NoWarn>$(NoWarn);NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Deterministic>true</Deterministic>
@@ -30,10 +30,6 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\Uno.UI\Uno.UI.csproj" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid80'">
-		<PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.2.1" PrivateAssets="none" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid90'">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,7 +21,7 @@
     <CreateHardLinksForAdditionalFilesIfPossible>true</CreateHardLinksForAdditionalFilesIfPossible>
     <CreateHardLinksForPublishFilesIfPossible>true</CreateHardLinksForPublishFilesIfPossible>
 
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
 
     <!-- Version management is now done through NuGet, this avoids issues related version mismatch -->
     <Version>255.255.255.255</Version>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -13,8 +13,8 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Update="Uno.SourceGenerationTasks" Version="1.32.0" />
-    <PackageReference Update="Uno.SourceGeneration" Version="1.32.0" />
+    <PackageReference Update="Uno.SourceGenerationTasks" Version="2.0.0-dev.304" />
+    <PackageReference Update="Uno.SourceGeneration" Version="2.0.0-dev.304" />
     <PackageReference Update="Uno.Core" Version="1.29.0" />
     <PackageReference Update="Uno.Core.Build" Version="1.29.0" />
     <PackageReference Update="Uno.Wasm.Bootstrap" Version="1.0.10" />

--- a/src/SamplesApp/SamplesApp.UITests.Generator/SnapShotTestGenerator.cs
+++ b/src/SamplesApp/SamplesApp.UITests.Generator/SnapShotTestGenerator.cs
@@ -194,8 +194,8 @@ namespace Uno.Samples.UITest.Generator
 		{
 			switch (Path.GetFileName(path).ToLowerInvariant())
 			{
-				case "monoandroid80":
-					yield return $@"{devEnvDir}\..\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v8.0";
+				case "monoandroid90":
+					yield return $@"{devEnvDir}\..\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v9.0";
 					yield return $@"{devEnvDir}\..\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v1.0";
 					yield break;
 				case "xamarinios10":

--- a/src/SolutionTemplate/UnoLibraryTemplate/CrossTargetedLibrary.csproj
+++ b/src/SolutionTemplate/UnoLibraryTemplate/CrossTargetedLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="MSBuild.Sdk.Extras/2.0.54">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid80;monoandroid90;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid90;uap10.0.16299</TargetFrameworks>
 
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -11,7 +11,7 @@
 		<DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid80' or '$(TargetFramework)'=='monoandroid90' or '$(TargetFramework)'=='netstandard2.0'">
+	<ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid90' or '$(TargetFramework)'=='netstandard2.0'">
 		<PackageReference Include="Uno.UI" Version="1.46.196-dev.2440" />
 	</ItemGroup>
 

--- a/src/SourceGenerators/Uno.UI.Tasks/Properties/AssemblyInfo.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/Properties/AssemblyInfo.cs
@@ -2,35 +2,3 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Uno.UI.Tasks")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Uno.UI.Tasks")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("946d318b-305a-4264-81a4-31698dcc22f7")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -1,100 +1,53 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputPath Condition="'$(OutputPath)' == ''">bin\$(Platform)\$(Configuration)</OutputPath>
-    <ProjectGuid>{946D318B-305A-4264-81A4-31698DCC22F7}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Uno.UI.Tasks</RootNamespace>
-    <AssemblyName>Uno.UI.Tasks.v0</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
+<Project Sdk="MSBuild.Sdk.Extras">
+	<PropertyGroup>
+		<TargetFramework>net461</TargetFramework>
+		<AssemblyName>Uno.UI.SourceGenerators</AssemblyName>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<RootNamespace>Uno.UI.Tasks</RootNamespace>
+		<AssemblyName>Uno.UI.Tasks.v0</AssemblyName>
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
 	</PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Windows" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Tasks.v4.0" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
+	
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+		<PackageReference Include="Uno.Core" />
+		<PackageReference Include="Microsoft.Build">
+			<Version>15.4.8</Version>
+			<ExcludeAssets>runtime</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Build.Framework">
+			<Version>15.4.8</Version>
+			<ExcludeAssets>runtime</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Build.Tasks.Core">
+			<Version>15.4.8</Version>
+			<ExcludeAssets>runtime</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Build.Utilities.Core">
+			<Version>15.4.8</Version>
+			<ExcludeAssets>runtime</ExcludeAssets>
+		</PackageReference>
 	</ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Uno.Core"/>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\..\Uno.UWP\ApplicationModel\Resources\Core\AndroidResourceConverter.cs">
-      <Link>Resources\AndroidResourceConverter.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UWP\ApplicationModel\Resources\Core\iOSResourceConverter.cs">
-      <Link>Resources\iOSResourceConverter.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UWP\ApplicationModel\Resources\Core\ResourceCandidate.cs">
-      <Link>Resources\ResourceCandidate.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UWP\ApplicationModel\Resources\Core\ResourceQualifier.cs">
-      <Link>Resources\ResourceQualifier.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UI\Services\AndroidResourceNameEncoder.cs">
-      <Link>Resources\AndroidResourceNameEncoder.cs</Link>
-    </Compile>
-    <Compile Include="Assets\RetargetAssets.cs" />
-    <Compile Include="Helpers\AnalyzerSuppressions.cs" />
-    <Compile Include="Helpers\PathHelper.cs" />
-    <Compile Include="Helpers\TaskLogger.cs" />
-    <Compile Include="Helpers\TaskLoggerProvider.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ResourcesGenerator\AndroidResourcesWriter.cs" />
-    <Compile Include="ResourcesGenerator\iOSResourcesWriter.cs" />
-    <Compile Include="ResourcesGenerator\ResourcesGenerationTask.cs" />
-    <Compile Include="ResourcesGenerator\UnoPRIResourcesWriter.cs" />
-    <Compile Include="ResourcesGenerator\WindowsResourcesReader.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <None Include="Content\Uno.UI.Tasks.targets">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 
+	<ItemGroup>
+		<Compile Include="..\..\Uno.UWP\ApplicationModel\Resources\Core\AndroidResourceConverter.cs">
+			<Link>Resources\AndroidResourceConverter.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UWP\ApplicationModel\Resources\Core\iOSResourceConverter.cs">
+			<Link>Resources\iOSResourceConverter.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UWP\ApplicationModel\Resources\Core\ResourceCandidate.cs">
+			<Link>Resources\ResourceCandidate.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UWP\ApplicationModel\Resources\Core\ResourceQualifier.cs">
+			<Link>Resources\ResourceQualifier.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UI\Services\AndroidResourceNameEncoder.cs">
+			<Link>Resources\AndroidResourceNameEncoder.cs</Link>
+		</Compile>
+	</ItemGroup>
+	
 	<Target Name="_copyUnoTasksBuildTime" AfterTargets="Build">
 		<ItemGroup>
 			<_unoTasksFiles Include="$(OutputPath)\*.*" />
@@ -105,7 +58,7 @@
 		-->
 		<Copy SkipUnchangedFiles="true" SourceFiles="@(_unoTasksFiles)" DestinationFolder="$(OutputPath)\..\$(Configuration)_Shadow" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
 	</Target>
-  <Import Project="..\..\Common.targets" />
+	<Import Project="..\..\Common.targets" />
 
 	<Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
 		<PropertyGroup>

--- a/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
+++ b/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
 		<TargetFrameworks>MonoAndroid90;xamarinios10;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10</TargetFrameworksCI>
+		<TargetFrameworksCI>MonoAndroid90;xamarinios10</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -20,18 +20,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
 		<DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
 	</PropertyGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
-		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>26.1.0.1</Version>
-		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-			<Version>26.1.0.1</Version>
-		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-			<Version>26.1.0.1</Version>
-		</PackageReference>
-	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
 		<TargetFrameworks>MonoAndroid90;xamarinios10;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10</TargetFrameworksCI>
+		<TargetFrameworksCI>MonoAndroid90;xamarinios10</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -20,18 +20,6 @@
 	<PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
 		<DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
 	</PropertyGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
-		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>26.1.0.1</Version>
-		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-			<Version>26.1.0.1</Version>
-		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-			<Version>26.1.0.1</Version>
-		</PackageReference>
-	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
@@ -121,4 +109,3 @@
 	<Import Project="..\..\Common.targets" />
 
 </Project>
- 

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFrameworks>xamarinmac20;xamarinios10;MonoAndroid90;net461;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+		<TargetFrameworksCI>MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">

--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>MonoAndroid80;MonoAndroid90;net461;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworks>
+		<TargetFrameworks>MonoAndroid90;net461;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworks>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<NoWarn>1701;1702;1705;109</NoWarn>
 
@@ -10,7 +10,7 @@
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>
 
-		<IsBindingProject Condition="'$(TargetFramework)' == 'MonoAndroid80' or '$(TargetFramework)' == 'MonoAndroid90'">true</IsBindingProject>
+		<IsBindingProject Condition="'$(TargetFramework)' == 'MonoAndroid90'">true</IsBindingProject>
 		<_isWindows>$([MSBuild]::IsOsPlatform(Windows))</_isWindows>
 	</PropertyGroup>
 
@@ -25,15 +25,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Xamarin.Build.Download" Version="0.4.11" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
-		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>26.1.0.1</Version>
-		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-			<Version>26.1.0.1</Version>
-		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">

--- a/src/Uno.UI.Maps/Uno.UI.Maps.csproj
+++ b/src/Uno.UI.Maps/Uno.UI.Maps.csproj
@@ -38,12 +38,6 @@
 		<PackageReference Include="Uno.Core.Build"/>
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
-		<PackageReference Include="Xamarin.GooglePlayServices.Location" Version="60.1142.1" />
-		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="60.1142.1" />
-		<PackageReference Include="Xamarin.Android.Support.v4" Version="26.1.0.1" PrivateAssets="none" />
-	</ItemGroup>
-
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.GooglePlayServices.Location" Version="71.1600.0" />
 		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="71.1600.0" />

--- a/src/Uno.UI.Maps/Uno.UI.Maps.csproj
+++ b/src/Uno.UI.Maps/Uno.UI.Maps.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
   <PropertyGroup>
 		<TargetFrameworks>MonoAndroid90;xamarinios10</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10</TargetFrameworksCI>
+		<TargetFrameworksCI>MonoAndroid90;xamarinios10</TargetFrameworksCI>
 		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
 	</PropertyGroup>
 	

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <TargetFrameworks>xamarinmac20;xamarinios10;MonoAndroid90;netstandard2.0</TargetFrameworks>
-    <TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+    <TargetFrameworksCI>MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
   </PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid80;monoandroid90;xamarinmac20;uap10.0.17763</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid90;xamarinmac20;uap10.0.17763</TargetFrameworks>
 		
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
 		<TargetFrameworks>xamarinmac20;MonoAndroid90;uap10.0.17763;xamarinios10;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;uap10.0.17763;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+		<TargetFrameworksCI>MonoAndroid90;uap10.0.17763;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworksCI>
 	</PropertyGroup>
 	
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
@@ -39,21 +39,6 @@
   <ItemGroup Condition=" $(IsMonoAndroid) or $(IsXamarinIOS) or $(IsXamarinMac) ">
 		<Reference Include="System.Numerics" />
 		<Reference Include="System.Numerics.Vectors" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
-		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>26.1.0.1</Version>
-			<PrivateAssets>none</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-			<Version>26.1.0.1</Version>
-			<PrivateAssets>none</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-			<Version>26.1.0.1</Version>
-			<PrivateAssets>none</PrivateAssets>
-		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
 		<TargetFrameworks>xamarinmac20;MonoAndroid90;xamarinios10;net461;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+		<TargetFrameworksCI>MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
@@ -163,18 +163,6 @@
 		<PackageReference Include="System.Memory" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
-		<PackageReference Include="Xamarin.Android.Support.v4" Version="26.1.0.1">
-			<PrivateAssets>none</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="26.1.0.1">
-			<PrivateAssets>none</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="26.1.0.1">
-			<PrivateAssets>none</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
-
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1">
 			<PrivateAssets>none</PrivateAssets>
@@ -199,7 +187,7 @@
 			<TreatAsPackageReference>false</TreatAsPackageReference>
 		</ProjectReference>
 		<ProjectReference Include="..\SourceGenerators\System.Xaml\Uno.Xaml.csproj" />
-		<ProjectReference Include="..\Uno.UI.BindingHelper.Android\Uno.UI.BindingHelper.Android.csproj" Condition="'$(TargetFramework)' == 'MonoAndroid80' or '$(TargetFramework)' == 'MonoAndroid90'">
+		<ProjectReference Include="..\Uno.UI.BindingHelper.Android\Uno.UI.BindingHelper.Android.csproj" Condition="'$(TargetFramework)' == 'MonoAndroid90'">
 			<TreatAsPackageReference>false</TreatAsPackageReference>
 		</ProjectReference>
 	</ItemGroup>

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <TargetFrameworks>xamarinmac20;xamarinios10;MonoAndroid90;net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+    <TargetFrameworksCI>MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
   </PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
@@ -46,17 +46,6 @@
 		<PackageReference Include="Uno.MonoAnalyzers" />
 	</ItemGroup>
 	
-	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
-		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>26.1.0.1</Version>
-			<PrivateAssets>none</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-			<Version>26.1.0.1</Version>
-			<PrivateAssets>none</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
-
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
 			<Version>28.0.0.1</Version>

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -115,9 +115,25 @@ namespace Uno.UWPSyncGenerator
 			process.WaitForExit();
 			var installPath = process.StandardOutput.ReadToEnd().Split('\r').First();
 
+			SetupMSBuildLookupPath(installPath);
+		}
+
+		private static void SetupMSBuildLookupPath(string installPath)
+		{
 			Environment.SetEnvironmentVariable("VSINSTALLDIR", installPath);
 
+			bool MSBuildExists() => File.Exists(Path.Combine(MSBuildBasePath, "Microsoft.Build.dll"));
+
 			MSBuildBasePath = Path.Combine(installPath, "MSBuild\\15.0\\Bin");
+
+			if (!MSBuildExists())
+			{
+				MSBuildBasePath = Path.Combine(installPath, "MSBuild\\Current\\Bin");
+				if (!MSBuildExists())
+				{
+					throw new InvalidOperationException($"Invalid Visual studio installation (Cannot find Microsoft.Build.dll)");
+				}
+			}
 		}
 
 		protected string GetNamespaceBasePath(INamedTypeSymbol type)
@@ -1406,7 +1422,7 @@ namespace Uno.UWPSyncGenerator
 
 			var properties = new Dictionary<string, string>
 							{
-								{ "VisualStudioVersion", "15.0" },
+								// { "VisualStudioVersion", "15.0" },
 								// { "Configuration", "Debug" },
 								//{ "BuildingInsideVisualStudio", "true" },
 								{ "SkipUnoResourceGeneration", "true" }, // Required to avoid loading a non-existent task


### PR DESCRIPTION
GitHub Issue (If applicable): #1217 #1440

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

- The CI is now built using C# 8.0, VS 2019 and macOS 10.14.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
