### PR TITLE
[iOS] Fix bug with ListViewItem.Margin application

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -191,6 +191,18 @@ namespace SamplesApp
 
 						//  Binder memory references tracking
 						// { "ReferenceHolder", LogLevel.Debug },
+
+						// ListView-related messages
+						// { "Windows.UI.Xaml.Controls.ListViewBase", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.ListView", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.GridView", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.VirtualizingPanelLayout", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.NativeListViewBase", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.ListViewBaseSource", LogLevel.Debug }, //iOS
+						// { "Windows.UI.Xaml.Controls.ListViewBaseInternalContainer", LogLevel.Debug }, //iOS
+						// { "Windows.UI.Xaml.Controls.NativeListViewBaseAdapter", LogLevel.Debug }, //Android
+						// { "Windows.UI.Xaml.Controls.BufferViewCache", LogLevel.Debug }, //Android
+						// { "Windows.UI.Xaml.Controls.VirtualizingPanelGenerator", LogLevel.Debug }, //WASM
 					}
 				)
 #if DEBUG

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -537,6 +537,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Margin_On_Container.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_WithScrollViewer.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3078,6 +3082,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Modes_Picker.xaml.cs">
       <DependentUpon>Image_Stretch_Modes_Picker.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Margin_On_Container.xaml.cs">
+      <DependentUpon>ListView_Margin_On_Container.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_WithScrollViewer.xaml.cs">
       <DependentUpon>ListView_WithScrollViewer.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Margin_On_Container.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Margin_On_Container.xaml
@@ -1,0 +1,104 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ListView.ListView_Margin_On_Container"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ListView"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+
+	<UserControl.Resources>
+		<Style x:Key="BillingAddressListViewStyle"
+			   TargetType="ListViewItem">
+
+			<Setter Property="Background"
+					Value="LightBlue" />
+			<Setter Property="BorderThickness"
+					Value="0" />
+			<Setter Property="Padding"
+					Value="0" />
+			<Setter Property="Margin"
+					Value="0,42,0,0" />
+
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ListViewItem">
+						<Grid x:Name="RootGrid"
+							  Background="{TemplateBinding Background}"
+							  BorderBrush="{TemplateBinding BorderBrush}"
+							  BorderThickness="0,0,0,1"
+							  Padding="{TemplateBinding Padding}">
+							<!-- ContentPresenter -->
+							<ContentPresenter x:Name="ContentPresenter"
+											  Content="{TemplateBinding Content}"
+											  ContentTemplate="{TemplateBinding ContentTemplate}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+		<!-- BillingAddress Template -->
+		<DataTemplate x:Key="BillingAddressTemplate">
+			<Grid Background="LightPink"
+				  x:Name="ContentGrid">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="Auto" />
+				</Grid.ColumnDefinitions>
+
+				<!-- Info -->
+				<StackPanel Margin="12,0">
+
+					<!-- Location Name -->
+					<TextBlock MaxLines="1">
+						<Run Text="Maximus" />
+						<Run Text="Aurelius" />
+					</TextBlock>
+
+					<!-- Address Line 1 -->
+					<TextBlock Text="215 St. Jacques" />
+
+					<!-- Address Line 2 -->
+					<TextBlock Text="Suite 500" />
+
+					<!-- Address Line 2 -->
+					<TextBlock>
+						<Run Text="Montreal" /><Run Text="," />
+						<Run Text="QC" /><Run Text="," />
+						<Run Text="H2Y 1M6" />
+					</TextBlock>
+
+					<StackPanel Margin="0,4,0,0">
+
+						<!-- Phone Number Day -->
+						<TextBlock>
+							<Run Text="1 888 926-1276" />
+							<Run Text="(jour)" />
+						</TextBlock>
+
+						<!-- Phone Number Evening -->
+						<TextBlock>
+							<Run Text="1 888 926-1276" />
+							<Run Text="(soir)" />
+						</TextBlock>
+					</StackPanel>
+				</StackPanel>
+			</Grid>
+		</DataTemplate>
+	</UserControl.Resources>
+
+	<Grid>
+		<ListView x:Name="ListTest"
+				  ItemsSource="012345678"
+				  ItemContainerStyle="{StaticResource BillingAddressListViewStyle}"
+				  ItemTemplate="{StaticResource BillingAddressTemplate}"
+				  IsItemClickEnabled="True"
+				  SelectionMode="Single"
+				  Margin="0,8,0,0" />
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Margin_On_Container.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Margin_On_Container.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfo(description: "ListView with Margin set on ListViewItems via ItemContainerStyle")]
+	public sealed partial class ListView_Margin_On_Container : UserControl
+	{
+
+		public ListView_Margin_On_Container()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml.cs
@@ -139,6 +139,18 @@ namespace $ext_safeprojectname$
 
 						// DependencyObject memory references tracking
 						// { "ReferenceHolder", LogLevel.Debug },
+
+						// ListView-related messages
+						// { "Windows.UI.Xaml.Controls.ListViewBase", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.ListView", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.GridView", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.VirtualizingPanelLayout", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.NativeListViewBase", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.ListViewBaseSource", LogLevel.Debug }, //iOS
+						// { "Windows.UI.Xaml.Controls.ListViewBaseInternalContainer", LogLevel.Debug }, //iOS
+						// { "Windows.UI.Xaml.Controls.NativeListViewBaseAdapter", LogLevel.Debug }, //Android
+						// { "Windows.UI.Xaml.Controls.BufferViewCache", LogLevel.Debug }, //Android
+						// { "Windows.UI.Xaml.Controls.VirtualizingPanelGenerator", LogLevel.Debug }, //WASM
 					}
 				)
 #if DEBUG

