### PR TITLE
automation: avoid labeling external PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,5 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v2
+      if: github.repository == 'unoplatform/uno' 
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Doing this to avoid a long-standing bug in GitHub labeler action, which results in failure for the labeler for PRs from forks: https://github.com/actions/labeler/issues/12