### PR TITLE
Fix iOS Picker selection

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -177,6 +177,7 @@
 * [#1924](https://github.com/unoplatform/uno/issues/1924) Fix Android `ListView.HeaderTemplate` (and `.FooterTemplate`) binding bug when changing `Header` and `Footer`.
 * 164480 [Android] fixed a text wrapping issue caused by layout height desync
 * [Wasm] Fix unable to reset `Image.Source` property
+* [#2014](https://github.com/unoplatform/uno/issues/2014) Fix iOS Picker for ComboBox not selecting the correct item.
 
 ## Release 1.45.0
 ### Features

--- a/src/Uno.UI/UI/Xaml/Controls/Picker/Picker.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Picker/Picker.iOS.cs
@@ -16,6 +16,11 @@ using Uno.Extensions.Specialized;
 
 namespace Windows.UI.Xaml.Controls
 {
+	/// <summary>
+	/// This class is mainly used for native looking ComboBox templates on iPhone.
+	/// This class will automatically prepend a null item to its Items when there's no selection.
+	/// Once a selection is made, that null item is removed. That means that this control cannot deselect (just like a ComboBox).
+	/// </summary>
 	public partial class Picker : UIPickerView, ISelector, IFrameworkElement, DependencyObject
 	{
 		public event SelectionChangedEventHandler SelectionChanged;
@@ -62,7 +67,7 @@ namespace Windows.UI.Xaml.Controls
 			return size;
 		}
 
-		public object[] Items { get; private set; } = new object[] { null }; // ensure there's always a null present to allow deselection
+		public object[] Items { get; private set; } = new object[] { null }; // Ensure there's always a null present to allow the empty selection at the beginning.
 
 		partial void OnItemsSourceChangedPartialNative(object oldItemsSource, object newItemsSource)
 		{
@@ -111,6 +116,8 @@ namespace Windows.UI.Xaml.Controls
 					SelectedItem = firstItem;
 					return;
 				}
+
+				Select(row, component: 0, animated: true);
 			}
 			else if (newSelectedItem != null && Items[0] == null)
 			{
@@ -118,9 +125,16 @@ namespace Windows.UI.Xaml.Controls
 				Items = Items
 					.Skip(1)
 					.ToObjectArray();
-			}
 
-			Select(row, component: 0, animated: true);
+				// Now that Items changed, we must reload the UIPickerView's components.
+				ReloadAllComponents();
+
+				// Because we removed the first item, we decrement the row by 1.
+				--row;
+
+				// We select the row without the animation, because the previous state has a different items source in wich the items have different indexes.
+				Select(row, component: 0, animated: false);
+			}
 
 			SelectionChanged?.Invoke(
 				this,


### PR DESCRIPTION
GitHub Issue (If applicable): #2014

## PR Type

- Bugfix

## What is the current behavior?

`Picker.SelectedItem` doesn't match what the native picker displays.

## What is the new behavior?

`Picker.SelectedItem` matches what the native picker displays.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
