### PR TITLE
Adjust the SetDependencyPropertyValue backdoor signature

### DIFF
--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -1556,7 +1556,7 @@
 		 *
 		 * Note that the casing of this method is intentionally Pascal for platform alignment.
 		 */
-		public SetDependencyPropertyValue(elementId: number, propertyName: string, propertyValue: string) : string {
+		public SetDependencyPropertyValue(elementId: number, propertyNameAndValue: string) : string {
 			if (!WindowManager.setDependencyPropertyValueMethod) {
 				WindowManager.setDependencyPropertyValueMethod = (<any>Module).mono_bind_static_method("[Uno.UI] Uno.UI.Helpers.Automation:SetDependencyPropertyValue");
 			}
@@ -1564,7 +1564,7 @@
 			const element = this.getView(elementId) as HTMLElement;
 			const htmlId = Number(element.getAttribute("XamlHandle"));
 
-			return WindowManager.setDependencyPropertyValueMethod(htmlId, propertyName, propertyValue);
+			return WindowManager.setDependencyPropertyValueMethod(htmlId, propertyNameAndValue);
 		}
 
 		/**

--- a/src/Uno.UI/Helpers/Automation.wasm.cs
+++ b/src/Uno.UI/Helpers/Automation.wasm.cs
@@ -29,13 +29,19 @@ namespace Uno.UI.Helpers
 			}
 		}
 
+		/// <summary>
+		/// Sets the specified dependency property value using the format "name|value"
+		/// </summary>
+		/// <param name="dependencyPropertyNameAndValue">The name and value of the property</param>
+        /// <param name="handle">The GCHandle of the UIElement to use</param>
+		/// <returns>The currenty set value at the Local precedence</returns>
 		[Preserve]
-		public static string SetDependencyPropertyValue(int handle, string dependencyPropertyName, string value)
+		public static string SetDependencyPropertyValue(int handle, string dependencyPropertyNameAndValue)
 		{
 			// Dispatch to right object, if we can find it
 			if (UIElement.GetElementFromHandle(handle) is UIElement element)
 			{
-				return UIElement.SetDependencyPropertyValueInternal(element, dependencyPropertyName, value);
+				return UIElement.SetDependencyPropertyValueInternal(element, dependencyPropertyNameAndValue);
 			}
             else
             {

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -1042,7 +1042,6 @@ namespace <#= mixin.NamespaceName #>
 		/// <param name="dependencyPropertyNameAndvalue">The name and value of the property</param>
 		/// <returns>The currenty set value at the Local precedence</returns>
 		[global::Foundation.Export("setDependencyPropertyValue:")]
-		[global::Foundation.Export("setDependencyPropertyValue:")]
 		public global::Foundation.NSString SetDependencyPropertyValue(global::Foundation.NSString dependencyPropertyNameAndValue)
 		{
 				return new global::Foundation.NSString(UIElement.SetDependencyPropertyValueInternal(this, dependencyPropertyNameAndValue) ?? "");

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -1031,23 +1031,21 @@ namespace <#= mixin.NamespaceName #>
 				return null;
 			}
 
-			Console.WriteLine($"GetDependencyPropertyValue({dependencyPropertyName}) = {dpValue}");
-
 			// If all else fails, just return the string representation of the DP's value
 			return new global::Foundation.NSString(dpValue.ToString());
 		}
 
 				
 		/// <summary>
-		/// Provides a native value for the dependency property with the given name on the current instance. If the value is a primitive type, 
-		/// its native representation is returned. Otherwise, the <see cref="object.ToString"/> implementation is used/returned instead.
+		/// Sets the specified dependency property value using the format "name|value"
 		/// </summary>
-		/// <param name="dependencyPropertyName">The name of the target dependency property</param>
-		/// <returns>The content of the target dependency property (its actual value if it is a primitive type ot its <see cref="object.ToString"/> representation otherwise</returns>
-		[global::Foundation.Export("setDependencyPropertyValue::")]
-		public global::Foundation.NSString SetDependencyPropertyValue(global::Foundation.NSString dependencyPropertyName, global::Foundation.NSString value)
+		/// <param name="dependencyPropertyNameAndvalue">The name and value of the property</param>
+		/// <returns>The currenty set value at the Local precedence</returns>
+		[global::Foundation.Export("setDependencyPropertyValue:")]
+		[global::Foundation.Export("setDependencyPropertyValue:")]
+		public global::Foundation.NSString SetDependencyPropertyValue(global::Foundation.NSString dependencyPropertyNameAndValue)
 		{
-			return new global::Foundation.NSString(UIElement.SetDependencyPropertyValueInternal(this, dependencyPropertyName, value));
+				return new global::Foundation.NSString(UIElement.SetDependencyPropertyValueInternal(this, dependencyPropertyNameAndValue) ?? "");
 		}
 		
 		#region AutomationPeer

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
@@ -997,15 +997,14 @@ namespace <#= mixin.NamespaceName #>
 
 						
 		/// <summary>
-		/// Provides a native value for the dependency property with the given name on the current instance. If the value is a primitive type, 
-		/// its native representation is returned. Otherwise, the <see cref="object.ToString"/> implementation is used/returned instead.
+		/// Sets the specified dependency property value using the format "name|value"
 		/// </summary>
-		/// <param name="dependencyPropertyName">The name of the target dependency property</param>
-		/// <returns>The content of the target dependency property (its actual value if it is a primitive type ot its <see cref="object.ToString"/> representation otherwise</returns>
-		[global::Foundation.Export("setDependencyPropertyValue::")]
-		public global::Foundation.NSString SetDependencyPropertyValue(global::Foundation.NSString dependencyPropertyName, global::Foundation.NSString value)
+		/// <param name="dependencyPropertyNameAndValue">The name and value of the property</param>
+		/// <returns>The currenty set value at the Local precedence</returns>
+		[global::Foundation.Export("setDependencyPropertyValue:")]
+		public global::Foundation.NSString SetDependencyPropertyValue(global::Foundation.NSString dependencyPropertyNameAndValue)
 		{
-			return new global::Foundation.NSString(UIElement.SetDependencyPropertyValueInternal(this, dependencyPropertyName, value));
+			return new global::Foundation.NSString(UIElement.SetDependencyPropertyValueInternal(this, dependencyPropertyNameAndValue) ?? "");
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/UIElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Android.cs
@@ -140,9 +140,15 @@ namespace Windows.UI.Xaml
 			);
 		}
 
+
+		/// <summary>
+        /// Sets the specified dependency property value using the format "name|value"
+        /// </summary>
+        /// <param name="dependencyPropertyNameAndvalue">The name and value of the property</param>
+        /// <returns>The currenty set value at the Local precedence</returns>
 		[Java.Interop.Export(nameof(SetDependencyPropertyValue))]
-		public string SetDependencyPropertyValue(string dependencyPropertyName, string value)
-			=> SetDependencyPropertyValueInternal(this, dependencyPropertyName, value);
+		public string SetDependencyPropertyValue(string dependencyPropertyNameAndValue)
+			=> SetDependencyPropertyValueInternal(this, dependencyPropertyNameAndValue);
 
 		/// <summary>
 		/// Provides a native value for the dependency property with the given name on the current instance. If the value is a primitive type, 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -270,7 +270,6 @@ namespace Windows.UI.Xaml
 		/// parameters passing on iOS, where the number of parameters follows a unconventional set of rules. Using
 		/// a single parameter with a simple delimitation format fits all platforms with little overhead.
 		/// </remarks>
-		[global::Foundation.Export("setDependencyPropertyValue:")]
 		internal static string SetDependencyPropertyValueInternal(DependencyObject owner, string dependencyPropertyNameAndValue)
 		{
 			var s = dependencyPropertyNameAndValue;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The signature of the `SetDependencyProperty` method was chosen to work around a limitation of Xamarin.UITest with regards to parameters passing on iOS, where the number of parameters follows a unconventional set of rules.

Using a single parameter with a simple delimitation format fits all platforms with little overhead.

Tests will be coming with a Uno.UITest package update.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
