### PR TITLE
Restore layout constraints in measure for native elements

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FrameworkElementTests/UnoSamples_Test_FrameworkElement.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FrameworkElementTests/UnoSamples_Test_FrameworkElement.cs
@@ -37,5 +37,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FrameworkElementTests
 
 			_app.WaitForDependencyPropertyValue(result, "Text", "Loaded: 1");
 		}
+
+
+		[Test]
+		[AutoRetry]
+		public void FrameworkElement_NativeLayout()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml.FrameworkElementTests.FrameworkElement_NativeLayout");
+
+			var button1 = _app.Marked("button1");
+			var button2 = _app.Marked("button2");
+
+			var button1Result = _app.Query(button1).First();
+			var button2Result = _app.Query(button2).First();
+
+			button1Result.Rect.Width.Should().Be(button2Result.Rect.Width);
+			button1Result.Rect.Height.Should().Be(button2Result.Rect.Height);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -229,6 +229,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_NativeLayout.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_UnloadedMeasure.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2837,6 +2841,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FocusManager\FocusManager_GetFocus_Automated.xaml.cs">
       <DependentUpon>FocusManager_GetFocus_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_NativeLayout.xaml.cs">
+      <DependentUpon>FrameworkElement_NativeLayout.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_UnloadedMeasure.xaml.cs">
       <DependentUpon>FrameworkElement_UnloadedMeasure.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_NativeLayout.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_NativeLayout.xaml
@@ -1,0 +1,129 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml.FrameworkElementTests.FrameworkElement_NativeLayout"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml.FrameworkElementTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<Style x:Key="LocationSearchButtonStyle"
+		   TargetType="Button" >
+			<Setter Property="MinHeight"
+				Value="44" />
+			<Setter Property="Padding"
+				Value="12,8,16,8" />
+			<Setter Property="Margin"
+				Value="20,20,7,20" />
+			<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+			<Setter Property="VerticalAlignment"
+				Value="Top" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="Button">
+						<Grid x:Name="RootGrid"
+						  Background="White"
+						  BorderBrush="Green"
+						  BorderThickness="2"
+						  CornerRadius="8">
+
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver" />
+									<VisualState x:Name="Pressed">
+										<VisualState.Setters>
+											<Setter Target="RootGrid.BorderBrush"
+												Value="Red" />
+											<Setter Target="ContentPresenter.Foreground"
+												Value="Red" />
+										</VisualState.Setters>
+									</VisualState>
+									<VisualState x:Name="Disabled" />
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+
+							<ContentPresenter x:Name="ContentPresenter"
+										  Content="{TemplateBinding Content}"
+										  ContentTransitions="{TemplateBinding ContentTransitions}"
+										  ContentTemplate="{TemplateBinding ContentTemplate}"
+										  Padding="{TemplateBinding Padding}"
+										  Foreground="{TemplateBinding Foreground}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+										  AutomationProperties.AccessibilityView="Raw" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<Grid Background="Green">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<Grid Grid.Row="1"
+			  Background="Azure">
+		</Grid>
+
+		<!--With progressive ring. Issue is present only with progressive ring-->
+
+		<Border Grid.Row="1">
+			<Button Style="{StaticResource LocationSearchButtonStyle}"
+					x:Name="button1"
+					Margin="20">
+				<Grid>
+
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto" />
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="Auto" />
+					</Grid.ColumnDefinitions>
+
+					<TextBlock Text="Test Address"
+							   VerticalAlignment="Center"
+							   Grid.Column="1" />
+
+					<!--
+					Set the opacity to zero, to avoid screenshots comparison to fail.
+					This will not change the result of the layout.
+					-->
+					<ProgressRing x:Name="ring"
+							  Grid.Column="2"
+							  Opacity="0"
+							  Width="20"
+							  Height="20" />
+				</Grid>
+			</Button>
+		</Border>
+
+		<!--Without progressive ring-->
+		<Border Grid.Row="1"
+				Margin="0,80,0,0">
+			<Button Style="{StaticResource LocationSearchButtonStyle}"
+					x:Name="button2"
+					Margin="20">
+				<Grid>
+
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto" />
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="Auto" />
+					</Grid.ColumnDefinitions>
+
+					<TextBlock Text="Test Address"
+							   VerticalAlignment="Center"
+							   Grid.Column="1" />
+				</Grid>
+			</Button>
+		</Border>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_NativeLayout.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_NativeLayout.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml.FrameworkElementTests
+{
+	[SampleControlInfo("FrameworkElement")]
+	public sealed partial class FrameworkElement_NativeLayout : UserControl
+    {
+        public FrameworkElement_NativeLayout()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes unoplatform/private#104

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Fixes native elements layout regression introduced in #1726, where native elements may not have size constraints applied properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
