### PR TITLE
feat: Windows.Devices.Sensors.Pedometer

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -688,6 +688,15 @@
 				<Member
 					fullName="System.Boolean Windows.UI.Xaml.Controls.TextBox.FocusTextView()"
 					reason="Not part of the WinUI API, Uno-specific implementation detail." />
+				<Member 
+					fullName="System.Void Windows.Devices.Sensors.PedometerReadingChangedEventArgs..ctor()"
+					reason="Parameter-less ctor does not exist in UWP"/>
+				<Member 
+					fullName="System.Void Windows.Devices.Sensors.Pedometer..ctor()"
+					reason="Parameter-less ctor does not exist in UWP"/>
+				<Member 
+					fullName="System.Void Windows.Devices.Sensors.PedometerReading..ctor()"
+					reason="Parameter-less ctor does not exist in UWP"/>
 			</Methods>
 			<Properties>
 				<Member

--- a/doc/articles/features/windows-devices-sensors.md
+++ b/doc/articles/features/windows-devices-sensors.md
@@ -45,3 +45,28 @@ On Android, when both `ReadingChanged` and `Shaken` events are attached and the 
 `ReportInterval` property on WASM is currently not supported directly. Uno uses an approximation in the form of raising the `ReadingChanged` event only when enough time has passed since the last report. The event is raised a bit more often to make sure the gap caused by the filter is not too large, but this is in-line with the behavior of UWP `Magnetometer`.
 
 `DirectionalAccuracy` is not reported on iOS, so it will always return `Unknown`.
+
+## `Pedometer`
+
+### Implementation notes
+
+#### Android
+
+On Android, the first reading returns the cumulative number of steps since the device was first booted up. I have noticed the sensor does not correctly respect the requested reporting interval, so we implemented this manually to make sure the `ReadingChanged` events are triggered only after the `ReportInterval` elapses.
+
+Since Android 10, your application must declare the permission to use the step counter sensor by adding the following `uses-feature` declaration to the `AndroidManifest.xml` in your project:
+
+```
+<uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+```
+
+#### iOS
+
+The first reading on iOS returns the cumulative number of steps from 24 hours back to current moment. Unfortunately, in case the tracking was not enabled before, this will likely return 0 steps. Once the tracking is enabled, `ReadingChanged` will be triggered and step count will be updated appropriately.
+
+Make sure to add the following capability declaration to your `Info.plist` file, otherwise the API will crash at runtime.
+
+```
+<key>NSMotionUsageDescription</key>
+<string>Some reason why your app wants to track motion.</string>
+```

--- a/doc/articles/features/windows-devices-sensors.md
+++ b/doc/articles/features/windows-devices-sensors.md
@@ -52,7 +52,7 @@ On Android, when both `ReadingChanged` and `Shaken` events are attached and the 
 
 #### Android
 
-On Android, the first reading returns the cumulative number of steps since the device was first booted up. I have noticed the sensor does not correctly respect the requested reporting interval, so we implemented this manually to make sure the `ReadingChanged` events are triggered only after the `ReportInterval` elapses.
+On Android, the first reading returns the cumulative number of steps since the device was first booted up. The sensor may not correctly respect the requested reporting interval, so the implementation does this manually to make sure the `ReadingChanged` events are triggered only after the `ReportInterval` elapses.
 
 Since Android 10, your application must declare the permission to use the step counter sensor by adding the following `uses-feature` declaration to the `AndroidManifest.xml` in your project:
 

--- a/src/SamplesApp/SamplesApp.Droid/Properties/AndroidManifest.xml
+++ b/src/SamplesApp/SamplesApp.Droid/Properties/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="uno.platform.unosampleapp" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
 	<uses-permission android:name="android.permission.VIBRATE" />
+	<uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
 	<application android:label="SamplesApp"></application>
 	<meta-data android:name="com.google.android.geo.API_KEY" android:value="YOUR API KEY" />
 </manifest>

--- a/src/SamplesApp/SamplesApp.iOS/Info.plist
+++ b/src/SamplesApp/SamplesApp.iOS/Info.plist
@@ -49,5 +49,7 @@
 		<key>NSExceptionMinimumTLSVersion</key>
 		<string>TLSv1.2</string>
 	</dict>
+    <key>NSMotionUsageDescription</key>
+    <string>This is a step counter, and we&apos;d like to track motion. </string>
 </dict>
 </plist>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -89,6 +89,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_Devices\PedometerTests.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_Globalization\Language_Properties.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3165,6 +3169,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\MagnetometerTests.xaml.cs">
       <DependentUpon>MagnetometerTests.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\PedometerTests.xaml.cs">
