### PR TITLE
iOS image alignment were incorrect when size was specified directly on the <Image> control

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -27,10 +27,10 @@
     <PackageReference Update="Microsoft.TypeScript.MSBuild" Version="3.1.5" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Update="Uno.UITest" Version="1.0.0-dev.97" />
-    <PackageReference Update="Uno.UITest.Selenium" Version="1.0.0-dev.97" />
-    <PackageReference Update="Uno.UITest.Xamarin" Version="1.0.0-dev.97" />
-    <PackageReference Update="Uno.UITest.Helpers" Version="1.0.0-dev.97" />
+    <PackageReference Update="Uno.UITest" Version="1.0.0-dev.105" />
+    <PackageReference Update="Uno.UITest.Selenium" Version="1.0.0-dev.105" />
+    <PackageReference Update="Uno.UITest.Xamarin" Version="1.0.0-dev.105" />
+    <PackageReference Update="Uno.UITest.Helpers" Version="1.0.0-dev.105" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -225,11 +225,11 @@ namespace SamplesApp.UITests
 			return Array.Empty<Platform>();
 		}
 
-		protected void Run(string metadataName, bool waitForSampleControl = true, bool skipInitialScreenshot = false)
+		protected void Run(string metadataName, bool waitForSampleControl = true, bool skipInitialScreenshot = false, int sampleLoadTimeout = 5)
 		{
 			if (waitForSampleControl)
 			{
-				_app.WaitForElement("sampleControl", timeout: TimeSpan.FromSeconds(5));
+				_app.WaitForElement("sampleControl", timeout: TimeSpan.FromSeconds(sampleLoadTimeout));
 			}
 
 			var testRunId = _app.InvokeGeneric("browser:SampleRunner|RunTest", metadataName);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -87,7 +87,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 		private void RunScreenShots_Image_Alignment_page(string testName)
 		{
-			Run(testName);
+			Run(testName, skipInitialScreenshot: true);
 
 			var picker = _app.Marked("modesPicker");
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -89,18 +89,18 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 		{
 			Run(testName);
 
+			var picker = _app.Marked("modesPicker");
+
 			var currentModeButton = _app.Marked("currentMode");
 			_app.WaitForElement(currentModeButton);
-
-			var nextStretchButton = _app.Marked("nextStretch");
-			nextStretchButton.Tap();
+			_app.WaitForDependencyPropertyValue(currentModeButton, "Content", "00");
 
 			for (var i = 0; i < 4; i++)
 			{
+				picker.SetDependencyPropertyValue("Mode", "S" + i);
 				_app.WaitForDependencyPropertyValue(currentModeButton, "Content", (i * 16).ToString("00"));
 
 				base.TakeScreenshot("Mode-" + i);
-				nextStretchButton.Tap();
 			}
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -97,6 +97,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 			for (var i = 0; i < 4; i++)
 			{
+				// Use SetDependencyPropertyValue instead of Tap for performance on iOS/Android (Tap takes multiple seconds to complete)
 				picker.SetDependencyPropertyValue("Mode", "S" + i);
 				_app.WaitForDependencyPropertyValue(currentModeButton, "Content", (i * 16).ToString("00"));
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -59,6 +59,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 		[Test]
 		[AutoRetry]
+		public void Screenshots_Image_Stretch_Alignment_SizeOnControl()
+		{
+			RunScreenShots_Image_Alignment_page("UITests.Shared.Windows_UI_Xaml_Controls.ImageTests.Image_Stretch_Alignment_SizeOnControl");
+		}
+
+		[Test]
+		[AutoRetry]
 		public void Screenshots_Image_Stretch_Alignment_Smaller()
 		{
 			RunScreenShots_Image_Alignment_page("Uno.UI.Samples.UITests.Image.Image_Stretch_Alignment_Smaller");

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -525,6 +525,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Alignment_SizeOnControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Modes_Picker.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3061,6 +3065,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Algmnt_Inf_Horizontal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Algmnt_Inf_Vertical.xaml.cs">
       <DependentUpon>Image_Stretch_Algmnt_Inf_Vertical.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Alignment_SizeOnControl.xaml.cs">
+      <DependentUpon>Image_Stretch_Alignment_SizeOnControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Modes_Picker.xaml.cs">
       <DependentUpon>Image_Stretch_Modes_Picker.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Stretch_Alignment_SizeOnControl.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Stretch_Alignment_SizeOnControl.xaml
@@ -1,5 +1,5 @@
 ﻿<Page
-	x:Class="Uno.UI.Samples.UITests.Image.Image_Stretch_Alignment_Smaller"
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ImageTests.Image_Stretch_Alignment_SizeOnControl"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:not_win="http://uno.ui/"
@@ -8,8 +8,7 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:local="using:Uno.UI.Samples.UITests.Image"
 	mc:Ignorable="d not_win"
-	d:DesignHeight="300"
-	d:DesignWidth="400">
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<Grid HorizontalAlignment="Center">
 		<Grid.RowDefinitions>
@@ -33,15 +32,17 @@
 								<LineBreak />h=<Run Text="{Binding HorizontalAlignment}" FontWeight="Bold" />
 								<LineBreak />v=<Run Text="{Binding VerticalAlignment}" FontWeight="Bold" />
 							</TextBlock>
-							<Border Width="125"
-							        Height="125"
-							        BorderThickness="1"
-							        BorderBrush="Black"
-							        Background="DeepPink">
+							<Border BorderThickness="1"
+							        Width="127"
+							        Height="152"
+									BorderBrush="Black"
+									Background="DeepPink">
 								<Image Stretch="{Binding Stretch}"
-								       VerticalAlignment="{Binding VerticalAlignment}"
-								       HorizontalAlignment="{Binding HorizontalAlignment}"
-								       Source="ms-appx:///Assets/test_image_100_100.png" />
+									   VerticalAlignment="{Binding VerticalAlignment}"
+									   HorizontalAlignment="{Binding HorizontalAlignment}"
+									   Width="125"
+									   Height="150"
+									   Source="ms-appx:///Assets/test_image_100_100.png" />
 							</Border>
 						</StackPanel>
 					</DataTemplate>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Stretch_Alignment_SizeOnControl.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Stretch_Alignment_SizeOnControl.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ImageTests
+{
+	[SampleControlInfo("Image")]
+	public sealed partial class Image_Stretch_Alignment_SizeOnControl : Page
+	{
+		public Image_Stretch_Alignment_SizeOnControl()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Stretch_Alignment_Smaller.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Stretch_Alignment_Smaller.xaml.cs
@@ -1,9 +1,10 @@
 ﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
 
 namespace Uno.UI.Samples.UITests.Image
 {
-	[Controls.SampleControlInfo("Image")]
-	public sealed partial class Image_Stretch_Alignment_Smaller : UserControl
+	[SampleControlInfo("Image")]
+	public sealed partial class Image_Stretch_Alignment_Smaller : Page
 	{
 		public Image_Stretch_Alignment_Smaller()
 		{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Stretch_Modes_Picker.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Stretch_Modes_Picker.xaml.cs
@@ -20,11 +20,41 @@ namespace Uno.UI.Samples.UITests.Image
 		public ComboBoxItem[] HorizontalAlignments { get; } = GetValues<HorizontalAlignment>().ToArray();
 		public ComboBoxItem[] VerticalAlignments { get; } = GetValues<VerticalAlignment>().ToArray();
 
+		public static readonly DependencyProperty ModeProperty = DependencyProperty.Register(
+			"Mode", typeof(string), typeof(Image_Stretch_Modes_Picker), new PropertyMetadata(default(string), ModeChanged));
+
+		public string Mode
+		{
+			get { return (string)GetValue(ModeProperty); }
+			set { SetValue(ModeProperty, value); }
+		}
+
 		public static readonly DependencyProperty ItemsProperty = DependencyProperty.Register(
 			"Items",
 			typeof(List<StretchModeItem>),
 			typeof(Image_Stretch_Modes_Picker),
 			new PropertyMetadata(default(List<StretchModeItem>)));
+
+		private static void ModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var picker = d as Image_Stretch_Modes_Picker;
+			var modeStr = e.NewValue as string ?? "";
+			if (modeStr.Length >= 1)
+			{
+				switch (modeStr[0])
+				{
+					case 'S':
+						picker.OnNextStretch(null, null);
+						break;
+					case 'H':
+						picker.OnNextHorizontal(null, null);
+						break;
+					case 'V':
+						picker.OnNextVertical(null, null);
+						break;
+				}
+			}
+		}
 
 		public List<StretchModeItem> Items
 		{

--- a/src/Uno.Foundation/Point.cs
+++ b/src/Uno.Foundation/Point.cs
@@ -1,6 +1,7 @@
 ﻿using Uno.Extensions;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Globalization;
@@ -10,6 +11,7 @@ using CoreGraphics;
 
 namespace Windows.Foundation
 {
+	[DebuggerDisplay("{X},{Y}")]
 	public partial struct Point
 	{
 		public Point(double x, double y)
@@ -48,21 +50,21 @@ namespace Windows.Foundation
 			return new Point(p1.X - p2.X, p1.Y - p2.Y);
 		}
 
-        public static implicit operator Point(string point)
-        {
-            var parts = point
-                .Split(new[] { ',' })
-                .Select(value => double.Parse(value, CultureInfo.InvariantCulture))
-                .ToArray();
+		public static implicit operator Point(string point)
+		{
+			var parts = point
+				.Split(new[] { ',' })
+				.Select(value => double.Parse(value, CultureInfo.InvariantCulture))
+				.ToArray();
 
-            return new Point(parts[0], parts[1]);
-        }
+			return new Point(parts[0], parts[1]);
+		}
 
-        public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode();
+		public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode();
 
 		public override bool Equals(object obj)
 		{
-			if(obj is Point)
+			if (obj is Point)
 			{
 				var point = (Point)obj;
 

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace Windows.Foundation
 {
-	[DebuggerDisplay("[Rect {X},{Y}-{Width}x{Height}]")]
+	[DebuggerDisplay("[Rect {Size}@{Location}]")]
 	public partial struct Rect
 	{
 		private const string _negativeErrorMessage = "Non-negative number required.";
@@ -88,7 +88,7 @@ namespace Windows.Foundation
 		public double Right => X + Width;
 		public double Bottom => Y + Height;
 
-		public bool IsEmpty => Empty.Equals(this);	
+		public bool IsEmpty => Empty.Equals(this);
 
 		public static implicit operator Rect(string text)
 		{
@@ -206,7 +206,7 @@ namespace Windows.Foundation
 			this = new Rect(left, top, right - left, bottom - top);
 		}
 
-		public bool Equals(Rect value) 
+		public bool Equals(Rect value)
 			=> value.X == X
 				&& value.Y == Y
 				&& value.Width == Width
@@ -218,7 +218,7 @@ namespace Windows.Foundation
 
 		public static bool operator !=(Rect left, Rect right) => !left.Equals(right);
 
-		public override bool Equals(object obj) 
+		public override bool Equals(object obj)
 			=> obj is Rect r ? r.Equals(this) : base.Equals(obj);
 	}
 }

--- a/src/Uno.Foundation/Size.cs
+++ b/src/Uno.Foundation/Size.cs
@@ -1,8 +1,10 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics;
 using System.Security;
 
 namespace Windows.Foundation
 {
+	[DebuggerDisplay("{Width}x{Height}")]
 	[TypeConverter(typeof(SizeConverter))]
 	public partial struct Size
 	{
@@ -22,9 +24,9 @@ namespace Windows.Foundation
 
 		public override bool Equals(object o)
 		{
-			if(o is Size other)
+			if (o is Size other)
 			{
-				return other.Width == Width 
+				return other.Width == Width
 					&& other.Height == Height;
 			}
 

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ImageTests/Given_ImageSizeHelper.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ImageTests/Given_ImageSizeHelper.cs
@@ -93,8 +93,8 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.ImageTests
 		public async Task MeasureSource_Expected_Result(
 			Stretch stretch,
 			string alignment,
-            double imageNaturalWidth,
-            double imageNaturalHeight,
+			double imageNaturalWidth,
+			double imageNaturalHeight,
 			double finalWidth,
 			double finalHeight,
 			double expectedX,
@@ -139,12 +139,10 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.ImageTests
 					break;
 			}
 
-			var image = new Image {Stretch = stretch, HorizontalAlignment = horizontal, VerticalAlignment = vertical};
+			var image = new Image { Stretch = stretch, HorizontalAlignment = horizontal, VerticalAlignment = vertical };
 
-			var measuredRect = new Rect(default, imageNaturalSize);
-
-			image.MeasureSource(finalSize, ref measuredRect);
-			image.ArrangeSource(finalSize, ref measuredRect);
+			var containerRect = image.MeasureSource(finalSize, imageNaturalSize);
+			var measuredRect = image.ArrangeSource(finalSize, containerRect);
 
 			measuredRect.Should().Be(
 				expectedRect,

--- a/src/Uno.UI/UI/LayoutHelper.cs
+++ b/src/Uno.UI/UI/LayoutHelper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Windows.Foundation;
 using Windows.UI.Xaml;
@@ -10,10 +12,13 @@ namespace Uno.UI
 {
 	internal static class LayoutHelper
 	{
+		[Pure]
 		internal static Size GetMinSize(this IFrameworkElement e) => new Size(e.MinWidth, e.MinHeight).NumberOrDefault(new Size(0, 0));
 
+		[Pure]
 		internal static Size GetMaxSize(this IFrameworkElement e) => new Size(e.MaxWidth, e.MaxHeight).NumberOrDefault(new Size(PositiveInfinity, PositiveInfinity));
 
+		[Pure]
 		internal static (Size min, Size max) GetMinMax(this IFrameworkElement e)
 		{
 			var size = new Size(e.Width, e.Height);
@@ -33,6 +38,7 @@ namespace Uno.UI
 			return (minSize, maxSize);
 		}
 
+		[Pure]
 		internal static Size ApplySizeConstraints(this IFrameworkElement e, Size forSize)
 		{
 			var (min, max) = e.GetMinMax();
@@ -41,6 +47,7 @@ namespace Uno.UI
 				.AtLeast(min); // UWP is applying "min" after "max", so if "min" > "max", "min" wins
 		}
 
+		[Pure]
 		internal static Size GetMarginSize(this IFrameworkElement frameworkElement)
 		{
 			var margin = frameworkElement.Margin;
@@ -49,6 +56,7 @@ namespace Uno.UI
 			return new Size(marginWidth, marginHeight);
 		}
 
+		[Pure]
 		internal static Point GetAlignmentOffset(this IFrameworkElement e, Size clientSize, Size renderSize)
 		{
 			// Start with Bottom-Right alignment, multiply by 0/0.5/1 for Top-Left/Center/Bottom-Right alignment
@@ -90,6 +98,7 @@ namespace Uno.UI
 			return offset;
 		}
 
+		[Pure]
 		internal static Size Min(Size val1, Size val2)
 		{
 			return new Size(
@@ -98,6 +107,7 @@ namespace Uno.UI
 			);
 		}
 
+		[Pure]
 		internal static Size Max(Size val1, Size val2)
 		{
 			return new Size(
@@ -106,6 +116,7 @@ namespace Uno.UI
 			);
 		}
 
+		[Pure]
 		internal static Size Add(this Size left, Size right)
 		{
 			return new Size(
@@ -114,6 +125,7 @@ namespace Uno.UI
 			);
 		}
 
+		[Pure]
 		internal static Size Add(this Size left, Thickness right)
 		{
 			return new Size(
@@ -122,6 +134,7 @@ namespace Uno.UI
 			);
 		}
 
+		[Pure]
 		internal static Size Subtract(this Size left, Size right)
 		{
 			return new Size(
@@ -130,6 +143,7 @@ namespace Uno.UI
 			);
 		}
 
+		[Pure]
 		internal static Size Subtract(this Size left, Thickness right)
 		{
 			return new Size(
@@ -138,6 +152,7 @@ namespace Uno.UI
 			);
 		}
 
+		[Pure]
 		internal static double NumberOrDefault(this double value, double defaultValue)
 		{
 			return IsNaN(value)
@@ -145,6 +160,7 @@ namespace Uno.UI
 				: value;
 		}
 
+		[Pure]
 		internal static Size NumberOrDefault(this Size value, Size defaultValue)
 		{
 			return new Size(
@@ -153,11 +169,12 @@ namespace Uno.UI
 			);
 		}
 
-		internal static double AtMost(this double value, double most)
-		{
-			return Math.Min(value, most);
-		}
+		[Pure]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		internal static double AtMost(this double value, double most) => Math.Min(value, most);
 
+		[Pure]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static Size AtMost(this Size value, Size most)
 		{
 			return new Size(
@@ -166,11 +183,15 @@ namespace Uno.UI
 			);
 		}
 
-		internal static double AtLeast(this double value, double least)
-		{
-			return Math.Max(value, least);
-		}
+		[Pure]
+		internal static Rect AtMost(this Rect value, Size most) => new Rect(value.Location, value.Size.AtMost(most));
 
+		[Pure]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		internal static double AtLeast(this double value, double least) => Math.Max(value, least);
+
+		[Pure]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static Size AtLeast(this Size value, Size least)
 		{
 			return new Size(
@@ -179,13 +200,30 @@ namespace Uno.UI
 			);
 		}
 
-		internal static Rect AtLeast(this Rect value, Size least)
+		[Pure]
+		internal static Rect AtLeast(this Rect value, Size least) => new Rect(value.Location, value.Size.AtLeast(least));
+
+		/// <summary>
+		/// Test if a Rect "fits" totally in another one.
+		/// </summary>
+		[Pure]
+		internal static bool IsEnclosedBy(this Rect enclosee, Rect encloser)
 		{
-			return new Rect(value.Location, value.Size.AtLeast(least));
+			if (enclosee.Equals(encloser))
+			{
+				return true;
+			}
+
+			return enclosee.Left >= encloser.Left
+				&& enclosee.Right <= encloser.Right
+				&& enclosee.Top >= encloser.Top
+				&& enclosee.Bottom <= encloser.Bottom;
 		}
 
+		[Pure]
 		internal static double AspectRatio(this Rect rect) => rect.Size.AspectRatio();
 
+		[Pure]
 		internal static double AspectRatio(this Size size)
 		{
 			var w = size.Width;
@@ -221,6 +259,7 @@ namespace Uno.UI
 		}
 
 #if __IOS__ || __MACOS__
+		[Pure]
 		internal static double AspectRatio(this CoreGraphics.CGSize size)
 		{
 			var w = size.Width;
@@ -268,6 +307,7 @@ namespace Uno.UI
 		}
 #endif
 
+		[Pure]
 		internal static Rect GetBoundsRectRelativeTo(this UIElement element, UIElement relativeTo)
 		{
 			var elementRect = new Rect(default, element.RenderSize);
@@ -281,6 +321,7 @@ namespace Uno.UI
 			return rect;
 		}
 
+		[Pure]
 		internal static Rect GetAbsoluteBoundsRect(this UIElement element)
 		{
 			var root = Window.Current.Content;

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
@@ -560,10 +560,11 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			var sourceRect = new Windows.Foundation.Rect(Windows.Foundation.Point.Zero, SourceImageSize);
+			// Calculate the resulting space required on screen for the image
+			var containerSize = this.MeasureSource(frameSize, SourceImageSize);
 
-			this.MeasureSource(frameSize, ref sourceRect);
-			this.ArrangeSource(frameSize, ref sourceRect);
+			// Calculate the position of the image to follow stretch and alignment requirements
+			var sourceRect = this.ArrangeSource(frameSize, containerSize);
 
 			var scaleX = (sourceRect.Width / SourceImageSize.Width) * _sourceImageScale;
 			var scaleY = (sourceRect.Height / SourceImageSize.Height) * _sourceImageScale;

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
@@ -43,7 +43,7 @@ namespace Windows.UI.Xaml.Controls
 		private bool? _hasFiniteBounds;
 		private Size _layoutSize;
 
-		private ILayouter _layouter;
+		private ImageLayouter _layouter;
 
 		public static class TraceProvider
 		{
@@ -94,7 +94,7 @@ namespace Windows.UI.Xaml.Controls
 			_successfullyOpenedImage = imageSource;
 		}
 
-#region Stretch
+		#region Stretch
 		public Stretch Stretch
 		{
 			get { return (Stretch)this.GetValue(StretchProperty); }
@@ -107,9 +107,9 @@ namespace Windows.UI.Xaml.Controls
 			((Image)s).OnStretchChanged((Stretch)e.NewValue, (Stretch)e.OldValue)));
 
 		partial void OnStretchChanged(Stretch newValue, Stretch oldValue);
-#endregion
+		#endregion
 
-#region Source
+		#region Source
 		public ImageSource Source
 		{
 			get { return (ImageSource)this.GetValue(SourceProperty); }
@@ -158,7 +158,7 @@ namespace Windows.UI.Xaml.Controls
 			TryOpenImage();
 		}
 
-#endregion
+		#endregion
 
 		partial void OnLoadedPartial()
 		{
@@ -302,16 +302,15 @@ namespace Windows.UI.Xaml.Controls
 
 					// Apply the Stretch=Uniform logic...
 
-					var rect = new Rect(default, sourceSize);
-					img.MeasureSource(availableSize, ref rect);
+					var containerSize = img.MeasureSource(availableSize, sourceSize);
 
 					if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 					{
-						this.Log().Debug(Panel.ToString() + $" measuring with Stretch.Uniform with availableSize={constrainedAvailableSize}, returning desiredSize={rect.Size}");
+						this.Log().Debug(Panel.ToString() + $" measuring with Stretch.Uniform with availableSize={constrainedAvailableSize}, returning desiredSize={containerSize}");
 					}
 
 					ImageControl._hasFiniteBounds = true;
-					return rect.Size;
+					return containerSize;
 				}
 
 				ImageControl._hasFiniteBounds = false;

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOS.cs
@@ -209,7 +209,6 @@ namespace Windows.UI.Xaml.Controls
 				SourceImageSize = image?.Size.ToFoundationSize() ?? default(Size);
 			}
 
-			this.InvalidateMeasure();
 			SetNeedsLayout();
 
 			if (Image != null)

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOS.cs
@@ -324,8 +324,8 @@ namespace Windows.UI.Xaml.Controls
 			var containerRect = new Rect(default, availableSize);
 			containerRect.Intersect(contentRect);
 
-			var relativeX = (contentRect.X - containerRect.X) / imageSize.Width;
-			var relativeY = (contentRect.Y - containerRect.Y) / imageSize.Height;
+			var relativeX = (contentRect.X - containerRect.X) / contentRect.Width;
+			var relativeY = (contentRect.Y - containerRect.Y) / contentRect.Height;
 			var relativeWidth =
 				containerRect.Width < contentRect.Width
 					? containerRect.Width / contentRect.Width
@@ -334,9 +334,6 @@ namespace Windows.UI.Xaml.Controls
 				containerRect.Height < contentRect.Height
 					? containerRect.Height / contentRect.Height
 					: 1.0d + relativeY;
-
-			//var relativeWidth = availableSize.Width / contentRect.Width;
-			//var relativeHeight = availableSize.Height / contentRect.Height;
 
 			var contentRelativeRect = new CGRect(-relativeX, -relativeY, relativeWidth, relativeHeight);
 

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOS.cs
@@ -270,7 +270,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			try
 			{
-				_layouter.Arrange(Bounds);
+				_layoutRequested = false;
+				base.LayoutSubviews();
 
 				UpdateLayerRect(Bounds.Size);
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
@@ -255,8 +255,6 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override Size ArrangeOverride(Size finalSize)
 		{
-			var finalPosition = new Windows.Foundation.Rect(Windows.Foundation.Point.Zero, _lastMeasuredSize);
-
 			// Calculate the resulting space required on screen for the image
 			var containerSize = this.MeasureSource(finalSize, _lastMeasuredSize);
 

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
@@ -257,8 +257,11 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var finalPosition = new Windows.Foundation.Rect(Windows.Foundation.Point.Zero, _lastMeasuredSize);
 
-			this.MeasureSource(finalSize, ref finalPosition);
-			this.ArrangeSource(finalSize, ref finalPosition);
+			// Calculate the resulting space required on screen for the image
+			var containerSize = this.MeasureSource(finalSize, _lastMeasuredSize);
+
+			// Calculate the position of the image to follow stretch and alignment requirements
+			var finalPosition = this.ArrangeSource(finalSize, containerSize);
 
 			_htmlImage.ArrangeElementNative(finalPosition, false, clipRect: null);
 

--- a/src/Uno.UI/UI/Xaml/Controls/Image/ImageSizeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/ImageSizeHelper.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using Windows.Foundation;
 using Windows.UI.Xaml.Media;
 using Uno.UI;
@@ -9,7 +9,8 @@ namespace Windows.UI.Xaml.Controls
 {
 	internal static class ImageSizeHelper
 	{
-		public static void MeasureSource(this Image image, Size finalSize, ref Rect child)
+		[Pure]
+		public static Size MeasureSource(this Image image, Size finalSize, Size child)
 		{
 			switch (image.Stretch)
 			{
@@ -56,16 +57,21 @@ namespace Windows.UI.Xaml.Controls
 
 				case Fill:
 					{
-						child.Size = finalSize;
+						child = finalSize;
 						break;
 					}
 
 					// In case of None, there's no adjustment to make to the size of the image
 			}
+
+			return child;
 		}
 
-		public static void ArrangeSource(this Image image, Size finalSize, ref Rect child)
+		[Pure]
+		public static Rect ArrangeSource(this Image image, Size finalSize, Size containerSize)
 		{
+			var child = new Rect(default, containerSize);
+
 			var stretch = image.Stretch;
 			var horizontalAlignment = image.HorizontalAlignment;
 
@@ -130,13 +136,17 @@ namespace Windows.UI.Xaml.Controls
 					child.Y = (finalSize.Height - child.Height) * 0.5f;
 					break;
 			}
+
+			return child;
 		}
 
+		[Pure]
 		public static (double x, double y) BuildScale(this Image image, Size destinationSize, Size sourceSize)
 		{
 			return BuildScale(image.Stretch, destinationSize, sourceSize);
 		}
 
+		[Pure]
 		internal static (double x, double y) BuildScale(Stretch stretch, Size destinationSize, Size sourceSize)
 		{
 			if (stretch != None)
@@ -184,11 +194,13 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		[Pure]
 		public static Size AdjustSize(this Image image, Size availableSize, Size measuredSize)
 		{
 			return AdjustSize(image.Stretch, availableSize, measuredSize);
 		}
 
+		[Pure]
 		internal static Size AdjustSize(Stretch stretch, Size availableSize, Size measuredSize)
 		{
 			var scale = BuildScale(stretch, availableSize, measuredSize);

--- a/src/Uno.UI/UI/Xaml/Controls/Image/ImageSizeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/ImageSizeHelper.cs
@@ -10,26 +10,26 @@ namespace Windows.UI.Xaml.Controls
 	internal static class ImageSizeHelper
 	{
 		[Pure]
-		public static Size MeasureSource(this Image image, Size finalSize, Size child)
+		public static Size MeasureSource(this Image image, Size finalSize, Size imageSize)
 		{
 			switch (image.Stretch)
 			{
 				case UniformToFill:
 					{
-						var childAspectRatio = child.AspectRatio();
+						var childAspectRatio = imageSize.AspectRatio();
 						var finalAspectRatio = finalSize.AspectRatio();
 						if (childAspectRatio <= finalAspectRatio)
 						{
 							// Child wider than parent, so we're using the width to fill
 							// It's also the default mode if aspect ratios are the same
-							child.Width = finalSize.Width;
-							child.Height = finalSize.Width / childAspectRatio;
+							imageSize.Width = finalSize.Width;
+							imageSize.Height = finalSize.Width / childAspectRatio;
 						}
 						else
 						{
 							// child is taller than parent, so where' using the height to fill
-							child.Width = finalSize.Height * childAspectRatio;
-							child.Height = finalSize.Height;
+							imageSize.Width = finalSize.Height * childAspectRatio;
+							imageSize.Height = finalSize.Height;
 						}
 
 						break;
@@ -37,19 +37,19 @@ namespace Windows.UI.Xaml.Controls
 
 				case Uniform:
 					{
-						var childAspectRatio = child.AspectRatio();
+						var childAspectRatio = imageSize.AspectRatio();
 						var finalAspectRatio = finalSize.AspectRatio();
 						if (childAspectRatio <= finalAspectRatio)
 						{
 							// Child wider than parent, so we're using the height to fill
-							child.Width = finalSize.Height * childAspectRatio;
-							child.Height = finalSize.Height;
+							imageSize.Width = finalSize.Height * childAspectRatio;
+							imageSize.Height = finalSize.Height;
 						}
 						else
 						{
 							// child is taller than parent, so where' using the width to fill
-							child.Width = finalSize.Width;
-							child.Height = finalSize.Width / childAspectRatio;
+							imageSize.Width = finalSize.Width;
+							imageSize.Height = finalSize.Width / childAspectRatio;
 						}
 
 						break;
@@ -57,14 +57,14 @@ namespace Windows.UI.Xaml.Controls
 
 				case Fill:
 					{
-						child = finalSize;
+						imageSize = finalSize;
 						break;
 					}
 
 					// In case of None, there's no adjustment to make to the size of the image
 			}
 
-			return child;
+			return imageSize;
 		}
 
 		[Pure]

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.cs
@@ -84,7 +84,13 @@ namespace Windows.UI.Xaml.Controls
 		public MediaPlayerPresenter() : base()
 		{
 		}
-		
+
+		protected override void OnUnloaded()
+		{
+			MediaPlayer.Stop();
+			base.OnUnloaded();
+		}
+
 		private void OnVideoRatioChanged(Windows.Media.Playback.MediaPlayer sender, double args)
 		{
 			_currentRatio = args;

--- a/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
@@ -48,7 +48,7 @@ namespace Windows.UI.Xaml
 
 			this.Layer.Mask = new CAShapeLayer
 			{
-				Path = CGPath.FromRect(ToCGRect(rect))
+				Path = CGPath.FromRect(rect.ToCGRect())
 			};
 		}
 
@@ -121,17 +121,6 @@ namespace Windows.UI.Xaml
 		internal Windows.Foundation.Point GetPosition(Point position, global::Windows.UI.Xaml.UIElement relativeTo)
 		{
 			return relativeTo.ConvertPointToCoordinateSpace(position, relativeTo);
-		}
-
-		private CGRect ToCGRect(Rect rect)
-		{
-			return new CGRect
-			(
-				(nfloat)(rect.X),
-				(nfloat)(rect.Y),
-				(nfloat)(rect.Width),
-				(nfloat)(rect.Height)
-			);
 		}
 
 		public GeneralTransform TransformToVisual(UIElement visual)


### PR DESCRIPTION
# Bugfix

## What is the current behavior?
On iOS, when a size restriction (`MinWidth`, `Width`, `MaxWidth`, `MinHeight`, `Height` or `MaxHeight`) were specified directly on the `<Image />` tag itself, the result alignment were wrong.

## What is the new behavior?
Behave like UWP and the same way as when the constraints is applied on a parent element.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Related issues
- #2311
- #2295
- https://dev.azure.com/nventive/Umbrella/_workitems/edit/170280
- https://dev.azure.com/nventive/Umbrella/_workitems/edit/168856