### PR TITLE
[Wasm] Fix LaunchUriAsync should not validate dispatcher

### DIFF
--- a/src/Uno.UWP/System/Launcher.cs
+++ b/src/Uno.UWP/System/Launcher.cs
@@ -25,6 +25,7 @@ namespace Windows.System
 				throw new ArgumentNullException(nameof(uri));
 			}
 
+#if !__WASM__
 			if (!CoreDispatcher.Main.HasThreadAccess)
 			{
 				if (typeof(Launcher).Log().IsEnabled(LogLevel.Error))
@@ -34,6 +35,7 @@ namespace Windows.System
 				// LaunchUriAsync throws the following exception if used on UI thread on UWP
 				throw new InvalidOperationException($"{nameof(LaunchUriAsync)} must be called on the UI thread");
 			}
+#endif
 
 			return LaunchUriPlatformAsync(uri);
 #else
@@ -58,7 +60,11 @@ namespace Windows.System
 			}
 
 			// this method may run on the background thread on UWP
+#if !__WASM__
 			if (CoreDispatcher.Main.HasThreadAccess)
+#else
+			if(true)
+#endif
 			{
 				return QueryUriSupportPlatformAsync(uri, launchQuerySupportType).AsAsyncOperation();
 			}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixed LaunchUriAsync fails on Wasm.

This kind of code cannot yet be validated because of the opening of an external tab. Will need to be adjusted once threading support is enabled (https://github.com/unoplatform/uno/issues/2302).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
