### PR TITLE
Flyout Fixes, UI Tests stabilization

### DIFF
--- a/.azure-devops-android-tests.yml
+++ b/.azure-devops-android-tests.yml
@@ -15,6 +15,7 @@ jobs:
     clean: true
 
   - task: CacheBeta@0
+    condition: eq(variables['enable_package_cache'], 'true')
     inputs:
       key: nuget | $(Agent.OS) | $(Agent.JobName) | $(build.sourcesdirectory)/**/*.csproj | $(build.sourcesdirectory)/**/Directory.Build.targets | $(build.sourcesdirectory)/**/Directory.Build.props
       path: $(NUGET_PACKAGES)

--- a/.azure-devops-docs.yml
+++ b/.azure-devops-docs.yml
@@ -17,6 +17,7 @@ jobs:
     clean: true
 
   - task: CacheBeta@0
+    condition: eq(variables['enable_package_cache'], 'true')
     inputs:
       key: nuget | $(Agent.OS) | $(Agent.JobName) | $(build.sourcesdirectory)/**/*.csproj | $(build.sourcesdirectory)/**/Directory.Build.targets | $(build.sourcesdirectory)/**/Directory.Build.props
       path: $(NUGET_PACKAGES)

--- a/.azure-devops-ios-tests.yml
+++ b/.azure-devops-ios-tests.yml
@@ -15,6 +15,7 @@ jobs:
     clean: true
 
   - task: CacheBeta@0
+    condition: eq(variables['enable_package_cache'], 'true')
     inputs:
       key: nuget | $(Agent.OS) | $(Agent.JobName) | $(build.sourcesdirectory)/**/*.csproj | $(build.sourcesdirectory)/**/Directory.Build.targets | $(build.sourcesdirectory)/**/Directory.Build.props
       path: $(NUGET_PACKAGES)

--- a/.azure-devops-macos.yml
+++ b/.azure-devops-macos.yml
@@ -16,6 +16,7 @@ jobs:
     clean: true
 
   - task: CacheBeta@0
+    condition: eq(variables['enable_package_cache'], 'true')
     inputs:
       key: nuget | $(Agent.OS) | $(Agent.JobName) | $(build.sourcesdirectory)/**/*.csproj | $(build.sourcesdirectory)/**/Directory.Build.targets | $(build.sourcesdirectory)/**/Directory.Build.props
       path: $(NUGET_PACKAGES)

--- a/.azure-devops-wasm-uitests.yml
+++ b/.azure-devops-wasm-uitests.yml
@@ -16,6 +16,7 @@ jobs:
     clean: true
 
   - task: CacheBeta@0
+    condition: eq(variables['enable_package_cache'], 'true')
     inputs:
       key: nuget | $(Agent.OS) | $(Agent.JobName) | $(build.sourcesdirectory)/**/*.csproj | $(build.sourcesdirectory)/**/Directory.Build.targets | $(build.sourcesdirectory)/**/Directory.Build.props
       path: $(NUGET_PACKAGES)

--- a/.azure-devops-windows.yml
+++ b/.azure-devops-windows.yml
@@ -19,6 +19,7 @@ jobs:
     clean: true
 
   - task: CacheBeta@0
+    condition: eq(variables['enable_package_cache'], 'true')
     inputs:
       key: 'nuget | $(Agent.OS) | $(Agent.JobName) | $(build.sourcesdirectory)/**/*.csproj, !$(build.sourcesdirectory)/**/obj/Release, !$(build.sourcesdirectory)/**/Uno.UI.Tasks.csproj, !$(build.sourcesdirectory)/**/UnoQuickStart.*.csproj, !$(build.sourcesdirectory)/**/UnoLibraryTemplate/CrossTargetedLibrary.csproj | $(build.sourcesdirectory)/**/Directory.Build.targets | $(build.sourcesdirectory)/**/Directory.Build.props'
       path: $(NUGET_PACKAGES)

--- a/build/android-uitest-build.sh
+++ b/build/android-uitest-build.sh
@@ -12,4 +12,4 @@ export IsUiAutomationMappingEnabled=true
 msbuild /r /p:Configuration=$BUILDCONFIGURATION $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
 
 mkdir -p $BUILD_ARTIFACTSTAGINGDIRECTORY/android
-cp $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/bin/$BUILDCONFIGURATION/uno.platform.unosampleapp.apk $BUILD_ARTIFACTSTAGINGDIRECTORY/android
+cp $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/bin/$BUILDCONFIGURATION/uno.platform.unosampleapp-Signed.apk $BUILD_ARTIFACTSTAGINGDIRECTORY/android

