### PR TITLE
Fix reveal of PasswordBox in ScrollViewer

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -164,5 +164,25 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			_app.EnterText(txt, "Works again!");
 			_app.WaitForText(txt, "This is the starting text...Hello !Works again!");
 		}
+
+		[Test]
+		[AutoRetry]
+		public void PasswordBox_RevealInScrollViewer()
+		{
+			Run("Uno.UI.Samples.Content.UITests.TextBoxControl.PasswordBox_Reveal_Scroll");
+
+			var passwordBox = _app.WaitForElement("MyPasswordBox").Single();
+			var initial = TakeScreenshot("initial");
+
+			// Focus the PasswordBox
+			_app.TapCoordinates(passwordBox.Rect.X + 10, passwordBox.Rect.Y);
+
+			// Press the reveal button, and move up (so the ScrollViewer will kick in and cancel the pointer), then release
+			_app.DragCoordinates(passwordBox.Rect.X + 10, passwordBox.Rect.Right - 10, passwordBox.Rect.X - 100, passwordBox.Rect.Right - 10);
+
+			var result = TakeScreenshot("result");
+
+			AssertScreenshotsAreEqual(initial, result, passwordBox.Rect);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -557,6 +557,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\PasswordBox_Reveal_Scroll.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_BeforeTextChanging.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3006,6 +3010,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Visibility_Arrange.xaml.cs">
       <DependentUpon>TextBlock_Visibility_Arrange.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\PasswordBox_Reveal_Scroll.xaml.cs">
+      <DependentUpon>PasswordBox_Reveal_Scroll.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_BeforeTextChanging.xaml.cs">
       <DependentUpon>TextBox_BeforeTextChanging.xaml</DependentUpon>
     </Compile>
@@ -4901,6 +4908,7 @@
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ChatBox\" />
     <Folder Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\Models\" />
+    <Folder Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\PasswordBoxTests\" />
     <Folder Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\Model\" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Reveal_Scroll.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Reveal_Scroll.xaml
@@ -1,0 +1,29 @@
+﻿<Page
+	x:Class="Uno.UI.Samples.Content.UITests.TextBoxControl.PasswordBox_Reveal_Scroll"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<TextBlock
+			Text="Focsu the PasswordBox, press the reveal button, move pointer up, release pointer. The should no longer be readable."
+			TextWrapping="Wrap"
+			VerticalAlignment="Top" />
+
+		<!--The scroll take the full page: it must become scrollable when the keyboard is open-->
+		<ScrollViewer VerticalAlignment="Stretch">
+			<Grid>
+				<PasswordBox
+					x:Name="MyPasswordBox"
+					BorderThickness="3"
+					BorderBrush="Purple"
+					Password="password1"
+					Width="200"
+					Height="50" />
+			</Grid>
+		</ScrollViewer>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Reveal_Scroll.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Reveal_Scroll.xaml
@@ -9,7 +9,7 @@
 
 	<Grid>
 		<TextBlock
-			Text="Focsu the PasswordBox, press the reveal button, move pointer up, release pointer. The should no longer be readable."
+			Text="Focus the PasswordBox, press the reveal button, move pointer up, release pointer. The should no longer be readable."
 			TextWrapping="Wrap"
 			VerticalAlignment="Top" />
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Reveal_Scroll.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Reveal_Scroll.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBoxControl
+{
+	[SampleControlInfo(category: "TextBox")]
+	public sealed partial class PasswordBox_Reveal_Scroll : Page
+	{
+		public PasswordBox_Reveal_Scroll()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
@@ -41,6 +41,7 @@ namespace Windows.UI.Xaml.Controls
 				_revealButton.AddHandler(PointerReleasedEvent, endReveal, handledEventsToo: true);
 				_revealButton.AddHandler(PointerExitedEvent, endReveal, handledEventsToo: true);
 				_revealButton.AddHandler(PointerCanceledEvent, endReveal, handledEventsToo: true);
+				_revealButton.AddHandler(PointerCaptureLostEvent, endReveal, handledEventsToo: true);
 
 				_revealButtonSubscription.Disposable = Disposable.Create(() =>
 				{
@@ -48,6 +49,7 @@ namespace Windows.UI.Xaml.Controls
 					_revealButton.RemoveHandler(PointerReleasedEvent, endReveal);
 					_revealButton.RemoveHandler(PointerExitedEvent, endReveal);
 					_revealButton.RemoveHandler(PointerCanceledEvent, endReveal);
+					_revealButton.RemoveHandler(PointerCaptureLostEvent, endReveal);
 				});
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #2156

## BugFix
The `PasswordBox` might stay in reveal state when used in a `ScrollViewer`

## What is the current behavior?
When a `PasswordBox` is used in a `ScrollViewer`, if you press the reveal button with a finger or a pen, move the pointer up / down far enough to trigger the scroll, and then release the pointer, the password remain visible.

## What is the new behavior?
The password is hidden as soon as the scroll starts

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)
