### PR TITLE
Add support for Automation SetDependencyPropertyValue

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -1,7 +1,7 @@
 ﻿# Release notes
 
 ### Features
--
+- Add support for Automation SetDependencyPropertyValue in Uno.UITest
 
 ### Breaking changes
 -

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -10,6 +10,7 @@ declare namespace Windows.UI.Core {
     class CoreDispatcher {
         static _coreDispatcherCallback: any;
         static _isIOS: boolean;
+        static _isSafari: boolean;
         static _isFirstCall: boolean;
         static _isReady: Promise<boolean>;
         static _isWaitingReady: boolean;
@@ -152,6 +153,7 @@ declare namespace Uno.UI {
         private static resizeMethod;
         private static dispatchEventMethod;
         private static getDependencyPropertyValueMethod;
+        private static setDependencyPropertyValueMethod;
         private constructor();
         /**
             * Creates the UWP-compatible splash screen
@@ -505,6 +507,12 @@ declare namespace Uno.UI {
          * Note that the casing of this method is intentionally Pascal for platform alignment.
          */
         GetDependencyPropertyValue(elementId: number, propertyName: string): string;
+        /**
+         * Sets a dependency property value.
+         *
+         * Note that the casing of this method is intentionally Pascal for platform alignment.
+         */
+        SetDependencyPropertyValue(elementId: number, propertyName: string, propertyValue: string): string;
         /**
             * Remove the loading indicator.
             *

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -39,6 +39,7 @@ var Windows;
                     CoreDispatcher.initMethods();
                     CoreDispatcher._isReady = isReady;
                     CoreDispatcher._isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+                    CoreDispatcher._isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
                 }
                 /**
                  * Enqueues a core dispatcher callback on the javascript's event loop
@@ -63,14 +64,14 @@ var Windows;
                     return true;
                 }
                 static InnerWakeUp() {
-                    if (CoreDispatcher._isIOS && CoreDispatcher._isFirstCall) {
+                    if ((CoreDispatcher._isIOS || CoreDispatcher._isSafari) && CoreDispatcher._isFirstCall) {
                         //
                         // This is a workaround for the available call stack during the first 5 (?) seconds
                         // of the startup of an application. See https://github.com/mono/mono/issues/12357 for
                         // more details.
                         //
                         CoreDispatcher._isFirstCall = false;
-                        console.debug("Detected iOS, delaying first CoreDispatched dispatch for 5s (see https://github.com/mono/mono/issues/12357)");
+                        console.warn("Detected iOS, delaying first CoreDispatcher dispatch for 5 seconds (see https://github.com/mono/mono/issues/12357)");
                         window.setTimeout(() => this.WakeUp(), 5000);
                     }
                     else {
@@ -1499,6 +1500,19 @@ var Uno;
                 const element = this.getView(elementId);
                 const htmlId = Number(element.getAttribute("XamlHandle"));
                 return WindowManager.getDependencyPropertyValueMethod(htmlId, propertyName);
+            }
+            /**
+             * Sets a dependency property value.
+             *
+             * Note that the casing of this method is intentionally Pascal for platform alignment.
+             */
+            SetDependencyPropertyValue(elementId, propertyName, propertyValue) {
+                if (!WindowManager.setDependencyPropertyValueMethod) {
+                    WindowManager.setDependencyPropertyValueMethod = Module.mono_bind_static_method("[Uno.UI] Uno.UI.Helpers.Automation:SetDependencyPropertyValue");
+                }
+                const element = this.getView(elementId);
+                const htmlId = Number(element.getAttribute("XamlHandle"));
+                return WindowManager.setDependencyPropertyValueMethod(htmlId, propertyName, propertyValue);
             }
             /**
                 * Remove the loading indicator.

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -133,6 +133,7 @@
 		private static resizeMethod: any;
 		private static dispatchEventMethod: any;
 		private static getDependencyPropertyValueMethod: any;
+		private static setDependencyPropertyValueMethod: any;
 
 		private constructor(private containerElementId: string, private loadingElementId: string) {
 			this.initDom();
@@ -1548,6 +1549,22 @@
 			const htmlId = Number(element.getAttribute("XamlHandle"));
 
 			return WindowManager.getDependencyPropertyValueMethod(htmlId, propertyName);
+		}
+
+		/**
+		 * Sets a dependency property value.
+		 *
+		 * Note that the casing of this method is intentionally Pascal for platform alignment.
+		 */
+		public SetDependencyPropertyValue(elementId: number, propertyName: string, propertyValue: string) : string {
+			if (!WindowManager.setDependencyPropertyValueMethod) {
+				WindowManager.setDependencyPropertyValueMethod = (<any>Module).mono_bind_static_method("[Uno.UI] Uno.UI.Helpers.Automation:SetDependencyPropertyValue");
+			}
+
+			const element = this.getView(elementId) as HTMLElement;
+			const htmlId = Number(element.getAttribute("XamlHandle"));
+
+			return WindowManager.setDependencyPropertyValueMethod(htmlId, propertyName, propertyValue);
 		}
 
 		/**

--- a/src/Uno.UI/Helpers/Automation.wasm.cs
+++ b/src/Uno.UI/Helpers/Automation.wasm.cs
@@ -28,5 +28,20 @@ namespace Uno.UI.Helpers
 				return "";
 			}
 		}
+
+		[Preserve]
+		public static string SetDependencyPropertyValue(int handle, string dependencyPropertyName, string value)
+		{
+			// Dispatch to right object, if we can find it
+			if (UIElement.GetElementFromHandle(handle) is UIElement element)
+			{
+				return UIElement.SetDependencyPropertyValueInternal(element, dependencyPropertyName, value);
+			}
+            else
+            {
+				Console.Error.WriteLine($"No UIElement found for htmlId \"{handle}\"");
+				return "";
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -1035,6 +1035,19 @@ namespace <#= mixin.NamespaceName #>
 			// If all else fails, just return the string representation of the DP's value
 			return new global::Foundation.NSString(dpValue.ToString());
 		}
+
+				
+		/// <summary>
+		/// Provides a native value for the dependency property with the given name on the current instance. If the value is a primitive type, 
+		/// its native representation is returned. Otherwise, the <see cref="object.ToString"/> implementation is used/returned instead.
+		/// </summary>
+		/// <param name="dependencyPropertyName">The name of the target dependency property</param>
+		/// <returns>The content of the target dependency property (its actual value if it is a primitive type ot its <see cref="object.ToString"/> representation otherwise</returns>
+		[global::Foundation.Export("setDependencyPropertyValue:")]
+		public global::Foundation.NSString SetDependencyPropertyValue(global::Foundation.NSString dependencyPropertyName, global::Foundation.NSString value)
+		{
+			return new global::Foundation.NSString(UIElement.SetDependencyPropertyValueInternal(this, dependencyPropertyName, value));
+		}
 		
 		#region AutomationPeer
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -1043,7 +1043,7 @@ namespace <#= mixin.NamespaceName #>
 		/// </summary>
 		/// <param name="dependencyPropertyName">The name of the target dependency property</param>
 		/// <returns>The content of the target dependency property (its actual value if it is a primitive type ot its <see cref="object.ToString"/> representation otherwise</returns>
-		[global::Foundation.Export("setDependencyPropertyValue:")]
+		[global::Foundation.Export("setDependencyPropertyValue::")]
 		public global::Foundation.NSString SetDependencyPropertyValue(global::Foundation.NSString dependencyPropertyName, global::Foundation.NSString value)
 		{
 			return new global::Foundation.NSString(UIElement.SetDependencyPropertyValueInternal(this, dependencyPropertyName, value));

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
@@ -993,7 +993,20 @@ namespace <#= mixin.NamespaceName #>
 		
 		private static readonly Uri _defaultUri = new Uri("ms-appx:///");
 		public Uri BaseUri { get; internal set; } = _defaultUri;
-		
+
+						
+		/// <summary>
+		/// Provides a native value for the dependency property with the given name on the current instance. If the value is a primitive type, 
+		/// its native representation is returned. Otherwise, the <see cref="object.ToString"/> implementation is used/returned instead.
+		/// </summary>
+		/// <param name="dependencyPropertyName">The name of the target dependency property</param>
+		/// <returns>The content of the target dependency property (its actual value if it is a primitive type ot its <see cref="object.ToString"/> representation otherwise</returns>
+		[global::Foundation.Export("setDependencyPropertyValue::")]
+		public global::Foundation.NSString SetDependencyPropertyValue(global::Foundation.NSString dependencyPropertyName, global::Foundation.NSString value)
+		{
+			return new global::Foundation.NSString(UIElement.SetDependencyPropertyValueInternal(this, dependencyPropertyName, value));
+		}
+
 		/// <summary>
 		/// Provides a native value for the dependency property with the given name on the current instance. If the value is a primitive type, 
 		/// its native representation is returned. Otherwise, the <see cref="object.ToString"/> implementation is used/returned instead.

--- a/src/Uno.UI/UI/Xaml/UIElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Android.cs
@@ -11,6 +11,8 @@ using Android.Views;
 using Matrix = Windows.UI.Xaml.Media.Matrix;
 using Point = Windows.Foundation.Point;
 using Rect = Windows.Foundation.Rect;
+using Java.Interop;
+using Windows.UI.Xaml.Markup;
 
 namespace Windows.UI.Xaml
 {
@@ -144,6 +146,10 @@ namespace Windows.UI.Xaml
 				currentViewLocation[1] - relativeToLocation[1]
 			);
 		}
+
+		[Java.Interop.Export(nameof(SetDependencyPropertyValue))]
+		public string SetDependencyPropertyValue(string dependencyPropertyName, string value)
+			=> SetDependencyPropertyValueInternal(this, dependencyPropertyName, value);
 
 		/// <summary>
 		/// Provides a native value for the dependency property with the given name on the current instance. If the value is a primitive type, 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -18,6 +18,8 @@ using Uno;
 using Uno.UI.Controls;
 using Uno.UI.Media;
 using System;
+using Windows.UI.Xaml.Markup;
+using Microsoft.Extensions.Logging;
 
 #if __IOS__
 using UIKit;
@@ -256,6 +258,29 @@ namespace Windows.UI.Xaml
 		{
 			var dp = DependencyProperty.GetProperty(owner.GetType(), dependencyPropertyName);
 			return dp == null ? null : owner.GetValue(dp);
+		}
+
+		internal static string SetDependencyPropertyValueInternal(DependencyObject owner, string dependencyPropertyName, string value)
+		{
+			if (DependencyProperty.GetProperty(owner.GetType(), dependencyPropertyName) is DependencyProperty dp)
+			{
+				if (owner.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				{
+					owner.Log().LogDebug($"SetDependencyPropertyValue({dependencyPropertyName}) = {value}");
+				}
+
+				owner.SetValue(dp, XamlBindingHelper.ConvertValue(dp.Type, value));
+
+				return owner.GetValue(dp)?.ToString();
+			}
+			else
+			{
+				if (owner.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				{
+					owner.Log().LogDebug($"Failed to find property [{dependencyPropertyName}] on [{owner}]");
+				}
+				return "";
+			}
 		}
 
 		internal Rect LayoutSlot { get; set; } = default;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Adds the ability for Uno.UITest to set `DependencyProperty` values.

Testing will be included in TBD

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
