### PR TITLE
Misc pointer events fixes

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -507,7 +507,15 @@
 				<Member
 					fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.Devices.Geolocation.GeolocationAccessStatus&gt; Windows.Devices.Geolocation.Geolocator.RequestAccessAsync()"
 					reason="Aligned API" />
-
+				<Member
+					fullName="System.Void Windows.UI.Xaml.RoutedEvent..ctor(System.String name)"
+					reason="Not part of the UWP API." />
+				<Member
+					fullName="Windows.Foundation.Point Windows.UI.Xaml.Input.DoubleTappedRoutedEventArgs.GetPosition()"
+					reason="Not part of the UWP API." />
+				<Member
+					fullName="Windows.Foundation.Point Windows.UI.Xaml.Input.TappedRoutedEventArgs.GetPosition()"
+					reason="Not part of the UWP API." />
             </Methods>
 			
 			<Fields>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -576,7 +576,7 @@
 			</Properties>
 		</IgnoreSet>
 		
-		<IgnoreSet baseVersion="2.0.0">
+		<IgnoreSet baseVersion="2.0.528">
 			<Methods>
 				<Member
 					fullName="System.Void Windows.UI.Xaml.RoutedEvent..ctor(System.String name)"

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -575,5 +575,19 @@
 					reason="Not part of the UWP API."/>
 			</Properties>
 		</IgnoreSet>
+		
+		<IgnoreSet baseVersion="2.0.0">
+			<Methods>
+				<Member
+					fullName="System.Void Windows.UI.Xaml.RoutedEvent..ctor(System.String name)"
+					reason="Not part of the UWP API." />
+				<Member
+					fullName="Windows.Foundation.Point Windows.UI.Xaml.Input.DoubleTappedRoutedEventArgs.GetPosition()"
+					reason="Not part of the UWP API." />
+				<Member
+					fullName="Windows.Foundation.Point Windows.UI.Xaml.Input.TappedRoutedEventArgs.GetPosition()"
+					reason="Not part of the UWP API." />
+            </Methods>
+		</IgnoreSet>
 	</IgnoreSets>
 </DiffIgnore>

--- a/doc/articles/features/routed-events.md
+++ b/doc/articles/features/routed-events.md
@@ -236,6 +236,9 @@ As those events are tightly coupled to the native events, Uno has to make some c
   > a `PointerReleased` when clicking on an `Hyperlink`.
 * Unlike UWP, on the `Hyperlink` the `Click` will be raised before the `PointerReleased`.
 * The property `PointerPointProperties.PointerUpdateKind` is not set on Android 5.x and lower (API level < 23)
+* On Firefox, pressed pointers are reported as finger. This means you will receive events with `PointerDeviceType == Pen` only for hoverring 
+  (i.e. `Pointer<Enter|Move|Exit>` - note that, as of 2019-11-28, once pressed `PointerMove` will be flagged as "touch") 
+  and you won't  be able to track the barrel button nor the eraser. (cf. https://bugzilla.mozilla.org/show_bug.cgi?id=1449660)
 
 ### Pointer capture
 

--- a/doc/articles/features/routed-events.md
+++ b/doc/articles/features/routed-events.md
@@ -236,7 +236,7 @@ As those events are tightly coupled to the native events, Uno has to make some c
   > a `PointerReleased` when clicking on an `Hyperlink`.
 * Unlike UWP, on the `Hyperlink` the `Click` will be raised before the `PointerReleased`.
 * The property `PointerPointProperties.PointerUpdateKind` is not set on Android 5.x and lower (API level < 23)
-* On Firefox, pressed pointers are reported as finger. This means you will receive events with `PointerDeviceType == Pen` only for hoverring 
+* On Firefox, pressed pointers are reported as finger. This means you will receive events with `PointerDeviceType == Pen` only for hovering 
   (i.e. `Pointer<Enter|Move|Exit>` - note that, as of 2019-11-28, once pressed `PointerMove` will be flagged as "touch") 
   and you won't  be able to track the barrel button nor the eraser. (cf. https://bugzilla.mozilla.org/show_bug.cgi?id=1449660)
 

--- a/doc/articles/features/routed-events.md
+++ b/doc/articles/features/routed-events.md
@@ -236,7 +236,7 @@ As those events are tightly coupled to the native events, Uno has to make some c
   > a `PointerReleased` when clicking on an `Hyperlink`.
 * Unlike UWP, on the `Hyperlink` the `Click` will be raised before the `PointerReleased`.
 * The property `PointerPointProperties.PointerUpdateKind` is not set on Android 5.x and lower (API level < 23)
-* On Firefox, pressed pointers are reported as finger. This means you will receive events with `PointerDeviceType == Pen` only for hovering 
+* On Firefox, pressed pointers are reported as fingers. This means you will receive events with `PointerDeviceType == Pen` only for hovering 
   (i.e. `Pointer<Enter|Move|Exit>` - note that, as of 2019-11-28, once pressed `PointerMove` will be flagged as "touch") 
   and you won't  be able to track the barrel button nor the eraser. (cf. https://bugzilla.mozilla.org/show_bug.cgi?id=1449660)
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Tapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Tapped_Tests.cs
@@ -46,5 +46,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			var result = _app.Marked("WhenChildHandlesPointers_Result").GetDependencyPropertyValue<string>("Text");
 			result.Should().Be("Tapped");
 		}
