### PR TITLE
[VSIX] Fix Folder recursion to apply port properties

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -140,7 +140,7 @@
 
 	<Target Name="PublishVisx">
 		<Copy SourceFiles="..\src\SolutionTemplate\UnoSolutionTemplate.VISX\bin\Release\UnoSolutionTemplate.VSIX.vsix"
-					DestinationFiles="$(OutputDir))\vslatest\UnoPlatform-$(GITVERSION_FullSemVer).vsix" />
+					DestinationFiles="$(OutputDir)\vslatest\UnoPlatform-$(GITVERSION_FullSemVer).vsix" />
 	</Target>
 
 	<Target Name="BuildNuGetPackage">

--- a/doc/qa/remotecontrol-qa.md
+++ b/doc/qa/remotecontrol-qa.md
@@ -1,0 +1,22 @@
+## Remote Control QA
+
+- Install Latest vsix from CI artifacts
+    - VS2017
+    - VS2019
+- Create a new App project
+- Build all projects one by one
+    - Validate no build error
+    - Validate no restore errors
+
+- Build and launch app [Wasm|iOS|Android]
+    - Restart VS if started
+    - In MainPage.xaml, change the Text property to something else
+    - Save 
+    - Observe a UI change
+
+- Move the iOS project in a solution folder
+    - Restart VS if started
+    - Build and launch iOS app
+    - In MainPage.xaml, change the Text property to something else
+    - Save 
+    - Observe a UI change

--- a/src/Uno.UI-iOS-hotreload-vsix-only.slnf
+++ b/src/Uno.UI-iOS-hotreload-vsix-only.slnf
@@ -1,0 +1,31 @@
+{
+  "solution": {
+    "path": "Uno.UI.sln",
+    "projects": [
+      "AddIns\\Uno.UI.Lottie\\Uno.UI.Lottie.csproj",
+      "SamplesApp\\SamplesApp.Shared\\SamplesApp.Shared.shproj",
+      "SamplesApp\\SamplesApp.UITests\\SamplesApp.UITests.csproj",
+      "SamplesApp\\SamplesApp.UnitTests.Shared\\SamplesApp.UnitTests.Shared.shproj",
+      "SamplesApp\\SamplesApp.iOS\\SamplesApp.iOS.csproj",
+      "SamplesApp\\UITests.Shared\\UITests.Shared.shproj",
+      "SolutionTemplate\\UnoLibraryTemplate\\UnoLibraryTemplate.csproj",
+      "SolutionTemplate\\UnoSolutionTemplate.VISX\\UnoSolutionTemplate.VISX.csproj",
+      "SolutionTemplate\\UnoSolutionTemplate.Wizard\\UnoSolutionTemplate.Wizard.csproj",
+      "SolutionTemplate\\UnoSolutionTemplate\\UnoSolutionTemplate.csproj",
+      "SourceGenerators\\System.Xaml\\Uno.Xaml.csproj",
+      "SourceGenerators\\Uno.UI.SourceGenerators\\Uno.UI.SourceGenerators.csproj",
+      "SourceGenerators\\Uno.UI.Tasks\\Uno.UI.Tasks.csproj",
+      "T4Generator\\T4Generator.csproj",
+      "Uno.Foundation\\Uno.Foundation.csproj",
+      "Uno.UI.RemoteControl.Host\\Uno.UI.RemoteControl.Host.csproj",
+      "Uno.UI.RemoteControl.VS\\Uno.UI.RemoteControl.VS.csproj",
+      "Uno.UI.RemoteControl\\Uno.UI.RemoteControl.csproj",
+      "Uno.UI.BindingHelper.Android\\Uno.UI.BindingHelper.Android.csproj",
+      "Uno.UI.Maps\\Uno.UI.Maps.csproj",
+      "Uno.UI.RuntimeTests\\Uno.UI.RuntimeTests.csproj",
+      "Uno.UI.Toolkit\\Uno.UI.Toolkit.csproj",
+      "Uno.UI\\Uno.UI.csproj",
+      "Uno.UWP\\Uno.csproj"
+    ]
+  }
+}

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -120,11 +120,27 @@ namespace Uno.UI.RemoteControl.VS
 
 		private async Task BuildEvents_OnBuildProjConfigBeginAsync(string project, string projectConfig, string platform, string solutionConfig)
 		{
-			await StartServerAsync();
-
-			foreach(var p in await GetProjectsAsync())
+			try
 			{
-				SetGlobalProperty(p.FileName, RemoteControlServerPortProperty, RemoteControlServerPort.ToString(CultureInfo.InvariantCulture));
+				await StartServerAsync();
+
+				await UpdateProjectsAsync();
+			}
+			catch (Exception e)
+			{
+				_debugAction($"BuildEvents_OnBuildProjConfigBeginAsync failed: {e}");
+			}
+		}
+
+		private async Task UpdateProjectsAsync()
+		{
+			foreach (var p in await GetProjectsAsync())
+			{
+				if (GetMsbuildProject(p.FileName) is Microsoft.Build.Evaluation.Project msbProject && IsApplication(msbProject))
+				{
+					var portString = RemoteControlServerPort.ToString(CultureInfo.InvariantCulture);
+					SetGlobalProperty(p.FileName, RemoteControlServerPortProperty, portString);
+				}
 			}
 		}
 
