### PR TITLE
Fix possible invalid text wrapping on WASM in Chromium based browsers

### DIFF
--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -1259,8 +1259,8 @@ var Uno;
                 const offsetHeight = element.offsetHeight;
                 const resultWidth = offsetWidth ? offsetWidth : element.clientWidth;
                 const resultHeight = offsetHeight ? offsetHeight : element.clientHeight;
-                // +0.5 is added to take rounding into account
-                return [resultWidth + 0.5, resultHeight];
+                // +1 is added to take rounding/flooring into account
+                return [resultWidth + 1, resultHeight];
             }
             measureViewInternal(viewId, maxWidth, maxHeight) {
                 const element = this.getView(viewId);

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -1240,8 +1240,8 @@
 			const resultWidth = offsetWidth ? offsetWidth : element.clientWidth;
 			const resultHeight = offsetHeight ? offsetHeight : element.clientHeight;
 
-			// +0.5 is added to take rounding into account
-			return [resultWidth + 0.5, resultHeight];
+			// +1 is added to take rounding/flooring into account
+			return [resultWidth + 1, resultHeight];
 		}
 
 		private measureViewInternal(viewId: number, maxWidth: number, maxHeight: number): [number, number] {


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/private/issues/106

## BugFix
Text might be wrapped

## What is the current behavior?
In some unclear circumstances, the width return by a chromium based browser for text measure is 1 pixel lower than the effective width needed to render the text. The result is that the text content will wrap, even if we already add half a pixel to the width.

## What is the new behavior?
Instead of adding half a pixel to the width on each measure text, we now add a full pixel.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~[Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)

## Other information
This bug was present since a while, but was hidden by the aggressive clipping that was removed by https://github.com/unoplatform/uno/pull/1726