### PR TITLE
Zip test results before publishing the artifacts

### DIFF
--- a/.azure-devops-wasm-uitests.yml
+++ b/.azure-devops-wasm-uitests.yml
@@ -169,6 +169,9 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
 
+  variables:
+    COMPARE_WORKDIR: $(Build.SourcesDirectory)\snapshot-compare
+
   steps:
   - checkout: self
     clean: true
@@ -192,7 +195,7 @@ jobs:
       createLogFile: false
 
   - script: |
-      src\Uno.UI.TestComparer\bin\Release\Uno.UI.TestComparer.exe "azdo" --pat="$(UITestsCompare_PAT)" --base-path="$(build.artifactstagingdirectory)" --source-branch="%GIT_SOURCEBRANCH%" --target-branch="%GIT_TARGETBRANCH%" --artifact-name="uitests-results" --artifact-inner-path="uitests-results\screenshots" --definition-name="$(Build.DefinitionName)" --project-name="$(System.TeamProject)" --server-uri="$(System.TeamFoundationCollectionUri)" --current-build="$(Build.BuildId)" --run-limit="3" --github-pat="$(CommentsGitHubPAT)" --source-repository="$(system.pullRequest.sourceRepositoryUri)" --github-pr-id="$(system.pullRequest.pullRequestNumber)"
+      src\Uno.UI.TestComparer\bin\Release\Uno.UI.TestComparer.exe "azdo" --pat="$(UITestsCompare_PAT)" --base-path="$(COMPARE_WORKDIR)" --source-branch="%GIT_SOURCEBRANCH%" --target-branch="%GIT_TARGETBRANCH%" --artifact-name="uitests-results" --artifact-inner-path="uitests-results\screenshots" --definition-name="$(Build.DefinitionName)" --project-name="$(System.TeamProject)" --server-uri="$(System.TeamFoundationCollectionUri)" --current-build="$(Build.BuildId)" --run-limit="3" --github-pat="$(CommentsGitHubPAT)" --source-repository="$(system.pullRequest.sourceRepositoryUri)" --github-pr-id="$(system.pullRequest.pullRequestNumber)"
       
     env:
       GIT_TARGETBRANCH: "$(System.PullRequest.TargetBranch)"
@@ -201,7 +204,6 @@ jobs:
     displayName: 'Compare UI Tests screenshots'
     condition: eq(variables['Build.Repository.Provider'], 'GitHub')
 
-
   - task: PublishTestResults@2
     condition: always()
     inputs:
@@ -209,6 +211,13 @@ jobs:
       testRunTitle: 'Screenshots Compare Test Run'
       testResultsFormat: 'NUnit'
       failTaskOnFailedTests: false
+
+  - task: ArchiveFiles@2
+    inputs:
+      rootFolderOrFile: '$(COMPARE_WORKDIR)' 
+      includeRootFolder: true 
+      archiveType: 'zip'
+      archiveFile: '$(Build.ArtifactStagingDirectory)/snapshot-compare-results-$(Build.BuildId).zip' 
 
   - task: PublishBuildArtifacts@1
     inputs:


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

This reduces the number of storage calls (> 14K as of this commit) which can be very slow.

Images won't be accessible from the artifacts view, but are still accessible from the test results in the ADO web interface.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
