### PR TITLE
Add ability to compare multiple zone of screenshot

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -134,20 +134,38 @@ namespace SamplesApp.UITests
 
 		public void AssertScreenshotsAreEqual(FileInfo expected, FileInfo actual, IAppRect rect)
 			=> AssertScreenshotsAreEqual(expected, actual, new Rectangle((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height));
+
 		public void AssertScreenshotsAreEqual(FileInfo expected, FileInfo actual, Rectangle? rect = null)
 		{
-			rect = rect ?? new Rectangle(0, 0, int.MaxValue, int.MinValue);
+			rect = rect ?? new Rectangle(0, 0, int.MaxValue, int.MaxValue);
+			AssertScreenshotsAreEqual(expected, rect.Value, actual, rect.Value);
+		}
+
+		public void AssertScreenshotsAreEqual(FileInfo expected, IAppRect expectedRect, FileInfo actual, IAppRect actualRect)
+			=> AssertScreenshotsAreEqual(
+				expected,
+				new Rectangle((int)expectedRect.X, (int)expectedRect.Y, (int)expectedRect.Width, (int)expectedRect.Height),
+				actual,
+				new Rectangle((int)actualRect.X, (int)actualRect.Y, (int)actualRect.Width, (int)actualRect.Height));
+
+		public void AssertScreenshotsAreEqual(FileInfo expected, Rectangle expectedRect, FileInfo actual, Rectangle actualRect)
+		{
+			Assert.AreEqual(expectedRect.Width, actualRect.Width, "Rect Width");
+			Assert.AreEqual(expectedRect.Height, actualRect.Height, "Rect Height");
 
 			using (var expectedBitmap = new Bitmap(expected.FullName))
 			using (var actualBitmap = new Bitmap(actual.FullName))
 			{
-				Assert.AreEqual(expectedBitmap.Size.Width, actualBitmap.Size.Width, "Width");
-				Assert.AreEqual(expectedBitmap.Size.Height, actualBitmap.Size.Height, "Height");
+				Assert.AreEqual(expectedBitmap.Size.Width, actualBitmap.Size.Width, "Screenshot Width");
+				Assert.AreEqual(expectedBitmap.Size.Height, actualBitmap.Size.Height, "Screenshot Height");
 
-				for (var x = rect.Value.X; x < Math.Min(rect.Value.Width, expectedBitmap.Size.Width); x++)
-				for (var y = rect.Value.Y; y < Math.Min(rect.Value.Height, expectedBitmap.Size.Height); y++)
+				for (var x = 0; x < Math.Min(expectedRect.Width, expectedBitmap.Size.Width); x++)
+				for (var y = 0; y < Math.Min(expectedRect.Height, expectedBitmap.Size.Height); y++)
 				{
-					Assert.AreEqual(expectedBitmap.GetPixel(x, y), actualBitmap.GetPixel(x, y), $"Pixel {x},{y} (rel: {x-rect.Value.X},{y - rect.Value.Y})");
+					Assert.AreEqual(
+						expectedBitmap.GetPixel(x + expectedRect.X, y + expectedRect.Y),
+						actualBitmap.GetPixel(x + actualRect.X, y + actualRect.Y),
+						$"Pixel {x},{y}");
 				}
 			}
 		}
@@ -157,20 +175,31 @@ namespace SamplesApp.UITests
 		public void AssertScreenshotsAreNotEqual(FileInfo expected, FileInfo actual, Rectangle? rect = null)
 		{
 			rect = rect ?? new Rectangle(0, 0, int.MaxValue, int.MinValue);
+			AssertScreenshotsAreNotEqual(expected, rect.Value, actual, rect.Value);
+		}
+
+		public void AssertScreenshotsAreNotEqual(FileInfo expected, IAppRect expectedRect, FileInfo actual, IAppRect actualRect)
+			=> AssertScreenshotsAreNotEqual(
+				expected,
+				new Rectangle((int)expectedRect.X, (int)expectedRect.Y, (int)expectedRect.Width, (int)expectedRect.Height),
+				actual,
+				new Rectangle((int)actualRect.X, (int)actualRect.Y, (int)actualRect.Width, (int)actualRect.Height));
+
+		public void AssertScreenshotsAreNotEqual(FileInfo expected, Rectangle expectedRect, FileInfo actual, Rectangle actualRect)
+		{
+			Assert.AreEqual(expectedRect.Width, actualRect.Width, "Rect Width");
+			Assert.AreEqual(expectedRect.Height, actualRect.Height, "Rect Height");
 
 			using (var expectedBitmap = new Bitmap(expected.FullName))
 			using (var actualBitmap = new Bitmap(actual.FullName))
 			{
-				if (expectedBitmap.Size.Width != actualBitmap.Size.Width
-					|| expectedBitmap.Size.Height != actualBitmap.Size.Height)
-				{
-					return;
-				}
+				Assert.AreEqual(expectedBitmap.Size.Width, actualBitmap.Size.Width, "Screenshot Width");
+				Assert.AreEqual(expectedBitmap.Size.Height, actualBitmap.Size.Height, "Screenshot Height");
 
-				for (var x = rect.Value.X; x < Math.Min(rect.Value.Width, expectedBitmap.Size.Width); x++)
-				for (var y = rect.Value.Y; y < Math.Min(rect.Value.Height, expectedBitmap.Size.Height); y++)
+				for (var x = 0; x < Math.Min(expectedRect.Width, expectedBitmap.Size.Width); x++)
+				for (var y = 0; y < Math.Min(expectedRect.Height, expectedBitmap.Size.Height); y++)
 				{
-					if (expectedBitmap.GetPixel(x, y) != actualBitmap.GetPixel(x, y))
+					if (expectedBitmap.GetPixel(x + expectedRect.X, y + expectedRect.Y) != actualBitmap.GetPixel(x + actualRect.X, y + actualRect.Y))
 					{
 						return;
 					}


### PR DESCRIPTION
## Test tooling
Add ability to compare multiple zone of screenshot

## What is the current behavior?
When comparing 2 screenshot with a rect, the 2 rect must be at the same location

## What is the new behavior?
We can compare 2 different zone of screenshots

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master~~/doc/ReleaseNotes)~~
- [ ] ~~Associated with an issue (GitHub or internal)~~