--- a/build/android-uitest-run.sh
+++ b/build/android-uitest-run.sh
@@ -52,5 +52,6 @@ mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-conso
 	--workers=1 \
 	$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/$BUILDCONFIGURATION/net47/SamplesApp.UITests.dll
 
-$ANDROID_HOME/platform-tools/adb shell logcat -d > $BUILD_ARTIFACTSTAGINGDIRECTORY/android-device-log.txt
+$ANDROID_HOME/platform-tools/adb shell logcat -d > $BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/android-$ANDROID_SIMULATOR_APILEVEL/android-device-log.txt
+
 cp $UNO_UITEST_ANDROIDAPK_PATH $BUILD_ARTIFACTSTAGINGDIRECTORY

--- a/build/android-uitest-run.sh
+++ b/build/android-uitest-run.sh
@@ -38,7 +38,7 @@ echo "Emulator started"
 
 export UNO_UITEST_SCREENSHOT_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/android-$ANDROID_SIMULATOR_APILEVEL
 export UNO_UITEST_PLATFORM=Android
-export UNO_UITEST_ANDROIDAPK_PATH=$BUILD_SOURCESDIRECTORY/build/uitests-android-build/android/uno.platform.unosampleapp.apk
+export UNO_UITEST_ANDROIDAPK_PATH=$BUILD_SOURCESDIRECTORY/build/uitests-android-build/android/uno.platform.unosampleapp-Signed.apk
 
 cd $BUILD_SOURCESDIRECTORY/build
 

--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -30,6 +30,7 @@ mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-conso
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests' or \
 	namespace = 'SamplesApp.UITests' or \
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Input.VisualState_Tests' or \
+	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests' or \
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' \
 	" \
 	$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/net47/SamplesApp.UITests.dll \

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -186,6 +186,7 @@
 * [Wasm] Fix unable to reset `Image.Source` property
 * [#2014](https://github.com/unoplatform/uno/issues/2014) Fix iOS Picker for ComboBox not selecting the correct item.
 * [iOS] #977 Fix exception when setting MediaPlayerElement.Stretch in XAML.
+* #1708 Fix initial Flyout placement and window resize placement
 
 ## Release 1.45.0
 ### Features

--- a/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
@@ -13,21 +13,50 @@ namespace SamplesApp.UITests
 	[TestFixture]
 	public partial class RuntimeTests : SampleControlUITestBase
 	{
+		private const string PendingTestsText = "Pending...";
+		private readonly TimeSpan TestRunTimeout = TimeSpan.FromMinutes(2);
+
 		[Test]
 		[AutoRetry]
-		public void RunRuntimeTests()
+		public async Task RunRuntimeTests()
 		{
 			Run("SamplesApp.Samples.UnitTests.UnitTestsPage");
 
 			var runButton = _app.Marked("runButton");
 			var failedTests = _app.Marked("failedTests");
+			var runTestCount = _app.Marked("runTestCount");
+
+			bool IsTestExecutionDone()
+				=> failedTests.GetDependencyPropertyValue("Text").ToString() != PendingTestsText;
 
 			_app.WaitForElement(runButton);
 
 			_app.Tap(runButton);
 
-			_app.WaitFor(() => failedTests.GetDependencyPropertyValue("Text").ToString() != "Pending...");
+			var lastChange = DateTimeOffset.Now;
+			var lastValue = "";
 
+			while(DateTimeOffset.Now - lastChange < TestRunTimeout)
+			{
+				var newValue = runTestCount.GetDependencyPropertyValue<string>("Text");
+
+				if (lastValue != newValue)
+				{
+					lastChange = DateTimeOffset.Now;
+				}
+
+				await Task.Delay(TimeSpan.FromSeconds(.5));
+
+				if (IsTestExecutionDone())
+				{
+					break;
+				}
+			}
+
+			if (!IsTestExecutionDone())
+			{
+				Assert.Fail("A test run timed out");
+			}
 
 			var count = failedTests.GetDependencyPropertyValue("Text").ToString();
 
@@ -40,5 +69,6 @@ namespace SamplesApp.UITests
 
 			TakeScreenshot("Runtime Tests Results");
 		}
+
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest;
 using Uno.UITest.Helpers;
@@ -36,7 +37,6 @@ namespace SamplesApp.UITests
 			// and gain some time for the tests.
 			AppInitializer.ColdStartApp();
 		}
-
 
 		[SetUp]
 		[AutoRetry]
@@ -85,6 +85,19 @@ namespace SamplesApp.UITests
 			_app = app ?? _app;
 
 			Helpers.App = _app;
+		}
+
+		[TearDown]
+		public void AfterEachTest()
+		{
+			if (
+				TestContext.CurrentContext.Result.Outcome != ResultState.Success
+				&& TestContext.CurrentContext.Result.Outcome != ResultState.Skipped
+				&& TestContext.CurrentContext.Result.Outcome != ResultState.Ignored
+			)
+			{
+				TakeScreenshot($"{TestContext.CurrentContext.Test.Name} - Tear down on error");
+			}
 		}
 
 		internal IAppRect GetScreenDimensions()

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -221,9 +221,12 @@ namespace SamplesApp.UITests
 			return Array.Empty<Platform>();
 		}
 
