### PR TITLE
[Android] Always clip non-UIElements

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -1,4 +1,4 @@
-# Release notes
+﻿# Release notes
 
 ### Features
 - Support for `EmailManager.ShowComposeNewEmailAsync`
@@ -31,6 +31,7 @@
 - `ViewBox` no longer alters its child's `RenderTransform`
 - [#2033] Add Missing `LostFocus` Value to `UpdateSourceTrigger` Enum
 - [Android] Fix Image margin calculation on fixed size
+- [Android] Native views weren't clipped correctly
 - [iOS] #2361 ListView would measure children with infinite width
 - [WASM] Fix bug where changing a property could remove the required clipping on a view
 - [Android] Fix unconstrained Image loading issue when contained in a ContentControl template

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/UIElementTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/UIElementTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -34,5 +35,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml
 			_app.WaitForText("TestsStatus", "SUCCESS");
 		}
 
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android)] // Tests display of Android native view
+		public void When_Native_View()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml.UIElementTests.UIElement_Native_Child");
+
+			_app.WaitForElement("SpacerBorder");
+			var spacerRect = _app.GetRect("SpacerBorder");
+
+			var scrn = TakeScreenshot("Ready");
+
+			ImageAssert.HasColorAt(scrn, spacerRect.X, spacerRect.Y, Color.Red);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -353,6 +353,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Native_Child.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_AdaptiveTrigger_Storyboard.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3057,6 +3061,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\TouchEventsTests\TouchViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\RectCloseComparer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\NativeView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\TransformToVisual_ScrollViewer.xaml.cs">
       <DependentUpon>TransformToVisual_ScrollViewer.xaml</DependentUpon>
     </Compile>
@@ -3065,6 +3070,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Layout_Constrains.xaml.cs">
       <DependentUpon>UIElement_Layout_Constrains.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Native_Child.xaml.cs">
+      <DependentUpon>UIElement_Native_Child.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_AdaptiveTrigger_UsingOneStateOnly.xaml.cs">
       <DependentUpon>VisualState_AdaptiveTrigger_UsingOneStateOnly.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/NativeView.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/NativeView.cs
@@ -1,0 +1,45 @@
+﻿#if __ANDROID__
+using Android.Graphics;
+using Android.Graphics.Drawables;
+using Android.Views;
+using Android.Widget;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Uno.UI;
+
+namespace UITests.Shared.Windows_UI_Xaml.UIElementTests
+{
+	/// <summary>
+	/// A native ScrollView with a long text inside
+	/// </summary>
+	public partial class NativeView : ScrollView
+	{
+		public NativeView() : base(ContextHelper.Current)
+		{
+			var txt = new TextView(ContextHelper.Current)
+			{
+				Text = GetLongText(),
+				Background = new ColorDrawable(Color.Yellow)
+			};
+
+			this.AddChild(txt);
+		}
+
+		private string GetLongText()
+		{
+			var rnd = new Random(5847900);
+			var sb = new StringBuilder();
+
+			for (int i = 0; i < 5000; i++)
+			{
+				var val = rnd.Next(0, 10);
+
+				sb.Append(val == 0 ? " " : val.ToString());
+			}
+
+			return sb.ToString();
+		}
+	}
+}
+#endif

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Native_Child.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Native_Child.xaml
@@ -1,0 +1,30 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml.UIElementTests.UIElement_Native_Child"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml.UIElementTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:android="http://platform.uno/android"
+			 mc:Ignorable="d android"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<StackPanel Background="Red"
+					HorizontalAlignment="Center"
+					VerticalAlignment="Top">
+			<android:Border Background="Orange"
+							Margin="50"
+							Width="100"
+							Height="200"
+							BorderBrush="Black"
+							BorderThickness="2">
+				<local:NativeView />
+			</android:Border>
+			<Border x:Name="SpacerBorder"
+					Width="200"
+					Height="200"
+					Background="Transparent" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Native_Child.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Native_Child.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml.UIElementTests
+{
+	[SampleControlInfo("UIElement", description: "(Android-only) The native content should be clipped by its UIElement container")]
+	public sealed partial class UIElement_Native_Child : UserControl
+	{
+		public UIElement_Native_Child()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/Extensions/ViewExtensions.Android.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.Android.cs
@@ -560,6 +560,7 @@ namespace Uno.UI
 
 				var fe = innerView as IFrameworkElement;
 				var u = innerView as UIElement;
+				var vg = innerView as ViewGroup;
 
 				return sb
 						.Append(spacing)
@@ -573,6 +574,7 @@ namespace Uno.UI
 						.Append(u != null ? $" DesiredSize={u.DesiredSize}" : "")
 						.Append(u?.Clip != null ? $" Clip={u.Clip.Rect}" : "")
 						.Append(u != null ? $" NeedsClipToSlot={u.NeedsClipToSlot}" : "")
+						.Append(u == null && vg != null ? $" ClipChildren={vg.ClipChildren}" : "")
 						.AppendLine();
 			}
 		}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -288,6 +288,15 @@ namespace Uno.UI
 			/// the values change subsequently. This restriction doesn't apply to debug Uno builds.
 			/// </remarks>
 			public static bool AssignDOMXamlProperties { get; set; } = false;
