### PR TITLE
corrected a tiny typo in the solution template

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Wasm/UnoQuickStart.Wasm.csproj
@@ -30,7 +30,7 @@
 
 	<ItemGroup>
 		<!--
-    This item group is required by the project templace because of the
+    This item group is required by the project template because of the
     new SDK-Style project, otherwise some files are not aded automatically.
 
     You can safely remove this ItemGroup completely.


### PR DESCRIPTION
the Wasm solution template had a tiny typo, small first PR whilst I get to grips with Uno :)

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When projects are generated via the VSIX extension the Wasm project has a small typo in a comment

## What is the new behavior?

Correct spelling :)