### PR TITLE
Fix PasswordBox reveal does not toggle back off

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
@@ -30,24 +30,24 @@ namespace Windows.UI.Xaml.Controls
 		private void RegisterSetPasswordScope()
 		{
 			_revealButton = this.GetTemplateChild(RevealButtonPartName) as Button;
-			_revealButton?.ApplyTemplate();
 
-			// Button doesn't raise the PointerPressed event, so we listen for it on the template visual root.
-			var revealTarget = (_revealButton?.TemplatedRoot ?? _revealButton?.ContentTemplateRoot) as UIElement;
-
-			if (revealTarget != null)
+			if (_revealButton != null)
 			{
-				revealTarget.PointerPressed += BeginReveal;
-				revealTarget.PointerReleased += EndReveal;
-				revealTarget.PointerExited += EndReveal;
-				revealTarget.PointerCanceled += EndReveal;
+				var beginReveal = new PointerEventHandler(BeginReveal);
+				var endReveal = new PointerEventHandler(EndReveal);
+
+				// Button will handle Pressed and Released, so we have subscribe to handled events too
+				_revealButton.AddHandler(PointerPressedEvent, beginReveal, handledEventsToo: true);
+				_revealButton.AddHandler(PointerReleasedEvent, endReveal, handledEventsToo: true);
+				_revealButton.AddHandler(PointerExitedEvent, endReveal, handledEventsToo: true);
+				_revealButton.AddHandler(PointerCanceledEvent, endReveal, handledEventsToo: true);
 
 				_revealButtonSubscription.Disposable = Disposable.Create(() =>
 				{
-					revealTarget.PointerPressed -= BeginReveal;
-					revealTarget.PointerReleased -= EndReveal;
-					revealTarget.PointerExited -= EndReveal;
-					revealTarget.PointerCanceled -= EndReveal;
+					_revealButton.RemoveHandler(PointerPressedEvent, beginReveal);
+					_revealButton.RemoveHandler(PointerReleasedEvent, endReveal);
+					_revealButton.RemoveHandler(PointerExitedEvent, endReveal);
+					_revealButton.RemoveHandler(PointerCanceledEvent, endReveal);
 				});
 			}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -376,7 +376,7 @@ namespace Windows.UI.Xaml
 			var handledInManaged = false;
 			var isIrrelevant = ValidateAndUpdateCapture(args, isOver);
 
-			handledInManaged |= SetOver(args, true, muteEvent: isIrrelevant);
+			handledInManaged |= SetOver(args, isOver);
 
 			if (isIrrelevant)
 			{


### PR DESCRIPTION
+ Fix minor issue where the IsOver is not updated properly

GitHub Issue (If applicable): https://github.com/unoplatform/private/issues/81

## PR Type
- Bugfix

## What is the current behavior?
Once the reveal button pressed, the `PasswordNox` never goes back to hidden mode

## What is the new behavior?
The password is obfuscated as soon as the pointer is released / goes out of the reveal button

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
