### PR TITLE
[iOS] ScrollViewer was uselessly applying its content's margin

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -629,6 +629,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Layout.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_MultipleControls.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3108,7 +3112,7 @@
       <DependentUpon>Image_ImageSource_PixelSize.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Margin.xaml.cs">
-      <DependentUpon>$fileinputname$.xaml</DependentUpon>
+      <DependentUpon>Image_Margin.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Algmnt_Inf_Horizontal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Algmnt_Inf_Vertical.xaml.cs">
@@ -3166,6 +3170,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Foreground_While_Collapsed.xaml.cs">
       <DependentUpon>TextBlock_Foreground_While_Collapsed.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Layout.xaml.cs">
+      <DependentUpon>TextBlock_Layout.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_MultipleControls.xaml.cs">
       <DependentUpon>TextBlock_LineHeight_MultipleControls.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Layout.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Layout.xaml
@@ -1,0 +1,49 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_Layout"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="120" />
+			<ColumnDefinition Width="120" />
+			<ColumnDefinition Width="120" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.Resources>
+			<DataTemplate x:Key="TextItemTemplate">
+				<Border BorderBrush="Black" BorderThickness="1">
+					<TextBlock Text="{Binding}" TextWrapping="Wrap" Foreground="DarkBlue" />
+				</Border>
+			</DataTemplate>
+		</Grid.Resources>
+
+		<TextBlock Grid.ColumnSpan="4">
+			Those 3 columns should be identical...
+		</TextBlock>
+
+		<ScrollViewer Grid.Column="0" Grid.Row="1">
+			<Grid Margin="16">
+				<ItemsControl ItemsSource="{Binding VariableLengthItems}" ItemTemplate="{StaticResource TextItemTemplate}" />
+			</Grid>
+		</ScrollViewer>
+		<ScrollViewer Grid.Column="1" Grid.Row="1">
+			<Border Padding="16">
+				<Grid>
+					<ItemsControl ItemsSource="{Binding VariableLengthItems}" ItemTemplate="{StaticResource TextItemTemplate}" />
+				</Grid>
+			</Border>
+		</ScrollViewer>
+		<ScrollViewer Grid.Column="2" Grid.Row="1">
+			<ItemsControl Margin="16" ItemsSource="{Binding VariableLengthItems}" ItemTemplate="{StaticResource TextItemTemplate}" />
+		</ScrollViewer>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Layout.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Layout.xaml.cs
@@ -1,0 +1,15 @@
+﻿using SamplesApp.Windows_UI_Xaml_Controls.Models;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[SampleControlInfo(viewModelType: typeof(ListViewViewModel))]
+	public sealed partial class TextBlock_Layout : Page
+	{
+		public TextBlock_Layout()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -17,8 +17,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		{
 			var tb = new TextBox();
 			tb.InputScope = null;
+#if !MONOANDROID80
 			tb.ImeOptions = Android.Views.InputMethods.ImeAction.Search;
+#endif
 		}
 #endif
-	}
+		}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.iOS.cs
@@ -176,9 +176,14 @@ namespace Windows.UI.Xaml.Controls
 
 				size = AdjustSize(size);
 
+
 				var availableSizeForChild = size;
-				availableSizeForChild.Width -= (nfloat)horizontalMargin;
-				availableSizeForChild.Height -= (nfloat)verticalMargin;
+				if (!(_content is IFrameworkElement))
+				{
+					// Apply margin if the content is native (otherwise it will apply it itself)
+					availableSizeForChild.Width -= (nfloat)horizontalMargin;
+					availableSizeForChild.Height -= (nfloat)verticalMargin;
+				}
 
 				_measuredSize = _content.SizeThatFits(availableSizeForChild);
 				_measuredSize.Width += (nfloat)horizontalMargin;


### PR DESCRIPTION
GitHub Issue: https://github.com/unoplatform/uno/issues/2358

# Bugfix

## What is the current behavior?
Putting a TextBlock into a list were creating extra spacing.

The bug was caused by a double application of a margin in the `ScrollContentPresenter`.

## What is the new behavior?
The margin needs to be applied only on non-managed (native) controls.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

Internal issues:
* https://nventive.visualstudio.com/Umbrella/_workitems/edit/169216