### PR TITLE
Fix missing measurement option for polyline and polygon

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -107,6 +107,7 @@
     > This change might break the compilation for projects that define duplicate resources in other globally accessible resource dictionaries. Adjustments to remove duplicate resources may be necessary.
 
 ### Bug fixes
+* [#2093](https://github.com/unoplatform/uno/pull/2093) Fix missing measurement option for polyline and polygon
 * Font size, used for ComboBoxItems, are same as in ComboBox content (not smaller)
 * [#2023](https://github.com/unoplatform/uno/pull/2023) Android WebView.NavigateToString doesn't throw exception even when string is very long.
 * [#2020](https://github.com/unoplatform/uno/pull/2020) `ContentControl` no longer display the datacontext type when ContentTemplate and content are empty

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
@@ -48,6 +48,44 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 
 		[Test]
 		[AutoRetry]
+		public void Affect_Measurement_polygon()
+		{
+			Run("SamplesApp.Windows_UI_Xaml_Shapes.PolygonPage");
+
+			_app.WaitForElement("DPolygon");
+			_app.Marked("ClearShape").Tap();
+			TakeScreenshot($"PolygonPage - ClearShape");
+
+			_app.Marked("ChangeShape").Tap();
+			var widthzize = _app.Query(_app.Marked("DPolygon")).First().Rect.Width;
+
+			if (widthzize == 0)
+				Assert.Fail("Shape not changed");
+
+			TakeScreenshot($"PolygonPage - ChangeShape-After clear");
+		}
+
+		[Test]
+		[AutoRetry]
+		public void Affect_Measurement_polyline()
+		{
+			Run("SamplesApp.Windows_UI_Xaml_Shapes.PolylinePage");
+
+			_app.WaitForElement("DPolyline");
+			_app.Marked("ClearShape").Tap();
+			TakeScreenshot($"PolylinePage - ClearShape");
+
+			_app.Marked("ChangeShape").Tap();
+			var widthzize = _app.Query(_app.Marked("DPolyline")).First().Rect.Width;
+
+			if(widthzize == 0)
+				Assert.Fail("Shape not changed");
+
+			TakeScreenshot($"PolylinePage - ChangeShape-After clear");
+		}
+
+		[Test]
+		[AutoRetry]
 		public void Draw_ellipse()
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Shapes.EllipsePage");

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PolygonPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PolygonPage.xaml
@@ -13,6 +13,7 @@
 			<Polygon x:Name="DPolygon" Points="300,200 400,125 400,275" Stroke="black" StrokeThickness="5" />
 		</StackPanel>
 		<Button x:Name="ChangeShape" Margin="0,5,0,0" Content="Change Shape" Click="Change_Shape"/>
+		<Button x:Name="ClearShape" Margin="0,5,0,0" Content="Clear Shape" Click="Clear_Shape"/>
 	</StackPanel>
 
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PolygonPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PolygonPage.xaml.cs
@@ -35,5 +35,10 @@ namespace SamplesApp.Windows_UI_Xaml_Shapes
 			points.Add(new Point(180, 220));
 			DPolygon.Points = points;
 		}
+
+		public void Clear_Shape(object sender, RoutedEventArgs e)
+		{
+			DPolygon.Points.Clear();
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PolylinePage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PolylinePage.xaml
@@ -14,5 +14,6 @@
 			<Polyline x:Name="DPolyline" Points="20,20 40,25 60,40 80,120 120,140 200,180" Stroke="black" StrokeThickness="5"/>
 		</StackPanel>
 		<Button x:Name="ChangeShape"  Content="Change Shape" Click="Change_Shape"/>
+		<Button x:Name="ClearShape"  Content="Clear Shape" Click="Clear_Shape"/>
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PolylinePage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PolylinePage.xaml.cs
@@ -33,5 +33,10 @@ namespace SamplesApp.Windows_UI_Xaml_Shapes
 			points.Add(new Point(180, 200));
 			DPolyline.Points = points;
 		}
+
+		public void Clear_Shape(object sender, RoutedEventArgs e)
+		{
+			DPolyline.Points.Clear();
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Polygon.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polygon.cs
@@ -24,6 +24,7 @@ namespace Windows.UI.Xaml.Shapes
 				typeof(global::Windows.UI.Xaml.Shapes.Polygon),
 				new FrameworkPropertyMetadata(
 					defaultValue: default(global::Windows.UI.Xaml.Media.PointCollection),
+					options: FrameworkPropertyMetadataOptions.LogicalChild | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange,
 					propertyChangedCallback: (s, e) => ((Polygon)s).OnPointsChanged()
 				)
 			);

--- a/src/Uno.UI/UI/Xaml/Shapes/Polyline.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polyline.cs
@@ -22,6 +22,7 @@ namespace Windows.UI.Xaml.Shapes
 				typeof(global::Windows.UI.Xaml.Shapes.Polyline),
 				new FrameworkPropertyMetadata(
 					defaultValue: default(global::Windows.UI.Xaml.Media.PointCollection),
+				    options: FrameworkPropertyMetadataOptions.LogicalChild | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange,
 					propertyChangedCallback: (s, e) => ((Polyline)s).OnPointsChanged()
 				)
 			);


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Polyline and Polygon was not affecting measurement on parent container when points collection change.

<!-- Please describe the new behavior after your modifications. -->

Polyline and Polygon affect measurement on their parent container

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
