### PR TITLE
Fix possible null-ref in TextBlock

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
@@ -305,6 +305,11 @@ namespace Windows.UI.Xaml.Controls
 
 		private Size LayoutTypography(Size size)
 		{
+			if (_textContainer == null || _attributedString == null)
+			{
+				return default(Size);
+			}
+			
 			if (UseLayoutManager)
 			{
 				_textContainer.Size = size;
@@ -312,7 +317,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else
 			{
-				return _attributedString?.GetBoundingRect(size, NSStringDrawingOptions.UsesLineFragmentOrigin, null).Size ?? new CGSize(0,0);
+				return _attributedString.GetBoundingRect(size, NSStringDrawingOptions.UsesLineFragmentOrigin, null).Size;
 			}
 		}
 


### PR DESCRIPTION
## Bugfix
Possible null-ref in `TextBVlock`

## What is the current behavior?
For some reason the `TextBlock` might invoke the `LayoutTypography` before the `UpdateTypography` has been invoked (for instance if a `TextBlock` is arranged while the measure was bypassed). In that case the null-ref is raised in the `LayoutTypography`.

## What is the new behavior?
We check if fields are still `null` before using them ...

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~[Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)

## Other information
This PR is an enhancement of https://github.com/unoplatform/uno/commit/149eb9ae192444e55892d0e4c8cfef4557c565e2 (Bug: https://github.com/unoplatform/uno/issues/2051).

Combined with a fix in `Image` which also prevent a null-ref in [`UpdateLayerRect` where the `Image` property can be null](https://github.com/unoplatform/uno/commit/cfcf58fd0e8496598adce28f113b03e3a4b8f80a#diff-de5d4ca4935e2e36671e5f312b3f676aR309), this prevent a crash in the `ListView`: Even if try-catched, if [the `MeasureChild` fails in `ListViewBaseSource`](https://github.com/unoplatform/uno/blob/master/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs#L822), it might crash iOS  (enough to require a restart of the phone).

**I'll see if it's possible to add some tests to prevent a future regression of those, but I want to confirm that effectively fixes the bug in canaries as soon as possible.**

Internal Issue: https://nventive.visualstudio.com/_workitems/edit/168815
