### PR TITLE
[Android] Fix WebView clipping issue

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1909,6 +1909,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Animated_Opacity.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_ChromeClient.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3841,6 +3845,9 @@
       <DependentUpon>UndefinedHeightListView.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Animated_Opacity.xaml.cs">
+      <DependentUpon>WebView_Animated_Opacity.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_NavigateToString2.xaml.cs">
       <DependentUpon>WebView_NavigateToString2.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Animated_Opacity.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Animated_Opacity.xaml
@@ -1,18 +1,17 @@
-﻿<UserControl
-    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.WebView.WebView_Animated_Opacity"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.WebView"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    d:DesignHeight="300"
-    d:DesignWidth="400">
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.WebView.WebView_Animated_Opacity"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.WebView"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
 
 
 	<Grid Background="Red">
 		<Grid.RowDefinitions>
-			<RowDefinition Height="auto" />
+			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 		<Button Content="Some Text !" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Animated_Opacity.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Animated_Opacity.xaml
@@ -1,0 +1,48 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.WebView.WebView_Animated_Opacity"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.WebView"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+
+	<Grid Background="Red">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Button Content="Some Text !" />
+
+		<ContentControl x:Name="test"
+						Grid.Row="1"
+						Width="100"
+						Height="100">
+			<ContentControl.Template>
+				<ControlTemplate TargetType="ContentControl">
+					<Grid>
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="LoadingStates">
+								<VisualState x:Name="Loading">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="PART_WebView"
+														 Storyboard.TargetProperty="Opacity"
+														 Duration="0:0:0.1"
+														 To="1" />
+									</Storyboard>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<!-- Value -->
+						<WebView x:Name="PART_WebView"
+								 Source="https://web.archive.org/web/20181010203846/https://www.bloomberg.com/view/articles/2018-10-09/google-is-big-and-google-was-small" />
+					</Grid>
+				</ControlTemplate>
+			</ContentControl.Template>
+		</ContentControl>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Animated_Opacity.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Animated_Opacity.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.WebView
+{
+	[SampleControlInfo(description: "Opacity is animated on WebView. It shouldn't exceed bounds while page is loading (Android bug #2006)")]
+	public sealed partial class WebView_Animated_Opacity : UserControl
+	{
+		public WebView_Animated_Opacity()
+		{
+			this.InitializeComponent();
+
+			VisualStateManager.GoToState(test, "Loading", true);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
@@ -22,12 +22,12 @@ using Uno.Disposables;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public partial class WebView : Control
+	public partial class WebView : Control, ICustomClippingElement
 	{
 		private Android.Webkit.WebView _webView;
-        private bool _wasLoadedFromString;
-		
-        protected override void OnApplyTemplate()
+		private bool _wasLoadedFromString;
+
+		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
 
@@ -71,8 +71,8 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-            _wasLoadedFromString = false;
-            if (uri.Scheme.Equals("local", StringComparison.OrdinalIgnoreCase))
+			_wasLoadedFromString = false;
+			if (uri.Scheme.Equals("local", StringComparison.OrdinalIgnoreCase))
 			{
 				var path = $"file:///android_asset/{uri.PathAndQuery}";
 				_webView.LoadUrl(path);
@@ -121,8 +121,8 @@ namespace Windows.UI.Xaml.Controls
 					element => element.Value.JoinBy(", ")
 				);
 
-            _wasLoadedFromString = false;
-            _webView.LoadUrl(uri.AbsoluteUri, headers);
+			_wasLoadedFromString = false;
+			_webView.LoadUrl(uri.AbsoluteUri, headers);
 		}
 
 		partial void NavigateToStringPartial(string text)
@@ -132,8 +132,8 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-            _wasLoadedFromString = true;
-            _webView.LoadData(text, "text/html; charset=utf-8", "utf-8");
+			_wasLoadedFromString = true;
+			_webView.LoadData(text, "text/html; charset=utf-8", "utf-8");
 		}
 
 		//This should be IAsyncOperation<string> instead of Task<string> but we use an extension method to enable the same signature in Win.
@@ -305,12 +305,12 @@ namespace Windows.UI.Xaml.Controls
 					IsSuccess = _webViewSuccess,
 					WebErrorStatus = _webErrorStatus
 				};
-                if (!_webView._wasLoadedFromString && !string.IsNullOrEmpty(url))
-                {
-                    args.Uri = new Uri(url);
-                }
+				if (!_webView._wasLoadedFromString && !string.IsNullOrEmpty(url))
+				{
+					args.Uri = new Uri(url);
+				}
 
-                _webView.NavigationCompleted?.Invoke(_webView, args);
+				_webView.NavigationCompleted?.Invoke(_webView, args);
 				base.OnPageFinished(view, url);
 			}
 
@@ -442,5 +442,10 @@ namespace Windows.UI.Xaml.Controls
 				return null;
 			}
 		}
+
+		bool ICustomClippingElement.AllowClippingToLayoutSlot => true;
+
+		// Force clipping, otherwise native WebView may exceed its bounds in some circumstances (eg when Xaml WebView is animated)
+		bool ICustomClippingElement.ForceClippingToLayoutSlot => true;
 	}
 }


### PR DESCRIPTION
Force WebView to always clip its child (namely, the inner native WebView).

GitHub Issue (If applicable): fixes #2006

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
