### PR TITLE
[iOS] Enable and Fix DatePicker tests

### DIFF
--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -26,8 +26,10 @@ mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-conso
 	--inprocess \
 	--agents=1 \
 	--workers=1 \
-	--where "namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests'" \
-	--where "namespace = 'SamplesApp.UITests'" \
-	--where "namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests'" \
+	--where " \
+	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests' or \
+	namespace = 'SamplesApp.UITests' or \
+	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' \
+	" \
 	$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/net47/SamplesApp.UITests.dll \
 	|| true

--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -28,5 +28,6 @@ mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-conso
 	--workers=1 \
 	--where "namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests'" \
 	--where "namespace = 'SamplesApp.UITests'" \
+	--where "namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests'" \
 	$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/net47/SamplesApp.UITests.dll \
 	|| true

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -97,7 +97,7 @@ namespace SamplesApp.UITests
 			var fileNameWithoutExt = Path.GetFileNameWithoutExtension(fileInfo.Name);
 			if (fileNameWithoutExt != title)
 			{
-				var destFileName = Path.Combine(Path.GetDirectoryName(fileInfo.FullName), fileNameWithoutExt + "." + Path.GetExtension(fileInfo.Name));
+				var destFileName = Path.Combine(Path.GetDirectoryName(fileInfo.FullName), title + Path.GetExtension(fileInfo.Name));
 				if (File.Exists(destFileName))
 				{
 					File.Delete(destFileName);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Test_NativeButtons.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Test_NativeButtons.cs
@@ -11,7 +11,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 	public class UnoSamples_Test_NativeButtons : SampleControlUITestBase
 	{
 		[Test]
-		[ActivePlatforms(Platform.iOS, Platform.Android)]
+		[ActivePlatforms(Platform.Android)] // Disabled on iOS: https://github.com/unoplatform/uno/issues/1955
 		[AutoRetry]
 		public void NativeButtonTests()
 		{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_Opacity_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_Opacity_Automated.cs
@@ -16,6 +16,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 	{
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.Browser)] // Disabled on iOS: https://github.com/unoplatform/uno/issues/1955
 		public void Button_IsOpacity_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.ButtonTestsControl.Button_Opacity_Automated");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -24,14 +24,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			_app.WaitForElement(_app.Marked("theDatePicker"));
 
 			var theDatePicker = _app.Marked("theDatePicker");
-			var datePickerFlyout = theDatePicker.Child;
+			var datePickerFlyout = _app.CreateQuery(q => q.WithClass("Windows_UI_Xaml_Controls_DatePickerSelector"));
+
+			Console.WriteLine($"1: {theDatePicker.GetDependencyPropertyValue<string>("DataContext")}");
+
+			_app.WaitForDependencyPropertyValue(theDatePicker, "DataContext", "UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.Models.DatePickerViewModel");
 
 			// Open flyout
 			theDatePicker.Tap();
 
-			//Assert
-			Assert.IsNotNull(theDatePicker.GetDependencyPropertyValue("DataContext"));
-			Assert.IsNotNull(datePickerFlyout.GetDependencyPropertyValue("DataContext"));
+			_app.WaitForElement(datePickerFlyout);
+
+			_app.WaitForDependencyPropertyValue(datePickerFlyout, "DataContext", "UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.Models.DatePickerViewModel");
+
 		}
 
 		[Test]
@@ -44,13 +49,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			_app.WaitForElement(_app.Marked("theDatePicker"));
 
 			var theDatePicker = _app.Marked("theDatePicker");
-			var datePickerFlyout = theDatePicker.Child;
+			var datePickerFlyout = _app.CreateQuery(q => q.WithClass("Windows_UI_Xaml_Controls_DatePickerFlyoutPresenter"));
 
 			// Open flyout
 			theDatePicker.Tap();
 
-			//Assert
-			Assert.IsNotNull(datePickerFlyout.GetDependencyPropertyValue("Content"));
+			_app.WaitForDependencyPropertyValue(datePickerFlyout, "Content", "Windows.UI.Xaml.Controls.DatePickerSelector");
 		}
 
 		[Test]
@@ -81,13 +85,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			_app.WaitForElement(_app.Marked("theDatePicker"));
 
 			var theDatePicker = _app.Marked("theDatePicker");
-			var datePickerFlyout = theDatePicker.Child;
+			var datePickerFlyout = _app.CreateQuery(q => q.WithClass("Windows_UI_Xaml_Controls_DatePickerSelector"));
+
+			_app.WaitFor(() => theDatePicker.GetDependencyPropertyValue<string>("MinYear") != null);
+			var minYear = theDatePicker.GetDependencyPropertyValue<string>("MinYear");
 
 			// Open flyout
 			theDatePicker.Tap();
 
-			//Assert
-			Assert.AreEqual(datePickerFlyout.GetDependencyPropertyValue("MinYear")?.ToString(), theDatePicker.GetDependencyPropertyValue("MinYear")?.ToString());
+			_app.WaitFor(() => datePickerFlyout.GetDependencyPropertyValue<string>("MinYear") == minYear);
 		}
 
 		[Test]
@@ -100,13 +106,16 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			_app.WaitForElement(_app.Marked("theDatePicker"));
 
 			var theDatePicker = _app.Marked("theDatePicker");
-			var datePickerFlyout = theDatePicker.Child;
+			var datePickerFlyout = _app.CreateQuery(q => q.WithClass("Windows_UI_Xaml_Controls_DatePickerSelector"));
+
+			_app.WaitFor(() => theDatePicker.GetDependencyPropertyValue<string>("MaxYear") != null);
+			var maxYear = theDatePicker.GetDependencyPropertyValue<string>("MaxYear");
 
 			// Open flyout
 			theDatePicker.Tap();
 
 			//Assert
