### PR TITLE
[iOS] Fix ListView children measured with infinite breadth

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -516,6 +516,13 @@
 				<Member
 					fullName="Windows.Foundation.Point Windows.UI.Xaml.Input.TappedRoutedEventArgs.GetPosition()"
 					reason="Not part of the UWP API." />
+
+				<Member
+					fullName="CoreGraphics.CGSize Windows.UI.Xaml.Controls.VirtualizingPanelLayout.GetItemSizeForIndexPath(Foundation.NSIndexPath indexPath)"
+					reason="Made internal, shouldn't normally be called by consumer code"/>
+				<Member
+					fullName="CoreGraphics.CGSize Windows.UI.Xaml.Controls.ListViewBaseSource.GetItemSize(UIKit.UICollectionView collectionView, Foundation.NSIndexPath indexPath)"
+					reason="Made internal, shouldn't normally be called by consumer code"/>
             </Methods>
 			
 			<Fields>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -516,13 +516,6 @@
 				<Member
 					fullName="Windows.Foundation.Point Windows.UI.Xaml.Input.TappedRoutedEventArgs.GetPosition()"
 					reason="Not part of the UWP API." />
-
-				<Member
-					fullName="CoreGraphics.CGSize Windows.UI.Xaml.Controls.VirtualizingPanelLayout.GetItemSizeForIndexPath(Foundation.NSIndexPath indexPath)"
-					reason="Made internal, shouldn't normally be called by consumer code"/>
-				<Member
-					fullName="CoreGraphics.CGSize Windows.UI.Xaml.Controls.ListViewBaseSource.GetItemSize(UIKit.UICollectionView collectionView, Foundation.NSIndexPath indexPath)"
-					reason="Made internal, shouldn't normally be called by consumer code"/>
             </Methods>
 			
 			<Fields>
@@ -597,6 +590,13 @@
 				<Member 
 					fullName="System.Void Windows.UI.ViewManagement.ApplicationViewTitleBar..ctor()"
 					reason="Parameter-less ctor does not exist in UWP" />
