### PR TITLE
Fix TextBlock might stay blank

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
@@ -305,18 +305,23 @@ namespace Windows.UI.Xaml.Controls
 
 		private Size LayoutTypography(Size size)
 		{
-			if (_textContainer == null || _attributedString == null)
-			{
-				return default(Size);
-			}
-			
 			if (UseLayoutManager)
 			{
+				if (_textContainer == null)
+				{
+					return default(Size);
+				}
+
 				_textContainer.Size = size;
 				return _layoutManager.GetUsedRectForTextContainer(_textContainer).Size;
 			}
 			else
 			{
+				if (_attributedString == null)
+				{
+					return default(Size);
+				}
+
 				return _attributedString.GetBoundingRect(size, NSStringDrawingOptions.UsesLineFragmentOrigin, null).Size;
 			}
 		}


### PR DESCRIPTION
## BugFix
`TextBlock` might stay blank

## What is the current behavior?
Since https://github.com/unoplatform/uno/pull/2312 `TextBlock` might stay blank

## What is the new behavior?
`TextBlock` appears

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~[Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [x] Associated with an issue (GitHub or internal)

## Other information
This is an enhancement of https://github.com/unoplatform/uno/pull/2312, same comment applies for UI tests.

Internal Issue: https://dev.azure.com/nventive/_workitems/edit/168675
