### PR TITLE
Applied a fix for an animation crash on iOS

### DIFF
--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -33,6 +33,7 @@ mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-conso
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests' or \
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' or \
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests' or \
+	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media.Animation_Tests' or \
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests' \
 	" \
 	$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/net47/SamplesApp.UITests.dll \

--- a/src/SamplesApp/SamplesApp.UITests/QueryExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/QueryExtensions.cs
@@ -20,10 +20,10 @@ namespace SamplesApp.UITests
 		/// <summary>
 		/// Wait for element to be available and to have the expected value for its Text property.
 		/// </summary>
-		public static void WaitForText(this IApp app, string elementName, string expectedText)
+		public static void WaitForText(this IApp app, string elementName, string expectedText, TimeSpan? timeout = null)
 		{
 			var element = app.Marked(elementName);
-			app.WaitForElement(element);
+			app.WaitForElement(element, timeout: timeout);
 			app.WaitForText(element, expectedText);
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/Animation_Tests/SequentialAnimations_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/Animation_Tests/SequentialAnimations_Tests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Media.Animation_Tests
+{
+	[TestFixture]
+	public partial class SequentialAnimations_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void SequentialAnimations()
+		{
+			// Navigate to this x:Class control name
+			Run("SamplesApp.Windows_UI_Xaml_Media.Animation.SequentialAnimationsPage");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2245,6 +2245,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Animation\SequentialAnimationsPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\CompositionTargetTests\CompositionTarget_Rendering.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3818,6 +3822,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\RoutedEvents\RoutedEvent_TappedControl.xaml.cs">
       <DependentUpon>RoutedEvent_TappedControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Animation\SequentialAnimationsPage.xaml.cs">
+      <DependentUpon>SequentialAnimationsPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\CompositionTargetTests\CompositionTarget_Rendering.xaml.cs">
       <DependentUpon>CompositionTarget_Rendering.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Animation/SequentialAnimationsPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Animation/SequentialAnimationsPage.xaml
@@ -1,0 +1,49 @@
+﻿<Page x:Class="SamplesApp.Windows_UI_Xaml_Media.Animation.SequentialAnimationsPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Rectangle x:Name="ScaleRectangle"
+				   HorizontalAlignment="Center"
+				   VerticalAlignment="Center"
+				   Fill="Lime"
+				   Width="150"
+				   Height="150"
+				   RenderTransformOrigin="0.5,0.5">
+			<Rectangle.RenderTransform>
+				<ScaleTransform />
+			</Rectangle.RenderTransform>
+		</Rectangle>
+
+		<Rectangle x:Name="RotateRectangle"
+				   HorizontalAlignment="Left"
+				   VerticalAlignment="Top"
+				   Fill="Cyan"
+				   Width="80"
+				   Height="80"
+				   RenderTransformOrigin="0.5,0.5">
+			<Rectangle.RenderTransform>
+				<RotateTransform />
+			</Rectangle.RenderTransform>
+		</Rectangle>
+
+		<Rectangle x:Name="TranslateRectangle"
+				   HorizontalAlignment="Center"
+				   VerticalAlignment="Center"
+				   Fill="Red"
+				   Width="100"
+				   Height="100">
+			<Rectangle.RenderTransform>
+				<TranslateTransform />
+			</Rectangle.RenderTransform>
+		</Rectangle>
+
+		<ToggleButton x:Name="ToggleStep"
+					  HorizontalAlignment="Center"
+					  VerticalAlignment="Bottom" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Animation/SequentialAnimationsPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Animation/SequentialAnimationsPage.xaml.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Threading.Tasks;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
+
+namespace SamplesApp.Windows_UI_Xaml_Media.Animation
+{
+	[SampleControlInfo("Animations", "Sequential Animations")]
+	public sealed partial class SequentialAnimationsPage : Page
+	{
+		private readonly TimeSpan DURATION = TimeSpan.FromMilliseconds(250);
+
+		public SequentialAnimationsPage()
+		{
+			this.InitializeComponent();
+
+			// Simply kick-off the task
+#pragma warning disable CS4014
+			this.Loaded += (sender, e) => StartAnimations();
+#pragma warning restore CS4014
+		}
+
+		internal void TranslateX(UIElement element, double to)
+			=> Animate(element, "(UIElement.RenderTransform).(TranslateTransform.X)", to);
+
+		internal void TranslateY(UIElement element, double to)
+			=> Animate(element, "(UIElement.RenderTransform).(TranslateTransform.Y)", to);
+
+		internal void ScaleX(UIElement element, double to)
+			=> Animate(element, "(UIElement.RenderTransform).(ScaleTransform.ScaleX)", to);
+
+		internal void ScaleY(UIElement element, double to)
+			=> Animate(element, "(UIElement.RenderTransform).(ScaleTransform.ScaleY)", to);
+
+		internal void Rotate(UIElement element, double to)
+			=> Animate(element, "(UIElement.RenderTransform).(RotateTransform.Angle)", to);
+
+		internal void Fade(UIElement element, double to)
+			=> Animate(element, "Opacity", to);
+
+		private void Animate(UIElement element, string targetProperty, double to)
+		{
+			var anim = new DoubleAnimation()
+			{
+				To = to,
+				Duration = DURATION,
+				EasingFunction = new CubicEase() { EasingMode = EasingMode.EaseInOut }
+			};
+
+			var storyboard = new Storyboard();
+
+			Storyboard.SetTarget(anim, element);
+			Storyboard.SetTargetProperty(anim, targetProperty);
+
+			storyboard.Children.Add(anim);
+			storyboard.Begin();
+		}
+
+		private async Task StartAnimations()
+		{
+			Fade(RotateRectangle, 0);
+			await Task.Delay(DURATION);
+
+			ToggleStep.IsChecked = true;
+			ToggleStep.IsChecked = false;
+			ToggleStep.Content = "STEP 1";
+
+			Fade(RotateRectangle, 1);
+			await Task.Delay(DURATION);
+
+			ToggleStep.IsChecked = true;
+			ToggleStep.IsChecked = false;
+			ToggleStep.Content = "STEP 2";
+
+			TranslateX(TranslateRectangle, 100);
+			await Task.Delay(DURATION);
+
+			ToggleStep.IsChecked = true;
+			ToggleStep.IsChecked = false;
+			ToggleStep.Content = "STEP 3";
+
+			TranslateY(TranslateRectangle, 100);
+			Rotate(RotateRectangle, 360);
+			ScaleX(ScaleRectangle, 1.5);
+			await Task.Delay(DURATION);
+
+			ToggleStep.IsChecked = true;
+			ToggleStep.IsChecked = false;
+			ToggleStep.Content = "STEP 4";
+
+			TranslateX(TranslateRectangle, -100);
+			ScaleY(ScaleRectangle, 1.5);
+			await Task.Delay(DURATION);
+
+			ToggleStep.IsChecked = true;
+			ToggleStep.IsChecked = false;
+			ToggleStep.Content = "STEP 5";
+
+			TranslateY(TranslateRectangle, 0);
+			Rotate(RotateRectangle, -360);
+			await Task.Delay(DURATION);
+
+			ToggleStep.IsChecked = true;
+			ToggleStep.IsChecked = false;
+			ToggleStep.Content = "STEP 6";
+
+			TranslateX(TranslateRectangle, 0);
+			await Task.Delay(DURATION);
+
+			ToggleStep.IsChecked = true;
+			ToggleStep.IsChecked = false;
+			ToggleStep.Content = "STEP 7";
+		}
+	}
+}

--- a/src/Uno.UI/Extensions/TimelineExtensions.iOS.cs
+++ b/src/Uno.UI/Extensions/TimelineExtensions.iOS.cs
@@ -18,11 +18,15 @@ namespace Windows.UI.Xaml.Media.Animation
 
 			var animatedItem = timeline.PropertyInfo.GetPathItems().Last();
 
+			// Get the property name from the last part of the
+			// specified name (for dotted paths, if they exist)
+			var propertyName = animatedItem.PropertyName.Split(new[] { '.' }).Last().Replace("(", "").Replace(")", "");
+
 			var dc = animatedItem.DataContext;
 			using (dc != null ?
 				DependencyObjectStore.BypassPropagation(
 					(DependencyObject)dc,
-					DependencyProperty.GetProperty(dc.GetType(), animatedItem.PropertyName)
+					DependencyProperty.GetProperty(dc.GetType(), propertyName)
 				) :
 				// DC may have been collected since it's weakly held
 				null


### PR DESCRIPTION
GitHub Issue (If applicable): #2148 

## PR Type

What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

iOS has an animation crash when animating an element in code-behind, with a target property such as ((UIElement.RenderTransform).(TranslateTransform.X))

## What is the new behavior?

No crash on iOS, the target property is retrieved correctly.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
