### PR TITLE
[iOS] Call UIElement.InvalidateMeasure() when Visibility changes

### DIFF
--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -32,7 +32,8 @@ mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-conso
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Input.VisualState_Tests' or \
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests' or \
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' or \
-	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests' \
+	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests' or \
+	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests' \
 	" \
 	$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/net47/SamplesApp.UITests.dll \
 	|| true

--- a/src/SamplesApp/SamplesApp.UITests/QueryExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/QueryExtensions.cs
@@ -41,5 +41,13 @@ namespace SamplesApp.UITests
 			app.WaitForElement(element);
 			return element.GetText();
 		}
+
+		/// <summary>
+		/// Get bounds rect for an element.
+		/// </summary>
+		public static IAppRect GetRect(this IApp app, string elementName)
+		{
+			return app.WaitForElement(elementName).Single().Rect;
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -76,7 +76,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			_app.Tap("ChangeTextBlockButton");
 
-			_app.WaitForNoElement("FunnyTextBlock");
+			//_app.WaitForNoElement("FunnyTextBlock"); // This times out on WASM because view is considered to be still there when collapsed - https://github.com/unoplatform/Uno.UITest/issues/25
 
 			_app.Tap("ChangeTextBlockButton");
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -76,6 +76,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls
 
 			_app.Tap("ChangeTextBlockButton");
 
+			_app.WaitForElement("FunnyTextBlock");
+
 			var blueAfter = TakeScreenshot("After - blue");
 
 			AssertScreenshotsAreEqual(blueBefore, blueAfter, textRect);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -76,6 +76,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			_app.Tap("ChangeTextBlockButton");
 
+			_app.WaitForNoElement("FunnyTextBlock");
+
+			_app.Tap("ChangeTextBlockButton");
+
 			_app.WaitForElement("FunnyTextBlock");
 
 			var blueAfter = TakeScreenshot("After - blue");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -55,5 +55,30 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls
 				left.Y.Should().Be(right.Y, "Y position");
 			}
 		}
+
+		[Test]
+		[AutoRetry]
+		public void When_Foreground_Changed_With_Visibility()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_Foreground_While_Collapsed");
+
+			_app.WaitForText("FunnyTextBlock", "Look at me now");
+
+			var blueBefore = TakeScreenshot("Before - blue");
+
+			_app.Tap("ChangeTextBlockButton");
+
+			var blackBefore = TakeScreenshot("Before - black");
+
+			var textRect = _app.GetRect("FunnyTextBlock");
+
+			AssertScreenshotsAreNotEqual(blueBefore, blackBefore, textRect);
+
+			_app.Tap("ChangeTextBlockButton");
+
+			var blueAfter = TakeScreenshot("After - blue");
+
+			AssertScreenshotsAreEqual(blueBefore, blueAfter, textRect);
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -9,10 +9,10 @@ using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
-namespace SamplesApp.UITests.Windows_UI_Xaml_Controls
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 {
 	[TestFixture]
-	public class TextBlockTests : SampleControlUITestBase
+	public class TextBlockTests_Tests : SampleControlUITestBase
 	{
 		[Test]
 		[AutoRetry]

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -549,6 +549,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Foreground_While_Collapsed.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_MultipleControls.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3015,6 +3019,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Pivot\Pivot_CustomContent_Automated.xaml.cs">
       <DependentUpon>Pivot_CustomContent_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Foreground_While_Collapsed.xaml.cs">
+      <DependentUpon>TextBlock_Foreground_While_Collapsed.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_MultipleControls.xaml.cs">
       <DependentUpon>TextBlock_LineHeight_MultipleControls.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Foreground_While_Collapsed.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Foreground_While_Collapsed.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_Foreground_While_Collapsed"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<TextBlock x:Name="FunnyTextBlock"
+				   Text="Look at me now"
+				   Foreground="Blue" />
+		<Button x:Name="ChangeTextBlockButton"
+				Click="ChangeText"
+				VerticalAlignment="Bottom">
+			<Rectangle Fill="Blue"
+					   Width="120"
+					   Height="42" />
+		</Button>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Foreground_While_Collapsed.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Foreground_While_Collapsed.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[SampleControlInfo(description: "Changing Foreground while synchronously setting TextBlock collapsed should show the new Foreground correctly when it becomes visible")]
+	public sealed partial class TextBlock_Foreground_While_Collapsed : UserControl
+	{
+		public TextBlock_Foreground_While_Collapsed()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ChangeText(object sender, RoutedEventArgs args)
+		{
+
+			if (FunnyTextBlock.Visibility == Visibility.Visible && (FunnyTextBlock.Foreground as SolidColorBrush).Color == Colors.Blue)
+			{
+				FunnyTextBlock.Foreground = new SolidColorBrush(Colors.Black);
+			}
+			else if (FunnyTextBlock.Visibility == Visibility.Visible)
+			{
+				FunnyTextBlock.Foreground = new SolidColorBrush(Colors.Blue);
+				FunnyTextBlock.Visibility = Visibility.Collapsed;
+			}
+			else
+			{
+				FunnyTextBlock.Visibility = Visibility.Visible;
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml
 			if (base.Hidden != newVisibility.IsHidden())
 			{
 				base.Hidden = newVisibility.IsHidden();
-				this.SetNeedsLayout();
+				InvalidateMeasure();
 
 				if (newVisibility == Visibility.Visible)
 				{


### PR DESCRIPTION
Calling this method instead of SetNeedsLayout means that OnInvalidateMeasure() is called for types that override it.

This fixes a bug introduced by #1726 (somehow) whereby changing TextBlock.Foreground and setting the TextBlock to Collapsed in the same synchronous pass would not result in the new Foreground showing when the TextBlock was made visible again.

GitHub Issue (If applicable): fixes #2162 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