+
+		[Test]
+		public void When_MultipleTappedRecognizer()
+		{
+			Run("UITests.Shared.Windows_UI_Input.GestureRecognizerTests.TappedTest");
+
+			var target = _app.WaitForElement("WhenMultipleTappedRecognizer_Target").Single();
+
+			const int tapX = 10, tapY = 10;
+			_app.TapCoordinates(target.Rect.X + tapX, target.Rect.Y + tapY);
+
+			var resultParent = _app.Marked("WhenMultipleTappedRecognizer_Result_Parent").GetDependencyPropertyValue<string>("Text");
+			var resultTarget = _app.Marked("WhenMultipleTappedRecognizer_Result_Target").GetDependencyPropertyValue<string>("Text");
+
+			resultParent.Should().Be("1");
+			resultTarget.Should().Be("1");
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Tapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Tapped_Tests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Input
+{
+	public class Tapped_Tests : SampleControlUITestBase
+	{
+		[Test]
+		public void TappedLocationTest()
+		{
+			Run("UITests.Shared.Windows_UI_Input.GestureRecognizerTests.TappedTest");
+
+			var root = _app.WaitForElement("LocationTestRoot").Single();
+			var target = _app.WaitForElement("LocationTestTarget").Single();
+
+			int tapX = 10, tapY = 10;
+			(int x, int y) targetToRoot = ((int)(target.Rect.X - root.Rect.X), (int)(target.Rect.Y - root.Rect.Y));
+
+			_app.TapCoordinates(target.Rect.X + tapX, target.Rect.Y + tapY);
+
+			var relativeToRoot = _app.Marked("LocationTestRelativeToRootLocation").GetDependencyPropertyValue<string>("Text");
+			var relativeToTarget = _app.Marked("LocationTestRelativeToTargetLocation").GetDependencyPropertyValue<string>("Text");
+
+			relativeToTarget.Should().Be($"({tapX:D},{tapY:D})");
+			relativeToRoot.Should().Be($"({tapX+targetToRoot.x:D},{tapY + targetToRoot.y:D})");
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Tapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Tapped_Tests.cs
@@ -14,6 +14,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 	public class Tapped_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[ActivePlatforms(Platform.Android)] // Fixed in another commit coming soon
 		public void When_Tapped_Then_ArgsLocationIsValid()
 		{
 			Run("UITests.Shared.Windows_UI_Input.GestureRecognizerTests.TappedTest");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Tapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Tapped_Tests.cs
@@ -14,6 +14,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 	public class Tapped_Tests : SampleControlUITestBase
 	{
 		[Test]
+		[AutoRetry]
 		[ActivePlatforms(Platform.Android)] // Fixed in another commit coming soon
 		public void When_Tapped_Then_ArgsLocationIsValid()
 		{
@@ -35,6 +36,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 		}
 
 		[Test]
+		[AutoRetry]
 		public void When_ChildHandlesPointers()
 		{
 			Run("UITests.Shared.Windows_UI_Input.GestureRecognizerTests.TappedTest");
@@ -49,6 +51,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 		}
 
 		[Test]
+		[AutoRetry]
 		public void When_MultipleTappedRecognizer()
 		{
 			Run("UITests.Shared.Windows_UI_Input.GestureRecognizerTests.TappedTest");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Tapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Tapped_Tests.cs
@@ -14,23 +14,37 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 	public class Tapped_Tests : SampleControlUITestBase
 	{
 		[Test]
-		public void TappedLocationTest()
+		public void When_Tapped_Then_ArgsLocationIsValid()
 		{
 			Run("UITests.Shared.Windows_UI_Input.GestureRecognizerTests.TappedTest");
 
-			var root = _app.WaitForElement("LocationTestRoot").Single();
-			var target = _app.WaitForElement("LocationTestTarget").Single();
+			var root = _app.WaitForElement("WhenTappedThenArgsLocationIsValid_Root").Single();
+			var target = _app.WaitForElement("WhenTappedThenArgsLocationIsValid_Target").Single();
 
-			int tapX = 10, tapY = 10;
+			const int tapX = 10, tapY = 10;
 			(int x, int y) targetToRoot = ((int)(target.Rect.X - root.Rect.X), (int)(target.Rect.Y - root.Rect.Y));
 
 			_app.TapCoordinates(target.Rect.X + tapX, target.Rect.Y + tapY);
 
-			var relativeToRoot = _app.Marked("LocationTestRelativeToRootLocation").GetDependencyPropertyValue<string>("Text");
-			var relativeToTarget = _app.Marked("LocationTestRelativeToTargetLocation").GetDependencyPropertyValue<string>("Text");
+			var relativeToRoot = _app.Marked("WhenTappedThenArgsLocationIsValid_Result_RelativeToRoot").GetDependencyPropertyValue<string>("Text");
+			var relativeToTarget = _app.Marked("WhenTappedThenArgsLocationIsValid_Result_RelativeToTarget").GetDependencyPropertyValue<string>("Text");
 
 			relativeToTarget.Should().Be($"({tapX:D},{tapY:D})");
 			relativeToRoot.Should().Be($"({tapX+targetToRoot.x:D},{tapY + targetToRoot.y:D})");
+		}
+
+		[Test]
+		public void When_ChildHandlesPointers()
+		{
+			Run("UITests.Shared.Windows_UI_Input.GestureRecognizerTests.TappedTest");
+
+			var target = _app.WaitForElement("WhenChildHandlesPointers_Target").Single();
+
+			const int tapX = 10, tapY = 10;
+			_app.TapCoordinates(target.Rect.X + tapX, target.Rect.Y + tapY);
+
+			var result = _app.Marked("WhenChildHandlesPointers_Result").GetDependencyPropertyValue<string>("Text");
+			result.Should().Be("Tapped");
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Helpers/UWPViewHelper.cs
+++ b/src/SamplesApp/UITests.Shared/Helpers/UWPViewHelper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.Foundation;
+
+namespace Uno.UI
+{
+	public static class UWPViewHelper
+	{
+		public static Point LogicalToPhysicalPixels(this Point point)
+#if XAMARIN
+			=> Uno.UI.ViewHelper.LogicalToPhysicalPixels(point);
+#else
+			=> point;
+#endif
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Helpers/UWPViewHelper.cs
+++ b/src/SamplesApp/UITests.Shared/Helpers/UWPViewHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Windows.Foundation;
 
@@ -7,10 +8,29 @@ namespace Uno.UI
 {
 	public static class UWPViewHelper
 	{
+#if !XAMARIN && !__WASM__
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Size PhysicalToLogicalPixels(this Size size)
+			=> size;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Size LogicalToPhysicalPixels(this Size size)
+			=> size;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Rect LogicalToPhysicalPixels(this Rect rect)
+			=> rect;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Rect PhysicalToLogicalPixels(this Rect rect)
+			=> rect;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Point PhysicalToLogicalPixels(this Point point)
+			=> point;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Point LogicalToPhysicalPixels(this Point point)
-#if XAMARIN
-			=> Uno.UI.ViewHelper.LogicalToPhysicalPixels(point);
-#else
 			=> point;
 #endif
 	}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -129,6 +129,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\TransformationsTests.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Capture.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -658,6 +662,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_NaturalSize.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PrefilledByBinding.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -2907,6 +2915,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\TappedTest.xaml.cs">
       <DependentUpon>TappedTest.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\TransformationsTests.xaml.cs">
+      <DependentUpon>TransformationsTests.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Capture.xaml.cs">
       <DependentUpon>Capture.xaml</DependentUpon>
     </Compile>
@@ -3179,6 +3190,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_NaturalSize.xaml.cs">
       <DependentUpon>TextBox_NaturalSize.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PrefilledByBinding.xaml.cs">
+      <DependentUpon>TextBox_PrefilledByBinding.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_RoundedCorners.xaml.cs">
       <DependentUpon>TextBox_RoundedCorners.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2832,6 +2832,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BindableBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\UWPViewHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ViewModelBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\Elevation.xaml.cs">
       <DependentUpon>Elevation.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -125,6 +125,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\TappedTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Capture.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2898,6 +2902,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\ManipulationEvents.xaml.cs">
       <DependentUpon>ManipulationEvents.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\TappedTest.xaml.cs">
+      <DependentUpon>TappedTest.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Capture.xaml.cs">
       <DependentUpon>Capture.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -661,10 +661,6 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PrefilledByBinding.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_RoundedCorners.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3183,9 +3179,6 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_NaturalSize.xaml.cs">
       <DependentUpon>TextBox_NaturalSize.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PrefilledByBinding.xaml.cs">
-      <DependentUpon>TextBox_PrefilledByBinding.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_RoundedCorners.xaml.cs">
       <DependentUpon>TextBox_RoundedCorners.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -129,10 +129,6 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\TransformationsTests.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Capture.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2914,9 +2910,6 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\TappedTest.xaml.cs">
       <DependentUpon>TappedTest.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\TransformationsTests.xaml.cs">
-      <DependentUpon>TransformationsTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Capture.xaml.cs">
       <DependentUpon>Capture.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml
@@ -2,21 +2,258 @@
 	x:Class="UITests.Shared.Windows_UI_Input.GestureRecognizer.PointersEvents"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Input.RoutedEvents">
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:not_win="http://platform.uno"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="not_win">
 
 	<Grid>
-		<Border x:Name="_flashingZone" Margin="100" Width="200" Height="200" VerticalAlignment="Top" HorizontalAlignment="Right" Background="DeepPink" />
+		<VisualStateManager.VisualStateGroups>
+			<VisualStateGroup>
+				<VisualState>
+					<VisualState.StateTriggers>
+						<!--<AdaptiveTrigger MinWindowWidth="700" />-->
+						<StateTrigger IsActive="{Binding ElementName=_splitButton, Path=IsChecked}" />
+					</VisualState.StateTriggers>
+					<VisualState.Setters>
+						<!--<Setter Target="_tabs.Visibility" Value="Collapsed" />-->
+						<Setter Target="_configColumn.Width" Value="300" />
+						<Setter Target="_benchColumn.Width" Value="*" />
+						<Setter Target="_outputColumn.Width" Value="2*" />
+					</VisualState.Setters>
+				</VisualState>
+				<win:VisualState x:Name="Config">
+					<VisualState.StateTriggers>
+						<StateTrigger IsActive="{Binding ElementName=_configButton, Path=IsChecked}" />
+					</VisualState.StateTriggers>
+					<VisualState.Setters>
+						<!--<Setter Target="_tabs.Visibility" Value="Visible" />-->
+						<Setter Target="_configColumn.Width" Value="*" />
+						<Setter Target="_benchColumn.Width" Value="0" />
+						<Setter Target="_outputColumn.Width" Value="0" />
+					</VisualState.Setters>
+				</win:VisualState>
+				<win:VisualState x:Name="Bench">
+					<VisualState.StateTriggers>
+						<StateTrigger IsActive="{Binding ElementName=_benchButton, Path=IsChecked}" />
+					</VisualState.StateTriggers>
+					<VisualState.Setters>
+						<Setter Target="_tabs.Visibility" Value="Visible" />
+						<Setter Target="_configColumn.Width" Value="0" />
+						<Setter Target="_benchColumn.Width" Value="*" />
+						<Setter Target="_outputColumn.Width" Value="0" />
+					</VisualState.Setters>
+				</win:VisualState>
+				<win:VisualState x:Name="Output">
+					<VisualState.StateTriggers>
+						<StateTrigger IsActive="{Binding ElementName=_outputButton, Path=IsChecked}" />
+					</VisualState.StateTriggers>
+					<VisualState.Setters>
+						<Setter Target="_tabs.Visibility" Value="Visible" />
+						<Setter Target="_configColumn.Width" Value="0" />
+						<Setter Target="_benchColumn.Width" Value="0" />
+						<Setter Target="_outputColumn.Width" Value="*" />
+					</VisualState.Setters>
+				</win:VisualState>
+			</VisualStateGroup>
+		</VisualStateManager.VisualStateGroups>
 
-		<ScrollViewer>
-			<Grid x:Name="_touchTarget" MinHeight="2048">
-				<TextBlock FontSize="8" x:Name="_output" Width="300" HorizontalAlignment="Left" TextWrapping="NoWrap" />
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition x:Name="_configColumn"/>
+			<ColumnDefinition x:Name="_benchColumn" />
+			<ColumnDefinition x:Name="_outputColumn" />
+		</Grid.ColumnDefinitions>
 
-				<Border Margin="200" Width="200" Height="200" ManipulationMode="None" Background="#33CC0000">
-					<TextBlock Text="Frozen region" />
-				</Border>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
 
-				<Button Margin="200, 600" Height="100" Width="300" Content="Click me ... but not while scrolling" Click="OnButtonClicked" Tapped="OnButtonTapped" />
+		<StackPanel Orientation="Horizontal" x:Name="_tabs" Grid.ColumnSpan="3">
+			<RadioButton GroupName="TabView" Content="Splitted" x:Name="_splitButton" IsChecked="True" />
+			<RadioButton GroupName="TabView" Content="Config" x:Name="_configButton" />
+			<RadioButton GroupName="TabView" Content="Bench" x:Name="_benchButton" />
+			<RadioButton GroupName="TabView" Content="Output" x:Name="_outputButton" />
+
+			<Button
+				Grid.ColumnSpan="3"
+				Grid.RowSpan="2"
+				HorizontalAlignment="Right"
+				VerticalAlignment="Top"
+				Content="Clear"
+				Click="ClearLog" />
+		</StackPanel>
+
+		<ScrollViewer Grid.Column="0" Grid.Row="1">
+			<StackPanel Padding="10,0">
+				<TextBlock
+					Text="This is a test bench to check the expected properties of pointer events args. Configure below the pointer you are going to use, then test it in the pink zone on right."
+					TextWrapping="Wrap"/>
+
+				<ComboBox
+					x:Name="_pointerType"
+					Header="Pointer type:"
+					SelectionChanged="OnPointerTypeChanged"  />
+
+				<TextBox
+					x:Name="_pointerId" 
+					Header="Pointer ID:"
+					Width="75"
+					HorizontalAlignment="Left" />
+
+				<TextBlock Text="Expected buttons:" />
+				<CheckBox
+					x:Name="_leftButton" 
+					Content="Left"
+					IsThreeState="True"
+					IsChecked="True" />
+				<CheckBox
+					x:Name="_middleButton" 
+					Content="Middle"
+					IsThreeState="True"
+					IsChecked="False" />
+				<CheckBox
+					x:Name="_rightButton" 
+					Content="Right"
+					IsThreeState="True"
+					IsChecked="False" />
+				<CheckBox
+					x:Name="_barrelButton"
+					Content="Pen's barrel"
+					IsThreeState="True"
+					IsChecked="False" />
+				<CheckBox
+					x:Name="_eraserButton"
+					Content="Pen's eraser"
+					IsThreeState="True"
+					IsChecked="False" />
+				<CheckBox
+					x:Name="_x1Button"
+					Content="X Button 1"
+					IsThreeState="True"
+					IsChecked="False" />
+				<CheckBox
+					x:Name="_x2Button"
+					Content="X Button 2"
+					IsThreeState="True"
+					IsChecked="False" />
+
+				<TextBlock Text="Expected properties:" />
+				<CheckBox
+					x:Name="_inRange" 
+					Content="In range"
+					IsThreeState="True"
+					IsChecked="True" />
+				<CheckBox
+					x:Name="_inContact" 
+					Content="In contact"
+					IsThreeState="True"
+					IsChecked="{x:Null}" />
+
+				<TextBlock Text="Bench config:" />
+				<ToggleSwitch
+					x:Name="_capture"
+					Header="Capture"
+					OnContent="Capture the pointer on press"
+					OffContent="Pointer won't be captured"
+					Toggled="OnConfigChanged" />
+				<ToggleSwitch
+					x:Name="_handledEventsToo"
+					Header="Handled events too"
+					OnContent="All events are subscribed for handled events too"
+					OffContent="Unhandled events only"
+					Toggled="OnConfigChanged" />
+				<ToggleSwitch
+					x:Name="_horizontalScroll" 
+					Header="Horizontal scroll"
+					OnContent="Horizontal scroll enabled"
+					OffContent="Horizontal scroll disabled"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+				<ToggleSwitch
+					x:Name="_verticalScroll" 
+					Header="Vertical scroll"
+					OnContent="Vertical scroll enabled"
+					OffContent="Vertical scroll disabled"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+
+				<ComboBox
+					x:Name="_manipMode" 
+					Header="Manipulation mode: "
+					SelectionChanged="OnManipModeChanged" />
+				<ToggleSwitch
+					x:Name="_manipStarting" 
+					Header="Manipulation starting"
+					OnContent="Subscribed to manip starting"
+					OffContent="Manip starting muted"
+					Toggled="OnConfigChanged" />
+				<ToggleSwitch
+					x:Name="_manipStarted" 
+					Header="Manipulation started"
+					OnContent="Subscribed to manip started"
+					OffContent="Manip started muted"
+					Toggled="OnConfigChanged" />
+				<ToggleSwitch
+					x:Name="_manipDelta"
+					Header="Manipulation delta"
+					OnContent="Subscribed to manip delta"
+					OffContent="Manip delta muted"
+					Toggled="OnConfigChanged" />
+				<ToggleSwitch
+					x:Name="_manipCompleted" 
+					Header="Manipulation completed"
+					OnContent="Subscribed to manip completed"
+					OffContent="Manip completed muted"
+					Toggled="OnConfigChanged" />
+
+				<ToggleSwitch
+					x:Name="_gestureTapped" 
+					Header="Tapped"
+					OnContent="Subscribed to tap"
+					OffContent="Tap disabled"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+				<ToggleSwitch
+					x:Name="_gestureDoubleTapped" 
+					Header="Double tapped"
+					OnContent="Subscribed to double tap"
+					OffContent="Double tap disabled"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+			</StackPanel>
+		</ScrollViewer>
+
+		<ScrollViewer Grid.Column="1" Grid.Row="1" x:Name="_myScrollViewer">
+			<Grid
+				x:Name="_touchTargetParent"
+				MinWidth="2048"
+				MinHeight="2048"
+				Background="DeepSkyBlue">
+				<Border
+					x:Name="_touchTarget"
+					HorizontalAlignment="Left"
+					VerticalAlignment="Top"
+					Margin="50, 50, 0, 0"
+					Width="200"
+					Height="200"
+					Background="DeepPink" />
 			</Grid>
 		</ScrollViewer>
+
+		<ListView Grid.Column="2" Grid.Row="1" x:Name="_log">
+			<ItemsControl.ItemTemplate>
+				<DataTemplate>
+					<StackPanel>
+						<TextBlock>
+							<Run Foreground="{Binding Sender.Background}" Text="{Binding Sender.Name}" />
+							<Run Text="{Binding Name}"/>
+							<Run Text="{Binding ValidityBullet}"/>
+						</TextBlock>
+						<TextBlock Text="{Binding Details}" TextWrapping="Wrap" FontSize="8" />
+					</StackPanel>
+				</DataTemplate>
+			</ItemsControl.ItemTemplate>
+		</ListView>
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml
@@ -27,7 +27,7 @@
 						<StateTrigger IsActive="{Binding ElementName=_configButton, Path=IsChecked}" />
 					</VisualState.StateTriggers>
 					<VisualState.Setters>
-						<!--<Setter Target="_tabs.Visibility" Value="Visible" />-->
+						<Setter Target="_tabs.Visibility" Value="Visible" />
 						<Setter Target="_configColumn.Width" Value="*" />
 						<Setter Target="_benchColumn.Width" Value="0" />
 						<Setter Target="_outputColumn.Width" Value="0" />
@@ -160,7 +160,7 @@
 				<ToggleSwitch
 					x:Name="_handledEventsToo"
 					Header="Handled events too"
-					OnContent="All events are subscribed for handled events too"
+					OnContent="Handlers added w/ handledEventsToo"
 					OffContent="Unhandled events only"
 					Toggled="OnConfigChanged" />
 				<ToggleSwitch
@@ -188,24 +188,44 @@
 					OnContent="Subscribed to manip starting"
 					OffContent="Manip starting muted"
 					Toggled="OnConfigChanged" />
+				<CheckBox
+					x:Name="_manipStartingHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_manipStarting, Path=IsOn}"/>
 				<ToggleSwitch
 					x:Name="_manipStarted" 
 					Header="Manipulation started"
 					OnContent="Subscribed to manip started"
 					OffContent="Manip started muted"
 					Toggled="OnConfigChanged" />
+				<CheckBox
+					x:Name="_manipStartedHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_manipStarted, Path=IsOn}"/>
 				<ToggleSwitch
 					x:Name="_manipDelta"
 					Header="Manipulation delta"
 					OnContent="Subscribed to manip delta"
 					OffContent="Manip delta muted"
 					Toggled="OnConfigChanged" />
+				<CheckBox
+					x:Name="_manipDeltaHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_manipDelta, Path=IsOn}"/>
 				<ToggleSwitch
 					x:Name="_manipCompleted" 
 					Header="Manipulation completed"
 					OnContent="Subscribed to manip completed"
 					OffContent="Manip completed muted"
 					Toggled="OnConfigChanged" />
+				<CheckBox
+					x:Name="_manipCompletedHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_manipCompleted, Path=IsOn}"/>
 
 				<ToggleSwitch
 					x:Name="_gestureTapped" 
@@ -214,6 +234,11 @@
 					OffContent="Tap disabled"
 					Toggled="OnConfigChanged"
 					IsOn="True" />
+				<CheckBox
+					x:Name="_gestureTappedHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_gestureTapped, Path=IsOn}"/>
 				<ToggleSwitch
 					x:Name="_gestureDoubleTapped" 
 					Header="Double tapped"
@@ -221,17 +246,22 @@
 					OffContent="Double tap disabled"
 					Toggled="OnConfigChanged"
 					IsOn="True" />
+				<CheckBox
+					x:Name="_gestureDoubleTappedHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_gestureDoubleTapped, Path=IsOn}"/>
 			</StackPanel>
 		</ScrollViewer>
 
 		<ScrollViewer Grid.Column="1" Grid.Row="1" x:Name="_myScrollViewer">
 			<Grid
-				x:Name="_touchTargetParent"
+				x:Name="TouchTargetParent"
 				MinWidth="2048"
 				MinHeight="2048"
 				Background="DeepSkyBlue">
 				<Border
-					x:Name="_touchTarget"
+					x:Name="TouchTarget"
 					HorizontalAlignment="Left"
 					VerticalAlignment="Top"
 					Margin="50, 50, 0, 0"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml
@@ -152,17 +152,18 @@
 
 				<TextBlock Text="Bench config:" />
 				<ToggleSwitch
-					x:Name="_capture"
-					Header="Capture"
-					OnContent="Capture the pointer on press"
-					OffContent="Pointer won't be captured"
-					Toggled="OnConfigChanged" />
-				<ToggleSwitch
 					x:Name="_handledEventsToo"
 					Header="Handled events too"
 					OnContent="Handlers added w/ handledEventsToo"
 					OffContent="Unhandled events only"
 					Toggled="OnConfigChanged" />
+				<ToggleSwitch
+					x:Name="_allEventsOnParent" 
+					Header="All events for parent"
+					OnContent="Parent subscribe to all events"
+					OffContent="Parent subscribe as config"
+					Toggled="OnConfigChanged"
+					IsOn="False" />
 				<ToggleSwitch
 					x:Name="_horizontalScroll" 
 					Header="Horizontal scroll"
@@ -177,6 +178,96 @@
 					OffContent="Vertical scroll disabled"
 					Toggled="OnConfigChanged"
 					IsOn="True" />
+
+				<ToggleSwitch
+					x:Name="_ptEntered" 
+					Header="Pointer entered"
+					OnContent="Subscribed to pointer entered"
+					OffContent="Pointer entered muted"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+				<CheckBox
+					x:Name="_ptEnteredHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_ptEntered, Path=IsOn}"/>
+				<ToggleSwitch
+					x:Name="_ptPressed" 
+					Header="Pointer pressed"
+					OnContent="Subscribed to pointer pressed"
+					OffContent="Pointer pressed muted"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+				<CheckBox
+					x:Name="_ptPressedHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_ptPressed, Path=IsOn}"/>
+				<CheckBox
+					x:Name="_ptPressedCapture"
+					Content="Capture pointer"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_ptPressed, Path=IsOn}"/>
+				<ToggleSwitch
+					x:Name="_ptMoved" 
+					Header="Pointer moved"
+					OnContent="Subscribed to pointer moved"
+					OffContent="Pointer moved muted"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+				<CheckBox
+					x:Name="_ptMovedHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_ptMoved, Path=IsOn}"/>
+				<ToggleSwitch
+					x:Name="_ptReleased" 
+					Header="Pointer released"
+					OnContent="Subscribed to pointer released"
+					OffContent="Pointer released muted"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+				<CheckBox
+					x:Name="_ptReleasedHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_ptReleased, Path=IsOn}"/>
+				<ToggleSwitch
+					x:Name="_ptExited" 
+					Header="Pointer exited"
+					OnContent="Subscribed to pointer exited"
+					OffContent="Pointer exited muted"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+				<CheckBox
+					x:Name="_ptExitedHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_ptExited, Path=IsOn}"/>
+				<ToggleSwitch
+					x:Name="_ptCanceled" 
+					Header="Pointer canceled"
+					OnContent="Subscribed to pointer canceled"
+					OffContent="Pointer canceled muted"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+				<CheckBox
+					x:Name="_ptCanceledHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_ptCanceled, Path=IsOn}"/>
+				<ToggleSwitch
+					x:Name="_ptCaptureLost" 
+					Header="Pointer capture lost"
+					OnContent="Subscribed to pointer capture lost"
+					OffContent="Pointer capture lost muted"
+					Toggled="OnConfigChanged"
+					IsOn="True" />
+				<CheckBox
+					x:Name="_ptCaptureLostHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_ptCaptureLost, Path=IsOn}"/>
 
 				<ComboBox
 					x:Name="_manipMode" 
@@ -233,7 +324,7 @@
 					OnContent="Subscribed to tap"
 					OffContent="Tap disabled"
 					Toggled="OnConfigChanged"
-					IsOn="True" />
+					IsOn="False" />
 				<CheckBox
 					x:Name="_gestureTappedHandle" 
 					Content="Handle event"
@@ -245,7 +336,7 @@
 					OnContent="Subscribed to double tap"
 					OffContent="Double tap disabled"
 					Toggled="OnConfigChanged"
-					IsOn="True" />
+					IsOn="False" />
 				<CheckBox
 					x:Name="_gestureDoubleTappedHandle" 
 					Content="Handle event"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml.cs
@@ -56,8 +56,8 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizer
 		{
 			_logPointerPressed = new PointerEventHandler((snd, e) =>
 			{
-				CreateHandler(PointerPressedEvent, "Pressed")(snd, e);
-				if (_capture.IsOn)
+				CreateHandler(PointerPressedEvent, "Pressed", _ptPressedHandle)(snd, e);
+				if (_ptPressedCapture.IsChecked ?? false)
 				{
 					((UIElement)snd).CapturePointer(e.Pointer);
 				}
@@ -65,12 +65,12 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizer
 
 			this.InitializeComponent();
 
-			_logPointerEntered = new PointerEventHandler(CreateHandler(PointerEnteredEvent, "Entered"));
-			_logPointerMoved = new PointerEventHandler(CreateHandler(PointerMovedEvent, "Moved"));
-			_logPointerReleased = new PointerEventHandler(CreateHandler(PointerReleasedEvent, "Released"));
-			_logPointerExited = new PointerEventHandler(CreateHandler(PointerExitedEvent, "Exited"));
-			_logPointerCanceled = new PointerEventHandler(CreateHandler(PointerCanceledEvent, "Canceled"));
-			_logPointerCaptureLost = new PointerEventHandler(CreateHandler(PointerCaptureLostEvent, "CaptureLost"));
+			_logPointerEntered = new PointerEventHandler(CreateHandler(PointerEnteredEvent, "Entered", _ptEnteredHandle));
+			_logPointerMoved = new PointerEventHandler(CreateHandler(PointerMovedEvent, "Moved", _ptMovedHandle));
+			_logPointerReleased = new PointerEventHandler(CreateHandler(PointerReleasedEvent, "Released", _ptReleasedHandle));
+			_logPointerExited = new PointerEventHandler(CreateHandler(PointerExitedEvent, "Exited", _ptExitedHandle));
+			_logPointerCanceled = new PointerEventHandler(CreateHandler(PointerCanceledEvent, "Canceled", _ptCanceledHandle));
+			_logPointerCaptureLost = new PointerEventHandler(CreateHandler(PointerCaptureLostEvent, "CaptureLost", _ptCaptureLostHandle));
 			_logManipulationStarting = new ManipulationStartingEventHandler(CreateHandler(ManipulationStartingEvent, "Manip starting", _manipStartingHandle));
 			_logManipulationStarted = new ManipulationStartedEventHandler(CreateHandler(ManipulationStartedEvent, "Manip started", _manipStartedHandle));
 			_logManipulationDelta = new ManipulationDeltaEventHandler(CreateHandler(ManipulationDeltaEvent, "Manip delta", _manipDeltaHandle));
@@ -143,11 +143,11 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizer
 			}
 
 			var handledToo = _handledEventsToo.IsOn;
-			SetupEvents(TouchTargetParent, handledToo);
+			SetupEvents(TouchTargetParent, handledToo, _allEventsOnParent.IsOn);
 			SetupEvents(TouchTarget, handledToo);
 		}
 
-		private void SetupEvents(FrameworkElement target, bool handledToo)
+		private void SetupEvents(FrameworkElement target, bool handledToo, bool allEvents = false)
 		{
 			target.RemoveHandler(PointerEnteredEvent, _logPointerEntered);
 			target.RemoveHandler(PointerPressedEvent, _logPointerPressed);
@@ -163,26 +163,33 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizer
 			target.RemoveHandler(TappedEvent, _logTapped);
 			target.RemoveHandler(DoubleTappedEvent, _logDoubleTapped);
 
-			target.AddHandler(PointerEnteredEvent, _logPointerEntered, handledToo);
-			target.AddHandler(PointerPressedEvent, _logPointerPressed, handledToo);
-			target.AddHandler(PointerMovedEvent, _logPointerMoved, handledToo);
-			target.AddHandler(PointerReleasedEvent, _logPointerReleased, handledToo);
-			target.AddHandler(PointerExitedEvent, _logPointerExited, handledToo);
-			target.AddHandler(PointerCanceledEvent, _logPointerCanceled, handledToo);
-			target.AddHandler(PointerCaptureLostEvent, _logPointerCaptureLost, handledToo);
+			if (allEvents || _ptEntered.IsOn)
+				target.AddHandler(PointerEnteredEvent, _logPointerEntered, handledToo);
+			if (allEvents || _ptPressed.IsOn)
+				target.AddHandler(PointerPressedEvent, _logPointerPressed, handledToo);
+			if (allEvents || _ptMoved.IsOn)
+				target.AddHandler(PointerMovedEvent, _logPointerMoved, handledToo);
+			if (allEvents || _ptReleased.IsOn)
+				target.AddHandler(PointerReleasedEvent, _logPointerReleased, handledToo);
+			if (allEvents || _ptExited.IsOn)
+				target.AddHandler(PointerExitedEvent, _logPointerExited, handledToo);
+			if (allEvents || _ptCanceled.IsOn)
+				target.AddHandler(PointerCanceledEvent, _logPointerCanceled, handledToo);
+			if (allEvents || _ptCaptureLost.IsOn)
+				target.AddHandler(PointerCaptureLostEvent, _logPointerCaptureLost, handledToo);
 
-			if (_manipStarting.IsOn)
+			if (allEvents || _manipStarting.IsOn)
 				target.AddHandler(ManipulationStartingEvent, _logManipulationStarting, handledToo);
-			if (_manipStarted.IsOn)
+			if (allEvents || _manipStarted.IsOn)
 				target.AddHandler(ManipulationStartedEvent, _logManipulationStarted, handledToo);
-			if (_manipDelta.IsOn)
+			if (allEvents || _manipDelta.IsOn)
 				target.AddHandler(ManipulationDeltaEvent, _logManipulationDelta, handledToo);
-			if (_manipCompleted.IsOn)
+			if (allEvents || _manipCompleted.IsOn)
 				target.AddHandler(ManipulationCompletedEvent, _logManipulationCompleted, handledToo);
 
-			if (_gestureTapped.IsOn)
+			if (allEvents || _gestureTapped.IsOn)
 				target.AddHandler(TappedEvent, _logTapped, handledToo);
-			if (_gestureDoubleTapped.IsOn)
+			if (allEvents || _gestureDoubleTapped.IsOn)
 				target.AddHandler(DoubleTappedEvent, _logDoubleTapped, handledToo);
 		}
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml.cs
@@ -20,7 +20,7 @@ using Uno.Extensions.ValueType;
 
 namespace UITests.Shared.Windows_UI_Input.GestureRecognizer
 {
-	[SampleControlInfo("Gesture recognizer", "Pointer Events")]
+	[SampleControlInfo("Gesture recognizer", "Pointer Events test bench")]
 	public sealed partial class PointersEvents : Page
 	{
 		private static readonly IDictionary<string, ManipulationModes> _manipulationModes = new Dictionary<string, ManipulationModes>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml.cs
@@ -2,107 +2,361 @@
 using Windows.UI.Xaml.Input;
 using Uno.UI.Samples.Controls;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using Windows.Devices.Input;
+using Windows.UI.Core;
 using Windows.UI.Input;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Documents;
+using Uno.Extensions;
 
 namespace UITests.Shared.Windows_UI_Input.GestureRecognizer
 {
 	[SampleControlInfo("Gesture recognizer", "Pointer Events")]
 	public sealed partial class PointersEvents : Page
 	{
+		private static readonly IDictionary<string, ManipulationModes> _manipulationModes = new Dictionary<string, ManipulationModes>
+		{
+			{"System", ManipulationModes.System},
+			{"None", ManipulationModes.None},
+			{"Translate", ManipulationModes.TranslateX | ManipulationModes.TranslateRailsX | ManipulationModes.TranslateY | ManipulationModes.TranslateRailsY | ManipulationModes.TranslateInertia},
+			{"Translate X", ManipulationModes.TranslateX | ManipulationModes.TranslateRailsX | ManipulationModes.TranslateInertia},
+			{"Translate Y", ManipulationModes.TranslateY | ManipulationModes.TranslateRailsY | ManipulationModes.TranslateInertia},
+			{"Rotate", ManipulationModes.Rotate | ManipulationModes.RotateInertia},
+			{"Scale", ManipulationModes.Scale | ManipulationModes.ScaleInertia},
+		};
+
+		private readonly ObservableCollection<RoutedEventLogEntry> _eventLog = new ObservableCollection<RoutedEventLogEntry>();
+
+		private readonly PointerEventHandler _logPointerEntered;
+		private readonly PointerEventHandler _logPointerPressed;
+		private readonly PointerEventHandler _logPointerMoved;
+		private readonly PointerEventHandler _logPointerReleased;
+		private readonly PointerEventHandler _logPointerExited;
+		private readonly PointerEventHandler _logPointerCanceled;
+		private readonly PointerEventHandler _logPointerCaptureLost;
+		private readonly ManipulationStartingEventHandler _logManipulationStarting;
+		private readonly ManipulationStartedEventHandler _logManipulationStarted;
+		private readonly ManipulationDeltaEventHandler _logManipulationDelta;
+		private readonly ManipulationCompletedEventHandler _logManipulationCompleted;
+		private readonly TappedEventHandler _logTapped;
+		private readonly DoubleTappedEventHandler _logDoubleTapped;
+		
 		public PointersEvents()
 		{
+			_logPointerPressed = new PointerEventHandler((snd, e) =>
+			{
+				Log(PointerPressedEvent, "Pressed")(snd, e);
+				if (_capture.IsOn)
+				{
+					((UIElement)snd).CapturePointer(e.Pointer);
+				}
+			});
+
+			_logPointerEntered = new PointerEventHandler(Log(PointerEnteredEvent, "Entered"));
+			_logPointerMoved = new PointerEventHandler(Log(PointerMovedEvent, "Moved"));
+			_logPointerReleased = new PointerEventHandler(Log(PointerReleasedEvent, "Released"));
+			_logPointerExited = new PointerEventHandler(Log(PointerExitedEvent, "Exited"));
+			_logPointerCanceled = new PointerEventHandler(Log(PointerCanceledEvent, "Canceled"));
+			_logPointerCaptureLost = new PointerEventHandler(Log(PointerCaptureLostEvent, "CaptureLost"));
+			_logManipulationStarting = new ManipulationStartingEventHandler(Log(ManipulationStartingEvent, "Manip starting"));
+			_logManipulationStarted = new ManipulationStartedEventHandler(Log(ManipulationStartedEvent, "Manip started"));
+			_logManipulationDelta = new ManipulationDeltaEventHandler(Log(ManipulationDeltaEvent, "Manip delta"));
+			_logManipulationCompleted = new ManipulationCompletedEventHandler(Log(ManipulationCompletedEvent, "Manip completed"));
+			_logTapped = new TappedEventHandler(Log(TappedEvent, "Tapped"));
+			_logDoubleTapped = new DoubleTappedEventHandler(Log(DoubleTappedEvent, "DoubleTapped"));
+
 			this.InitializeComponent();
 
-			// Those are the base pointers events from which the gestures are built
-			_touchTarget.PointerEntered += (snd, e) =>
-			{
-				Log(e, "Entered");
-			};
-			_touchTarget.PointerPressed += (snd, e) =>
-			{
-				Log(e, "Pressed");
-				CapturePointer(e.Pointer);
-			};
-			_touchTarget.PointerMoved += (snd, e) =>
-			{
-				Log(e, "Moved");
-			};
-			_touchTarget.PointerReleased += (snd, e) =>
-			{
-				Log(e, "Released");
-			};
-			_touchTarget.PointerCanceled += (snd, e) =>
-			{
-				Log(e, "Canceled");
-			};
-			_touchTarget.PointerExited += (snd, e) =>
-			{
-				Log(e, "Exited");
-			};
-			_touchTarget.PointerCaptureLost += (snd, e) =>
-			{
-				Log(e, "Capture lost");
-			};
-
-			// Those events are built using the GestureRecognizer
-			_touchTarget.Tapped += (snd, e) =>
-			{
-				Log($"[GESTURE] Tapped: type={e.PointerDeviceType} | position={e.GetPosition(this)}");
-			};
-			_touchTarget.DoubleTapped += (snd, e) =>
-			{
-				Log($"[GESTURE] Double tapped: type={e.PointerDeviceType} | position={e.GetPosition(this)}");
-			};
-
-			_flashingZone.PointerEntered += (snd, e) =>
-			{
-				Log(e, "FLASHING Entered");
-			};
-			_flashingZone.PointerExited += (snd, e) =>
-			{
-				Log(e, "FLASHING Exited");
-			};
-			//var timer = new DispatcherTimer()
-			//{
-			//	Interval = TimeSpan.FromSeconds(15)
-			//};
-			//timer.Tick += (snd, e) => { _flashingZone.Visibility = _flashingZone.Visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible; };
-			//timer.Start();
+			_log.ItemsSource = _eventLog;
+			_pointerType.ItemsSource = Enum.GetNames(typeof(PointerDeviceType));
+			_pointerType.SelectedValue = PointerDeviceType.Touch.ToString();
+			_manipMode.ItemsSource = _manipulationModes.Keys;
+			_manipMode.SelectedValue = _manipulationModes.First().Key;
 		}
 
-		private void OnButtonClicked(object sender, RoutedEventArgs e)
+		private Action<object, RoutedEventArgs> Log(RoutedEvent evt, string eventName)
+			=> (object sender, RoutedEventArgs args) => _eventLog.Add(new RoutedEventLogEntry(evt, eventName, sender, args, Validate(sender, evt, args)));
+
+		private void ClearLog(object sender, RoutedEventArgs e)
+			=> _eventLog.Clear();
+
+		private void OnPointerTypeChanged(object sender, SelectionChangedEventArgs e)
 		{
-			Log("[BUTTON] Button clicked");
+			if (!Enum.TryParse<PointerDeviceType>(_pointerType.SelectedValue?.ToString(), out var type))
+			{
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+				Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => _pointerType.SelectedValue = PointerDeviceType.Mouse.ToString());
+#pragma warning restore CS4014
+				return;
+			}
+
+			OnConfigChanged(sender, e);
 		}
 
-		private void OnButtonTapped(object sender, TappedRoutedEventArgs e)
+		private void OnManipModeChanged(object sender, SelectionChangedEventArgs e)
+			=> OnConfigChanged(sender, e);
+
+		private void OnConfigChanged(object sender, RoutedEventArgs e)
 		{
-			Log("[BUTTON] Button tapped");
+			if (_horizontalScroll.IsOn)
+			{
+				_myScrollViewer.HorizontalScrollMode = ScrollMode.Enabled;
+				_myScrollViewer.HorizontalScrollBarVisibility = ScrollBarVisibility.Visible;
+			}
+			else
+			{
+				_myScrollViewer.HorizontalScrollMode = ScrollMode.Disabled;
+				_myScrollViewer.HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden;
+			}
+			if (_verticalScroll.IsOn)
+			{
+				_myScrollViewer.VerticalScrollMode = ScrollMode.Enabled;
+				_myScrollViewer.VerticalScrollBarVisibility = ScrollBarVisibility.Visible;
+			}
+			else
+			{
+				_myScrollViewer.VerticalScrollMode = ScrollMode.Disabled;
+				_myScrollViewer.VerticalScrollBarVisibility = ScrollBarVisibility.Hidden;
+			}
+
+			if (_manipMode.SelectedValue is string modeKey
+				&& _manipulationModes.TryGetValue(modeKey, out var mode))
+			{
+				_touchTarget.ManipulationMode = mode;
+			}
+
+			var handledToo = _handledEventsToo.IsOn;
+			SetupEvents(_touchTargetParent, handledToo);
+			SetupEvents(_touchTarget, handledToo);
 		}
 
-		private void Log(PointerRoutedEventArgs e, string eventName)
+		private void SetupEvents(FrameworkElement target, bool handledToo)
 		{
-			var point = e.GetCurrentPoint(this);
-			var message = $"[POINTER] {eventName}: id={e.Pointer.PointerId} "
-				+ $"| src={e.OriginalSource}"
-				+ $"| frame={point.FrameId}"
-				+ $"| type={e.Pointer.PointerDeviceType} "
-				+ $"| position={point.Position} "
-				+ $"| rawPosition={point.RawPosition} "
-				+ $"| inContact={point.IsInContact} "
-				+ $"| inRange={point.Properties.IsInRange} "
-				+ $"| primary={point.Properties.IsPrimary}"
-				+ $"| intermediates={e.GetIntermediatePoints(this)?.Count.ToString() ?? "null"}";
+			target.RemoveHandler(PointerEnteredEvent, _logPointerEntered);
+			target.RemoveHandler(PointerPressedEvent, _logPointerPressed);
+			target.RemoveHandler(PointerMovedEvent, _logPointerMoved);
+			target.RemoveHandler(PointerReleasedEvent, _logPointerReleased);
+			target.RemoveHandler(PointerExitedEvent, _logPointerExited);
+			target.RemoveHandler(PointerCanceledEvent, _logPointerCanceled);
+			target.RemoveHandler(PointerCaptureLostEvent, _logPointerCaptureLost);
+			target.RemoveHandler(ManipulationStartingEvent, _logManipulationStarting);
+			target.RemoveHandler(ManipulationStartedEvent, _logManipulationStarted);
+			target.RemoveHandler(ManipulationDeltaEvent, _logManipulationDelta);
+			target.RemoveHandler(ManipulationCompletedEvent, _logManipulationCompleted);
+			target.RemoveHandler(TappedEvent, _logTapped);
+			target.RemoveHandler(DoubleTappedEvent, _logDoubleTapped);
 
-			Log(message);
+			target.AddHandler(PointerEnteredEvent, _logPointerEntered, handledToo);
+			target.AddHandler(PointerPressedEvent, _logPointerPressed, handledToo);
+			target.AddHandler(PointerMovedEvent, _logPointerMoved, handledToo);
+			target.AddHandler(PointerReleasedEvent, _logPointerReleased, handledToo);
+			target.AddHandler(PointerExitedEvent, _logPointerExited, handledToo);
+			target.AddHandler(PointerCanceledEvent, _logPointerCanceled, handledToo);
+			target.AddHandler(PointerCaptureLostEvent, _logPointerCaptureLost, handledToo);
+
+			if (_manipStarting.IsOn)
+				target.AddHandler(ManipulationStartingEvent, _logManipulationStarting, handledToo);
+			if (_manipStarted.IsOn)
+				target.AddHandler(ManipulationStartedEvent, _logManipulationStarted, handledToo);
+			if (_manipDelta.IsOn)
+				target.AddHandler(ManipulationDeltaEvent, _logManipulationDelta, handledToo);
+			if (_manipCompleted.IsOn)
+				target.AddHandler(ManipulationCompletedEvent, _logManipulationCompleted, handledToo);
+
+			if (_gestureTapped.IsOn)
+				target.AddHandler(TappedEvent, _logTapped, handledToo);
+			if (_gestureDoubleTapped.IsOn)
+				target.AddHandler(DoubleTappedEvent, _logDoubleTapped, handledToo);
 		}
 
-		void Log(string message)
+		private EventValidity Validate(object snd, RoutedEvent evt, RoutedEventArgs args)
 		{
-			System.Diagnostics.Debug.WriteLine(message);
-			_output.Text += message + "\r\n";
+			if (args is PointerRoutedEventArgs pointer)
+			{
+				var expectedPointerType = (PointerDeviceType)Enum.Parse(typeof(PointerDeviceType), _pointerType.SelectedValue as string);
+				if (expectedPointerType != pointer.Pointer.PointerDeviceType)
+				{
+					return EventValidity.Invalid;
+				}
+
+				var expectedPointerId = _pointerId.Text;
+				if (expectedPointerId.HasValueTrimmed()
+					&& (!uint.TryParse(expectedPointerId, out var pointerId) || pointer.Pointer.PointerId != pointerId))
+				{
+					return EventValidity.Invalid;
+				}
+
+				var properties = pointer.GetCurrentPoint(null).Properties;
+				if (!Check(_inRange, pointer.Pointer.IsInRange)
+					|| !Check(_inContact, pointer.Pointer.IsInContact))
+				{
+					return EventValidity.Invalid;
+				}
+
+				var validity = EventValidity.Valid;
+				if (CheckButton(_leftButton, properties.IsLeftButtonPressed)
+					&& CheckButton(_middleButton, properties.IsMiddleButtonPressed)
+					&& CheckButton(_rightButton,properties.IsRightButtonPressed)
+					&& CheckButton(_barrelButton, properties.IsBarrelButtonPressed)
+					&& CheckButton(_eraserButton, properties.IsEraser)
+					&& CheckButton(_x1Button, properties.IsXButton1Pressed)
+					&& CheckButton(_x2Button, properties.IsXButton2Pressed))
+				{	
+					return validity;
+				}
+				else
+				{
+					return EventValidity.Invalid;
+				}
+
+				bool CheckButton(CheckBox expected, bool actual)
+				{
+					if (!expected.IsChecked.HasValue || expected.IsChecked.Value == actual)
+					{
+						return true;
+					}
+					else if (!actual && (evt == PointerReleasedEvent || !Any(PointerPressedEvent) || Any(PointerReleasedEvent)))
+					{
+						validity = EventValidity.SequenceValid;
+						return true;
+					}
+					else
+					{
+						validity = EventValidity.Invalid;
+						return false;
+					}
+				}
+			}
+			else
+			{
+				return EventValidity.Valid;
+			}
+
+			bool Check(CheckBox expected, bool actual)
+				=> !expected.IsChecked.HasValue || expected.IsChecked.Value == actual;
+
+			bool Any(RoutedEvent re)
+				=> _eventLog.Any(e => e.Sender == snd
+					&& e.Event == re
+					&& ((PointerRoutedEventArgs)e.Args).Pointer.PointerDeviceType == pointer.Pointer.PointerDeviceType
+					&& ((PointerRoutedEventArgs)e.Args).Pointer.PointerId == pointer.Pointer.PointerId);
+		}
+
+		[Windows.UI.Xaml.Data.Bindable]
+		public class RoutedEventLogEntry
+		{
+			public RoutedEventLogEntry(RoutedEvent evt, string eventName, object sender, RoutedEventArgs args, EventValidity validity)
+			{
+				Event = evt;
+				Name = eventName;
+				Sender = sender;
+				Args = args;
+				Validity = validity;
+			}
+
+			public RoutedEvent Event { get; }
+
+			public string Name { get; }
+
+			public object Sender { get; }
+
+			public RoutedEventArgs Args { get; }
+
+			public EventValidity Validity { get; }
+
+			public string ValidityBullet
+				=> Validity == EventValidity.Valid ? "🟩 ok"
+					: Validity == EventValidity.SequenceValid ? "🟨 ~ok"
+					: "🟥 error";
+
+			public string Details
+			{
+				get
+				{
+					switch (Args)
+					{
+						case PointerRoutedEventArgs ptArgs:
+							var point = ptArgs.GetCurrentPoint(Sender as UIElement);
+							return $"ptId={ptArgs.Pointer.PointerId} "
+								+ $"| frame={point.FrameId}"
+								+ $"| type={ptArgs.Pointer.PointerDeviceType} "
+								+ $"| position={point.Position} "
+								+ $"| rawPosition={point.RawPosition} "
+								+ $"| inContact={point.IsInContact} "
+								+ $"| props={ToString(point.Properties)} "
+								+ $"| intermediates={ptArgs.GetIntermediatePoints(Sender as UIElement)?.Count.ToString() ?? "null"} ";
+
+						case ManipulationStartingRoutedEventArgs startingArgs:
+							return $"mode={startingArgs.Mode}";
+						case ManipulationStartedRoutedEventArgs startArgs:
+							return $"position={startArgs.Position} | {ToString(startArgs.Cumulative, startArgs.Cumulative)}";
+						case ManipulationDeltaRoutedEventArgs deltaArgs:
+							return $"position={deltaArgs.Position} | {ToString(deltaArgs.Delta, deltaArgs.Cumulative)}";
+						case ManipulationCompletedRoutedEventArgs endArgs:
+							return $"position={endArgs.Position} | {ToString(new ManipulationDelta {Scale = 1}, endArgs.Cumulative)}";
+
+						case TappedRoutedEventArgs tapped:
+							return $"position={tapped.GetPosition(Sender as UIElement)}";
+						case DoubleTappedRoutedEventArgs doubleTapped:
+							return $"position={doubleTapped.GetPosition(Sender as UIElement)}";
+
+						default:
+							return string.Empty;
+					}
+				}
+			}
+
+			/// <inheritdoc />
+			public override string ToString()
+				=> $"[{(Sender as FrameworkElement)?.Name ?? Sender?.ToString()}] {Name} ({Validity}) - {Details}";
+
+			private static string ToString(ManipulationDelta delta, ManipulationDelta cumulative)
+				=>  $"X=(Σ:{cumulative.Translation.X:' '000.00;'-'000.00} / Δ:{delta.Translation.X:' '00.00;'-'00.00}) "
+				+ $"| Y=(Σ:{cumulative.Translation.Y:' '000.00;'-'000.00} / Δ:{delta.Translation.Y:' '00.00;'-'00.00}) ";
+
+			private static string ToString(PointerPointProperties props)
+			{
+				var builder = new StringBuilder();
+
+				// Common
+				if (props.IsPrimary) builder.Append("primary ");
+				if (props.IsInRange) builder.Append("in_range ");
+
+				if (props.IsLeftButtonPressed) builder.Append("left ");
+				if (props.IsMiddleButtonPressed) builder.Append("middle ");
+				if (props.IsRightButtonPressed) builder.Append("right ");
+
+				// Mouse
+				if (props.IsHorizontalMouseWheel) builder.Append("scroll_Y ");
+				if (props.IsXButton1Pressed) builder.Append("alt_butt_1 ");
+				if (props.IsXButton2Pressed) builder.Append("alt_butt_2");
+
+				// Pen
+				if (props.IsBarrelButtonPressed) builder.Append("barrel ");
+				if (props.IsEraser) builder.Append("eraser ");
+
+				// Misc
+				builder.Append('(');
+				builder.Append(props.PointerUpdateKind);
+				builder.Append(')');
+
+				return builder.ToString();
+			}
+		}
+
+		public enum EventValidity
+		{
+			Valid,
+			SequenceValid,
+			Invalid,
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml
@@ -69,5 +69,38 @@
 				<TextBlock x:Name="WhenChildHandlesPointers_Result" />
 			</StackPanel>
 		</Border>
+
+		<Border
+			Width="250"
+			BorderThickness="3"
+			BorderBrush="#FFFF41"
+			HorizontalAlignment="Left"
+			VerticalAlignment="Top">
+			<StackPanel>
+				<TextBlock Text="Test duplicated tapped event" />
+				<Border
+					Width="100"
+					Height="100"
+					Background="#FFFF41"
+					Tapped="WhenMultipleTappedRecognizer_OnParentTapped">
+					<Border
+						x:Name="WhenMultipleTappedRecognizer_Target"
+						Width="70"
+						Height="70"
+						Background="#66FFFFFF"
+						Tapped="WhenMultipleTappedRecognizer_OnTargetTapped">
+						<TextBlock Text="Touch target"/>
+					</Border>
+				</Border>
+				<StackPanel Orientation="Horizontal">
+					<TextBlock Text="Tapped on parent: " />
+					<TextBlock x:Name="WhenMultipleTappedRecognizer_Result_Parent" Text="0" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal">
+					<TextBlock Text="Tapped on target: " />
+					<TextBlock x:Name="WhenMultipleTappedRecognizer_Result_Target" Text="0" />
+				</StackPanel>
+			</StackPanel>
+		</Border>
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml
@@ -11,7 +11,7 @@
 	<StackPanel>
 		<Border
 			x:Name="LocationTestRoot"
-			Width="200"
+			Width="250"
 			BorderThickness="3"
 			BorderBrush="Red"
 			HorizontalAlignment="Left"
@@ -26,8 +26,14 @@
 					Background="Red">
 					<TextBlock Text="Touch target" />
 				</Border>
-				<TextBlock>Relative to test root: <Run Name="LocationTestRelativeToRootLocation" /></TextBlock>
-				<TextBlock>Relative to target: <Run Name="LocationTestRelativeToTargetLocation" /></TextBlock>
+				<StackPanel Orientation="Horizontal">
+					<TextBlock Text="Relative to test root (physical px): " />
+					<TextBlock Name="LocationTestRelativeToRootLocation" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal">
+					<TextBlock Text="Relative to target (physical px): " />
+					<TextBlock Name="LocationTestRelativeToTargetLocation" />
+				</StackPanel>
 			</StackPanel>
 		</Border>
 	</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml
@@ -1,0 +1,34 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Input.GestureRecognizerTests.TappedTest"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Input.GestureRecognizerTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+		<Border
+			x:Name="LocationTestRoot"
+			Width="200"
+			BorderThickness="3"
+			BorderBrush="Red"
+			HorizontalAlignment="Left"
+			VerticalAlignment="Top">
+			<StackPanel>
+				<TextBlock Text="Test event args location" />
+				<Border
+					x:Name="LocationTestTarget"
+					Width="100"
+					Height="100"
+					Tapped="OnLocationTestTargetTapped"
+					Background="Red">
+					<TextBlock Text="Touch target" />
+				</Border>
+				<TextBlock>Relative to test root: <Run Name="LocationTestRelativeToRootLocation" /></TextBlock>
+				<TextBlock>Relative to target: <Run Name="LocationTestRelativeToTargetLocation" /></TextBlock>
+			</StackPanel>
+		</Border>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml
@@ -10,30 +10,63 @@
 
 	<StackPanel>
 		<Border
-			x:Name="LocationTestRoot"
+			x:Name="WhenTappedThenArgsLocationIsValid_Root"
 			Width="250"
 			BorderThickness="3"
-			BorderBrush="Red"
+			BorderBrush="#FF0018"
 			HorizontalAlignment="Left"
 			VerticalAlignment="Top">
 			<StackPanel>
 				<TextBlock Text="Test event args location" />
 				<Border
-					x:Name="LocationTestTarget"
+					x:Name="WhenTappedThenArgsLocationIsValid_Target"
 					Width="100"
 					Height="100"
-					Tapped="OnLocationTestTargetTapped"
-					Background="Red">
+					Tapped="WhenTappedThenArgsLocationIsValid_OnTargetTapped"
+					Background="#FF0018">
 					<TextBlock Text="Touch target" />
 				</Border>
 				<StackPanel Orientation="Horizontal">
 					<TextBlock Text="Relative to test root (physical px): " />
-					<TextBlock Name="LocationTestRelativeToRootLocation" />
+					<TextBlock Name="WhenTappedThenArgsLocationIsValid_Result_RelativeToRoot" />
 				</StackPanel>
 				<StackPanel Orientation="Horizontal">
 					<TextBlock Text="Relative to target (physical px): " />
-					<TextBlock Name="LocationTestRelativeToTargetLocation" />
+					<TextBlock Name="WhenTappedThenArgsLocationIsValid_Result_RelativeToTarget" />
 				</StackPanel>
+			</StackPanel>
+		</Border>
+
+		<Border
+			Width="250"
+			BorderThickness="3"
+			BorderBrush="#FFA52C"
+			HorizontalAlignment="Left"
+			VerticalAlignment="Top">
+			<StackPanel>
+				<TextBlock Text="Test when child handles all pointer events" />
+				<Border
+					Width="100"
+					Height="100"
+					Background="#FFA52C"
+					Tapped="WhenChildHandlesPointers_OnParentTapped">
+					<Border
+						x:Name="WhenChildHandlesPointers_Target"
+						Width="70"
+						Height="70"
+						Background="#66FFFFFF"
+						PointerEntered="HandlePointerEvent"
+						PointerPressed="HandlePointerEvent"
+						PointerMoved="HandlePointerEvent"
+						PointerReleased="HandlePointerEvent"
+						PointerExited="HandlePointerEvent"
+						PointerCanceled="HandlePointerEvent"
+						PointerCaptureLost="HandlePointerEvent"
+						PointerWheelChanged="HandlePointerEvent">
+						<TextBlock Text="Touch target"/>
+					</Border>
+				</Border>
+				<TextBlock x:Name="WhenChildHandlesPointers_Result" />
 			</StackPanel>
 		</Border>
 	</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
+{
+	[SampleControlInfo("Gesture recognizer")]
+	public sealed partial class TappedTest : Page
+	{
+		public TappedTest()
+		{
+			this.InitializeComponent();
+		}
+
+		private void OnLocationTestTargetTapped(object sender, TappedRoutedEventArgs e)
+		{
+			LocationTestRelativeToRootLocation.Text = e.GetPosition(LocationTestRoot).ToString();
+			LocationTestRelativeToTargetLocation.Text = e.GetPosition(LocationTestTarget).ToString();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml.cs
@@ -29,5 +29,15 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
 
 		private void WhenChildHandlesPointers_OnParentTapped(object sender, TappedRoutedEventArgs e)
 			=> WhenChildHandlesPointers_Result.Text = "Tapped";
+
+		private void WhenMultipleTappedRecognizer_OnParentTapped(object sender, TappedRoutedEventArgs e)
+			=> WhenMultipleTappedRecognizer_Result_Parent.Text = int.TryParse(WhenMultipleTappedRecognizer_Result_Parent.Text, out var count)
+				? (count + 1).ToString()
+				: "1";
+
+		private void WhenMultipleTappedRecognizer_OnTargetTapped(object sender, TappedRoutedEventArgs e)
+			=> WhenMultipleTappedRecognizer_Result_Target.Text = int.TryParse(WhenMultipleTappedRecognizer_Result_Target.Text, out var count)
+				? (count + 1).ToString()
+				: "1";
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Uno.UI;
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
@@ -16,8 +17,11 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
 
 		private void OnLocationTestTargetTapped(object sender, TappedRoutedEventArgs e)
 		{
-			LocationTestRelativeToRootLocation.Text = e.GetPosition(LocationTestRoot).ToString();
-			LocationTestRelativeToTargetLocation.Text = e.GetPosition(LocationTestTarget).ToString();
+			var relativeToRoot = e.GetPosition(LocationTestRoot).LogicalToPhysicalPixels();
+			var relativeToTarget = e.GetPosition(LocationTestTarget).LogicalToPhysicalPixels();
+
+			LocationTestRelativeToRootLocation.Text = $"({(int)relativeToRoot.X:D},{(int)relativeToRoot.Y:D})";
+			LocationTestRelativeToTargetLocation.Text = $"({(int)relativeToTarget.X:D},{(int)relativeToTarget.Y:D})";
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml.cs
@@ -15,13 +15,19 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
 			this.InitializeComponent();
 		}
 
-		private void OnLocationTestTargetTapped(object sender, TappedRoutedEventArgs e)
+		private void WhenTappedThenArgsLocationIsValid_OnTargetTapped(object sender, TappedRoutedEventArgs e)
 		{
-			var relativeToRoot = e.GetPosition(LocationTestRoot).LogicalToPhysicalPixels();
-			var relativeToTarget = e.GetPosition(LocationTestTarget).LogicalToPhysicalPixels();
+			var relativeToRoot = e.GetPosition(WhenTappedThenArgsLocationIsValid_Root).LogicalToPhysicalPixels();
+			var relativeToTarget = e.GetPosition(WhenTappedThenArgsLocationIsValid_Target).LogicalToPhysicalPixels();
 
-			LocationTestRelativeToRootLocation.Text = $"({(int)relativeToRoot.X:D},{(int)relativeToRoot.Y:D})";
-			LocationTestRelativeToTargetLocation.Text = $"({(int)relativeToTarget.X:D},{(int)relativeToTarget.Y:D})";
+			WhenTappedThenArgsLocationIsValid_Result_RelativeToRoot.Text = $"({(int)relativeToRoot.X:D},{(int)relativeToRoot.Y:D})";
+			WhenTappedThenArgsLocationIsValid_Result_RelativeToTarget.Text = $"({(int)relativeToTarget.X:D},{(int)relativeToTarget.Y:D})";
 		}
+
+		private void HandlePointerEvent(object sender, PointerRoutedEventArgs e)
+			=> e.Handled = true;
+
+		private void WhenChildHandlesPointers_OnParentTapped(object sender, TappedRoutedEventArgs e)
+			=> WhenChildHandlesPointers_Result.Text = "Tapped";
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
@@ -312,24 +312,13 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 
 				case PointerDeviceType.Pen:
 				case PointerDeviceType.Touch:
-#if __IOS__ || __ANDROID__
-					// KNOWN ISSUE:
-					//	On iOS and Android as the Entered/Exited are generated on Pressed/Released, which are Handled by the ListViewItem,
-					//	so we do not receive the expected Entered/Exited on parent control.
-					//	As a side effect we will also not receive the Tap as it is an interpretation of those missing Pointer events.
-					result =
-						args.Click()
-						&& args.End();
-#else
 					result =
 						args.One(PointerEnteredEvent)
+						&& args.MaybeSome(PointerMovedEvent)
 						&& args.Click()
-#if NETFX_CORE // We should get a Tapped on all platforms but ListView is a weird/complex control ...
 						&& args.One(TappedEvent)
-#endif
 						&& args.One(PointerExitedEvent)
 						&& args.End();
-#endif
 					break;
 			}
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
@@ -247,8 +247,6 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 #if NETFX_CORE
 						&& args.One(PointerReleasedEvent)
 						&& args.Click()
-#elif __WASM__ // KNOWN ISSUE: We don't get a released if not previously pressed, but pressed are muted by the Hyperlink which is a UIElement on wasm
-						&& args.Click()
 #else
 						&& args.Click()
 						&& args.One(PointerReleasedEvent)

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
@@ -304,9 +304,7 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 						args.One(PointerEnteredEvent)
 						&& args.Some(PointerMovedEvent) // Could be "Maybe" but WASM UI test generate it and we want to validate it
 						&& args.Click()
-#if NETFX_CORE // We should get a Tapped on all platforms but ListView is a weird/complex control ...
 						&& args.One(TappedEvent)
-#endif
 						&& args.MaybeSome(PointerMovedEvent)
 						&& args.One(PointerExitedEvent)
 						&& args.End();

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
@@ -306,18 +306,18 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 						&& args.Click()
 						&& args.One(TappedEvent)
 						&& args.MaybeSome(PointerMovedEvent)
-						&& args.One(PointerExitedEvent)
+						&& args.MaybeOne(PointerExitedEvent) // This should be "One" (Not maybe) ... but the ListView is a complex control
 						&& args.End();
 					break;
 
 				case PointerDeviceType.Pen:
 				case PointerDeviceType.Touch:
 					result =
-						args.One(PointerEnteredEvent)
+						args.MaybeOne(PointerEnteredEvent) // This should be "One" (Not maybe) ... but the ListView is a complex control
 						&& args.MaybeSome(PointerMovedEvent)
 						&& args.Click()
-						&& args.One(TappedEvent)
-						&& args.One(PointerExitedEvent)
+						&& args.MaybeOne(TappedEvent) // This should be "One" (Not maybe) ... but the ListView is a complex control
+						&& args.MaybeOne(PointerExitedEvent) // This should be "One" (Not maybe) ... but the ListView is a complex control
 						&& args.End();
 					break;
 			}

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -1000,7 +1000,7 @@ var Uno;
                     }
                     src = src.parentElement;
                 }
-                return `${evt.pointerId};${evt.clientX};${evt.clientY};${(evt.ctrlKey ? "1" : "0")};${(evt.shiftKey ? "1" : "0")};${evt.button};${evt.pointerType};${srcHandle};${evt.timeStamp}`;
+                return `${evt.pointerId};${evt.clientX};${evt.clientY};${(evt.ctrlKey ? "1" : "0")};${(evt.shiftKey ? "1" : "0")};${evt.buttons};${evt.button};${evt.pointerType};${srcHandle};${evt.timeStamp}`;
             }
             /**
              * keyboard event extractor to be used with registerEventOnView

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -901,7 +901,7 @@
 				src = src.parentElement;
 			}
 
-			return `${evt.pointerId};${evt.clientX};${evt.clientY};${(evt.ctrlKey ? "1" : "0")};${(evt.shiftKey ? "1" : "0")};${evt.button};${evt.pointerType};${srcHandle};${evt.timeStamp}`;
+			return `${evt.pointerId};${evt.clientX};${evt.clientY};${(evt.ctrlKey ? "1" : "0")};${(evt.shiftKey ? "1" : "0")};${evt.buttons};${evt.button};${evt.pointerType};${srcHandle};${evt.timeStamp}`;
 		}
 
 		/**

--- a/src/Uno.UI/Extensions/ViewHelper.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/ViewHelper.iOSmacOS.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Runtime.CompilerServices;
 using Uno.UI.Extensions;
 using Uno.Logging;
 using Uno.Extensions;
@@ -61,6 +62,7 @@ namespace Uno.UI
 			} 
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static CGSize PhysicalToLogicalPixels(this CGSize size)
 		{
 			return size;
@@ -68,6 +70,7 @@ namespace Uno.UI
 			// return new SizeF(size.Width / MainScreenScale, size.Height / MainScreenScale);
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Windows.Foundation.Size PhysicalToLogicalPixels(this Windows.Foundation.Size size)
 		{
 			return size;
@@ -75,6 +78,7 @@ namespace Uno.UI
 			// return new SizeF(size.Width / MainScreenScale, size.Height / MainScreenScale);
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static CGSize LogicalToPhysicalPixels(this Windows.Foundation.Size size)
 		{
 			var ret = new CGSize((nfloat)size.Width, (nfloat)size.Height);
@@ -83,6 +87,7 @@ namespace Uno.UI
 			// return new SizeF(size.Width * MainScreenScale, size.Height * MainScreenScale);
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static CGSize LogicalToPhysicalPixels(this CGSize size)
 		{
 			return size;
@@ -90,6 +95,7 @@ namespace Uno.UI
 			// return new SizeF(size.Width * MainScreenScale, size.Height * MainScreenScale);
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static CGRect PhysicalToLogicalPixels(this CGRect size)
 		{
 			return size;
@@ -102,6 +108,19 @@ namespace Uno.UI
 			//);
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Windows.Foundation.Point PhysicalToLogicalPixels(this Windows.Foundation.Point point)
+		{
+			return point;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Windows.Foundation.Point LogicalToPhysicalPixels(this Windows.Foundation.Point point)
+		{
+			return point;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static CGRect LogicalToPhysicalPixels(this CGRect size)
 		{
 			// https://markpospesel.wordpress.com/2013/02/27/cgrectintegral/

--- a/src/Uno.UI/Extensions/ViewHelper.net.cs
+++ b/src/Uno.UI/Extensions/ViewHelper.net.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Windows.Foundation;
+
+namespace Uno.UI
+{
+	public static class ViewHelper
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Size PhysicalToLogicalPixels(this Size size)
+			=> size;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Size LogicalToPhysicalPixels(this Size size)
+			=> size;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Rect LogicalToPhysicalPixels(this Rect rect)
+			=> rect;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Rect PhysicalToLogicalPixels(this Rect rect)
+			=> rect;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Point PhysicalToLogicalPixels(this Point point)
+			=> point;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Point LogicalToPhysicalPixels(this Point point)
+			=> point;
+	}
+}

--- a/src/Uno.UI/Extensions/ViewHelper.wasm.cs
+++ b/src/Uno.UI/Extensions/ViewHelper.wasm.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Windows.Foundation;
+
+namespace Uno.UI
+{
+	public static class ViewHelper
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Size PhysicalToLogicalPixels(this Size size)
+			=> size;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Size LogicalToPhysicalPixels(this Size size)
+			=> size;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Rect LogicalToPhysicalPixels(this Rect rect)
+			=> rect;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Rect PhysicalToLogicalPixels(this Rect rect)
+			=> rect;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Point PhysicalToLogicalPixels(this Point point)
+			=> point;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Point LogicalToPhysicalPixels(this Point point)
+			=> point;
+	}
+}

--- a/src/Uno.UI/Mixins/Android/VisualStatesMixins.tt
+++ b/src/Uno.UI/Mixins/Android/VisualStatesMixins.tt
@@ -9,6 +9,7 @@
 	AddClass("Windows.UI.Xaml.Controls", "RadioButton", hasCommonStates: true, hasCheckedStates: true, hasCommonOverState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "HyperlinkButton", hasCommonStates: true, hasCommonOverState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "DatePicker", hasCommonStates: true);
+	AddClass("Windows.UI.Xaml.Controls", "ToggleSwitch", hasCommonStates: true, hasCommonOverState: true, hasCommonPressedState: true);
 #>
 <#@include file="..\..\UI\Xaml\Controls\VisualStatesImplementation.tt"#>
 #endif

--- a/src/Uno.UI/Mixins/Wasm/VisualStatesMixins.tt
+++ b/src/Uno.UI/Mixins/Wasm/VisualStatesMixins.tt
@@ -8,6 +8,7 @@
 	AddClass("Windows.UI.Xaml.Controls", "RadioButton", hasCommonStates: true, hasCheckedStates: true, hasCommonOverState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "HyperlinkButton", hasCommonStates: true, hasCommonOverState: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "CheckBox", hasCommonStates: true, hasCombinedCheckedState: true, hasCommonOverState: true, hasCommonPressedState: true);
+	AddClass("Windows.UI.Xaml.Controls", "ToggleSwitch", hasCommonStates: true, hasCommonOverState: true, hasCommonPressedState: true);
 #>
 <#@include file="..\..\UI\Xaml\Controls\VisualStatesImplementation.tt"#>
 #endif

--- a/src/Uno.UI/Mixins/iOS/VisualStatesMixins.tt
+++ b/src/Uno.UI/Mixins/iOS/VisualStatesMixins.tt
@@ -8,6 +8,7 @@
 	AddClass("Windows.UI.Xaml.Controls", "RadioButton", hasCommonStates: true, hasCheckedStates: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "HyperlinkButton", hasCommonStates: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "CheckBox", hasCommonStates: true, hasCombinedCheckedState: true, hasCommonPressedState: true);
+	AddClass("Windows.UI.Xaml.Controls", "ToggleSwitch", hasCommonStates: true, hasCommonPressedState: true);
 #>
 <#@include file="..\..\UI\Xaml\Controls\VisualStatesImplementation.tt"#>
 #endif

--- a/src/Uno.UI/Mixins/macOS/VisualStatesMixins.tt
+++ b/src/Uno.UI/Mixins/macOS/VisualStatesMixins.tt
@@ -8,6 +8,7 @@
 	AddClass("Windows.UI.Xaml.Controls", "RadioButton", hasCommonStates: true, hasCheckedStates: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "HyperlinkButton", hasCommonStates: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "CheckBox", hasCommonStates: true, hasCombinedCheckedState: true, hasCommonPressedState: true);
+	AddClass("Windows.UI.Xaml.Controls", "ToggleSwitch", hasCommonStates: true, hasCommonOverState: true, hasCommonPressedState: true);
 #>
 <#@include file="..\..\UI\Xaml\Controls\VisualStatesImplementation.tt"#>
 #endif

--- a/src/Uno.UI/Mixins/net461/VisualStatesMixins.tt
+++ b/src/Uno.UI/Mixins/net461/VisualStatesMixins.tt
@@ -8,6 +8,7 @@
 	AddClass("Windows.UI.Xaml.Controls", "RadioButton", hasCommonStates: true, hasCheckedStates: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "HyperlinkButton", hasCommonStates: true, hasCommonPressedState: true);
 	AddClass("Windows.UI.Xaml.Controls", "CheckBox", hasCommonStates: true, hasCombinedCheckedState: true, hasCommonPressedState: true);
+	AddClass("Windows.UI.Xaml.Controls", "ToggleSwitch", hasCommonStates: true, hasCommonOverState: true, hasCommonPressedState: true);
 #>
 <#@include file="..\..\UI\Xaml\Controls\VisualStatesImplementation.tt"#>
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -55,7 +55,6 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override bool IsSimpleLayout => true;
 
-
 		private void SetDefaultForeground()
 		{
 			//override the default value from dependency property based on application theme
@@ -638,9 +637,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsFocusableChanged();
 		internal bool IsFocusable =>
-			Visibility == Visibility.Visible &&
-			IsEnabled &&
-			IsTabStop;
+			Visibility == Visibility.Visible
+			&& IsEnabled
+			&& IsTabStop;
 
 		public bool Focus(FocusState value)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/DragCompletedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/DragCompletedEventArgs.cs
@@ -6,26 +6,25 @@ namespace Windows.UI.Xaml.Controls.Primitives
 {
 	public partial class DragCompletedEventArgs : RoutedEventArgs
 	{
-		public bool Canceled
-		{
-			get;
-		}
-
-		public double HorizontalChange
-		{
-			get;
-		}
-
-		public double VerticalChange
-		{
-			get;
-		}
-
 		public DragCompletedEventArgs(double horizontalChange, double verticalChange, bool canceled)
 		{
 			Canceled = canceled;
 			HorizontalChange = horizontalChange;
 			VerticalChange = verticalChange;
 		}
+
+		public DragCompletedEventArgs(object originalSource, double horizontalChange, double verticalChange, bool canceled)
+			: base(originalSource)
+		{
+			Canceled = canceled;
+			HorizontalChange = horizontalChange;
+			VerticalChange = verticalChange;
+		}
+
+		public bool Canceled { get; }
+
+		public double HorizontalChange { get; }
+
+		public double VerticalChange { get; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/DragDeltaEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/DragDeltaEventArgs.cs
@@ -6,20 +6,22 @@ namespace Windows.UI.Xaml.Controls.Primitives
 {
 	public partial class DragDeltaEventArgs : RoutedEventArgs
 	{
-		public double HorizontalChange
-		{
-			get;
-		}
-
-		public double VerticalChange
-		{
-			get;
-		}
-
 		public DragDeltaEventArgs(double horizontalChange, double verticalChange)
 		{
 			HorizontalChange = horizontalChange;
 			VerticalChange = verticalChange;
 		}
+
+		internal DragDeltaEventArgs(object originalSource, double horizontalChange, double verticalChange)
+			: base(originalSource)
+		{
+			HorizontalChange = horizontalChange;
+			VerticalChange = verticalChange;
+		}
+
+		public double HorizontalChange { get; }
+
+		public double VerticalChange { get; }
+
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/DragStartedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/DragStartedEventArgs.cs
@@ -6,20 +6,23 @@ namespace Windows.UI.Xaml.Controls.Primitives
 {
 	public partial class DragStartedEventArgs : RoutedEventArgs
 	{
-		public double HorizontalOffset
-		{
-			get;
-		}
-
-		public double VerticalOffset
-		{
-			get;
-		}
-
-		public  DragStartedEventArgs(double horizontalOffset, double verticalOffset)
+		public DragStartedEventArgs(double horizontalOffset, double verticalOffset)
 		{
 			HorizontalOffset = horizontalOffset;
 			VerticalOffset = verticalOffset;
 		}
+
+		internal DragStartedEventArgs(object originalSource, double horizontalOffset, double verticalOffset)
+			: base(originalSource)
+		{
+			HorizontalOffset = horizontalOffset;
+			VerticalOffset = verticalOffset;
+		}
+
+
+		public double HorizontalOffset { get; }
+
+		public double VerticalOffset { get; }
+
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Thumb.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Thumb.cs
@@ -76,7 +76,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 			if (ShouldCapturePointer)
 			{
-				args.Handled = true;
+				// Note: We don't handle event as UWP does not, and otherwise it will prevent parent control to update its visual state
 				CapturePointer(args.Pointer);
 				StartDrag(args.GetCurrentPoint(this).Position);
 			}
@@ -88,7 +88,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 			if (ShouldCapturePointer)
 			{
-				args.Handled = true;
+				// Note: We don't handle event as UWP does not, and otherwise it will prevent parent control to update its visual state
 				ReleasePointerCapture(args.Pointer);
 				CompleteDrag(args.GetCurrentPoint(this).Position);
 			}
@@ -100,7 +100,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 			if (ShouldCapturePointer)
 			{
-				args.Handled = true;
+				// Note: We don't handle event as UWP does not, and otherwise it will prevent parent control to update its visual state
 				ReleasePointerCapture(args.Pointer);
 				CompleteDrag(args.GetCurrentPoint(this).Position);
 			}
@@ -112,7 +112,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 			if (ShouldCapturePointer && IsCaptured(args.Pointer))
 			{
-				args.Handled = true;
+				// Note: We don't handle event as UWP does not, and otherwise it will prevent parent control to update its visual state
 				DeltaDrag(args.GetCurrentPoint(this).Position);
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Thumb.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Thumb.cs
@@ -56,18 +56,18 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			_startLocation = location;
 
 			IsDragging = true;
-			DragStarted?.Invoke(this, new DragStartedEventArgs(0, 0));
+			DragStarted?.Invoke(this, new DragStartedEventArgs(this, 0, 0));
 		}
 
 		internal void DeltaDrag(Point location)
 		{
-			DragDelta?.Invoke(this, new DragDeltaEventArgs(location.X - _startLocation.X, location.Y - _startLocation.Y));
+			DragDelta?.Invoke(this, new DragDeltaEventArgs(this, location.X - _startLocation.X, location.Y - _startLocation.Y));
 		}
 
 		internal void CompleteDrag(Point location)
 		{
 			IsDragging = false;
-			DragCompleted?.Invoke(this, new DragCompletedEventArgs(location.X - _startLocation.X, location.Y - _startLocation.Y, false));
+			DragCompleted?.Invoke(this, new DragCompletedEventArgs(this, location.X - _startLocation.X, location.Y - _startLocation.Y, false));
 		}
 
 		protected override void OnPointerPressed(PointerRoutedEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
@@ -57,15 +57,8 @@ namespace Windows.UI.Xaml.Controls
 			_horizontalThumb = GetTemplateChild("HorizontalThumb") as Thumb;
 			_verticalThumb = GetTemplateChild("VerticalThumb") as Thumb;
 
-			if (_horizontalThumb != null)
-			{
-				_horizontalThumb.ShouldCapturePointer = false;
-			}
-
-			if (_verticalThumb != null)
-			{
-				_verticalThumb.ShouldCapturePointer = false;
-			}
+			_horizontalThumb?.DisablePointersTracking();
+			_verticalThumb?.DisablePointersTracking();
 
 			_verticalTemplate = GetTemplateChild("VerticalTemplate") as FrameworkElement;
 			_verticalTrackRect = GetTemplateChild("VerticalTrackRect") as Rectangle;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -639,6 +639,9 @@ namespace Windows.UI.Xaml.Controls
 			if (sender is Hyperlink hyperlink
 				&& hyperlink.IsCaptured(e.Pointer))
 			{
+				// Un UWP we don't get the Tapped event, so make sure to abort it
+				(hyperlink.GetParent() as TextBlock)?.CompleteGesture();
+
 				hyperlink.ReleasePointerPressed(e.Pointer);
 			}
 
@@ -689,6 +692,9 @@ namespace Windows.UI.Xaml.Controls
 			if (sender is TextBlock that
 				&& that.IsCaptured(e.Pointer))
 			{
+				// On UWP we don't get the Tapped event, so make sure to abort it.
+				that.CompleteGesture();
+
 				// On UWP we don't get any CaptureLost, so make sure to manually release the capture silently
 				that.ReleasePointerCapture(e.Pointer, muteEvent: true);
 

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch.cs
@@ -35,6 +35,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public ToggleSwitch()
 		{
+			InitializeVisualStates();
 		}
 
 		protected override void OnLoaded()

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Uno.Disposables;
 using Windows.UI.Xaml.Automation.Peers;
@@ -43,10 +44,7 @@ namespace Windows.UI.Xaml.Controls
 			if (!IsNativeTemplate)
 			{
 				AddHandler(PointerPressedEvent, (PointerEventHandler)OnPointerPressed, true);
-				AddHandler(PointerExitedEvent, (PointerEventHandler)OnPointerExited, true);
 				AddHandler(PointerReleasedEvent, (PointerEventHandler)OnPointerReleased, true);
-				AddHandler(PointerCanceledEvent, (PointerEventHandler)OnPointerCanceled, true);
-				AddHandler(PointerEnteredEvent, (PointerEventHandler)OnPointerEntered, true);
 			}
 
 			OnLoadedPartial();
@@ -61,10 +59,7 @@ namespace Windows.UI.Xaml.Controls
 			if (!IsNativeTemplate)
 			{
 				RemoveHandler(PointerPressedEvent, (PointerEventHandler) OnPointerPressed);
-				RemoveHandler(PointerExitedEvent, (PointerEventHandler) OnPointerExited);
 				RemoveHandler(PointerReleasedEvent, (PointerEventHandler) OnPointerReleased);
-				RemoveHandler(PointerCanceledEvent, (PointerEventHandler) OnPointerCanceled);
-				RemoveHandler(PointerEnteredEvent, (PointerEventHandler) OnPointerEntered);
 			}
 		}
 
@@ -84,42 +79,16 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnPointerPressed(object sender, PointerRoutedEventArgs args)
 		{
-			IsPointerOver = true;
-			IsPointerPressed = true;
 			args.Handled = true;
 			Focus(FocusState.Pointer);
-			UpdateCommonState();
-		}
-
-		private void OnPointerExited(object sender, PointerRoutedEventArgs args)
-		{
-			IsPointerOver = false;
-			UpdateCommonState();
 		}
 
 		private void OnPointerReleased(object sender, PointerRoutedEventArgs args)
 		{
-			IsPointerOver = false;
-			IsPointerPressed = false;
-			UpdateCommonState();
-
 			if (_switchThumb == null)
 			{
 				IsOn = !IsOn;
 			}
-		}
-
-		private void OnPointerCanceled(object sender, PointerRoutedEventArgs args)
-		{
-			IsPointerOver = false;
-			IsPointerPressed = false;
-			UpdateCommonState();
-		}
-
-		private void OnPointerEntered(object sender, PointerRoutedEventArgs args)
-		{
-			IsPointerOver = true;
-			UpdateCommonState();
 		}
 
 		protected virtual void OnToggled()
@@ -203,7 +172,6 @@ namespace Windows.UI.Xaml.Controls
 
 			_eventSubscriptions.Disposable = RegisterHandlers();
 
-			UpdateCommonState(false);
 			UpdateToggleState(false);
 			UpdateContentState(false);
 		}
@@ -244,9 +212,6 @@ namespace Windows.UI.Xaml.Controls
 			_maxDragDistance = 0;
 			UpdateSwitchKnobPosition(e.HorizontalOffset);
 
-			IsPointerPressed = true;
-			IsPointerOver = true;
-			UpdateCommonState();
 			UpdateToggleState();
 		}
 
@@ -270,9 +235,6 @@ namespace Windows.UI.Xaml.Controls
 
 			UpdateSwitchKnobPosition(0);
 
-			IsPointerPressed = false;
-			IsPointerOver = false;
-			UpdateCommonState();
 			UpdateToggleState();
 		}
 
@@ -302,22 +264,6 @@ namespace Windows.UI.Xaml.Controls
 			if (_knobTranslateTransform != null)
 			{
 				_knobTranslateTransform.X = GetAbsoluteOffset(relativeOffset);
-			}
-		}
-
-		private void UpdateCommonState(bool useTransitions = true)
-		{
-			if (!IsEnabled)
-			{
-				VisualStateManager.GoToState(this, "Disabled", useTransitions);
-			}
-			else if (IsPointerPressed && IsPointerOver)
-			{
-				VisualStateManager.GoToState(this, "Pressed", useTransitions);
-			}
-			else
-			{
-				VisualStateManager.GoToState(this, "Normal", useTransitions);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch.cs
@@ -247,7 +247,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			// If the user only drags the thumb by a few pixels before releasing it, 
 			// we interpret it as a Tap rather than a drag gesture.
-			// Note: We do not use the Tapped event as this offers a better sync between 
+			// Note: We do not use the Tapped event as this offers a better sync between
+			//		 the drag state / events and the IsOn update.
 			if (_maxDragDistance < GestureRecognizer.TapMaxXDelta)
 			{
 				IsOn = !IsOn;

--- a/src/Uno.UI/UI/Xaml/Input/DoubleTappedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/DoubleTappedRoutedEventArgs.cs
@@ -10,33 +10,36 @@ namespace Windows.UI.Xaml.Input
 {
 	public sealed partial class DoubleTappedRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
 	{
+		private readonly UIElement _originalSource;
 		private readonly Point _position;
 
 		public DoubleTappedRoutedEventArgs() { }
 
-		internal DoubleTappedRoutedEventArgs(object originalSource, TappedEventArgs args)
+		internal DoubleTappedRoutedEventArgs(UIElement originalSource, TappedEventArgs args)
 			: base(originalSource)
 		{
+			_originalSource = originalSource;
 			PointerDeviceType = args.PointerDeviceType;
 			_position = args.Position;
 		}
 
-		public Point GetPosition()
-			=> _position;
-
 		public bool Handled { get; set; }
 
-		public PointerDeviceType PointerDeviceType { get; internal set; }
+		public PointerDeviceType PointerDeviceType { get; }
 
 		public Point GetPosition(UIElement relativeTo)
 		{
-			if (relativeTo == null)
+			if (_originalSource == null)
+			{
+				return default; // Required for the default public ctor ...
+			}
+			else if(relativeTo == _originalSource)
 			{
 				return _position;
 			}
 			else
 			{
-				return relativeTo.GetPosition(_position, relativeTo);
+				return _originalSource.GetPosition(_position, relativeTo);
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -48,17 +48,20 @@ namespace Windows.UI.Xaml.Input
 				// Don't change the focus if the element already has the focus
 				&& !ReferenceEquals(element, _focusedElement))
 			{
-				// Make sure that the managed UI knowns that the element was unfocused, no matter if the new focused element can be focused or not
-				(_focusedElement as Control)?.SetFocused(false);
-
 				// Try to find the first focusable parent and set it as focused, otherwise just keep it for reference (GetFocusedElement())
 				var ownerControl = element.GetParents().OfType<Control>().Where(control => control.IsFocusable).FirstOrDefault();
 				if (ownerControl == null)
 				{
+					// Make sure that the managed UI knows that the element was unfocused, no matter if the new focused element can be focused or not
+					(_focusedElement as Control)?.SetFocused(false);
+
 					_focusedElement = element;
 				}
-				else
+				else if (!ReferenceEquals(ownerControl, _focusedElement))
 				{
+					// Make sure that the managed UI knows that the element was unfocused, no matter if the new focused element can be focused or not
+					(_focusedElement as Control)?.SetFocused(false);
+
 					if (ownerControl.SetFocused(true))
 					{
 						_fallbackFocusedElement = element;

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.cs
@@ -28,6 +28,8 @@ namespace Windows.UI.Xaml.Input
 
 		internal uint FrameId { get; }
 
+		internal bool CanceledByDirectManipulation { get; set; }
+
 		public bool IsGenerated { get; } = false; // Generated events are not supported by UNO
 
 		public bool Handled { get; set; }

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.wasm.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Globalization;
-using System.Threading;
 using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Input;
-using Uno;
-using Uno.Extensions;
 using Uno.Foundation;
+using Uno.UI.Xaml;
 
 namespace Windows.UI.Xaml.Input
 {
@@ -15,8 +12,8 @@ namespace Windows.UI.Xaml.Input
 	{
 		private readonly double _timestamp;
 		private readonly Point _absolutePosition;
-		private readonly VirtualKey _button;
-		private readonly PointerUpdateKind _updateKind;
+		private readonly WindowManagerInterop.HtmlPointerButtonsState _buttons;
+		private readonly WindowManagerInterop.HtmlPointerButtonUpdate _buttonUpdate;
 
 		internal PointerRoutedEventArgs(
 			double timestamp,
@@ -24,17 +21,17 @@ namespace Windows.UI.Xaml.Input
 			PointerDeviceType pointerType,
 			Point absolutePosition,
 			bool isInContact,
-			VirtualKey button,
+			WindowManagerInterop.HtmlPointerButtonsState buttons,
+			WindowManagerInterop.HtmlPointerButtonUpdate buttonUpdate,
 			VirtualKeyModifiers keys,
-			PointerUpdateKind updateKind,
 			UIElement source,
 			bool canBubbleNatively)
 			: this()
 		{
 			_timestamp = timestamp;
 			_absolutePosition = absolutePosition;
-			_button = button;
-			_updateKind = updateKind;
+			_buttons = buttons;
+			_buttonUpdate = buttonUpdate;
 
 			FrameId = ToFrameId(timestamp);
 			Pointer = new Pointer(pointerId, pointerType, isInContact, isInRange: true);
@@ -62,15 +59,27 @@ namespace Windows.UI.Xaml.Input
 			{
 				IsPrimary = true,
 				IsInRange = Pointer.IsInRange,
-				PointerUpdateKind = _updateKind
 			};
 
-			if (Pointer.IsInContact)
+			props.IsLeftButtonPressed = _buttons.HasFlag(WindowManagerInterop.HtmlPointerButtonsState.Left);
+			props.IsMiddleButtonPressed = _buttons.HasFlag(WindowManagerInterop.HtmlPointerButtonsState.Middle);
+			if (_buttons.HasFlag(WindowManagerInterop.HtmlPointerButtonsState.Right))
 			{
-				props.IsLeftButtonPressed = _button == VirtualKey.LeftButton;
-				props.IsMiddleButtonPressed = _button == VirtualKey.MiddleButton;
-				props.IsRightButtonPressed = _button == VirtualKey.RightButton;
+				switch (Pointer.PointerDeviceType)
+				{
+					case PointerDeviceType.Mouse:
+						props.IsMiddleButtonPressed = true;
+						break;
+					case PointerDeviceType.Pen:
+						props.IsBarrelButtonPressed = true;
+						break;
+				}
 			}
+			props.IsXButton1Pressed = _buttons.HasFlag(WindowManagerInterop.HtmlPointerButtonsState.X1);
+			props.IsXButton2Pressed = _buttons.HasFlag(WindowManagerInterop.HtmlPointerButtonsState.X2);
+			props.IsEraser = _buttons.HasFlag(WindowManagerInterop.HtmlPointerButtonsState.Eraser);
+
+			props.PointerUpdateKind = ToUpdateKind(_buttonUpdate, props);
 
 			return props;
 		}
@@ -92,6 +101,24 @@ namespace Windows.UI.Xaml.Input
 		{
 			// Known limitation: After 49 days, we will overflow the uint and frame IDs will restart at 0.
 			return (uint)(timestamp % uint.MaxValue);
+		}
+
+		private static PointerUpdateKind ToUpdateKind(WindowManagerInterop.HtmlPointerButtonUpdate update, PointerPointProperties props)
+		{
+			switch (update)
+			{
+				case WindowManagerInterop.HtmlPointerButtonUpdate.Left when props.IsLeftButtonPressed: return PointerUpdateKind.LeftButtonPressed;
+				case WindowManagerInterop.HtmlPointerButtonUpdate.Left: return PointerUpdateKind.LeftButtonReleased;
+				case WindowManagerInterop.HtmlPointerButtonUpdate.Middle when props.IsMiddleButtonPressed: return PointerUpdateKind.MiddleButtonPressed;
+				case WindowManagerInterop.HtmlPointerButtonUpdate.Middle: return PointerUpdateKind.MiddleButtonReleased;
+				case WindowManagerInterop.HtmlPointerButtonUpdate.Right when props.IsRightButtonPressed: return PointerUpdateKind.RightButtonPressed;
+				case WindowManagerInterop.HtmlPointerButtonUpdate.Right: return PointerUpdateKind.RightButtonReleased;
+				case WindowManagerInterop.HtmlPointerButtonUpdate.X1 when props.IsXButton1Pressed: return PointerUpdateKind.XButton1Pressed;
+				case WindowManagerInterop.HtmlPointerButtonUpdate.X1: return PointerUpdateKind.XButton1Released;
+				case WindowManagerInterop.HtmlPointerButtonUpdate.X2 when props.IsXButton2Pressed: return PointerUpdateKind.XButton1Pressed;
+				case WindowManagerInterop.HtmlPointerButtonUpdate.X2: return PointerUpdateKind.XButton1Released;
+				default: return PointerUpdateKind.Other;
+			}
 		}
 		#endregion
 	}

--- a/src/Uno.UI/UI/Xaml/Input/TappedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/TappedRoutedEventArgs.cs
@@ -10,32 +10,36 @@ namespace Windows.UI.Xaml.Input
 {
 	public sealed partial class TappedRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs
 	{
+		private readonly UIElement _originalSource;
 		private readonly Point _position;
 
 		public TappedRoutedEventArgs() { }
 		
-		internal TappedRoutedEventArgs(object originalSource, TappedEventArgs args)
+		internal TappedRoutedEventArgs(UIElement originalSource, TappedEventArgs args)
 			: base(originalSource)
 		{
+			_originalSource = originalSource;
 			_position = args.Position;
 			PointerDeviceType = args.PointerDeviceType;
 		}
 
 		public bool Handled { get; set; }
 
-		public Point GetPosition() => _position;
-
-		public PointerDeviceType PointerDeviceType { get; internal set; }
+		public PointerDeviceType PointerDeviceType { get; }
 
 		public Point GetPosition(UIElement relativeTo)
 		{
-			if(relativeTo == null)
+			if (_originalSource == null)
+			{
+				return default; // Required for the default public ctor ...
+			}
+			else if (relativeTo == _originalSource)
 			{
 				return _position;
 			}
 			else
 			{
-				return relativeTo.GetPosition(_position, relativeTo);
+				return _originalSource.GetPosition(_position, relativeTo);
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/RoutedEvent.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEvent.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using Uno.UI.Xaml;
 
@@ -30,10 +31,15 @@ namespace Windows.UI.Xaml
 
 		internal RoutedEventFlag Flag { get; }
 
+		[Pure]
 		internal bool IsPointerEvent { get; }
+		[Pure]
 		internal bool IsKeyEvent { get; }
+		[Pure]
 		internal bool IsFocusEvent { get; }
+		[Pure]
 		internal bool IsManipulationEvent { get; }
+		[Pure]
 		internal bool IsGestureEvent { get; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/RoutedEvent.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEvent.cs
@@ -8,11 +8,6 @@ namespace Windows.UI.Xaml
 	[DebuggerDisplay("{" + nameof(Name) + "}")]
 	public partial class RoutedEvent
 	{
-		internal RoutedEvent([CallerMemberName] string name = null)
-			: this(RoutedEventFlag.None, name)
-		{
-		}
-
 		internal RoutedEvent(
 			RoutedEventFlag flag,
 			[CallerMemberName] string name = null)

--- a/src/Uno.UI/UI/Xaml/RoutedEvent.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEvent.cs
@@ -8,7 +8,7 @@ namespace Windows.UI.Xaml
 	[DebuggerDisplay("{" + nameof(Name) + "}")]
 	public partial class RoutedEvent
 	{
-		public RoutedEvent([CallerMemberName] string name = null)
+		internal RoutedEvent([CallerMemberName] string name = null)
 			: this(RoutedEventFlag.None, name)
 		{
 		}
@@ -27,9 +27,24 @@ namespace Windows.UI.Xaml
 			IsGestureEvent = flag.IsGestureEvent();
 		}
 
+		[Pure]
 		internal string Name { get; }
 
+		[Pure]
 		internal RoutedEventFlag Flag { get; }
+
+		/// <summary>
+		/// Determines if this event is bubbled to the parent, not matter is a parent is subscribed
+		/// to the handler with the flag handledEventToo or not.
+		/// </summary>
+		/// <remarks>
+		/// For some events like PointerEvent, we always needs to get the full events sequence to maintain the
+		/// internal state, so we always needs the handled events too.
+		/// This flag avoids the complex update of the SubscribedToHandledEventsToo property coercing and inheritance
+		/// for those kind of well-known events.
+		/// </remarks>
+		[Pure]
+		internal bool IsAlwaysBubbled => IsPointerEvent;
 
 		[Pure]
 		internal bool IsPointerEvent { get; }

--- a/src/Uno.UI/UI/Xaml/UIElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Android.cs
@@ -126,17 +126,30 @@ namespace Windows.UI.Xaml
 			Alpha = IsRenderingSuspended ? 0 : (float)Opacity;
 		}
 
-		internal Windows.Foundation.Point GetPosition(Point position, global::Windows.UI.Xaml.UIElement relativeTo)
+		internal Point GetPosition(Point position, UIElement relativeTo)
 		{
+			if (relativeTo == this)
+			{
+				return position;
+			}
+
 			var currentViewLocation = new int[2];
 			GetLocationInWindow(currentViewLocation);
 
+			if (relativeTo == null)
+			{
+				return new Point(
+					position.X + ViewHelper.PhysicalToLogicalPixels(currentViewLocation[0]),
+					position.Y + ViewHelper.PhysicalToLogicalPixels(currentViewLocation[1])
+				);
+			}
+
 			var relativeToLocation = new int[2];
-			GetLocationInWindow(relativeToLocation);
+			relativeTo.GetLocationInWindow(relativeToLocation);
 
 			return new Point(
-				currentViewLocation[0] - relativeToLocation[0],
-				currentViewLocation[1] - relativeToLocation[1]
+				position.X + ViewHelper.PhysicalToLogicalPixels(currentViewLocation[0] - relativeToLocation[0]),
+				position.Y + ViewHelper.PhysicalToLogicalPixels(currentViewLocation[1] - relativeToLocation[1])
 			);
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.PointerCapture.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.PointerCapture.cs
@@ -257,7 +257,7 @@ namespace Windows.UI.Xaml
 					{
 						if (capture != this)
 						{
-							throw new InvalidOperationException("There is already another ");
+							throw new InvalidOperationException("There is already another active capture.");
 						}
 					}
 					else

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -323,20 +323,21 @@ namespace Windows.UI.Xaml
 
 		partial void PrepareBubblingManipulationEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
 		{
+			// When we bubble a manipulation event from a child, we make sure to abort any pending gesture/manipulation on the current element
 			if (routedEvent != ManipulationStartingEvent && _gestures.IsValueCreated)
 			{
-				_gestures.Value.CompleteGesture(); // TODO: Abort ?
+				_gestures.Value.CompleteGesture();
 			}
-			// TODO: Alter location
+			// Note: We do not need to alter the location of the events, on UWP they are always relative to the OriginalSource.
 		}
 
 		partial void PrepareBubblingGestureEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
 		{
+			// When we bubble a gesture event from a child, we make sure to abort any pending gesture/manipulation on the current element
 			if (_gestures.IsValueCreated)
 			{
-				_gestures.Value.CompleteGesture(); // TODO: Abort ?
+				_gestures.Value.CompleteGesture();
 			}
-			// TODO: Alter location
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -321,6 +321,24 @@ namespace Windows.UI.Xaml
 		}
 		#endregion
 
+		partial void PrepareBubblingManipulationEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
+		{
+			if (routedEvent != ManipulationStartingEvent && _gestures.IsValueCreated)
+			{
+				_gestures.Value.CompleteGesture(); // TODO: Abort ?
+			}
+			// TODO: Alter location
+		}
+
+		partial void PrepareBubblingGestureEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
+		{
+			if (_gestures.IsValueCreated)
+			{
+				_gestures.Value.CompleteGesture(); // TODO: Abort ?
+			}
+			// TODO: Alter location
+		}
+
 		/// <summary>
 		/// Prevents the gesture recognizer to generate a manipulation. It's designed to be invoked in Pointers events handlers.
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -322,7 +322,7 @@ namespace Windows.UI.Xaml
 		}
 		#endregion
 
-		partial void PrepareBubblingPointerEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
+		partial void PrepareManagedPointerEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
 		{
 			var ptArgs = (PointerRoutedEventArgs)args;
 			switch (routedEvent.Flag)
@@ -349,7 +349,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		partial void PrepareBubblingManipulationEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
+		partial void PrepareManagedManipulationEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
 		{
 			// When we bubble a manipulation event from a child, we make sure to abort any pending gesture/manipulation on the current element
 			if (routedEvent != ManipulationStartingEvent && _gestures.IsValueCreated)
@@ -359,7 +359,7 @@ namespace Windows.UI.Xaml
 			// Note: We do not need to alter the location of the events, on UWP they are always relative to the OriginalSource.
 		}
 
-		partial void PrepareBubblingGestureEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
+		partial void PrepareManagedGestureEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
 		{
 			// When we bubble a gesture event from a child, we make sure to abort any pending gesture/manipulation on the current element
 			if (_gestures.IsValueCreated)
@@ -384,10 +384,8 @@ namespace Windows.UI.Xaml
 		#endregion
 
 		#region Partial API to raise pointer events and gesture recognition (OnNative***)
-		private bool OnNativePointerEnter(PointerRoutedEventArgs args)
-			=> OnPointerEnter(args, isManagedBubblingEvent: false);
-		private void OnManagedPointerEnter(PointerRoutedEventArgs args)
-			=> OnPointerEnter(args, isManagedBubblingEvent: true);
+		private bool OnNativePointerEnter(PointerRoutedEventArgs args) => OnPointerEnter(args, isManagedBubblingEvent: false);
+		private void OnManagedPointerEnter(PointerRoutedEventArgs args) => OnPointerEnter(args, isManagedBubblingEvent: true);
 
 		private bool OnPointerEnter(PointerRoutedEventArgs args, bool isManagedBubblingEvent)
 		{
@@ -398,8 +396,8 @@ namespace Windows.UI.Xaml
 			return handledInManaged;
 		}
 
-		private bool OnNativePointerDown(PointerRoutedEventArgs args) => OnPointerDown(args, false);
-		private void OnManagedPointerDown(PointerRoutedEventArgs args) => OnPointerDown(args, true);
+		private bool OnNativePointerDown(PointerRoutedEventArgs args) => OnPointerDown(args, isManagedBubblingEvent: false);
+		private void OnManagedPointerDown(PointerRoutedEventArgs args) => OnPointerDown(args, isManagedBubblingEvent: true);
 
 		private bool OnPointerDown(PointerRoutedEventArgs args, bool isManagedBubblingEvent)
 		{
@@ -474,8 +472,8 @@ namespace Windows.UI.Xaml
 			return handledInManaged;
 		}
 
-		private bool OnNativePointerMove(PointerRoutedEventArgs args) => OnPointerMove(args, false);
-		private void OnManagePointerMove(PointerRoutedEventArgs args) => OnPointerMove(args, true);
+		private bool OnNativePointerMove(PointerRoutedEventArgs args) => OnPointerMove(args, isManagedBubblingEvent: false);
+		private void OnManagePointerMove(PointerRoutedEventArgs args) => OnPointerMove(args, isManagedBubblingEvent: true);
 
 		private bool OnPointerMove(PointerRoutedEventArgs args, bool isManagedBubblingEvent)
 		{
@@ -502,8 +500,8 @@ namespace Windows.UI.Xaml
 			return handledInManaged;
 		}
 
-		private bool OnNativePointerUp(PointerRoutedEventArgs args) => OnPointerUp(args, false);
-		private void OnManagedPointerUp(PointerRoutedEventArgs args) => OnPointerUp(args, true);
+		private bool OnNativePointerUp(PointerRoutedEventArgs args) => OnPointerUp(args, isManagedBubblingEvent: false);
+		private void OnManagedPointerUp(PointerRoutedEventArgs args) => OnPointerUp(args, isManagedBubblingEvent: true);
 
 		private bool OnPointerUp(PointerRoutedEventArgs args, bool isManagedBubblingEvent)
 		{
@@ -534,8 +532,8 @@ namespace Windows.UI.Xaml
 			return handledInManaged;
 		}
 
-		private bool OnNativePointerExited(PointerRoutedEventArgs args) => OnPointerExited(args, false);
-		private void OnManagedPointerExited(PointerRoutedEventArgs args) => OnPointerExited(args, true);
+		private bool OnNativePointerExited(PointerRoutedEventArgs args) => OnPointerExited(args, isManagedBubblingEvent: false);
+		private void OnManagedPointerExited(PointerRoutedEventArgs args) => OnPointerExited(args, isManagedBubblingEvent: true);
 
 		private bool OnPointerExited(PointerRoutedEventArgs args, bool isManagedBubblingEvent)
 		{
@@ -564,9 +562,9 @@ namespace Windows.UI.Xaml
 		private bool OnNativePointerCancel(PointerRoutedEventArgs args, bool isSwallowedBySystem)
 		{
 			args.CanceledByDirectManipulation = isSwallowedBySystem;
-			return OnPointerCancel(args, false);
+			return OnPointerCancel(args, isManagedBubblingEvent: false);
 		}
-		private void OnManagedPointerCancel(PointerRoutedEventArgs args) => OnNativePointerCancel(args, true);
+		private void OnManagedPointerCancel(PointerRoutedEventArgs args) => OnPointerCancel(args, isManagedBubblingEvent: true);
 
 		private bool OnPointerCancel(PointerRoutedEventArgs args, bool isManagedBubblingEvent)
 		{

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -153,6 +153,8 @@ namespace Windows.UI.Xaml
 				default:
 					type = PointerDeviceType.Mouse;
 					break;
+				// Note: As of 2019-11-28, once pen pressed events pressed/move/released are reported as TOUCH on Firefox
+				//		 https://bugzilla.mozilla.org/show_bug.cgi?id=1449660
 				case "PEN":
 					type = PointerDeviceType.Pen;
 					break;

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -8,6 +8,7 @@ using Windows.Foundation;
 using Windows.UI.Xaml.Input;
 using Windows.System;
 using Windows.UI.Input;
+using Uno.UI;
 using Uno.UI.Xaml;
 
 namespace Windows.UI.Xaml

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -121,7 +121,7 @@ namespace Windows.UI.Xaml
 			var buttons = int.Parse(parts[5], CultureInfo.InvariantCulture);
 			var buttonUpdate = int.Parse(parts[6], CultureInfo.InvariantCulture);
 			var typeStr = parts[7];
-			var srcHandle = int.Parse(parts[8]);
+			var srcHandle = int.Parse(parts[8], CultureInfo.InvariantCulture);
 			var timestamp = double.Parse(parts[9], CultureInfo.InvariantCulture);
 
 			var src = GetElementFromHandle(srcHandle) ?? (UIElement)snd;

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -569,42 +569,42 @@ namespace Windows.UI.Xaml
 		// This method is a workaround for https://github.com/mono/mono/issues/12981
 		// It can be inlined in RaiseEvent when fixed.
 		private static bool RaiseOnParent(RoutedEvent routedEvent, RoutedEventArgs args, UIElement parent)
-			=> parent.PrepareBubblingEvent(routedEvent, args, out args)
+			=> parent.PrepareManagedEventBubbling(routedEvent, args, out args)
 				&& parent.RaiseEvent(routedEvent, args);
 
-		private bool PrepareBubblingEvent(RoutedEvent routedEvent, RoutedEventArgs args, out RoutedEventArgs alteredArgs)
+		private bool PrepareManagedEventBubbling(RoutedEvent routedEvent, RoutedEventArgs args, out RoutedEventArgs alteredArgs)
 		{
 			var isBubblingAllowed = true;
 			alteredArgs = args;
 			if (routedEvent.IsPointerEvent)
 			{
-				PrepareBubblingPointerEvent(routedEvent, ref alteredArgs, ref isBubblingAllowed);
+				PrepareManagedPointerEventBubbling(routedEvent, ref alteredArgs, ref isBubblingAllowed);
 			}
 			else if (routedEvent.IsKeyEvent)
 			{
-				PrepareBubblingKeyEvent(routedEvent, ref alteredArgs, ref isBubblingAllowed);
+				PrepareManagedKeyEventBubbling(routedEvent, ref alteredArgs, ref isBubblingAllowed);
 			}
 			else if (routedEvent.IsFocusEvent)
 			{
-				PrepareBubblingFocusEvent(routedEvent, ref alteredArgs, ref isBubblingAllowed);
+				PrepareManagedFocusEventBubbling(routedEvent, ref alteredArgs, ref isBubblingAllowed);
 			}
 			else if (routedEvent.IsManipulationEvent)
 			{
-				PrepareBubblingManipulationEvent(routedEvent, ref alteredArgs, ref isBubblingAllowed);
+				PrepareManagedManipulationEventBubbling(routedEvent, ref alteredArgs, ref isBubblingAllowed);
 			}
 			else if (routedEvent.IsGestureEvent)
 			{
-				PrepareBubblingGestureEvent(routedEvent, ref alteredArgs, ref isBubblingAllowed);
+				PrepareManagedGestureEventBubbling(routedEvent, ref alteredArgs, ref isBubblingAllowed);
 			}
 
 			return isBubblingAllowed;
 		}
 
-		partial void PrepareBubblingPointerEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
-		partial void PrepareBubblingKeyEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
-		partial void PrepareBubblingFocusEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
-		partial void PrepareBubblingManipulationEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
-		partial void PrepareBubblingGestureEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
+		partial void PrepareManagedPointerEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
+		partial void PrepareManagedKeyEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
+		partial void PrepareManagedFocusEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
+		partial void PrepareManagedManipulationEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
+		partial void PrepareManagedGestureEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
 
 		private static bool IsHandled(RoutedEventArgs args)
 		{
@@ -631,7 +631,7 @@ namespace Windows.UI.Xaml
 		{
 			// Pointer events must always be dispatched to all parents in order to update visual states,
 			// update manipulation, detect gestures, etc.
-			// (They are then interpreted by each parent in the PrepareBubblingPointerEvent)
+			// (They are then interpreted by each parent in the PrepareManagedPointerEventBubbling)
 			if (routedEvent.IsAlwaysBubbled)
 			{
 				return true;

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -398,7 +398,7 @@ namespace Windows.UI.Xaml
 					handlers.Remove(matchingHandler);
 
 					if (matchingHandler.HandledEventsToo
-						&& !routedEvent.IsAlwaysBubbled) // This event is always bubbled, no needs to update the flag
+						&& !routedEvent.IsAlwaysBubbled) // This event is always bubbled, no need to update the flag
 					{
 						UpdateSubscribedToHandledEventsToo();
 					}
@@ -455,7 +455,7 @@ namespace Windows.UI.Xaml
 			{
 				if (eventHandlers.Key.IsAlwaysBubbled)
 				{
-					// This event is always bubbled, no needs to include it in the SubscribedToHandledEventsToo
+					// This event is always bubbled, no need to include it in the SubscribedToHandledEventsToo
 					continue;
 				}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -560,7 +560,42 @@ namespace Windows.UI.Xaml
 		// This method is a workaround for https://github.com/mono/mono/issues/12981
 		// It can be inlined in RaiseEvent when fixed.
 		private static bool RaiseOnParent(RoutedEvent routedEvent, RoutedEventArgs args, UIElement parent)
-			=> parent.RaiseEvent(routedEvent, args);
+			=> parent.PrepareBubblingEvent(routedEvent, args, out args)
+				&& parent.RaiseEvent(routedEvent, args);
+
+		private bool PrepareBubblingEvent(RoutedEvent routedEvent, RoutedEventArgs args, out RoutedEventArgs alteredArgs)
+		{
+			var isBubblingAllowed = true;
+			alteredArgs = args;
+			if (routedEvent.IsPointerEvent)
+			{
+				PrepareBubblingPointerEvent(routedEvent, ref alteredArgs, ref isBubblingAllowed);
+			}
+			else if (routedEvent.IsKeyEvent)
+			{
+				PrepareBubblingKeyEvent(routedEvent, ref alteredArgs, ref isBubblingAllowed);
+			}
+			else if (routedEvent.IsFocusEvent)
+			{
+				PrepareBubblingFocusEvent(routedEvent, ref alteredArgs, ref isBubblingAllowed);
+			}
+			else if (routedEvent.IsManipulationEvent)
+			{
+				PrepareBubblingManipulationEvent(routedEvent, ref alteredArgs, ref isBubblingAllowed);
+			}
+			else if (routedEvent.IsGestureEvent)
+			{
+				PrepareBubblingGestureEvent(routedEvent, ref alteredArgs, ref isBubblingAllowed);
+			}
+
+			return isBubblingAllowed;
+		}
+
+		partial void PrepareBubblingPointerEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
+		partial void PrepareBubblingKeyEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
+		partial void PrepareBubblingFocusEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
+		partial void PrepareBubblingManipulationEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
+		partial void PrepareBubblingGestureEvent(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed);
 
 		private static bool IsHandled(RoutedEventArgs args)
 		{

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -993,5 +993,32 @@ namespace Uno.UI.Xaml
 			public IntPtr HtmlId;
 		}
 		#endregion
+
+		#region Pointers
+		[Flags]
+		internal enum HtmlPointerButtonsState
+		{
+			// https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#Determining_button_states
+
+			None = 0,
+			Left = 1,
+			Middle = 4,
+			Right = 2,
+			X1 = 8,
+			X2 = 16,
+			Eraser = 32,
+		}
+
+		internal enum HtmlPointerButtonUpdate
+		{
+			None = -1,
+			Left = 0,
+			Middle = 1,
+			Right = 2,
+			X1 = 3,
+			X2 = 4,
+			Eraser = 5
+		}
+		#endregion
 	}
 }

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -179,8 +179,8 @@ namespace Windows.UI.Input
 
 		#region Tap (includes DoubleTap)
 		internal const ulong MultiTapMaxDelayTicks = TimeSpan.TicksPerMillisecond * 1000;
-		internal const int TapMaxXDelta = 15;
-		internal const int TapMaxYDelta = 15;
+		internal const int TapMaxXDelta = 10;
+		internal const int TapMaxYDelta = 10;
 
 		public event TypedEventHandler<GestureRecognizer, TappedEventArgs> Tapped;
 


### PR DESCRIPTION
GitHub Issues:
fixes https://github.com/unoplatform/uno/issues/2193
fixes https://github.com/unoplatform/uno/issues/2180

## Bug fixes
Misc bugs fixes for pointer events

## What is the current behavior?
* On Android, the location of the Tapped event args is always `0,0`
* When in a `ScrollViewer`, the `ToggleSwitch` might stay in _pressed_ visual state
* When 2 nested controls subscribes to the `Tapped` event, the parent one will receive the `Tapped` twice when tapping on the child.
* On WASM the pressed buttons are reported only in `PointerPressed` and `PointerReleased` event. As we validate the pressed state in the `GestureRecognizer`, this means that no gesture can be detected (i.e. `Tapped` and `DoubleTapped` events are never fired)
* The `Thumb` does fire the `DragCompleted` if the event `PointerCanceled` is raised (eg. when scrolling)
* If a child control handles the pointer events, a parent control won't get them so it won't be able to use them with its own `GestureRecognizer` to detect **Manipulation** and **Gesture** (i.e. it won't be able to fire the `Tapped` event for instance).

## What is the new behavior?
_the opposite_

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)

## Internal
Might fix https://nventive.visualstudio.com/_workitems/edit/168971