### PR TITLE
[WASM] IsReadOnly was not working when set directly in XAML

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/FileInfoExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/FileInfoExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SamplesApp.UITests
+{
+	public static class FileInfoExtensions
+	{
+		private static bool PlatformRequiresLongPathNormalization { get; } = CheckIfNeedToNormalizeLongPaths();
+
+		// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfullpathnamea
+		[DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+		private static extern uint GetFullPathName(string lpFileName, uint nBufferLength,  StringBuilder lpBuffer, IntPtr lpFilePart);
+
+
+		private static bool CheckIfNeedToNormalizeLongPaths()
+		{
+			if (Type.GetType("Mono.Runtime") != null)
+			{
+				return false;
+			}
+
+			if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
+			{
+				return false; // no need to normalize long paths on .net core
+			}
+
+			switch (Environment.OSVersion.Platform)
+			{
+				case PlatformID.Win32NT:
+				case PlatformID.Win32S:
+				case PlatformID.Win32Windows:
+					return true;
+			}
+
+			return false;
+		}
+
+
+		public static string GetNormalizedLongPath(this string fileName)
+		{
+			if (PlatformRequiresLongPathNormalization)
+			{
+				if (fileName.StartsWith(@"\\?"))
+				{
+					return fileName; // already normalized
+				}
+
+				var sb = new StringBuilder(fileName.Length + 1);
+				var length = GetFullPathName(fileName, (uint)sb.Capacity, sb, IntPtr.Zero);
+
+				if (length > sb.Capacity)
+				{
+					// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfullpathnamea#return-value
+					sb.Capacity = (int)length; // increase capacity
+					length = GetFullPathName(fileName, (uint)sb.Capacity, sb, IntPtr.Zero);
+				}
+
+				if (length < 260)
+				{
+					return sb.ToString();
+				}
+
+				return @"\\?\" + sb;
+			}
+
+			return fileName;
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -145,7 +145,9 @@ namespace SamplesApp.UITests
 			var fileNameWithoutExt = Path.GetFileNameWithoutExtension(fileInfo.Name);
 			if (fileNameWithoutExt != title)
 			{
-				var destFileName = Path.Combine(Path.GetDirectoryName(fileInfo.FullName), title + Path.GetExtension(fileInfo.Name));
+				var destFileName = Path
+					.Combine(Path.GetDirectoryName(fileInfo.FullName), title + Path.GetExtension(fileInfo.Name))
+					.GetNormalizedLongPath();
 
 				if (File.Exists(destFileName))
 				{
@@ -165,7 +167,9 @@ namespace SamplesApp.UITests
 
 			if(options != null)
 			{
-				var fileName = Path.Combine(fileInfo.DirectoryName, Path.GetFileNameWithoutExtension(fileInfo.FullName) + ".metadata");
+				var fileName = Path
+					.Combine(fileInfo.DirectoryName, Path.GetFileNameWithoutExtension(fileInfo.FullName) + ".metadata")
+					.GetNormalizedLongPath();
 
 				File.WriteAllText(fileName, $"IgnoreInSnapshotCompare={options.IgnoreInSnapshotCompare}");
 			}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -150,21 +150,26 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 		{
 			Run("Uno.UI.Samples.UITests.TextBoxControl.TextBox_IsReadOnly");
 
-			var button = _app.Marked("button");
+			var tglReadonly = _app.Marked("tglReadonly");
 			var txt = _app.Marked("txt");
 
-			_app.EnterText(txt, "Hello !");
+			const string initialText = "This text should initially be READONLY and ENABLED...";
+			_app.WaitForText(txt, initialText);
 
-			_app.WaitForText(txt, "This is the starting text...Hello !");
+			_app.EnterText(txt, "ERROR1");
+			_app.WaitForText(txt, initialText);
 
-			button.Tap();
-			_app.EnterText(txt, "Hello did not work!");
+			tglReadonly.Tap();
+			_app.EnterText(txt, "Hello!");
+			_app.WaitForText(txt, initialText + "Hello!");
 
-			_app.WaitForText(txt, "This is the starting text...Hello !");
+			tglReadonly.Tap();
+			_app.EnterText(txt, "ERROR2");
+			_app.WaitForText(txt, initialText + "Hello!");
 
-			button.Tap();
-			_app.EnterText(txt, "Works again!");
-			_app.WaitForText(txt, "This is the starting text...Hello !Works again!");
+			tglReadonly.Tap();
+			_app.EnterText(txt, " Works again!");
+			_app.WaitForText(txt, initialText + "Hello! Works again!");
 		}
 
 		[Test]

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly.xaml
@@ -1,27 +1,11 @@
 <UserControl
 	x:Class="Uno.UI.Samples.UITests.TextBoxControl.TextBox_IsReadOnly"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:ios="http://uno.ui/ios"
-	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:android="http://uno.ui/android"
-	mc:Ignorable="d ios android"
-	d:DesignHeight="2000"
-	d:DesignWidth="400">
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-	<Grid>
-		<Grid.RowDefinitions>
-			<RowDefinition Height="*" />
-			<RowDefinition Height="auto" />
-		</Grid.RowDefinitions>
-		<TextBox Grid.Row="0"
-				 Text="This is the starting text..."
-				 x:Name="txt" />
-		<Button Grid.Row="1"
-				x:Name="button"
-				Click="OnClick"
-				Content="Toggle IsReadOnly" />
-	</Grid>
+	<StackPanel>
+		<TextBox Text="This text should initially be READONLY and ENABLED..." x:Name="txt" IsReadOnly="True" IsEnabled="True" />
+		<ToggleButton IsChecked="{Binding IsReadOnly, ElementName=txt, Mode=TwoWay}" x:Name="tglReadonly">IsReadOnly</ToggleButton>
+		<ToggleButton IsChecked="{Binding IsEnabled, ElementName=txt, Mode=TwoWay}" x:Name="tglEnabled">IsEnabled</ToggleButton>
+	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly.xaml.cs
@@ -1,20 +1,14 @@
 using Uno.UI.Samples.Controls;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Samples.UITests.TextBoxControl
 {
-	[SampleControlInfo("TextBox", "TextBox_IsReadOnly")]
+	[SampleControlInfo("TextBox")]
 	public sealed partial class TextBox_IsReadOnly : UserControl
 	{
 		public TextBox_IsReadOnly()
 		{
 			InitializeComponent();
-		}
-
-		private void OnClick(object sender, RoutedEventArgs args)
-		{
-			txt.IsReadOnly = !txt.IsReadOnly;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -69,10 +69,7 @@ namespace Windows.UI.Xaml.Controls
 			this.RegisterParentChangedCallback(this, OnParentChanged);
 		}
 
-		private void OnParentChanged(object instance, object key, DependencyObjectParentChangedEventArgs args)
-		{
-			UpdateFontPartial();
-		}
+		private void OnParentChanged(object instance, object key, DependencyObjectParentChangedEventArgs args) => UpdateFontPartial();
 
 		protected TextBox(bool isPassword)
 		{
@@ -86,6 +83,7 @@ namespace Windows.UI.Xaml.Controls
 			OnInputScopeChanged(CreateInitialValueChangerEventArgs(InputScopeProperty, null, InputScope));
 			OnMaxLengthChanged(CreateInitialValueChangerEventArgs(MaxLengthProperty, null, MaxLength));
 			OnAcceptsReturnChanged(CreateInitialValueChangerEventArgs(AcceptsReturnProperty, null, AcceptsReturn));
+			OnIsReadonlyChanged(CreateInitialValueChangerEventArgs(IsReadOnlyProperty, null, IsReadOnly));
 			OnIsEnabledChanged(false, IsEnabled);
 			OnForegroundColorChanged(null, Foreground);
 			UpdateFontPartial();
@@ -142,16 +140,13 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void InitializePropertiesPartial();
 
-		private DependencyPropertyChangedEventArgs CreateInitialValueChangerEventArgs(DependencyProperty property, object oldValue, object newValue)
-		{
-			return new DependencyPropertyChangedEventArgs(property, oldValue, DependencyPropertyValuePrecedences.DefaultValue, newValue, DependencyPropertyValuePrecedences.DefaultValue);
-		}
+		private DependencyPropertyChangedEventArgs CreateInitialValueChangerEventArgs(DependencyProperty property, object oldValue, object newValue) => new DependencyPropertyChangedEventArgs(property, oldValue, DependencyPropertyValuePrecedences.DefaultValue, newValue, DependencyPropertyValuePrecedences.DefaultValue);
 
 		#region Text DependencyProperty
 
 		public string Text
 		{
-			get { return (string)this.GetValue(TextProperty); }
+			get => (string)this.GetValue(TextProperty);
 			set {
 				if (value == null)
 				{
@@ -295,10 +290,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void UpdateFontPartial();
 
-		protected override void OnForegroundColorChanged(Brush oldValue, Brush newValue)
-		{
-			OnForegroundColorChangedPartial(newValue);
-		}
+		protected override void OnForegroundColorChanged(Brush oldValue, Brush newValue) => OnForegroundColorChangedPartial(newValue);
 
 		partial void OnForegroundColorChangedPartial(Brush newValue);
 
@@ -306,8 +298,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public string PlaceholderText
 		{
-			get { return (string)this.GetValue(PlaceholderTextProperty); }
-			set { this.SetValue(PlaceholderTextProperty, value); }
+			get => (string)this.GetValue(PlaceholderTextProperty);
+			set => this.SetValue(PlaceholderTextProperty, value);
 		}
 
 		public static readonly DependencyProperty PlaceholderTextProperty =
@@ -324,8 +316,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public InputScope InputScope
 		{
-			get { return (InputScope)this.GetValue(InputScopeProperty); }
-			set { this.SetValue(InputScopeProperty, value); }
+			get => (InputScope)this.GetValue(InputScopeProperty);
+			set => this.SetValue(InputScopeProperty, value);
 		}
 
 		public static readonly DependencyProperty InputScopeProperty =
@@ -348,10 +340,7 @@ namespace Windows.UI.Xaml.Controls
 				)
 			);
 
-		protected void OnInputScopeChanged(DependencyPropertyChangedEventArgs e)
-		{
-			OnInputScopeChangedPartial(e);
-		}
+		protected void OnInputScopeChanged(DependencyPropertyChangedEventArgs e) => OnInputScopeChangedPartial(e);
 		partial void OnInputScopeChangedPartial(DependencyPropertyChangedEventArgs e);
 
 		#endregion
@@ -360,8 +349,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public int MaxLength
 		{
-			get { return (int)this.GetValue(MaxLengthProperty); }
-			set { this.SetValue(MaxLengthProperty, value); }
+			get => (int)this.GetValue(MaxLengthProperty);
+			set => this.SetValue(MaxLengthProperty, value);
 		}
 
 		public static readonly DependencyProperty MaxLengthProperty =
@@ -375,10 +364,7 @@ namespace Windows.UI.Xaml.Controls
 				)
 			);
 
-		private void OnMaxLengthChanged(DependencyPropertyChangedEventArgs e)
-		{
-			OnMaxLengthChangedPartial(e);
-		}
+		private void OnMaxLengthChanged(DependencyPropertyChangedEventArgs e) => OnMaxLengthChangedPartial(e);
 
 		partial void OnMaxLengthChangedPartial(DependencyPropertyChangedEventArgs e);
 
@@ -388,8 +374,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public bool AcceptsReturn
 		{
-			get { return (bool)this.GetValue(AcceptsReturnProperty); }
-			set { this.SetValue(AcceptsReturnProperty, value); }
+			get => (bool)this.GetValue(AcceptsReturnProperty);
+			set => this.SetValue(AcceptsReturnProperty, value);
 		}
 
 		public static readonly DependencyProperty AcceptsReturnProperty =
@@ -416,8 +402,8 @@ namespace Windows.UI.Xaml.Controls
 		#region TextWrapping DependencyProperty
 		public TextWrapping TextWrapping
 		{
-			get { return (TextWrapping)this.GetValue(TextWrappingProperty); }
-			set { this.SetValue(TextWrappingProperty, value); }
+			get => (TextWrapping)this.GetValue(TextWrappingProperty);
+			set => this.SetValue(TextWrappingProperty, value);
 		}
 
 		public static readonly DependencyProperty TextWrappingProperty =
@@ -444,8 +430,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public bool IsReadOnly
 		{
-			get { return (bool)GetValue(IsReadOnlyProperty); }
-			set { SetValue(IsReadOnlyProperty, value); }
+			get => (bool)GetValue(IsReadOnlyProperty);
+			set => SetValue(IsReadOnlyProperty, value);
 		}
 
 		public static readonly DependencyProperty IsReadOnlyProperty =
@@ -473,9 +459,10 @@ namespace Windows.UI.Xaml.Controls
 
 		public object Header
 		{
-			get { return (object)GetValue(HeaderProperty); }
-			set { SetValue(HeaderProperty, value); }
+			get => (object)GetValue(HeaderProperty);
+			set => SetValue(HeaderProperty, value);
 		}
+
 		public static readonly DependencyProperty HeaderProperty =
 			DependencyProperty.Register("Header",
 				typeof(object),
@@ -487,8 +474,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public DataTemplate HeaderTemplate
 		{
-			get { return (DataTemplate)GetValue(HeaderTemplateProperty); }
-			set { SetValue(HeaderTemplateProperty, value); }
+			get => (DataTemplate)GetValue(HeaderTemplateProperty);
+			set => SetValue(HeaderTemplateProperty, value);
 		}
 
 		public static readonly DependencyProperty HeaderTemplateProperty =
@@ -516,8 +503,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public bool IsSpellCheckEnabled
 		{
-			get { return (bool)this.GetValue(IsSpellCheckEnabledProperty); }
-			set { this.SetValue(IsSpellCheckEnabledProperty, value); }
+			get => (bool)this.GetValue(IsSpellCheckEnabledProperty);
+			set => this.SetValue(IsSpellCheckEnabledProperty, value);
 		}
 
 		public static readonly DependencyProperty IsSpellCheckEnabledProperty =
@@ -531,10 +518,7 @@ namespace Windows.UI.Xaml.Controls
 				)
 			);
 
-		protected virtual void OnIsSpellCheckEnabledChanged(DependencyPropertyChangedEventArgs e)
-		{
-			OnIsSpellCheckEnabledChangedPartial(e);
-		}
+		protected virtual void OnIsSpellCheckEnabledChanged(DependencyPropertyChangedEventArgs e) => OnIsSpellCheckEnabledChangedPartial(e);
 
 		partial void OnIsSpellCheckEnabledChangedPartial(DependencyPropertyChangedEventArgs e);
 
@@ -545,8 +529,8 @@ namespace Windows.UI.Xaml.Controls
 		[Uno.NotImplemented]
 		public bool IsTextPredictionEnabled
 		{
-			get { return (bool)this.GetValue(IsTextPredictionEnabledProperty); }
-			set { this.SetValue(IsTextPredictionEnabledProperty, value); }
+			get => (bool)this.GetValue(IsTextPredictionEnabledProperty);
+			set => this.SetValue(IsTextPredictionEnabledProperty, value);
 		}
 
 		[Uno.NotImplemented]
@@ -561,10 +545,7 @@ namespace Windows.UI.Xaml.Controls
 				)
 			);
 
-		protected virtual void OnIsTextPredictionEnabledChanged(DependencyPropertyChangedEventArgs e)
-		{
-			OnIsTextPredictionEnabledChangedPartial(e);
-		}
+		protected virtual void OnIsTextPredictionEnabledChanged(DependencyPropertyChangedEventArgs e) => OnIsTextPredictionEnabledChangedPartial(e);
 
 		partial void OnIsTextPredictionEnabledChangedPartial(DependencyPropertyChangedEventArgs e);
 
@@ -586,10 +567,7 @@ namespace Windows.UI.Xaml.Controls
 			DependencyProperty.Register("TextAlignment", typeof(TextAlignment), typeof(TextBox), new PropertyMetadata(TextAlignment.Left, (s, e) => ((TextBox)s)?.OnTextAlignmentChanged(e)));
 
 
-		protected virtual void OnTextAlignmentChanged(DependencyPropertyChangedEventArgs e)
-		{
-			OnTextAlignmentChangedPartial(e);
-		}
+		protected virtual void OnTextAlignmentChanged(DependencyPropertyChangedEventArgs e) => OnTextAlignmentChangedPartial(e);
 
 		partial void OnTextAlignmentChangedPartial(DependencyPropertyChangedEventArgs e);
 
@@ -597,6 +575,7 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override void OnFocusStateChanged(FocusState oldValue, FocusState newValue)
 			=> OnFocusStateChanged(oldValue, newValue, initial: false);
+
 		private void OnFocusStateChanged(FocusState oldValue, FocusState newValue, bool initial)
 		{
 			base.OnFocusStateChanged(oldValue, newValue);
@@ -702,24 +681,12 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextClearedPartial();
 
-		internal void OnSelectionChanged()
-		{
-			SelectionChanged?.Invoke(this, new RoutedEventArgs(this));
-		}
+		internal void OnSelectionChanged() => SelectionChanged?.Invoke(this, new RoutedEventArgs(this));
 
-		public void OnTemplateRecycled()
-		{
-			DeleteText();
-		}
+		public void OnTemplateRecycled() => DeleteText();
 
-		protected override AutomationPeer OnCreateAutomationPeer()
-		{
-			return new TextBoxAutomationPeer(this);
-		}
+		protected override AutomationPeer OnCreateAutomationPeer() => new TextBoxAutomationPeer(this);
 
-		public override string GetAccessibilityInnerText()
-		{
-			return Text;
-		}
+		public override string GetAccessibilityInnerText() => Text;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -1,18 +1,7 @@
 ﻿using Uno.Extensions;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Uno.Disposables;
-using System.Text;
-using Uno.UI;
-using Windows.UI.Core;
-using Windows.UI.Xaml.Media;
-using System.Threading.Tasks;
-using Windows.UI.Text;
-using Uno.Logging;
 using Uno.UI.UI.Xaml.Documents;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -24,9 +13,6 @@ namespace Windows.UI.Xaml.Controls
 		protected override bool RequestFocus(FocusState state) => FocusTextView();
 		partial void OnTextClearedPartial() => FocusTextView();
 		protected virtual bool FocusTextView() => FocusManager.Focus(_textBoxView);
-
-
-
 
 		private void UpdateTextBoxView()
 		{
@@ -61,9 +47,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void InitializePropertiesPartial()
 		{
-			ApplyEnabled();
-
-			if(_header != null)
+			if (_header != null)
 			{
 				AddHandler(PointerReleasedEvent, (PointerEventHandler)OnHeaderClick, true);
 			}
@@ -82,21 +66,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		partial void OnIsReadonlyChangedPartial(DependencyPropertyChangedEventArgs e)
-		{
-			if(e.NewValue is bool isReadonly)
-			{
-				if (isReadonly)
-				{
-					_textBoxView?.SetAttribute("readonly", "readonly");
-				}
-				else
-				{
-					_textBoxView?.RemoveAttribute("readonly");
-				}
-			}
-		}
-
 		partial void OnForegroundColorChangedPartial(Brush newValue)
 		{
 			_textBoxView?.SetForeground(newValue);
@@ -104,10 +73,15 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void UpdateFontPartial()
 		{
-			_textBoxView?.SetFontSize(FontSize);
-			_textBoxView?.SetFontStyle(FontStyle);
-			_textBoxView?.SetFontWeight(FontWeight);
-			_textBoxView?.SetFontFamily(FontFamily);
+			if(_textBoxView == null)
+			{
+				return;
+			}
+
+			_textBoxView.SetFontSize(FontSize);
+			_textBoxView.SetFontStyle(FontStyle);
+			_textBoxView.SetFontWeight(FontWeight);
+			_textBoxView.SetFontFamily(FontFamily);
 		}
 
 		partial void OnTextWrappingChangedPartial(DependencyPropertyChangedEventArgs e)
@@ -129,10 +103,20 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnIsEnabledChanged(oldValue, newValue);
 
-			ApplyEnabled();
+			ApplyEnabled(newValue);
 		}
 
-		private void ApplyEnabled() => _textBoxView?.SetEnabled(IsEnabled);
+		partial void OnIsReadonlyChangedPartial(DependencyPropertyChangedEventArgs e)
+		{
+			if (e.NewValue is bool isReadonly)
+			{
+				ApplyIsReadonly(isReadonly);
+			}
+		}
+
+		private void ApplyEnabled(bool? isEnabled = null) => _textBoxView?.SetEnabled(isEnabled ?? IsEnabled);
+
+		private void ApplyIsReadonly(bool? isReadOnly = null) => _textBoxView?.SetIsReadOnly(isReadOnly ?? IsReadOnly);
 
 		public int SelectionStart
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -15,12 +15,10 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private readonly TextBox _textBox;
 
-
-
 		public Brush Foreground
 		{
-			get { return (Brush)GetValue(ForegroundProperty); }
-			set { SetValue(ForegroundProperty, value); }
+			get => (Brush)GetValue(ForegroundProperty);
+			set => SetValue(ForegroundProperty, value);
 		}
 
 		internal static readonly DependencyProperty ForegroundProperty =
@@ -95,15 +93,9 @@ namespace Windows.UI.Xaml.Controls
 			InvalidateMeasure();
 		}
 
-		internal void SetTextNative(string text)
-		{
-			SetProperty("value", text);
-		}
+		internal void SetTextNative(string text) => SetProperty("value", text);
 
-		protected override Size MeasureOverride(Size availableSize)
-		{
-			return MeasureView(availableSize);
-		}
+		protected override Size MeasureOverride(Size availableSize) => MeasureView(availableSize);
 
 		internal void SetIsPassword(bool isPassword)
 		{
@@ -114,9 +106,18 @@ namespace Windows.UI.Xaml.Controls
 			SetAttribute("type", isPassword ? "password" : "text");
 		}
 
-		internal void SetEnabled(bool newValue)
+		internal void SetEnabled(bool newValue) => SetProperty("disabled", newValue ? "false" : "true");
+
+		internal void SetIsReadOnly(bool isReadOnly)
 		{
-			SetProperty("disabled", newValue ? "false" : "true");
+			if (isReadOnly)
+			{
+				SetAttribute("readonly", "readonly");
+			}
+			else
+			{
+				RemoveAttribute("readonly");
+			}
 		}
 
 		public int SelectionStart
@@ -131,9 +132,6 @@ namespace Windows.UI.Xaml.Controls
 			set => SetProperty("selectionEnd", value.ToString());
 		}
 
-		internal override bool IsViewHit()
-		{
-			return true;
-		}
+		internal override bool IsViewHit() => true;
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/2408

# Bugfix

## What is the current behavior?
Using `IsReadOnly` were not working when set directly in XAML.

The `readonly` _html attribute_ were not (re)applied after the `OnApplyTemplate()`, causing this bug.

## What is the new behavior?
`IsReadOnly` and `IsEnabled` has been unified to use the same patterns.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
