### PR TITLE
[iOS] Fix double margin on Image

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -517,6 +517,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Margin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Algmnt_Inf_Vertical.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3057,6 +3061,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_ImageSource_PixelSize.xaml.cs">
       <DependentUpon>Image_ImageSource_PixelSize.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Margin.xaml.cs">
+      <DependentUpon>$fileinputname$.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Algmnt_Inf_Horizontal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Algmnt_Inf_Vertical.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margin.xaml
@@ -1,0 +1,114 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ImageTests.Image_Margin"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ImageTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<Grid Grid.Row="0"
+			  Grid.Column="0"
+			  Background="Orange"
+			  Width="100"
+			  Height="100">
+			<StackPanel HorizontalAlignment="Stretch"
+						VerticalAlignment="Center">
+				<Image Source="ms-appx:///Assets/ingredient3.png"
+					   Stretch="Uniform"
+					   Margin="0,0" />
+			</StackPanel>
+		</Grid>
+
+		<Grid Grid.Row="0"
+			  Grid.Column="1"
+			  Background="Orange"
+			  Width="100"
+			  Height="100">
+			<StackPanel HorizontalAlignment="Stretch"
+						VerticalAlignment="Center">
+				<Image Source="ms-appx:///Assets/ingredient3.png"
+					   Stretch="Uniform"
+					   Margin="20,0" />
+			</StackPanel>
+		</Grid>
+
+		<Grid Grid.Row="0"
+			  Grid.Column="2"
+			  Background="Orange"
+			  Width="100"
+			  Height="100">
+			<StackPanel HorizontalAlignment="Stretch"
+						VerticalAlignment="Center">
+				<Image Source="ms-appx:///Assets/ingredient3.png"
+					   Stretch="Uniform"
+					   Margin="0,20" />
+			</StackPanel>
+		</Grid>
+
+		<Grid Grid.Row="1"
+			  Grid.Column="0"
+			  Background="Orange"
+			  Width="100"
+			  Height="100">
+			<StackPanel HorizontalAlignment="Stretch"
+						VerticalAlignment="Center">
+				<Image Source="ms-appx:///Assets/ingredient3.png"
+					   Stretch="Uniform"
+					   Margin="20,0,0,0" />
+			</StackPanel>
+		</Grid>
+
+		<Grid Grid.Row="1"
+			  Grid.Column="1"
+			  Background="Orange"
+			  Width="100"
+			  Height="100">
+			<StackPanel HorizontalAlignment="Stretch"
+						VerticalAlignment="Center">
+				<Image Source="ms-appx:///Assets/ingredient3.png"
+					   Stretch="Uniform"
+					   Margin="0,20,0,0" />
+			</StackPanel>
+		</Grid>
+
+		<Grid Grid.Row="1"
+			  Grid.Column="2"
+			  Background="Orange"
+			  Width="100"
+			  Height="100">
+			<StackPanel HorizontalAlignment="Stretch"
+						VerticalAlignment="Center">
+				<Image Source="ms-appx:///Assets/ingredient3.png"
+					   Stretch="Uniform"
+					   Margin="0,0,20,0" />
+			</StackPanel>
+		</Grid>
+
+		<Grid Grid.Row="2"
+			  Grid.Column="0"
+			  Background="Orange"
+			  Width="100"
+			  Height="100">
+			<StackPanel HorizontalAlignment="Stretch"
+						VerticalAlignment="Center">
+				<Image Source="ms-appx:///Assets/ingredient3.png"
+					   Stretch="Uniform"
+					   Margin="0,0,0,20" />
+			</StackPanel>
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margin.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ImageTests
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo]
+	public sealed partial class Image_Margin : Page
+    {
+        public Image_Margin()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -298,7 +298,10 @@ namespace Windows.UI.Xaml.Controls
 				return ret;
 			}
 
-			if (frameworkElement != null && !(frameworkElement is FrameworkElement))
+			if (frameworkElement != null
+				&& !(frameworkElement is FrameworkElement)
+				&& !(frameworkElement is Image)
+				)
 			{
 				// For IFrameworkElement implementers that are not FrameworkElements, the constraint logic must
 				// be performed by the parent. Otherwise, the native element will take the size it needs without


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fix regression when applying a margin on an Image control on iOS.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
