### PR TITLE
Fix ellipse on all platform

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
@@ -86,11 +87,23 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 
 		[Test]
 		[AutoRetry]
-		public void Draw_ellipse()
+		public void Ellipse_Page()
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Shapes.EllipsePage");
-			_app.WaitForElement("DEllipsePage");
-			TakeScreenshot($"EllipsePage");
+			_app.WaitForElement("ellipse0");
+
+			var ellipse1 = _app.Marked("ellipse1").FirstResult().Rect;
+			var ellipse2 = _app.Marked("ellipse2").FirstResult().Rect;
+			var ellipse3 = _app.Marked("ellipse3").FirstResult().Rect;
+			var ellipse4 = _app.Marked("ellipse4").FirstResult().Rect;
+
+			ellipse2.Width.Should().Be(ellipse1.Width, "Invalid ellipse2 width");
+			ellipse3.Width.Should().Be(ellipse1.Width, "Invalid ellipse3 width");
+			ellipse4.Width.Should().Be(0, "Invalid ellipse4 width");
+
+			ellipse2.Height.Should().Be(ellipse1.Height, "Invalid ellipse2 height");
+			ellipse3.Height.Should().Be(ellipse1.Height, "Invalid ellipse3 height");
+			ellipse4.Height.Should().Be(ellipse1.Height, "Invalid ellipse4 height");
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
@@ -95,15 +95,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			var ellipse1 = _app.Marked("ellipse1").FirstResult().Rect;
 			var ellipse2 = _app.Marked("ellipse2").FirstResult().Rect;
 			var ellipse3 = _app.Marked("ellipse3").FirstResult().Rect;
-			var ellipse4 = _app.Marked("ellipse4").FirstResult().Rect;
+			var ellipse4 = _app.Marked("ellipse4").FirstResult()?.Rect;
 
 			ellipse2.Width.Should().Be(ellipse1.Width, "Invalid ellipse2 width");
 			ellipse3.Width.Should().Be(ellipse1.Width, "Invalid ellipse3 width");
-			ellipse4.Width.Should().Be(0, "Invalid ellipse4 width");
+			ellipse4?.Width.Should().Be(0, "Invalid ellipse4 width");
 
 			ellipse2.Height.Should().Be(ellipse1.Height, "Invalid ellipse2 height");
 			ellipse3.Height.Should().Be(ellipse1.Height, "Invalid ellipse3 height");
-			ellipse4.Height.Should().Be(ellipse1.Height, "Invalid ellipse4 height");
+			ellipse4?.Height.Should().Be(ellipse1.Height, "Invalid ellipse4 height");
 		}
 
 		[Test]

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Transform_Ellipse_in_Two_Canvas_in_Grid.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Transform_Ellipse_in_Two_Canvas_in_Grid.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+﻿<Page
 	x:Class="SamplesApp.Windows_UI_Xaml.Clipping.Transform_Ellipse_in_Two_Canvas_in_Grid"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -30,4 +30,4 @@
 					 Height="200" />
 	</Grid>
 
