### PR TITLE
Fixing DataContext checks in PopupBase

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2895,6 +2895,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentDialogTests\ContentDialog_ComboBox.xaml.cs">
       <DependentUpon>ContentDialog_ComboBox.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\FlyoutButtonViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_MinWidthColumns.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_ImageSource_PixelSize.xaml.cs">
       <DependentUpon>Image_ImageSource_PixelSize.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/FlyoutButtonViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/FlyoutButtonViewModel.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Uno.UI.Samples.UITests.Helpers;
+using Windows.UI.Core;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.Samples.Content.UITests.Flyout
+{
+	public class FlyoutButonViewModel : ViewModelBase
+	{
+		public FlyoutButonViewModel(CoreDispatcher dispatcher) : base(dispatcher)
+		{
+			DataBoundText = "Button not clicked";
+		}
+
+		public Command ChangeTextCommand => new Command((p) =>
+		{
+			DataBoundText = "Button was clicked";
+		});
+
+		private string _dataBoundText;
+
+		public string DataBoundText
+		{
+			get { return _dataBoundText; }
+			set
+			{
+				_dataBoundText = value;
+				RaisePropertyChanged();
+			}
+		}
+
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ButtonInContent.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ButtonInContent.xaml
@@ -13,7 +13,8 @@
 			<Button
 				Width="48"
 				Height="48"
-				Margin="0,0,10,0">
+				Margin="0,0,10,0"
+				x:Name="FlyoutButton">
 
 				<TextBlock>Here</TextBlock>
 
@@ -33,6 +34,10 @@
 								Clicking here should
 								not close the flyout
 							</TextBlock>
+							<Button Command="{Binding ChangeTextCommand}"
+									Content="Click to change the text below"
+									x:Name="DataBoundButton" />
+							<TextBlock x:Name="DataBoundText" Text="{Binding DataBoundText}" />
 						</StackPanel>
 					</Flyout>
 				</Button.Flyout>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ButtonInContent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ButtonInContent.xaml.cs
@@ -1,10 +1,11 @@
 ﻿using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Content.UITests.Flyout;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.Flyout
 {
-	[SampleControlInfo("Flyout", "Flyout_ButtonInContent")]
+	[SampleControlInfo("Flyout", "Flyout_ButtonInContent", viewModelType: typeof(FlyoutButonViewModel))]
 	public sealed partial class Flyout_ButtonInContent : Page
 	{
 		public Flyout_ButtonInContent()

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -122,7 +122,8 @@ namespace Windows.UI.Xaml.Controls
 			_childHasOwnDataContext = false;
 			if (Child is IDependencyObjectStoreProvider provider)
 			{
-				if (provider.Store.ReadLocalValue(provider.Store.DataContextProperty) != DependencyProperty.UnsetValue)
+				var dataContextProperty = provider.Store.ReadLocalValue(provider.Store.DataContextProperty);
+				if (dataContextProperty != null && dataContextProperty != DependencyProperty.UnsetValue)
 				{
 					// Child already has locally set DataContext, we shouldn't overwrite it.
 					_childHasOwnDataContext = true;


### PR DESCRIPTION
## PR Type

- Bugfix

## What is the current behavior?
When a PopupBase Child has  it's DataContextProperty set to null it is considered a valid value.


## What is the new behavior?
Both null and UnsetValue are considered empty values

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~[Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
[164452](https://nventive.visualstudio.com/Umbrella/_workitems/edit/164452)
