### PR TITLE
more functional Geolocator.RequestAccessAsync()

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -100,7 +100,7 @@
     > This change might break the compilation for projects that define duplicate resources in other globally accessible resource dictionaries. Adjustments to remove duplicate resources may be necessary.
 
 ### Bug fixes
-
+* [droid] Geolocator:RequestAccessAsync() returns real state of permission, not always Granted.
 * [#1987](https://github.com/unoplatform/uno/pull/1987) Missing XML comment warnings are disabled on generated code
 * [#1939](https://github.com/unoplatform/uno/pull/1939) Handles nullables types in XAML file generator
 * [#1741](https://github.com/unoplatform/uno/issues/1741) On Android, `ApplicationData.Current.[LocalFolder|RoamingFolder]` can now be used in the ctor of App.xaml.cs

--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -36,7 +36,24 @@ namespace Windows.Devices.Geolocation
 		public Task<Geoposition> GetGeopositionAsync(TimeSpan maximumAge, TimeSpan timeout)
 			=> GetGeopositionAsync();
 
-		public static async Task<GeolocationAccessStatus> RequestAccessAsync() => GeolocationAccessStatus.Allowed;
+		public static async Task<GeolocationAccessStatus> RequestAccessAsync()
+		{
+			// below 6.0 (API 23), permission are granted
+			if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.M)
+			{
+				return GeolocationAccessStatus.Allowed;
+			}
+
+			// check if permission is granted
+			if (Android.Support.V4.Content.ContextCompat.CheckSelfPermission(Uno.UI.ContextHelper.Current, Android.Manifest.Permission.AccessFineLocation)
+					== Android.Content.PM.Permission.Granted)
+			{
+				return GeolocationAccessStatus.Allowed;
+			}
+
+			return GeolocationAccessStatus.Denied;
+
+		}
 
 		private LocationManager InitializeLocationProvider(double desiredAccuracy)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #1967

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
RequestAccessAsync() => GeolocationAccessStatus.Allowed;

## What is the new behavior?
Above is correct only on API <23. 
Now, it RequestAccessAsync() returns real GeolocationAccessStatus.

## PR Checklist
- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
