### PR TITLE
Added support for the CreateFromStringAttribute for xaml type conversion

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+* [#2039] Added support for Xaml type conversions using CreateFromStringAttribute.
 * [#] Support for `Windows.Devices.Lights.Lamp` on iOS, Android.
 * [#1970](https://github.com/unoplatform/uno/pull/1970) Added support for `AnalyticsInfo` properties on iOS, Android and WASM
 * [#1207] Implemented some `PackageId` properties

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/RoslynMetadataHelper.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/RoslynMetadataHelper.cs
@@ -39,7 +39,7 @@ namespace Uno.Roslyn
 			_additionalTypes = additionalTypes ?? new string[0];
 			_legacyTypes = BuildLegacyTypes(legacyTypes);
 			_getAllDerivingTypes = Funcs.Create<INamedTypeSymbol, IEnumerable<INamedTypeSymbol>>(GetAllDerivingTypes).AsLockedMemoized();
-			_getAllTypesAttributedWith = Funcs.Create<string, IEnumerable<INamedTypeSymbol>>(GetAllAttributedTypes).AsLockedMemoized();
+			_getAllTypesAttributedWith = Funcs.Create<string, IEnumerable<INamedTypeSymbol>>(SourceGetAllTypesAttributedWith).AsLockedMemoized();
 			_project = roslynProject;
 			_nullableSymbol = Compilation.GetTypeByMetadataName("System.Nullable`1");
 		}
@@ -280,7 +280,7 @@ namespace Uno.Roslyn
 			return _getAllTypesAttributedWith(attributeClassFullName);
 		}
 
-		private IEnumerable<INamedTypeSymbol> GetAllAttributedTypes(string attributeClassFullName)
+		private IEnumerable<INamedTypeSymbol> SourceGetAllTypesAttributedWith(string attributeClassFullName)
 		{
 			return GetTypesAttributedWith(Compilation.GlobalNamespace);
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/RoslynMetadataHelper.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/RoslynMetadataHelper.cs
@@ -23,6 +23,7 @@ namespace Uno.Roslyn
 		private readonly Func<string, ITypeSymbol[]> _findTypesByName;
 		private readonly Func<string, ITypeSymbol> _findTypeByFullName;
 		private readonly Func<INamedTypeSymbol, IEnumerable<INamedTypeSymbol>> _getAllDerivingTypes;
+		private readonly Func<string, IEnumerable<INamedTypeSymbol>> _getAllTypesAttributedWith;
 		private readonly Dictionary<string, INamedTypeSymbol> _additionalTypesMap;
 
 		public Compilation Compilation { get; }
@@ -38,7 +39,8 @@ namespace Uno.Roslyn
 			_additionalTypes = additionalTypes ?? new string[0];
 			_legacyTypes = BuildLegacyTypes(legacyTypes);
 			_getAllDerivingTypes = Funcs.Create<INamedTypeSymbol, IEnumerable<INamedTypeSymbol>>(GetAllDerivingTypes).AsLockedMemoized();
-			 _project = roslynProject;
+			_getAllTypesAttributedWith = Funcs.Create<string, IEnumerable<INamedTypeSymbol>>(GetAllAttributedTypes).AsLockedMemoized();
+			_project = roslynProject;
 			_nullableSymbol = Compilation.GetTypeByMetadataName("System.Nullable`1");
 		}
 
@@ -265,6 +267,37 @@ namespace Uno.Roslyn
 					else if (member is INamedTypeSymbol type)
 					{
 						if (((INamedTypeSymbol)member).Is(baseType))
+						{
+							yield return type;
+						}
+					}
+				}
+			}
+		}
+
+		public IEnumerable<INamedTypeSymbol> GetAllTypesAttributedWith(string attributeClassFullName)
+		{
+			return _getAllTypesAttributedWith(attributeClassFullName);
+		}
+
+		private IEnumerable<INamedTypeSymbol> GetAllAttributedTypes(string attributeClassFullName)
+		{
+			return GetTypesAttributedWith(Compilation.GlobalNamespace);
+
+			IEnumerable<INamedTypeSymbol> GetTypesAttributedWith(INamespaceSymbol ns)
+			{
+				foreach (var member in ns.GetMembers())
+				{
+					if (member is INamespaceSymbol nsInner)
+					{
+						foreach (var t in GetTypesAttributedWith(nsInner))
+						{
+							yield return t;
+						}
+					}
+					else if (member is INamedTypeSymbol type)
+					{
+						if (type.FindAttribute(attributeClassFullName) is AttributeData _)
 						{
 							yield return type;
 						}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
@@ -72,6 +72,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			// Attributes
 			public const string ContentPropertyAttribute = Markup + ".ContentPropertyAttribute";
+			public const string CreateFromStringAttribute = Metadata + ".CreateFromStringAttribute";
 
 			// Text
 			public const string FontWeight = Namespaces.Text + ".FontWeight";
@@ -116,7 +117,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			public const string MarkupExtension = Markup + ".MarkupExtension";
 			public const string IMarkupExtensionOverrides = Markup + ".IMarkupExtensionOverrides";
 			public const string MarkupExtensionReturnTypeAttribute = Markup + ".MarkupExtensionReturnTypeAttribute";
-			public const string CreateFromStringAttribute = Metadata + ".CreateFromStringAttribute";
 		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
@@ -11,6 +11,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		public const string XmlXmlNamespace = "http://www.w3.org/XML/1998/namespace";
 		public const string BundleResourcePrefix = "ms-appx:///";
 
+		public const string RootFoundationNamespace = "Windows.Foundation";
 		public const string RootUINamespace = "Windows.UI";
 		public const string BaseXamlNamespace = RootUINamespace + ".Xaml";
 		public const string UnoXamlNamespace = "Windows.UI.Xaml";
@@ -67,6 +68,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			public const string ElementStub = BaseXamlNamespace + ".ElementStub";
 			public const string ContentPresenter = Namespaces.Controls + ".ContentPresenter";
 			public const string Markup = BaseXamlNamespace + ".Markup";
+			public const string Metadata = RootFoundationNamespace + ".Metadata";
 
 			// Attributes
 			public const string ContentPropertyAttribute = Markup + ".ContentPropertyAttribute";
@@ -114,6 +116,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			public const string MarkupExtension = Markup + ".MarkupExtension";
 			public const string IMarkupExtensionOverrides = Markup + ".IMarkupExtensionOverrides";
 			public const string MarkupExtensionReturnTypeAttribute = Markup + ".MarkupExtensionReturnTypeAttribute";
+			public const string CreateFromStringAttribute = Metadata + ".CreateFromStringAttribute";
 		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -167,7 +167,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
             _styleSymbol = GetType(XamlConstants.Types.Style);
 
             _markupExtensionTypes = _medataHelper.GetAllTypesDerivingFrom(_markupExtensionSymbol).ToList();
-			_xamlConversionTypes = _medataHelper.GetAllTypesAttributedWith(XamlConstants.Types.CreateFromStringAttribute).ToList();
+            _xamlConversionTypes = _medataHelper.GetAllTypesAttributedWith(XamlConstants.Types.CreateFromStringAttribute).ToList();
 
 			_isWasm = isWasm;
         }
@@ -1465,7 +1465,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var returnType = attributeData?.NamedArguments.FirstOrDefault(kvp => kvp.Key == "MethodName").Value.Value;
 
 			// Return a string that contains the code which calls the "conversion" function with the member value
-			return "{0}".InvariantCultureFormat($"{returnType}(\"{memberValue}\")");
+			return "{0}(\"{1}\")".InvariantCultureFormat(returnType, memberValue);
 		}
 
 		private XamlMemberDefinition FindMember(XamlObjectDefinition xamlObjectDefinition, string memberName)
@@ -2890,13 +2890,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
                 }
             }
 
