### PR TITLE
Fix pressed state of ListView items

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
@@ -91,7 +91,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			"MyHyperlink"); // There is no "VisualState" for Hyperlink, only a hardcoded opacity of .5 (kind-of like UWP)
 
 		[Test]
-		[ActivePlatforms(Platform.iOS, Platform.Android)]
 		public void TestListViewReleasedOut()
 		{
 			Run("UITests.Shared.Windows_UI_Input.VisualStatesTests.ListViewItem");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
@@ -16,7 +16,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 	{
 		[Test]
 		[ActivePlatforms(Platform.iOS, Platform.Android)]
-		public void TestButtonReleasedOut() => TestReleasedOutState(
+		public void TestButtonReleasedOut() => TestButtonReleasedOutState(
 			"MyButton",
 			"CommonStates.PointerOver",
 			"CommonStates.Pressed",
@@ -24,7 +24,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[ActivePlatforms(Platform.iOS, Platform.Android)]
-		public void TestIndeterminateToggleButtonReleasedOut() => TestReleasedOutState(
+		public void TestIndeterminateToggleButtonReleasedOut() => TestButtonReleasedOutState(
 			"MyIndeterminateToggleButton",
 			"CommonStates.IndeterminatePointerOver",
 			"CommonStates.IndeterminatePressed",
@@ -32,7 +32,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[ActivePlatforms(Platform.iOS, Platform.Android)]
-		public void TestCheckedToggleButtonReleasedOut() => TestReleasedOutState(
+		public void TestCheckedToggleButtonReleasedOut() => TestButtonReleasedOutState(
 			"MyCheckedToggleButton",
 			"CommonStates.CheckedPointerOver",
 			"CommonStates.CheckedPressed",
@@ -40,7 +40,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[Ignore("We get an invalid 'PointerOver' on release, a fix in pending in another PR")]
-		public void TestUncheckedToggleButtonReleasedOut() => TestReleasedOutState(
+		public void TestUncheckedToggleButtonReleasedOut() => TestButtonReleasedOutState(
 			"MyUncheckedToggleButton",
 			"CommonStates.UncheckedPointerOver",
 			"CommonStates.UncheckedPressed",
@@ -48,7 +48,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[ActivePlatforms(Platform.iOS, Platform.Android)]
-		public void TestRadioButtonReleasedOut() => TestReleasedOutState(
+		public void TestRadioButtonReleasedOut() => TestButtonReleasedOutState(
 			"MyRadioButton",
 			"CommonStates.PointerOver",
 			"CommonStates.Pressed",
@@ -56,7 +56,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[ActivePlatforms(Platform.iOS, Platform.Android)]
-		public void TestHyperlinkButtonReleasedOut() => TestReleasedOutState(
+		public void TestHyperlinkButtonReleasedOut() => TestButtonReleasedOutState(
 			"MyHyperlinkButton",
 			"CommonStates.PointerOver",
 			"CommonStates.Pressed",
@@ -64,7 +64,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[ActivePlatforms(Platform.iOS, Platform.Android)]
-		public void TestIndeterminateCheckboxReleasedOut() => TestReleasedOutState(
+		public void TestIndeterminateCheckboxReleasedOut() => TestButtonReleasedOutState(
 			"MyIndeterminateCheckbox",
 			"CombinedStates.IndeterminatePointerOver",
 			"CombinedStates.IndeterminatePressed",
@@ -72,7 +72,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[ActivePlatforms(Platform.iOS, Platform.Android)]
-		public void TestCheckedCheckboxReleasedOut() => TestReleasedOutState(
+		public void TestCheckedCheckboxReleasedOut() => TestButtonReleasedOutState(
 			"MyCheckedCheckbox",
 			"CombinedStates.CheckedPointerOver",
 			"CombinedStates.CheckedPressed",
@@ -80,17 +80,33 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[ActivePlatforms(Platform.iOS, Platform.Android)]
-		public void TestUncheckedCheckboxReleasedOut() => TestReleasedOutState(
+		public void TestUncheckedCheckboxReleasedOut() => TestButtonReleasedOutState(
 			"MyUncheckedCheckbox",
 			"CombinedStates.UncheckedPointerOver",
 			"CombinedStates.UncheckedPressed",
 			"CombinedStates.UncheckedNormal");
 
 		[Test]
-		public void TestHyperlinkReleasedOut() => TestReleasedOutState(
+		public void TestHyperlinkReleasedOut() => TestButtonReleasedOutState(
 			"MyHyperlink"); // There is no "VisualState" for Hyperlink, only a hardcoded opacity of .5 (kind-of like UWP)
 
-		private void TestReleasedOutState(string target, params string[] expectedStates)
+		[Test]
+		[ActivePlatforms(Platform.iOS, Platform.Android)]
+		public void TestListViewReleasedOut()
+		{
+			Run("UITests.Shared.Windows_UI_Input.VisualStatesTests.ListViewItem");
+
+			var initial = TakeScreenshot("Initial");
+			var rect = _app.WaitForElement("MyListView").Single().Rect;
+
+			// Press over and move out to release
+			_app.DragCoordinates(rect.X + 10, rect.Y + 10, rect.X - 30, rect.Y);
+
+			var final = TakeScreenshot("Final");
+			AssertScreenshotsAreEqual(initial, final, rect);
+		}
+
+		private void TestButtonReleasedOutState(string target, params string[] expectedStates)
 		{
 			Run("UITests.Shared.Windows_UI_Input.VisualStatesTests.Buttons");
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/VisualStatesTests/Buttons.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/VisualStatesTests/Buttons.xaml.cs
@@ -18,7 +18,7 @@ namespace UITests.Shared.Windows_UI_Input.VisualStatesTests
 			this.InitializeComponent();
 		}
 
-		private async void ListenVisualStates(object sender, RoutedEventArgs e)
+		private void ListenVisualStates(object sender, RoutedEventArgs e)
 		{
 			FrameworkElement target;
 			IEnumerable<VisualStateGroup> groups;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/VisualStatesTests/ListViewItem.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/VisualStatesTests/ListViewItem.xaml
@@ -71,7 +71,7 @@
 	</Page.Resources>
 
 	<Grid>
-		<ListView ItemContainerStyle="{StaticResource ItemStyle}">
+		<ListView ItemContainerStyle="{StaticResource ItemStyle}" Width="300" Background="Purple" x:Name="MyListView">
 			<ListView.Items>
 				<TextBlock Text="Item 1" />
 				<TextBlock Text="Item 2" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/VisualStatesTests/ListViewItem.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/VisualStatesTests/ListViewItem.xaml.cs
@@ -1,6 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Uno.Extensions;
+using Uno.UI.Sample.Views.Helper;
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Input.VisualStatesTests

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -155,15 +155,11 @@ namespace Uno.UI
 		{
 			/// <summary>
 			/// <para>
-			/// Determines if the visual states "PointerOver", "PointerOverSelected" and the "PointerOverPressed" (ListViewItem and GridViewItem only, cf. remarks)
+			/// Determines if the visual states "PointerOver", "PointerOverSelected"
 			/// are used or not. If disabled, those states will never be activated by the selector items.
 			/// </para>
 			/// <para>The default value is `true`.</para>
 			/// </summary>
-			/// <remarks>
-			/// For backward compatibility, only the ListViewBaseItem's "PointerOverPressed" is problematic
-			/// as it will be activated instead of the "Pressed" while using finger.
-			/// </remarks>
 			public static bool UseOverStates { get; set; } = true;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/GridView/GridViewItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/GridView/GridViewItem.cs
@@ -7,8 +7,6 @@ namespace Windows.UI.Xaml.Controls
 {
     public partial class GridViewItem : SelectorItem
 	{
-		internal sealed override bool HasPointerOverPressedState => true;
-
 		public GridViewItem()
 		{
 			Initialize();

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -21,8 +21,11 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			public const string Over = "PointerOver";
 			public const string Pressed = "Pressed";
 			public const string OverSelected = "PointerOverSelected"; // "SelectedPointerOver" for ListBoxItem, ComboBoxItem and PivotHeaderItem
-			public const string OverPressed = "PointerOverPressed"; // Only for ListViewItem and GridViewItem
 			public const string PressedSelected = "PressedSelected"; // "SelectedPressed" for ListBoxItem, ComboBoxItem and PivotHeaderItem
+
+			// On ListViewItem and GridViewItem we also have this state declared in default style,
+			// however it seems to never been activated
+			// public const string OverPressed = "PointerOverPressed";
 		}
 
 		private static class DisabledStates
@@ -57,11 +60,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		/// parent and displayed.
 		/// </remarks>
 		protected override bool CanCreateTemplateWithoutParent { get; } = true;
-
-		/// <summary>
-		/// Indicates if the SelectorItem has the "PointerOverPressed" visual state (GridViewItem and ListViewItem only)
-		/// </summary>
-		internal virtual bool HasPointerOverPressedState => false;
 
 		private string _currentState;
 		private uint _goToStateRequest;
@@ -145,7 +143,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			bool pause; // should we force a pause after applying the 'state'
 			if (manipulationUpdate == ManipulationUpdateKind.Clicked
 				&& _currentState != CommonStates.PressedSelected
-				&& _currentState != CommonStates.OverPressed
 				&& _currentState != CommonStates.Pressed)
 			{
 				// When clicked (i.e. pointer released), but not yet in pressed state, we force to go immediately in pressed state
@@ -212,11 +209,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				&& isSelected && isOver)
 			{
 				state = CommonStates.OverSelected;
-			}
-			else if (FeatureConfiguration.SelectorItem.UseOverStates && HasPointerOverPressedState
-				&& isOver && isPressed)
-			{
-				state = CommonStates.OverPressed;
 			}
 			else if (isSelected)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -132,7 +132,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		private void UpdateCommonStates(ManipulationUpdateKind manipulationUpdate = ManipulationUpdateKind.None)
 		{
-			var state = GetState(IsSelected, IsPointerOver, IsPointerPressed);
+			var state = GetState(IsSelected, IsPointerOver, HasPointerCapture);
 
 			// On Windows, the pressed state appears only after a few, and won't appear at all if you quickly start to scroll with the finger.
 			// So here we make sure to delay the beginning of a manipulation to match this behavior (and avoid flickering when scrolling)

--- a/src/Uno.UI/UI/Xaml/ListView/ListViewItem.cs
+++ b/src/Uno.UI/UI/Xaml/ListView/ListViewItem.cs
@@ -14,8 +14,6 @@ namespace Windows.UI.Xaml.Controls
 	/// <remarks>This container supports vertical scrolling and stretching for the whole item.</remarks>
 	public partial class ListViewItem : SelectorItem
 	{
-		internal sealed override bool HasPointerOverPressedState => true;
-
 		public ListViewItem()
 		{
 		}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -677,8 +677,17 @@ namespace Windows.UI.Xaml
 
 		public IReadOnlyList<Pointer> PointerCaptures => (IReadOnlyList<Pointer>)this.GetValue(PointerCapturesProperty);
 
+		/// <summary>
+		/// Indicates if this UIElement has any active ** EXPLICIT ** pointer capture.
+		/// </summary>
+#if __ANDROID__
+		internal new bool HasPointerCapture => (_localExplicitCaptures?.Count ?? 0) != 0;
+#else
+		internal bool HasPointerCapture => (_localExplicitCaptures?.Count ?? 0) != 0;
+#endif
+
 		internal bool IsCaptured(Pointer pointer)
-			=> HasExplicitCapture
+			=> HasPointerCapture
 				&& PointerCapture.TryGet(pointer, out var capture)
 				&& capture.IsTarget(this, PointerCaptureKind.Explicit);
 
@@ -714,7 +723,7 @@ namespace Windows.UI.Xaml
 
 		public void ReleasePointerCaptures()
 		{
-			if (!HasExplicitCapture)
+			if (!HasPointerCapture)
 			{
 				if (this.Log().IsEnabled(LogLevel.Information))
 				{
@@ -730,8 +739,6 @@ namespace Windows.UI.Xaml
 
 		partial void CapturePointerNative(Pointer pointer);
 		partial void ReleasePointerNative(Pointer pointer);
-
-		private bool HasExplicitCapture => (_localExplicitCaptures?.Count ?? 0) != 0;
 
 		private bool ValidateAndUpdateCapture(PointerRoutedEventArgs args)
 			=> ValidateAndUpdateCapture(args, IsOver(args.Pointer));


### PR DESCRIPTION
GitHub Issue: fixes https://github.com/unoplatform/uno/issues/2077

## Bugfix
Pressed state of `ListView`

## What is the current behavior?
On `ListView` and `GridView` if you press an item, move pointer out, then release the press, the `<List|Grid>ViewItem` state in **pressed** visual state.

## What is the new behavior?
Goes back to the **Normal** (or **Selected**) as soon as the pointer goes out of the bounds of the item.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)
