### PR TITLE
Wasm "Set Cursor"

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
@@ -62,11 +62,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 
 			var redBorderRect = _app.GetRect("CanvasBorderRed");
 
-			AssertHasColorAt(screenshot, redBorderRect.CenterX, redBorderRect.CenterY, Color.Green /*psych*/);
+			ImageAssert.AssertHasColorAt(screenshot, redBorderRect.CenterX, redBorderRect.CenterY, Color.Green /*psych*/);
 
 			var greenBorderRect = _app.GetRect("CanvasBorderGreen");
 
-			AssertHasColorAt(screenshot, greenBorderRect.CenterX, greenBorderRect.CenterY, Color.Blue);
+			ImageAssert.AssertHasColorAt(screenshot, greenBorderRect.CenterX, greenBorderRect.CenterY, Color.Blue);
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -245,6 +245,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Core\SetCursor.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\LoadEvents.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2905,6 +2909,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\ItemsControl_Loaded.xaml.cs">
       <DependentUpon>ItemsControl_Loaded.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Core\SetCursor.xaml.cs">
+      <DependentUpon>SetCursor.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\LoadEvents.xaml.cs">
       <DependentUpon>LoadEvents.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/SetCursor.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/SetCursor.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Core.SetCursor"
+    xmlns:controls="using:Uno.UI.Samples.Controls"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:android="http:///umbrella/ui/android"
+    mc:Ignorable="d android"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+	    <StackPanel>
+			<ComboBox x:Name="Box" />
+			<Button Content="Reset" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/SetCursor.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/SetCursor.xaml
@@ -1,5 +1,5 @@
-﻿<UserControl
-    x:Class="UITests.Shared.Windows_UI_Core.SetCursor"
+﻿<Page
+    x:Class="SamplesApp.Wasm.Windows_UI_Core.SetCursor"
     xmlns:controls="using:Uno.UI.Samples.Controls"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,9 +11,10 @@
     d:DesignWidth="400">
 
     <Grid>
-	    <StackPanel>
-			<ComboBox x:Name="Box" />
-			<Button Content="Reset" />
+		<StackPanel>
+			<ComboBox Name="Box"/>
+			<Button Content="Reset" Tapped="ResetTapped" />
+			<TextBlock Name="Txt"/>
 		</StackPanel>
 	</Grid>
