### PR TITLE
fix(articles): fix broken paths to images in .md files

### DIFF
--- a/doc/articles/controls/CommandBar.md
+++ b/doc/articles/controls/CommandBar.md
@@ -17,7 +17,7 @@ The `CommandBar` supports 2 different modes:
 
 This mode replicates **UWP**'s `CommandBar`. It is templatable and supports a template that's almost identical to **UWP**'s default `CommandBar`.
 
-![](Assets/CommandBar/windows/example.png)
+![](assets/commandbar/windows/example.png)
 
 #### Usage Example
 
@@ -34,9 +34,9 @@ This mode replicates **UWP**'s `CommandBar`. It is templatable and supports a te
 
 This mode is the preferred one and is enabled by default. It uses platform-specific controls to ensure a more native user experience. 
 
-![](Assets/CommandBar/android/example.png)
+![](assets/commandbar/android/example.png)
 
-![](Assets/CommandBar/ios/example.png)
+![](assets/commandbar/ios/example.png)
 
 | Platform | Native control      | Benefits                                              |
 |----------|---------------------|-------------------------------------------------------|
@@ -63,9 +63,9 @@ You must use `VisibleBoundsPadding.PaddingMask="Top"` on `CommandBar` to properl
 
 An important difference with this mode is the presence of a back button. Whenever the `CommandBar` is part of a `Page` whose `Frame` has a non-empty back stack, the back button will be displayed.
 
-![](Assets/CommandBar/android/back.png)
+![](assets/commandbar/android/back.png)
 
-![](Assets/CommandBar/ios/back.png)
+![](assets/commandbar/ios/back.png)
 
 On **Android**, tapping the back button triggers `SystemNavigationService.BackRequested`. It's the responsibility of the application's navigation controller to eventually call `Frame.GoBack()`.
 
@@ -94,9 +94,9 @@ On **iOS**, tapping the back button automatically triggers a back navigation on 
 
 Gets or sets a brush that describes the background of a control.
 
-![](Assets/CommandBar/android/background.png)
+![](assets/commandbar/android/background.png)
 
-![](Assets/CommandBar/ios/background.png)
+![](assets/commandbar/ios/background.png)
 
 #### Remarks
 
@@ -113,9 +113,9 @@ The `Content` is processed differently whether it's of type `string` or `Framewo
 
 When `Content` is a `string`, it's displayed using the platform's default font family, font size, font style and text alignment. Only the foreground color can be changed, using `Foreground`.
 
-![](Assets/CommandBar/android/content-string.png)
+![](assets/commandbar/android/content-string.png)
 
-![](Assets/CommandBar/ios/content-string.png)
+![](assets/commandbar/ios/content-string.png)
 
 | Platform | FontFamily    | FontSize | HorizontalAlignment |
 |----------|---------------|----------|---------------------|
@@ -124,9 +124,9 @@ When `Content` is a `string`, it's displayed using the platform's default font f
 
 When `Content` is a `FrameworkElement`, it's displayed within the available area:
 
-![](Assets/CommandBar/android/content-frameworkelement.png)
+![](assets/commandbar/android/content-frameworkelement.png)
 
-![](Assets/CommandBar/ios/content-frameworkelement.png)
+![](assets/commandbar/ios/content-frameworkelement.png)
 
 | Platform | Available height |
 |----------|:----------------:|
@@ -141,9 +141,9 @@ Please note that:
 
 Gets or sets a brush that describes the foreground color.
 
-![](Assets/CommandBar/android/foreground.png)
+![](assets/commandbar/android/foreground.png)
 
-![](Assets/CommandBar/ios/foreground.png)
+![](assets/commandbar/ios/foreground.png)
 
 #### Remarks
 
@@ -154,9 +154,9 @@ Gets or sets a brush that describes the foreground color.
 
 Gets the collection of primary command elements for the `CommandBar`.
 
-![](Assets/CommandBar/android/primarycommands.png)
+![](assets/commandbar/android/primarycommands.png)
 
-![](Assets/CommandBar/ios/primarycommands.png)
+![](assets/commandbar/ios/primarycommands.png)
 
 #### Remarks
 
