### PR TITLE
Adds support for FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -3,6 +3,7 @@
 ### Features
 - Add support for Automation SetDependencyPropertyValue in Uno.UITest
 - Added support for using a `string` value in a `StaticResource` when using `CreateFromStringAttribute'
+- [Android] Adds support for `FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay`
 
 ### Breaking changes
 -

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -237,6 +237,7 @@ namespace SamplesApp
 
 #if __ANDROID__
 							Windows.ApplicationModel.Core.CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = false;
+							Uno.UI.FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay = TimeSpan.Zero;
 #endif
 
 #if HAS_UNO

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/UIElementTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/UIElementTests.cs
@@ -18,7 +18,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml
 		[ActivePlatforms(Platform.Browser)]
 		public void When_TransformToVisual_Transform()
 		{
-			Run("UITests.Shared.Windows_UI_Xaml.UIElementTests.TransformToVisual_Transform");
+			Run("UITests.Shared.Windows_UI_Xaml.UIElementTests.TransformToVisual_Transform", skipInitialScreenshot: false);
 
 			_app.WaitForText("TestsStatus", "SUCCESS");
 		}
@@ -29,7 +29,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml
 		[ActivePlatforms(Platform.Browser)]
 		public void When_TransformToVisual_ScrollViewer()
 		{
-			Run("UITests.Shared.Windows_UI_Xaml.UIElementTests.TransformToVisual_ScrollViewer");
+			Run("UITests.Shared.Windows_UI_Xaml.UIElementTests.TransformToVisual_ScrollViewer", skipInitialScreenshot: false);
 
 			_app.WaitForText("TestsStatus", "SUCCESS");
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
@@ -62,11 +62,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 
 			var redBorderRect = _app.GetRect("CanvasBorderRed");
 
-			AssertHasColorAt(screenshot, redBorderRect.CenterX, redBorderRect.CenterY, Color.Green /*psych*/);
+			ImageAssert.AssertHasColorAt(screenshot, redBorderRect.CenterX, redBorderRect.CenterY, Color.Green /*psych*/);
 
 			var greenBorderRect = _app.GetRect("CanvasBorderGreen");
 
-			AssertHasColorAt(screenshot, greenBorderRect.CenterX, greenBorderRect.CenterY, Color.Blue);
+			ImageAssert.AssertHasColorAt(screenshot, greenBorderRect.CenterX, greenBorderRect.CenterY, Color.Blue);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
@@ -16,6 +16,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 	public partial class ContentDialog_Tests : SampleControlUITestBase
 	{
 		private void CurrentTestTakeScreenShot(string name) =>
+			// Screenshot taking for this fixture is disabled on Android because of the
+			// presence of the status bar when native popups are opened, adding the clock
+			// (that is always changing :)).
 			TakeScreenshot(name, ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() != Platform.Android);
 
 		[Test]

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Examples.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Examples.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DateTimePicker/DateTimePicker.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DateTimePicker/DateTimePicker.xaml.cs
@@ -6,7 +6,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.DateTimePicker
 {
-	[SampleControlInfo("DateTimePicker", "DateTimePicker", typeof(DateTimePickerViewModel))]
+	[SampleControlInfo("DateTimePicker", "DateTimePicker", typeof(DateTimePickerViewModel), ignoreInSnapshotTests: true)]
 	public sealed partial class DateTimePicker : UserControl
     {
         public DateTimePicker()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample1.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample1.xaml.cs
@@ -17,7 +17,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.TimePicker
 {
-	[SampleControlInfo("Time Picker", "Sample1", typeof(TimePickerViewModel))]
+	[SampleControlInfo("Time Picker", "Sample1", typeof(TimePickerViewModel), ignoreInSnapshotTests: true)]
 	public sealed partial class Sample1 : UserControl
 	{
 		public Sample1()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample2.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample2.xaml.cs
@@ -17,7 +17,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.TimePicker
 {
-	[SampleControlInfo("Time Picker", "Sample2", typeof(TimePickerViewModel))]
+	[SampleControlInfo("Time Picker", "Sample2", typeof(TimePickerViewModel), ignoreInSnapshotTests: true)]
 	public sealed partial class Sample2 : UserControl
 	{
 		public Sample2()

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -305,6 +305,15 @@ namespace Uno.UI
 			/// referencing the ** type ** ScrollViewer in any way.
 			/// </remarks>
 			public static ScrollViewerUpdatesMode DefaultUpdatesMode { get; set; } = ScrollViewerUpdatesMode.AsynchronousIdle;
+
+#if __ANDROID__
+			/// <summary>
+			/// This value defines an optional delay to be set for native ScrollBar thumbs to disapear. The
+			/// platform default is 300ms, which can make the thumbs appear on screenshots, changing this value
+			/// to <see cref="TimeSpan.Zero"/> makes those disapear faster.
+			/// </summary>
+			public static TimeSpan? AndroidScrollbarFadeDelay { get; set; }
+#endif
 		}
 
 		public static class ToolTip

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.Android.cs
@@ -87,6 +87,11 @@ namespace Windows.UI.Xaml.Controls
 			else
 			{
 				InitializeScrollbars(null);
+
+				if(FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay != null)
+				{
+					ScrollBarDefaultDelayBeforeFade = (int)FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay.Value.TotalMilliseconds;
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Android.cs
@@ -97,6 +97,11 @@ namespace Windows.UI.Xaml.Controls
 			{
 				InitializeScrollbars(null);
 			}
+
+			if (FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay != null)
+			{
+				ScrollBarDefaultDelayBeforeFade = (int)FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay.Value.TotalMilliseconds;
+			}
 		}
 
 		List<View> IShadowChildrenProvider.ChildrenShadow => Content != null ? new List<View>(1) { Content } : _emptyList;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature
- Build or CI related changes

## What is the new behavior?

- Adds support for `FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay`
- Remove more screenshots for changing tests

Needs #2293 to be merged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
