### PR TITLE
Handling strings from a StaticResource for CreateFromStringAttribute

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ### Features
 - Add support for Automation SetDependencyPropertyValue in Uno.UITest
+- Added support for using a `string` value in a `StaticResource` when using `CreateFromStringAttribute'
 
 ### Breaking changes
 -
@@ -20,7 +21,7 @@
 * [#2040] Support for ms-settings:// special URIs on Android and iOS, Launcher API alignments to match UWP behavior
 * [#2029](https://github.com/unoplatform/uno/pull/2029) Support for MenuFlyoutItem.Click
 * support /[file]/[name] format in ResourceLoader.GetForCurrentView().GetString()
-* [#2039] Added support for Xaml type conversions using CreateFromStringAttribute.
+* [#2039] Added support for Xaml type conversions using `CreateFromStringAttribute`.
 * [#] Support for `Windows.Devices.Lights.Lamp` on iOS, Android.
 * [#1970](https://github.com/unoplatform/uno/pull/1970) Added support for `AnalyticsInfo` properties on iOS, Android and WASM
 * [#1207] Implemented some `PackageId` properties

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1467,13 +1467,22 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return _xamlConversionTypes.Any(ns => ns.Equals(symbol));
 		}
 
-		private string BuildXamlTypeConverterLiteralValue(INamedTypeSymbol symbol, string memberValue)
+		private string BuildXamlTypeConverterLiteralValue(INamedTypeSymbol symbol, string memberValue, bool includeQuotations)
 		{
 			var attributeData = symbol.FindAttribute(XamlConstants.Types.CreateFromStringAttribute);
 			var returnType = attributeData?.NamedArguments.FirstOrDefault(kvp => kvp.Key == "MethodName").Value.Value;
 
-			// Return a string that contains the code which calls the "conversion" function with the member value
-			return "{0}(\"{1}\")".InvariantCultureFormat(returnType, memberValue);
+			if (includeQuotations)
+			{
+				// Return a string that contains the code which calls the "conversion" function with the member value
+				return "{0}(\"{1}\")".InvariantCultureFormat(returnType, memberValue);
+			}
+			else
+			{
+				// Return a string that contains the code which calls the "conversion" function with the member value.
+				// By not including quotations, this allows us to use static resources instead of string values.
+				return "{0}({1})".InvariantCultureFormat(returnType, memberValue);
+			}
 		}
 
 		private XamlMemberDefinition FindMember(XamlObjectDefinition xamlObjectDefinition, string memberName)
@@ -2832,7 +2841,15 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
                 targetPropertyType = targetPropertyType ?? FindPropertyType(member.Member);
 
-                if (!_isGeneratingGlobalResource && _staticResources.TryGetValue(resourcePath, out var res))
+				// If the property Type is attributed with the CreateFromStringAttribute
+				if (IsXamlTypeConverter(targetPropertyType))
+				{
+					var memberValue = $"StaticResources.{SanitizeResourceName(resourcePath)}";
+
+					// We must build the member value as a call to a "conversion" function
+					return BuildXamlTypeConverterLiteralValue(targetPropertyType, memberValue, includeQuotations: false);
+				}
+				if (!_isGeneratingGlobalResource && _staticResources.TryGetValue(resourcePath, out var res))
                 {
                     return ApplyCast($"StaticResources.{SanitizeResourceName(resourcePath)}", useSafeCast, res);
                 }
@@ -2930,7 +2947,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
             if (IsXamlTypeConverter(propertyType))
             {
                 // We must build the member value as a call to a "conversion" function
-                return BuildXamlTypeConverterLiteralValue(propertyType, memberValue);
+                return BuildXamlTypeConverterLiteralValue(propertyType, memberValue, includeQuotations: true);
             }
 
             propertyType = FindUnderlyingType(propertyType);

--- a/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml
@@ -6,9 +6,16 @@
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 mc:Ignorable="d">
 
-	<Grid>
+	<UserControl.Resources>
+		<x:String x:Key="StaticCoordinates">33.33, 22</x:String>
+	</UserControl.Resources>
+
+	<StackPanel>
 		<ctl:MyLocationPointControl x:Name="TestLocationControl"
 									LocationPoint="45.0392, 25.29232" />
-	</Grid>
+
+		<ctl:MyLocationPointControl x:Name="TestLocationControl2"
+									LocationPoint="{StaticResource StaticCoordinates}" />
+	</StackPanel>
 
 </UserControl>

--- a/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml.cs
+++ b/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml.cs
@@ -19,6 +19,7 @@ namespace Uno.UI.Tests.App.Xaml
 	public sealed partial class Test_CreateFromString : UserControl
 	{
 		public MyLocationPointControl TestLocationPoint => TestLocationControl;
+		public MyLocationPointControl TestLocationPoint2 => TestLocationControl2;
 
 		public Test_CreateFromString()
 		{

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/CreateFromStringTests/Given_CreateFromString.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/CreateFromStringTests/Given_CreateFromString.cs
@@ -23,6 +23,11 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.CreateFromStringTests
 
 			Assert.AreEqual(45.0392, pt.Latitude);
 			Assert.AreEqual(25.29232, pt.Longitude);
+
+			var pt2 = control.TestLocationPoint2.LocationPoint;
+
+			Assert.AreEqual(33.33, pt2.Latitude);
+			Assert.AreEqual(22, pt2.Longitude);
 		}
 	}
 


### PR DESCRIPTION
Added support for handling strings from a StaticResource when performing xaml type conversions using CreateFromStringAttribute

GitHub Issue (If applicable): #2039

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Specifying a string from a StaticResource wasn't implemented

## What is the new behavior?

The conversion function for CreateFromStringAttribute will now be able to handle a string value from a StaticResource

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)