### PR TITLE
[Android] Fix bug where Canvas.ZIndex applies shadow

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -12,6 +12,7 @@
 - [WASM] Fix bug where changing `IsEnabled` from false to true on `Control` inside another `Control` didn't work
 - [Wasm] Add arbitrary delay in Safari macOS to avoid StackOverflow issues
 - #2227 fixed Color & SolidColorBrush literal values generation
+- [Android] Fix bug where setting Canvas.ZIndex would apply shadow effect in some cases
 
 ## Release 2.0
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
@@ -50,5 +50,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 
 			AssertHasColorAt(screenshot, unclippedLocation.CenterX, unclippedLocation.CenterY, Color.Blue);
 		}
+
+		[Test]
+		[AutoRetry]
+		public void Verify_Canvas_ZIndex()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.Canvas.Canvas_ZIndex");
+
+			var screenshot = TakeScreenshot("Rendered");
+
+			var redBorderRect = _app.GetRect("CanvasBorderRed");
+
+			AssertHasColorAt(screenshot, redBorderRect.CenterX, redBorderRect.CenterY, Color.Green /*psych*/);
+
+			var greenBorderRect = _app.GetRect("CanvasBorderGreen");
+
+			AssertHasColorAt(screenshot, greenBorderRect.CenterX, greenBorderRect.CenterY, Color.Blue);
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
@@ -53,6 +53,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // Canvas.ZIndex isn't implemented for WASM yet
 		public void Verify_Canvas_ZIndex()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.Canvas.Canvas_ZIndex");

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -381,6 +381,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Canvas\Canvas_ZIndex.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Canvas\Measure_Children_In_Canvas.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2978,6 +2982,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Canvas\Canvas_With_Outer_Clip.xaml.cs">
       <DependentUpon>Canvas_With_Outer_Clip.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Canvas\Canvas_ZIndex.xaml.cs">
+      <DependentUpon>Canvas_ZIndex.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Canvas\Measure_Children_In_Canvas.xaml.cs">
       <DependentUpon>Measure_Children_In_Canvas.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Canvas/Canvas_ZIndex.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Canvas/Canvas_ZIndex.xaml
