### PR TITLE
[Wasm] Move textblock updates to measure phase

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -435,6 +435,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			if (_isUiAutomationMappingEnabled)
 			{
 				writer.AppendLineInvariant("global::Uno.UI.FrameworkElementHelper.IsUiAutomationMappingEnabled = true;");
+
+				if (_isWasm)
+				{
+					// When automation mapping is enabled, remove the element ID from the ToString so test screenshots stay the same.
+					writer.AppendLineInvariant("global::Uno.UI.FeatureConfiguration.UIElement.RenderToStringWithId = false;");
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -19,6 +19,19 @@ namespace Windows.UI.Xaml.Controls
 		private const int MaxMeasureCache = 50;
 
 		private static TextBlockMeasureCache _cache = new TextBlockMeasureCache();
+		private bool _fontStyleChanged;
+		private bool _fontWeightChanged;
+		private bool _textChanged;
+		private bool _fontFamilyChanged;
+		private bool _fontSizeChanged;
+		private bool _maxLinesChanged;
+		private bool _textTrimmingChanged;
+		private bool _textAlignmentChanged;
+		private bool _lineHeightChanged;
+		private bool _characterSpacingChanged;
+		private bool _textDecorationsChanged;
+		private bool _textWrappingChanged;
+		private bool _paddingChangedChanged;
 
 		public TextBlock() : base("p")
 		{
@@ -37,8 +50,45 @@ namespace Windows.UI.Xaml.Controls
 
 		}
 
+		private void ConditionalUpdate(ref bool condition, Action action)
+		{
+			if (condition)
+			{
+				condition = false;
+				action();
+			}
+		}
+
+		private void SynchronizeHtmlParagraphAttributes()
+		{
+			ConditionalUpdate(ref _fontStyleChanged, () => this.SetFontStyle(FontStyle));
+			ConditionalUpdate(ref _fontWeightChanged, () => this.SetFontWeight(FontWeight));
+			ConditionalUpdate(ref _fontFamilyChanged, () => this.SetFontFamily(FontFamily));
+			ConditionalUpdate(ref _fontSizeChanged, () => this.SetFontSize(FontSize));
+			ConditionalUpdate(ref _maxLinesChanged, () => this.SetMaxLines(MaxLines));
+			ConditionalUpdate(ref _textTrimmingChanged, () => this.SetTextTrimming(TextTrimming));
+			ConditionalUpdate(ref _textAlignmentChanged, () => this.SetTextAlignment(TextAlignment));
+			ConditionalUpdate(ref _lineHeightChanged, () => this.SetLineHeight(LineHeight));
+			ConditionalUpdate(ref _characterSpacingChanged, () => this.SetCharacterSpacing(CharacterSpacing));
+			ConditionalUpdate(ref _textDecorationsChanged, () => this.SetTextDecorations(TextDecorations));
+			ConditionalUpdate(ref _textWrappingChanged, () => this.SetTextWrapping(TextWrapping));
+			ConditionalUpdate(ref _paddingChangedChanged, () => this.SetTextPadding(Padding));
+
+			if (_textChanged)
+			{
+				_textChanged = false;
+
+				if (UseInlinesFastPath)
+				{
+					this.SetText(Text);
+				}
+			}
+		}
+
 		protected override Size MeasureOverride(Size availableSize)
 		{
+			SynchronizeHtmlParagraphAttributes();
+
 			if (UseInlinesFastPath)
 			{
 				if (_cache.FindMeasuredSize(this, availableSize) is Size desiredSize)
@@ -64,94 +114,43 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private int GetCharacterIndexAtPoint(Point point)
-		{
-			throw new NotSupportedException();
-		}
+		private int GetCharacterIndexAtPoint(Point point) => throw new NotSupportedException();
 
-		partial void OnFontStyleChangedPartial()
-		{
-			this.SetFontStyle(FontStyle);
-		}
+		partial void OnFontStyleChangedPartial() => _fontStyleChanged = true;
 
-		partial void OnFontWeightChangedPartial()
-		{
-			this.SetFontWeight(FontWeight);
-		}
+		partial void OnFontWeightChangedPartial() => _fontWeightChanged = true;
 
 		partial void OnTextChangedPartial()
 		{
-			if (UseInlinesFastPath)
-			{
-				this.SetText(Text);
-			}
+			_textChanged = true;
 
 			UpdateHitTest();
 		}
 
-		partial void ClearTextPartial()
-		{
-			SetHtmlContent(""); // Remove any child element
-		}
+		partial void ClearTextPartial() => SetHtmlContent("");
 
-		partial void OnFontFamilyChangedPartial()
-		{
-			this.SetFontFamily(FontFamily);
-		}
+		partial void OnFontFamilyChangedPartial() => _fontFamilyChanged = true;
 
-		partial void OnFontSizeChangedPartial()
-		{
-			this.SetFontSize(FontSize);
-		}
+		partial void OnFontSizeChangedPartial() => _fontSizeChanged = true;
 
-		partial void OnMaxLinesChangedPartial()
-		{
-			this.SetMaxLines(MaxLines);
-		}
+		partial void OnMaxLinesChangedPartial() => _maxLinesChanged = true;
 
-		partial void OnTextTrimmingChangedPartial()
-		{
-			this.SetTextTrimming(TextTrimming);
-		}
+		partial void OnTextTrimmingChangedPartial() => _textTrimmingChanged = true;
 
-		partial void OnForegroundChangedPartial()
-		{
-			this.SetForeground(Foreground);
-		}
+		partial void OnForegroundChangedPartial() => this.SetForeground(Foreground);
 
-		partial void OnTextAlignmentChangedPartial()
-		{
-			this.SetTextAlignment(TextAlignment);
-		}
+		partial void OnTextAlignmentChangedPartial() => _textAlignmentChanged = true;
 
-		partial void OnLineHeightChangedPartial()
-		{
-			this.SetLineHeight(LineHeight);
-		}
+		partial void OnLineHeightChangedPartial() => _lineHeightChanged = true;
 
-		partial void OnCharacterSpacingChangedPartial()
-		{
-			this.SetCharacterSpacing(CharacterSpacing);
-		}
+		partial void OnCharacterSpacingChangedPartial() => _characterSpacingChanged = true;
 
-		partial void OnTextDecorationsChangedPartial()
-		{
-			this.SetTextDecorations(TextDecorations);
-		}
+		partial void OnTextDecorationsChangedPartial() => _textDecorationsChanged = true;
 
-		partial void OnTextWrappingChangedPartial()
-		{
-			this.SetTextWrapping(TextWrapping);
-		}
+		partial void OnTextWrappingChangedPartial() => _textWrappingChanged = true;
 
-		partial void OnPaddingChangedPartial()
-		{
-			this.SetTextPadding(Padding);
-		}
+		partial void OnPaddingChangedPartial() => _paddingChangedChanged = true;
 
-		internal override bool IsViewHit()
-		{
-			return Text != null || base.IsViewHit();
-		}
+		internal override bool IsViewHit() => Text != null || base.IsViewHit();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -66,13 +66,17 @@ namespace Windows.UI.Xaml.Controls
 			ConditionalUpdate(ref _fontFamilyChanged, () => this.SetFontFamily(FontFamily));
 			ConditionalUpdate(ref _fontSizeChanged, () => this.SetFontSize(FontSize));
 			ConditionalUpdate(ref _maxLinesChanged, () => this.SetMaxLines(MaxLines));
-			ConditionalUpdate(ref _textTrimmingChanged, () => this.SetTextTrimming(TextTrimming));
 			ConditionalUpdate(ref _textAlignmentChanged, () => this.SetTextAlignment(TextAlignment));
 			ConditionalUpdate(ref _lineHeightChanged, () => this.SetLineHeight(LineHeight));
 			ConditionalUpdate(ref _characterSpacingChanged, () => this.SetCharacterSpacing(CharacterSpacing));
 			ConditionalUpdate(ref _textDecorationsChanged, () => this.SetTextDecorations(TextDecorations));
-			ConditionalUpdate(ref _textWrappingChanged, () => this.SetTextWrapping(TextWrapping));
 			ConditionalUpdate(ref _paddingChangedChanged, () => this.SetTextPadding(Padding));
+
+			if(_textTrimmingChanged || _textWrappingChanged)
+			{
+				_textTrimmingChanged = _textWrappingChanged = false;
+				this.SetTextWrappingAndTrimming(textTrimming: TextTrimming, textWrapping: TextWrapping);
+			}
 
 			if (_textChanged)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -112,7 +112,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextWrappingChangedPartial(DependencyPropertyChangedEventArgs e)
 		{
-			_textBoxView?.SetTextWrapping(TextWrapping);
+			_textBoxView?.SetTextWrappingAndTrimming(textWrapping: TextWrapping, textTrimming: null);
 		}
 
 		partial void OnTextAlignmentChangedPartial(DependencyPropertyChangedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Documents/UIElementTextHelper.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UIElementTextHelper.wasm.cs
@@ -110,7 +110,7 @@ namespace Uno.UI.UI.Xaml.Documents
 			// Not available yet
 		}
 
-		internal static void SetTextTrimming(this UIElement element, object localValue)
+		private static void SetTextTrimming(this UIElement element, object localValue)
 		{
 			switch (localValue)
 			{
@@ -214,23 +214,28 @@ namespace Uno.UI.UI.Xaml.Documents
 			}
 		}
 
-		internal static void SetTextWrapping(this UIElement element, object localValue)
+		internal static void SetTextWrappingAndTrimming(this UIElement element, object textWrapping, object textTrimming)
 		{
-			if (localValue is UnsetValue)
+			if (textWrapping is UnsetValue)
 			{
 				element.ResetStyle("white-space", "word-break", "text-overflow");
 			}
 			else
 			{
-				var value = (TextWrapping) localValue;
+				var value = (TextWrapping) textWrapping;
 				switch (value)
 				{
 					case TextWrapping.NoWrap:
 						element.SetAttribute("wrap", "off");
 						element.SetStyle(
 							("white-space", "pre"),
-							("word-break", ""),
-							("text-overflow", ""));
+							("word-break", ""));
+
+						// Triming and wrapping are not yet supported by browsers. This spec would enable it:
+						// https://drafts.csswg.org/css-overflow-3/#propdef-block-ellipsis
+						//
+						// For now, trimming isonly supported when wrapping is disabled.
+						SetTextTrimming(element, textTrimming);
 						break;
 					case TextWrapping.Wrap:
 						element.SetAttribute("wrap", "soft");

--- a/src/Uno.UI/UI/Xaml/Documents/UIElementTextHelper.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UIElementTextHelper.wasm.cs
@@ -101,7 +101,7 @@ namespace Uno.UI.UI.Xaml.Documents
 			else
 			{
 				var value = (double)localValue;
-				element.SetStyle("font-size", $"{value.ToStringInvariant()}px");
+				element.SetStyle("font-size", value.ToStringInvariant() + "px");
 			}
 		}
 
@@ -159,7 +159,7 @@ namespace Uno.UI.UI.Xaml.Documents
 			else
 			{
 				var value = (int) localValue;
-				element.SetStyle("letter-spacing", $"{(value / 1000.0).ToStringInvariant()}em");
+				element.SetStyle("letter-spacing", (value / 1000.0).ToStringInvariant() + "em");
 			}
 		}
 
@@ -178,7 +178,7 @@ namespace Uno.UI.UI.Xaml.Documents
 				}
 				else
 				{
-					element.SetStyle("line-height", $"{value.ToStringInvariant()}px");
+					element.SetStyle("line-height", value.ToStringInvariant() + "px");
 				}
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #2181, fixes #2185

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The TextBlock properties synchronization to the native HtmlParagraph are done synchronously, and the measure pass is performed a dispatcher loop later. This creates a window where the textblock properties are desynchronized, and shows an invalid resizing visual effect.

## What is the new behavior?
TextBlock properties update in fast path (without inlines at this time) are delayed and applied during the measure phase, removing the invalid state that can appear visually.

**Note:** This update only delays the application of the properties, and while a performance improvement may be visible, most of the updates invocations to javascript could be batched into a single call that applies differences in html styles.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
