### PR TITLE
Remove the space between "world" and "!"

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/Shared/MainPage.xaml
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Shared/MainPage.xaml
@@ -8,6 +8,6 @@
     mc:Ignorable="d">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-		<TextBlock Text="Hello, world !" Margin="20" FontSize="30" />
+		<TextBlock Text="Hello, world!" Margin="20" FontSize="30" />
     </Grid>
 </Page>


### PR DESCRIPTION
GitHub Issue (If applicable): #

Issue: #1895

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

There's a space between "world" and "!".

## What is the new behavior?

The space between "world" and "!" is removed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