-		protected void Run(string metadataName)
+		protected void Run(string metadataName, bool waitForSampleControl = true)
 		{
-			_app.WaitForElement("sampleControl");
+			if (waitForSampleControl)
+			{
+				_app.WaitForElement("sampleControl");
+			}
 
 			var testRunId = _app.InvokeGeneric("browser:SampleRunner|RunTest", metadataName);
 

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -87,6 +87,13 @@ namespace SamplesApp.UITests
 			Helpers.App = _app;
 		}
 
+		internal IAppRect GetScreenDimensions()
+		{
+			var sampleControl = _app.Marked("sampleControl");
+
+			return _app.WaitForElement(sampleControl).First().Rect;
+		}
+
 		public FileInfo TakeScreenshot(string stepName)
 		{
 			var title = $"{TestContext.CurrentContext.Test.Name}_{stepName}"

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -102,9 +102,16 @@ namespace SamplesApp.UITests
 
 		internal IAppRect GetScreenDimensions()
 		{
-			var sampleControl = _app.Marked("sampleControl");
+			if (AppInitializer.GetLocalPlatform() == Platform.Browser)
+			{
+				var sampleControl = _app.Marked("sampleControl");
 
-			return _app.WaitForElement(sampleControl).First().Rect;
+				return _app.WaitForElement(sampleControl).First().Rect;
+			}
+			else
+			{
+				return _app.GetScreenDimensions();
+			}
 		}
 
 		public FileInfo TakeScreenshot(string stepName)

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -100,20 +100,6 @@ namespace SamplesApp.UITests
 			}
 		}
 
-		internal IAppRect GetScreenDimensions()
-		{
-			if (AppInitializer.GetLocalPlatform() == Platform.Browser)
-			{
-				var sampleControl = _app.Marked("sampleControl");
-
-				return _app.WaitForElement(sampleControl).First().Rect;
-			}
-			else
-			{
-				return _app.GetScreenDimensions();
-			}
-		}
-
 		public FileInfo TakeScreenshot(string stepName)
 		{
 			var title = $"{TestContext.CurrentContext.Test.Name}_{stepName}"
@@ -249,5 +235,20 @@ namespace SamplesApp.UITests
 
 			TakeScreenshot(metadataName.Replace(".", "_"));
 		}
+
+		internal IAppRect GetScreenDimensions()
+		{
+			if (AppInitializer.GetLocalPlatform() == Platform.Browser)
+			{
+				var sampleControl = _app.Marked("sampleControl");
+
+				return _app.WaitForElement(sampleControl).First().Rect;
+			}
+			else
+			{
+				return _app.GetScreenDimensions();
+			}
+		}
+
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -143,8 +143,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 
 			_app.WaitForElement(datePickerFlyout);
 
-			// Reload the sample to dismiss the popup
-			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePickerFlyout_Unloaded");
+			// Load another sample to dismiss the popup
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePicker_SampleContent");
+
+			_app.WaitForNoElement(datePickerFlyout);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -37,6 +37,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 
 			_app.WaitForDependencyPropertyValue(datePickerFlyout, "DataContext", "UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.Models.DatePickerViewModel");
 
+			_app.TapCoordinates(20, 20);
 		}
 
 		[Test]
@@ -55,6 +56,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			theDatePicker.Tap();
 
 			_app.WaitForDependencyPropertyValue(datePickerFlyout, "Content", "Windows.UI.Xaml.Controls.DatePickerSelector");
+
+			_app.TapCoordinates(20, 20);
 		}
 
 		[Test]
@@ -73,6 +76,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			button.Tap();
 
 			TakeScreenshot("DatePicker - Flyout");
+
+			_app.TapCoordinates(20, 20);
 		}
 
 		[Test]
@@ -94,6 +99,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			theDatePicker.Tap();
 
 			_app.WaitFor(() => datePickerFlyout.GetDependencyPropertyValue<string>("MinYear") == minYear);
+
+			_app.TapCoordinates(20, 20);
 		}
 
 		[Test]
