### PR TITLE
Added additional tip for debugging with Chrome

### DIFF
--- a/doc/articles/debugging-wasm.md
+++ b/doc/articles/debugging-wasm.md
@@ -43,3 +43,4 @@ Debugging WebAssembly via Google Chrome is experimentally supported by the Uno P
 > * For breakpoints to work properly, you should not open the debugger tools (<kbd>F12</kbd>) in the app's tab.
 > * If you are **debugging a library which is publishing SourceLinks**, you must disable it or you'll
 > always see the SourceLink code in the debugger. SourceLink should be activated only on Release build.
+> * When debugging in Chrome, <kbd>Ctrl</kbd>+<kbd>O</kbd> brings up a file-search field. That way it's a lot easier to find .cs files versus searching through the whole folder hierarchy.


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the new behavior?

Added an additional tip for debugging with Chrome


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

