### PR TITLE
[WASM] Fix Control can't be re-enabled

### DIFF
--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -34,6 +34,7 @@ mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-conso
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' or \
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests' or \
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media.Animation_Tests' or \
+	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ControlTests' or \
 	namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests' \
 	" \
 	$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/net47/SamplesApp.UITests.dll \

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 - [#2230] `DisplayInformation` leaks memory
 - [WASM] Shapes now update when their Fill brush's Color changes
+- [WASM] Fix bug where changing `IsEnabled` from false to true on `Control` inside another `Control` didn't work
 
 ## Release 2.0
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ControlTests/Control_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ControlTests/Control_Tests.cs
@@ -25,6 +25,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ControlTests
 
 			_app.Tap("ToggleEnabledButton");
 
+			_app.WaitForText("IsEnabledTextBlock", "True");
+
 			_app.Tap("ButtonUnderTest");
 
 			_app.WaitForText("CounterTextBlock", "1");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ControlTests/Control_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ControlTests/Control_Tests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ControlTests
+{
+	[TestFixture]
+	public class Control_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void When_IsEnabled_Initially_False_And_Inherited()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ControlTests.Control_IsEnabled_Inheritance");
+
+			_app.WaitForText("CounterTextBlock", "0");
+
+			_app.Tap("ButtonUnderTest");
+
+			_app.WaitForText("CounterTextBlock", "0");
+
+			_app.Tap("ToggleEnabledButton");
+
+			_app.Tap("ButtonUnderTest");
+
+			_app.WaitForText("CounterTextBlock", "1");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -469,6 +469,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ControlTests\Control_IsEnabled_Inheritance.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_MinYear.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2994,6 +2998,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentDialogTests\ContentDialog_ComboBox.xaml.cs">
       <DependentUpon>ContentDialog_ComboBox.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ControlTests\Control_IsEnabled_Inheritance.xaml.cs">
+      <DependentUpon>Control_IsEnabled_Inheritance.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\FlyoutButtonViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_Unloaded.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Control_IsEnabled_Inheritance.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Control_IsEnabled_Inheritance.xaml
@@ -12,6 +12,7 @@
 		<ContentControl>
 			<StackPanel>
 				<ContentControl x:Name="ButtonUnderTest"
+								HorizontalAlignment="Left"
 								Margin="15"
 								Content="Pseudo-button under test"
 								IsEnabled="False"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Control_IsEnabled_Inheritance.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Control_IsEnabled_Inheritance.xaml
@@ -18,7 +18,8 @@
 								PointerPressed="IncrementCounter" />
 				<TextBlock x:Name="CounterTextBlock"
 						   Text="0" />
-				<TextBlock Text="{Binding ElementName=ButtonUnderTest, Path=IsEnabled}" />
+				<TextBlock x:Name="IsEnabledTextBlock"
+						   Text="{Binding ElementName=ButtonUnderTest, Path=IsEnabled}" />
 				<Button x:Name="ToggleEnabledButton"
 						Content="Toggle enabled"
 						Click="ToggleEnabled" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Control_IsEnabled_Inheritance.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Control_IsEnabled_Inheritance.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ControlTests.Control_IsEnabled_Inheritance"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ControlTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<ContentControl>
+			<StackPanel>
+				<ContentControl x:Name="ButtonUnderTest"
+								Margin="15"
+								Content="Pseudo-button under test"
+								IsEnabled="False"
+								PointerPressed="IncrementCounter" />
+				<TextBlock x:Name="CounterTextBlock"
+						   Text="0" />
+				<TextBlock Text="{Binding ElementName=ButtonUnderTest, Path=IsEnabled}" />
+				<Button x:Name="ToggleEnabledButton"
+						Content="Toggle enabled"
+						Click="ToggleEnabled" />
+			</StackPanel>
+		</ContentControl>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Control_IsEnabled_Inheritance.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Control_IsEnabled_Inheritance.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ControlTests
+{
+	[SampleControlInfo(description: "Toggling inner control to enabled should enable it")]
+	public sealed partial class Control_IsEnabled_Inheritance : UserControl
+	{
+		public Control_IsEnabled_Inheritance()
+		{
+			this.InitializeComponent();
+		}
+
+		private int _count = 0;
+		private void IncrementCounter(object sender, PointerRoutedEventArgs args)
+		{
+			_count++;
+			CounterTextBlock.Text = _count.ToString();
+		}
+
+		private void ToggleEnabled(object sender, RoutedEventArgs args)
+		{
+			var currentlyEnabled = ButtonUnderTest.IsEnabled;
+			ButtonUnderTest.IsEnabled = !currentlyEnabled;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
@@ -81,11 +81,11 @@ namespace Windows.UI.Xaml
 
 		private static void OnTransitionsChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
-			
+
 		}
 		#endregion
 
-		public IFrameworkElement FindName(string name) 
+		public IFrameworkElement FindName(string name)
 			=> IFrameworkElementHelper.FindName(this, GetChildren(), name);
 
 
@@ -97,7 +97,7 @@ namespace Windows.UI.Xaml
 		{
 			return finalSize;
 		}
-		
+
 		#region Background DependencyProperty
 
 		public Brush Background
@@ -190,8 +190,9 @@ namespace Windows.UI.Xaml
 						var elt = (FrameworkElement)s;
 						elt?.OnIsEnabledChanged((bool)e.OldValue, (bool)e.NewValue);
 						elt?.IsEnabledChanged?.Invoke(s, e);
-					},
-					(element, inherited) => (bool)inherited && ((FrameworkElement)element).IsEnabled));
+					}
+				)
+	);
 
 		protected virtual void OnIsEnabledChanged(bool oldValue, bool newValue)
 		{


### PR DESCRIPTION
Remove coercion on IsEnabled. In the best case, this coercion wasn't doing anything:
 - if there was no value set at a higher precedence, it was just &&-ing the new value with itself
 - if IsEnabled was already set 'false' at a higher precedence, the coercion was unnecessary because the existing value would still take precedence

In the worst case it was preventing IsEnabled ever being set to true:
 - if a control is materialized with IsEnabled=False, and then put in the tree with a parent with IsEnabled=True, then on entering the tree the coercion callback would set False with precedence Coercion. Since this is the highest precedence, setting IsEnabled=true locally on the control will now have no effect.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
