### PR TITLE
[iOS] Fix margin constraint applied to fixed sized Image control

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -19,6 +19,7 @@
 - [Android] Fix bug where setting Canvas.ZIndex would apply shadow effect in some cases
 - #2287 Vertical `ListView` containing a horizontal `ScrollViewer`: horizontal scrolling is difficult, only works when the gesture is perfectly horizontal
 - #2130 Grid - fix invalid measure when total star size is 0
+- [iOS] Fix invalid image measure on constrained images with `Margin`
 
 ## Release 2.0
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_IsEnabled.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_IsEnabled.xaml.cs
@@ -7,7 +7,7 @@ using Uno.UI.Samples.Presentation.SamplePages;
 
 namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
 {
-	[SampleControlInfo("Button", "Button_IsEnabled", typeof(ButtonTestsViewModel))]
+	[SampleControlInfo("Button", "Button_IsEnabled", typeof(ButtonTestsViewModel), ignoreInSnapshotTests: true)]
 	public sealed partial class Button_IsEnabled : UserControl
 	{
 		public Button_IsEnabled()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margin.xaml
@@ -110,5 +110,22 @@
 					   Margin="0,0,0,20" />
 			</StackPanel>
 		</Grid>
+
+		<StackPanel Grid.Row="2"
+					Grid.Column="1"
+					Orientation="Horizontal"
+					Margin="16,0,0,0">
+
+		  <Border Width="32"
+				  Height="32"
+				  Margin="16,0,0,0"
+				  Background="Red" />
+
+		  <Border>
+			<Image Source="Assets/ingredient3.png"
+				   Width="32"
+				   Margin="16,0,0,0" />
+		  </Border>
+		</StackPanel>
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margin.xaml
@@ -1,5 +1,5 @@
 ﻿<Page
-    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ImageTests.Image_Margin"
+    x:Class="Uno.UI.Samples.UITests.Image.Image_Margin"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ImageTests"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margin.xaml.cs
@@ -16,7 +16,7 @@ using Windows.UI.Xaml.Navigation;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
-namespace UITests.Shared.Windows_UI_Xaml_Controls.ImageTests
+namespace Uno.UI.Samples.UITests.Image
 {
 	/// <summary>
 	/// An empty page that can be used on its own or navigated to within a Frame.

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOS.cs
@@ -291,8 +291,6 @@ namespace Windows.UI.Xaml.Controls
 
 		public override CGSize SizeThatFits(CGSize size)
 		{
-			size = IFrameworkElementHelper.SizeThatFits(this, size);
-
 			size = _layouter.Measure(size.ToFoundationSize());
 
 			return _previousSize = size;

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -728,17 +728,6 @@ namespace Windows.UI.Xaml.Controls
 			return MeasureChild(view, slotSize);
 		}
 
-		private Size GetConstrainedSize(Size availableSize)
-		{
-			var constrainedSize = IFrameworkElementHelper.SizeThatFits(Panel as IFrameworkElement, availableSize);
-
-#if XAMARIN_IOS
-			return constrainedSize.ToFoundationSize();
-#else
-			return constrainedSize;
-#endif
-		}
-
 		private string LoggingOwnerTypeName => ((object)Panel ?? this).GetType().Name;
 
 		public override string ToString() => $"[{LoggingOwnerTypeName}.Layouter]" + (string.IsNullOrEmpty(Panel?.Name) ? default : $"(name='{Panel.Name}')");

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -95,8 +95,13 @@ namespace Windows.UI.Xaml.Controls
 
 				var marginSize = Panel.GetMarginSize();
 
+				// NaN values are accepted as input here, particularly when coming from
+				// SizeThatFits in Image or Scrollviewer. Clamp the value here as it is reused
+				// below for the clipping value.
+				availableSize = availableSize
+					.NumberOrDefault(MaxSize);
+
 				var frameworkAvailableSize = availableSize
-					.NumberOrDefault(MaxSize)
 					.Subtract(marginSize)
 					.AtLeast(default) // 0.0,0.0
 					.AtMost(maxSize);


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixed sized image may apply margin to already constrained size, resulting in an image smaller that it should.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
