### PR TITLE
Fixed possible Nan/Infinity measurement on iOS 11

### DIFF
--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.iOSmacOS.cs
@@ -300,9 +300,25 @@ namespace Windows.UI.Xaml.Shapes
 			var path = GetPath();
 			if (path == null)
 			{
-				return default(Size);
+				return default;
 			}
 			var bounds = path.PathBoundingBox;
+
+			if (bounds.IsEmpty)
+			{
+				return default;
+			}
+
+			// On iOS 11, the origin (X, Y) of bounds could be infinite, leading to strange results.
+			if (nfloat.IsInfinity(bounds.X))
+			{
+				bounds.X = 1;
+			}
+
+			if (nfloat.IsInfinity(bounds.Y))
+			{
+				bounds.Y = 1;
+			}
 
 			var pathWidth = bounds.Width;
 			var pathHeight = bounds.Height;

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.iOSmacOS.cs
@@ -312,12 +312,12 @@ namespace Windows.UI.Xaml.Shapes
 			// On iOS 11, the origin (X, Y) of bounds could be infinite, leading to strange results.
 			if (nfloat.IsInfinity(bounds.X))
 			{
-				bounds.X = 1;
+				bounds.X = 0;
 			}
 
 			if (nfloat.IsInfinity(bounds.Y))
 			{
-				bounds.Y = 1;
+				bounds.Y = 0;
 			}
 
 			var pathWidth = bounds.Width;


### PR DESCRIPTION
GitHub Issue (If applicable): #2140

# Bugfix

## What is the current behavior?
Application using `<Path>` was crashing on iOS 11

## What is the new behavior?
Works fine.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
