### PR TITLE
Add support for Popup.LightDismissOverlayMode

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -6,6 +6,7 @@
 - [Android] Adds support for `FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay`
 - Add support for `Grid.ColumnSpacing` and `Grid.RowSpacing`
 - Add clarification in [documentation](../articles/uno-development/working-with-the-samples-apps.md) for adding automated UI tests
+- Add support for `Popup.LightDismissOverlayMode`, as well as `DatePicker.LightDismissOverlayMode` and `Flyout.LightDismissOverlayMode`
 
 ### Breaking changes
 -

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
@@ -73,5 +73,17 @@ namespace SamplesApp.UITests.TestFramework
 				Assert.AreEqual(expectedColor.ToArgb(), pixel.ToArgb()); //Convert to ARGB value, because 'named colors' are not considered equal to their unnamed equivalents(!)
 			}
 		}
+
+		public static void AssertDoesNotHaveColorAt(FileInfo screenshot, float x, float y, Color excludedColor)
+		{
+			using (var bitmap = new Bitmap(screenshot.FullName))
+			{
+				Assert.GreaterOrEqual(bitmap.Width, (int)x);
+				Assert.GreaterOrEqual(bitmap.Height, (int)y);
+				var pixel = bitmap.GetPixel((int)x, (int)y);
+
+				Assert.AreNotEqual(excludedColor.ToArgb(), pixel.ToArgb()); //Convert to ARGB value, because 'named colors' are not considered equal to their unnamed equivalents(!)
+			}
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,6 +8,7 @@ using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
+using Uno.UITests.Helpers;
 
 namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 {
@@ -99,6 +101,34 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 			toggleButton.Tap(); // should dismiss here
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", false);
 			TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup closed"); // We add a screen shot in order to make sure that the check of the bool IsChecked is valid!
+		}
+
+		[Test]
+		[AutoRetry]
+		public void PopupWithOverlay()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.Popup.Popup_Overlay_On");
+
+			var before = TakeScreenshot("Before");
+			var rect = _app.GetRect("LocatorRectangle");
+			ImageAssert.AssertHasColorAt(before, rect.CenterX, rect.CenterY, Color.Blue);
+
+			_app.Tap("PopupCheckBox");
+
+			_app.WaitForElement("PopupChild");
+
+			var during = TakeScreenshot("During", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Status bar appears with clock*/);
+
+			ImageAssert.AssertDoesNotHaveColorAt(during, rect.CenterX, rect.CenterY, Color.Blue);
+
+			// Dismiss popup
+			_app.TapCoordinates(10, 10);
+
+			_app.WaitForNoElement("PopupChild");
+
+			var after = TakeScreenshot("After");
+
+			ImageAssert.AssertHasColorAt(after, rect.CenterX, rect.CenterY, Color.Blue);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
@@ -122,7 +122,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 			ImageAssert.AssertDoesNotHaveColorAt(during, rect.CenterX, rect.CenterY, Color.Blue);
 
 			// Dismiss popup
-			_app.TapCoordinates(10, 10);
+			var screenRect = _app.Marked("sampleContent").FirstResult().Rect;
+			_app.TapCoordinates(10, screenRect.Bottom - 10);
 
 			_app.WaitForNoElement("PopupChild");
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -597,6 +597,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Overlay_On.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Simple.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3116,6 +3120,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Pivot\Pivot_CustomContent_Automated.xaml.cs">
       <DependentUpon>Pivot_CustomContent_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Overlay_On.xaml.cs">
+      <DependentUpon>Popup_Overlay_On.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Foreground_While_Collapsed.xaml.cs">
       <DependentUpon>TextBlock_Foreground_While_Collapsed.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Overlay_On.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Overlay_On.xaml
@@ -1,0 +1,33 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Popup.Popup_Overlay_On"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.Popup"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<StackPanel Margin="20,80,20,20"
+				Background="Blue">
+		<Rectangle x:Name="LocatorRectangle"
+				   Fill="Transparent"
+				   Width="50"
+				   Height="50" />
+		<CheckBox x:Name="PopupCheckBox"
+				  IsChecked="False" />
+		<Popup IsOpen="{Binding ElementName=PopupCheckBox, Path=IsChecked, Mode=TwoWay}"
+			   IsLightDismissEnabled="True"
+			   LightDismissOverlayMode="On">
+			<Popup.Child>
+				<Border x:Name="PopupChild"
+						Background="LightPink"
+						CornerRadius="5"
+						Width="75"
+						Height="150">
+					<TextBlock Text="YePopupChild" />
+				</Border>
+			</Popup.Child>
+		</Popup>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Overlay_On.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Overlay_On.xaml
@@ -9,7 +9,8 @@
 			 d:DesignWidth="400">
 
 	<StackPanel Margin="20,80,20,20"
-				Background="Blue">
+				Background="Blue"
+				x:Name="sampleContent">
 		<Rectangle x:Name="LocatorRectangle"
 				   Fill="Transparent"
 				   Width="50"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Overlay_On.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Overlay_On.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Popup
+{
+	[SampleControlInfo(description:"Popup with light-dismiss and overlay enabled")]
+	public sealed partial class Popup_Overlay_On : UserControl
+	{
+		public Popup_Overlay_On()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -436,6 +436,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						{
 							writer.AppendLineInvariant("_initialized = true;");
 
+							foreach (var file in files)
+							{
+								writer.AppendLineInvariant("RegisterResources_{0}();", file.UniqueID);
+								writer.AppendLineInvariant("RegisterImplicitStylesResources_{0}();", file.UniqueID);
+							}
+
 							foreach (var ambientResource in _ambientGlobalResources)
 							{
 								if (ambientResource.GetMethods().Any(m => m.Name == "Initialize"))
@@ -444,12 +450,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								}
 
 								writer.AppendLineInvariant("AddResolver(global::{0}.FindResource);", ambientResource.GetFullName());
-							}
-
-							foreach (var file in files)
-							{
-								writer.AppendLineInvariant("RegisterResources_{0}();", file.UniqueID);
-								writer.AppendLineInvariant("RegisterImplicitStylesResources_{0}();", file.UniqueID);
 							}
 						}
 					}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -471,8 +471,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					writer.AppendLineInvariant("/// <returns>The instance of the resources, otherwise null.</returns>");
 					using (writer.BlockInvariant("public static object FindResource(string name)"))
 					{
-						using (writer.BlockInvariant("foreach(var resolver in _resolvers)"))
+						using (writer.BlockInvariant("for (int i = _resolvers.Count - 1; i>=0; i--)"))
 						{
+							writer.AppendLineInvariant("var resolver = _resolvers[i];");
 							writer.AppendLineInvariant("var resource = resolver(name);");
 							writer.AppendLineInvariant("if(resource != null){{ return resource; }}");
 						}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -436,12 +436,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						{
 							writer.AppendLineInvariant("_initialized = true;");
 
-							foreach (var file in files)
-							{
-								writer.AppendLineInvariant("RegisterResources_{0}();", file.UniqueID);
-								writer.AppendLineInvariant("RegisterImplicitStylesResources_{0}();", file.UniqueID);
-							}
-
 							foreach (var ambientResource in _ambientGlobalResources)
 							{
 								if (ambientResource.GetMethods().Any(m => m.Name == "Initialize"))
@@ -450,6 +444,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								}
 
 								writer.AppendLineInvariant("AddResolver(global::{0}.FindResource);", ambientResource.GetFullName());
+							}
+
+							foreach (var file in files)
+							{
+								writer.AppendLineInvariant("RegisterResources_{0}();", file.UniqueID);
+								writer.AppendLineInvariant("RegisterImplicitStylesResources_{0}();", file.UniqueID);
 							}
 						}
 					}

