### PR TITLE
[Android] Adjust for synchronous image loading

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Uniform100x100.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Uniform100x100.xaml
@@ -12,7 +12,7 @@
 	<controls:SampleControl SampleDescription="Uniform100x100">
 		<controls:SampleControl.SampleContent>
 			<DataTemplate>
-				<Image Source="http://lh5.ggpht.com/lxBMauupBiLIpgOgu5apeiX_YStXeHRLK1oneS4NfwwNt7fGDKMP0KpQIMwfjfL9GdHRVEavmg7gOrj5RYC4qwrjh3Y0jCWFDj83jzg"
+				<Image Source="https://lh5.ggpht.com/lxBMauupBiLIpgOgu5apeiX_YStXeHRLK1oneS4NfwwNt7fGDKMP0KpQIMwfjfL9GdHRVEavmg7gOrj5RYC4qwrjh3Y0jCWFDj83jzg"
 					   Width="100"
 					   Height="100"
 					   Stretch="Uniform" />

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
@@ -517,14 +517,15 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		/// <summary>
-		/// If the image control does not have finite bounds, then it must go through another measure/arrange pass after the image is set. 
+		/// If the image control does not have finite bounds, or if finite bounds have not yet been computed, then it must go through
+		/// another measure/arrange pass after the image is set. 
 		/// This is not guaranteed to happen if RequestLayout is called from within a layout pass, so we must set the image on the dispatcher 
 		/// even if we wouldn't otherwise.
 		/// </summary>
 		/// <returns></returns>
 		private bool MustDispatchSetSource()
 		{
-			return (!_hasFiniteBounds ?? false) && _isInLayout;
+			return (!_hasFiniteBounds ?? true) && _isInLayout;
 		}
 
 		private void ResetSource()


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Images may not load properly when cached.

## What is the new behavior?

Update the loading of cached images, after the layout passes changes in #2316 and #2252.

UI Tests in `src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ImageTests\UniformToFill100x100.xaml` and `src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ImageTests\Uniform100x100.xaml` were not reloading if the image was already cached.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
