### PR TITLE
Added macOS to GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -35,6 +35,7 @@ Affected platform(s):
 - [ ] Android
 - [ ] WebAssembly
 - [ ] WebAssembly renderers for Xamarin.Forms
+- [ ] macOS
 - [ ] Windows
 - [ ] Build tasks
 - [ ] Solution Templates

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -24,6 +24,7 @@ labels: kind/consumer-experience, kind/documentation, triage/untriaged
 - [ ] iOS
 - [ ] Android
 - [ ] WebAssembly
+- [ ] macOS
 - [ ] Windows
 
 ## Anything else we need to know?

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -16,6 +16,7 @@ labels: kind/enhancement, triage/untriaged
 - [ ] Android
 - [ ] WebAssembly
 - [ ] WebAssembly renderers for Xamarin.Forms
+- [ ] macOS
 - [ ] Windows
 - [ ] Build tasks
 - [ ] Solution Templates

--- a/.github/ISSUE_TEMPLATE/samples-request.md
+++ b/.github/ISSUE_TEMPLATE/samples-request.md
@@ -16,6 +16,7 @@ labels: kind/contributor-experience, kind/documentation, triage/untriaged
 - [ ] Android
 - [ ] WebAssembly
 - [ ] WebAssembly renderers for Xamarin.Forms
+- [ ] macOS
 - [ ] Windows
 
 


### PR DESCRIPTION
GitHub Issue (If applicable): #2427

## PR Type

What kind of change does this PR introduce?

- Other... GitHub templates

## What is the current behavior?

GitHub templates don't include macOS


## What is the new behavior?

GitHub templates include macOS


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)