--- a/src/Uno.UI.Tests/App/Xaml/Test_Dictionary.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_Dictionary.xaml
@@ -11,7 +11,8 @@
 
 	<SolidColorBrush x:Key="SuperiorColor"
 					 Color="MediumSpringGreen" />
-
+	<SolidColorBrush x:Key="DatePickerLightDismissOverlayBackground"
+					 Color="Orchid" />
 	<!--Default CheckBox style-->
 	<Style TargetType="CheckBox">
 		<Setter Property="Foreground"

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ComboBoxTests/Given_ComboBox.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ComboBoxTests/Given_ComboBox.cs
@@ -13,7 +13,13 @@ namespace Uno.UI.Tests.ComboBoxTests
 {
 	[TestClass]
     public class Given_ComboBox
-    {
+	{
+		[TestInitialize]
+		public void Init()
+		{
+			UnitTestsApp.App.EnsureApplication();
+		}
+
 		[TestMethod]
 		public void When_ComboBox_Is_First_Opening()
 		{

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ContentDialogTests/Given_ContentDialog.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ContentDialogTests/Given_ContentDialog.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Tests.ContentDialogTests
@@ -11,6 +12,16 @@ namespace Uno.UI.Tests.ContentDialogTests
 	[TestClass]
 	public class Given_ContentDialog
 	{
+		[TestInitialize]
+		public void Init()
+		{
+			UnitTestsApp.App.EnsureApplication();
+
+			// The real Style contains a template, which causes ContentControl.IsContentPresenterBypassEnabled to return false. This is a workaround
+			// which shouldn't be necessary once Styles handling is overhauled.
+			Style.RegisterDefaultStyleForType(typeof(ContentDialog), new Style());
+		}
+
 		[TestMethod]
 		public void When_Has_DataContext()
 		{

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/DatePickerTests/Given_DatePicker.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/DatePickerTests/Given_DatePicker.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace Uno.UI.Tests.DatePickerTests
+{
+	[TestClass]
+	public class Given_DatePicker
+	{
+		[TestMethod]
+		public void Verify_LightDismissOverlayBackground()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+			Assert.IsNotNull(app.Resources["DatePickerLightDismissOverlayBackground"]);
+			var dp = new DatePicker();
+			Assert.AreEqual(Colors.Orchid, (dp.LightDismissOverlayBackground as SolidColorBrush)?.Color);
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/FlyoutTests/Given_Flyout.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/FlyoutTests/Given_Flyout.cs
@@ -15,6 +15,12 @@ namespace Uno.UI.Tests.FlyoutTests
 	[TestClass]
 	public class Given_Flyout
 	{
+		[TestInitialize]
+		public void Init()
+		{
+			UnitTestsApp.App.EnsureApplication();
+		}
+
 		[TestMethod]
 		public void When_ChildIsBigger_PlacementBottom()
 		{

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/Frame/Given_Frame.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/Frame/Given_Frame.cs
@@ -15,6 +15,12 @@ namespace Uno.UI.Tests.FrameTests
 	[TestClass]
 	public class Given_Frame
 	{
+		[TestInitialize]
+		public void Init()
+		{
+			UnitTestsApp.App.EnsureApplication();
+		}
+
 		[TestMethod]
 		public void When_RemovedPage()
 		{

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/PivotTests/Given_Pivot.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/PivotTests/Given_Pivot.cs
@@ -12,7 +12,13 @@ namespace Uno.UI.Tests.PivotTests
 {
 	[TestClass]
 	public class Given_Pivot
-    {
+	{
+		[TestInitialize]
+		public void Init()
+		{
+			UnitTestsApp.App.EnsureApplication();
+		}
+
 		[TestMethod]
 		public void When_Empty()
 		{
@@ -26,7 +32,6 @@ namespace Uno.UI.Tests.PivotTests
 			SUT.Arrange(default(Rect));
 
 			Assert.AreEqual(default(Size), SUT.DesiredSize);
-			Assert.IsTrue(SUT.GetChildren().None());
 		}
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -23,23 +23,29 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 	[TestClass]
 	public class Given_XamlReader : Context
 	{
+		/// <summary>
+		/// The DefaultResolver associated with the active app, temporarily removed while these tests are run.
+		/// </summary>
+		Func<string, object> _appResolver;
+
 		[TestCleanup]
 		public void Cleanup()
 		{
-			ResourceDictionary.DefaultResolver = null;
+			ResourceDictionary.DefaultResolver = _appResolver;
 		}
 
 		[TestInitialize]
 		public void Initialize()
 		{
+			UnitTestsApp.App.EnsureApplication();
+
+			_appResolver = ResourceDictionary.DefaultResolver;
 			ResourceDictionary.DefaultResolver = null;
 
 			Uno.Extensions.LogExtensionPoint
 				.AmbientLoggerFactory
 				.AddConsole(LogLevel.Debug)
 				.AddDebug(LogLevel.Debug);
-
-			UnitTestsApp.App.EnsureApplication();
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -38,6 +38,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 				.AmbientLoggerFactory
 				.AddConsole(LogLevel.Debug)
 				.AddDebug(LogLevel.Debug);
+
+			UnitTestsApp.App.EnsureApplication();
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutBase.cs
@@ -10,20 +10,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		// Skipping already declared property Placement
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.Controls.LightDismissOverlayMode LightDismissOverlayMode
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)this.GetValue(LightDismissOverlayModeProperty);
-			}
-			set
-			{
-				this.SetValue(LightDismissOverlayModeProperty, value);
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.ElementSoundMode ElementSoundMode
 		{
 			get
@@ -159,14 +145,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			"ElementSoundMode", typeof(global::Windows.UI.Xaml.ElementSoundMode), 
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.ElementSoundMode)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
-			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ComboBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ComboBox.cs
@@ -59,20 +59,6 @@ namespace Windows.UI.Xaml.Controls
 		// Skipping already declared property Header
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.Controls.LightDismissOverlayMode LightDismissOverlayMode
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)this.GetValue(LightDismissOverlayModeProperty);
-			}
-			set
-			{
-				this.SetValue(LightDismissOverlayModeProperty, value);
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
 		public  bool IsTextSearchEnabled
 		{
 			get
@@ -167,14 +153,6 @@ namespace Windows.UI.Xaml.Controls
 			"IsTextSearchEnabled", typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(bool)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
-			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePicker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePicker.cs
@@ -113,20 +113,6 @@ namespace Windows.UI.Xaml.Controls
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.Controls.LightDismissOverlayMode LightDismissOverlayMode
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)this.GetValue(LightDismissOverlayModeProperty);
-			}
-			set
-			{
-				this.SetValue(LightDismissOverlayModeProperty, value);
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
 		public  global::System.DateTimeOffset? SelectedDate
 		{
 			get
@@ -201,14 +187,6 @@ namespace Windows.UI.Xaml.Controls
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
 		// Skipping already declared property YearVisibleProperty
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
-			typeof(global::Windows.UI.Xaml.Controls.DatePicker), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
-		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedDateProperty { get; } = 

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/LightDismissOverlayMode.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/LightDismissOverlayMode.cs
@@ -2,21 +2,21 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if false || false || false || false || false
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
-	#endif
+#endif
 	public   enum LightDismissOverlayMode 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		Auto,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		On,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#endif
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		Off,
-		#endif
+#endif
 	}
-	#endif
+#endif
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePicker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePicker.cs
@@ -66,20 +66,6 @@ namespace Windows.UI.Xaml.Controls
 		// Skipping already declared property ClockIdentifier
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.Controls.LightDismissOverlayMode LightDismissOverlayMode
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)this.GetValue(LightDismissOverlayModeProperty);
-			}
-			set
-			{
-				this.SetValue(LightDismissOverlayModeProperty, value);
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
 		public  global::System.TimeSpan? SelectedTime
 		{
 			get
@@ -124,14 +110,6 @@ namespace Windows.UI.Xaml.Controls
 			"Time", typeof(global::System.TimeSpan), 
 			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
 			new FrameworkPropertyMetadata(default(global::System.TimeSpan)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
-			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePicker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePicker.cs
@@ -64,6 +64,20 @@ namespace Windows.UI.Xaml.Controls
 		}
 		#endif
 		// Skipping already declared property ClockIdentifier
+		#if false || false || NET461 || __WASM__ || false
+		[global::Uno.NotImplemented]
+		public  global::Windows.UI.Xaml.Controls.LightDismissOverlayMode LightDismissOverlayMode
+		{
+			get
+			{
+				return (global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)this.GetValue(LightDismissOverlayModeProperty);
+			}
+			set
+			{
+				this.SetValue(LightDismissOverlayModeProperty, value);
+			}
+		}
+		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::System.TimeSpan? SelectedTime
@@ -110,6 +124,14 @@ namespace Windows.UI.Xaml.Controls
 			"Time", typeof(global::System.TimeSpan), 
 			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
 			new FrameworkPropertyMetadata(default(global::System.TimeSpan)));
+		#endif
+		#if false || false || NET461 || __WASM__ || false
+		[global::Uno.NotImplemented]
+		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
+			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
+			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Mock/Brush.net.cs
+++ b/src/Uno.UI/Mock/Brush.net.cs
@@ -12,7 +12,7 @@ namespace Windows.UI.Xaml.Media
 	{
 		internal static IDisposable AssignAndObserveBrush(Brush b, Action<Color> colorSetter)
 		{
-			throw new NotImplementedException();
+			return null;
 		}
 
 	}

--- a/src/Uno.UI/Mock/Popup.net.cs
+++ b/src/Uno.UI/Mock/Popup.net.cs
@@ -8,7 +8,7 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class Popup
 	{
-		public Popup()
+		partial void InitializePartial()
 		{
 			PopupPanel = new PopupPanel(this);
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -53,6 +53,11 @@ namespace Windows.UI.Xaml.Controls
 
 		public ComboBox()
 		{
+			LightDismissOverlayBackground = Resources["ComboBoxLightDismissOverlayBackground"] as Brush ??
+				// This is normally a no-op - the above line should retrieve the framework-level resource. This is purely to fail the build when
+				// Resources/Styles are overhauled (and the above will no longer be valid)
+				Uno.UI.GlobalStaticResources.ComboBoxLightDismissOverlayBackground as Brush;
+
 			IsItemClickEnabled = true;
 		}
 
@@ -78,6 +83,9 @@ namespace Windows.UI.Xaml.Controls
 			if (_popup is PopupBase popup)
 			{
 				popup.CustomLayouter = new DropDownLayouter(this, popup);
+
+				popup.BindToEquivalentProperty(this, nameof(LightDismissOverlayMode));
+				popup.BindToEquivalentProperty(this, nameof(LightDismissOverlayBackground));
 			}
 
 			UpdateHeaderVisibility();
@@ -370,6 +378,36 @@ namespace Windows.UI.Xaml.Controls
 		{
 			return new ComboBoxAutomationPeer(this);
 		}
+
+		public LightDismissOverlayMode LightDismissOverlayMode
+		{
+			get
+			{
+				return (LightDismissOverlayMode)this.GetValue(LightDismissOverlayModeProperty);
+			}
+			set
+			{
+				this.SetValue(LightDismissOverlayModeProperty, value);
+			}
+		}
+
+		public static DependencyProperty LightDismissOverlayModeProperty { get; } =
+		DependencyProperty.Register(
+			"LightDismissOverlayMode", typeof(LightDismissOverlayMode),
+			typeof(ComboBox),
+			new FrameworkPropertyMetadata(default(LightDismissOverlayMode)));
+
+		/// <summary>
+		/// Sets the light-dismiss colour, if the overlay is enabled. The external API for modifying this is to override the PopupLightDismissOverlayBackground, etc, static resource values.
+		/// </summary>
+		internal Brush LightDismissOverlayBackground
+		{
+			get { return (Brush)GetValue(LightDismissOverlayBackgroundProperty); }
+			set { SetValue(LightDismissOverlayBackgroundProperty, value); }
+		}
+
+		internal static readonly DependencyProperty LightDismissOverlayBackgroundProperty =
+			DependencyProperty.Register("LightDismissOverlayBackground", typeof(Brush), typeof(ComboBox), new PropertyMetadata(null));
 
 		private class DropDownLayouter : PopupBase.IDynamicPopupLayouter
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.Android.cs
@@ -13,7 +13,7 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class DatePicker
 	{
-		public DatePicker()
+		partial void InitializePartial()
 		{
 			InitializeVisualStates();
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -112,6 +113,48 @@ namespace Windows.UI.Xaml.Controls
 		partial void OnMinYearChangedPartial();
 		#endregion
 
+		public LightDismissOverlayMode LightDismissOverlayMode
+		{
+			get
+			{
+				return (LightDismissOverlayMode)this.GetValue(LightDismissOverlayModeProperty);
+			}
+			set
+			{
+				this.SetValue(LightDismissOverlayModeProperty, value);
+			}
+		}
+
+		public static DependencyProperty LightDismissOverlayModeProperty { get; } =
+		DependencyProperty.Register(
+			"LightDismissOverlayMode", typeof(LightDismissOverlayMode),
+			typeof(DatePicker),
+			new FrameworkPropertyMetadata(default(LightDismissOverlayMode)));
+
+		/// <summary>
+		/// Sets the light-dismiss colour, if the overlay is enabled. The external API for modifying this is to override the PopupLightDismissOverlayBackground, etc static resource values.
+		/// </summary>
+		internal Brush LightDismissOverlayBackground
+		{
+			get { return (Brush)GetValue(LightDismissOverlayBackgroundProperty); }
+			set { SetValue(LightDismissOverlayBackgroundProperty, value); }
+		}
+
+		internal static readonly DependencyProperty LightDismissOverlayBackgroundProperty =
+			DependencyProperty.Register("LightDismissOverlayBackground", typeof(Brush), typeof(DatePicker), new PropertyMetadata(null));
+
+		public DatePicker()
+		{
+			LightDismissOverlayBackground = Resources["DatePickerLightDismissOverlayBackground"] as Brush ??
+				// This is normally a no-op - the above line should retrieve the framework-level resource. This is purely to fail the build when
+				// Resources/Styles are overhauled (and the above will no longer be valid)
+				Uno.UI.GlobalStaticResources.DatePickerLightDismissOverlayBackground as Brush;
+
+			InitializePartial();
+		}
+
+		partial void InitializePartial();
+
 #if XAMARIN
 
 		#region Template parts
@@ -207,6 +250,8 @@ namespace Windows.UI.Xaml.Controls
 				BindToFlyout(nameof(Date));
 				BindToFlyout(nameof(MinYear));
 				BindToFlyout(nameof(MaxYear));
+				_flyoutButton.Flyout.BindToEquivalentProperty(this, nameof(LightDismissOverlayMode));
+				_flyoutButton.Flyout.BindToEquivalentProperty(this, nameof(LightDismissOverlayBackground));
 #endif
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.iOS.cs
@@ -13,7 +13,6 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class DatePicker
 	{
-		public DatePicker() { }
 
 		/// <summary>
 		/// iOS-specific property that allows apps to specify any flyout placement 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.md
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.md
@@ -21,3 +21,12 @@ DatePicker flyout appear centered to screen.
 Native date picker is wrapped in the flyout.
 Set 'FlyoutPlacement' property to change flyout docking placement
 Default 'FlyoutPlacement' is 'Full' and will dock of the flyout at the bottom of the screen
+
+
+If you want to show a dimmed overlay underneath the picker, set the `DatePicker.LightDismissOverlayMode` property to `On`.
+
+If you wish to customise the overlay color, add the following to your top-level `App.Resources`:
+```xaml
+		<SolidColorBrush x:Key="DatePickerLightDismissOverlayBackground"
+						 Color="Pink" />
+```

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 
 		/// <summary>
-		/// Sets the light-dismiss colour, if the overlay is enabled. The external API for modifying this is to override the PopupLightDismissOverlayBackground, etc static resource values.
+		/// Sets the light-dismiss colour, if the overlay is enabled. The external API for modifying this is to override the PopupLightDismissOverlayBackground, etc, static resource values.
 		/// </summary>
 		internal Brush LightDismissOverlayBackground
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -29,7 +29,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		public FlyoutBase()
 		{
-			LightDismissOverlayBackground = Resources["FlyoutLightDismissOverlayBackground"] as Brush ??
+			LightDismissOverlayBackground = Application.Current?.Resources["FlyoutLightDismissOverlayBackground"] as Brush ??
 				// This is normally a no-op - the above line should retrieve the framework-level resource. This is purely to fail the build when
 				// Resources/Styles are overhauled (and the above will no longer be valid)
 				Uno.UI.GlobalStaticResources.FlyoutLightDismissOverlayBackground as Brush;

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Uno.Disposables;
 using Windows.Foundation;
+using Windows.UI.Xaml.Media;
 
 #if XAMARIN_IOS
 using View = UIKit.UIView;
@@ -28,6 +29,11 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		public FlyoutBase()
 		{
+			LightDismissOverlayBackground = Resources["FlyoutLightDismissOverlayBackground"] as Brush ??
+				// This is normally a no-op - the above line should retrieve the framework-level resource. This is purely to fail the build when
+				// Resources/Styles are overhauled (and the above will no longer be valid)
+				Uno.UI.GlobalStaticResources.FlyoutLightDismissOverlayBackground as Brush;
+
 			_popup = new Windows.UI.Xaml.Controls.Popup()
 			{
 				Child = CreatePresenter(),
@@ -35,6 +41,9 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 			_popup.Opened += OnPopupOpened;
 			_popup.Closed += OnPopupClosed;
+
+			_popup.BindToEquivalentProperty(this, nameof(LightDismissOverlayMode));
+			_popup.BindToEquivalentProperty(this, nameof(LightDismissOverlayBackground));
 
 			InitializePopupPanel();
 		}
@@ -83,6 +92,37 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			);
 
 		#endregion
+
+		public LightDismissOverlayMode LightDismissOverlayMode
+		{
+			get
+			{
+				return (LightDismissOverlayMode)this.GetValue(LightDismissOverlayModeProperty);
+			}
+			set
+			{
+				this.SetValue(LightDismissOverlayModeProperty, value);
+			}
+		}
+
+		public static DependencyProperty LightDismissOverlayModeProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"LightDismissOverlayMode", typeof(LightDismissOverlayMode),
+			typeof(FlyoutBase),
+			new FrameworkPropertyMetadata(default(LightDismissOverlayMode)));
+
+
+		/// <summary>
+		/// Sets the light-dismiss colour, if the overlay is enabled. The external API for modifying this is to override the PopupLightDismissOverlayBackground, etc static resource values.
+		/// </summary>
+		internal Brush LightDismissOverlayBackground
+		{
+			get { return (Brush)GetValue(LightDismissOverlayBackgroundProperty); }
+			set { SetValue(LightDismissOverlayBackgroundProperty, value); }
+		}
+
+		internal static readonly DependencyProperty LightDismissOverlayBackgroundProperty =
+			DependencyProperty.Register("LightDismissOverlayBackground", typeof(Brush), typeof(FlyoutBase), new PropertyMetadata(null));
 
 		public FrameworkElement Target { get; private set; }
 

--- a/src/Uno.UI/UI/Xaml/Controls/LightDismissOverlayMode.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/LightDismissOverlayMode.cs
@@ -1,0 +1,10 @@
+
+namespace Windows.UI.Xaml.Controls
+{
+	public enum LightDismissOverlayMode
+	{
+		Auto,
+		On,
+		Off,
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Android.cs
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Controls
 
 		internal FlyoutPlacementMode Placement { get; set; }
 
-		public Popup()
+		partial void InitializePartial()
 		{
 			_popupWindow = new PopupWindow(this, WindowManagerLayoutParams.MatchParent, WindowManagerLayoutParams.MatchParent, true);
 
@@ -116,14 +116,7 @@ namespace Windows.UI.Xaml.Controls
 				return; // nothing to do
 			}
 
-			if (isLightDismiss)
-			{
-				PopupPanel.Background = new SolidColorBrush(Colors.Transparent);
-			}
-			else
-			{
-				PopupPanel.Background = null;
-			}
+			PopupPanel.Background = GetPanelBackground();
 		}
 
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Android.cs
@@ -13,7 +13,7 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class Popup
 	{
-		private readonly PopupWindow _popupWindow;
+		private PopupWindow _popupWindow;
 
 		internal FlyoutPlacementMode Placement { get; set; }
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
@@ -32,7 +32,8 @@ namespace Windows.UI.Xaml.Controls
 				switch (LightDismissOverlayMode)
 				{
 					case LightDismissOverlayMode.Auto:
-						return false; //TODO: establish sensible platform defaults
+						// For now, default to false for all platforms. This may be adjusted in the future.
+						return false;
 					case LightDismissOverlayMode.On:
 						return true;
 					case LightDismissOverlayMode.Off:

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
@@ -17,10 +17,6 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private UIView _mainWindow;
 
-		public Popup()
-		{
-		}
-
 		public UIView MainWindow
 		{
 			get
@@ -57,9 +53,7 @@ namespace Windows.UI.Xaml.Controls
 					newPanel.AddSubview(Child);
 				}
 
-				newPanel.Background = IsLightDismissEnabled
-					? new SolidColorBrush(Colors.Transparent)
-					: null;
+				newPanel.Background = GetPanelBackground();
 
 				RegisterPopupPanel();
 			}
@@ -125,9 +119,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (PopupPanel != null)
 			{
-				PopupPanel.Background = newIsLightDismissEnabled
-					? new SolidColorBrush(Colors.Transparent)
-					: null;
+				PopupPanel.Background = GetPanelBackground();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.wasm.cs
@@ -11,7 +11,7 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private readonly SerialDisposable _closePopup = new SerialDisposable();
 
-		public Popup()
+		partial void InitializePartial()
 		{
 			PopupPanel = new PopupPanel(this);
 		}
@@ -30,9 +30,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (PopupPanel != null)
 			{
-				PopupPanel.Background = newIsLightDismissEnabled
-					? new SolidColorBrush(Colors.Transparent)
-					: null;
+				PopupPanel.Background = GetPanelBackground();
 			}
 		}
 
@@ -67,9 +65,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 					newPanel.Children.Add(Child);
 				}
-				newPanel.Background = IsLightDismissEnabled
-					? new SolidColorBrush(Colors.Transparent)
-					: null;
+				newPanel.Background = GetPanelBackground();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
@@ -9,6 +9,7 @@ using Windows.Globalization;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -30,7 +31,13 @@ namespace Windows.UI.Xaml.Controls
 		private bool _isLoaded;
 		private bool _isViewReady;
 
-		public TimePicker() { }
+		public TimePicker()
+		{
+			LightDismissOverlayBackground = Resources["TimePickerLightDismissOverlayBackground"] as Brush ??
+				// This is normally a no-op - the above line should retrieve the framework-level resource. This is purely to fail the build when
+				// Resources/Styles are overhauled (and the above will no longer be valid)
+				Uno.UI.GlobalStaticResources.TimePickerLightDismissOverlayBackground as Brush;
+		}
 
 		#region Time DependencyProperty
 
@@ -108,6 +115,36 @@ namespace Windows.UI.Xaml.Controls
 
 		#endregion
 
+
+		public LightDismissOverlayMode LightDismissOverlayMode
+		{
+			get
+			{
+				return (LightDismissOverlayMode)this.GetValue(LightDismissOverlayModeProperty);
+			}
+			set
+			{
+				this.SetValue(LightDismissOverlayModeProperty, value);
+			}
+		}
+		public static DependencyProperty LightDismissOverlayModeProperty { get; } =
+		DependencyProperty.Register(
+			"LightDismissOverlayMode", typeof(LightDismissOverlayMode),
+			typeof(TimePicker),
+			new FrameworkPropertyMetadata(default(LightDismissOverlayMode)));
+
+		/// <summary>
+		/// Sets the light-dismiss colour, if the overlay is enabled. The external API for modifying this is to override the PopupLightDismissOverlayBackground, etc, static resource values.
+		/// </summary>
+		internal Brush LightDismissOverlayBackground
+		{
+			get { return (Brush)GetValue(LightDismissOverlayBackgroundProperty); }
+			set { SetValue(LightDismissOverlayBackgroundProperty, value); }
+		}
+
+		internal static readonly DependencyProperty LightDismissOverlayBackgroundProperty =
+			DependencyProperty.Register("LightDismissOverlayBackground", typeof(Brush), typeof(TimePicker), new PropertyMetadata(null));
+
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
@@ -168,6 +205,8 @@ namespace Windows.UI.Xaml.Controls
 				BindToFlyout(nameof(Time));
 				BindToFlyout(nameof(MinuteIncrement));
 				BindToFlyout(nameof(ClockIdentifier));
+				_flyoutButton.Flyout.BindToEquivalentProperty(this, nameof(LightDismissOverlayMode));
+				_flyoutButton.Flyout.BindToEquivalentProperty(this, nameof(LightDismissOverlayBackground));
 #endif
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.md
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.md
@@ -45,3 +45,11 @@ Some ColorBrushes are specific to IOS and could be changed by copying and redoin
  IOSTimePickerAcceptButtonForegroundBrush  Color="#324f85"
  IOSTimePickerDismissButtonForegroundBrush  Color="#324f85"
  IOSTimePickerHeaderBackgroundBrush  Color="#f8f8f8" 
+
+If you want to show a dimmed overlay underneath the picker, set the `TimePicker.LightDismissOverlayMode` property to `On`.
+
+If you wish to customise the overlay color, add the following to your top-level `App.Resources`:
+```xaml
+		<SolidColorBrush x:Key="TimePickerLightDismissOverlayBackground"
+						 Color="Pink" />
+```

--- a/src/Uno.UI/UI/Xaml/FrameworkElementExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElementExtensions.cs
@@ -208,7 +208,6 @@ namespace Windows.UI.Xaml
 			return element.Margin(new Thickness(leftRight, topBottom, leftRight, topBottom));
 		}
 
-#if !NET461
 		/// <summary>
 		/// Bind property on <param name="element"/> to a property on <param name="source"/> of the same name.
 		/// </summary>
@@ -216,7 +215,6 @@ namespace Windows.UI.Xaml
 		{
 			return element.Binding(property, property, source, bindingMode);
 		}
-#endif
 
 		internal static Thickness? GetPadding(this IFrameworkElement frameworkElement)
 		{

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.Native.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.Native.xaml
@@ -118,7 +118,11 @@
 	<wasm:Style
 		x:Key="NativeDefaultCheckBox"
 		TargetType="CheckBox"
-		BasedOn="{StaticResource XamlDefaultCheckBox}" />
+				BasedOn="{StaticResource XamlDefaultCheckBox}" />
+
+	<net461:Style x:Key="NativeDefaultCheckBox"
+				TargetType="CheckBox"
+				BasedOn="{StaticResource XamlDefaultCheckBox}" />
 
 	<xamarin:Style
 		TargetType="CheckBox"
@@ -454,7 +458,12 @@
 	<wasm:Style
 		x:Key="NativeDefaultFrame"
 		TargetType="Frame"
-		BasedOn="{StaticResource XamlDefaultFrame}" />
+				BasedOn="{StaticResource XamlDefaultFrame}" />
+
+	<!-- Default native Frame styles -->
+	<net461:Style x:Key="NativeDefaultFrame"
+				TargetType="Frame"
+				BasedOn="{StaticResource XamlDefaultFrame}" />
 
 	<xamarin:Style
 		TargetType="Frame"

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.Native.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.Native.xaml
@@ -16,8 +16,9 @@
 					xmlns:maps="using:Windows.UI.Xaml.Controls.Maps"
 					xmlns:mapsPresenter="using:Windows.UI.Xaml.Controls.Maps"
 					xmlns:wasm="http://uno.ui/wasm"
+					xmlns:net461="http://uno.ui/net461"
 					xmlns:not_wasm="http://uno.ui/not_wasm"
-					mc:Ignorable="d xamarin ios android wasm not_wasm">
+					mc:Ignorable="d xamarin ios android wasm not_wasm net461">
 
 	<wasm:ResourceDictionary.MergedDictionaries>
 		<!--
@@ -67,7 +68,11 @@
 	<wasm:Style
 		x:Key="NativeDefaultButton"
 		TargetType="Button"
-		BasedOn="{StaticResource XamlDefaultButton}" />
+				BasedOn="{StaticResource XamlDefaultButton}" />
+
+	<net461:Style x:Key="NativeDefaultButton"
+				TargetType="Button"
+				BasedOn="{StaticResource XamlDefaultButton}" />
 
 	<xamarin:Style
 		TargetType="Button"

--- a/src/Uno.UI/UI/Xaml/Style/Generic/SystemResources.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/SystemResources.xaml
@@ -1002,6 +1002,19 @@
 			<StaticResource x:Key="AccentButtonBorderBrushPointerOver" ResourceKey="SystemControlHighlightBaseMediumLowBrush" />
 			<StaticResource x:Key="AccentButtonBorderBrushPressed" ResourceKey="SystemControlHighlightTransparentBrush" />
 			<StaticResource x:Key="AccentButtonBorderBrushDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
+			
+			<!-- Light Dismiss Overlay Resources -->
+			<!--<StaticResource x:Key="AppBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />-->
+			<StaticResource x:Key="AutoSuggestBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="CalendarDatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="ComboBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<!--<StaticResource x:Key="CommandBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />-->
+			<StaticResource x:Key="DatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="FlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="MenuFlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="PopupLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="SplitViewLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="TimePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 		</ResourceDictionary>
 		<ResourceDictionary x:Key="HighContrast">
 			<!-- Added manually (not part of UWP's SystemResources.xaml) -->
@@ -1987,6 +2000,20 @@
 			<StaticResource x:Key="AccentButtonBorderBrushPointerOver" ResourceKey="SystemControlHighlightBaseMediumLowBrush" />
 			<StaticResource x:Key="AccentButtonBorderBrushPressed" ResourceKey="SystemControlHighlightTransparentBrush" />
 			<StaticResource x:Key="AccentButtonBorderBrushDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
+			
+			
+			<!-- Light Dismiss Overlay Resources -->
+			<!--<StaticResource x:Key="AppBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />-->
+			<StaticResource x:Key="AutoSuggestBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="CalendarDatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="ComboBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<!--<StaticResource x:Key="CommandBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />-->
+			<StaticResource x:Key="DatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="FlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="MenuFlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="PopupLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="SplitViewLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="TimePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 		</ResourceDictionary>
 		<ResourceDictionary x:Key="Light">
 			<!-- Added manually (not part of UWP's SystemResources.xaml) -->
@@ -2970,6 +2997,20 @@
 			<StaticResource x:Key="AccentButtonBorderBrushPointerOver" ResourceKey="SystemControlHighlightBaseMediumLowBrush" />
 			<StaticResource x:Key="AccentButtonBorderBrushPressed" ResourceKey="SystemControlHighlightTransparentBrush" />
 			<StaticResource x:Key="AccentButtonBorderBrushDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
+			
+			
+			<!-- Light Dismiss Overlay Resources -->
+			<!--<StaticResource x:Key="AppBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />-->
+			<StaticResource x:Key="AutoSuggestBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="CalendarDatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="ComboBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<!--<StaticResource x:Key="CommandBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />-->
+			<StaticResource x:Key="DatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="FlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="MenuFlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="PopupLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="SplitViewLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+			<StaticResource x:Key="TimePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 		</ResourceDictionary>
 	</ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): #2081

This allows to configure whether a darkened background should be shown behind a Popup. 

This provides a forward path for the previous workaround of adding a background to the Popup.Child content, which breaks light-dismiss after recent pointer-handling updates.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Feature
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
