### PR TITLE
Add Missing LostFocus Value to UpdateSourceTrigger

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -24,6 +24,7 @@
 - #2287 Vertical `ListView` containing a horizontal `ScrollViewer`: horizontal scrolling is difficult, only works when the gesture is perfectly horizontal
 - #2130 Grid - fix invalid measure when total star size is 0
 - [iOS] Fix invalid image measure on constrained images with `Margin`
+- [#2033] Add Missing `LostFocus` Value to `UpdateSourceTrigger` Enum
 
 ## Release 2.0
 

--- a/src/Uno.UI/UI/Xaml/Data/UpdateSourceTrigger.cs
+++ b/src/Uno.UI/UI/Xaml/Data/UpdateSourceTrigger.cs
@@ -1,4 +1,6 @@
-﻿namespace Windows.UI.Xaml.Data
+﻿using Uno;
+
+namespace Windows.UI.Xaml.Data
 {
 	/// <summary>
 	/// Defines constants that indicate when a binding source is updated by its binding target in two-way binding.
@@ -12,11 +14,16 @@
 		/// <summary>
 		/// The binding source is updated whenever the binding target value changes. This is detected automatically by the binding system.
 		/// </summary>
-		PropertyChanged,
+		PropertyChanged = 1,
 		/// <summary>
 		/// The binding source is updated only when you call the BindingExpression.UpdateSource method.
 		/// </summary>
-		Explicit,
+		Explicit = 2,
+		/// <summary>	
+		/// The binding source is updated whenever the binding target element loses focus.
+		/// </summary>
+		[NotImplemented]
+		LostFocus = 3,
 	}
 }
 


### PR DESCRIPTION
GitHub Issue (If applicable): #2033 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Compile errors when referencing the 'LostFocus' Attribute of the UpdateSourceTrigger Enum.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

The LostFocus Attribute of the UpdateSourceTrigger Enum can be used as expected without errors.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
