### PR TITLE
Fix ContentControl.Content binding in Android ListView Header and Footer

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -164,6 +164,7 @@
 * Fix color refresh of `BitmapIcon` monochrome Foreground
 * [IOS] DatePickerFlyout min and max year were resetting to FallbackNullValue
 * [Android] Fix bug in `ListView` when using an `ObservableCollection` as its source and using `Header` and `Footer`.
+* [#1924](https://github.com/unoplatform/uno/issues/1924) Fix Android `ListView.HeaderTemplate` (and `.FooterTemplate`) binding bug when changing `Header` and `Footer`.
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/SamplesApp.UITests/Constants.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Constants.cs
@@ -15,6 +15,6 @@ namespace SamplesApp.UITests
 		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (3rd generation)";
 
 		// Default active platform when running under Visual Studio test runner
-		public const Platform CurrentPlatform = Platform.Browser;
+		public const Platform CurrentPlatform = Platform.Android;
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
@@ -81,5 +81,17 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 			_app.Screenshot($"ListView_VirtualizePanelAdaptaterCache");
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Android)]
+		public void ListView_Header_DataContextChanged()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ListView_Header_DataContextChanging");
+
+			_app.WaitForText("MyTextBlock", "InitialText InitialDataContext");
+			_app.Marked("MyButton").Tap();
+			_app.WaitForText("MyTextBlock", "InitialText InitialDataContext UpdatedDataContext");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -393,6 +393,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Header_DataContextChanging.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ItemsPanel_HotSwap.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2750,6 +2754,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ChangeView.xaml.cs">
       <DependentUpon>ListView_ChangeView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Header_DataContextChanging.xaml.cs">
+      <DependentUpon>ListView_Header_DataContextChanging.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ItemsPanel_HotSwap.xaml.cs">
       <DependentUpon>ListView_ItemsPanel_HotSwap.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Header_DataContextChanging.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Header_DataContextChanging.xaml
@@ -1,0 +1,39 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ListView_Header_DataContextChanging"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ListView"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d">
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<StackPanel>
+			<TextBlock x:Name="MyTextBlock"
+					   Text="InitialText" />
+
+			<Button x:Name="MyButton"
+					Content="Change DataContext"
+					Click="OnChangedDataContext" />
+		</StackPanel>
+
+		<ListView x:Name="MyListView"
+				  Grid.Row="1"
+				  Header="{Binding}">
+			<ListView.HeaderTemplate>
+				<DataTemplate>
+					<Border x:Name="MyBorder"
+							DataContextChanged="OnDataContextChanged"
+							Background="Red"
+							Height="50"
+							Width="50">
+						<TextBlock Text="{Binding}" />
+					</Border>
+				</DataTemplate>
+			</ListView.HeaderTemplate>
+		</ListView>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Header_DataContextChanging.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Header_DataContextChanging.xaml.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls
+{
+	[SampleControlInfo("ListView", "ListView_Header_DataContextChanging")]
+	public sealed partial class ListView_Header_DataContextChanging : UserControl
+	{
+		public ListView_Header_DataContextChanging()
+		{
+			this.InitializeComponent();
+
+			// Delay to refresh the content
+			_ = Dispatcher.RunIdleAsync(
+				async _ =>
+				{
+					DataContext = "InitialDataContext";
+				}
+			);
+		}
+
+		public void OnChangedDataContext(object sender, object args)
+		{
+			DataContext = "UpdatedDataContext";
+		}
+
+		public void OnDataContextChanged(object sender, object args)
+		{
+			// On android text updates from the header are not propagated during
+			// DataContext changed ?
+			_ = Dispatcher.RunAsync(
+				CoreDispatcherPriority.Normal,
+				async () =>
+				{
+					var dobj = (FrameworkElement)sender;
+					var change = dobj.DataContext?.ToString() ?? "null";
+
+					MyTextBlock.Text += " " + change;
+				}
+			);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBaseAdapter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBaseAdapter.Android.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using System.Diagnostics;
 using Windows.UI.Core;
 using Uno.UI.DataBinding;
+using Windows.UI.Xaml.Data;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -86,7 +87,10 @@ namespace Windows.UI.Xaml.Controls
 
 				container.DataContext = item;
 				container.ContentTemplate = dataTemplate;
-				container.Binding("Content", "");
+				if (container.GetBindingExpression(ContentControl.ContentProperty) == null)
+				{
+					container.SetBinding(ContentControl.ContentProperty, new Binding());
+				}
 			}
 			else if(viewType == IsOwnContainerType)
 			{


### PR DESCRIPTION
GitHub Issue: #1924

## PR Type

- Bugfix

## What is the current behavior?

Bindings for views inside `ListView.HeaderTemplate` receive `null` when changing `ListView.Header`.

## What is the new behavior?

Bindings for views inside `ListView.HeaderTemplate` don't receive `null` when changing `ListView.Header`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
