### PR TITLE
Fix for the Elevation not appearing when CornerRadius is present in iOS

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
@@ -53,19 +53,45 @@ namespace Windows.UI.Xaml.Shapes
 			var bounds = owner.Bounds;
 			var area = new CGRect(0, 0, bounds.Width, bounds.Height);
 
-			var newState = new LayoutState(area, background, borderThickness, borderBrush, cornerRadius, backgroundImage);
-			var previousLayoutState = _currentState;
-
-			if (!newState.Equals(previousLayoutState))
+			if (cornerRadius != CornerRadius.None)
 			{
+				//Creating a new view so that the CornerRadius does not mask the Elevation of the control
+				var viewGrid = new _View();
+
+				var newState = new LayoutState(area, background, borderThickness, borderBrush, cornerRadius, backgroundImage);
+				var previousLayoutState = _currentState;
+
+				if (!newState.Equals(previousLayoutState))
+				{
 #if __MACOS__
-				owner.WantsLayer = true;
+					owner.WantsLayer = true;
 #endif
 
-				_layerDisposable.Disposable = null;
-				_layerDisposable.Disposable = InnerCreateLayer(owner as UIElement, owner.Layer, area, background, borderThickness, borderBrush, cornerRadius);
+					_layerDisposable.Disposable = null;
+					_layerDisposable.Disposable = InnerCreateLayer(viewGrid as UIElement, viewGrid.Layer, area, background, borderThickness, borderBrush, cornerRadius);
 
-				_currentState = newState;
+					_currentState = newState;
+				}
+
+				//TODO Cleanup layers
+				owner.Layer.InsertSublayer(viewGrid.Layer, owner.Layer.Sublayers.Length - 1);
+			}
+			else
+			{
+				var newState = new LayoutState(area, background, borderThickness, borderBrush, cornerRadius, backgroundImage);
+				var previousLayoutState = _currentState;
+
+				if (!newState.Equals(previousLayoutState))
+				{
+#if __MACOS__
+					owner.WantsLayer = true;
+#endif
+
+					_layerDisposable.Disposable = null;
+					_layerDisposable.Disposable = InnerCreateLayer(owner as UIElement, owner.Layer, area, background, borderThickness, borderBrush, cornerRadius);
+
+					_currentState = newState;
+				}
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #2395

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A control cannot display Elevation when CornerRadius is present

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

A control can display Elevation and CornerRadius at the same time


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
