### PR TITLE
support /[file]/[name] format in ResourceLoader.GetForCurrentView().GetString()

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
@@ -50,7 +50,7 @@ namespace Windows.ApplicationModel.Resources
 		{
 			
 			// "/[file]/[name]" format support
-			if(resource.ElementAt(0) == '/')
+			if(resource.ElementAtOrDefault(0) == '/')
 			{
 				int iInd;
 				string sFile, sId;

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
@@ -48,6 +48,23 @@ namespace Windows.ApplicationModel.Resources
 
 		public string GetString(string resource)
 		{
+			
+			// "/[file]/[name]" format support
+			if(resource.ElementAt(0) == '/')
+			{
+				int iInd;
+				string sFile, sId;
+				sId = resource.Substring(1);
+				iInd = sId.IndexOf("/");
+				if(iInd > 0)
+				{
+					sFile = sId.Substring(0, iInd);
+					sId = sId.Substring(iInd + 1);
+					return GetForCurrentView(sFile).GetString(sId);
+				}
+			}
+
+			
 			// First make sure that resource cache matches the current culture
 			var cultures = EnsureLoadersCultures();
 


### PR DESCRIPTION
GitHub Issue (If applicable): #1928

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Feature
I don't know if it is bugfix - it is implementation of missed functionality.

## What is the current behavior?
ResourceLoader.GetForCurrentView().GetString("/file/name") returns empty string

## What is the new behavior?
ResourceLoader.GetForCurrentView().GetString("/file/name") returns string from selected resources file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs]  (tested as patch in 2.0.311-dev.3092 build).
- [ ] Docs have been added/updated which fit 
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests]
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Other information
 Made possible only because of Jerome Laban comment in Issue