-			// If the property Type is attributed with the CreateFromStringAttribute
-			if (IsXamlTypeConverter(propertyType))
-			{
-				// We must build the member value as a call to a "conversion" function
-				return BuildXamlTypeConverterLiteralValue(propertyType, memberValue);
-			}
-            
+            // If the property Type is attributed with the CreateFromStringAttribute
+            if (IsXamlTypeConverter(propertyType))
+            {
+                // We must build the member value as a call to a "conversion" function
+                return BuildXamlTypeConverterLiteralValue(propertyType, memberValue);
+            }
+
             propertyType = FindUnderlyingType(propertyType);
             switch (propertyType.ToDisplayString())
             {

--- a/src/SourceGenerators/XamlGenerationTests/CreateFromString.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/CreateFromString.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl x:Class="XamlGenerationTests.Shared.CreateFromString"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:ctl="using:XamlGenerationTests.Shared.CreateFromStringTests"
+			 mc:Ignorable="d">
+
+	<ctl:MyLocationPointControl x:Name="TestLocationControl"
+								LocationPoint="45.0392, 25.29232" />
+	
+</UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/CreateFromString.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/CreateFromString.xaml.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Windows.UI.Xaml.Controls;
+
+namespace XamlGenerationTests.Shared
+{
+	public sealed partial class CreateFromString : UserControl
+	{
+		public CreateFromString()
+		{
+			this.InitializeComponent();
+		}
+	}
+}
+
+namespace XamlGenerationTests.Shared.CreateFromStringTests
+{
+	public partial class MyLocationPointControl : Control
+	{
+		public Location LocationPoint { get; set; }
+	}
+
+	[Windows.Foundation.Metadata.CreateFromString(MethodName = "XamlGenerationTests.Shared.CreateFromStringTests.Location.ConvertToLatLong")]
+	public class Location
+	{
+		public double Latitude { get; set; }
+
+		public double Longitude { get; set; }
+
+		public static Location ConvertToLatLong(string rawString)
+		{
+			var coords = rawString.Split(',');
+
+			return new Location
+			{
+				Latitude = Convert.ToDouble(coords[0]),
+				Longitude = Convert.ToDouble(coords[1])
+			};
+		}
+	}
+}

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -94,6 +94,9 @@
 	  <None Update="ColorCodesTest - Copy.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </None>
+	  <None Update="CreateFromString.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </None>
 	  <None Update="FieldModifiers.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </None>

--- a/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="Uno.UI.Tests.App.Xaml.Test_CreateFromString"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:ctl="using:Uno.UI.Tests.Windows_UI_Xaml.CreateFromStringTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d">
+
+	<Grid>
+		<ctl:MyLocationPointControl x:Name="TestLocationControl"
+									LocationPoint="45.0392, 25.29232" />
+	</Grid>
+
+</UserControl>

--- a/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml.cs
+++ b/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Tests.Windows_UI_Xaml.CreateFromStringTests;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.Tests.App.Xaml
+{
+	public sealed partial class Test_CreateFromString : UserControl
+	{
+		public MyLocationPointControl TestLocationPoint => TestLocationControl;
+
+		public Test_CreateFromString()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -100,6 +100,7 @@
 	<ItemGroup Condition="'$(BuildingInsideUnoSourceGenerator)'!=''">
 		<Page Include="Windows_UI_Xaml_Data\xBindTests\Given_StaticResource_Control.xaml" />
 		<Page Include="App\App.xaml" />
+		<Page Include="App\Xaml\Test_CreateFromString.xaml" />
 		<Page Include="App\Xaml\Test_Dictionary.xaml" />
 		<Page Include="App\Xaml\Test_Control.xaml" />
 		<Page Include="App\Xaml\Test_MarkupExtension.xaml" />

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/CreateFromStringTests/Given_CreateFromString.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/CreateFromStringTests/Given_CreateFromString.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Tests.App.Xaml;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.CreateFromStringTests
+{
+	[TestClass]
+	public class Given_CreateFromString
+	{
+		[TestMethod]
+		public void When_AttributeCreatesEntity()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			var control = new Test_CreateFromString();
+			app.HostView.Children.Add(control);
+
+			var pt = control.TestLocationPoint.LocationPoint;
+
+			Assert.AreEqual(45.0392, pt.Latitude);
+			Assert.AreEqual(25.29232, pt.Longitude);
+		}
+	}
+
+	public partial class MyLocationPointControl : Windows.UI.Xaml.Controls.Control
+	{
+		public Location LocationPoint { get; set; }
+	}
+
+	[Windows.Foundation.Metadata.CreateFromString(MethodName = "Uno.UI.Tests.Windows_UI_Xaml.CreateFromStringTests.Location.ConvertToLatLong")]
+	public class Location
+	{
+		public double Latitude { get; set; }
+
+		public double Longitude { get; set; }
+
+		public static Location ConvertToLatLong(string rawString)
+		{
+			var coords = rawString.Split(',');
+
+			return new Location
+			{
+				Latitude = Convert.ToDouble(coords[0]),
+				Longitude = Convert.ToDouble(coords[1])
+			};
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #2039 

## PR Type

What kind of change does this PR introduce?

*Feature*: Added support for UWP Xaml Type Conversion with CreateFromStringAttribute.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Other information

Not much documentation exists for CreateFromStringAttribute but this article explains it nicely:

[https://timheuer.com/blog/implement-type-converter-uwp-winrt-windows-10-xaml](https://timheuer.com/blog/implement-type-converter-uwp-winrt-windows-10-xaml)