### PR TITLE
Add arbitrary delay in Safari macOS to avoid StackOverflow issues

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -8,7 +8,8 @@
 
 ### Bug fixes
 - [#2230] `DisplayInformation` leaks memory
-- [WASM] Shapes now update when their Fill brush's Color changes
+- [Wasm] Shapes now update when their Fill brush's Color changes
+- [Wasm] Add arbitrary delay in Safari macOS to avoid StackOverflow issues
 
 ## Release 2.0
 

--- a/src/Uno.UI.Wasm/ts/CoreDispatcher.ts
+++ b/src/Uno.UI.Wasm/ts/CoreDispatcher.ts
@@ -5,6 +5,7 @@
 	export class CoreDispatcher {
 		static _coreDispatcherCallback: any;
 		static _isIOS: boolean;
+		static _isSafari: boolean;
 		static _isFirstCall: boolean = true;
 		static _isReady: Promise<boolean>;
 		static _isWaitingReady: boolean;
@@ -15,6 +16,7 @@
 			CoreDispatcher._isReady = isReady;
 
 			CoreDispatcher._isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(<any>window).MSStream;
+			CoreDispatcher._isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 		}
 
 		/**
@@ -45,14 +47,14 @@
 
 		private static InnerWakeUp() {
 
-			if (CoreDispatcher._isIOS && CoreDispatcher._isFirstCall) {
+			if ((CoreDispatcher._isIOS || CoreDispatcher._isSafari) && CoreDispatcher._isFirstCall) {
 				//
 				// This is a workaround for the available call stack during the first 5 (?) seconds
 				// of the startup of an application. See https://github.com/mono/mono/issues/12357 for
 				// more details.
 				//
 				CoreDispatcher._isFirstCall = false;
-				console.debug("Detected iOS, delaying first CoreDispatched dispatch for 5s (see https://github.com/mono/mono/issues/12357)");
+				console.warn("Detected iOS, delaying first CoreDispatcher dispatch for 5 seconds (see https://github.com/mono/mono/issues/12357)");
 				window.setTimeout(() => this.WakeUp(), 5000);
 			} else {
 				(<any>window).setImmediate(() => {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Running a WebAssembly application on Safari for macOS or iOS automatically adds 5 second arbitrary delay to work around stack size issues using the interpreter.

See https://github.com/mono/mono/issues/12357

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