+      <DependentUpon>PedometerTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Globalization\Language_Properties.xaml.cs">
       <DependentUpon>Language_Properties.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/PedometerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/PedometerTests.xaml
@@ -5,7 +5,7 @@
     xmlns:local="using:UITests.Shared.Windows_Devices"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:valueconverters="clr-namespace:UITests.Shared.ValueConverters"
+	xmlns:valueconverters="using:UITests.Shared.ValueConverters"
 	mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400">

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/PedometerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/PedometerTests.xaml
@@ -20,10 +20,24 @@
 		<TextBlock Text="{Binding PedometerStatus}" />
 		<ContentControl IsEnabled="{Binding IsAvailable}">
 			<StackPanel Spacing="8">
-				<TextBox Header="Brightness level"
-						 Text="{Binding BrightnessLevel,Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-						 InputScope="Number" />
-				<ToggleSwitch Header="Is enabled?" IsOn="{Binding IsEnabled, Mode=TwoWay}" />
+
+				<Button Command="{Binding AttachReadingChangedCommand}" Content="Attach ReadingChanged" IsEnabled="{Binding ReadingChangedAttached, Converter={StaticResource BoolNegation}}" />
+				<Button Command="{Binding DetachReadingChangedCommand}" Content="Detach ReadingChanged" IsEnabled="{Binding ReadingChangedAttached}" />
+
+				<TextBlock Text="Last reading" Style="{ThemeResource SubtitleTextBlockStyle}" />
+				<TextBlock>
+					<Run FontWeight="Bold">Timestamp: </Run>
+					<Run Text="{Binding Timestamp}" />
+				</TextBlock>
+				<TextBlock>
+					<Run FontWeight="Bold">Cumulative steps: </Run>
+					<Run Text="{Binding CumulativeSteps}" />
+				</TextBlock>
+				<TextBlock>
+					<Run FontWeight="Bold">Cumulative steps duration: </Run>
+					<Run Text="{Binding CumulativeStepsDurationInSeconds}" />
+					<Run Text="s" />
+				</TextBlock>
 			</StackPanel>
 		</ContentControl>
 	</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/PedometerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/PedometerTests.xaml