-</UserControl>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/SetCursor.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/SetCursor.xaml.cs
@@ -13,7 +13,6 @@ namespace SamplesApp.Wasm.Windows_UI_Core
 	[SampleControlInfo("Cursor", "SetCursor")]
 	public sealed partial class SetCursor : Page
 	{
-		Windows.UI.Core.CoreCursorType CurrentCursor = Windows.UI.Core.CoreCursorType.Arrow;
 		public SetCursor()
 		{
 			this.InitializeComponent();
@@ -31,11 +30,14 @@ namespace SamplesApp.Wasm.Windows_UI_Core
 		private void OnUnLoaded(object sender, RoutedEventArgs e)
 		{
 			this.Unloaded -= OnUnLoaded;
+#if NET461 || __WASM__
 			Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(Windows.UI.Core.CoreCursorType.Arrow, 0);
+#endif
 		}
 
 		private void InitList()
 		{
+			#if NET461 || __WASM__
 			var _enumval = Enum.GetValues(typeof(Windows.UI.Core.CoreCursorType));
 			Box.ItemsSource = _enumval;
 			Box.SelectedIndex = 0;
@@ -43,18 +45,23 @@ namespace SamplesApp.Wasm.Windows_UI_Core
 			void handleSelection(object sender, object args)
 			{
 				Txt.Text = "Current selection : " + Box.SelectedItem.ToString();
+
 				Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor((Windows.UI.Core.CoreCursorType)Box.SelectedItem, 0);
+
+
 			}
 
 			Box.Loaded += (s, e) => Box.SelectionChanged += handleSelection;
 			Box.Unloaded += (s, e) => Box.SelectionChanged -= handleSelection;
+			#endif
 		}
 		private void ResetTapped(object sender, TappedRoutedEventArgs e)
 		{
-			CurrentCursor = Windows.UI.Core.CoreCursorType.Arrow;
+#if NET461 || __WASM__
 			Txt.Text = "";
-			Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(Windows.UI.Core.CoreCursorType.Arrow, 0);
 
+			Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(Windows.UI.Core.CoreCursorType.Arrow, 0);
+#endif
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/SetCursor.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/SetCursor.xaml.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Uno.UI.Samples.Controls;
+using System;
+using Windows.Foundation;
+
+// Pour en savoir plus sur le modèle d'élément Contrôle utilisateur, consultez la page https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Wasm.Windows_UI_Core
+{
+	[SampleControlInfo("Cursor", "SetCursor")]
+	public sealed partial class SetCursor : UserControl
+	{
+		public SetCursor()
+		{
+			this.InitializeComponent();
+			this.Loaded += OnLoaded;
+			this.Unloaded += OnUnLoaded;
+
+		}
+		private void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			this.Loaded -= OnLoaded;
+
+			InitList();
+		}
+
+
+		private void InitList()
+		{
+			//var _enumval = Enum.GetValues(typeof(Windows.UI.Core.CoreCursorType));
+			//Box.ItemsSource = _enumval.;
+
+
+
+			//void handleSelection(object sender, object args)
+			//{
+
+			//	//var item = (string)Box.SelectedItem;
+			//	//Windows.UI.Core.CoreCursorType choice;
+			//	//if (Enum.TryParse(item, out choice))
+			//	//{
+			//	//	Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(choice, 0);
+			//	//}
+
+			//	//Box.Loaded += (s, e) => Box.SelectionChanged += handleSelection;
+			//	//Box.Unloaded += (s, e) => Box.SelectionChanged -= handleSelection;
+			//}
+		}
+
+		private void OnUnLoaded(object sender, RoutedEventArgs e)
+		{
+			this.Unloaded -= OnUnLoaded;
+
+			Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(Windows.UI.Core.CoreCursorType.Arrow, 0);
+		}
+		private void ResetTapped(object sender, TappedRoutedEventArgs e)
+		{
+			Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(Windows.UI.Core.CoreCursorType.Arrow, 0);
+
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/SetCursor.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/SetCursor.xaml.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
-using Windows.UI.Xaml;
+﻿using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Uno.UI.Samples.Controls;
+using System.Collections.Generic;
 using System;
 using Windows.Foundation;
 
@@ -11,53 +11,48 @@ using Windows.Foundation;
 namespace SamplesApp.Wasm.Windows_UI_Core
 {
 	[SampleControlInfo("Cursor", "SetCursor")]
-	public sealed partial class SetCursor : UserControl
+	public sealed partial class SetCursor : Page
 	{
+		Windows.UI.Core.CoreCursorType CurrentCursor = Windows.UI.Core.CoreCursorType.Arrow;
 		public SetCursor()
 		{
 			this.InitializeComponent();
 			this.Loaded += OnLoaded;
 			this.Unloaded += OnUnLoaded;
-
+			this.DataContext = this;
 		}
+
 		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
 			this.Loaded -= OnLoaded;
-
 			InitList();
-		}
-
-
-		private void InitList()
-		{
-			//var _enumval = Enum.GetValues(typeof(Windows.UI.Core.CoreCursorType));
-			//Box.ItemsSource = _enumval.;
-
-
-
-			//void handleSelection(object sender, object args)
-			//{
-
-			//	//var item = (string)Box.SelectedItem;
-			//	//Windows.UI.Core.CoreCursorType choice;
-			//	//if (Enum.TryParse(item, out choice))
-			//	//{
-			//	//	Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(choice, 0);
-			//	//}
-
-			//	//Box.Loaded += (s, e) => Box.SelectionChanged += handleSelection;
-			//	//Box.Unloaded += (s, e) => Box.SelectionChanged -= handleSelection;
-			//}
 		}
 
 		private void OnUnLoaded(object sender, RoutedEventArgs e)
 		{
 			this.Unloaded -= OnUnLoaded;
-
 			Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(Windows.UI.Core.CoreCursorType.Arrow, 0);
+		}
+
+		private void InitList()
+		{
+			var _enumval = Enum.GetValues(typeof(Windows.UI.Core.CoreCursorType));
+			Box.ItemsSource = _enumval;
+			Box.SelectedIndex = 0;
+
+			void handleSelection(object sender, object args)
+			{
+				Txt.Text = "Current selection : " + Box.SelectedItem.ToString();
+				Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor((Windows.UI.Core.CoreCursorType)Box.SelectedItem, 0);
+			}
+
+			Box.Loaded += (s, e) => Box.SelectionChanged += handleSelection;
+			Box.Unloaded += (s, e) => Box.SelectionChanged -= handleSelection;
 		}
 		private void ResetTapped(object sender, TappedRoutedEventArgs e)
 		{
+			CurrentCursor = Windows.UI.Core.CoreCursorType.Arrow;
+			Txt.Text = "";
 			Window.Current.CoreWindow.PointerCursor = new Windows.UI.Core.CoreCursor(Windows.UI.Core.CoreCursorType.Arrow, 0);
 
 		}

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -128,6 +128,8 @@
 		private containerElement: HTMLDivElement;
 		private rootContent: HTMLElement;
 
+		private cursorStyleElement: HTMLElement;
+
 		private allActiveElementsById: { [id: number]: HTMLElement | SVGElement } = {};
 
 		private static resizeMethod: any;
@@ -1665,6 +1667,31 @@
 				return false;
 			}
 			return rootElement === element || rootElement.contains(element);
+		}
+
+		public setCursor( cssCursor: string) {
+			const unoBody = document.getElementById(this.containerElementId);
+
+			if (unoBody) {
+
+				//always cleanup
+				if (this.cursorStyleElement != undefined) {
+					this.cursorStyleElement.remove();
+					this.cursorStyleElement= undefined
+				}
+
+				//only add custom overriding style if not auto 
+				if (cssCursor != "auto") {
+
+					// this part is only to override default css:  .uno-buttonbase {cursor: pointer;}
+
+					this.cursorStyleElement = document.createElement("style");
+					this.cursorStyleElement.innerHTML = ".uno-buttonbase { cursor: " + cssCursor + "; }";
+					document.body.appendChild(this.cursorStyleElement);
+				}
+
+				unoBody.style.cursor = cssCursor;
+			}
 		}
 	}
 

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -1669,7 +1669,7 @@
 			return rootElement === element || rootElement.contains(element);
 		}
 
-		public setCursor( cssCursor: string) {
+		public setCursor(cssCursor: string): string {
 			const unoBody = document.getElementById(this.containerElementId);
 
 			if (unoBody) {
@@ -1692,6 +1692,7 @@
 
 				unoBody.style.cursor = cssCursor;
 			}
+			return "ok";
 		}
 	}
 

--- a/src/Uno.UWP/UI/Core/CoreCursorTypeExtensions.wasm.cs
+++ b/src/Uno.UWP/UI/Core/CoreCursorTypeExtensions.wasm.cs
@@ -1,0 +1,56 @@
+﻿using Uno.Extensions;
+using Uno.Logging;
+
+namespace Windows.UI.Core
+{
+	internal static class CoreCursorTypeExtensions
+	{
+		internal static string ToCssCursor(this CoreCursorType coreCursorType)
+		{
+			//best matches between 
+			// https://docs.microsoft.com/id-id/uwp/api/windows.ui.core.corecursortype
+			//and 
+			//https://developer.mozilla.org/fr/docs/Web/CSS/cursor
+			// no support for Custom Cursor for now
+
+			switch (coreCursorType)
+			{
+				case CoreCursorType.Custom:
+					coreCursorType.Log().Warn("Cursor type 'Custom' not supported yet. Default cursor is used instead.");
+					return "auto";
+				case CoreCursorType.Arrow:
+					return "auto";
+				case CoreCursorType.Cross:
+					return "crosshair";
+				case CoreCursorType.Hand:
+					return "pointer";
+				case CoreCursorType.Help:
+					return "help";
+				case CoreCursorType.IBeam:
+					return "text";
+				case CoreCursorType.SizeAll:
+					return "move";
+				case CoreCursorType.SizeNortheastSouthwest:
+					return "nesw-resize";
+				case CoreCursorType.SizeNorthSouth:
+					return "ns-resize";
+				case CoreCursorType.SizeNorthwestSoutheast:
+					return "nwse-resize";
+				case CoreCursorType.SizeWestEast:
+					return "ew-resize";
+				case CoreCursorType.UniversalNo:
+					return "not-allowed";
+				case CoreCursorType.UpArrow:
+					return "n-resize";
+				case CoreCursorType.Wait:
+					return "wait";
+
+				case CoreCursorType.Pin:
+				case CoreCursorType.Person:
+					return "pointer";
+				default:
+					return "auto";
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Core/CoreWindow.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.cs
@@ -31,8 +31,10 @@ namespace Windows.UI.Core
 			set => _pointerPosition = value;
 		}
 
+#if !__WASM__
 		[Uno.NotImplemented]
 		public CoreCursor PointerCursor { get; set; } = new CoreCursor(CoreCursorType.Arrow, 0);
+#endif
 
 		[Uno.NotImplemented]
 		public CoreVirtualKeyStates GetAsyncKeyState(System.VirtualKey virtualKey)

--- a/src/Uno.UWP/UI/Core/CoreWindow.wasm.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.wasm.cs
@@ -1,15 +1,10 @@
-using System;
-using System.Runtime.InteropServices;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.Foundation.Metadata;
 using Uno.Foundation;
 
 namespace Windows.UI.Core
 {
-	public partial class CoreWindow 
+	public partial class CoreWindow
 	{
-		private CoreCursor _pointerCursor;
+		private CoreCursor _pointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);
 
 		public global::Windows.UI.Core.CoreCursor PointerCursor
 		{
@@ -24,59 +19,14 @@ namespace Windows.UI.Core
 
 		private void Internal_SetPointerCursor()
 		{
-			string cssCoreCursorType = GetCssCursor(_pointerCursor.Type);
-			WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.current.setCursor(\"{cssCoreCursorType}\");");
-		}
-
-		string GetCssCursor(CoreCursorType coreCursorType)
-		{
-			//best matches between 
-			// https://docs.microsoft.com/id-id/uwp/api/windows.ui.core.corecursortype
-			//and 
-			//https://developer.mozilla.org/fr/docs/Web/CSS/cursor
-			// no support for Custom Cursor for now
-
-			switch (coreCursorType)
+			var command = string.Concat(new[]
 			{
-				case CoreCursorType.Custom:
-				case CoreCursorType.Arrow:
-					return "auto";
-				case CoreCursorType.Cross:
-					return "crosshair";
-				case CoreCursorType.Hand:
-					return "pointer";
-				case CoreCursorType.Help:
-					return "help";
-				case CoreCursorType.IBeam:
-					return "text";
-				case CoreCursorType.SizeAll:
-					return "move";
-				case CoreCursorType.SizeNortheastSouthwest:
-					return "nesw-resize";
-				case CoreCursorType.SizeNorthSouth:
-					return "ns-resize";
-				case CoreCursorType.SizeNorthwestSoutheast:
-					return "nwse-resize";
-				case CoreCursorType.SizeWestEast:
-					return "ew-resize";
-				case CoreCursorType.UniversalNo:
-					return "not-allowed";
-				case CoreCursorType.UpArrow:
-					return "n-resize";
-				case CoreCursorType.Wait:
-					return "wait";
+				"Uno.UI.WindowManager.current.setCursor(\"",
+				_pointerCursor.Type.ToCssCursor(),
+				"\");"
+			});
 
-				case CoreCursorType.Pin:
-				case CoreCursorType.Person:
-					return "pointer";
-				default:
-					return "auto";
-			}
-		}
-		[global::Uno.NotImplemented]
-		public global::Windows.UI.Core.CoreVirtualKeyStates GetKeyState(global::Windows.System.VirtualKey virtualKey)
-		{
-			return CoreVirtualKeyStates.None;
+			WebAssemblyRuntime.InvokeJS(command);
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Core/CoreWindow.wasm.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.wasm.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Runtime.InteropServices;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.Foundation.Metadata;
+using Uno.Foundation;
+
+namespace Windows.UI.Core
+{
+	public partial class CoreWindow 
+	{
+		private CoreCursor _pointerCursor;
+
+		public global::Windows.UI.Core.CoreCursor PointerCursor
+		{
+			get => _pointerCursor;
+			set
+			{
+				_pointerCursor = value;
+				Internal_SetPointerCursor();
+			}
+
+		}
+
+		private void Internal_SetPointerCursor()
+		{
+			string cssCoreCursorType = GetCssCursor(_pointerCursor.Type);
+			WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.current.setCursor(\"{cssCoreCursorType}\");");
+		}
+
+		string GetCssCursor(CoreCursorType coreCursorType)
+		{
+			//best matches between 
+			// https://docs.microsoft.com/id-id/uwp/api/windows.ui.core.corecursortype
+			//and 
+			//https://developer.mozilla.org/fr/docs/Web/CSS/cursor
+			// no support for Custom Cursor for now
+
+			switch (coreCursorType)
+			{
+				case CoreCursorType.Custom:
+				case CoreCursorType.Arrow:
+					return "auto";
+				case CoreCursorType.Cross:
+					return "crosshair";
+				case CoreCursorType.Hand:
+					return "pointer";
+				case CoreCursorType.Help:
+					return "help";
+				case CoreCursorType.IBeam:
+					return "text";
+				case CoreCursorType.SizeAll:
+					return "move";
+				case CoreCursorType.SizeNortheastSouthwest:
+					return "nesw-resize";
+				case CoreCursorType.SizeNorthSouth:
+					return "ns-resize";
+				case CoreCursorType.SizeNorthwestSoutheast:
+					return "nwse-resize";
+				case CoreCursorType.SizeWestEast:
+					return "ew-resize";
+				case CoreCursorType.UniversalNo:
+					return "not-allowed";
+				case CoreCursorType.UpArrow:
+					return "n-resize";
+				case CoreCursorType.Wait:
+					return "wait";
+
+				case CoreCursorType.Pin:
+				case CoreCursorType.Person:
+					return "pointer";
+				default:
+					return "auto";
+			}
+		}
+		[global::Uno.NotImplemented]
+		public global::Windows.UI.Core.CoreVirtualKeyStates GetKeyState(global::Windows.System.VirtualKey virtualKey)
+		{
+			return CoreVirtualKeyStates.None;
+		}
+	}
+}


### PR DESCRIPTION
New version of https://github.com/unoplatform/uno/pull/629
# Feature


## What is the new behavior?
Rebased the excellent PR from @Firefly74940.

Implemented the `Window.Current.CoreWindow.PointerCursor` on Wasm

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