@@ -167,9 +167,9 @@ Gets the collection of primary command elements for the `CommandBar`.
 
 Gets the collection of secondary command elements for the `CommandBar`.
 
-![](Assets/CommandBar/android/secondarycommands.png)
+![](assets/commandbar/android/secondarycommands.png)
 
-![](Assets/CommandBar/android/secondarycommands-popup.png)
+![](assets/commandbar/android/secondarycommands-popup.png)
 
 #### Remarks
 
@@ -212,9 +212,9 @@ Extensions to extend the functionality of `CommandBar` can be found in the `Comm
 
 Gets or sets the back button foreground for the `CommandBar`.
 
-![](Assets/CommandBar/android/backbuttonforeground.png)
+![](assets/commandbar/android/backbuttonforeground.png)
 
-![](Assets/CommandBar/ios/backbuttonforeground.png)
+![](assets/commandbar/ios/backbuttonforeground.png)
 
 #### Remarks
 
@@ -224,9 +224,9 @@ Gets or sets the back button foreground for the `CommandBar`.
 
 Gets or sets the back button icon for the `CommandBar`.
 
-![](Assets/CommandBar/android/backbuttonicon.png)
+![](assets/commandbar/android/backbuttonicon.png)
 
-![](Assets/CommandBar/ios/backbuttonicon.png)
+![](assets/commandbar/ios/backbuttonicon.png)
 
 #### Remarks
 
@@ -236,7 +236,7 @@ Gets or sets the back button icon for the `CommandBar`.
 
 Gets or sets the back button title for the `CommandBar`.
 
-![](Assets/CommandBar/ios/backbuttontitle.png)
+![](assets/commandbar/ios/backbuttontitle.png)
 
 #### Remarks
 
@@ -254,9 +254,9 @@ To remove the back button title from all pages (and only leave the back arrow), 
 
 Gets or sets the elevation of the `UIElement`.
 
-![](Assets/CommandBar/android/elevation.png)
+![](assets/commandbar/android/elevation.png)
 
-![](Assets/CommandBar/ios/elevation.png)
+![](assets/commandbar/ios/elevation.png)
 
 #### Remarks
 
@@ -267,9 +267,9 @@ Gets or sets the elevation of the `UIElement`.
 
 Gets or sets the navigation command for the `CommandBar`.
 
-![](Assets/CommandBar/android/navigationcommand.png)
+![](assets/commandbar/android/navigationcommand.png)
 
-![](Assets/CommandBar/ios/navigationcommand.png)
+![](assets/commandbar/ios/navigationcommand.png)
 
 #### Remarks
 
@@ -288,7 +288,7 @@ On **Android**, only icons are supported (`AppBarButton.Icon`). This is due to a
 
 Gets or sets the subtitle for the `CommandBar`.
 
-![](Assets/CommandBar/android/subtitle.png)
+![](assets/commandbar/android/subtitle.png)
 
 #### Remarks
 
@@ -343,9 +343,9 @@ When `AppBarButton` is used within a native `CommandBar`, its control template i
 
 Gets or sets a brush that describes the foreground color.
 
-![](Assets/CommandBar/android/appbarbutton-foreground.png)
+![](assets/commandbar/android/appbarbutton-foreground.png)
 
-![](Assets/CommandBar/ios/appbarbutton-foreground.png)
+![](assets/commandbar/ios/appbarbutton-foreground.png)
 
 #### Remarks
 
@@ -358,9 +358,9 @@ Gets or sets a brush that describes the foreground color.
 
 Gets or sets the content of a `ContentControl`.
 
-![](Assets/CommandBar/android/appbarbutton-content.png)
+![](assets/commandbar/android/appbarbutton-content.png)
 
-![](Assets/CommandBar/ios/appbarbutton-content.png)
+![](assets/commandbar/ios/appbarbutton-content.png)
 
 #### Remarks
 
@@ -374,9 +374,9 @@ Gets or sets the content of a `ContentControl`.
 
 Gets or sets the graphic content of the app bar button.
 
-![](Assets/CommandBar/android/appbarbutton-icon.png)
+![](assets/commandbar/android/appbarbutton-icon.png)
 
-![](Assets/CommandBar/ios/appbarbutton-icon.png)
+![](assets/commandbar/ios/appbarbutton-icon.png)
 
 #### Remarks
 
@@ -394,9 +394,9 @@ Gets or sets the graphic content of the app bar button.
 
 Gets or sets the text description displayed on the app bar button.
 
-![](Assets/CommandBar/android/appbarbutton-tooltip.png)
+![](assets/commandbar/android/appbarbutton-tooltip.png)
 
-![](Assets/CommandBar/android/secondarycommands-popup.png)
+![](assets/commandbar/android/secondarycommands-popup.png)
 
 #### Remarks
 
@@ -410,9 +410,9 @@ It is highly recommended to set and localize `Label` on all `AppBarButton`s, if 
 
 Gets or sets a value indicating whether the user can interact with the control.
 
-![](Assets/CommandBar/android/appbarbutton-disabled.png)
+![](assets/commandbar/android/appbarbutton-disabled.png)
 
-![](Assets/CommandBar/ios/appbarbutton-disabled.png)
+![](assets/commandbar/ios/appbarbutton-disabled.png)
 
 #### Remarks
 
@@ -784,7 +784,7 @@ Gets or sets a value indicating whether the user can interact with the control.
   </Grid>
   ```
   