-			Assert.AreEqual(datePickerFlyout.GetDependencyPropertyValue("MaxYear")?.ToString(), theDatePicker.GetDependencyPropertyValue("MaxYear")?.ToString());
+			_app.WaitFor(() => datePickerFlyout.GetDependencyPropertyValue<string>("MaxYear") == maxYear);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -87,7 +87,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			theDatePicker.Tap();
 
 			//Assert
-			Assert.AreEqual(datePickerFlyout.GetDependencyPropertyValue("MinYear").ToString(), theDatePicker.GetDependencyPropertyValue("MinYear").ToString());
+			Assert.AreEqual(datePickerFlyout.GetDependencyPropertyValue("MinYear")?.ToString(), theDatePicker.GetDependencyPropertyValue("MinYear")?.ToString());
 		}
 
 		[Test]
@@ -106,7 +106,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			theDatePicker.Tap();
 
 			//Assert
-			Assert.AreEqual(datePickerFlyout.GetDependencyPropertyValue("MaxYear").ToString(), theDatePicker.GetDependencyPropertyValue("MaxYear").ToString());
+			Assert.AreEqual(datePickerFlyout.GetDependencyPropertyValue("MaxYear")?.ToString(), theDatePicker.GetDependencyPropertyValue("MaxYear")?.ToString());
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.iOS.cs
@@ -76,7 +76,7 @@ namespace Windows.UI.Xaml.Controls
 				"Content",
 				typeof(IUIElement),
 				typeof(DatePickerFlyout),
-				new FrameworkPropertyMetadata(default(IUIElement), FrameworkPropertyMetadataOptions.AffectsMeasure, OnContentChanged));
+				new FrameworkPropertyMetadata(default(IUIElement), FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.ValueInheritsDataContext, OnContentChanged));
 		private DatePickerFlyoutPresenter _datePickerPresenter;
 
 		private static void OnContentChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
@@ -88,6 +88,7 @@ namespace Windows.UI.Xaml.Controls
 				if (args.NewValue is IDependencyObjectStoreProvider binder)
 				{
 					binder.Store.SetValue(binder.Store.TemplatedParentProperty, flyout.TemplatedParent, DependencyPropertyValuePrecedences.Local);
+					binder.Store.SetValue(binder.Store.DataContextProperty, flyout.DataContext, DependencyPropertyValuePrecedences.Local);
 				}
 
 				flyout._datePickerPresenter.Content = args.NewValue;

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -37,6 +37,8 @@ namespace Windows.UI.Xaml.Controls
 
 				RegisterValueChanged();
 			}
+
+			UpdatMinMaxYears();
 		}
 
 		private void RegisterValueChanged()
@@ -67,53 +69,52 @@ namespace Windows.UI.Xaml.Controls
 			// Animate to cover up the small delay in setting the date when the flyout is opened
 			var animated = !UIDevice.CurrentDevice.CheckSystemVersion(10, 0);
 
-			if (newDate < MinYear || newDate > MaxYear)
+			if (newDate < MinYear )
 			{
-				Date = oldDate;
+				Date = MinYear;
 			}
-			else
+			else if(newDate > MaxYear)
 			{
-				_picker?.SetDate(
-					DateTime.SpecifyKind(newDate.DateTime, DateTimeKind.Local).ToNSDate(),
-					animated: animated
-				);
+				Date = MaxYear;
 			}
+
+			_picker?.SetDate(
+				DateTime.SpecifyKind(Date.DateTime, DateTimeKind.Local).ToNSDate(),
+				animated: animated
+			);
 		}
 
 		partial void OnMinYearChangedPartialNative(DateTimeOffset oldMinYear, DateTimeOffset newMinYear)
-		{
-			if (_picker == null)
-			{
-				return;
-			}
-
-			var calendar = new NSCalendar(NSCalendarType.Gregorian);
-			var minimumDateComponents = new NSDateComponents
-			{
-				Day = newMinYear.Day,
-				Month = newMinYear.Month,
-				Year = newMinYear.Year
-			};
-
-			_picker.MinimumDate = calendar.DateFromComponents(minimumDateComponents);
-		}
+			=> UpdatMinMaxYears();
 
 		partial void OnMaxYearChangedPartialNative(DateTimeOffset oldMaxYear, DateTimeOffset newMaxYear)
+			=> UpdatMinMaxYears();
+
+		private void UpdatMinMaxYears()
 		{
 			if (_picker == null)
 			{
 				return;
 			}
-			
+
 			var calendar = new NSCalendar(NSCalendarType.Gregorian);
 			var maximumDateComponents = new NSDateComponents
 			{
-				Day = newMaxYear.Day,
-				Month = newMaxYear.Month,
-				Year = newMaxYear.Year
+				Day = MaxYear.Day,
+				Month = MaxYear.Month,
+				Year = MaxYear.Year
 			};
 
 			_picker.MaximumDate = calendar.DateFromComponents(maximumDateComponents);
+
+			var minimumDateComponents = new NSDateComponents
+			{
+				Day = MinYear.Day,
+				Month = MinYear.Month,
+				Year = MinYear.Year
+			};
+
+			_picker.MinimumDate = calendar.DateFromComponents(minimumDateComponents);
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
- iOS DatePicker tests are not enabled
- Selecting a date outside of the bounds does not properly reset to the min or max bounds
- The Min and Max dates visual cues are not enabled properly in the native picker

## What is the new behavior?
- UI Tests are now enabled
- Selecting a date outside of the bounds clamps to the nearest bound
- Min and Max visual cues are enabled
- Fix for invalid iOS and Android screenshot file names

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): https://nventive.visualstudio.com/Umbrella/_workitems/edit/163432
