### PR TITLE
Fix problem with Measure size in DrawerLayout's Pane

### DIFF
--- a/src/Uno.UI/Controls/BindableDrawerLayout.Android.cs
+++ b/src/Uno.UI/Controls/BindableDrawerLayout.Android.cs
@@ -14,6 +14,7 @@ using Windows.UI.Xaml;
 using Uno.UI;
 using Uno.Extensions;
 using Windows.UI.Xaml.Media;
+using Size = Windows.Foundation.Size;
 
 namespace Uno.UI.Controls
 {
@@ -515,6 +516,22 @@ namespace Uno.UI.Controls
 					};
 					break;
 			}
+		}
+
+		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		{
+			// For some reason it seams Android is always measuring the Pane with a width at 100px.
+			// This behavior could break the Measure & Arrange phases where some controls may be arranged
+			// at a wrong size.
+
+			// To fix this, we simply apply the control's constraints (min+max defined sizes)
+
+			var availableSize = ViewHelper.LogicalSizeFromSpec(widthMeasureSpec, heightMeasureSpec);
+			var sizeForChildren = this.ApplySizeConstraints(availableSize).LogicalToPhysicalPixels();
+
+			base.OnMeasure(
+				(int)sizeForChildren.Width | (int)MeasureSpecMode.AtMost,
+				(int)sizeForChildren.Height | (int)MeasureSpecMode.AtMost);
 		}
 
 		/// <inheritdoc />

--- a/src/Uno.UI/Controls/BindableDrawerLayout.Android.cs
+++ b/src/Uno.UI/Controls/BindableDrawerLayout.Android.cs
@@ -525,13 +525,12 @@ namespace Uno.UI.Controls
 			// at a wrong size.
 
 			// To fix this, we simply apply the control's constraints (min+max defined sizes)
-
 			var availableSize = ViewHelper.LogicalSizeFromSpec(widthMeasureSpec, heightMeasureSpec);
 			var sizeForChildren = this.ApplySizeConstraints(availableSize).LogicalToPhysicalPixels();
 
 			base.OnMeasure(
-				(int)sizeForChildren.Width | (int)MeasureSpecMode.AtMost,
-				(int)sizeForChildren.Height | (int)MeasureSpecMode.AtMost);
+				ViewHelper.MakeMeasureSpec((int)sizeForChildren.Width, MeasureSpecMode.AtMost),
+				ViewHelper.MakeMeasureSpec((int)sizeForChildren.Height, MeasureSpecMode.AtMost));
 		}
 
 		/// <inheritdoc />


### PR DESCRIPTION
# Bugfix

## What is the current behavior?
When using `<BindableDrawerLayout />` (native Android control), the `Pane` is measured at a wrong size (but the arrange is correct). This could lead to strange result when the `desiredSize` is used in the layouting logic.  This could happen with the following XAML code is used in the `Pane`:

``` xml
<ContentControl>
    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
        <Image Width="150" Height="150" />
        <TextBlock Text="Some text..." />
    </StackPanel>
</ContentControl>
```
The _arrange size_ of the `<StackPanel>` will be `100px`, leading to a clipping of its content.

## What is the new behavior?
The content of the `<StackPanel>` shouldn't be clipped when the `LeftPaneOpenLength` is enough for its content.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
