### PR TITLE
[Android] Fix MeasureOverride taking NaN;Nan is input failure

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
@@ -98,6 +98,24 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			});
 		}
 
+		[TestMethod]
+		public async Task MeasureOverride_With_Nan_In_Grid()
+		{
+			await Dispatch(() =>
+			{
+				var grid = new Grid();
+
+				var SUT = new MyControl02();
+				SUT.Content = new Grid();
+				grid.Children.Add(SUT);
+
+				SUT.BaseAvailableSize = new Size(double.NaN, double.NaN);
+				grid.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+				Assert.AreEqual(new Size(double.PositiveInfinity, double.PositiveInfinity), SUT.MeasureOverrides.Last());
+				Assert.AreEqual(new Size(0, 0), SUT.DesiredSize);
+			});
+		}
+
 #if __WASM__
 		// TODO Android does not handle measure invalidation properly
 		[TestMethod]
@@ -124,6 +142,19 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 	}
 
 	public partial class MyControl01 : FrameworkElement
+	{
+		public List<Size> MeasureOverrides { get; } = new List<Size>();
+
+		public Size? BaseAvailableSize;
+
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			MeasureOverrides.Add(availableSize);
+			return base.MeasureOverride(BaseAvailableSize ?? availableSize);
+		}
+	}
+
+	public partial class MyControl02 : ContentControl
 	{
 		public List<Size> MeasureOverrides { get; } = new List<Size>();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -269,6 +269,8 @@ namespace Windows.UI.Xaml.Controls
 			var frameworkElement = view as IFrameworkElement;
 			var ret = default(Size);
 
+			// NaN values are accepted as input for MeasureOverride, but are treated as Infinity.
+			slotSize = slotSize.NumberOrDefault(MaxSize);
 
 			if (frameworkElement?.Visibility == Visibility.Collapsed)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/private#93

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restores the ability for a FrameworkElement to measure its children using `[NaN;NaN]` on Android.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
