### PR TITLE
[iOS] Fix animation might run twice

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -221,6 +221,7 @@
 * #2129 WebAssembly Bootstrapper update to remove the implicit .NET 4.6.2 dependency, and support for long file paths on Windows.
 * #2147 Fix NRE in android-specific TextBox.ImeOptions
 * #2146 [iOS] ListView doesn't take extra space when items are added to collection
+* [iOS] Animation might run twice
 
 ## Release 1.45.0
 ### Features

--- a/src/Uno.UWP/UI/Composition/CoreAnimation.iOS.cs
+++ b/src/Uno.UWP/UI/Composition/CoreAnimation.iOS.cs
@@ -140,7 +140,13 @@ namespace Windows.UI.Composition
 				animation.TimingFunction = _timingFunction;
 				_animation = animation;
 			}
-			_animation.BeginTime = CAAnimation.CurrentMediaTime() + delayMilliseconds / __millisecondsPerSecond;
+
+			if (delayMilliseconds > 0)
+			{
+				// Note: We must make sure to use the time relative to the 'layer', otherwise we might introduce a random delay and the animations
+				//		 will run twice (once "managed" while updating the DP, and a second "native" using this animator)
+				_animation.BeginTime = layer.ConvertTimeFromLayer(CAAnimation.CurrentMediaTime() + delayMilliseconds / __millisecondsPerSecond, null);
+			}
 			_animation.Duration = durationMilliseconds / __millisecondsPerSecond;
 			_animation.FillMode = CAFillMode.Forwards;
 			_animation.RemovedOnCompletion = false;


### PR DESCRIPTION
## BugFix
Animation might run twice

## What is the current behavior?
When we start a native animation on iOS, we also start a managed faked animation which only updates the target DP. For some unknown (?!) reasons, the 2 animations might become out-of sync, resulting in a double animation (first the managed, then the native). After investigation, this is because the native animation starts with a delay.

Apparently on iOS each layer might have its own "relative time", and when we configure the `BeginTime` we used a kind-of absolute time. 

## What is the new behavior?
We know don't set the `BegingTime` when not needed (avoids useless interop), and if needed, we make sure to convert the absolute time to the target layer's relative time.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ **➡ We were not able to determine the reason why the time become relative for a given layer.**
- [ ] ~~[Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~ **➡ Not applicable**
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)


## Other information
Internal Issue: https://nventive.visualstudio.com/_workitems/edit/168212