### PR TITLE
Remove "min size" constrains to available size in layouter

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -317,6 +317,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Layout_Constrains.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_AdaptiveTrigger_Storyboard.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2932,10 +2936,13 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\TouchEventsTests\TouchViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\TransformToVisual_ScrollViewer.xaml.cs">
-      <DependentUpon>$fileinputname$.xaml</DependentUpon>
+      <DependentUpon>TransformToVisual_ScrollViewer.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\TransformToVisual_Transform.xaml.cs">
       <DependentUpon>TransformToVisual_Transform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Layout_Constrains.xaml.cs">
+      <DependentUpon>UIElement_Layout_Constrains.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_AdaptiveTrigger_UsingOneStateOnly.xaml.cs">
       <DependentUpon>VisualState_AdaptiveTrigger_UsingOneStateOnly.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Layout_Constrains.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Layout_Constrains.xaml
@@ -1,0 +1,111 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml.UIElementTests.UIElement_Layout_Constrains"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:toolkit="using:Uno.UI.Toolkit"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<ScrollViewer>
+		<StackPanel Spacing="12" toolkit:VisibleBoundsPadding.PaddingMask="All">
+			<TextBlock FontSize="18">Following controls should be of same look:</TextBlock>
+
+			<Border Height="40" Background="Aquamarine">
+
+				<StackPanel Orientation="Horizontal" Spacing="10">
+					<Button Width="80" VerticalAlignment="Stretch" Padding="5">BUTTON</Button>
+					<Button Width="80" Height="60" VerticalAlignment="Center" Padding="5">BUTTON</Button>
+					<Button Width="80" Height="80" Padding="5">BUTTON</Button>
+				</StackPanel>
+			</Border>
+
+			<TextBlock FontSize="18">Following controls should be of same look:</TextBlock>
+
+			<Border Background="Orange" Height="28">
+				<StackPanel Orientation="Horizontal" Spacing="10">
+					<Button Width="65" Padding="0" VerticalAlignment="Stretch">
+						<Border BorderThickness="2" BorderBrush="Blue">
+							<TextBlock FontSize="8" Padding="0">
+							BUTTON
+							</TextBlock>
+						</Border>
+					</Button>
+					<Button Width="65" Padding="0" Height="36">
+						<Border BorderThickness="2" BorderBrush="Blue">
+							<TextBlock FontSize="8" Padding="0">
+							BUTTON
+							</TextBlock>
+						</Border>
+					</Button>
+					<Button Width="65" Padding="0" Height="36" VerticalAlignment="Center">
+						<Border BorderThickness="2" BorderBrush="Blue">
+							<TextBlock FontSize="8" Padding="0">
+							BUTTON
+							</TextBlock>
+						</Border>
+					</Button>
+				</StackPanel>
+			</Border>
+
+			<Grid ColumnSpacing="10">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="*" />
+				</Grid.ColumnDefinitions>
+				<Rectangle Width="100" HorizontalAlignment="Left" Fill="DarkSeaGreen"></Rectangle>
+				<StackPanel Spacing="3">
+					<TextBlock>green width is 100</TextBlock>
+					<Border BorderBrush="Blue" BorderThickness="2" HorizontalAlignment="Left" MaxWidth="100">
+						<TextBlock>Max=100</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" HorizontalAlignment="Left" MaxWidth="100">
+						<TextBlock TextWrapping="NoWrap">Max=100 + very long text</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" HorizontalAlignment="Left" MaxWidth="40" MinWidth="80">
+						<TextBlock TextWrapping="NoWrap">Max=40<LineBreak />Min=80</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" HorizontalAlignment="Left" Width="100">
+						<TextBlock>Width=100</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" HorizontalAlignment="Left" MinWidth="80" MaxWidth="120">
+						<TextBlock>min/max<LineBreak />80/120</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" HorizontalAlignment="Left" MinWidth="80" MaxWidth="40">
+						<TextBlock>min/max<LineBreak />80/40</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" HorizontalAlignment="Left" MinWidth="80" MaxWidth="120">
+						<TextBlock TextWrapping="NoWrap">min/max<LineBreak />80/120 + very very very long text</TextBlock>
+					</Border>
+				</StackPanel>
+				<Rectangle Height="100" VerticalAlignment="Top" Fill="LightPink" Grid.Column="1"></Rectangle>
+				<StackPanel Orientation="Horizontal" Grid.Column="1" Spacing="3">
+					<TextBlock>pink height is 100</TextBlock>
+					<Border BorderBrush="Blue" BorderThickness="2" VerticalAlignment="Top" MaxHeight="100">
+						<TextBlock>MaxH=100<LineBreak />+<LineBreak />very<LineBreak />very<LineBreak />very<LineBreak />very<LineBreak />very<LineBreak />long<LineBreak />text</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" VerticalAlignment="Top" MaxHeight="100">
+						<TextBlock>MaxH=100</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" VerticalAlignment="Top" MaxHeight="10" MinHeight="50">
+						<TextBlock>MaxH=100, MinH=50<LineBreak />+<LineBreak />very<LineBreak />very<LineBreak />very<LineBreak />very<LineBreak />very<LineBreak />long<LineBreak />text</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" VerticalAlignment="Top" Height="100">
+						<TextBlock>H=100</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" VerticalAlignment="Top" MinHeight="80" MaxHeight="120">
+						<TextBlock>min/max<LineBreak />80/120</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" VerticalAlignment="Top" MinHeight="80" MaxHeight="40">
+						<TextBlock>min/max<LineBreak />80/40</TextBlock>
+					</Border>
+					<Border BorderBrush="Blue" BorderThickness="2" VerticalAlignment="Top" MinHeight="80" MaxHeight="120">
+						<TextBlock>min/max<LineBreak />80/120<LineBreak />+<LineBreak />very<LineBreak />very<LineBreak />very<LineBreak />very<LineBreak />very<LineBreak />very<LineBreak />long<LineBreak />text</TextBlock>
+					</Border>
+				</StackPanel>
+			</Grid>
+
+		</StackPanel>
+	</ScrollViewer>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Layout_Constrains.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Layout_Constrains.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml.UIElementTests
+{
+	[SampleControlInfo("UIElement")]
+	public sealed partial class UIElement_Layout_Constrains : Page
+	{
+		public UIElement_Layout_Constrains()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
@@ -179,10 +179,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			{
 				var ls1 = LayoutInformation.GetLayoutSlot(grid);
 				Assert.AreEqual(new Rect(0, 0, 50, 50), ls1);
+#if NETFX_CORE || __WASM__ // TODO: align all platforms with Windows here
 				var ls2 = LayoutInformation.GetLayoutSlot(contentCtl);
 				Assert.AreEqual(new Rect(0, 0, 120, 50), ls2);
 				var ls3 = LayoutInformation.GetLayoutSlot(content);
 				Assert.AreEqual(new Rect(0, 0, 100, 15), ls3);
+#endif
 			});
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
@@ -12,6 +12,8 @@ using Windows.Foundation;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Private.Infrastructure;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -139,6 +141,50 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			});
 		}
 #endif