@@ -236,11 +252,16 @@ namespace Uno.UI.RemoteControl.VS
 			}
 		}
 
-		private IEnumerable<EnvDTE.Project> EnumSubProjects(EnvDTE.Project solutionFolder)
+		private IEnumerable<EnvDTE.Project> EnumSubProjects(EnvDTE.Project folder)
 		{
-			if (solutionFolder.ProjectItems != null)
+			if (folder.ProjectItems != null)
 			{
-				foreach(var project in solutionFolder.ProjectItems.OfType<EnvDTE.Project>())
+				var subProjects = folder.ProjectItems
+					.OfType<EnvDTE.ProjectItem>()
+					.Select(p => p.Object)
+					.Cast<EnvDTE.Project>();
+
+				foreach (var project in subProjects)
 				{
 					if(project.Kind == FolderKind)
 					{
@@ -259,7 +280,7 @@ namespace Uno.UI.RemoteControl.VS
 
 		public void SetGlobalProperty(string projectFullName, string propertyName, string propertyValue)
 		{
-			var msbuildProject = ProjectCollection.GlobalProjectCollection.GetLoadedProjects(projectFullName).FirstOrDefault();
+			var msbuildProject = GetMsbuildProject(projectFullName);
 			if (msbuildProject == null)
 			{
 				_debugAction($"Failed to find project {projectFullName}, cannot provide listen port to the app.");
@@ -269,6 +290,9 @@ namespace Uno.UI.RemoteControl.VS
 				SetGlobalProperty(msbuildProject, propertyName, propertyValue);
 			}
 		}
+
+		private static Microsoft.Build.Evaluation.Project GetMsbuildProject(string projectFullName)
+			=> ProjectCollection.GlobalProjectCollection.GetLoadedProjects(projectFullName).FirstOrDefault();
 
 		public void SetGlobalProperties(string projectFullName, IDictionary<string, string> properties)
 		{
@@ -289,6 +313,21 @@ namespace Uno.UI.RemoteControl.VS
 		private void SetGlobalProperty(Microsoft.Build.Evaluation.Project msbuildProject, string propertyName, string propertyValue)
 		{
 			msbuildProject.SetGlobalProperty(propertyName, propertyValue);
+
+		}
+
+		private bool IsApplication(Microsoft.Build.Evaluation.Project project)
+		{
+			var isAndroidApp = project.GetPropertyValue("AndroidApplication")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+			var isiOSApp = project.GetPropertyValue("ProjectTypeGuids")?.Equals("{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) ?? false;
+			var ismacOSApp = project.GetPropertyValue("ProjectTypeGuids")?.Equals("{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) ?? false;
+			var isExe = project.GetPropertyValue("OutputType")?.Equals("Exe", StringComparison.OrdinalIgnoreCase) ?? false;
+			var isWasm = project.GetPropertyValue("WasmHead")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+
+			return isAndroidApp
+				|| (isiOSApp && isExe)
+				|| (ismacOSApp && isExe)
+				|| isWasm;
 		}
 	}
 }

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -138,8 +138,8 @@ namespace Uno.UI.RemoteControl.HotReload
 							yield return EnumerateInstances(border.Child, baseUri);
 							break;
 
-						case ContentControl control when control.ContentTemplateRoot != null: 
-							yield return EnumerateInstances(control.ContentTemplateRoot, baseUri);
+						case ContentControl control when control.ContentTemplateRoot != null || control.Content != null: 
+							yield return EnumerateInstances(control.ContentTemplateRoot ?? control.Content, baseUri);
 							break;
 
 						case Control control:

--- a/src/Uno.UI.RemoteControl/LinkerDefinition.Xamarin.xml
+++ b/src/Uno.UI.RemoteControl/LinkerDefinition.Xamarin.xml
@@ -1,0 +1,3 @@
+<linker>
+  <assembly fullname="Uno.UI.RemoteControl" />
+</linker>

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.csproj
@@ -29,9 +29,15 @@
 	<ItemGroup>
 		<UpToDateCheckInput Include="**\*.cs" Exclude="bin\**\*.cs;obj\**\*.cs;" />
 	</ItemGroup>
-	
+
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
 		<EmbeddedResource Include="LinkerDefinition.Wasm.xml">
+			<LogicalName>$(AssemblyName).xml</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'!='netstandard2.0'">
+		<EmbeddedResource Include="LinkerDefinition.Xamarin.xml">
 			<LogicalName>$(AssemblyName).xml</LogicalName>
 		</EmbeddedResource>
 	</ItemGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Fix XAML Hot Reload not working in projects located in solution folders
- Fix possible null reference for solution folders
- Start the RC server early for android and iOS projects
- Fix template-less ContentControl control lookup
- Fix linker issue for RC client

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