+#elif __ANDROID__
+			/// <summary>
+			/// When this is set, non-UIElements will always be clipped to their bounds (<see cref="Android.Views.ViewGroup.ClipChildren"/> will
+			/// always be set to true on their parent). 
+			/// </summary>
+			/// <remarks>
+			/// This is true by default as most native views assume that they will be clipped, and can display incorrectly otherwise.
+			/// </remarks>
+			public static bool AlwaysClipNativeChildren { get; set; } = true;
 #endif
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Android.cs
@@ -56,7 +56,7 @@ namespace Windows.UI.Xaml
 			// This won't work when UIElements and non-UIElements are mixed in the same Panel,
 			// but it should cover most cases in practice, and anyway should be superceded when
 			// IFrameworkElement will be removed.
-			SetClipChildren(AreChildrenNativeViewsOnly);
+			SetClipChildren(FeatureConfiguration.UIElement.AlwaysClipNativeChildren ? AreChildrenNativeViewsOnly : false);
 
 			if (rect.IsEmpty)
 			{

--- a/src/Uno.UI/UI/Xaml/UIElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Android.cs
@@ -18,6 +18,32 @@ namespace Windows.UI.Xaml
 {
 	public partial class UIElement : BindableView
 	{
+		/// <summary>
+		/// Returns true if this element has children and they are all native (non-UIElements), false if it has no children or if at
+		/// least one is a UIElement.
+		/// </summary>
+		private bool AreChildrenNativeViewsOnly
+		{
+			get
+			{
+				var shadow = (this as IShadowChildrenProvider).ChildrenShadow;
+				if (shadow.Count == 0)
+				{
+					return false;
+				}
+
+				foreach (var child in shadow)
+				{
+					if (child is UIElement)
+					{
+						return false;
+					}
+				}
+
+				return true;
+			}
+		}
+
 		public UIElement()
 			: base(ContextHelper.Current)
 		{
@@ -26,6 +52,12 @@ namespace Windows.UI.Xaml
 
 		partial void ApplyNativeClip(Rect rect)
 		{
+			// Non-UIElements typically expect to be clipped, and display incorrectly otherwise
+			// This won't work when UIElements and non-UIElements are mixed in the same Panel,
+			// but it should cover most cases in practice, and anyway should be superceded when
+			// IFrameworkElement will be removed.
+			SetClipChildren(AreChildrenNativeViewsOnly);
+
 			if (rect.IsEmpty)
 			{
 				ViewCompat.SetClipBounds(this, null);
@@ -154,10 +186,10 @@ namespace Windows.UI.Xaml
 
 
 		/// <summary>
-        /// Sets the specified dependency property value using the format "name|value"
-        /// </summary>
-        /// <param name="dependencyPropertyNameAndvalue">The name and value of the property</param>
-        /// <returns>The currenty set value at the Local precedence</returns>
+		/// Sets the specified dependency property value using the format "name|value"
+		/// </summary>
+		/// <param name="dependencyPropertyNameAndvalue">The name and value of the property</param>
+		/// <returns>The currenty set value at the Local precedence</returns>
 		[Java.Interop.Export(nameof(SetDependencyPropertyValue))]
 		public string SetDependencyPropertyValue(string dependencyPropertyNameAndValue)
 			=> SetDependencyPropertyValueInternal(this, dependencyPropertyNameAndValue);


### PR DESCRIPTION
Native Android views typically expect to be clipped, and display incorrectly otherwise. Ensure they're always clipped.

This allows native controls defined outside the framework to display correctly without additional adjustments.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): https://github.com/unoplatform/private/issues/117
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