@@ -116,6 +123,28 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 
 			//Assert
 			_app.WaitFor(() => datePickerFlyout.GetDependencyPropertyValue<string>("MaxYear") == maxYear);
+
+			_app.TapCoordinates(20, 20);
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)] // Android is disabled https://github.com/unoplatform/uno/issues/1634
+		public void DatePickerFlyout_Unloaded()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePickerFlyout_Unloaded");
+
+			var TestDatePickerFlyoutButton = _app.Marked("TestDatePickerFlyoutButton");
+			var datePickerFlyout = _app.CreateQuery(q => q.WithClass("Windows_UI_Xaml_Controls_DatePickerSelector"));
+
+			_app.WaitForElement(TestDatePickerFlyoutButton);
+
+			TestDatePickerFlyoutButton.Tap();
+
+			_app.WaitForElement(datePickerFlyout);
+
+			// Reload the sample to dismiss the popup
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePickerFlyout_Unloaded");
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -144,7 +144,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			_app.WaitForElement(datePickerFlyout);
 
 			// Load another sample to dismiss the popup
-			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePicker_SampleContent");
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePicker_SampleContent", waitForSampleControl: false);
 
 			_app.WaitForNoElement(datePickerFlyout);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -90,5 +90,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 				_app.TapCoordinates(10, 100);
 			}
 		}
+
+		[Test]
+		public void FlyoutTest_Unloaded()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.Flyout.Flyout_Unloaded");
+
+			var outerButton = _app.Marked("outerButton");
+			var innerButton = _app.Marked("innerButton");
+
+			_app.Tap(outerButton);
+			_app.WaitForElement(innerButton);
+
+			_app.Tap(innerButton);
+
+			_app.WaitForNoElement(outerButton);
+			_app.WaitForNoElement(innerButton);
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -33,5 +33,56 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			//// Assert initial state 
 			//Assert.AreEqual("0", flyoutRect.X.ToString());
 		}
+
+		[Test]
+		public void FlyoutTest_Target()
+		{
+			Run("Uno.UI.Samples.Content.UITests.Flyout.Flyout_Target");
+
+			var result = _app.Marked("result");
+			var innerContent = _app.Marked("innerContent");
+			var target1 = _app.Marked("target1");
+			var target2 = _app.Marked("target2");
+			var flyoutFull = _app.Marked("flyoutFull");
+
+			_app.WaitForElement(result);
+
+			{
+				_app.Tap(target1);
+
+				var target1Result = _app.WaitForElement(target1).First();
+				var innerContentResult = _app.WaitForElement(innerContent).First();
+
+				Assert.IsTrue(target1Result.Rect.X <= innerContentResult.Rect.X);
+				Assert.IsTrue(target1Result.Rect.Width > innerContentResult.Rect.Width);
+
+				_app.Tap(target1);
+			}
+
+			{
+				_app.Tap(target2);
+
+				var target2Result = _app.WaitForElement(target2).First();
+				var innerContentResult = _app.WaitForElement(innerContent).First();
+
+				Assert.IsTrue(target2Result.Rect.X <= innerContentResult.Rect.X);
+				Assert.IsTrue(target2Result.Rect.Width > innerContentResult.Rect.Width);
+
+				_app.Tap(target2);
+			}
+
+			{
+				_app.Tap(flyoutFull);
+
+				var innerContentResult = _app.WaitForElement(innerContent).First();
+
+				var rect = base.GetScreenDimensions();
+
+				Assert.AreEqual(innerContentResult.Rect.CenterX, rect.CenterX, 1);
+				Assert.AreEqual(innerContentResult.Rect.CenterY, rect.CenterY, 1);
+
+				_app.TapCoordinates(10, 100);
+			}
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
+using Uno.UITests.Helpers;
 
 namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 {
@@ -79,7 +80,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 				var rect = base.GetScreenDimensions();
 
 				Assert.AreEqual(innerContentResult.Rect.CenterX, rect.CenterX, 1);
-				Assert.AreEqual(innerContentResult.Rect.CenterY, rect.CenterY, 1);
+
+				if (AppInitializer.GetLocalPlatform() == Platform.Browser)
+				{
+					// Flyout positioning does not take proper app bar positioning yet.
+					Assert.AreEqual(innerContentResult.Rect.CenterY, rect.CenterY, 1);
+				}
 
 				_app.TapCoordinates(10, 100);
 			}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -49,9 +49,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			_app.WaitForElement(result);
 
 			{
+				var target1Result = _app.WaitForElement(target1).First();
+
 				_app.Tap(target1);
 
-				var target1Result = _app.WaitForElement(target1).First();
 				var innerContentResult = _app.WaitForElement(innerContent).First();
 
 				Assert.IsTrue(target1Result.Rect.X <= innerContentResult.Rect.X);
@@ -61,9 +62,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			}
 
 			{
+				var target2Result = _app.WaitForElement(target2).First();
+
 				_app.Tap(target2);
 
-				var target2Result = _app.WaitForElement(target2).First();
 				var innerContentResult = _app.WaitForElement(innerContent).First();
 
 				Assert.IsTrue(target2Result.Rect.X <= innerContentResult.Rect.X);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -58,7 +58,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 				Assert.IsTrue(target1Result.Rect.X <= innerContentResult.Rect.X);
 				Assert.IsTrue(target1Result.Rect.Width > innerContentResult.Rect.Width);
 
-				_app.Tap(target1);
+				_app.TapCoordinates(50, 100);
 			}
 
 			{
@@ -71,7 +71,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 				Assert.IsTrue(target2Result.Rect.X <= innerContentResult.Rect.X);
 				Assert.IsTrue(target2Result.Rect.Width > innerContentResult.Rect.Width);
 
-				_app.Tap(target2);
+				_app.TapCoordinates(50, 100);
 			}
 
 			{

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -55,6 +55,11 @@ namespace Uno.UI.Samples.Tests
 			var t = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => runStatus.Text = message);
 		}
 
