### PR TITLE
Fix memory leaks in Android DisplayInformation

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -6,8 +6,8 @@
 ### Breaking changes
 -
 
-### Breaking changes
-- 
+### Bug fixes
+- [#2230] `DisplayInformation` leaks memory
 
 ## Release 2.0
 

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
@@ -24,14 +24,16 @@ namespace Windows.Graphics.Display
 
 		private void UpdateProperties()
 		{
-			var realDisplayMetrics = new DisplayMetrics();
-			var windowManager = ContextHelper.Current.GetSystemService(Context.WindowService).JavaCast<IWindowManager>();
-			windowManager.DefaultDisplay.GetRealMetrics(realDisplayMetrics);
+			using (var realDisplayMetrics = new DisplayMetrics())
+			using (var windowManager = ContextHelper.Current.GetSystemService(Context.WindowService).JavaCast<IWindowManager>())
+			{
+				windowManager.DefaultDisplay.GetRealMetrics(realDisplayMetrics);
 
-			UpdateLogicalProperties(realDisplayMetrics);
-			UpdateRawProperties(realDisplayMetrics);
-			UpdateNativeOrientation(windowManager);
-			UpdateCurrentOrientation(windowManager);
+				UpdateLogicalProperties(realDisplayMetrics);
+				UpdateRawProperties(realDisplayMetrics);
+				UpdateNativeOrientation(windowManager);
+				UpdateCurrentOrientation(windowManager);
+			}
 		}
 
 		private void UpdateLogicalProperties(DisplayMetrics realDisplayMetrics)
@@ -99,68 +101,70 @@ namespace Windows.Graphics.Display
 		private void UpdateCurrentOrientation(IWindowManager windowManager)
 		{
 			var rotation = windowManager.DefaultDisplay.Rotation;
-			var displayMetrics = new DisplayMetrics();
-			windowManager.DefaultDisplay.GetMetrics(displayMetrics);
-
-			int width = displayMetrics.WidthPixels;
-			int height = displayMetrics.HeightPixels;
-
-			if (width == height)
+			using (var displayMetrics = new DisplayMetrics())
 			{
-				//square device, can't tell orientation
-				CurrentOrientation = DisplayOrientations.None;
-				return;
-			}
+				windowManager.DefaultDisplay.GetMetrics(displayMetrics);
 
-			if (NativeOrientation == DisplayOrientations.Portrait)
-			{
-				switch (rotation)
+				int width = displayMetrics.WidthPixels;
+				int height = displayMetrics.HeightPixels;
+
+				if (width == height)
 				{
-					case SurfaceOrientation.Rotation0:
-						CurrentOrientation = DisplayOrientations.Portrait;
-						break;
-					case SurfaceOrientation.Rotation90:
-						CurrentOrientation = DisplayOrientations.Landscape;
-						break;
-					case SurfaceOrientation.Rotation180:
-						CurrentOrientation = DisplayOrientations.PortraitFlipped;
-						break;
-					case SurfaceOrientation.Rotation270:
-						CurrentOrientation = DisplayOrientations.LandscapeFlipped;
-						break;
-					default:
-						//invalid rotation
-						CurrentOrientation = DisplayOrientations.None;
-						break;
+					//square device, can't tell orientation
+					CurrentOrientation = DisplayOrientations.None;
+					return;
 				}
-			}
-			else if (NativeOrientation == DisplayOrientations.Landscape)
-			{
-				//device is landscape or square
-				switch (rotation)
+
+				if (NativeOrientation == DisplayOrientations.Portrait)
 				{
-					case SurfaceOrientation.Rotation0:
-						CurrentOrientation = DisplayOrientations.Landscape;
-						break;
-					case SurfaceOrientation.Rotation90:
-						CurrentOrientation = DisplayOrientations.Portrait;
-						break;
-					case SurfaceOrientation.Rotation180:
-						CurrentOrientation = DisplayOrientations.LandscapeFlipped;
-						break;
-					case SurfaceOrientation.Rotation270:
-						CurrentOrientation = DisplayOrientations.PortraitFlipped;
-						break;
-					default:
-						//invalid rotation
-						CurrentOrientation = DisplayOrientations.None;
-						break;
+					switch (rotation)
+					{
+						case SurfaceOrientation.Rotation0:
+							CurrentOrientation = DisplayOrientations.Portrait;
+							break;
+						case SurfaceOrientation.Rotation90:
+							CurrentOrientation = DisplayOrientations.Landscape;
+							break;
+						case SurfaceOrientation.Rotation180:
+							CurrentOrientation = DisplayOrientations.PortraitFlipped;
+							break;
+						case SurfaceOrientation.Rotation270:
+							CurrentOrientation = DisplayOrientations.LandscapeFlipped;
+							break;
+						default:
+							//invalid rotation
+							CurrentOrientation = DisplayOrientations.None;
+							break;
+					}
 				}
-			}
-			else
-			{
-				//fallback
-				CurrentOrientation = DisplayOrientations.None;
+				else if (NativeOrientation == DisplayOrientations.Landscape)
+				{
+					//device is landscape or square
+					switch (rotation)
+					{
+						case SurfaceOrientation.Rotation0:
+							CurrentOrientation = DisplayOrientations.Landscape;
+							break;
+						case SurfaceOrientation.Rotation90:
+							CurrentOrientation = DisplayOrientations.Portrait;
+							break;
+						case SurfaceOrientation.Rotation180:
+							CurrentOrientation = DisplayOrientations.LandscapeFlipped;
+							break;
+						case SurfaceOrientation.Rotation270:
+							CurrentOrientation = DisplayOrientations.PortraitFlipped;
+							break;
+						default:
+							//invalid rotation
+							CurrentOrientation = DisplayOrientations.None;
+							break;
+					}
+				}
+				else
+				{
+					//fallback
+					CurrentOrientation = DisplayOrientations.None;
+				}
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #2230 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Memory leaks when `DisplayInformation` properties are re-initialized

## What is the new behavior?

Memory no longer leaks when `DisplayInformation` properties are re-initialized


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)