+					
+				<Member
+					fullName="CoreGraphics.CGSize Windows.UI.Xaml.Controls.VirtualizingPanelLayout.GetItemSizeForIndexPath(Foundation.NSIndexPath indexPath)"
+					reason="Made internal, shouldn't normally be called by consumer code"/>
+				<Member
+					fullName="CoreGraphics.CGSize Windows.UI.Xaml.Controls.ListViewBaseSource.GetItemSize(UIKit.UICollectionView collectionView, Foundation.NSIndexPath indexPath)"
+					reason="Made internal, shouldn't normally be called by consumer code"/>
             </Methods>
 		</IgnoreSet>
 	</IgnoreSets>

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -30,6 +30,7 @@
 - `ViewBox` no longer alters its child's `RenderTransform`
 - [#2033] Add Missing `LostFocus` Value to `UpdateSourceTrigger` Enum
 - [Android] Fix Image margin calculation on fixed size
+- [iOS] #2361 ListView would measure children with infinite width
 
 ## Release 2.0
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -569,6 +569,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ProportionalPanel.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_WithScrollViewer.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3149,6 +3153,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Margin_On_Container.xaml.cs">
       <DependentUpon>ListView_Margin_On_Container.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ProportionalPanel.xaml.cs">
+      <DependentUpon>ListView_ProportionalPanel.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_WithScrollViewer.xaml.cs">
       <DependentUpon>ListView_WithScrollViewer.xaml</DependentUpon>
     </Compile>
@@ -3172,6 +3179,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\MeasureDetectorControl\MeasureDetectorControl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\MeasureDetectorControl\MeasureDetectorInner.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ProportionalPanel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\StringToHeightConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\RotatedListView_WithRotatedItems.xaml.cs">
       <DependentUpon>RotatedListView_WithRotatedItems.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ProportionalPanel.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ProportionalPanel.xaml
@@ -9,7 +9,7 @@
     d:DesignHeight="300"
     d:DesignWidth="400">
 
-	<Page.Resources>
+	<UserControl.Resources>
 		<DataTemplate x:Key="ProportionalItemTemplate">
 			<u:ProportionalPanel Mode="HeightFollowsWidth"
 								 Ratio="1"
@@ -46,7 +46,7 @@
 				</Grid>
 			</u:ProportionalPanel>
 		</DataTemplate>
-	</Page.Resources>
+	</UserControl.Resources>
 
 	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 		<ListView ItemsSource="0123456789"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ProportionalPanel.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ProportionalPanel.xaml
@@ -1,0 +1,56 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ListView.ListView_ProportionalPanel"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:u="using:UITests.Shared.Windows_UI_Xaml_Controls.ListView"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Page.Resources>
+		<DataTemplate x:Key="ProportionalItemTemplate">
+			<u:ProportionalPanel Mode="HeightFollowsWidth"
+								 Ratio="1"
+								 Margin="10">
+				<Grid VerticalAlignment="Stretch"
+					  HorizontalAlignment="Stretch">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="*" />
+						<RowDefinition Height="Auto" />
+					</Grid.RowDefinitions>
+
+					<Grid Grid.Row="1"
+						  BorderBrush="Pink"
+						  CornerRadius="0,0,5,5"
+						  Height="55"
+						  Margin="0,-5,0,0"
+						  BorderThickness="2"
+						  HorizontalAlignment="Stretch">
+
+						<TextBlock Text="Read more"
+								   HorizontalAlignment="Center"
+								   VerticalAlignment="Center" />
+					</Grid>
+
+					<Border Background="SkyBlue"
+							CornerRadius="5,5,0,0">
+						<ContentControl Padding="5,0"
+										HorizontalAlignment="Stretch"
+										VerticalAlignment="Stretch"
+										HorizontalContentAlignment="Stretch"
+										VerticalContentAlignment="Stretch"
+										Content="{Binding}" />
+					</Border>
+				</Grid>
+			</u:ProportionalPanel>
+		</DataTemplate>
+	</Page.Resources>
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+		<ListView ItemsSource="0123456789"
+				  ItemTemplate="{StaticResource ProportionalItemTemplate}">
+		</ListView>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ProportionalPanel.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_ProportionalPanel.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfo(description: "ListView containing a ProportionalPanel, which must be measured with correct width to work properly")]
+	public sealed partial class ListView_ProportionalPanel : UserControl
+	{
+		public ListView_ProportionalPanel()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ProportionalPanel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ProportionalPanel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Text;
 using Windows.Foundation;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
 {
@@ -76,8 +77,6 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
 			{
 				child.Arrange(new Rect(0, 0, finalSize.Width, finalSize.Height));
 			}
-
-			this.Log().Info(() => "Arrange final size.");
 
 			return finalSize;
 #endif

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ProportionalPanel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ProportionalPanel.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+using Windows.Foundation;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
+{
+	public partial class ProportionalPanel : Panel
+	{
+		// source from: src\Umbrella.View\Panels\ProportionalPanel\ProportionalPanel.cs
+
+		public enum ProportionMode
+		{
+			HeightFollowsWidth,
+			WidthFollowsHeight
+		}
+
+		[DefaultValue(ProportionMode.HeightFollowsWidth)]
+		public ProportionMode Mode { get; set; }
+
+		[DefaultValue(1.0)]
+		public double Ratio { get; set; } = 1.0;
+
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			var initialAvailableSize = availableSize;
+
+			var calculatedWidth = availableSize.Height * Ratio;
+			var calculatedHeight = availableSize.Width / Ratio;
+
+			// Assign Height/Width according to ProportionMode
+			if (Mode == ProportionMode.HeightFollowsWidth)
+			{
+				if (calculatedHeight <= availableSize.Height)
+				{
+					availableSize.Height = calculatedHeight;
+				}
+				else
+				{
+					availableSize.Width = calculatedWidth;
+				}
+			}
+			else if (Mode == ProportionMode.WidthFollowsHeight)
+			{
+				if (calculatedWidth <= availableSize.Width)
+				{
+					availableSize.Width = calculatedWidth;
+				}
+				else
+				{
+					availableSize.Height = calculatedHeight;
+				}
+			}
+
+#if __IOS__ || __ANDROID__
+			base.MeasureOverride(availableSize);
+#else
+			foreach (UIElement child in Children)
+			{
+				child.Measure(availableSize);
+			}
+#endif
+
+			return availableSize;
+		}
+
+		protected override Size ArrangeOverride(Size finalSize)
+		{
+#if __IOS__ || __ANDROID__
+			var output = base.ArrangeOverride(finalSize);
+			return output;
+#else
+			foreach (UIElement child in Children)
+			{
+				child.Arrange(new Rect(0, 0, finalSize.Width, finalSize.Height));
+			}
+
+			this.Log().Info(() => "Arrange final size.");
+
+			return finalSize;
+#endif
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
@@ -46,7 +46,7 @@ namespace Windows.UI.Xaml.Controls
 			for (var row = 0; row < numberOfItems; ++row)
 			{
 				var indexPath = GetNSIndexPathFromRowSection(row, group);
-				frame.Size = oldItemSizes?.UnoGetValueOrDefault(indexPath) ?? GetItemSizeForIndexPath(indexPath);
+				frame.Size = oldItemSizes?.UnoGetValueOrDefault(indexPath) ?? GetItemSizeForIndexPath(indexPath, availableBreadth);
 
 				//Give the maximum breadth available, since for now we don't adjust the measured width of the list based on the databound item
 				SetBreadth(ref frame, availableBreadth);

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsWrapGrid/ItemsWrapGridLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsWrapGrid/ItemsWrapGridLayout.iOS.cs
@@ -33,12 +33,12 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var itemsInGroup = CollectionView.NumberOfItemsInSection(group);
 			if (itemsInGroup == 0)
-		{
+			{
 				_sectionEnd[group] = GetExtentEnd(frame);
 				return 0;
-		}
+			}
 
-			var itemSize = ResolveItemSize(group);
+			var itemSize = ResolveItemSize(group, availableBreadth);
 			var itemBreadth = GetBreadth(itemSize);
 			var itemsDisplayablePerLine = Math.Max((int)(availableBreadth / itemBreadth), 1);
 			var itemsPerLine = MaximumRowsOrColumns > 0 ? Math.Min(itemsDisplayablePerLine, MaximumRowsOrColumns) : itemsDisplayablePerLine;
@@ -50,35 +50,35 @@ namespace Windows.UI.Xaml.Controls
 
 			int item = -1;
 			for (int line = 0; line < numberOfLines; line++)
-		{
-				for (int column = 0; column < itemsPerLine; column++)
 			{
+				for (int column = 0; column < itemsPerLine; column++)
+				{
 					item++;
 					if (item == itemsInGroup)
-			{
-					break;
-			}
-			if (createLayoutInfo)
-			{
+					{
+						break;
+					}
+					if (createLayoutInfo)
+					{
 						CreateItemLayoutInfo(item, group, frame);
-			}
+					}
 					IncrementBreadth(ref frame);
-		}
+				}
 
 				_sectionEnd[group] = GetExtentEnd(frame);
 				IncrementExtent(ref frame);
 				SetBreadthStart(ref frame, groupBreadthStart);
-				}
+			}
 
 			return itemBreadth * Math.Min(itemsPerLine, itemsInGroup);
-					}
+		}
 
-		private CGSize ResolveItemSize(int currentGroup)
-					{
+		private CGSize ResolveItemSize(int currentGroup, nfloat availableBreadth)
+		{
 			if ((double.IsNaN(ItemWidth) || double.IsNaN(ItemHeight)) && _implicitItemSize == null)
-				{
+			{
 				//TODO: this should measure the databound item, currently it only measures the empty template
-				_implicitItemSize = GetItemSizeForIndexPath(GetNSIndexPathFromRowSection(0, currentGroup));
+				_implicitItemSize = GetItemSizeForIndexPath(GetNSIndexPathFromRowSection(0, currentGroup), availableBreadth);
 			}
 
 			return new CGSize(

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -485,24 +485,24 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		internal CGSize GetHeaderSize()
+		internal CGSize GetHeaderSize(Size availableSize)
 		{
-			return Owner.HeaderTemplate != null ? GetTemplateSize(Owner.HeaderTemplate, NativeListViewBase.ListViewHeaderElementKindNS) : CGSize.Empty;
+			return Owner.HeaderTemplate != null ? GetTemplateSize(Owner.HeaderTemplate, NativeListViewBase.ListViewHeaderElementKindNS, availableSize) : CGSize.Empty;
 		}
 
-		internal CGSize GetFooterSize()
+		internal CGSize GetFooterSize(Size availableSize)
 		{
-			return Owner.FooterTemplate != null ? GetTemplateSize(Owner.FooterTemplate, NativeListViewBase.ListViewFooterElementKindNS) : CGSize.Empty;
+			return Owner.FooterTemplate != null ? GetTemplateSize(Owner.FooterTemplate, NativeListViewBase.ListViewFooterElementKindNS, availableSize) : CGSize.Empty;
 		}
 
-		internal CGSize GetSectionHeaderSize(int section)
+		internal CGSize GetSectionHeaderSize(int section, Size availableSize)
 		{
 			var template = GetTemplateForGroupHeader(section);
-			return template.SelectOrDefault(ht => GetTemplateSize(ht, NativeListViewBase.ListViewSectionHeaderElementKindNS), CGSize.Empty);
+			return template.SelectOrDefault(ht => GetTemplateSize(ht, NativeListViewBase.ListViewSectionHeaderElementKindNS, availableSize), CGSize.Empty);
 		}
 
 
-		public virtual CGSize GetItemSize(UICollectionView collectionView, NSIndexPath indexPath)
+		internal CGSize GetItemSize(UICollectionView collectionView, NSIndexPath indexPath, Size availableSize)
 		{
 			DataTemplate itemTemplate = GetTemplateForItem(indexPath);
 
@@ -514,7 +514,7 @@ namespace Windows.UI.Xaml.Controls
 				_templateCells.Clear();
 			}
 
-			var size = GetTemplateSize(itemTemplate, NativeListViewBase.ListViewItemElementKindNS);
+			var size = GetTemplateSize(itemTemplate, NativeListViewBase.ListViewItemElementKindNS, availableSize);
 
 			if (size == CGSize.Empty)
 			{
@@ -564,9 +564,8 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		/// <param name="dataTemplate">A data template</param>
 		/// <returns>The actual size of the template</returns>
-		private CGSize GetTemplateSize(DataTemplate dataTemplate, NSString elementKind)
+		private CGSize GetTemplateSize(DataTemplate dataTemplate, NSString elementKind, Size availableSize)
 		{
-			//TODO: this should take an available breadth
 			CGSize size;
 
 			// Cache the sizes to avoid creating new templates every time.
@@ -600,7 +599,7 @@ namespace Windows.UI.Xaml.Controls
 					Owner.XamlParent.AddSubview(BlockLayout);
 					BlockLayout.AddSubview(container);
 					// Measure with PositiveInfinity rather than MaxValue, since some views handle this better.
-					size = Owner.NativeLayout.Layouter.MeasureChild(container, new Size(double.PositiveInfinity, double.PositiveInfinity));
+					size = Owner.NativeLayout.Layouter.MeasureChild(container, availableSize);
 
 					if ((size.Height > nfloat.MaxValue / 2 || size.Width > nfloat.MaxValue / 2) &&
 						this.Log().IsEnabled(LogLevel.Warning)

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -878,7 +878,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected CGSize GetItemSizeForIndexPath(NSIndexPath indexPath, nfloat availableBreadth)
+		private protected CGSize GetItemSizeForIndexPath(NSIndexPath indexPath, nfloat availableBreadth)
 		{
 			return Source.GetTarget()?.GetItemSize(CollectionView, indexPath, GetAvailableChildSize(availableBreadth)) ?? CGSize.Empty;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using Windows.UI.Xaml;
 using Uno.Extensions;
 using Uno.UI.Extensions;
@@ -18,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using System.Collections.Specialized;
 using Windows.UI.Xaml.Controls.Primitives;
 using Uno.UI;
+using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -546,7 +546,7 @@ namespace Windows.UI.Xaml.Controls
 			if (xamlParent.ShouldShowHeader)
 			{
 				//1. Layout header at start
-				frame.Size = oldHeaderSize ?? GetHeaderSize();
+				frame.Size = oldHeaderSize ?? GetHeaderSize(size);
 				//Give the maximum breadth available, since for now we don't adjust the measured width of the list based on the databound item
 				SetBreadth(ref frame, availableBreadth);
 				if (createLayoutInfo)
@@ -574,7 +574,7 @@ namespace Windows.UI.Xaml.Controls
 					availableGroupBreadth -= (nfloat)GroupPaddingBreadthEnd;
 
 					//a. Layout group header, if present
-					frame.Size = oldGroupHeaderSizes?.UnoGetValueOrDefault(section) ?? GetSectionHeaderSize(section);
+					frame.Size = oldGroupHeaderSizes?.UnoGetValueOrDefault(section) ?? GetSectionHeaderSize(section, size);
 					if (RelativeGroupHeaderPlacement != RelativeHeaderPlacement.Adjacent)
 					{
 						//Give the maximum breadth available, since for now we don't adjust the measured width of the list based on the databound item
@@ -634,7 +634,7 @@ namespace Windows.UI.Xaml.Controls
 			if (xamlParent.ShouldShowFooter)
 			{
 				//3. Layout footer 
-				frame.Size = oldFooterSize ?? GetFooterSize();
+				frame.Size = oldFooterSize ?? GetFooterSize(size);
 				//Give the maximum breadth available, since for now we don't adjust the measured width of the list based on the databound item
 				SetBreadth(ref frame, availableBreadth);
 				if (createLayoutInfo)
@@ -878,24 +878,24 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected CGSize GetItemSizeForIndexPath(NSIndexPath indexPath)
+		protected CGSize GetItemSizeForIndexPath(NSIndexPath indexPath, nfloat availableBreadth)
 		{
-			return Source.GetTarget()?.GetItemSize(CollectionView, indexPath) ?? CGSize.Empty;
+			return Source.GetTarget()?.GetItemSize(CollectionView, indexPath, GetAvailableChildSize(availableBreadth)) ?? CGSize.Empty;
 		}
 
-		private CGSize GetHeaderSize()
+		private CGSize GetHeaderSize(CGSize availableViewportSize)
 		{
-			return Source.GetTarget()?.GetHeaderSize() ?? CGSize.Empty;
+			return Source.GetTarget()?.GetHeaderSize(GetAvailableChildSize(availableViewportSize)) ?? CGSize.Empty;
 		}
 
-		private CGSize GetFooterSize()
+		private CGSize GetFooterSize(CGSize availableViewportSize)
 		{
-			return Source.GetTarget()?.GetFooterSize() ?? CGSize.Empty;
+			return Source.GetTarget()?.GetFooterSize(GetAvailableChildSize(availableViewportSize)) ?? CGSize.Empty;
 		}
 
-		private CGSize GetSectionHeaderSize(int section)
+		private CGSize GetSectionHeaderSize(int section, CGSize availableViewportSize)
 		{
-			return Source.GetTarget()?.GetSectionHeaderSize(section) ?? CGSize.Empty;
+			return Source.GetTarget()?.GetSectionHeaderSize(section, GetAvailableChildSize(availableViewportSize)) ?? CGSize.Empty;
 		}
 
 		/// <summary>
@@ -1629,6 +1629,26 @@ namespace Windows.UI.Xaml.Controls
 		protected CGRect GetInlineHeaderFrame(int section)
 		{
 			return _inlineHeaderFrames[section];
+		}
+
+		/// <summary>
+		/// Get size available to children, given an available breadth.
+		/// </summary>
+		private Size GetAvailableChildSize(nfloat availableBreadth)
+		{
+			return ScrollOrientation == Orientation.Vertical ?
+				new Size(availableBreadth, double.PositiveInfinity) :
+				new Size(double.PositiveInfinity, availableBreadth);
+		}
+
+		/// <summary>
+		/// Get size available to children, given an available size for the viewport.
+		/// </summary>
+		private Size GetAvailableChildSize(CGSize availableViewportSize)
+		{
+			return ScrollOrientation == Orientation.Vertical ?
+				new Size(availableViewportSize.Width, double.PositiveInfinity) :
+				new Size(double.PositiveInfinity, availableViewportSize.Height);
 		}
 
 #if DEBUG


### PR DESCRIPTION
When measuring the unbound template of the list, supply the actual available breadth (rather than infinity), as some panels rely on it to measure themselves correctly.

GitHub Issue (If applicable): fixes #2361

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