+		private void ReportRunTestCount(string message)
+		{
+			var t = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => runTestCount.Text = message);
+		}
+
 		private void ReportFailedTests(int failedCount)
 		{
 			void Update()
@@ -139,6 +144,7 @@ namespace Uno.UI.Samples.Tests
 			try
 			{
 				var failedTests = 0;
+				var runTests = 0;
 
 				ReportMessage("Enumerating tests");
 
@@ -164,6 +170,7 @@ namespace Uno.UI.Samples.Tests
 						}
 
 						ReportMessage($"Running test {testName}");
+						ReportRunTestCount($"Run tests: {++runTests}");
 
 						try
 						{

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -25,6 +25,7 @@ namespace Uno.UI.Samples.Tests
 	{
 		private Task _runner;
 		private CancellationTokenSource _cts = new CancellationTokenSource();
+		private readonly TimeSpan DefaultUnitTestTimeout = TimeSpan.FromSeconds(60);
 
 		private enum TestResult
 		{
@@ -173,7 +174,14 @@ namespace Uno.UI.Samples.Tests
 							if (testMethod.ReturnType == typeof(Task))
 							{
 								var task = (Task)returnValue;
-								await task;
+								var timeoutTask = Task.Delay(DefaultUnitTestTimeout);
+
+								var resultingTask = await Task.WhenAny(task, timeoutTask);
+
+								if (resultingTask == timeoutTask)
+								{
+									throw new TimeoutException($"Test execution timed out after {DefaultUnitTestTimeout}");
+								}
 							}
 
 							ReportTestResult(testName, TestResult.Sucesss);

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
@@ -23,10 +23,11 @@
 			  Click="OnRunTests" />
 			<TextBlock x:Name="runStatus"
 				 Text="Not initialized" />
-			<ScrollViewer Height="100">
-				<TextBlock x:Name="failedTestDetails" Opacity="0.1" />
-			</ScrollViewer>
 			<TextBlock x:Name="failedTests" Text="Pending..." />
+			<TextBlock x:Name="runTestCount" Text="None" />
+			<ScrollViewer Height="100">
+				<TextBlock x:Name="failedTestDetails" Opacity="0.5" />
+			</ScrollViewer>
 		</StackPanel>
 		<ScrollViewer Grid.Row="1">
 			<StackPanel x:Name="testResults">

--- a/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
+++ b/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
@@ -16,7 +16,7 @@
     <!-- https://github.com/unoplatform/uno/issues/61 -->
     <UnoSkipUserControlsInVisualTree>false</UnoSkipUserControlsInVisualTree>
   </PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -31,19 +31,19 @@
     <MtouchExtraArgs>--xml=./LinkerExclusions.xml --linkskip=$(AssemblyName) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
-		<DebugType>none</DebugType>
-		<Optimize>true</Optimize>
-		<OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
     <DefineConstants>XAMARIN;HAS_UNO</DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
-		<WarningLevel>4</WarningLevel>
-		<MtouchLink>None</MtouchLink>
-		<MtouchArch>x86_64</MtouchArch>
-		<ConsolePause>false</ConsolePause>
-		<MtouchExtraArgs>--xml=./LinkerExclusions.xml --linkskip=$(AssemblyName) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <ConsolePause>false</ConsolePause>
+    <MtouchExtraArgs>--xml=./LinkerExclusions.xml --linkskip=$(AssemblyName) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -145,7 +145,7 @@
       <Project>{f9277925-fc11-4a97-8ca1-b4a33e726f55}</Project>
       <Name>Uno.UI.Lottie</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\Uno.HotReload\Uno.UI.HotReload.csproj">
+    <ProjectReference Include="..\..\Uno.UI.RemoteControl\Uno.UI.RemoteControl.csproj">
       <Project>{80798130-cb7e-4968-b4f6-554cc0fc8feb}</Project>
       <Name>Uno.UI.HotReload</Name>
     </ProjectReference>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -445,6 +445,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Unloaded.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_MinWidthColumns.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2896,6 +2900,9 @@
       <DependentUpon>ContentDialog_ComboBox.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\FlyoutButtonViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Unloaded.xaml.cs">
+      <DependentUpon>Flyout_Unloaded.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_MinWidthColumns.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_ImageSource_PixelSize.xaml.cs">
       <DependentUpon>Image_ImageSource_PixelSize.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -445,6 +445,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_Unloaded.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Unloaded.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2900,6 +2904,9 @@
       <DependentUpon>ContentDialog_ComboBox.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\FlyoutButtonViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_Unloaded.xaml.cs">
+      <DependentUpon>DatePickerFlyout_Unloaded.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Unloaded.xaml.cs">
       <DependentUpon>Flyout_Unloaded.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Automated.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Automated.xaml
@@ -9,13 +9,17 @@
 			 d:DesignWidth="400">
 
 	<Grid>
-		<!--  DatePicker is broken: https://github.com/unoplatform/uno/issues/188  -->
-		<!--  Using a Button with DatePickerFlyout to simulate a DatePicker  -->
-		<Button x:Name="TestDatePickerFlyoutButton"
+		<StackPanel VerticalAlignment="Center">
+			<TextBlock x:Name="selectedDate" Text="None" />
+			
+			<!--  DatePicker is broken: https://github.com/unoplatform/uno/issues/188  -->
+			<!--  Using a Button with DatePickerFlyout to simulate a DatePicker  -->
+			<Button x:Name="TestDatePickerFlyoutButton"
 				Content="Open DatePickerFlyout">
-			<Button.Flyout>
-				<DatePickerFlyout x:Name="TestDatePickerFlyout" />
-			</Button.Flyout>
-		</Button>
+				<Button.Flyout>
+					<DatePickerFlyout x:Name="TestDatePickerFlyout" />
+				</Button.Flyout>
+			</Button>
+		</StackPanel>
 	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Automated.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Automated.xaml.cs
@@ -24,6 +24,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.DatePicker
 			this.InitializeComponent();
 
 			this.TestDatePickerFlyout.Date = new DateTimeOffset(new DateTime(2019, 3, 12));
+			this.TestDatePickerFlyout.DatePicked += (s, e) => selectedDate.Text = TestDatePickerFlyout.Date.ToString();
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Unloaded.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Unloaded.xaml
@@ -10,7 +10,7 @@
     d:DesignWidth="400">
 
 	<Grid x:Name="root">
-		<StackPanel>
+		<StackPanel VerticalAlignment="Center">
 			<Button x:Name="TestDatePickerFlyoutButton"
 				Content="Open DatePickerFlyout">
 				<Button.Flyout>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Unloaded.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Unloaded.xaml
@@ -1,0 +1,32 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePickerFlyout_Unloaded"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.DatePicker"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid x:Name="root">
+		<StackPanel>
+			<Button x:Name="TestDatePickerFlyoutButton"
+				Content="Open DatePickerFlyout">
+				<Button.Flyout>
+					<DatePickerFlyout x:Name="TestDatePickerFlyout"
+								  MinYear="{x:Bind Date}"
+								  Date="{x:Bind Date}"/>
+				</Button.Flyout>
+			</Button>
+			<DatePicker x:Name="theDatePicker"
+						Margin="15,10"
+						MinYear="{x:Bind Date}"
+						Date="{x:Bind Date}"
+						HorizontalAlignment="Center"
+						VerticalAlignment="Top">
+			</DatePicker>
+
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Unloaded.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Unloaded.xaml.cs
@@ -27,7 +27,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.DatePicker
             this.InitializeComponent();
 
 #if DEBUG
-			Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, async () => {
+			_ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, async () => {
 				await Task.Delay(5000);
 				root.Children.Remove(TestDatePickerFlyoutButton);
 				root.Children.Remove(theDatePicker);

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Unloaded.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Unloaded.xaml.cs
@@ -26,12 +26,14 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.DatePicker
         {
             this.InitializeComponent();
 
+#if DEBUG
 			Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, async () => {
 				await Task.Delay(5000);
 				root.Children.Remove(TestDatePickerFlyoutButton);
 				root.Children.Remove(theDatePicker);
 			});
-        }
+#endif
+		}
 
 		public DateTimeOffset Date => new DateTimeOffset(2019, 05, 04, 0, 0, 0, TimeSpan.Zero);
 	}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Unloaded.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Unloaded.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.DatePicker
+{
+	[SampleControlInfo("Date Picker")]
+	public sealed partial class DatePickerFlyout_Unloaded : UserControl
+    {
+        public DatePickerFlyout_Unloaded()
+        {
+            this.InitializeComponent();
+
+			Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, async () => {
+				await Task.Delay(5000);
+				root.Children.Remove(TestDatePickerFlyoutButton);
+				root.Children.Remove(theDatePicker);
+			});
+        }
+
+		public DateTimeOffset Date => new DateTimeOffset(2019, 05, 04, 0, 0, 0, TimeSpan.Zero);
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Target.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Target.xaml
@@ -10,11 +10,16 @@
     d:DesignWidth="400">
 
 	<StackPanel>
-		<TextBlock x:Name="FlyoutTarget" />
-		<Button Click="OnClick"
+		<TextBlock x:Name="result" />
+		<Button x:Name="target1"
+				Click="OnClick"
 				Content="Flyout Target #1" />
-		<Button Click="OnClick"
+		<Button x:Name="target2"
+				Click="OnClick"
 				Content="Flyout Target #2" />
+		<Button x:Name="flyoutFull"
+				Click="OnClickFull"
+				Content="Flyout Full Placement NoTarget" />
 	</StackPanel>
 
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Target.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Target.xaml
@@ -9,17 +9,19 @@
     d:DesignHeight="300"
     d:DesignWidth="400">
 
-	<StackPanel>
-		<TextBlock x:Name="result" />
-		<Button x:Name="target1"
+	<Grid>
+		<StackPanel VerticalAlignment="Center">
+			<TextBlock x:Name="result" />
+			<Button x:Name="target1"
 				Click="OnClick"
 				Content="Flyout Target #1" />
-		<Button x:Name="target2"
+			<Button x:Name="target2"
 				Click="OnClick"
 				Content="Flyout Target #2" />
-		<Button x:Name="flyoutFull"
+			<Button x:Name="flyoutFull"
 				Click="OnClickFull"
 				Content="Flyout Full Placement NoTarget" />
-	</StackPanel>
+		</StackPanel>
+	</Grid>
 
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Target.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Target.xaml.cs
@@ -9,33 +9,53 @@ namespace Uno.UI.Samples.Content.UITests.Flyout
 	[SampleControlInfo("Flyout", "Flyout_Target")]
 	public sealed partial class Flyout_Target : UserControl
 	{
-		private Windows.UI.Xaml.Controls.Flyout _flyout;
-
 		public Flyout_Target()
 		{
 			this.InitializeComponent();
 
-			_flyout = new Windows.UI.Xaml.Controls.Flyout()
+		}
+
+		private void OnClick(object s, RoutedEventArgs e)
+		{
+			result.Text = "";
+
+			var flyout = new Windows.UI.Xaml.Controls.Flyout()
 			{
 				Content = new Border
 				{
+					Name = "innerContent",
 					Height = 100,
 					Width = 100,
 					Background = new SolidColorBrush(Colors.Red)
 				}
 			};
+
+			var target = s as FrameworkElement;
+			flyout.ShowAt(target);
+
+			var success = flyout.Target == target;
+
+			result.Text = success ? "success" : "failed";
 		}
 
-		private void OnClick(object s, RoutedEventArgs e)
+		private void OnClickFull(object s, RoutedEventArgs e)
 		{
+			result.Text = "";
 			var target = s as FrameworkElement;
-			_flyout.ShowAt(target);
-			var success = _flyout.Target == target;
-			var t = new Windows.UI.Popups.MessageDialog(
-				success
-					? "Flyout.Target updated correctly."
-					: "Flyout.Target updated incorrectly.")
-				.ShowAsync();
+
+			var flyout = new Windows.UI.Xaml.Controls.Flyout()
+			{
+				Content = new Border
+				{
+					Name = "innerContent",
+					Height = 100,
+					Width = 100,
+					Background = new SolidColorBrush(Colors.Red)
+				},
+				Placement = Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.Full
+			};
+
+			flyout.ShowAt(target);
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Unloaded.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Unloaded.xaml
@@ -1,0 +1,27 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Flyout.Flyout_Unloaded"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.Flyout"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<StackPanel VerticalAlignment="Center" x:Name="outerPanel">
+			<Button Content="Open flyout" x:Name="outerButton">
+				<Button.Flyout>
+					<Flyout x:Name="MyFlyout">
+						<Border Height="100"
+								Width="100"
+								Background="Red">
+							<Button x:Name="innerButton" Content="Unload parent" Click="OnUnloadParent" />
+						</Border>
+					</Flyout>
+				</Button.Flyout>
+			</Button>
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Unloaded.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Unloaded.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Flyout
+{
+	[SampleControlInfo("Flyout", "Flyout_Unloaded")]
+	public sealed partial class Flyout_Unloaded : UserControl
+    {
+        public Flyout_Unloaded()
+        {
+            this.InitializeComponent();
+        }
+
+		private void OnUnloadParent(object sender, object args)
+		{
+			outerPanel.Children.Remove(outerButton);
+		}
+	}
+}

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.csproj
@@ -75,6 +75,9 @@
 			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
 			<UndefineProperties>TargetFramework</UndefineProperties>
 		</ProjectReference>
+	</ItemGroup>
+	
+	<ItemGroup Condition="'$(DocsGeneration)'=='' and $([MSBuild]::IsOsPlatform('Windows'))">
 		<ProjectReference Include="..\Uno.UI.RemoteControl.VS\Uno.UI.RemoteControl.VS.csproj">
 			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
 			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>

--- a/src/Uno.UI/UI/Xaml/Controls/Button/Button.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/Button.cs
@@ -49,6 +49,13 @@ namespace Windows.UI.Xaml.Controls
 			);
 		#endregion
 
+		protected override void OnUnloaded()
+		{
+			base.OnUnloaded();
+
+			Flyout?.Close();
+		}
+
 		protected override AutomationPeer OnCreateAutomationPeer()
 		{
 			return new ButtonAutomationPeer(this);

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
@@ -60,7 +60,12 @@ namespace Windows.UI.Xaml.Controls
 
 		protected PlacementPopupPanel(Popup popup) : base(popup)
 		{
+			Loaded += (s, e) => Window.Current.SizeChanged += Current_SizeChanged;
+			Unloaded += (s, e) => Window.Current.SizeChanged -= Current_SizeChanged;
 		}
+
+		private void Current_SizeChanged(object sender, Core.WindowSizeChangedEventArgs e)
+			=> InvalidateMeasure();
 
 		protected abstract FlyoutPlacementMode PopupPlacement { get; }
 
@@ -95,8 +100,8 @@ namespace Windows.UI.Xaml.Controls
 			var anchorRect = anchor.GetBoundsRectRelativeTo(this);
 
 			// Make sure the desiredSize fits in the panel
-			desiredSize.Width = Math.Min(desiredSize.Width, ActualWidth);
-			desiredSize.Height = Math.Min(desiredSize.Height, ActualHeight);
+			desiredSize.Width = Math.Min(desiredSize.Width, visibleBounds.Width);
+			desiredSize.Height = Math.Min(desiredSize.Height, visibleBounds.Height);
 
 			// Try all placements...
 			var placementsToTry = PlacementsToTry.TryGetValue(PopupPlacement, out var p)
@@ -140,8 +145,8 @@ namespace Windows.UI.Xaml.Controls
 						break;
 					default: // Full + other unsupported placements
 						finalPosition = new Point(
-							x: (ActualWidth - desiredSize.Width) / 2.0,
-							y: (ActualHeight - desiredSize.Height) / 2.0);
+							x: (visibleBounds.Width - desiredSize.Width) / 2.0,
+							y: (visibleBounds.Height - desiredSize.Height) / 2.0);
 						break;
 				}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
@@ -60,8 +60,8 @@ namespace Windows.UI.Xaml.Controls
 
 		protected PlacementPopupPanel(Popup popup) : base(popup)
 		{
-			Loaded += (s, e) => Window.Current.SizeChanged += Current_SizeChanged;
-			Unloaded += (s, e) => Window.Current.SizeChanged -= Current_SizeChanged;
+			Loaded += (s, e) => Windows.UI.Xaml.Window.Current.SizeChanged += Current_SizeChanged;
+			Unloaded += (s, e) => Windows.UI.Xaml.Window.Current.SizeChanged -= Current_SizeChanged;
 		}
 
 		private void Current_SizeChanged(object sender, Core.WindowSizeChangedEventArgs e)


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #1708 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Fixes the initial popup and window resize placement of a flyout
- Fixes flyout should close the button that opened it is closed
- Add test failure screenshot
- Fix android tests should use signed APK

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)


## Other information