-</UserControl>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Transform_Ellipse_in_Two_Canvas_in_Grid.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Transform_Ellipse_in_Two_Canvas_in_Grid.xaml.cs
@@ -4,7 +4,7 @@ using Uno.UI.Samples.Controls;
 namespace SamplesApp.Windows_UI_Xaml.Clipping
 {
 	[SampleControlInfo("Clipping")]
-	public sealed partial class Transform_Ellipse_in_Two_Canvas_in_Grid : UserControl
+	public sealed partial class Transform_Ellipse_in_Two_Canvas_in_Grid : Page
 	{
 		public Transform_Ellipse_in_Two_Canvas_in_Grid()
 		{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageInStackPanel.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageInStackPanel.xaml.cs
@@ -1,23 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Uno.UI.Samples.Controls;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-
 
 namespace Uno.UI.Samples.UITests.Image
 {
-	[SampleControlInfo("Image", "ImageInStackPanel")]
+	[SampleControlInfo(category: "Image")]
 	public sealed partial class ImageInStackPanel : UserControl
 	{
 		public ImageInStackPanel()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/EllipsePage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/EllipsePage.xaml
@@ -9,7 +9,7 @@
 
 	<StackPanel Spacing="5">
 		<TextBlock FontSize="22">This is an ellipse</TextBlock>
-		<Ellipse x:Name="DEllipsePage" Stroke="Black" Height="125" Width="150" StrokeThickness="5" HorizontalAlignment="Left"/>
+		<Ellipse x:Name="ellipse0" Stroke="Black" Height="125" Width="150" StrokeThickness="5" HorizontalAlignment="Left"/>
 
 		<TextBlock FontSize="22">Those 3 ellipses should be identical (you should not see 4 ellipses!)</TextBlock>
 		<Grid>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/EllipsePage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/EllipsePage.xaml
@@ -1,14 +1,43 @@
 ﻿<Page
-    x:Class="SamplesApp.Windows_UI_Xaml_Shapes.EllipsePage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	x:Class="SamplesApp.Windows_UI_Xaml_Shapes.EllipsePage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<StackPanel Spacing="5">
-		<TextBlock Text="This is a ellipse" />
-		<Ellipse x:Name="DEllipsePage"  Stroke="Black" Height="200" Width="250" StrokeThickness="5"/>
+		<TextBlock FontSize="22">This is an ellipse</TextBlock>
+		<Ellipse x:Name="DEllipsePage" Stroke="Black" Height="125" Width="150" StrokeThickness="5" HorizontalAlignment="Left"/>
+
+		<TextBlock FontSize="22">Those 3 ellipses should be identical (you should not see 4 ellipses!)</TextBlock>
+		<Grid>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="175" />
+				<ColumnDefinition Width="20" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="20" />
+				<ColumnDefinition Width="175" />
+				<ColumnDefinition Width="20" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+			<Grid Grid.Column="0" Width="175" Height="125">
+				<Rectangle StrokeDashArray="2.5,1" Stroke="Brown" StrokeThickness="3" />
+				<Ellipse Width="175" Height="125" Fill="DarkSalmon" x:Name="ellipse1" />
+			</Grid>
+			<Grid Grid.Column="2" Width="175" Height="125">
+				<Rectangle StrokeDashArray="2.5,1" Stroke="Brown" StrokeThickness="3" />
+				<Ellipse Fill="DarkSalmon" x:Name="ellipse2" />
+			</Grid>
+			<Grid Grid.Column="4">
+				<Rectangle StrokeDashArray="2.5,1" Stroke="Brown" StrokeThickness="3" />
+				<Ellipse Height="125" Fill="DarkSalmon" x:Name="ellipse3" />
+			</Grid>
+			<Grid Grid.Column="6" MaxWidth="175" HorizontalAlignment="Left">
+				<Rectangle StrokeDashArray="2.5,1" Stroke="Brown" StrokeThickness="3" />
+				<Ellipse Height="125" Fill="DarkSalmon" x:Name="ellipse4" />
+			</Grid>
+		</Grid>
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/EllipsePage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/EllipsePage.xaml.cs
@@ -1,24 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Uno.UI.Samples.Controls;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
+﻿using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
 namespace SamplesApp.Windows_UI_Xaml_Shapes
 {
-	[SampleControlInfo("Shapes", "EllipsePage")]
+	[SampleControlInfo("Shapes")]
 	public sealed partial class EllipsePage : Page
 	{
 		public EllipsePage()

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.Android.cs
@@ -243,13 +243,13 @@ namespace Windows.UI.Xaml.Shapes
 			_scaleY = (calculatedHeight - strokeThickness) / pathHeight;
 
 			//Make sure that we have a valid scale if both of them are not set
-			if (double.IsInfinity((double)_scaleY))
-			{
-				_scaleY = 1;
-			}
-			if (double.IsInfinity((double)_scaleX))
+			if (double.IsInfinity(_scaleX) || double.IsNaN(_scaleX))
 			{
 				_scaleX = 1;
+			}
+			if (double.IsInfinity(_scaleY) || double.IsNaN(_scaleY))
+			{
+				_scaleY = 1;
 			}
 
 			// Here we will override some of the default values

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.cs
@@ -96,7 +96,7 @@ namespace Windows.UI.Xaml.Shapes
 			{
 				if (double.IsNaN(height))
 				{
-					return new Rect(0.0, 0.0, 100.0, 100.0);
+					return new Rect(0.0, 0.0, 0.0, 0.0);
 				}
 
 				return new Rect(0.0, 0.0, height, height);

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.iOSmacOS.cs
@@ -24,7 +24,6 @@ namespace Windows.UI.Xaml.Shapes
 		// Drawing scale
 		private nfloat _scaleX;
 		private nfloat _scaleY;
-		internal Size _measuredSize;
 
 		public ArbitraryShapeBase()
 		{
@@ -362,8 +361,7 @@ namespace Windows.UI.Xaml.Shapes
 			calculatedWidth += strokeThickness;
 			calculatedHeight += strokeThickness;
 
-			_measuredSize = new Size(calculatedWidth, calculatedHeight);
-			return _measuredSize;
+			return new Size(calculatedWidth, calculatedHeight);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.iOSmacOS.cs
@@ -24,6 +24,7 @@ namespace Windows.UI.Xaml.Shapes
 		// Drawing scale
 		private nfloat _scaleX;
 		private nfloat _scaleY;
+		internal Size _measuredSize;
 
 		public ArbitraryShapeBase()
 		{
@@ -361,7 +362,8 @@ namespace Windows.UI.Xaml.Shapes
 			calculatedWidth += strokeThickness;
 			calculatedHeight += strokeThickness;
 
-			return new Size(calculatedWidth, calculatedHeight);
+			_measuredSize = new Size(calculatedWidth, calculatedHeight);
+			return _measuredSize;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.Android.cs
@@ -6,20 +6,21 @@ using Rect = Windows.Foundation.Rect;
 
 namespace Windows.UI.Xaml.Shapes
 {
-    public partial class Ellipse : ArbitraryShapeBase
+	public partial class Ellipse : ArbitraryShapeBase
 	{
-        public Ellipse()
-        {
+		public Ellipse()
+		{
 			//Set default stretch value
 			this.Stretch = Windows.UI.Xaml.Media.Stretch.Fill;
-        }
+		}
 
-        protected override Android.Graphics.Path GetPath()
+		protected override Android.Graphics.Path GetPath()
 		{
-			var bounds = GetBounds();
+			var viewGroup = this as UnoViewGroup;
+			var bounds = new RectF(0, 0, viewGroup.Width, viewGroup.Height);
 
 			var output = new Android.Graphics.Path();
-			output.AddOval(bounds.ToRectF(), Android.Graphics.Path.Direction.Cw);
+			output.AddOval(bounds, Android.Graphics.Path.Direction.Cw);
 			return output;
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.Android.cs
@@ -3,7 +3,6 @@ using Uno.UI;
 using System;
 using System.Drawing;
 using Size = Windows.Foundation.Size;
-using Rect = Windows.Foundation.Rect;
 
 namespace Windows.UI.Xaml.Shapes
 {
@@ -17,15 +16,15 @@ namespace Windows.UI.Xaml.Shapes
 
 		protected override Android.Graphics.Path GetPath()
 		{
-			var minMax = this.GetMinMax();
+			var minMaxInLogicalPixels = this.GetMinMax();
 
 			var viewGroup = this as UnoViewGroup;
-			var finalSize =
+			var finalSizeInPhysicalPixels =
 				new Size(viewGroup.Width, viewGroup.Height)
-					.AtMost(minMax.max)
-					.AtLeast(minMax.min);
+					.AtMost(minMaxInLogicalPixels.max.LogicalToPhysicalPixels())
+					.AtLeast(minMaxInLogicalPixels.min.LogicalToPhysicalPixels());
 
-			var bounds = new RectF(0, 0, (float)finalSize.Width, (float)finalSize.Height);
+			var bounds = new RectF(0, 0, (float)finalSizeInPhysicalPixels.Width, (float)finalSizeInPhysicalPixels.Height);
 
 			var output = new Android.Graphics.Path();
 			output.AddOval(bounds, Android.Graphics.Path.Direction.Cw);

--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.Android.cs
@@ -2,6 +2,7 @@
 using Uno.UI;
 using System;
 using System.Drawing;
+using Size = Windows.Foundation.Size;
 using Rect = Windows.Foundation.Rect;
 
 namespace Windows.UI.Xaml.Shapes
@@ -16,8 +17,15 @@ namespace Windows.UI.Xaml.Shapes
 
 		protected override Android.Graphics.Path GetPath()
 		{
+			var minMax = this.GetMinMax();
+
 			var viewGroup = this as UnoViewGroup;
-			var bounds = new RectF(0, 0, viewGroup.Width, viewGroup.Height);
+			var finalSize =
+				new Size(viewGroup.Width, viewGroup.Height)
+					.AtMost(minMax.max)
+					.AtLeast(minMax.min);
+
+			var bounds = new RectF(0, 0, (float)finalSize.Width, (float)finalSize.Height);
 
 			var output = new Android.Graphics.Path();
 			output.AddOval(bounds, Android.Graphics.Path.Direction.Cw);

--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.iOSmacOS.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Foundation;
 using CoreAnimation;
 using CoreGraphics;
+using Uno.UI;
 using Size = Windows.Foundation.Size;
 
 namespace Windows.UI.Xaml.Shapes
@@ -18,10 +19,10 @@ namespace Windows.UI.Xaml.Shapes
 
 		protected override CGPath GetPath()
 		{
-			var calculatedBounds = SizeFromUISize(Bounds.Size); ;
-
-			var width = double.IsNaN(Width) ? calculatedBounds.Width : Width;
-			var height = double.IsNaN(Height) ? calculatedBounds.Height : Height;
+			var minMax = this.GetMinMax();
+			var calculatedBounds = SizeFromUISize(Bounds.Size)
+				.AtLeast(minMax.min)
+				.AtMost(minMax.max);
 
 			var strokeThickness = (nfloat)this.ActualStrokeThickness;
 
@@ -31,8 +32,8 @@ namespace Windows.UI.Xaml.Shapes
 
 				//In ios we need to inflate the bounds because the stroke thickness is not taken into account when
 				//forming the ellipse from rect.
-				width: width - strokeThickness, 
-				height: height - strokeThickness
+				width: calculatedBounds.Width - strokeThickness, 
+				height: calculatedBounds.Height - strokeThickness
             );
 
 			return CGPath.EllipseFromRect(area);

--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.iOSmacOS.cs
@@ -6,19 +6,19 @@ using System.Text;
 using Foundation;
 using CoreAnimation;
 using CoreGraphics;
+using Size = Windows.Foundation.Size;
 
 namespace Windows.UI.Xaml.Shapes
 {
 	public partial class Ellipse : ArbitraryShapeBase
     {
-		public Ellipse()
+	    public Ellipse()
 		{
 		}
 
 		protected override CGPath GetPath()
 		{
-			var bounds = Bounds;
-			var calculatedBounds = GetBounds();
+			var calculatedBounds = SizeFromUISize(Bounds.Size); ;
 
 			var width = double.IsNaN(Width) ? calculatedBounds.Width : Width;
 			var height = double.IsNaN(Height) ? calculatedBounds.Height : Height;

--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.wasm.cs
@@ -20,12 +20,10 @@ namespace Windows.UI.Xaml.Shapes
 			return _ellipse;
 		}
 
-		protected override Size MeasureOverride(Size availableSize)
+		protected override Size ArrangeOverride(Size finalSize)
 		{
-			var bounds = GetBounds();
-
-			var cx = bounds.Width / 2;
-			var cy = bounds.Height / 2;
+			var cx = finalSize.Width / 2;
+			var cy = finalSize.Height / 2;
 
 			var strokeThickness = ActualStrokeThickness;
 
@@ -35,7 +33,7 @@ namespace Windows.UI.Xaml.Shapes
 				("rx", (cx - strokeThickness).ToStringInvariant()),
 				("ry", (cy - strokeThickness).ToStringInvariant()));
 
-			return base.MeasureOverride(availableSize);
+			return base.ArrangeOverride(finalSize);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.wasm.cs
@@ -1,6 +1,7 @@
 ﻿using Windows.Foundation;
 using Windows.UI.Xaml.Wasm;
 using Uno.Extensions;
+using Uno.UI;
 
 namespace Windows.UI.Xaml.Shapes
 {
@@ -22,8 +23,14 @@ namespace Windows.UI.Xaml.Shapes
 
 		protected override Size ArrangeOverride(Size finalSize)
 		{
-			var cx = finalSize.Width / 2;
-			var cy = finalSize.Height / 2;
+			var minMax = this.GetMinMax();
+
+			var arrangeSize = finalSize
+				.AtLeast(minMax.min)
+				.AtMost(minMax.max);
+
+			var cx = arrangeSize.Width / 2;
+			var cy = arrangeSize.Height / 2;
 
 			var strokeThickness = ActualStrokeThickness;
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

# Bugfix

## What is the current behavior?
Ellipse were not using the `LayoutSlot` to draw itself on any platform.

## What is the new behavior?
Instead of trying to calculate the bounds of shape, the LayoutSlot is used to determine the measurements of the ellipse.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- ~~[ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [X] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- ~~[ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [X] Associated with an issue (GitHub or internal)
