### PR TITLE
Fix pointers support of Android 5.x

### DIFF
--- a/doc/articles/features/routed-events.md
+++ b/doc/articles/features/routed-events.md
@@ -226,6 +226,7 @@ As those events are tightly coupled to the native events, Uno has to make some c
   > On WASM as `TextElement` are `UIElement`, it means that unlike UWP `TextBlock` won't raise the 
   > a `PointerReleased` when clicking on an `Hyperlink`.
 * Unlike UWP, on the `Hyperlink` the `Click` will be raised before the `PointerReleased`.
+* The property `PointerPointProperties.PointerUpdateKind` is not set on Android 5.x and lower (API level < 23)
 
 ### Pointer capture
 

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
@@ -8,6 +8,7 @@ using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Input;
 using Windows.UI.Xaml.Extensions;
+using Android.OS;
 using Uno.Extensions;
 
 namespace Windows.UI.Xaml.Input
@@ -135,7 +136,8 @@ namespace Windows.UI.Xaml.Input
 					break;
 			}
 
-			if (updates.TryGetValue(_nativeEvent.ActionButton, out var update))
+			if (Android.OS.Build.VERSION.SdkInt >= BuildVersionCodes.M // ActionButton was introduced with API 23 (https://developer.android.com/reference/android/view/MotionEvent.html#getActionButton())
+				&& updates.TryGetValue(_nativeEvent.ActionButton, out var update))
 			{
 				props.PointerUpdateKind = update;
 			}


### PR DESCRIPTION
GitHub Issue: fixes https://github.com/unoplatform/uno/issues/1838

## Bugfix
Support of Android 5.x devices was broken since pointers refactor

## What is the current behavior?
When creating the `PointerPointProperties` in order to fulfill the `PointerUpdaterKind` [we try to use the `ActionButton`](https://github.com/unoplatform/uno/blob/master/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs#L138), which [available only since API 23 (Android 6.0)](https://developer.android.com/reference/android/view/MotionEvent.html#getActionButton())

## What is the new behavior?
We don't set the `PointerUpdaterKind`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~[Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