--- a/src/Uno.UI/Extensions/CGSizeExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/CGSizeExtensions.iOSmacOS.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using CoreGraphics;
 using Windows.Foundation;
+using Windows.UI.Xaml;
 
 namespace CoreGraphics
 {
@@ -16,5 +17,13 @@ namespace CoreGraphics
 
 		public static bool HasZeroArea(this CGSize size)
 			=> size.Height == 0 || size.Width == 0;
+
+		internal static CGSize Add(this CGSize left, Thickness right)
+		{
+			return new CGSize(
+				left.Width + right.Left + right.Right,
+				left.Height + right.Top + right.Bottom
+			);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -229,11 +229,11 @@ namespace Windows.UI.Xaml.Controls
 						}
 
 						FrameworkElement.InitializePhaseBinding(selectorItem);
-                        
-                        // Ensure the item has a parent, since it's added to the native collection view
-                        // which does not automatically sets the parent DependencyObject.
-                        selectorItem.SetParent(Owner?.XamlParent);
-                    }
+
+						// Ensure the item has a parent, since it's added to the native collection view
+						// which does not automatically sets the parent DependencyObject.
+						selectorItem.SetParent(Owner?.XamlParent);
+					}
 					else if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 					{
 						this.Log().Debug($"Reusing view at indexPath={indexPath}, previously bound to {selectorItem.DataContext}.");
@@ -792,7 +792,7 @@ namespace Windows.UI.Xaml.Controls
 				return null;
 			}
 
-			if(Content == null)
+			if (Content == null)
 			{
 				this.Log().Error("Empty ListViewBaseInternalContainer content.");
 				return null;
@@ -840,13 +840,13 @@ namespace Windows.UI.Xaml.Controls
 						// cachedAttributes may be null if we have modified the collection with DeleteItems
 						var frame = cachedAttributes?.Frame ?? layoutAttributes.Frame;
 						SetExtent(ref frame, _measuredContentSize.Value);
-						if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
-						{
-							this.Log().Debug($"Adjusting layout attributes for item at {layoutAttributes.IndexPath}({layoutAttributes.RepresentedElementKind}), Content={Content?.Content}. Previous frame={layoutAttributes.Frame}, new frame={frame}.");
-						}
 						var sizesAreDifferent = frame.Size != layoutAttributes.Frame.Size;
 						if (sizesAreDifferent)
 						{
+							if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+							{
+								this.Log().Debug($"Adjusting layout attributes for item at {layoutAttributes.IndexPath}({layoutAttributes.RepresentedElementKind}), Content={Content?.Content}. Previous frame={layoutAttributes.Frame}, new frame={frame}.");
+							}
 							Owner.NativeLayout.HasDynamicElementSizes = true;
 							this.Frame = frame;
 							SetNeedsLayout();

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -475,6 +475,10 @@ namespace Windows.UI.Xaml.Controls
 		/// <returns>The total collection size</returns>
 		private CGSize PrepareLayoutInternal(bool createLayoutInfo, bool isCollectionChanged, CGSize size)
 		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug($"PrepareLayoutInternal() - recalculating layout, createLayoutInfo={createLayoutInfo}, dirtyState={_dirtyState}, size={size} ");
+			}
 			Dictionary<NSIndexPath, CGSize?> oldItemSizes = null;
 			Dictionary<int, CGSize?> oldGroupHeaderSizes = null;
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -48,7 +48,8 @@ namespace Windows.UI.Xaml
 
 					if (RequiresMeasure)
 					{
-						XamlMeasure(Bounds.Size);
+						// Add back the Margin (which is normally 'outside' the view's bounds) - the layouter will subtract it again
+						XamlMeasure(Bounds.Size.Add(Margin));
 					}
 
 					OnBeforeArrange();
@@ -64,7 +65,7 @@ namespace Windows.UI.Xaml
 					RequiresArrange = false;
 				}
 			}
-			catch(Exception e)
+			catch (Exception e)
 			{
 				this.Log().Error($"Layout failed in {GetType()}", e);
 			}
@@ -122,7 +123,7 @@ namespace Windows.UI.Xaml
 
 				var xamlMeasure = XamlMeasure(size);
 
-				if(xamlMeasure != null)
+				if (xamlMeasure != null)
 				{
 					return _lastMeasure = xamlMeasure.Value;
 				}


### PR DESCRIPTION
When a view requires measure in LayoutSubviews(), add its Margin to its Bounds to determine the available size. This fixes a bug where the contents of a ListViewItem could be squished by the size of its Margin.

This is required because of recent changes where Margin is handled by views themselves, rather than their parent layouter.

It probably manifests itself in the case of ListViewItem because (a) its parent is a non-Uno view and/or because (b) the ListView intercepts layout requests, so only a portion of the view tree gets rearranged.

GitHub Issue (If applicable): fixes #2339, fixes #2188 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
