### PR TITLE
[WASM] Fix possible invalid scrolling

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Mesaure_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Mesaure_Tests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
+{
+	public class Mesaure_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void Measure_CollapsedShapeInSmallScrollViewer()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Shapes.MeasurePage");
+
+			var sut = _app.WaitForElement("CollapsedInSmallScrollViewer").Single();
+			var initial = TakeScreenshot("initial");
+
+			// Try to scroll up
+			_app.DragCoordinates(sut.Rect.CenterX, sut.Rect.Bottom - 5, sut.Rect.CenterX, sut.Rect.Y + 5); // Touch scroll
+			for (var i = 0; i < 10; i++) _app.TapCoordinates(sut.Rect.Right - 5, sut.Rect.Bottom - 5); // Mouse scroll
+
+			var final = TakeScreenshot("final");
+
+			AssertScreenshotsAreEqual(initial, final, sut.Rect);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2569,6 +2569,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\MeasurePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PathTestsControl\AutoSizedPathCentered.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4018,6 +4022,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\LinePage.xaml.cs">
       <DependentUpon>LinePage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\MeasurePage.xaml.cs">
+      <DependentUpon>MeasurePage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PathTestsControl\AutoSizedPathCentered.xaml.cs">
       <DependentUpon>AutoSizedPathCentered.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/MeasurePage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/MeasurePage.xaml
@@ -1,0 +1,22 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Shapes.MeasurePage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Shapes"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<StackPanel>
+			<TextBlock Text="Collapsed in a small ScrollViewer (might cause scrolling on WASM)" />
+			<ScrollViewer Height="100" Width="100" Background="DeepSkyBlue" HorizontalAlignment="Left">
+				<Grid Height="100" Width="100">
+					<Ellipse Fill="DeepPink" Visibility="Collapsed" />
+					<TextBlock Text="This must not be scrollable" />
+				</Grid>
+			</ScrollViewer>
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/MeasurePage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/MeasurePage.xaml
@@ -10,8 +10,8 @@
 
 	<Grid>
 		<StackPanel>
-			<TextBlock Text="Collapsed in a small ScrollViewer (might cause scrolling on WASM)" />
-			<ScrollViewer Height="100" Width="100" Background="DeepSkyBlue" HorizontalAlignment="Left">
+			<TextBlock Text="Collapsed in a small ScrollViewer (might enable scrolling on WASM)" />
+			<ScrollViewer Height="100" Width="100" Background="DeepSkyBlue" HorizontalAlignment="Left" x:Name="CollapsedInSmallScrollViewer">
 				<Grid Height="100" Width="100">
 					<Ellipse Fill="DeepPink" Visibility="Collapsed" />
 					<TextBlock Text="This must not be scrollable" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/MeasurePage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/MeasurePage.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Shapes
+{
+	[SampleControlInfo("Shapes", "Measure")]
+	public sealed partial class MeasurePage : Page
+	{
+		public MeasurePage()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
@@ -53,6 +53,35 @@ body {
   position: fixed;
 }
 
+svg.uno-frameworkelement.uno-unarranged,
+iframe.uno-frameworkelement.uno-unarranged,
+img.uno-frameworkelement.uno-unarranged,
+video.uno-frameworkelement.uno-unarranged,
+embed.uno-frameworkelement.uno-unarranged {
+  /*
+    "Replaced element" (like iFrame, img, video, ... cf. https://developer.mozilla.org/en-US/docs/Web/CSS/Replaced_element)
+    have a default size of 300x150px (as described here https://www.w3.org/TR/css-sizing-3/#intrinsic-sizes)
+    > For boxes without an intrinsic aspect ratio:
+    >     [../..]
+    >     Otherwise, use 300px for the width and/or 150px for the height as needed.
+
+    SVG element that does not have a measurable viewport are also requested to follow the same logic
+    https://www.w3.org/TR/SVGMobile12/coords.html#InitialViewport
+    >  If the parent document is styled with CSS, then the negotiation process must follow the CSS rules for replaced elements.
+
+    Here we make sure that any unarranged "replaced element" have a fixed with / height to 0,
+    so they won't be taken in consideration by scroll viewers (overflow) which are computing their extent in native.
+
+    A common visual effect of this, is that a non virtualized GridView with items smaller than 150px height
+    is vertically scrollable why it should not! (There is a Rectagle in their template, which rendered using an SVG element).
+
+    Note: this is required has have set a "transform: translate(0, 0);" on all ".uno-uielement",
+          which has a side effect to establish a "containing block" (cf. WindowManager.ts on measureViewInternal()).
+  */
+  width: 0;
+  height: 0;
+}
+
 .uno-textblock {
   text-rendering: optimizeLegibility; /* iOS Safari */
   -webkit-touch-callout: none; /* Safari */

--- a/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
@@ -73,7 +73,7 @@ embed.uno-frameworkelement.uno-unarranged {
     so they won't be taken in consideration by scroll viewers (overflow) which are computing their extent in native.
 
     A common visual effect of this, is that a non virtualized GridView with items smaller than 150px height
-    is vertically scrollable why it should not! (There is a Rectagle in their template, which rendered using an SVG element).
+    is vertically scrollable when it should not! (There is a Rectangle in their template, which rendered using an SVG element).
 
     Note: this is required has have set a "transform: translate(0, 0);" on all ".uno-uielement",
           which has a side effect to establish a "containing block" (cf. WindowManager.ts on measureViewInternal()).


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/2111

## Bugfix
A visibility collapsed shape may enable the scrolling

## What is the current behavior?
SVG elements that are not arranged (like a `Rectangle` used by the "Selected" visual state of a `GridViewItem`) are implicitly measured to 300x150 by web browser (cf. comment in `Uno.UI.css`)

## What is the new behavior?
While not arranged, SVG element are forced to be (0, 0).

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)

## Other information
This was a "regression" introduced by #1726, but which was actually only revealing the real issue.