### PR TITLE
Merge TextBox "common" visual state handling

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -147,7 +147,7 @@ namespace SamplesApp.UITests
 				for (var x = rect.Value.X; x < Math.Min(rect.Value.Width, expectedBitmap.Size.Width); x++)
 				for (var y = rect.Value.Y; y < Math.Min(rect.Value.Height, expectedBitmap.Size.Height); y++)
 				{
-					Assert.AreEqual(expectedBitmap.GetPixel(x, y), actualBitmap.GetPixel(x, y), $"Pixel {x},{y}");
+					Assert.AreEqual(expectedBitmap.GetPixel(x, y), actualBitmap.GetPixel(x, y), $"Pixel {x},{y} (rel: {x-rect.Value.X},{y - rect.Value.Y})");
 				}
 			}
 		}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -587,7 +587,7 @@ namespace SampleControl.Presentation
 		{
 			try
 			{
-				if (!type.Namespace.StartsWith("System.Windows"))
+				if (!(type.Namespace?.StartsWith("System.Windows") ?? true))
 				{
 					return type?.GetCustomAttributes()
 						.OfType<SampleControlInfoAttribute>()

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -145,6 +145,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\VisualStatesTests\TextBox_VisualStates.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_StartScreen\JumpListTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2778,6 +2782,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Capture.xaml.cs">
       <DependentUpon>Capture.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\VisualStatesTests\TextBox_VisualStates.xaml.cs">
+      <DependentUpon>TextBox_VisualStates.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_StartScreen\JumpListTests.xaml.cs">
       <DependentUpon>JumpListTests.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/VisualStatesTests/TextBox_VisualStates.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/VisualStatesTests/TextBox_VisualStates.xaml
@@ -1,0 +1,81 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Input.VisualStatesTests.TextBox_VisualStates"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Input.VisualStatesTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<ControlTemplate x:Key="TextBoxTemplate" TargetType="TextBox">
+			<Grid x:Name="RootGrid">
+				<VisualStateManager.VisualStateGroups>
+					<VisualStateGroup x:Name="CommonStates">
+						<VisualState x:Name="Disabled">
+							<VisualState.Setters>
+								<Setter Target="State.Text" Value="Disabled" />
+							</VisualState.Setters>
+						</VisualState>
+						<VisualState x:Name="Normal">
+							<VisualState.Setters>
+								<Setter Target="State.Text" Value="Normal" />
+							</VisualState.Setters>
+						</VisualState>
+						<VisualState x:Name="PointerOver">
+							<VisualState.Setters>
+								<Setter Target="State.Text" Value="PointerOver" />
+							</VisualState.Setters>
+						</VisualState>
+						<VisualState x:Name="Focused">
+							<VisualState.Setters>
+								<Setter Target="State.Text" Value="Focused" />
+							</VisualState.Setters>
+						</VisualState>
+					</VisualStateGroup>
+				</VisualStateManager.VisualStateGroups>
+
+				<Grid>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="200" />
+					</Grid.ColumnDefinitions>
+
+					<Border
+						x:Name="BorderElement"
+						BorderBrush="Black"
+						BorderThickness="1"
+						MinWidth="100">
+						<ScrollViewer x:Name="ContentElement" />
+					</Border>
+
+					<TextBlock
+						x:Name="State" 
+						Grid.Column="1" />
+				</Grid>
+			</Grid>
+		</ControlTemplate>
+	</Page.Resources>
+
+	<ScrollViewer>
+		<Grid>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="250" />
+			</Grid.ColumnDefinitions>
+
+			<StackPanel>
+				<TextBlock Text="TextBox (CommonStates: Normal | PointerOver | Focused | Disabled)" TextWrapping="Wrap" />
+				<TextBox
+					x:Name="MyTextBox"
+					Template="{StaticResource TextBoxTemplate}"
+					Loaded="ListenVisualStates" />
+			</StackPanel>
+
+			<TextBlock
+				x:Name="VisualStatesLog"
+				Grid.Column="1" />
+		</Grid>
+	</ScrollViewer>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/VisualStatesTests/TextBox_VisualStates.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/VisualStatesTests/TextBox_VisualStates.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.Extensions;
+using Uno.UI.Sample.Views.Helper;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Input.VisualStatesTests
+{
+	[SampleControlInfo("Gesture recognizer", "VisualStates TextBox")]
+	public sealed partial class TextBox_VisualStates : Page
+	{
+		public TextBox_VisualStates()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ListenVisualStates(object sender, RoutedEventArgs e)
+		{
+			FrameworkElement target;
+			IEnumerable<VisualStateGroup> groups;
+			if (!(sender is FrameworkElement ctrl)
+				|| (target = ctrl.FindFirstChild<FrameworkElement>(includeCurrent: false)) == null)
+			{
+				Console.WriteLine($"{sender?.GetType().Name ?? "-null-"} is not a FrameworkElement or has no child.");
+			}
+			else if ((groups = VisualStateManager.GetVisualStateGroups(target))?.None() ?? true)
+			{
+				Console.WriteLine($"Not visual states groups found on {target.Name}.");
+			}
+			else
+			{
+				foreach (var group in groups)
+				{
+					group.CurrentStateChanged += (snd, args) => VisualStatesLog.Text += $"{ctrl.Name}:{group.Name}.{args.NewState.Name}\r\n";
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI/Mixins/Android/VisualStatesMixins.tt
+++ b/src/Uno.UI/Mixins/Android/VisualStatesMixins.tt
@@ -2,7 +2,7 @@
 <#@output extension="g.cs" #>
 #if XAMARIN_ANDROID
 <# 
-	AddClass("Windows.UI.Xaml.Controls", "TextBox", hasCommonStates: true, hasCommonOverState: true);
+	AddClass("Windows.UI.Xaml.Controls", "TextBox", hasCommonStates: true, hasCommonOverState: true, hasCommonFocusedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "Button", hasCommonStates: true, hasCommonOverState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls.Primitives", "ToggleButton", hasCommonStates: true, hasCommonCheckedState: true, hasCommonOverState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "CheckBox", hasCommonStates: true, hasCombinedCheckedState: true, hasCommonOverState: true, hasCommonPressedState: true);

--- a/src/Uno.UI/Mixins/Wasm/VisualStatesMixins.tt
+++ b/src/Uno.UI/Mixins/Wasm/VisualStatesMixins.tt
@@ -2,7 +2,7 @@
 <#@output extension="g.cs" #>
 #if __WASM__
 <# 	
-	AddClass("Windows.UI.Xaml.Controls", "TextBox", hasCommonStates: true, hasCommonOverState: true);
+	AddClass("Windows.UI.Xaml.Controls", "TextBox", hasCommonStates: true, hasCommonOverState: true, hasCommonFocusedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "Button", hasCommonStates: true, hasCommonOverState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls.Primitives", "ToggleButton", hasCommonStates: true, hasCommonCheckedState: true, hasCommonOverState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "RadioButton", hasCommonStates: true, hasCheckedStates: true, hasCommonOverState: true, hasCommonPressedState: true);

--- a/src/Uno.UI/Mixins/iOS/VisualStatesMixins.tt
+++ b/src/Uno.UI/Mixins/iOS/VisualStatesMixins.tt
@@ -1,8 +1,8 @@
 ﻿<#@template language="C#"#>
 <#@output extension="g.cs" #>
 #if __IOS__
-<# 	
-	AddClass("Windows.UI.Xaml.Controls", "TextBox", hasCommonStates: true);
+<#
+	AddClass("Windows.UI.Xaml.Controls", "TextBox", hasCommonStates: true, hasCommonOverState: true, hasCommonFocusedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "Button", hasCommonStates: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls.Primitives", "ToggleButton", hasCommonStates: true, hasCommonCheckedState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "RadioButton", hasCommonStates: true, hasCheckedStates: true, hasCommonPressedState: true);

--- a/src/Uno.UI/Mixins/macOS/VisualStatesMixins.tt
+++ b/src/Uno.UI/Mixins/macOS/VisualStatesMixins.tt
@@ -2,7 +2,7 @@
 <#@output extension="g.cs" #>
 #if __MACOS__
 <# 	
-	AddClass("Windows.UI.Xaml.Controls", "TextBox", hasCommonStates: true);
+	AddClass("Windows.UI.Xaml.Controls", "TextBox", hasCommonStates: true, hasCommonOverState: true, hasCommonFocusedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "Button", hasCommonStates: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls.Primitives", "ToggleButton", hasCommonStates: true, hasCommonCheckedState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "RadioButton", hasCommonStates: true, hasCheckedStates: true, hasCommonPressedState: true);

--- a/src/Uno.UI/Mixins/net461/VisualStatesMixins.tt
+++ b/src/Uno.UI/Mixins/net461/VisualStatesMixins.tt
@@ -2,7 +2,7 @@
 <#@output extension="g.cs" #>
 #if NET461
 <# 	
-	AddClass("Windows.UI.Xaml.Controls", "TextBox", hasCommonStates: true);
+	AddClass("Windows.UI.Xaml.Controls", "TextBox", hasCommonStates: true, hasCommonFocusedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "Button", hasCommonStates: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls.Primitives", "ToggleButton", hasCommonStates: true, hasCommonCheckedState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "RadioButton", hasCommonStates: true, hasCheckedStates: true, hasCommonPressedState: true);

--- a/src/Uno.UI/UI/Xaml/Controls/Button/Button.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/Button.cs
@@ -12,6 +12,8 @@ namespace Windows.UI.Xaml.Controls
 	{
 		static Button()
 		{
+			StaticInitializeVisualStates();
+
 			HorizontalContentAlignmentProperty.OverrideMetadata(
 				typeof(Button),
 				new FrameworkPropertyMetadata(HorizontalAlignment.Center)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -83,7 +83,6 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnLoaded();
 			SetupTextBoxView();
-			UpdateCommonStates();
 		}
 
 		partial void InitializePropertiesPartial()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -596,9 +596,8 @@ namespace Windows.UI.Xaml.Controls
 
 		#endregion
 
-		protected override void OnFocusStateChanged(FocusState oldValue, FocusState newValue)
+		partial void OnFocusStateChangedPartial(FocusState oldValue, FocusState newValue)
 		{
-			base.OnFocusStateChanged(oldValue, newValue);
 			OnFocusStateChangedPartial(newValue);
 
 			if (newValue == FocusState.Unfocused)
@@ -608,9 +607,10 @@ namespace Windows.UI.Xaml.Controls
 				bindingExpression?.UpdateSource(Text);
 			}
 
-			UpdateCommonStates();
 			UpdateButtonStates();
 		}
+		partial void OnFocusStateChangedPartial(FocusState focusState);
+
 
 		protected override void OnPointerPressed(PointerRoutedEventArgs args)
 		{
@@ -649,25 +649,6 @@ namespace Windows.UI.Xaml.Controls
 					break;
 			}
 		}
-
-		private void UpdateCommonStates()
-		{
-			var commonState = "Normal";
-
-			if (FocusState != FocusState.Unfocused)
-			{
-				commonState = "Focused";
-			}
-
-			if (!IsEnabled)
-			{
-				commonState = "Disabled";
-			}
-
-			VisualStateManager.GoToState(this, commonState, true);
-		}
-
-		partial void OnFocusStateChangedPartial(FocusState focusState);
 
 		private void UpdateButtonStates()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -596,7 +596,7 @@ namespace Windows.UI.Xaml.Controls
 
 		#endregion
 
-		partial void OnFocusStateChangedPartial(FocusState oldValue, FocusState newValue)
+		protected override void OnFocusStateChanged(FocusState oldValue, FocusState newValue)
 		{
 			OnFocusStateChangedPartial(newValue);
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -598,6 +598,7 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override void OnFocusStateChanged(FocusState oldValue, FocusState newValue)
 		{
+			base.OnFocusStateChanged(oldValue, newValue);
 			OnFocusStateChangedPartial(newValue);
 
 			if (newValue == FocusState.Unfocused)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
@@ -57,10 +57,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		partial void OnForegroundColorChangedPartial(Brush newValue)
-		{
-		}
-
 		public override bool BecomeFirstResponder()
 		{
 			return (_textBoxView?.BecomeFirstResponder())

--- a/src/Uno.UI/UI/Xaml/Controls/VisualStatesImplementation.tt
+++ b/src/Uno.UI/UI/Xaml/Controls/VisualStatesImplementation.tt
@@ -74,10 +74,6 @@ namespace <#= mixin.NamespaceName #>
 #if <#= mixin.HasCommonStates #>
 			this.IsEnabledChanged += On<#= mixin.ClassName #>IsEnabledChanged;
 
-#if <#= mixin.HasCommonFocusedState #>
-			this.FocusChange += On<#= mixin.ClassName #>FocusChange;
-#endif
-
 #if <#= mixin.HasCommonCheckedState #> || <#= mixin.HasCombinedCheckedState #>
 			RegisterToCheckedStateChanges();
 #endif
@@ -94,10 +90,6 @@ namespace <#= mixin.NamespaceName #>
 		{
 #if <#= mixin.HasCommonStates #>
 			this.IsEnabledChanged -= On<#= mixin.ClassName #>IsEnabledChanged;
-
-#if <#= mixin.HasCommonFocusedState #>
-			this.FocusChange -= On<#= mixin.ClassName #>FocusChange;
-#endif
 #endif
 		}
 
@@ -168,10 +160,14 @@ namespace <#= mixin.NamespaceName #>
 #endif
 
 #if <#= mixin.HasCommonFocusedState #>
-		private void On<#= mixin.ClassName #>FocusChange(object sender, FocusChangeEventArgs e)
+		protected override void OnFocusStateChanged(FocusState oldState, FocusState newState)
 		{
+			base.OnFocusStateChanged(oldState, newState);
+			OnFocusStateChangedPartial(oldState, newState);
+
 			this.UpdateCommonStates(true);
 		}
+		partial void OnFocusStateChangedPartial(FocusState oldValue, FocusState newValue);
 #endif
 
 		private void UpdateCommonStates(bool useTransitions)
@@ -214,7 +210,7 @@ namespace <#= mixin.NamespaceName #>
 		private string GetCommonState()
 		{
 			var targetState = __normalState;
-			if (!this.IsEnabled)
+			if (!IsEnabled)
 			{
 				return __disabledState;
 			}
@@ -231,7 +227,7 @@ namespace <#= mixin.NamespaceName #>
 			}
 #endif
 #if <#= mixin.HasCommonFocusedState #>
-			else if (this.IsFocused)
+			else if (FocusState != FocusState.Unfocused)
 			{
 				return __focusedState;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/VisualStatesImplementation.tt
+++ b/src/Uno.UI/UI/Xaml/Controls/VisualStatesImplementation.tt
@@ -52,15 +52,6 @@ namespace <#= mixin.NamespaceName #>
 		private const string __uncheckedState = "Unchecked";
 #endif
 
-		private static readonly RoutedEventHandler _updateAllStatesOnEvent = (snd, e) => ((<#= mixin.ClassName #>)snd).UpdateAllStates();
-#if <#= mixin.HasCommonStates #>
-		private static readonly PointerEventHandler _updateCommonStatesOnPointerEvent = (snd, e) => ((<#= mixin.ClassName #>)snd).UpdateCommonStates(true);
-		private static readonly PropertyChangedCallback _updateCommonStatesOnPropertyChanged = (snd, e) => ((<#= mixin.ClassName #>)snd).UpdateCommonStates(true);
-#endif
-#if <#= mixin.HasCheckedStates #>
-		private static readonly PropertyChangedCallback _updateCheckedStatesOnPropertyChanged = (snd, e) => ((<#= mixin.ClassName #>)snd).UpdateCheckedStates(true);
-#endif
-
 #if <#= mixin.HasCommonStates #> || <#= mixin.HasCheckedStates #>
 #if <#= (mixin.ClassName != "Button").ToString().ToLowerInvariant() #>
 		static <#= mixin.ClassName #>()
@@ -76,14 +67,14 @@ namespace <#= mixin.NamespaceName #>
 		{
 			var type = typeof(<#= mixin.ClassName #>);
 
-			IsEnabledProperty.GetMetadata(type).MergePropertyChangedCallback(_updateCommonStatesOnPropertyChanged);
+			IsEnabledProperty.GetMetadata(type).MergePropertyChangedCallback(OnPropertyChangedUpdateCommonStates);
 #if <#= mixin.HasCommonFocusedState #>
-			FocusStateProperty.GetMetadata(type).MergePropertyChangedCallback(_updateCommonStatesOnPropertyChanged);
+			FocusStateProperty.GetMetadata(type).MergePropertyChangedCallback(OnPropertyChangedUpdateCommonStates);
 #endif
 #if <#= mixin.HasCommonCheckedState #> || <#= mixin.HasCombinedCheckedState #>
-			IsCheckedProperty.GetMetadata(type).MergePropertyChangedCallback(_updateCommonStatesOnPropertyChanged);
+			IsCheckedProperty.GetMetadata(type).MergePropertyChangedCallback(OnPropertyChangedUpdateCommonStates);
 #elif <#= mixin.HasCheckedStates #>
-			IsCheckedProperty.GetMetadata(type).MergePropertyChangedCallback(_updateCheckedStatesOnPropertyChanged);
+			IsCheckedProperty.GetMetadata(type).MergePropertyChangedCallback(OnPropertyChangedUpdateCheckedStates);
 #endif
 		}
 #endif
@@ -93,23 +84,56 @@ namespace <#= mixin.NamespaceName #>
 		/// </summary>
 		private void InitializeVisualStates()
 		{
-			Loaded += _updateAllStatesOnEvent;
+			Loaded += OnRoutedEventUpdateAllStates;
 
 #if <#= mixin.HasCommonOverState #>
-			PointerEntered += _updateCommonStatesOnPointerEvent;
-			PointerExited += _updateCommonStatesOnPointerEvent;
+			InsertHandler(PointerEnteredEvent, OnPointerEventUpdateCommonStates, handledEventsToo: false);
+			InsertHandler(PointerExitedEvent, OnPointerEventUpdateCommonStates, handledEventsToo: false);
 #endif
 #if <#= mixin.HasCommonPressedState #> 
-			PointerPressed += _updateCommonStatesOnPointerEvent;
-			PointerReleased += _updateCommonStatesOnPointerEvent;
+			InsertHandler(PointerPressedEvent, OnPointerEventUpdateCommonStates, handledEventsToo: false);
+			InsertHandler(PointerReleasedEvent, OnPointerEventUpdateCommonStates, handledEventsToo: false);
 #endif
 #if <#= mixin.HasCommonPressedState #> || <#= mixin.HasCommonOverState #>
-			PointerCanceled += _updateCommonStatesOnPointerEvent;
-			PointerCaptureLost += _updateCommonStatesOnPointerEvent;
+			InsertHandler(PointerCanceledEvent, OnPointerEventUpdateCommonStates, handledEventsToo: false);
+			InsertHandler(PointerCaptureLostEvent, OnPointerEventUpdateCommonStates, handledEventsToo: false);
 #endif
 
 			UpdateAllStates();
 		}
+
+		private static readonly RoutedEventHandler OnRoutedEventUpdateAllStates = (snd, e) =>
+		{
+			if (snd is <#= mixin.ClassName #> elt)
+			{
+				elt.UpdateAllStates();
+			}
+		};
+#if <#= mixin.HasCommonStates #>
+		private static readonly PointerEventHandler OnPointerEventUpdateCommonStates = (snd, e) =>
+		{
+			if (snd is <#= mixin.ClassName #> elt)
+			{
+				elt.UpdateCommonStates(true);
+			}
+		};
+		private static readonly PropertyChangedCallback OnPropertyChangedUpdateCommonStates = (snd, e) =>
+		{
+			if (snd is <#= mixin.ClassName #> elt)
+			{
+				elt.UpdateCommonStates(true);
+			}
+		};
+#endif
+#if <#= mixin.HasCheckedStates #>
+		private static readonly PropertyChangedCallback OnPropertyChangedUpdateCheckedStates = (snd, e) =>
+		{
+			if (snd is <#= mixin.ClassName #> elt)
+			{
+				elt.UpdateCheckedStates(true);
+			}
+		};
+#endif
 
 		private void UpdateAllStates()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/VisualStatesImplementation.tt
+++ b/src/Uno.UI/UI/Xaml/Controls/VisualStatesImplementation.tt
@@ -31,25 +31,61 @@ namespace <#= mixin.NamespaceName #>
 	public partial class <#= mixin.ClassName #>
 	{
 #if <#= mixin.HasCommonStates #>
-		private static readonly string __normalState = "Normal";
-		private static readonly string __disabledState = "Disabled";
+		private const string __normalState = "Normal";
+		private const string __disabledState = "Disabled";
 
 #if <#= mixin.HasCommonPressedState #>
-		private static readonly string __pressedState = "Pressed";
+		private const string __pressedState = "Pressed";
 #endif
 #if <#= mixin.HasCommonOverState #>
-		private static readonly string __pointerOverState = "PointerOver";
+		private const string __pointerOverState = "PointerOver";
 #endif
 
 #if <#= mixin.HasCommonFocusedState #>
-		private static readonly string __focusedState = "Focused";
+		private const string __focusedState = "Focused";
 #endif
 #endif
 
 #if <#= mixin.HasCheckedStates #> || <#= mixin.HasCombinedCheckedState #> || <#= mixin.HasCommonCheckedState #>
-		private static readonly string __indeterminateState = "Indeterminate";
-		private static readonly string __checkedState = "Checked";
-		private static readonly string __uncheckedState = "Unchecked";
+		private const string __indeterminateState = "Indeterminate";
+		private const string __checkedState = "Checked";
+		private const string __uncheckedState = "Unchecked";
+#endif
+
+		private static readonly RoutedEventHandler _updateAllStatesOnEvent = (snd, e) => ((<#= mixin.ClassName #>)snd).UpdateAllStates();
+#if <#= mixin.HasCommonStates #>
+		private static readonly PointerEventHandler _updateCommonStatesOnPointerEvent = (snd, e) => ((<#= mixin.ClassName #>)snd).UpdateCommonStates(true);
+		private static readonly PropertyChangedCallback _updateCommonStatesOnPropertyChanged = (snd, e) => ((<#= mixin.ClassName #>)snd).UpdateCommonStates(true);
+#endif
+#if <#= mixin.HasCheckedStates #>
+		private static readonly PropertyChangedCallback _updateCheckedStatesOnPropertyChanged = (snd, e) => ((<#= mixin.ClassName #>)snd).UpdateCheckedStates(true);
+#endif
+
+#if <#= mixin.HasCommonStates #> || <#= mixin.HasCheckedStates #>
+#if <#= (mixin.ClassName != "Button").ToString().ToLowerInvariant() #>
+		static <#= mixin.ClassName #>()
+		{
+			StaticInitializeVisualStates();
+		}
+#endif
+
+		/// <summary>
+		/// This method must be called from the static constructor in the non-generated part of the class in order to register visual state changes.
+		/// </summary>
+		private static void StaticInitializeVisualStates()
+		{
+			var type = typeof(<#= mixin.ClassName #>);
+
+			IsEnabledProperty.GetMetadata(type).MergePropertyChangedCallback(_updateCommonStatesOnPropertyChanged);
+#if <#= mixin.HasCommonFocusedState #>
+			FocusStateProperty.GetMetadata(type).MergePropertyChangedCallback(_updateCommonStatesOnPropertyChanged);
+#endif
+#if <#= mixin.HasCommonCheckedState #> || <#= mixin.HasCombinedCheckedState #>
+			IsCheckedProperty.GetMetadata(type).MergePropertyChangedCallback(_updateCommonStatesOnPropertyChanged);
+#elif <#= mixin.HasCheckedStates #>
+			IsCheckedProperty.GetMetadata(type).MergePropertyChangedCallback(_updateCheckedStatesOnPropertyChanged);
+#endif
+		}
 #endif
 
 		/// <summary>
@@ -57,119 +93,35 @@ namespace <#= mixin.NamespaceName #>
 		/// </summary>
 		private void InitializeVisualStates()
 		{
-			this.Loaded += On<#= mixin.ClassName #>Loaded;
-			this.Unloaded += On<#= mixin.ClassName #>Unloaded;
-
-#if <#= mixin.HasCommonStates #>
-			UpdateCommonStates(false);
-#endif
-
-#if <#= mixin.HasCheckedStates #>
-			UpdateCheckedStates(false);
-#endif
-		}
-
-		private void On<#= mixin.ClassName #>Loaded(object sender, RoutedEventArgs e)
-		{
-#if <#= mixin.HasCommonStates #>
-			this.IsEnabledChanged += On<#= mixin.ClassName #>IsEnabledChanged;
-
-#if <#= mixin.HasCommonCheckedState #> || <#= mixin.HasCombinedCheckedState #>
-			RegisterToCheckedStateChanges();
-#endif
-			UpdateCommonStates(false);
-#endif
-
-#if <#= mixin.HasCheckedStates #>
-			RegisterToCheckedStateChanges();
-			UpdateCheckedStates(false);
-#endif
-		}
-
-		private void On<#= mixin.ClassName #>Unloaded(object sender, RoutedEventArgs e)
-		{
-#if <#= mixin.HasCommonStates #>
-			this.IsEnabledChanged -= On<#= mixin.ClassName #>IsEnabledChanged;
-#endif
-		}
-
-#if <#= mixin.HasCommonStates #>
-		private void On<#= mixin.ClassName #>IsEnabledChanged(object sender, EventArgs e)
-		{
-			this.UpdateCommonStates(true);
-		}
+			Loaded += _updateAllStatesOnEvent;
 
 #if <#= mixin.HasCommonOverState #>
-		protected override void OnPointerEntered(PointerRoutedEventArgs args)
-		{
-			base.OnPointerEntered(args);
-			OnPointerEnteredPartial(args);
-			
-			this.UpdateCommonStates(true);
-		}
-		partial void OnPointerEnteredPartial(PointerRoutedEventArgs args);
-
-		protected override void OnPointerExited(PointerRoutedEventArgs args)
-		{
-			base.OnPointerExited(args);
-			OnPointerExitedPartial(args);
-			
-			this.UpdateCommonStates(true);
-		}
-		partial void OnPointerExitedPartial(PointerRoutedEventArgs args);
+			PointerEntered += _updateCommonStatesOnPointerEvent;
+			PointerExited += _updateCommonStatesOnPointerEvent;
 #endif
-
-#if <#= mixin.HasCommonPressedState #>
-		protected override void OnPointerPressed(PointerRoutedEventArgs args)
-		{
-			base.OnPointerPressed(args);
-			OnPointerPressedPartial(args);
-
-			this.UpdateCommonStates(true);
-		}
-		partial void OnPointerPressedPartial(PointerRoutedEventArgs args);
-
-		protected override void OnPointerReleased(PointerRoutedEventArgs args)
-		{
-			base.OnPointerReleased(args);
-			OnPointerReleasedPartial(args);
-
-			this.UpdateCommonStates(true);
-		}
-		partial void OnPointerReleasedPartial(PointerRoutedEventArgs args);
+#if <#= mixin.HasCommonPressedState #> 
+			PointerPressed += _updateCommonStatesOnPointerEvent;
+			PointerReleased += _updateCommonStatesOnPointerEvent;
 #endif
-
 #if <#= mixin.HasCommonPressedState #> || <#= mixin.HasCommonOverState #>
-		protected override void OnPointerCanceled(PointerRoutedEventArgs args)
-		{
-			base.OnPointerCanceled(args);
-			OnPointerCanceledPartial(args);
-
-			this.UpdateCommonStates(true);
-		}
-		partial void OnPointerCanceledPartial(PointerRoutedEventArgs args);
-
-		protected override void OnPointerCaptureLost(PointerRoutedEventArgs args)
-		{
-			base.OnPointerCaptureLost(args);
-			OnPointerCaptureLostPartial(args);
-
-			this.UpdateCommonStates(true);
-		}
-		partial void OnPointerCaptureLostPartial(PointerRoutedEventArgs args);
+			PointerCanceled += _updateCommonStatesOnPointerEvent;
+			PointerCaptureLost += _updateCommonStatesOnPointerEvent;
 #endif
 
-#if <#= mixin.HasCommonFocusedState #>
-		protected override void OnFocusStateChanged(FocusState oldState, FocusState newState)
-		{
-			base.OnFocusStateChanged(oldState, newState);
-			OnFocusStateChangedPartial(oldState, newState);
-
-			this.UpdateCommonStates(true);
+			UpdateAllStates();
 		}
-		partial void OnFocusStateChangedPartial(FocusState oldValue, FocusState newValue);
-#endif
 
+		private void UpdateAllStates()
+		{
+#if <#= mixin.HasCommonStates #>
+			UpdateCommonStates(false);
+#endif
+#if <#= mixin.HasCheckedStates #>
+			UpdateCheckedStates(false);
+#endif
+		}
+
+#if <#= mixin.HasCommonStates #>
 		private void UpdateCommonStates(bool useTransitions)
 		{
 #if <#= mixin.HasCommonCheckedState #> || <#= mixin.HasCombinedCheckedState #>
@@ -184,6 +136,15 @@ namespace <#= mixin.NamespaceName #>
 			// states are in different VisualStateGroups, and follows UWP in the non-standard case that they are in the same group (Checked/Unchecked is always reapplied last)
 			UpdateCheckedStates(useTransitions);
 #endif
+		}
+#endif
+
+#if <#= mixin.HasCheckedStates #>
+		private void UpdateCheckedStates(bool useTransitions)
+		{
+			var state = GetCheckedState();
+
+			VisualStateManager.GoToState(this, state, useTransitions);
 		}
 #endif
 
@@ -209,7 +170,6 @@ namespace <#= mixin.NamespaceName #>
 
 		private string GetCommonState()
 		{
-			var targetState = __normalState;
 			if (!IsEnabled)
 			{
 				return __disabledState;
@@ -253,42 +213,6 @@ namespace <#= mixin.NamespaceName #>
 			{
 				return __uncheckedState;
 			}
-		}
-#endif
-
-
-#if <#= mixin.HasCommonCheckedState #> || <#= mixin.HasCombinedCheckedState #>
-		private IDisposable _isCheckedChanged = null;
-
-		private void RegisterToCheckedStateChanges()
-		{
-			if (_isCheckedChanged == null)
-			{
-				_isCheckedChanged = this.RegisterDisposablePropertyChangedCallback(
-					<#= mixin.ClassName #>.IsCheckedProperty,
-					(s, a) => UpdateCommonStates(true)
-				);
-			}
-		}
-#endif
-
-#if <#= mixin.HasCheckedStates #>
-		private IDisposable _isCheckedChanged = null;
-
-		private void RegisterToCheckedStateChanges()
-		{
-			if (_isCheckedChanged == null)
-			{
-				_isCheckedChanged = this.RegisterDisposablePropertyChangedCallback(
-					<#= mixin.ClassName #>.IsCheckedProperty,
-					(s, a) => UpdateCheckedStates(true)
-				);
-			}
-		}
-
-		private void UpdateCheckedStates(bool useTransitions)
-		{
-			VisualStateManager.GoToState(this, GetCheckedState(), useTransitions);
 		}
 #endif
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/VisualStatesImplementation.tt
+++ b/src/Uno.UI/UI/Xaml/Controls/VisualStatesImplementation.tt
@@ -204,16 +204,16 @@ namespace <#= mixin.NamespaceName #>
 				return __pressedState;
 			}
 #endif
-#if <#= mixin.HasCommonOverState #>
-			else if (IsPointerOver)
-			{
-				return __pointerOverState;
-			}
-#endif
 #if <#= mixin.HasCommonFocusedState #>
 			else if (FocusState != FocusState.Unfocused)
 			{
 				return __focusedState;
+			}
+#endif
+#if <#= mixin.HasCommonOverState #>
+			else if (IsPointerOver)
+			{
+				return __pointerOverState;
 			}
 #endif
 			else


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #2021 

## BugFix
Visual states of `TextBox`

## What is the current behavior?
The `TextBox` had 2 way to trigger a visual state, one by the generated "VisualStateMixin" which was configured to handle pointer events; and a second directly in the code of the control which handle the *Normal*, *Disabled* and *Focused* states.

When we clicked on a `TextBox` the first logic was enabling the *PointerOver*, then the second was activating the *Focused* state as expected. Then when was the pointer was released, as the first trigger was not aware of the *Focused* state, it was reseting to *Normal*.

## What is the new behavior?
All "common states" are managed by the "Visual states mixins"

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)
