### PR TITLE
Applied a change to also support global StaticResources

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2844,7 +2844,18 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				// If the property Type is attributed with the CreateFromStringAttribute
 				if (IsXamlTypeConverter(targetPropertyType))
 				{
-					var memberValue = $"StaticResources.{SanitizeResourceName(resourcePath)}";
+					string memberValue;
+
+					// Build the member string based on wether it's a local
+					// StaticResource or a global StaticResource
+					if (_staticResources.TryGetValue(resourcePath, out var _))
+					{
+						memberValue = $"StaticResources.{SanitizeResourceName(resourcePath)}";
+					}
+					else
+					{
+						memberValue = $"{GetGlobalStaticResource(resourcePath)}.ToString()";
+					}
 
 					// We must build the member value as a call to a "conversion" function
 					return BuildXamlTypeConverterLiteralValue(targetPropertyType, memberValue, includeQuotations: false);

--- a/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml
@@ -16,6 +16,10 @@
 
 		<ctl:MyLocationPointControl x:Name="TestLocationControl2"
 									LocationPoint="{StaticResource StaticCoordinates}" />
+
+		<ctl:MyLocationPointControl x:Name="TestLocationControl3"
+									LocationPoint="{StaticResource GlobalCoordinates}" />
+
 	</StackPanel>
 
 </UserControl>

--- a/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml.cs
+++ b/src/Uno.UI.Tests/App/Xaml/Test_CreateFromString.xaml.cs
@@ -20,6 +20,7 @@ namespace Uno.UI.Tests.App.Xaml
 	{
 		public MyLocationPointControl TestLocationPoint => TestLocationControl;
 		public MyLocationPointControl TestLocationPoint2 => TestLocationControl2;
+		public MyLocationPointControl TestLocationPoint3 => TestLocationControl3;
 
 		public Test_CreateFromString()
 		{

--- a/src/Uno.UI.Tests/App/Xaml/Test_Dictionary.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_Dictionary.xaml
@@ -1,14 +1,21 @@
-﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<x:String x:Key="GlobalCoordinates">11.22, 33</x:String>
+
 	<Style TargetType="Button"
 		   x:Key="ExplicitButtonStyle">
 		<Setter Property="FontSize"
 				Value="20" />
 	</Style>
-	<SolidColorBrush x:Key="SuperiorColor" Color="MediumSpringGreen"/>
+
+	<SolidColorBrush x:Key="SuperiorColor"
+					 Color="MediumSpringGreen" />
+
 	<!--Default CheckBox style-->
 	<Style TargetType="CheckBox">
-		<Setter Property="Foreground" Value="LightGoldenrodYellow"/>
+		<Setter Property="Foreground"
+				Value="LightGoldenrodYellow" />
 	</Style>
+
 </ResourceDictionary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/CreateFromStringTests/Given_CreateFromString.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/CreateFromStringTests/Given_CreateFromString.cs
@@ -28,6 +28,11 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.CreateFromStringTests
 
 			Assert.AreEqual(33.33, pt2.Latitude);
 			Assert.AreEqual(22, pt2.Longitude);
+
+			var pt3 = control.TestLocationPoint3.LocationPoint;
+
+			Assert.AreEqual(11.22, pt3.Latitude);
+			Assert.AreEqual(33, pt3.Longitude);
 		}
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #2039

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

CreateFromStringAttribute supports Xaml Type conversions using string values or local StaticResources, but not global StaticResources (ex: App.xaml).

## What is the new behavior?

CreateFromStringAttribute should support all three cases: string values, local StaticResources, as well as global StaticResources.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)