### PR TITLE
Add support for ToggleButton.IsThreeState and Indeterminate

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -94,6 +94,7 @@
 * Add support for GitPod Workspace and prebuilds
 * Add Android support for `CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar` to programatically draw under the status bar
 * [Wasm] Add the ability to focus a TextBox by clicking its header
+* Add support for `ToggleButton.IsThreeState` and `ToggleButton.Indeterminate`
 
 ### Breaking changes
 * `TextBox` no longer raises TextChanged when its template is applied, in line with UWP.

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CheckBoxTests/UnoSamples_CheckBox.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CheckBoxTests/UnoSamples_CheckBox.cs
@@ -1,0 +1,64 @@
+using System.Globalization;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
+{
+	public class UnoSamples_CheckBox : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void TwoStates()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.CheckBoxTests.CheckBox_Automated");
+
+			var twoState01 = _app.Marked("twoState01");
+			var result = _app.Marked("result");
+
+			_app.WaitForElement(twoState01);
+
+			_app.Tap(twoState01);
+			_app.WaitForText(result, "Checked twoState01 True");
+
+			_app.Tap(twoState01);
+			_app.WaitForText(result, "Unchecked twoState01 False");
+
+			_app.Tap(twoState01);
+			_app.WaitForText(result, "Checked twoState01 True");
+		}
+
+		[Test]
+		[AutoRetry]
+		public void ThreeStates()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.CheckBoxTests.CheckBox_Automated");
+
+			var twoState01 = _app.Marked("threeState01");
+			var result = _app.Marked("result");
+
+			_app.WaitForElement(twoState01);
+
+			_app.Tap(twoState01);
+			_app.WaitForText(result, "Checked threeState01 True");
+
+			TakeScreenshot("Checked");
+
+			_app.Tap(twoState01);
+			_app.WaitForText(result, "Indeterminate threeState01 ");
+
+			TakeScreenshot("Indeterminate");
+
+			_app.Tap(twoState01);
+			_app.WaitForText(result, "Unchecked threeState01 False");
+
+			TakeScreenshot("Unchecked");
+
+			_app.Tap(twoState01);
+			_app.WaitForText(result, "Checked threeState01 True");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -361,6 +361,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CheckBoxTests\CheckBox_Automated.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ItemDataContext.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2892,6 +2896,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Buttons_Native.xaml.cs">
       <DependentUpon>Buttons_Native.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CheckBoxTests\CheckBox_Automated.xaml.cs">
+      <DependentUpon>CheckBox_Automated.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_VisibleBounds.xaml.cs">
       <DependentUpon>ComboBox_VisibleBounds.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CheckBoxTests/CheckBox_Automated.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CheckBoxTests/CheckBox_Automated.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.CheckBoxTests.CheckBox_Automated"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.CheckBoxTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid>
