### PR TITLE
StorageFile:DeleteAsync support

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -3,7 +3,7 @@
 ## Next version
 
 ### Features
-
+* StorageFile:DeleteAsync() support 
 * [#1919](https://github.com/unoplatform/uno/pull/1919) Support for `PathGeometry` on WASM.
 * Support for `Geolocator` on WASM, improvements for support on Android, iOS
 * [#1813](https://github.com/unoplatform/uno/pull/1813) - Added polyline support for WASM and samples for all shapes

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageItem.cs
@@ -37,7 +37,7 @@ namespace Windows.Storage
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		global::Windows.Foundation.IAsyncAction RenameAsync( string desiredName,  global::Windows.Storage.NameCollisionOption option);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __MACOS__
 		global::Windows.Foundation.IAsyncAction DeleteAsync();
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageItem.cs
@@ -37,7 +37,7 @@ namespace Windows.Storage
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		global::Windows.Foundation.IAsyncAction RenameAsync( string desiredName,  global::Windows.Storage.NameCollisionOption option);
 		#endif
-		#if false || false || NET461 || false || false
+		#if false || false || false || false || false
 		global::Windows.Foundation.IAsyncAction DeleteAsync();
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageItem.cs
@@ -37,7 +37,7 @@ namespace Windows.Storage
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		global::Windows.Foundation.IAsyncAction RenameAsync( string desiredName,  global::Windows.Storage.NameCollisionOption option);
 		#endif
-		#if false || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || false || false
 		global::Windows.Foundation.IAsyncAction DeleteAsync();
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
@@ -180,7 +180,7 @@ namespace Windows.Storage
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.RenameAsync(string desiredName, NameCollisionOption option) is not implemented in Uno.");
 		}
 		#endif
-		#if false || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || false || false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction DeleteAsync()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
@@ -180,7 +180,7 @@ namespace Windows.Storage
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.RenameAsync(string desiredName, NameCollisionOption option) is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || false || false
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction DeleteAsync()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
@@ -180,7 +180,7 @@ namespace Windows.Storage
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.RenameAsync(string desiredName, NameCollisionOption option) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction DeleteAsync()
 		{

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -34,7 +34,19 @@ namespace Windows.Storage
 			_fileUri = uri;
 		}
 
-		public async Task DeleteAsync(CancellationToken ct)
+		public async Task DeleteAsync()
+		{
+			if (Scheme != "FILE")
+			{
+				throw new InvalidOperationException("Cannot delete a file on a non local storage.");
+			}
+
+			var fileInfo = new FileInfo(Path);
+
+			fileInfo.Delete();
+		}
+
+public async Task DeleteAsync(CancellationToken ct)
 		{
 			if (Scheme != "FILE")
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #1187 (partly)

## PR Type
- Feature

## What is the current behavior?
StorageFile:DeleteAsync not supported (workaround exist)

## What is the new behavior?
StorageFile:DeleteAsync supported

## PR Checklist

Please check if your PR fulfills the following requirements:
- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
