### PR TITLE
Fix RemoteControl client invalid generation for server endpoints

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
@@ -19,8 +19,9 @@ namespace Uno.UI.SourceGenerators.RemoteControl
 	{
 		public override void Execute(SourceGeneratorContext context)
 		{
-			if(
+			if (
 				context.GetProjectInstance().GetPropertyValue("Configuration") == "Debug"
+				&& IsRemoteControlClientInstalled(context)
 				&& IsApplication(context.GetProjectInstance()))
 			{
 				var sb = new IndentedStringBuilder();
@@ -31,6 +32,9 @@ namespace Uno.UI.SourceGenerators.RemoteControl
 				context.AddCompilationUnit("RemoteControl", sb.ToString());
 			}
 		}
+
+		private static bool IsRemoteControlClientInstalled(SourceGeneratorContext context)
+			=> context.Compilation.GetTypeByMetadataName("Uno.UI.RemoteControl.RemoteControlClient") != null;
 
 		private static void BuildSearchPaths(SourceGeneratorContext context, IndentedStringBuilder sb)
 		{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
Fix `Uno.UI.RemoteControl` package is now not required in debug configuration.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

The scenario will need to be tested with https://github.com/unoplatform/uno/issues/1876

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