+		<StackPanel>
+			<TextBlock x:Name="result" Text="none" />
+			<CheckBox x:Name="twoState01" Content="Two State" Checked="OnChecked" Unchecked="OnUnchecked" Indeterminate="OnIndeterminate" />
+			<CheckBox x:Name="threeState01" Content="Two State" IsThreeState="true" Checked="OnChecked" Unchecked="OnUnchecked" Indeterminate="OnIndeterminate" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CheckBoxTests/CheckBox_Automated.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CheckBoxTests/CheckBox_Automated.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.CheckBoxTests
+{
+	[SampleControlInfo("CheckBox")]
+	public sealed partial class CheckBox_Automated : UserControl
+	{
+		public CheckBox_Automated()
+		{
+			this.InitializeComponent();
+		}
+
+		private void OnChecked(object sender, object args)
+		{
+			if (sender is CheckBox cb)
+			{
+				result.Text = $"Checked {cb.Name} {cb.IsChecked}";
+			}
+		}
+
+		private void OnUnchecked(object sender, object args)
+		{
+			if (sender is CheckBox cb)
+			{
+				result.Text = $"Unchecked {cb.Name} {cb.IsChecked}";
+			}
+		}
+
+		private void OnIndeterminate(object sender, object args)
+		{
+			if (sender is CheckBox cb)
+			{
+				result.Text = $"Indeterminate {cb.Name} {cb.IsChecked}";
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/CheckBoxTests/Given_CheckBox.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/CheckBoxTests/Given_CheckBox.cs
@@ -1,0 +1,115 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_XAML_Controls.CheckBoxTests
+{
+	[TestClass]
+	public class Given_CheckBox
+	{
+		[TestMethod]
+		public void When_IsChecked()
+		{
+			var checkedCount = 0;
+			var uncheckedCount = 0;
+			var indeterminateCount = 0;
+
+			var SUT = new CheckBox();
+			SUT.Checked += (s, e) => checkedCount++;
+			SUT.Unchecked += (s, e) => uncheckedCount++;
+			SUT.Indeterminate += (s, e) => indeterminateCount++;
+
+			SUT.IsChecked = true;
+			checkedCount.Should().Be(1);
+			uncheckedCount.Should().Be(0);
+			SUT.IsChecked.Should().BeTrue();
+
+			SUT.IsChecked = true;
+			checkedCount.Should().Be(1);
+			uncheckedCount.Should().Be(0);
+			SUT.IsChecked.Should().BeTrue();
+
+			SUT.IsChecked = false;
+			checkedCount.Should().Be(1);
+			uncheckedCount.Should().Be(1);
+			SUT.IsChecked.Should().BeFalse();
+
+			SUT.IsChecked = false;
+			checkedCount.Should().Be(1);
+			uncheckedCount.Should().Be(1);
+			SUT.IsChecked.Should().BeFalse();
+
+			indeterminateCount.Should().Be(0);
+		}
+
+		[TestMethod]
+		public void When_IsChecked_True_And_Null()
+		{
+			var checkedCount = 0;
+			var uncheckedCount = 0;
+			var indeterminateCount = 0;
+
+			var SUT = new CheckBox();
+			SUT.Checked += (s, e) => checkedCount++;
+			SUT.Unchecked += (s, e) => uncheckedCount++;
+			SUT.Indeterminate += (s, e) => indeterminateCount++;
+
+			SUT.IsChecked = true;
+			checkedCount.Should().Be(1);
+			uncheckedCount.Should().Be(0);
+			SUT.IsChecked.Should().BeTrue();
+
+			SUT.IsChecked = true;
+			checkedCount.Should().Be(1);
+			uncheckedCount.Should().Be(0);
+			SUT.IsChecked.Should().BeTrue();
+
+			SUT.IsChecked = null;
+			checkedCount.Should().Be(1);
+			indeterminateCount.Should().Be(1);
+			uncheckedCount.Should().Be(0);
+			SUT.IsChecked.Should().BeNull();
+
+			SUT.IsChecked = null;
+			checkedCount.Should().Be(1);
+			uncheckedCount.Should().Be(0);
+			SUT.IsChecked.Should().BeNull();
+
+			indeterminateCount.Should().Be(1);
+		}
+
+		[TestMethod]
+		public void When_ThreeState()
+		{
+			var checkedCount = 0;
+			var uncheckedCount = 0;
+			var indeterminateCount = 0;
+
+			var SUT = new CheckBox() { IsThreeState = true };
+			SUT.Checked += (s, e) => checkedCount++;
+			SUT.Unchecked += (s, e) => uncheckedCount++;
+			SUT.Indeterminate += (s, e) => indeterminateCount++;
+
+			SUT.RaiseClick();
+
+			SUT.IsChecked.Should().BeTrue();
+			checkedCount.Should().Be(1);
+			uncheckedCount.Should().Be(0);
+			indeterminateCount.Should().Be(0);
+
+			SUT.RaiseClick();
+
+			SUT.IsChecked.Should().BeNull();
+			checkedCount.Should().Be(1);
+			uncheckedCount.Should().Be(0);
+			indeterminateCount.Should().Be(1);
+
+			SUT.RaiseClick();
+
+			SUT.IsChecked.Should().BeFalse();
+			checkedCount.Should().Be(1);
+			uncheckedCount.Should().Be(1);
+			indeterminateCount.Should().Be(1);
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -1323,6 +1323,7 @@ var Uno;
                         this.containerElement.appendChild(unconnectedRoot);
                         var textSize = this.measureElement(textOnlyElement);
                         var inputSize = this.measureElement(element);
+                        // Take the width of the inner text, but keep the height of the input element.
                         return [textSize[0], inputSize[1]];
                     }
                     else {

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ToggleButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ToggleButton.cs
@@ -7,30 +7,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 	#endif
 	public  partial class ToggleButton : global::Windows.UI.Xaml.Controls.Primitives.ButtonBase
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  bool IsThreeState
-		{
-			get
-			{
-				return (bool)this.GetValue(IsThreeStateProperty);
-			}
-			set
-			{
-				this.SetValue(IsThreeStateProperty, value);
-			}
-		}
-		#endif
-		// Skipping already declared property IsChecked
-		// Skipping already declared property IsCheckedProperty
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty IsThreeStateProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			"IsThreeState", typeof(bool), 
-			typeof(global::Windows.UI.Xaml.Controls.Primitives.ToggleButton), 
-			new FrameworkPropertyMetadata(default(bool)));
-		#endif
 		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.ToggleButton.ToggleButton()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.ToggleButton.ToggleButton()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.ToggleButton.IsChecked.get
@@ -47,22 +23,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.ToggleButton.IsCheckedProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.ToggleButton.IsThreeStateProperty.get
 		// Skipping already declared event Windows.UI.Xaml.Controls.Primitives.ToggleButton.Checked
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  event global::Windows.UI.Xaml.RoutedEventHandler Indeterminate
-		{
-			[global::Uno.NotImplemented]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Primitives.ToggleButton", "event RoutedEventHandler ToggleButton.Indeterminate");
-			}
-			[global::Uno.NotImplemented]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Primitives.ToggleButton", "event RoutedEventHandler ToggleButton.Indeterminate");
-			}
-		}
-		#endif
 		// Skipping already declared event Windows.UI.Xaml.Controls.Primitives.ToggleButton.Unchecked
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.cs
@@ -8,10 +8,9 @@ namespace Windows.UI.Xaml.Controls.Primitives
 {
 	public partial class ToggleButton : ButtonBase, IFrameworkTemplatePoolAware
 	{
-		//Renamed to have the same naming as Windows.
-		//https://msdn.microsoft.com/en-us/library/system.windows.controls.primitives.togglebutton.checked(v=vs.110).aspx
 		public event RoutedEventHandler Checked;
 		public event RoutedEventHandler Unchecked;
+		public event RoutedEventHandler Indeterminate;
 
 		public ToggleButton()
 		{
@@ -28,12 +27,25 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		/// </summary>
 		internal bool CanRevertState { get; set; } = true;
 
-		#region IsChecked DependencyProperty
+		public bool IsThreeState
+		{
+			get => (bool)this.GetValue(IsThreeStateProperty);
+			set => this.SetValue(IsThreeStateProperty, value);
+		}
+
+		public static DependencyProperty IsThreeStateProperty { get; } =
+			DependencyProperty.Register(
+				name: nameof(IsThreeState),
+				propertyType: typeof(bool),
+				ownerType: typeof(ToggleButton),
+				typeMetadata: new FrameworkPropertyMetadata(
+					defaultValue: false));
+
 
 		public bool? IsChecked
 		{
-			get { return (bool?)this.GetValue(IsCheckedProperty); }
-			set { this.SetValue(IsCheckedProperty, value); }
+			get => (bool?)this.GetValue(IsCheckedProperty);
+			set => this.SetValue(IsCheckedProperty, value);
 		}
 
 		public static readonly DependencyProperty IsCheckedProperty =
@@ -46,16 +58,22 @@ namespace Windows.UI.Xaml.Controls.Primitives
 					propertyChangedCallback: (s, e) => ((ToggleButton)s).OnIsCheckedChanged(e.OldValue as bool?, e.NewValue as bool?)
 				)
 			);
-		#endregion
 
 		protected virtual void OnIsCheckedChanged(bool? oldValue, bool? newValue)
 		{
-			if (newValue.HasValue && newValue.Value)
+			if (IsChecked == null)
 			{
+				// Indeterminate
+				Indeterminate?.Invoke(this, new RoutedEventArgs(this));
+			}
+			else if (IsChecked.Value)
+			{
+				// Checked
 				Checked?.Invoke(this, new RoutedEventArgs(this));
 			}
 			else
 			{
+				// Unchecked
 				Unchecked?.Invoke(this, new RoutedEventArgs(this));
 			}
 		}
@@ -69,7 +87,32 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		{
 			if (CanRevertState)
 			{
-				IsChecked = IsChecked.HasValue ? !IsChecked.Value : true;
+				if (IsChecked == null)
+				{
+					// Indeterminate
+					// Set to Unchecked
+					IsChecked = false;
+				}
+				else if (IsChecked is bool isChecked && isChecked)
+				{
+					// Checked
+					if (IsThreeState)
+					{
+						// Set to Indeterminate
+						IsChecked = null;
+					}
+					else
+					{
+						// Set to Unchecked
+						IsChecked = false;
+					}
+				}
+				else
+				{
+					// Unchecked
+					// Set to Checked
+					IsChecked = true;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/2109

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

ToggleButton and derivatives are now supporting Three States mode.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)