### PR TITLE
fixed a text wrapping issue caused by layout height desync

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -169,6 +169,7 @@
 * [IOS] DatePickerFlyout min and max year were resetting to FallbackNullValue
 * [Android] Fix bug in `ListView` when using an `ObservableCollection` as its source and using `Header` and `Footer`.
 * [#1924](https://github.com/unoplatform/uno/issues/1924) Fix Android `ListView.HeaderTemplate` (and `.FooterTemplate`) binding bug when changing `Header` and `Footer`.
+* 164480 [Android] fixed a text wrapping issue caused by layout height desync
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -429,6 +429,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextWrapping_PR1954_EdgeCase.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Visibility_Arrange.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2798,6 +2802,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Pivot\Pivot_CustomContent_Automated.xaml.cs">
       <DependentUpon>Pivot_CustomContent_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextWrapping_PR1954_EdgeCase.xaml.cs">
+      <DependentUpon>TextBlock_TextWrapping_PR1954_EdgeCase.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Visibility_Arrange.xaml.cs">
       <DependentUpon>TextBlock_Visibility_Arrange.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextWrapping_PR1954_EdgeCase.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextWrapping_PR1954_EdgeCase.xaml
@@ -38,14 +38,15 @@
 				Grid.Row="2" Grid.ColumnSpan="3"
 				Background="SkyBlue"
 				Width="138" Height="40">
-			<TextBlock x:Name="SampleText"
-					   Text="XyXyXyXyXyXyXyXyXyXyXyXyXyXy"
-					   VerticalAlignment="Center"
-					   Background="Pink"
-					   FontSize="16"
-					   MaxLines="2"
-					   TextWrapping="Wrap"
-					   TextTrimming="CharacterEllipsis" />
+			<Border Background="Pink">
+				<TextBlock x:Name="SampleText"
+						   Text="XyXyXyXyXyXyXyXyXyXyXyXyXyXy"
+						   VerticalAlignment="Center"
+						   FontSize="16"
+						   MaxLines="2"
+						   TextWrapping="Wrap"
+						   TextTrimming="CharacterEllipsis" />
+				</Border>
 		</Border>
 	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextWrapping_PR1954_EdgeCase.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextWrapping_PR1954_EdgeCase.xaml
@@ -1,0 +1,51 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_TextWrapping_PR1954_EdgeCase"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<!-- Description, Button, -Button -->
+			<!-- Description, Button, -Button -->
+			<!-- 0-2: Sample -->
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="Auto" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<!-- 0: Text length controllers -->
+			<!-- 1: Container height controllers -->
+			<!-- 2: Sample -->
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<!-- R0: Text length controllers -->
+		<TextBlock Grid.Row="0" Grid.Column="0" Text="Text length" />
+		<Button Grid.Row="0" Grid.Column="1" Content="+" Click="AdjustTextLength" />
+		<Button Grid.Row="0" Grid.Column="2" Content="-" Click="AdjustTextLength" />
+
+		<TextBlock Grid.Row="1" Grid.Column="0" Text="Container height" />
+		<Button Grid.Row="1" Grid.Column="1" Content="+" Click="AdjustContainerHeight" />
+		<Button Grid.Row="1" Grid.Column="2" Content="-" Click="AdjustContainerHeight" />
+
+		<Border x:Name="SampleContainer"
+				Grid.Row="2" Grid.ColumnSpan="3"
+				Background="SkyBlue"
+				Width="138" Height="40">
+			<TextBlock x:Name="SampleText"
+					   Text="XyXyXyXyXyXyXyXyXyXyXyXyXyXy"
+					   VerticalAlignment="Center"
+					   Background="Pink"
+					   FontSize="16"
+					   MaxLines="2"
+					   TextWrapping="Wrap"
+					   TextTrimming="CharacterEllipsis" />
+		</Border>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextWrapping_PR1954_EdgeCase.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextWrapping_PR1954_EdgeCase.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", nameof(TextBlock_TextWrapping_PR1954_EdgeCase), description: "[Droid]Repro sample for PR1954. When the text is limited to 1 line, due to enough height available for 2 lines, it should take the size of 1 line only. You may need to adjust text lenght and/or container height depending on the device. Expected behavior: text should always be in the center of pink area")]
+	public sealed partial class TextBlock_TextWrapping_PR1954_EdgeCase : UserControl
+	{
+		public TextBlock_TextWrapping_PR1954_EdgeCase()
+		{
+			this.InitializeComponent();
+		}
+
+		private void AdjustTextLength(object sender, RoutedEventArgs e)
+		{
+			if (GetButtonDirection(sender) is bool direction)
+			{
+				var text = SampleText.Text;
+				if (text.Length > 0 || direction)
+				{
+					SampleText.Text = direction
+						? text + "Xy"[text.Length % 2]
+						: text.Substring(0, text.Length - 1);
+				}
+			}
+		}
+
+		private void AdjustContainerHeight(object sender, RoutedEventArgs e)
+		{
+			if (GetButtonDirection(sender) is bool direction)
+			{
+				if (SampleContainer.Height + (direction ? 5 : -5) is var finalHeight && finalHeight > 0)
+				{
+					SampleContainer.Height = finalHeight;
+				}
+			}
+		}
+
+		private bool? GetButtonDirection(object sender)
+		{
+			switch ((sender as Windows.UI.Xaml.Controls.Button)?.Content)
+			{
+				case "+": return true;
+				case "-": return false;
+
+				default: return default;
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -572,6 +572,9 @@ namespace Windows.UI.Xaml.Controls
 						desiredWidth,
 						maxLines: lineAtHeight
 					);
+
+					// re-measuring the height at the new line count
+					measuredHeight = Layout.GetLineTop(Layout.LineCount);
 				}
 
 				return new Size(PhysicalToLogicalPixels(Layout.Width), PhysicalToLogicalPixels(measuredHeight));


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Currently when the `TextBlock` changes layout to accommodate for the available height, the height measured with the old layout is returned.

## What is the new behavior?
The height is recalculated on layout changes.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
Internal Issue (If applicable):
[AB#164480](https://dev.azure.com/nventive/67eedefd-9293-4f70-a624-89ecbe8ad34f/_workitems/edit/164480)
https://github.com/unoplatform/private/issues/83