### PR TITLE
Update Xamarin.Android to 10.0 in CI

### DIFF
--- a/.azure-devops-android-tests.yml
+++ b/.azure-devops-android-tests.yml
@@ -20,7 +20,7 @@ jobs:
       path: $(NUGET_PACKAGES)
     displayName: Cache NuGet packages
 
-  - bash: /bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_18_1"
+  - bash: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0
     displayName: Select Xamarin Version
 
   - bash: |

--- a/.azure-devops-android-tests.yml
+++ b/.azure-devops-android-tests.yml
@@ -28,6 +28,11 @@ jobs:
       echo "##vso[task.setvariable variable=PATH;]/Library/Frameworks/Mono.framework/Versions/$SYMLINK/bin:$PATH"
     displayName: Select Xamarin and Mono Version
 
+  - task: UseDotNet@2
+    inputs:
+      version: 3.0.100
+    displayName: 'Use .Net Core SDK 3.0.100'
+
   - bash: |
       chmod +x $(build.sourcesdirectory)/build/android-uitest-run.sh
       $(build.sourcesdirectory)/build/android-uitest-run.sh

--- a/.azure-devops-android-tests.yml
+++ b/.azure-devops-android-tests.yml
@@ -20,8 +20,13 @@ jobs:
       path: $(NUGET_PACKAGES)
     displayName: Cache NuGet packages
 
-  - bash: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 6_4_0
-    displayName: Select Xamarin Version
+  - bash: |
+      SYMLINK="6_4_0"
+      # Set Xamarin.Android 10.0
+      sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh $SYMLINK
+      # Set Mono 6.4.0
+      echo "##vso[task.setvariable variable=PATH;]/Library/Frameworks/Mono.framework/Versions/$SYMLINK/bin:$PATH"
+    displayName: Select Xamarin and Mono Version
 
   - bash: |
       chmod +x $(build.sourcesdirectory)/build/android-uitest-run.sh


### PR DESCRIPTION
To build for Android v10 we need to set `6_4_0` bundle in ADO.
It contains Xamarin.Android 10.0 and Mono 6.4.0.
Also need to set .NET Core 3.0.100 to support latest features.
Source: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#mono