-  ![](Assets/CommandBar/ios/transparent.png)
+  ![](assets/commandbar/ios/transparent.png)
   
 - > What size should my AppBarButton icons be?
   

--- a/doc/articles/uno-development/Uno-UI-Debugging-Android-Studio.md
+++ b/doc/articles/uno-development/Uno-UI-Debugging-Android-Studio.md
@@ -17,19 +17,19 @@ sourceSets {
     }
 ```
 
-![gradle](Assets/Debugging-Android-Studio/Gradle-changes.png)
+![gradle](assets/debugging-android-studio/Gradle-changes.png)
 
 * Press 'Sync Now' to update the project.
 * You should now see Uno.UI files in the Project tab. (Don't worry about red squiggles.)
 
-![Project-files](Assets/Debugging-Android-Studio/Project-files.png)
+![Project-files](assets/debugging-android-studio/Project-files.png)
 
 ## Debugging
 
 * Run the app you wish to debug, which should be using a local debug build of Uno.UI.
 * In Android Studio, select Run->Attach debugger to Android process. Select your app. (Toggle on 'Show all processes' if it's not visible.)
 
-![Attach-to-process](Assets/Debugging-Android-Studio/Attach-to-process.png)
+![Attach-to-process](assets/debugging-android-studio/Attach-to-process.png)
 
 * You should now be able to debug and place breakpoints in Uno.UI code. 
 * Android Studio supports a similar feature set to Visual Studio. Here are some of the basics:
@@ -38,7 +38,7 @@ sourceSets {
     * Add 'watch' values.
     * Add conditions and logging to breakpoints.
 
-![Debugging](Assets/Debugging-Android-Studio/Debugging.png)
+![Debugging](assets/debugging-android-studio/Debugging.png)
 
 * One powerful feature of debugging Android code is the level of integration with framework code. You should be able to see not only the native stack trace, but even local variable values in framework methods (e.g. ViewGroup.dispatchTouchEvent().) 
     * Note that Android Studio may prompt you to download source code and debug symbols: this will fail unless you started Android Studio with Administrator privileges (right-click in Start menu + 'Run as Administrator'). 

--- a/doc/articles/uno-development/Uno-UI-Layouting-Android.md
+++ b/doc/articles/uno-development/Uno-UI-Layouting-Android.md
@@ -4,4 +4,4 @@ The layouting cycle (measure and arrange) in Uno on Android involves a complex i
 methods. These interactions are summarized in the diagram below. This information is primarily intended to help when debugging Uno, but 
 may be interesting to anyone curious as to how native Android methods are connected to the UWP contract exposed by Uno.
 
-![android-layouting-diagram](Assets/layouting-android.png)
+![android-layouting-diagram](assets/layouting-android.png)

--- a/doc/articles/uno-development/Uno-UI-Layouting-iOS.md
+++ b/doc/articles/uno-development/Uno-UI-Layouting-iOS.md
@@ -2,4 +2,4 @@
 
 The layouting cycle (measure and arrange) in Uno on iOS is a mingling of native layouting logic and logic in managed code. These interactions are summarized in the diagram below. This information is primarily intended to help when debugging Uno, but may also be useful when attempting to incorporate non-Uno views into the visual tree.
 
-![ios-layouting-diagram](Assets/layouting-ios.png)
+![ios-layouting-diagram](assets/layouting-ios.png)

--- a/doc/articles/uno-development/debugging-inspect-visual-tree.md
+++ b/doc/articles/uno-development/debugging-inspect-visual-tree.md
@@ -7,14 +7,14 @@ Tools for inspecting the visual tree differ by platform.
 ## UWP 
 UWP has by far the easiest and most convenient experience for debugging the visual tree. The small black toolbar at the top center of your app during debugging enable buttons to go to the Live Visual Tree view, directly select a visual element for inspection, and show layouting decorations. The complement to the Live Visual Tree is the Live Property Explorer, which allows you to inspect current values for any property of a view, and even change some of them on the fly.  
 
-![UWP Live Visual Tree](Assets/debugging-inspect-visual-tree/UWP-Live-Visual-Tree.jpg)
+![UWP Live Visual Tree](assets/debugging-inspect-visual-tree/UWP-Live-Visual-Tree.jpg)
 
 ## Android 
 There are a couple of options for viewing the visual tree of an Uno app running on Android. 
 
 One approach is to use [Android Studio](https://developer.android.com/studio). You can then attach the debugger to your running process and take a snapshot with the [Layout Inspector](https://developer.android.com/studio/debug/layout-inspector), which allows you to select different elements visually, see their properties, see the whole visual tree, etc.
 
-![Android Studio Layout Inspector](Assets/debugging-inspect-visual-tree/Android-Layout-Inspector.jpg)
+![Android Studio Layout Inspector](assets/debugging-inspect-visual-tree/Android-Layout-Inspector.jpg)
 
 The other approach is to use the [Stetho package](https://www.nuget.org/packages/nventive.Stetho.Xamarin). It integrates into your app with a few lines of code, and then allows you to inspect the visual tree in Chrome. One nice feature is it allows you to press any element on the device's screen to locate it in the visual tree. 
 
@@ -26,7 +26,7 @@ In principle it's possible to use XCode's 'Debug View Hierarchy' feature on any 
 ## Web 
 For an Uno.WASM app you can simply use the layout inspection tools built into whatever browser you're using. For example, for Chrome, open the 'Developer tools' panel (`F12`) and select the 'Elements' tab, or just right-click any element in the visual tree and choose 'Inspect.'
 
-![DOM tree in Chrome](Assets/debugging-inspect-visual-tree/WASM-DOM-Elements.jpg)
+![DOM tree in Chrome](assets/debugging-inspect-visual-tree/WASM-DOM-Elements.jpg)
 
 ## Retrieving the visual tree through code/at a breakpoint (Android + iOS) 
 It's common enough when debugging Uno to be at a breakpoint and want to quickly know exactly where the view is in the visual tree, that we added a helper method.  
@@ -35,7 +35,7 @@ If you're using a debug build of Uno, this is directly available on UIElement as
 
 The method returns the visual tree from a certain 'height' above the target element as an indented string. So if you call ShowLocalVisualTree(2), you'll get the visual subtree from the target element's grandparent down. If you call ShowLocalVisualTree(100), you'll almost certainly get the entire visual tree starting from the root element. The original target is picked out with an asterisk (*) so you can find it.  
 
-![ShowLocalVisualTree() on iOS](Assets/debugging-inspect-visual-tree/iOS-ShowLocalVisualTree.jpg)
+![ShowLocalVisualTree() on iOS](assets/debugging-inspect-visual-tree/iOS-ShowLocalVisualTree.jpg)
 
 ## Tips for interpreting runtime view information 
 


### PR DESCRIPTION
GitHub Issue (If applicable): #1893 
## PR Type
What kind of change does this PR introduce?

- Bugfix
- Documentation content changes

## What is the current behavior?
Described in #1893, you can't see images in docs.


## What is the new behavior?
Fixed broken paths to images, now, they're visible


## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)

closes #1893 