@@ -1,0 +1,53 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Canvas.Canvas_ZIndex"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.Canvas"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<Canvas Width="240"
+				Height="240">
+			<Border x:Name="CanvasBorderBlue"
+					Width="80"
+					Height="40"
+					CornerRadius="10"
+					Background="Blue"
+					Canvas.Left="100"
+					Canvas.Top="80"
+					Canvas.ZIndex="30" />
+			<Border x:Name="CanvasBorderGreen"
+					Width="40"
+					Height="120"
+					CornerRadius="10"
+					Background="Green"
+					Canvas.Left="100"
+					Canvas.Top="40"
+					Canvas.ZIndex="20" />
+			<Border x:Name="CanvasBorderRed"
+					Width="120"
+					Height="40"
+					CornerRadius="10"
+					Background="Red"
+					Canvas.Left="60"
+					Canvas.Top="40"
+					Canvas.ZIndex="10" />
+			<ContentControl Content="7"
+							Canvas.ZIndex="60"
+							Canvas.Top="10"
+							Canvas.Left="10">
+				<ContentControl.ContentTemplate>
+					<DataTemplate>
+						<Ellipse Fill="Brown"
+								 Height="18"
+								 Width="18"
+								 IsHitTestVisible="False" />
+					</DataTemplate>
+				</ContentControl.ContentTemplate>
+			</ContentControl>
+		</Canvas>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Canvas/Canvas_ZIndex.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Canvas/Canvas_ZIndex.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Canvas
+{
+	[SampleControlInfo(description: "Demonstrates correct application of Canvas.ZIndex")]
+	public sealed partial class Canvas_ZIndex : UserControl
+	{
+		public Canvas_ZIndex()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.Android.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class Canvas
+	{
+		/// <summary>
+		/// Order of children determined by Canvas.ZIndex, keyed by position in Children
+		/// </summary>
+		private Dictionary<int, int> _zSortedChildren;
+
+		partial void InitializePartial()
+		{
+			// Set this in order for GetChildDrawingOrder() to be called
+			ChildrenDrawingOrderEnabled = true;
+		}
+
+		partial void MeasureOverridePartial()
+		{
+			_zSortedChildren = Children
+				.Select((view, childrenIndex) => (view, childrenIndex))
+				.OrderBy(tpl => tpl.view is DependencyObject obj ? Canvas.GetZIndex(obj) : 0)
+				.Select((tpl, orderedIndex) => (tpl.childrenIndex, orderedIndex))
+				.ToDictionary(keySelector: tpl => tpl.childrenIndex, elementSelector: tpl => tpl.orderedIndex);
+		}
+
+		protected override int GetChildDrawingOrder(int childCount, int i)
+		{
+			return _zSortedChildren?[i] ?? i;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.Layout.cs
@@ -13,6 +13,7 @@ namespace Windows.UI.Xaml.Controls
 	{
 		protected override Size MeasureOverride(Size availableSize)
 		{
+			MeasureOverridePartial();
 			// A canvas does not have dimensions and will always return zero even with a chidren collection.
 			foreach (var child in Children.Where(c => c is DependencyObject))
 			{
@@ -20,6 +21,8 @@ namespace Windows.UI.Xaml.Controls
 			}
 			return new Size(0, 0);
 		}
+
+		partial void MeasureOverridePartial();
 
 		protected override Size ArrangeOverride(Size finalSize)
 		{
@@ -38,18 +41,6 @@ namespace Windows.UI.Xaml.Controls
 
 #if __IOS__
 				child.Layer.ZPosition = (nfloat)GetZIndex(childDO);
-#elif __ANDROID__
-				if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Lollipop)
-				{
-					child.SetZ((float)GetZIndex(childDO));
-				}
-				else
-				{
-					if (this.Log().IsEnabled(LogLevel.Warning))
-					{
-						this.Log().Warn("Canvas.ZIndex is not support on Android 4.4 and less. Canvas will arrange its Children in the order they were added.");
-					}
-				}
 #endif
 
 				ArrangeElement(child, childRect);

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.cs
@@ -128,7 +128,10 @@ namespace Windows.UI.Xaml.Controls
 
 		public Canvas()
 		{
+			InitializePartial();
 		}
+
+		partial void InitializePartial();
 
 		public static double GetLeft(global::Windows.UI.Xaml.UIElement element) => GetLeft((DependencyObject)element);
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Android.cs
@@ -261,6 +261,53 @@ namespace Windows.UI.Xaml
 			}
 		}
 
+		/// <summary>
+		/// Convenience method to find all views with the given name.
+		/// </summary>
+		public FrameworkElement[] FindViewsByName(string name) => FindViewsByName(name, searchDescendantsOnly: false);
+
+
+		/// <summary>
+		/// Convenience method to find all views with the given name.
+		/// </summary>
+		/// <param name="searchDescendantsOnly">If true, only look in descendants of the current view; otherwise search the entire visual tree.</param>
+		public FrameworkElement[] FindViewsByName(string name, bool searchDescendantsOnly)
+		{
+
+			View topLevel = this;
+
+			if (!searchDescendantsOnly)
+			{
+				while (topLevel.Parent is View newTopLevel)
+				{
+					topLevel = newTopLevel;
+				}
+			}
+
+			return GetMatchesInChildren(topLevel).ToArray();
+
+			IEnumerable<FrameworkElement> GetMatchesInChildren(View parentView)
+			{
+				if (!(parentView is ViewGroup parent))
+				{
+					yield break;
+				}
+
+				foreach (var child in parent.GetChildren())
+				{
+					if (child is FrameworkElement fe && fe.Name == name)
+					{
+						yield return fe;
+					}
+
+					foreach (var match in GetMatchesInChildren(child))
+					{
+						yield return match;
+					}
+				}
+			}
+		}
+
 		// Typed properties for easier inspection
 
 		public Controls.ContentControl ContentControlOfInterest => ViewOfInterest as Controls.ContentControl;


### PR DESCRIPTION
Previous implementation of Canvas.ZIndex was calling View.SetZ(), which affects draw order but also applies a shadow effect (though only for Controls for some reason - perhaps because they're doing funky stuff with ViewOutlineProvider). Switch to use GetChildDrawingOrder() instead.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
