### PR TITLE
Add support for XAML literal Color and SolidColorBrush

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -11,6 +11,7 @@
 - [WASM] Shapes now update when their Fill brush's Color changes
 - [WASM] Fix bug where changing `IsEnabled` from false to true on `Control` inside another `Control` didn't work
 - [Wasm] Add arbitrary delay in Safari macOS to avoid StackOverflow issues
+- #2227 fixed Color & SolidColorBrush literal values generation
 
 ## Release 2.0
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/SymbolExtensions.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/SymbolExtensions.cs
@@ -380,5 +380,10 @@ namespace Microsoft.CodeAnalysis
 
 			throw new ArgumentOutOfRangeException($"{symbol.DeclaredAccessibility} is not supported.");
 		}
+
+		public static IFieldSymbol FindField(this INamedTypeSymbol symbol, INamedTypeSymbol fieldType, string fieldName, StringComparison comparison = default)
+		{
+			return symbol.GetFields().FirstOrDefault(x => x.Type == fieldType && x.Name.Equals(fieldName, comparison));
+		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
@@ -84,6 +84,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			public const string SolidColorBrushHelper = BaseXamlNamespace + ".SolidColorBrushHelper";
 			public const string GridLength = BaseXamlNamespace + ".GridLength";
 			public const string GridUnitType = BaseXamlNamespace + ".GridUnitType";
+			public const string Color = RootUINamespace + ".Color";
 			public const string Colors = RootUINamespace + ".Colors";
 			public const string Thickness = BaseXamlNamespace + ".Thickness";
 			public const string Application = BaseXamlNamespace + ".Application";

--- a/src/SourceGenerators/XamlGenerationTests/NamedColorsTest.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/NamedColorsTest.xaml
@@ -1,0 +1,28 @@
+﻿<Page x:Class="XamlGenerationTests.NamedColorsTest"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:XamlGenerationTests"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Page.Resources>
+		<Color x:Key="NamedRedColor">Red</Color>
+		<Color x:Key="NamedRedColor_LowerCase">red</Color><!-- error CS0117: 'Colors' does not contain a definition for 'red' -->
+		<SolidColorBrush x:Key="SolidColorBrush_From_NamedRedColor" Color="{StaticResource NamedRedColor}" />
+		<SolidColorBrush x:Key="SolidColorBrush_From_NamedRedColor_LowerCase" Color="{StaticResource NamedRedColor_LowerCase}" />
+
+		<SolidColorBrush x:Key="NamedRedSolidColorBrush">Red</SolidColorBrush>
+		<SolidColorBrush x:Key="NamedRedSolidColorBrush_LowerCase">red</SolidColorBrush>
+		<SolidColorBrush x:Key="SolidColorBrush_With_ARGB">#FFFF0000</SolidColorBrush>
+	</Page.Resources>
+
+	<StackPanel>
+		<TextBlock>asdsad</TextBlock>
+		<TextBlock Text="SolidColorBrush_From_NamedRedColor" Foreground="{StaticResource SolidColorBrush_From_NamedRedColor}" />
+		<TextBlock Text="SolidColorBrush_From_NamedRedColor_LowerCase" Foreground="{StaticResource SolidColorBrush_From_NamedRedColor_LowerCase}" />
+		<TextBlock Text="NamedRedSolidColorBrush" Foreground="{StaticResource NamedRedSolidColorBrush}" />
+		<TextBlock Text="NamedRedSolidColorBrush_LowerCase" Foreground="{StaticResource NamedRedSolidColorBrush_LowerCase}" />
+		<TextBlock Text="SolidColorBrush_With_ARGB" Foreground="{StaticResource SolidColorBrush_With_ARGB}" />
+	</StackPanel>
+</Page>

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -50,6 +50,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <None Remove="NamedColorsTest.xaml" />
 	  <None Remove="NonDPAssignableTest.xaml" />
 	  <None Remove="StoryboardTargetTest.xaml" />
 	  <None Remove="ThemeResourcesTest.xaml" />


### PR DESCRIPTION
GitHub Issue (If applicable): #2227

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The xaml source generation doesn't properly handle literal values for `Color` and `SolidColorBrush` which is accepted by uwp.

## What is the new behavior?
The xaml source generation should handle literal values for `Color` and `SolidColorBrush` properly.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)