### PR TITLE
fixed TextBox.Text flickering when using custom IInputFilter with MaxLength set

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -52,6 +52,7 @@
 - Enable partial `NavigationView.ItemSource` scenario (https://github.com/unoplatform/uno/issues/2477)
 - [Wasm] Fail gracefully if IDBFS is not enabled in emscripten
 - [#2513] Fix `TransformGroup` not working
+- [Android] 164249 fixed TextBox.Text flickering when using custom IInputFilter with MaxLength set
 
 ## Release 2.0
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -197,5 +197,29 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 				100, // Ignore the reveal button on right (as we are still focused)
 				(int)passwordBox.Rect.Height - 16));
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android)]
+		public void TextBox_Formatting_FlickerText()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Formatting_Flicker");
+
+			var textbox = _app.Marked("SomeTextBox");
+			var scoreboard = _app.Marked("Scoreboard");
+			_app.WaitForElement(textbox);
+
+			textbox.Tap().EnterTextAndDismiss("a");
+			var text1 = textbox.GetDependencyPropertyValue<string>("Text");
+
+			text1.Should().StartWith("modified ", because: "custom IInputFilter should've hijacked the input");
+
+			textbox.Tap().EnterTextAndDismiss("a");
+			var text2 = textbox.GetDependencyPropertyValue<string>("Text");
+			var text3 = scoreboard.GetDependencyPropertyValue<string>("Text");
+
+			text2.Should().Be(text1, because: "Text content should not change at max length.");
+			text3.Should().Be("TextChanged: 1");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -733,6 +733,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Formatting_Flicker.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_MaxLength.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3325,6 +3329,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Disabled.xaml.cs">
       <DependentUpon>TextBox_Disabled.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Formatting_Flicker.xaml.cs">
+      <DependentUpon>TextBox_Formatting_Flicker.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_MaxLength.xaml.cs">
       <DependentUpon>TextBox_MaxLength.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Formatting_Flicker.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Formatting_Flicker.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Formatting_Flicker"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock>Just type anything:</TextBlock>
+		<TextBox x:Name="SomeTextBox" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Formatting_Flicker.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Formatting_Flicker.xaml
@@ -11,5 +11,7 @@
 	<StackPanel>
 		<TextBlock>Just type anything:</TextBlock>
 		<TextBox x:Name="SomeTextBox" />
+		<TextBlock x:Name="Scoreboard"
+				   Margin="0,15,0,0"/>
 	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Formatting_Flicker.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Formatting_Flicker.xaml.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using Uno.Extensions;
+using Uno.UI.Sample.Views.Helper;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Uno.UI.Samples.Controls;
+
+#if __ANDROID__
+using Android.Text;
+using Java.Lang;
+#endif
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
+{
+	[SampleControlInfo("TextBox", "TextBox_Formatting_Flicker", description: "Continuing to enter value once the max length is reached, should not cause the text box content to be changed again.")]
+	public sealed partial class TextBox_Formatting_Flicker : UserControl
+	{
+		public TextBox_Formatting_Flicker()
+		{
+			this.InitializeComponent();
+		}
+
+#if __ANDROID__
+		protected override void OnApplyTemplate()
+		{
+			base.OnApplyTemplate();
+
+			var filters = new IInputFilter[] { new CustomInputFilter() };
+
+			var view = SomeTextBox.FindFirstChild<TextBoxView>();
+			if (view != null)
+			{
+				SetFilter(view);
+			}
+			else
+			{
+				SomeTextBox.Loaded += (s, e) =>
+				{
+					SomeTextBox.ApplyTemplate();
+					SomeTextBox.FindFirstChild<TextBoxView>()?.Apply(SetFilter);
+				};
+			}
+
+			SomeTextBox.MaxLength = $"modified on {DateTime.Now:HHmmss.fff}".Length;
+			void SetFilter(TextBoxView tbv) => tbv.SetFilters(new IInputFilter[] { new CustomInputFilter() });
+		}
+
+		private class CustomInputFilter : Java.Lang.Object, Android.Text.IInputFilter
+		{
+			public ICharSequence FilterFormatted(ICharSequence source, int start, int end, ISpanned dest, int dstart, int dend)
+			{
+				return new Java.Lang.String($"modified on {DateTime.Now:HHmmss.fff}");
+			}
+		}
+#endif
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Formatting_Flicker.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Formatting_Flicker.xaml.cs
@@ -26,12 +26,17 @@ using Java.Lang;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
 {
-	[SampleControlInfo("TextBox", "TextBox_Formatting_Flicker", description: "Continuing to enter value once the max length is reached, should not cause the text box content to be changed again.")]
+	[SampleControlInfo("TextBox", "TextBox_Formatting_Flicker", description: "Continuing to enter value past the max length specified, should not cause the text box content to be changed again.")]
 	public sealed partial class TextBox_Formatting_Flicker : UserControl
 	{
+		private int _textChangedCounter = 0;
+
 		public TextBox_Formatting_Flicker()
 		{
 			this.InitializeComponent();
+
+			SomeTextBox.MaxLength = $"modified {0:D3} times".Length;
+			SomeTextBox.TextChanged += (s, e) => Scoreboard.Text = $"TextChanged: {++_textChangedCounter}";
 		}
 
 #if __ANDROID__
@@ -55,15 +60,16 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
 				};
 			}
 
-			SomeTextBox.MaxLength = $"modified on {DateTime.Now:HHmmss.fff}".Length;
 			void SetFilter(TextBoxView tbv) => tbv.SetFilters(new IInputFilter[] { new CustomInputFilter() });
 		}
 
 		private class CustomInputFilter : Java.Lang.Object, Android.Text.IInputFilter
 		{
+			private int _counter = 0;
+
 			public ICharSequence FilterFormatted(ICharSequence source, int start, int end, ISpanned dest, int dstart, int dend)
 			{
-				return new Java.Lang.String($"modified on {DateTime.Now:HHmmss.fff}");
+				return new Java.Lang.String($"modified {++_counter:D3} times");
 			}
 		}
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Overrides.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Overrides.Android.cs
@@ -56,6 +56,13 @@ namespace Windows.UI.Xaml.Controls
 				copy.Replace(start, end, tb, tbstart, tbend);
 				var previewText = copy.ToString();
 
+				// Modifying the text beyond max length will not be accepted. We discard this replace in advance to prevent
+				// raising the chain of text-related events: BeforeTextChanging, TextChanging, and TextChanged.
+				if (Owner.MaxLength > 0 && previewText.Length > Owner.MaxLength)
+				{
+					return this;
+				}
+
 				var finalText = Owner.ProcessTextInput(previewText);
 
 				if (Owner._wasLastEditModified = previewText != finalText)


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
We have a custom attached property for `TextBox` that adds an `IInputFilter` and hooks on `TextChanged` to apply custom constraint and formatting to the text. With a `MaxLength` set and `InputScope="Number"`, upon reaching max length, the text would flicker/toggle between "(12345)" and "12345" as you type.

## What is the new behavior?
No flickering.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)


## Other information
Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/164249 (issue 1 of 2)
https://github.com/unoplatform/private/issues/116