### PR TITLE
Fix invalid error message when using custom themes

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1048,7 +1048,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
                     if (!containsDefaultCase)
                     {
                         var msg = customThemes.Any()
-                            ? $"$\"The themed resource {resourcePropertyName} cannot be found for custom theme \\\"{{{{currentCustomTheme}}}}\\\", theme={{{{currentTheme}}}}.\""
+                            ? $"$\"The themed resource {resourcePropertyName} cannot be found for custom theme \\\"{{{{currentCustomTheme}}}}\\\".\""
                             : $"$\"The themed resource {resourcePropertyName} cannot be found for theme {{{{currentTheme}}}}.\"";
                         writer.AppendLine();
                         writer.AppendLineInvariant($"throw new InvalidOperationException({msg});");

--- a/src/SourceGenerators/XamlGenerationTests/GlobalStaticResources02.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/GlobalStaticResources02.xaml
@@ -20,6 +20,11 @@
 		<ResourceDictionary x:Key="Light">
 			<x:Double x:Key="ThemedDouble">2.0</x:Double>
 		</ResourceDictionary>
+		<ResourceDictionary x:Key="HighContrast">
+			<x:Double x:Key="ThemedDouble">22.0</x:Double>
+			<SolidColorBrush x:Key="AppControlListLowRevealHighlightBrush"
+							 Color="{ThemeResource SystemColorHighlightColor}" />
+		</ResourceDictionary>
 		<ResourceDictionary x:Key="Dark">
 			<x:Double x:Key="ThemedDouble">3.0</x:Double>
 		</ResourceDictionary>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Using a theme resource in a custom theme builds properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