+
+		[TestMethod]
+		public async Task When_MinWidth_SmallerThan_AvailableSize()
+		{
+			Border content = null;
+			ContentControl contentCtl = null;
+			Grid grid = null;
+
+			await Dispatch(() =>
+			{
+				content = new Border { Width = 100, Height = 15 };
+
+				contentCtl = new ContentControl { MinWidth = 110, Content = content };
+
+				grid = new Grid() { MinWidth = 120 };
+
+				grid.Children.Add(contentCtl);
+
+				grid.Measure(new Size(50, 50));
+#if NETFX_CORE || __WASM__ // TODO: align all platforms with Windows here
+				Assert.AreEqual(new Size(50, 15), grid.DesiredSize);
+				Assert.AreEqual(new Size(110, 15), contentCtl.DesiredSize);
+				Assert.AreEqual(new Size(100, 15), content.DesiredSize);
+#endif
+
+				grid.Arrange(new Rect(default, new Size(50, 50)));
+
+				TestServices.WindowHelper.WindowContent = new Border { Child = grid, Width = 50, Height = 50 };
+			});
+
+			await TestServices.WindowHelper.WaitForIdle();
+			await Dispatch(() => { });
+			await TestServices.WindowHelper.WaitForIdle();
+
+			await Dispatch(() =>
+			{
+				var ls1 = LayoutInformation.GetLayoutSlot(grid);
+				Assert.AreEqual(new Rect(0, 0, 50, 50), ls1);
+				var ls2 = LayoutInformation.GetLayoutSlot(contentCtl);
+				Assert.AreEqual(new Rect(0, 0, 120, 50), ls2);
+				var ls3 = LayoutInformation.GetLayoutSlot(content);
+				Assert.AreEqual(new Rect(0, 0, 100, 15), ls3);
+			});
+		}
 
 		[TestMethod]
 		[RunsOnUIThread]

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -1,4 +1,4 @@
-﻿// #define LOG_LAYOUT
+// #define LOG_LAYOUT
 
 using Microsoft.Extensions.Logging;
 using Uno.UI;
