### PR TITLE
[Wasm] Fix support for TextBox clear button and header focus

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -64,5 +64,66 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			textBox1Result_After.Rect.X.Should().Be(textBox1Result_Before.Rect.X);
 			textBox1Result_After.Rect.Y.Should().Be(textBox1Result_Before.Rect.Y);
 		}
+
+		[Test]
+		[AutoRetry]
+		public void TextBox_DeleteButton()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_DeleteButton_Automated");
+
+			var textBox1 = _app.Marked("textBox1");
+			var textBox2 = _app.Marked("textBox2");
+
+			textBox1.Tap();
+			textBox1.EnterText("hello 01");
+
+			_app.WaitForText(textBox1, "hello 01");
+
+			textBox2.Tap();
+			textBox2.EnterText("hello 02");
+
+			_app.WaitForText(textBox2, "hello 02");
+
+			var textBox1Result = _app.Query(textBox1).First();
+			var textBox2Result = _app.Query(textBox2).First();
+
+			// Focus the first textbox
+			textBox1.Tap();
+
+			var deleteButton1 = FindDeleteButton(textBox1Result);
+
+			_app.TapCoordinates(deleteButton1.Rect.CenterX, deleteButton1.Rect.CenterY);
+
+			// Second tap is required on Wasm https://github.com/unoplatform/uno/issues/2138
+			_app.TapCoordinates(deleteButton1.Rect.CenterX, deleteButton1.Rect.CenterY);
+
+			_app.WaitForText(textBox1, "");
+
+			// Focus the first textbox
+			textBox2.Tap();
+
+			var deleteButton2 = FindDeleteButton(textBox2Result);
+
+			_app.TapCoordinates(deleteButton2.Rect.CenterX, deleteButton2.Rect.CenterY);
+
+			// Second tap is required on Wasm https://github.com/unoplatform/uno/issues/2138
+			_app.TapCoordinates(deleteButton2.Rect.CenterX, deleteButton2.Rect.CenterY);
+
+			_app.WaitForText(textBox2, "");
+		}
+
+		private Uno.UITest.IAppResult FindDeleteButton(Uno.UITest.IAppResult source)
+		{
+			var deleteButtons = _app.Marked("DeleteButton");
+			var appResult = _app.Query(deleteButtons).ToArray();
+			var deleteButton = appResult
+				.First(r =>
+					r.Rect.CenterX > source.Rect.X
+					&& r.Rect.CenterX < source.Rect.Right
+					&& r.Rect.CenterY > source.Rect.Y
+					&& r.Rect.CenterY < source.Rect.Bottom
+				);
+			return deleteButton;
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -549,6 +549,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_DeleteButton_Automated.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Disabled.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2979,6 +2983,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_BeforeTextChanging.xaml.cs">
       <DependentUpon>TextBox_BeforeTextChanging.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_DeleteButton_Automated.xaml.cs">
+      <DependentUpon>TextBox_DeleteButton_Automated.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Disabled.xaml.cs">
       <DependentUpon>TextBox_Disabled.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_DeleteButton_Automated.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_DeleteButton_Automated.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_DeleteButton_Automated"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid>
+		<StackPanel>
+			<TextBox x:Name="textBox1" />
+			<TextBox x:Name="textBox2" Header="My Custom TextBox" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_DeleteButton_Automated.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_DeleteButton_Automated.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
+{
+	[SampleControlInfo("TextBox")]
+	public sealed partial class TextBox_DeleteButton_Automated : UserControl
+    {
+        public TextBox_DeleteButton_Automated()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -137,7 +137,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			UpdateTextBoxView();
-
 			InitializeProperties();
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -25,14 +25,8 @@ namespace Windows.UI.Xaml.Controls
 		partial void OnTextClearedPartial() => FocusTextView();
 		protected virtual bool FocusTextView() => FocusManager.Focus(_textBoxView);
 
-		partial void OnFocusStateChangedPartial(FocusState focusState)
-		{
-		}
 
-		partial void OnAcceptsReturnChangedPartial(DependencyPropertyChangedEventArgs e)
-		{
 
-		}
 
 		private void UpdateTextBoxView()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -27,17 +27,12 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnFocusStateChangedPartial(FocusState focusState)
 		{
-			if(focusState != FocusState.Unfocused)
-			{
-				FocusTextView();
-			}
 		}
 
 		partial void OnAcceptsReturnChangedPartial(DependencyPropertyChangedEventArgs e)
 		{
 
 		}
-
 
 		private void UpdateTextBoxView()
 		{
@@ -73,6 +68,16 @@ namespace Windows.UI.Xaml.Controls
 		partial void InitializePropertiesPartial()
 		{
 			ApplyEnabled();
+
+			if(_header != null)
+			{
+				AddHandler(PointerReleasedEvent, (PointerEventHandler)OnHeaderClick, true);
+			}
+		}
+
+		private void OnHeaderClick(object sender, object args)
+		{
+			FocusTextView();
 		}
 
 		protected void SetIsPassword(bool isPassword)


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #2132 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Tapping on the TextBox clear button on Wasm fails to clear the content of the TextBox.

## What is the new behavior?

The original behavior is restored for Wasm, though tapping twice on the button is required. See https://github.com/unoplatform/uno/issues/2138 for more information.

Tests have been added to validated the clear button behavior.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes]~~(https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
