### PR TITLE
[Hot Reload] Add fail-safe port propagation during build

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
@@ -72,7 +72,18 @@ namespace Uno.UI.SourceGenerators.RemoteControl
 
 			if (string.IsNullOrEmpty(unoRemoteControlPort))
 			{
-				unoRemoteControlPort = "0";
+				// This file is set through the RemoteControl VS addin, in case
+				// the global properties don't get set properly
+				var rcPath = Path.Combine(context.GetProjectInstance().Directory, "obj", "UnoRemoteControlPort.data");
+
+				if (File.Exists(rcPath))
+				{
+					unoRemoteControlPort = File.ReadAllLines(rcPath).FirstOrDefault() ?? "0";
+				}
+				else
+				{
+					unoRemoteControlPort = "0";
+				}
 			}
 
 			var unoRemoteControlHost = context.GetProjectInstance().GetPropertyValue("UnoRemoteControlHost");

--- a/src/Uno.UI-iOS-hotreload-vsix-only.slnf
+++ b/src/Uno.UI-iOS-hotreload-vsix-only.slnf
@@ -1,0 +1,31 @@
+{
+  "solution": {
+    "path": "Uno.UI.sln",
+    "projects": [
+      "AddIns\\Uno.UI.Lottie\\Uno.UI.Lottie.csproj",
+      "SamplesApp\\SamplesApp.Shared\\SamplesApp.Shared.shproj",
+      "SamplesApp\\SamplesApp.UITests\\SamplesApp.UITests.csproj",
+      "SamplesApp\\SamplesApp.UnitTests.Shared\\SamplesApp.UnitTests.Shared.shproj",
+      "SamplesApp\\SamplesApp.iOS\\SamplesApp.iOS.csproj",
+      "SamplesApp\\UITests.Shared\\UITests.Shared.shproj",
+      "SolutionTemplate\\UnoLibraryTemplate\\UnoLibraryTemplate.csproj",
+      "SolutionTemplate\\UnoSolutionTemplate.VISX\\UnoSolutionTemplate.VISX.csproj",
+      "SolutionTemplate\\UnoSolutionTemplate.Wizard\\UnoSolutionTemplate.Wizard.csproj",
+      "SolutionTemplate\\UnoSolutionTemplate\\UnoSolutionTemplate.csproj",
+      "SourceGenerators\\System.Xaml\\Uno.Xaml.csproj",
+      "SourceGenerators\\Uno.UI.SourceGenerators\\Uno.UI.SourceGenerators.csproj",
+      "SourceGenerators\\Uno.UI.Tasks\\Uno.UI.Tasks.csproj",
+      "T4Generator\\T4Generator.csproj",
+      "Uno.Foundation\\Uno.Foundation.csproj",
+      "Uno.UI.RemoteControl.Host\\Uno.UI.RemoteControl.Host.csproj",
+      "Uno.UI.RemoteControl.VS\\Uno.UI.RemoteControl.VS.csproj",
+      "Uno.UI.RemoteControl\\Uno.UI.RemoteControl.csproj",
+      "Uno.UI.BindingHelper.Android\\Uno.UI.BindingHelper.Android.csproj",
+      "Uno.UI.Maps\\Uno.UI.Maps.csproj",
+      "Uno.UI.RuntimeTests\\Uno.UI.RuntimeTests.csproj",
+      "Uno.UI.Toolkit\\Uno.UI.Toolkit.csproj",
+      "Uno.UI\\Uno.UI.csproj",
+      "Uno.UWP\\Uno.csproj"
+    ]
+  }
+}

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -120,11 +120,29 @@ namespace Uno.UI.RemoteControl.VS
 
 		private async Task BuildEvents_OnBuildProjConfigBeginAsync(string project, string projectConfig, string platform, string solutionConfig)
 		{
-			await StartServerAsync();
-
-			foreach(var p in await GetProjectsAsync())
+			try
 			{
-				SetGlobalProperty(p.FileName, RemoteControlServerPortProperty, RemoteControlServerPort.ToString(CultureInfo.InvariantCulture));
+				await StartServerAsync();
+
+				await UpdateProjectsAsync();
+			}
+			catch (Exception e)
+			{
+				_debugAction($"BuildEvents_OnBuildProjConfigBeginAsync failed: {e}");
+			}
+		}
+
+		private async Task UpdateProjectsAsync()
+		{
+			foreach (var p in await GetProjectsAsync())
+			{
+				var portString = RemoteControlServerPort.ToString(CultureInfo.InvariantCulture);
+				SetGlobalProperty(p.FileName, RemoteControlServerPortProperty, portString);
+
+				if (GetMsbuildProject(p.FileName) is Microsoft.Build.Evaluation.Project msbProject && IsApplication(msbProject))
+				{
+					File.WriteAllText(Path.Combine(msbProject.DirectoryPath, "obj", "UnoRemoteControlPort.data"), portString);
+				}
 			}
 		}
 
@@ -259,7 +277,7 @@ namespace Uno.UI.RemoteControl.VS
 
 		public void SetGlobalProperty(string projectFullName, string propertyName, string propertyValue)
 		{
-			var msbuildProject = ProjectCollection.GlobalProjectCollection.GetLoadedProjects(projectFullName).FirstOrDefault();
+			var msbuildProject = GetMsbuildProject(projectFullName);
 			if (msbuildProject == null)
 			{
 				_debugAction($"Failed to find project {projectFullName}, cannot provide listen port to the app.");
@@ -269,6 +287,9 @@ namespace Uno.UI.RemoteControl.VS
 				SetGlobalProperty(msbuildProject, propertyName, propertyValue);
 			}
 		}
+
+		private static Microsoft.Build.Evaluation.Project GetMsbuildProject(string projectFullName)
+			=> ProjectCollection.GlobalProjectCollection.GetLoadedProjects(projectFullName).FirstOrDefault();
 
 		public void SetGlobalProperties(string projectFullName, IDictionary<string, string> properties)
 		{
@@ -289,6 +310,21 @@ namespace Uno.UI.RemoteControl.VS
 		private void SetGlobalProperty(Microsoft.Build.Evaluation.Project msbuildProject, string propertyName, string propertyValue)
 		{
 			msbuildProject.SetGlobalProperty(propertyName, propertyValue);
+
+		}
+
+		private bool IsApplication(Microsoft.Build.Evaluation.Project project)
+		{
+			var isAndroidApp = project.GetPropertyValue("AndroidApplication")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+			var isiOSApp = project.GetPropertyValue("ProjectTypeGuids")?.Equals("{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) ?? false;
+			var ismacOSApp = project.GetPropertyValue("ProjectTypeGuids")?.Equals("{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) ?? false;
+			var isExe = project.GetPropertyValue("OutputType")?.Equals("Exe", StringComparison.OrdinalIgnoreCase) ?? false;
+			var isWasm = project.GetPropertyValue("WasmHead")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+
+			return isAndroidApp
+				|| (isiOSApp && isExe)
+				|| (ismacOSApp && isExe)
+				|| isWasm;
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Add fail-safe propagation of the RemoteControl server port through an intermediate path file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
