### PR TITLE
Align ContentControl Behavior with UWP behavior for empty children.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -89,7 +89,6 @@
 * The _feature flag_ `FeatureConfiguration.UseLegacyClipping` is now deprecated and not used anymore
 
 ### Breaking changes
-
 * `TextBox` no longer raises TextChanged when its template is applied, in line with UWP.
 * `TextBox.TextChanged` is now called asynchronously after the UI is updated, in line with UWP. For most uses `TextChanging` should be preferred.
 * [Android] `TextBox.IsSpellCheckEnabled = false` is now enforced in a way that may cause issues in certain use cases (see https://stackoverflow.com/a/5188119/1902058). The old behavior can be restored by setting `ShouldForceDisableSpellCheck = false`, per `TextBox`.

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -101,7 +101,7 @@
     > This change might break the compilation for projects that define duplicate resources in other globally accessible resource dictionaries. Adjustments to remove duplicate resources may be necessary.
 
 ### Bug fixes
-
+* [#2020](https://github.com/unoplatform/uno/pull/2020) `ContentControl` no longer display the datacontext type when ContentTemplate and content are empty
 * [#1987](https://github.com/unoplatform/uno/pull/1987) Missing XML comment warnings are disabled on generated code
 * [#1939](https://github.com/unoplatform/uno/pull/1939) Handles nullables types in XAML file generator
 * [#1741](https://github.com/unoplatform/uno/issues/1741) On Android, `ApplicationData.Current.[LocalFolder|RoamingFolder]` can now be used in the ctor of App.xaml.cs

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ContentControlTests/ContentControlBehaviorTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ContentControlTests/ContentControlBehaviorTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml.ContentControlTests
+{
+	public class ContentControlBehaviorTests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void LoadEmptyContentControl()
+		{
+			Run("SamplesApp.Windows_UI_Xaml_Controls.ContentControlNoTemplateNoContent");
+
+			_app.WaitForElement("CContentControl");
+			TakeScreenshot($"CContentControl");
+			TabWaitAndThenScreenshot("bntContentClear");
+
+			void TabWaitAndThenScreenshot(string buttonName)
+			{
+				_app.Marked(buttonName).Tap();
+				TakeScreenshot($"ContentControlNoTemplateNoContent - {buttonName}");
+			}
+
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -361,6 +361,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentControlTestsControl\ContentControlNoTemplateNoContent.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentControlTestsControl\ContentControl_NoTemplateDataContext.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2860,6 +2864,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Generic.xaml.cs">
       <DependentUpon>BitmapIcon_Generic.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentControlTestsControl\ContentControlNoTemplateNoContent.xaml.cs">
+      <DependentUpon>ContentControlNoTemplateNoContent.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentDialogTests\ComboBoxContentDialog.xaml.cs">
       <DependentUpon>ComboBoxContentDialog.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentControlTestsControl/ContentControlNoTemplateNoContent.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentControlTestsControl/ContentControlNoTemplateNoContent.xaml
@@ -1,0 +1,22 @@
+﻿<Page
+    x:Class="SamplesApp.Windows_UI_Xaml_Controls.ContentControlNoTemplateNoContent"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<DataTemplate x:Key="ContentControlTemplate">
+			<StackPanel>
+				<TextBlock Text="{Binding}" />
+			</StackPanel>
+		</DataTemplate>
+	</Page.Resources>
+
+	<StackPanel>
+		<ContentControl x:Name="CContentControl" ContentTemplate="{StaticResource ContentControlTemplate}" Content="I'm a content"/>
+		<Button x:Name="bntContentClear" Content="Clear ContentControl" Click="bntContentClear_click" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentControlTestsControl/ContentControlNoTemplateNoContent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentControlTestsControl/ContentControlNoTemplateNoContent.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace SamplesApp.Windows_UI_Xaml_Controls
+{
+	[SampleControlInfo("ContentControlTestsControl", "ContentControl_NoTemplateNoContent")]
+	public sealed partial class ContentControlNoTemplateNoContent : Page
+	{
+		public ContentControlNoTemplateNoContent()
+		{
+			this.InitializeComponent();
+		}
+
+		public void bntContentClear_click(object sender, RoutedEventArgs e)
+		{
+			CContentControl.Content = null;
+			CContentControl.ContentTemplate = null;
+			CContentControl.DataContext = null;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PolylinePage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PolylinePage.xaml.cs
@@ -14,8 +14,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace SamplesApp.Windows_UI_Xaml_Shapes
 {
 	[SampleControlInfo("Shapes", "PolylinePage")]

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -67,9 +67,19 @@ namespace Windows.UI.Xaml.Controls
 		{
 			get
 			{
-				return this.IsDependencyPropertySet(ContentProperty)
-					? GetValue(ContentProperty)
-					: DataContext;
+				if(this.IsDependencyPropertySet(ContentProperty))
+				{
+					return GetValue(ContentProperty);
+				}
+				else if(ContentTemplate != null)
+				{										 
+				   return DataContext;
+				}
+				else
+				{
+					return null;
+				}
+
 			}
 			set { SetValue(ContentProperty, value); }
 		}
@@ -323,7 +333,7 @@ namespace Windows.UI.Xaml.Controls
 
 				if (Content != null
 					&& !(Content is View)
-					&& ContentTemplateRoot == null
+					&& ContentTemplateRoot == null && dataTemplate == null && ContentTemplate == null
 				)
 				{
 					SetContentTemplateRootToPlaceholder();

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -67,19 +67,19 @@ namespace Windows.UI.Xaml.Controls
 		{
 			get
 			{
-				if(this.IsDependencyPropertySet(ContentProperty))
+				if (this.IsDependencyPropertySet(ContentProperty))
 				{
 					return GetValue(ContentProperty);
 				}
-				else if(ContentTemplate != null)
-				{										 
-				   return DataContext;
+				else if (ContentTemplate != null)
+				{
+					return DataContext;
 				}
 				else
 				{
+					// Return null to be sure that the Content will be empty and prevent the type to be dispayed.
 					return null;
 				}
-
 			}
 			set { SetValue(ContentProperty, value); }
 		}
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Controls
 					ContentTemplateRoot = null;
 				}
 
-				if(newValue != null)
+				if (newValue != null)
 				{
 					SetUpdateTemplate();
 				}
@@ -333,7 +333,9 @@ namespace Windows.UI.Xaml.Controls
 
 				if (Content != null
 					&& !(Content is View)
-					&& ContentTemplateRoot == null && dataTemplate == null && ContentTemplate == null
+					&& ContentTemplateRoot == null
+					&& dataTemplate == null
+					&& ContentTemplate == null
 				)
 				{
 					SetContentTemplateRootToPlaceholder();
@@ -428,20 +430,20 @@ namespace Windows.UI.Xaml.Controls
 		/// Return false in this case, even if the Template is null.
 		/// </remarks>
 		internal bool IsContentPresenterBypassEnabled => Template == null && !HasDefaultTemplate(GetDefaultStyleType());
-		
+
 		/// <summary>
 		/// Gets whether the default style for the given type sets a non-null Template.
 		/// </summary>
-		private static Func<Type, bool> HasDefaultTemplate = 
+		private static Func<Type, bool> HasDefaultTemplate =
 			Funcs.CreateMemoized((Type type) =>
-				Style.DefaultStyleForType(type) is Style defaultStyle 
+				Style.DefaultStyleForType(type) is Style defaultStyle
 					&& defaultStyle
 						.Flatten(s => s.BasedOn)
 						.SelectMany(s => s.Setters)
 						.OfType<Setter>()
 						.Any(s => s.Property == TemplateProperty && s.Value != null)
 			);
-		
+
 		/// <summary>
 		/// Creates a ContentControl which can be measured without being added to the visual tree (eg as container in virtualized lists).
 		/// </summary>


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When a ContentControl in the Visual Tree does not have child elements, the dataContext is displayed instead of nothing like on UWP
## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Now when a ContentControl does not have content, the control will be empty.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