@@ -1,0 +1,30 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_Devices.PedometerTests"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_Devices"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:valueconverters="clr-namespace:UITests.Shared.ValueConverters"
+	mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<valueconverters:BoolNegationValueConverter x:Key="BoolNegation" />
+	</UserControl.Resources>
+
+	<StackPanel Padding="12">
+		<Button Command="{Binding GetPedometerCommand}"
+				IsEnabled="{Binding IsAvailable, Converter={StaticResource BoolNegation}}">Get default pedometer</Button>
+		<TextBlock Text="{Binding PedometerStatus}" />
+		<ContentControl IsEnabled="{Binding IsAvailable}">
+			<StackPanel Spacing="8">
+				<TextBox Header="Brightness level"
+						 Text="{Binding BrightnessLevel,Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+						 InputScope="Number" />
+				<ToggleSwitch Header="Is enabled?" IsOn="{Binding IsEnabled, Mode=TwoWay}" />
+			</StackPanel>
+		</ContentControl>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/PedometerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/PedometerTests.xaml.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Windows.Input;
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.UITests.Helpers;
+using Windows.Devices.Sensors;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_Devices
+{
+	[SampleControlInfo(
+		"Windows.Devices",
+		"Pedometer",
+		description: "Demonstrates the Windows.Devices.Sensors.Pedometer",
+		viewModelType: typeof(PedometerTestsViewModel))]
+    public sealed partial class PedometerTests : UserControl
+    {
+        public PedometerTests()
+        {
+            this.InitializeComponent();
+        }
+    }
+
+	public class PedometerTestsViewModel : ViewModelBase
+	{
+		private Pedometer _pedometer = null;
+		private string _pedometerStatus;
+
+		public PedometerTestsViewModel(CoreDispatcher dispatcher) :
+			base(dispatcher)
+		{
+		}
+
+		public ICommand GetPedometerCommand => GetOrCreateCommand(GetPedometerAsync);
+		
+		public string PedometerStatus
+		{
+			get => _pedometerStatus;
+			private set
+			{
+				_pedometerStatus = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public bool IsAvailable => _pedometer != null;
+
+		private async void GetPedometerAsync()
+		{
+			_pedometer = await Pedometer.GetDefaultAsync();
+			RaisePropertyChanged(nameof(IsAvailable));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/PedometerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/PedometerTests.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -66,17 +67,24 @@ namespace UITests.Shared.Windows_Devices
 
 		private async void GetPedometerAsync()
 		{
-			_pedometer = await Pedometer.GetDefaultAsync();
-			_pedometer.ReportInterval = 10000;
-			Disposables.Add(Disposable.Create(() =>
+			try
 			{
-				if (_pedometer != null)
+				_pedometer = await Pedometer.GetDefaultAsync();
+				_pedometer.ReportInterval = 10000;
+				Disposables.Add(Disposable.Create(() =>
 				{
-					_pedometer.ReadingChanged -= Pedometer_ReadingChanged;
-				}
-			}));
+					if (_pedometer != null)
+					{
+						_pedometer.ReadingChanged -= Pedometer_ReadingChanged;
+					}
+				}));
 
-			RaisePropertyChanged(nameof(IsAvailable));
+				RaisePropertyChanged(nameof(IsAvailable));
+			}
+			catch (Exception ex)
+			{
+				PedometerStatus = $"Error occurred trying to get pedometer instance: {ex.Message}";
+			}
 		}
 
 		public Command AttachReadingChangedCommand => new Command((p) =>

--- a/src/Uno.UWP/Devices/Sensors/Accelerometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Accelerometer.Android.cs
@@ -13,7 +13,7 @@ namespace Windows.Devices.Sensors
 
 		private ReadingChangedListener _readingChangedListener;
 		private ShakeListener _shakeListener;
-		private uint _reportInterval = 0;
+		private uint _reportInterval = SensorHelpers.UiReportingInterval;
 
 		private Accelerometer(Sensor accelerometer)
 		{

--- a/src/Uno.UWP/Devices/Sensors/Barometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Barometer.Android.cs
@@ -14,7 +14,7 @@ namespace Windows.Devices.Sensors
 	{
 		private readonly Sensor _sensor;
 		private BarometerListener _listener;
-		private uint _reportInterval = 0;
+		private uint _reportInterval = SensorHelpers.UiReportingInterval;
 
 		private Barometer(Sensor barometerSensor)
 		{
@@ -54,7 +54,10 @@ namespace Windows.Devices.Sensors
 		private void StartReading()
 		{
 			_listener = new BarometerListener(this);
-			SensorHelpers.GetSensorManager().RegisterListener(_listener, _sensor, SensorDelay.Normal);
+			SensorHelpers.GetSensorManager().RegisterListener(
+				_listener,
+				_sensor,
+				(SensorDelay)(_reportInterval * 1000));
 		}
 
 		private void StopReading()

--- a/src/Uno.UWP/Devices/Sensors/Gyrometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Gyrometer.Android.cs
@@ -13,7 +13,7 @@ namespace Windows.Devices.Sensors
 	public partial class Gyrometer
 	{
 		private readonly Sensor _sensor;
-		private uint _reportInterval = 0;
+		private uint _reportInterval = SensorHelpers.UiReportingInterval;
 
 		private GyrometerListener _listener;
 
@@ -55,7 +55,10 @@ namespace Windows.Devices.Sensors
 		private void StartReading()
 		{
 			_listener = new GyrometerListener(this);
-			SensorHelpers.GetSensorManager().RegisterListener(_listener, _sensor, SensorDelay.Normal);
+			SensorHelpers.GetSensorManager().RegisterListener(
+				_listener,
+				_sensor,
+				(SensorDelay)(_reportInterval * 1000));
 		}
 
 		private void StopReading()
@@ -70,7 +73,7 @@ namespace Windows.Devices.Sensors
 
 		private class GyrometerListener : Java.Lang.Object, ISensorEventListener, IDisposable
 		{
-			private readonly Gyrometer _gyrometer;			
+			private readonly Gyrometer _gyrometer;
 
 			public GyrometerListener(Gyrometer gyrometer)
 			{

--- a/src/Uno.UWP/Devices/Sensors/Helpers/SensorHelpers.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Helpers/SensorHelpers.Android.cs
@@ -12,6 +12,11 @@ namespace Uno.Devices.Sensors.Helpers
 {
 	internal static class SensorHelpers
 	{
+		public const uint UiReportingInterval = 60;
+
+		public static DateTimeOffset SystemBootDateTimeOffset =>
+			DateTimeOffset.Now.AddMilliseconds(-SystemClock.ElapsedRealtime());
+
 		public static DateTimeOffset TimestampToDateTimeOffset(long timestamp)
 		{
 			return DateTimeOffset.Now

--- a/src/Uno.UWP/Devices/Sensors/Helpers/SensorHelpers.iOS.cs
+++ b/src/Uno.UWP/Devices/Sensors/Helpers/SensorHelpers.iOS.cs
@@ -33,11 +33,11 @@ namespace Uno.Devices.Sensors.Helpers
 
 		public static NSDate DateTimeOffsetToNSDate(DateTimeOffset dateTimeOffset)
 		{
-			if (dateTimeOffset == DateTime.MinValue)
+			if (dateTimeOffset == DateTimeOffset.MinValue)
 			{
 				return NSDate.DistantPast;
 			}
-			else if (dateTimeOffset == DateTime.MaxValue)
+			else if (dateTimeOffset == DateTimeOffset.MaxValue)
 			{
 				return NSDate.DistantFuture;
 			}

--- a/src/Uno.UWP/Devices/Sensors/Helpers/SensorHelpers.iOS.cs
+++ b/src/Uno.UWP/Devices/Sensors/Helpers/SensorHelpers.iOS.cs
@@ -6,11 +6,48 @@ namespace Uno.Devices.Sensors.Helpers
 {
 	internal static class SensorHelpers
 	{
+		private static readonly DateTimeOffset NSDateConversionStart =
+			new DateTimeOffset(2001, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
 		public static DateTimeOffset TimestampToDateTimeOffset(double timestamp)
 		{
 			var bootTime = NSDate.FromTimeIntervalSinceNow(-NSProcessInfo.ProcessInfo.SystemUptime);
 			var date = (DateTime)bootTime.AddSeconds(timestamp);
 			return new DateTimeOffset(date);
+		}
+
+		public static DateTimeOffset NSDateToDateTimeOffset(NSDate nsDate)
+		{
+			if (nsDate == NSDate.DistantPast)
+			{
+				return DateTimeOffset.MinValue;
+			}
+			else if (nsDate == NSDate.DistantFuture)
+			{
+				return DateTimeOffset.MaxValue;
+			}
+
+			return NSDateConversionStart.AddSeconds(
+				nsDate.SecondsSinceReferenceDate);
+		}
+
+		public static NSDate DateTimeOffsetToNSDate(DateTimeOffset dateTimeOffset)
+		{
+			if (dateTimeOffset == DateTime.MinValue)
+			{
+				return NSDate.DistantPast;
+			}
+			else if (dateTimeOffset == DateTime.MaxValue)
+			{
+				return NSDate.DistantFuture;
+			}
+
+			var dateInSecondsFromStart = dateTimeOffset
+				.ToUniversalTime()
+				.Subtract(NSDateConversionStart.UtcDateTime);
+
+			return NSDate.FromTimeIntervalSinceReferenceDate(
+				dateInSecondsFromStart.TotalSeconds);
 		}
 	}
 }

--- a/src/Uno.UWP/Devices/Sensors/Magnetometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Magnetometer.Android.cs
@@ -13,7 +13,7 @@ namespace Windows.Devices.Sensors
 	public partial class Magnetometer
 	{
 		private readonly Sensor _sensor;
-		private uint _reportInterval = 0;
+		private uint _reportInterval = SensorHelpers.UiReportingInterval;
 
 		private MagnetometerListener _listener;
 
@@ -55,7 +55,10 @@ namespace Windows.Devices.Sensors
 		private void StartReading()
 		{
 			_listener = new MagnetometerListener(this);
-			SensorHelpers.GetSensorManager().RegisterListener(_listener, _sensor, SensorDelay.Normal);
+			SensorHelpers.GetSensorManager().RegisterListener(
+				_listener,
+				_sensor,
+				(SensorDelay)(_reportInterval * 1000));
 		}
 
 		private void StopReading()

--- a/src/Uno.UWP/Devices/Sensors/Pedometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Pedometer.Android.cs
@@ -1,0 +1,111 @@
+﻿
+using Android.Hardware;
+using Android.Runtime;
+#if __ANDROID__
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Uno.Devices.Sensors.Helpers;
+
+namespace Windows.Devices.Sensors
+{
+	public partial class Pedometer
+	{
+		private readonly Sensor _sensor;
+		private StepCounterListener _listener;
+		private uint _reportInterval = SensorHelpers.UiReportingInterval;
+
+		private Pedometer(Sensor stepCounterSensor)
+		{
+			_sensor = stepCounterSensor;
+		}
+
+		public uint ReportInterval
+		{
+			get => _reportInterval;
+			set
+			{
+				if (_reportInterval == value)
+				{
+					return;
+				}
+
+				lock (_syncLock)
+				{
+					_reportInterval = value;
+
+					if (_readingChanged != null)
+					{
+						//restart reading to apply interval
+						StartReading();
+						StopReading();
+					}
+				}
+			}
+		}
+
+		private static Pedometer TryCreateInstance()
+		{
+			var sensorManager = SensorHelpers.GetSensorManager();
+			var sensor = sensorManager.GetDefaultSensor(Android.Hardware.SensorType.StepCounter);
+			if (sensor != null)
+			{
+				return new Pedometer(sensor);
+			}
+			return null;
+		}
+
+		private void StartReading()
+		{
+			_listener = new StepCounterListener(this);
+			SensorHelpers.GetSensorManager().RegisterListener(
+				_listener,
+				_sensor,
+				(SensorDelay)(_reportInterval * 1000));
+		}
+
+		private void StopReading()
+		{
+			if (_listener != null)
+			{
+				SensorHelpers.GetSensorManager().UnregisterListener(_listener, _sensor);
+				_listener.Dispose();
+				_listener = null;
+			}
+		}
+
+		private class StepCounterListener : Java.Lang.Object, ISensorEventListener, IDisposable
+		{
+			private readonly Pedometer _pedometer;
+
+			private DateTimeOffset _lastTime = SensorHelpers.SystemBootDateTimeOffset;
+            
+			public StepCounterListener(Pedometer pedometer)
+			{
+				_pedometer = pedometer;
+			}
+
+			void ISensorEventListener.OnAccuracyChanged(Sensor sensor, [GeneratedEnum]SensorStatus accuracy)
+			{
+			}
+
+			void ISensorEventListener.OnSensorChanged(SensorEvent e)
+			{
+				var currentTime = SensorHelpers.TimestampToDateTimeOffset(e.Timestamp);
+				var timeDifference = _lastTime - currentTime;
+	                
+				var pedometerReading = new PedometerReading(
+					Convert.ToInt32(e.Values[0]),
+					timeDifference,
+                    PedometerStepKind.Unknown,
+                    currentTime);
+				_pedometer._readingChanged?.Invoke(
+					_pedometer,
+					new PedometerReadingChangedEventArgs(pedometerReading));
+
+				_lastTime = currentTime;
+			}
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/Devices/Sensors/Pedometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Pedometer.Android.cs
@@ -33,8 +33,8 @@ namespace Windows.Devices.Sensors
 						if (_readingChanged != null)
 						{
 							//restart reading to apply interval
-							StartReading();
 							StopReading();
+							StartReading();
 						}
 					}
 				}

--- a/src/Uno.UWP/Devices/Sensors/Pedometer.cs
+++ b/src/Uno.UWP/Devices/Sensors/Pedometer.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading.Tasks;
+using Windows.Foundation;
+
+namespace Windows.Devices.Sensors
+{
+	public partial class Pedometer
+	{
+		private readonly static object _syncLock = new object();
+		
+		private static Pedometer _instance;
+		private static bool _initializationAttempted;
+
+		private TypedEventHandler<Pedometer, PedometerReadingChangedEventArgs> _readingChanged;
+		
+		public static IAsyncOperation<Pedometer> GetDefaultAsync()
+		{
+			if (_initializationAttempted)
+			{
+				return Task.FromResult(_instance).AsAsyncOperation();
+			}
+			lock (_syncLock)
+			{
+				if (!_initializationAttempted)
+				{
+					_instance = TryCreateInstance();
+					_initializationAttempted = true;
+				}
+				return Task.FromResult(_instance).AsAsyncOperation();
+			}
+		}
+
+		public event TypedEventHandler<Pedometer, PedometerReadingChangedEventArgs> ReadingChanged
+		{
+			add
+			{
+				lock (_syncLock)
+				{
+					var isFirstSubscriber = _readingChanged == null;
+					_readingChanged += value;
+					if (isFirstSubscriber)
+					{
+						StartReading();
+					}
+				}
+			}
+			remove
+			{
+				lock (_syncLock)
+				{
+					_readingChanged -= value;
+					if (_readingChanged == null)
+					{
+						StopReading();
+					}
+				}
+			}
+		}
+
+		private void OnReadingChanged(PedometerReading reading)
+		{
+			_readingChanged?.Invoke(this, new PedometerReadingChangedEventArgs(reading));
+		}
+	}
+}

--- a/src/Uno.UWP/Devices/Sensors/Pedometer.cs
+++ b/src/Uno.UWP/Devices/Sensors/Pedometer.cs
@@ -1,3 +1,4 @@
+#if __IOS__ || __ANDROID__
 using System;
 using System.Threading.Tasks;
 using Windows.Foundation;
@@ -63,3 +64,4 @@ namespace Windows.Devices.Sensors
 		}
 	}
 }
+#endif

--- a/src/Uno.UWP/Devices/Sensors/Pedometer.iOS.cs
+++ b/src/Uno.UWP/Devices/Sensors/Pedometer.iOS.cs
@@ -1,7 +1,5 @@
 ﻿#if __IOS__
 using System;
-using System.Collections.Generic;
-using System.Threading;
 using CoreMotion;
 using Foundation;
 using Uno.Devices.Sensors.Helpers;
@@ -10,6 +8,7 @@ namespace Windows.Devices.Sensors
 {
 	public partial class Pedometer
 	{
+		private const int SecondsPerDay = 24 * 60 * 60;
 		private readonly CMPedometer _pedometer;
 		private DateTimeOffset _lastReading = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
@@ -29,7 +28,7 @@ namespace Windows.Devices.Sensors
 		private void StartReading()
 		{
 			_pedometer.StartPedometerUpdates(
-				SensorHelpers.DateTimeOffsetToNSDate(DateTimeOffset.Now.Date),
+				NSDate.Now.AddSeconds(-SecondsPerDay),
 				PedometerUpdateReceived);
 		}
 
@@ -44,7 +43,8 @@ namespace Windows.Devices.Sensors
 			{
 				var startDate = SensorHelpers.NSDateToDateTimeOffset(data.StartDate);
 				var endDate = SensorHelpers.NSDateToDateTimeOffset(data.EndDate);
-				OnReadingChanged(new PedometerReading(data.NumberOfSteps.Int32Value, endDate - startDate, PedometerStepKind.Unknown, endDate));
+				_lastReading = DateTime.UtcNow;
+				OnReadingChanged(new PedometerReading(data.NumberOfSteps.Int32Value, endDate - startDate, PedometerStepKind.Unknown, endDate));				
 			}
 		}
 	}

--- a/src/Uno.UWP/Devices/Sensors/Pedometer.iOS.cs
+++ b/src/Uno.UWP/Devices/Sensors/Pedometer.iOS.cs
@@ -1,0 +1,77 @@
+﻿#if __IOS__
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using CoreMotion;
+using Foundation;
+using Uno.Devices.Sensors.Helpers;
+
+namespace Windows.Devices.Sensors
+{
+	public partial class Pedometer
+	{
+		private readonly CMPedometer _pedometer;
+		private readonly EventWaitHandle _currentReadingWaiter =
+			new EventWaitHandle(false, EventResetMode.AutoReset);
+
+		private CMPedometerData _currentData = null;
+
+		private Pedometer(CMPedometer pedometer)
+		{
+			_pedometer = pedometer;
+		}
+
+		public static Pedometer TryCreateInstance()
+		{
+			if (CMPedometer.IsStepCountingAvailable)
+			{
+				return new Pedometer(new CMPedometer());
+			}
+			return null;
+		}
+
+		public IReadOnlyDictionary<PedometerStepKind, PedometerReading> GetCurrentReadings()
+		{
+			var readings = new Dictionary<PedometerStepKind, PedometerReading>();
+			_currentData = null;
+			_pedometer.QueryPedometerData(
+				NSDate.FromTimeIntervalSince1970(DateTimeOffset.Now.Subtract(DateTimeOffset.Now.TimeOfDay).ToUnixTimeSeconds()),
+				NSDate.FromTimeIntervalSince1970(DateTimeOffset.Now.ToUnixTimeSeconds()), HandlePedometerData);
+			_currentReadingWaiter.WaitOne();
+			var timeDifferenceInSeconds = TimeSpan.FromSeconds(
+				_currentData.EndDate.SecondsSinceReferenceDate -
+				_currentData.StartDate.SecondsSinceReferenceDate);
+			if (_currentData != null)
+			{
+				readings.Add(
+					PedometerStepKind.Unknown,
+					new PedometerReading(
+						_currentData.NumberOfSteps.Int32Value,
+						timeDifferenceInSeconds,
+						PedometerStepKind.Unknown,
+						SensorHelpers.NSDateToDateTimeOffset(_currentData.EndDate)));
+			}
+
+			return readings;
+		}
+
+		private void StartReading()
+		{
+			_pedometer.StartPedometerUpdates(
+				SensorHelpers.DateTimeOffsetToNSDate(DateTimeOffset.Now),
+				HandlePedometerData);
+		}
+
+		private void StopReading()
+		{
+			_pedometer.StopPedometerUpdates();
+		}
+
+		private void HandlePedometerData(CMPedometerData data, NSError err)
+		{
+			_currentData = data;
+			_currentReadingWaiter.Set();
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/Devices/Sensors/PedometerReading.cs
+++ b/src/Uno.UWP/Devices/Sensors/PedometerReading.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Windows.Devices.Sensors
+{
+	public partial class PedometerReading
+	{
+		internal PedometerReading(
+			int cumulativeSteps,
+			TimeSpan cumulativeStepsDuration,
+			PedometerStepKind stepKind,
+			DateTimeOffset timestamp)
+		{
+			CumulativeSteps = cumulativeSteps;
+			CumulativeStepsDuration = cumulativeStepsDuration;
+			StepKind = stepKind;
+			Timestamp = timestamp;
+		}
+
+		public int CumulativeSteps { get; }
+
+		public TimeSpan CumulativeStepsDuration { get; }
+
+		public PedometerStepKind StepKind { get; }
+
+		public DateTimeOffset Timestamp { get; }
+	}
+}

--- a/src/Uno.UWP/Devices/Sensors/PedometerReadingChangedEventArgs.cs
+++ b/src/Uno.UWP/Devices/Sensors/PedometerReadingChangedEventArgs.cs
@@ -1,0 +1,13 @@
+namespace Windows.Devices.Sensors
+{
+	public partial class PedometerReadingChangedEventArgs
+	{
+		internal PedometerReadingChangedEventArgs(
+			PedometerReading reading)
+		{
+			Reading = reading;
+		}
+
+		public PedometerReading Reading { get; }
+	}
+}

--- a/src/Uno.UWP/Devices/Sensors/PedometerStepKind.cs
+++ b/src/Uno.UWP/Devices/Sensors/PedometerStepKind.cs
@@ -1,0 +1,9 @@
+namespace Windows.Devices.Sensors
+{
+	public enum PedometerStepKind
+	{
+		Unknown,
+		Walking,
+		Running,
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Pedometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Pedometer.cs
@@ -7,7 +7,7 @@ namespace Windows.Devices.Sensors
 	#endif
 	public  partial class Pedometer 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  uint ReportInterval
 		{
@@ -58,7 +58,7 @@ namespace Windows.Devices.Sensors
 		// Forced skipping of method Windows.Devices.Sensors.Pedometer.ReportInterval.get
 		// Forced skipping of method Windows.Devices.Sensors.Pedometer.ReadingChanged.add
 		// Forced skipping of method Windows.Devices.Sensors.Pedometer.ReadingChanged.remove
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if __ANDROID__ || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::System.Collections.Generic.IReadOnlyDictionary<global::Windows.Devices.Sensors.PedometerStepKind, global::Windows.Devices.Sensors.PedometerReading> GetCurrentReadings()
 		{
@@ -79,7 +79,7 @@ namespace Windows.Devices.Sensors
 			throw new global::System.NotImplementedException("The member IAsyncOperation<Pedometer> Pedometer.FromIdAsync(string deviceId) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if __ANDROID__ || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Devices.Sensors.Pedometer> GetDefaultAsync()
 		{
@@ -107,7 +107,7 @@ namespace Windows.Devices.Sensors
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IReadOnlyList<PedometerReading>> Pedometer.GetSystemHistoryAsync(DateTimeOffset fromTime, TimeSpan duration) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if __ANDROID__ || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.Devices.Sensors.Pedometer, global::Windows.Devices.Sensors.PedometerReadingChangedEventArgs> ReadingChanged
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Pedometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Pedometer.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Pedometer 
 	{
-		#if false || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  uint ReportInterval
 		{
@@ -58,7 +58,7 @@ namespace Windows.Devices.Sensors
 		// Forced skipping of method Windows.Devices.Sensors.Pedometer.ReportInterval.get
 		// Forced skipping of method Windows.Devices.Sensors.Pedometer.ReadingChanged.add
 		// Forced skipping of method Windows.Devices.Sensors.Pedometer.ReadingChanged.remove
-		#if __ANDROID__ || false || NET461 || __WASM__ || __MACOS__
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::System.Collections.Generic.IReadOnlyDictionary<global::Windows.Devices.Sensors.PedometerStepKind, global::Windows.Devices.Sensors.PedometerReading> GetCurrentReadings()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Pedometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Pedometer.cs
@@ -79,7 +79,7 @@ namespace Windows.Devices.Sensors
 			throw new global::System.NotImplementedException("The member IAsyncOperation<Pedometer> Pedometer.FromIdAsync(string deviceId) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || false || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Devices.Sensors.Pedometer> GetDefaultAsync()
 		{
@@ -107,7 +107,7 @@ namespace Windows.Devices.Sensors
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IReadOnlyList<PedometerReading>> Pedometer.GetSystemHistoryAsync(DateTimeOffset fromTime, TimeSpan duration) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || false || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.Devices.Sensors.Pedometer, global::Windows.Devices.Sensors.PedometerReadingChangedEventArgs> ReadingChanged
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerReading.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerReading.cs
@@ -5,48 +5,12 @@ namespace Windows.Devices.Sensors
 	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
-	public partial class PedometerReading 
+	public  partial class PedometerReading 
 	{
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  int CumulativeSteps
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int PedometerReading.CumulativeSteps is not implemented in Uno.");
-			}
-		}
-#endif
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::System.TimeSpan CumulativeStepsDuration
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member TimeSpan PedometerReading.CumulativeStepsDuration is not implemented in Uno.");
-			}
-		}
-#endif
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.Devices.Sensors.PedometerStepKind StepKind
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member PedometerStepKind PedometerReading.StepKind is not implemented in Uno.");
-			}
-		}
-#endif
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::System.DateTimeOffset Timestamp
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member DateTimeOffset PedometerReading.Timestamp is not implemented in Uno.");
-			}
-		}
-#endif
+		// Skipping already declared property CumulativeSteps
+		// Skipping already declared property CumulativeStepsDuration
+		// Skipping already declared property StepKind
+		// Skipping already declared property Timestamp
 		// Forced skipping of method Windows.Devices.Sensors.PedometerReading.StepKind.get
 		// Forced skipping of method Windows.Devices.Sensors.PedometerReading.CumulativeSteps.get
 		// Forced skipping of method Windows.Devices.Sensors.PedometerReading.Timestamp.get

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerReading.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerReading.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
-	public  partial class PedometerReading 
+	public partial class PedometerReading 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  int CumulativeSteps
 		{
@@ -16,8 +16,8 @@ namespace Windows.Devices.Sensors
 				throw new global::System.NotImplementedException("The member int PedometerReading.CumulativeSteps is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  global::System.TimeSpan CumulativeStepsDuration
 		{
@@ -26,8 +26,8 @@ namespace Windows.Devices.Sensors
 				throw new global::System.NotImplementedException("The member TimeSpan PedometerReading.CumulativeStepsDuration is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Sensors.PedometerStepKind StepKind
 		{
@@ -36,8 +36,8 @@ namespace Windows.Devices.Sensors
 				throw new global::System.NotImplementedException("The member PedometerStepKind PedometerReading.StepKind is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  global::System.DateTimeOffset Timestamp
 		{
@@ -46,7 +46,7 @@ namespace Windows.Devices.Sensors
 				throw new global::System.NotImplementedException("The member DateTimeOffset PedometerReading.Timestamp is not implemented in Uno.");
 			}
 		}
-		#endif
+#endif
 		// Forced skipping of method Windows.Devices.Sensors.PedometerReading.StepKind.get
 		// Forced skipping of method Windows.Devices.Sensors.PedometerReading.CumulativeSteps.get
 		// Forced skipping of method Windows.Devices.Sensors.PedometerReading.Timestamp.get

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerReadingChangedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerReadingChangedEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if false || false || false || false || false
 	[global::Uno.NotImplemented]
-	#endif
-	public  partial class PedometerReadingChangedEventArgs 
+#endif
+	public partial class PedometerReadingChangedEventArgs
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Sensors.PedometerReading Reading
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerReadingChangedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerReadingChangedEventArgs.cs
@@ -2,21 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-#if false || false || false || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
-#endif
-	public partial class PedometerReadingChangedEventArgs
+	#endif
+	public  partial class PedometerReadingChangedEventArgs 
 	{
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.Devices.Sensors.PedometerReading Reading
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member PedometerReading PedometerReadingChangedEventArgs.Reading is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property Reading
 		// Forced skipping of method Windows.Devices.Sensors.PedometerReadingChangedEventArgs.Reading.get
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerStepKind.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerStepKind.cs
@@ -3,20 +3,14 @@
 namespace Windows.Devices.Sensors
 {
 	#if false || false || false || false || false
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum PedometerStepKind 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Unknown,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Walking,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Running,
-		#endif
+		// Skipping already declared field Windows.Devices.Sensors.PedometerStepKind.Unknown
+		// Skipping already declared field Windows.Devices.Sensors.PedometerStepKind.Walking
+		// Skipping already declared field Windows.Devices.Sensors.PedometerStepKind.Running
 	}
 	#endif
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerStepKind.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/PedometerStepKind.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif


### PR DESCRIPTION
GitHub Issue (If applicable): #2069

## PR Type

- Feature

## What is the current behavior?

`Pedometer` is not supported.

## What is the new behavior?

`Pedometer` is supported for active step-counting :-) .

This PR also unifies the default `ReportInterval` of other sensors on Android (previously it was not adjustable)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)