### PR TITLE
Fix TextBox might erase prefilled value

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -94,7 +94,7 @@ namespace Windows.UI.Xaml.Controls
 			OnIsSpellCheckEnabledChanged(CreateInitialValueChangerEventArgs(IsSpellCheckEnabledProperty, IsSpellCheckEnabledProperty.GetMetadata(GetType()).DefaultValue, IsSpellCheckEnabled));
 			OnTextAlignmentChanged(CreateInitialValueChangerEventArgs(TextAlignmentProperty, TextAlignmentProperty.GetMetadata(GetType()).DefaultValue, TextAlignment));
 			OnTextWrappingChanged(CreateInitialValueChangerEventArgs(TextWrappingProperty, TextWrappingProperty.GetMetadata(GetType()).DefaultValue, TextWrapping));
-			OnFocusStateChanged((FocusState)FocusStateProperty.GetMetadata(GetType()).DefaultValue, FocusState);
+			OnFocusStateChanged((FocusState)FocusStateProperty.GetMetadata(GetType()).DefaultValue, FocusState, initial: true);
 
 			var buttonRef = _deleteButton?.GetTarget();
 
@@ -596,11 +596,13 @@ namespace Windows.UI.Xaml.Controls
 		#endregion
 
 		protected override void OnFocusStateChanged(FocusState oldValue, FocusState newValue)
+			=> OnFocusStateChanged(oldValue, newValue, initial: false);
+		private void OnFocusStateChanged(FocusState oldValue, FocusState newValue, bool initial)
 		{
 			base.OnFocusStateChanged(oldValue, newValue);
 			OnFocusStateChangedPartial(newValue);
 
-			if (newValue == FocusState.Unfocused)
+			if (!initial && newValue == FocusState.Unfocused)
 			{
 				// Manually update Source when losing focus because TextProperty's default UpdateSourceTrigger is Explicit
 				var bindingExpression = GetBindingExpression(TextProperty);


### PR DESCRIPTION
## BugFix


## What is the current behavior?
In some cases when inserting a `TextBox` in the visual tree while already data-bound to a VM, the `TextBox` will push an empty string when initializing its template, **BUT** will still keep the value initial value visible. This is because we init the unfocused state.

## What is the new behavior?
It updates the binding on focus lost, only it it's not due to template init.

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
Internal Issue: https://dev.azure.com/nventive/_workitems/edit/167304

