### PR TITLE
StorageFile.DateCreated support

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -3,7 +3,7 @@
 ## Next version
 
 ### Features
-* StorageFile:DateCreated is supported
+* Add support for `StorageFile.DateCreated`
 * [#1970](https://github.com/unoplatform/uno/pull/1970) Added support for `AnalyticsInfo` properties on iOS, Android and WASM
 * [#1207] Implemented some `PackageId` properties
 * [#1919](https://github.com/unoplatform/uno/pull/1919) Support for `PathGeometry` on WASM.

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -3,7 +3,7 @@
 ## Next version
 
 ### Features
-
+* StorageFile:DateCreated is supported
 * [#1970](https://github.com/unoplatform/uno/pull/1970) Added support for `AnalyticsInfo` properties on iOS, Android and WASM
 * [#1207] Implemented some `PackageId` properties
 * [#1919](https://github.com/unoplatform/uno/pull/1919) Support for `PathGeometry` on WASM.

--- a/src/SamplesApp/SamplesApp.UITests/Windows_Storage/StorageFileTests/UnoSamples_Test_StorageFile_DateCreated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_Storage/StorageFileTests/UnoSamples_Test_StorageFile_DateCreated.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_Storage.StorageFileTests
+{
+	[TestFixture]
+	class UnoSamples_Test_StorageFile_DateCreated : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)]
+		public void StorageFile_DateCreated()
+		{
+			Run("UITests.Shared.Windows_Storage.StorageFileTests.StorageFile_DateCreated");
+
+			_app.WaitForElement(_app.Marked("sfdButtonCreate"));
+
+			TakeScreenshot("Initial");
+
+			var resultMessage = _app.Marked("sfdResult");
+
+			// step 1: create file
+			_app.Tap(_app.Marked("sfdButtonCreate"));
+
+			_app.WaitForText(resultMessage, "created");  // timeout here means: something impossible?
+
+			// step 2: test date just after create
+			_app.Tap(_app.Marked("sfdButtonTest"));
+			_app.WaitForText(resultMessage, "success");   // timeout here means: date is wrong
+			TakeScreenshot("AfterFirstCheck");
+
+			// step 3: test date several seconds later
+			_app.Wait(TimeSpan.FromSeconds(30));
+			_app.Tap(_app.Marked("sfdButtonTest"));
+			_app.WaitForText(resultMessage, "success");   // timeout here means: DateCreated returns other date (maybe current date)
+
+			TakeScreenshot("AfterSuccess");
+
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_Storage/StorageFileTests/UnoSamples_Test_StorageFile_DateCreated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_Storage/StorageFileTests/UnoSamples_Test_StorageFile_DateCreated.cs
@@ -38,7 +38,7 @@ namespace SamplesApp.UITests.Windows_Storage.StorageFileTests
 			TakeScreenshot("AfterFirstCheck");
 
 			// step 3: test date several seconds later
-			_app.Wait(TimeSpan.FromSeconds(30));
+			_app.Wait(TimeSpan.FromSeconds(10));
 			_app.Tap(_app.Marked("sfdButtonTest"));
 			_app.WaitForText(resultMessage, "success");   // timeout here means: DateCreated returns other date (maybe current date)
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -81,6 +81,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_Storage\StorageFileTests\StorageFile_DateCreated.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_Storage\StorageFolderTests\Persistence.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2660,6 +2664,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Phone\Devices_Notifications_VibrationDevice.xaml.cs">
       <DependentUpon>Devices_Notifications_VibrationDevice.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_Storage\StorageFileTests\StorageFile_DateCreated.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Storage\StorageFolderTests\Persistence.xaml.cs">
       <DependentUpon>Persistence.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/StorageFileTests/StorageFile_DateCreated.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/StorageFileTests/StorageFile_DateCreated.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_Storage.StorageFileTests.StorageFile_DateCreated"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_Storage.StorageFileTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<StackPanel>
+			<TextBlock x:Name="sfdResult" Text="Waiting..." />
+			<Button x:Name="sfdButtonCreate" Content="Create file" Click="sfdButtonCreate_Click"/>
+			<Button x:Name="sfdButtonTest" Content="Test date" Click="sfdButtonTest_Click"/>
+		</StackPanel>
+
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/StorageFileTests/StorageFile_DateCreated.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/StorageFileTests/StorageFile_DateCreated.xaml.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_Storage.StorageFileTests
+{
+	[Uno.UI.Samples.Controls.SampleControlInfo("StorageFile", "StorageFile_DateCreated", description: "Testing attribute DateCreated of StorageFile")]
+	public sealed partial class StorageFile_DateCreated : UserControl
+    {
+        public DateCreated()
+        {
+            this.InitializeComponent();
+        }
+
+		static string _name;
+		static DateTimeOffset _date;
+
+		private void sfdButtonCreate_Click(object sender, RoutedEventArgs e)
+		{
+			// creating
+			_date = DateTimeOffset.Now;
+			_name = _date.ToString("hhMMss") + ".txt";
+			Windows.Storage.StorageFolder fold = Windows.Storage.ApplicationData.Current.LocalFolder;
+			System.IO.File.Create(fold.Path + "\\" + _name);
+			//Windows.Storage.StorageFile file;
+			//file = await Windows.Storage.StorageFile.GetFileFromPathAsync(fold.Path + "\\" + _name);
+			//file = await fold.CreateFileAsync(_name);
+			sfdResult.Text = "created";
+		}
+
+
+		private async void sfdButtonTest_Click(object sender, RoutedEventArgs e)
+		{
+			Windows.Storage.StorageFolder fold = Windows.Storage.ApplicationData.Current.LocalFolder;
+			Windows.Storage.StorageFile file = await fold.GetFileAsync(_name);
+
+			DateTimeOffset filedate = file.DateCreated;
+			if (Math.Abs((filedate - _date).TotalSeconds) < 2)
+			{
+				sfdResult.Text = "success";
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/StorageFileTests/StorageFile_DateCreated.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/StorageFileTests/StorageFile_DateCreated.xaml.cs
@@ -20,7 +20,7 @@ namespace UITests.Shared.Windows_Storage.StorageFileTests
 	[Uno.UI.Samples.Controls.SampleControlInfo("StorageFile", "StorageFile_DateCreated", description: "Testing attribute DateCreated of StorageFile")]
 	public sealed partial class StorageFile_DateCreated : UserControl
     {
-        public DateCreated()
+        public StorageFile_DateCreated()
         {
             this.InitializeComponent();
         }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
@@ -7,7 +7,7 @@ namespace Windows.Storage
 	#endif
 	public  partial class StorageFile : global::Windows.Storage.IStorageFile,global::Windows.Storage.Streams.IInputStreamReference,global::Windows.Storage.Streams.IRandomAccessStreamReference,global::Windows.Storage.IStorageItem,global::Windows.Storage.IStorageItemProperties,global::Windows.Storage.IStorageItemProperties2,global::Windows.Storage.IStorageItem2,global::Windows.Storage.IStorageItemPropertiesWithProvider,global::Windows.Storage.IStorageFilePropertiesWithAvailability,global::Windows.Storage.IStorageFile2
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  string ContentType
 		{
@@ -16,8 +16,8 @@ namespace Windows.Storage
 				throw new global::System.NotImplementedException("The member string StorageFile.ContentType is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  string FileType
 		{
@@ -26,8 +26,8 @@ namespace Windows.Storage
 				throw new global::System.NotImplementedException("The member string StorageFile.FileType is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  bool IsAvailable
 		{
@@ -36,8 +36,8 @@ namespace Windows.Storage
 				throw new global::System.NotImplementedException("The member bool StorageFile.IsAvailable is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Storage.FileAttributes Attributes
 		{
@@ -46,8 +46,8 @@ namespace Windows.Storage
 				throw new global::System.NotImplementedException("The member FileAttributes StorageFile.Attributes is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  global::System.DateTimeOffset DateCreated
 		{
@@ -56,11 +56,11 @@ namespace Windows.Storage
 				throw new global::System.NotImplementedException("The member DateTimeOffset StorageFile.DateCreated is not implemented in Uno.");
 			}
 		}
-		#endif
-		// Skipping already declared property Name
-		// Skipping already declared property Path
-		// Skipping already declared property DisplayName
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+        // Skipping already declared property Name
+        // Skipping already declared property Path
+        // Skipping already declared property DisplayName
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  string DisplayType
 		{
@@ -69,8 +69,8 @@ namespace Windows.Storage
 				throw new global::System.NotImplementedException("The member string StorageFile.DisplayType is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  string FolderRelativeId
 		{
@@ -79,8 +79,8 @@ namespace Windows.Storage
 				throw new global::System.NotImplementedException("The member string StorageFile.FolderRelativeId is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Storage.FileProperties.StorageItemContentProperties Properties
 		{
@@ -89,8 +89,8 @@ namespace Windows.Storage
 				throw new global::System.NotImplementedException("The member StorageItemContentProperties StorageFile.Properties is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Storage.StorageProvider Provider
 		{
@@ -99,254 +99,254 @@ namespace Windows.Storage
 				throw new global::System.NotImplementedException("The member StorageProvider StorageFile.Provider is not implemented in Uno.");
 			}
 		}
-		#endif
-		// Forced skipping of method Windows.Storage.StorageFile.FileType.get
-		// Forced skipping of method Windows.Storage.StorageFile.ContentType.get
-		// Skipping already declared method Windows.Storage.StorageFile.OpenAsync(Windows.Storage.FileAccessMode)
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+        // Forced skipping of method Windows.Storage.StorageFile.FileType.get
+        // Forced skipping of method Windows.Storage.StorageFile.ContentType.get
+        // Skipping already declared method Windows.Storage.StorageFile.OpenAsync(Windows.Storage.FileAccessMode)
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageStreamTransaction> OpenTransactedWriteAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageStreamTransaction> StorageFile.OpenTransactedWriteAsync() is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CopyAsync( global::Windows.Storage.IStorageFolder destinationFolder)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.CopyAsync(IStorageFolder destinationFolder) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CopyAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.CopyAsync(IStorageFolder destinationFolder, string desiredNewName) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CopyAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName,  global::Windows.Storage.NameCollisionOption option)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.CopyAsync(IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction CopyAndReplaceAsync( global::Windows.Storage.IStorageFile fileToReplace)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.CopyAndReplaceAsync(IStorageFile fileToReplace) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction MoveAsync( global::Windows.Storage.IStorageFolder destinationFolder)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.MoveAsync(IStorageFolder destinationFolder) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction MoveAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.MoveAsync(IStorageFolder destinationFolder, string desiredNewName) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction MoveAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName,  global::Windows.Storage.NameCollisionOption option)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.MoveAsync(IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction MoveAndReplaceAsync( global::Windows.Storage.IStorageFile fileToReplace)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.MoveAndReplaceAsync(IStorageFile fileToReplace) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction RenameAsync( string desiredName)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.RenameAsync(string desiredName) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction RenameAsync( string desiredName,  global::Windows.Storage.NameCollisionOption option)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.RenameAsync(string desiredName, NameCollisionOption option) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction DeleteAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.DeleteAsync() is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncAction DeleteAsync( global::Windows.Storage.StorageDeleteOption option)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.DeleteAsync(StorageDeleteOption option) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.FileProperties.BasicProperties> GetBasicPropertiesAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<BasicProperties> StorageFile.GetBasicPropertiesAsync() is not implemented in Uno.");
 		}
-		#endif
-		// Forced skipping of method Windows.Storage.StorageFile.Name.get
-		// Forced skipping of method Windows.Storage.StorageFile.Path.get
-		// Forced skipping of method Windows.Storage.StorageFile.Attributes.get
-		// Forced skipping of method Windows.Storage.StorageFile.DateCreated.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+        // Forced skipping of method Windows.Storage.StorageFile.Name.get
+        // Forced skipping of method Windows.Storage.StorageFile.Path.get
+        // Forced skipping of method Windows.Storage.StorageFile.Attributes.get
+        // Forced skipping of method Windows.Storage.StorageFile.DateCreated.get
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  bool IsOfType( global::Windows.Storage.StorageItemTypes type)
 		{
 			throw new global::System.NotImplementedException("The member bool StorageFile.IsOfType(StorageItemTypes type) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Streams.IRandomAccessStreamWithContentType> OpenReadAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IRandomAccessStreamWithContentType> StorageFile.OpenReadAsync() is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Streams.IInputStream> OpenSequentialReadAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IInputStream> StorageFile.OpenSequentialReadAsync() is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.FileProperties.StorageItemThumbnail> GetThumbnailAsync( global::Windows.Storage.FileProperties.ThumbnailMode mode)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageItemThumbnail> StorageFile.GetThumbnailAsync(ThumbnailMode mode) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.FileProperties.StorageItemThumbnail> GetThumbnailAsync( global::Windows.Storage.FileProperties.ThumbnailMode mode,  uint requestedSize)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageItemThumbnail> StorageFile.GetThumbnailAsync(ThumbnailMode mode, uint requestedSize) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.FileProperties.StorageItemThumbnail> GetThumbnailAsync( global::Windows.Storage.FileProperties.ThumbnailMode mode,  uint requestedSize,  global::Windows.Storage.FileProperties.ThumbnailOptions options)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageItemThumbnail> StorageFile.GetThumbnailAsync(ThumbnailMode mode, uint requestedSize, ThumbnailOptions options) is not implemented in Uno.");
 		}
-		#endif
-		// Forced skipping of method Windows.Storage.StorageFile.DisplayName.get
-		// Forced skipping of method Windows.Storage.StorageFile.DisplayType.get
-		// Forced skipping of method Windows.Storage.StorageFile.FolderRelativeId.get
-		// Forced skipping of method Windows.Storage.StorageFile.Properties.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+        // Forced skipping of method Windows.Storage.StorageFile.DisplayName.get
+        // Forced skipping of method Windows.Storage.StorageFile.DisplayType.get
+        // Forced skipping of method Windows.Storage.StorageFile.FolderRelativeId.get
+        // Forced skipping of method Windows.Storage.StorageFile.Properties.get
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.FileProperties.StorageItemThumbnail> GetScaledImageAsThumbnailAsync( global::Windows.Storage.FileProperties.ThumbnailMode mode)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageItemThumbnail> StorageFile.GetScaledImageAsThumbnailAsync(ThumbnailMode mode) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.FileProperties.StorageItemThumbnail> GetScaledImageAsThumbnailAsync( global::Windows.Storage.FileProperties.ThumbnailMode mode,  uint requestedSize)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageItemThumbnail> StorageFile.GetScaledImageAsThumbnailAsync(ThumbnailMode mode, uint requestedSize) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.FileProperties.StorageItemThumbnail> GetScaledImageAsThumbnailAsync( global::Windows.Storage.FileProperties.ThumbnailMode mode,  uint requestedSize,  global::Windows.Storage.FileProperties.ThumbnailOptions options)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageItemThumbnail> StorageFile.GetScaledImageAsThumbnailAsync(ThumbnailMode mode, uint requestedSize, ThumbnailOptions options) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFolder> GetParentAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFolder> StorageFile.GetParentAsync() is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  bool IsEqual( global::Windows.Storage.IStorageItem item)
 		{
 			throw new global::System.NotImplementedException("The member bool StorageFile.IsEqual(IStorageItem item) is not implemented in Uno.");
 		}
-		#endif
-		// Forced skipping of method Windows.Storage.StorageFile.Provider.get
-		// Forced skipping of method Windows.Storage.StorageFile.IsAvailable.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+        // Forced skipping of method Windows.Storage.StorageFile.Provider.get
+        // Forced skipping of method Windows.Storage.StorageFile.IsAvailable.get
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Streams.IRandomAccessStream> OpenAsync( global::Windows.Storage.FileAccessMode accessMode,  global::Windows.Storage.StorageOpenOptions options)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IRandomAccessStream> StorageFile.OpenAsync(FileAccessMode accessMode, StorageOpenOptions options) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageStreamTransaction> OpenTransactedWriteAsync( global::Windows.Storage.StorageOpenOptions options)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageStreamTransaction> StorageFile.OpenTransactedWriteAsync(StorageOpenOptions options) is not implemented in Uno.");
 		}
-		#endif
-		// Skipping already declared method Windows.Storage.StorageFile.GetFileFromPathAsync(string)
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+        // Skipping already declared method Windows.Storage.StorageFile.GetFileFromPathAsync(string)
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> GetFileFromApplicationUriAsync( global::System.Uri uri)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.GetFileFromApplicationUriAsync(Uri uri) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CreateStreamedFileAsync( string displayNameWithExtension,  global::Windows.Storage.StreamedFileDataRequestedHandler dataRequested,  global::Windows.Storage.Streams.IRandomAccessStreamReference thumbnail)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.CreateStreamedFileAsync(string displayNameWithExtension, StreamedFileDataRequestedHandler dataRequested, IRandomAccessStreamReference thumbnail) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> ReplaceWithStreamedFileAsync( global::Windows.Storage.IStorageFile fileToReplace,  global::Windows.Storage.StreamedFileDataRequestedHandler dataRequested,  global::Windows.Storage.Streams.IRandomAccessStreamReference thumbnail)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.ReplaceWithStreamedFileAsync(IStorageFile fileToReplace, StreamedFileDataRequestedHandler dataRequested, IRandomAccessStreamReference thumbnail) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CreateStreamedFileFromUriAsync( string displayNameWithExtension,  global::System.Uri uri,  global::Windows.Storage.Streams.IRandomAccessStreamReference thumbnail)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.CreateStreamedFileFromUriAsync(string displayNameWithExtension, Uri uri, IRandomAccessStreamReference thumbnail) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> ReplaceWithStreamedFileFromUriAsync( global::Windows.Storage.IStorageFile fileToReplace,  global::System.Uri uri,  global::Windows.Storage.Streams.IRandomAccessStreamReference thumbnail)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.ReplaceWithStreamedFileFromUriAsync(IStorageFile fileToReplace, Uri uri, IRandomAccessStreamReference thumbnail) is not implemented in Uno.");
 		}
-		#endif
-		// Processing: Windows.Storage.IStorageFile
-		// Processing: Windows.Storage.IStorageItem
-		// Processing: Windows.Storage.Streams.IRandomAccessStreamReference
-		// Processing: Windows.Storage.Streams.IInputStreamReference
-		// Processing: Windows.Storage.IStorageItemProperties
-		// Processing: Windows.Storage.IStorageItemProperties2
-		// Processing: Windows.Storage.IStorageItem2
-		// Processing: Windows.Storage.IStorageItemPropertiesWithProvider
-		// Processing: Windows.Storage.IStorageFilePropertiesWithAvailability
-		// Processing: Windows.Storage.IStorageFile2
-	}
+#endif
+        // Processing: Windows.Storage.IStorageFile
+        // Processing: Windows.Storage.IStorageItem
+        // Processing: Windows.Storage.Streams.IRandomAccessStreamReference
+        // Processing: Windows.Storage.Streams.IInputStreamReference
+        // Processing: Windows.Storage.IStorageItemProperties
+        // Processing: Windows.Storage.IStorageItemProperties2
+        // Processing: Windows.Storage.IStorageItem2
+        // Processing: Windows.Storage.IStorageItemPropertiesWithProvider
+        // Processing: Windows.Storage.IStorageFilePropertiesWithAvailability
+        // Processing: Windows.Storage.IStorageFile2
+    }
 }

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -34,7 +34,16 @@ namespace Windows.Storage
 			_fileUri = uri;
 		}
 
-		public async Task DeleteAsync(CancellationToken ct)
+        public global::System.DateTimeOffset DateCreated
+        {
+            get
+            {
+                var fileInfo = new FileInfo(Path);
+                return fileInfo.CreationTime;
+            }
+        }
+
+        public async Task DeleteAsync(CancellationToken ct)
 		{
 			if (Scheme != "FILE")
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #1187 (partly)

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
StorageFile:DateCreated is not supported.

## What is the new behavior?
StorageFile:DateCreated is supported.


## PR Checklist

Please check if your PR fulfills the following requirements:
- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
Re-created #1961, with added test.
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