@@ -98,8 +98,7 @@ namespace Windows.UI.Xaml.Controls
 					.NumberOrDefault(MaxSize)
 					.Subtract(marginSize)
 					.AtLeast(default) // 0.0,0.0
-					.AtMost(maxSize)
-					.AtLeast(minSize);
+					.AtMost(maxSize);
 
 				var desiredSize = MeasureOverride(frameworkAvailableSize);
 
@@ -204,7 +203,6 @@ namespace Windows.UI.Xaml.Controls
 				var (minSize, maxSize) = this.Panel.GetMinMax();
 
 				arrangeSize = arrangeSize
-					.AtLeast(minSize)
 					.AtLeast(default); // 0.0,0.0
 
 				// We have to choose max between _unclippedDesiredSize and maxSize here, because
@@ -405,7 +403,7 @@ namespace Windows.UI.Xaml.Controls
 					// Report the size to the parent without the margin, only if the
 					// size has changed or that the control required a measure
 					//
-					// This condition is required because of the measure caching that 
+					// This condition is required because of the measure caching that
 					// some systems apply (Like android UI).
 					ret = new Size(
 						ret.Width + margin.Left + margin.Right,
@@ -475,7 +473,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			// In this implementation, since we do not have the ability to intercept proprely the measure and arrange
 			// because of the type of hierarchy (inheriting from native views), we must apply the margins and alignements
-			// from within the panel to its children. This makes the authoring of custom panels that do not inherit from 
+			// from within the panel to its children. This makes the authoring of custom panels that do not inherit from
 			// Panel that do not use this helper a bit more complex, but for all other panels that use this
 			// layouter, the logic is implied.
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.wasm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using Uno.Diagnostics.Eventing;
@@ -75,8 +75,7 @@ namespace Windows.UI.Xaml
 				.NumberOrDefault(MaxSize)
 				.Subtract(marginSize)
 				.AtLeast(new Size(0, 0))
-				.AtMost(maxSize)
-				.AtLeast(minSize);
+				.AtMost(maxSize);
 
 			var desiredSize = MeasureOverride(frameworkAvailableSize);
 


### PR DESCRIPTION
This is to align with the UWP/WinUI behavior.
The Width/MinWidth restrictions are applied by the control itself,
not the layouting process.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

# Bugfix

## What is the current behavior?
The `Layouter` (and the equivalent for Wasm) was applying the `minSize` (calculated from `Width`, `MinWidth`, `Height`, `MinHeight`) on the `availableSize` during the `Arrange()` phase.

This was allowing the `availableSize` to grow when smaller than `minSize`.

## What is the new behavior?
The `availableSize` passed to the `ArrangeOverride()` of a control won't apply the `minSize` anymore.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
* https://nventive.visualstudio.com/Umbrella/_workitems/edit/168813 (this is the reference for the sample)
* https://nventive.visualstudio.com/Umbrella/_workitems/edit/168844 (tentatively)
* https://nventive.visualstudio.com/Umbrella/_workitems/edit/168858 (tentatively)
* https://nventive.visualstudio.com/Umbrella/_workitems/edit/168973 (tentatively)
 