### PR TITLE
[iOS] Fix Picker crash

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -34,6 +34,7 @@
 - [Android] Fix Image margin calculation on fixed size
 - [Android] Native views weren't clipped correctly
 - [iOS] #2361 ListView would measure children with infinite width
+- [iOS] Fix crash when using ComboBox template with native Picker and changing ItemsSource to null after SelectedItem was set
 - [#2398] Fully qualify the `MethodName` value for `CreateFromStringAttribute' if it's not fully qualified it the code
 - [WASM] Fix bug where changing a property could remove the required clipping on a view
 - [Android] Fix unconstrained Image loading issue when contained in a ContentControl template

--- a/src/Uno.UI/UI/Xaml/Controls/Picker/Picker.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Picker/Picker.iOS.cs
@@ -117,7 +117,10 @@ namespace Windows.UI.Xaml.Controls
 					return;
 				}
 
-				Select(row, component: 0, animated: true);
+				if (Items.Length > 0) // If we have no Items, we don't need to call UIPickerView.Select(). Skipping the call avoids a native crash under certain narrow circumstances. (https://github.com/unoplatform/private/issues/115)
+				{
+					Select(row, component: 0, animated: true);
+				}
 			}
 			else if (newSelectedItem != null && Items[0] == null)
 			{


### PR DESCRIPTION
Don't call Select() to change the spinner selection when there are no Items present. This avoids a crash under certain hard-to-reproduce circumstances with the following error:

```
Exception Type:  EXC_BAD_ACCESS (SIGKILL)
Exception Subtype: KERN_INVALID_ADDRESS at 0xfffffffffffffffc

...

Thread 0 Crashed:
0   UIKitCore                      0x00000001b3d932e8 0x1b3147000 + 12894952
1   UIKitCore                      0x00000001b3d98770 0x1b3147000 + 12916592
2   UIKitCore                      0x00000001b3d98770 0x1b3147000 + 12916592
3   UIKitCore                      0x00000001b3d99fcc 0x1b3147000 + 12922828
4   UIKitCore                      0x00000001b3d5887c 0x1b3147000 + 12654716
5   UIKitCore                      0x00000001b3d5874c 0x1b3147000 + 12654412
6   UIKitCore                      0x00000001b3b158d4 0x1b3147000 + 10283220
7   UIKitCore                      0x00000001b3b13be8 0x1b3147000 + 10275816
8   UIKitCore                      0x00000001b3b13ffc 0x1b3147000 + 10276860
9   UIKitCore                      0x00000001b3b1bf58 0x1b3147000 + 10309464
10  [AppName]iOS                   0x0000000103a0c97c wrapper_managed_to_native_ObjCRuntime_Messaging_objc_msgSendSuper_intptr_intptr_System_nint_System_nint_bool + 140
11  [AppName]iOS                   0x0000000103a5d8f8 Xamarin_iOS_UIKit_UIPickerView_Select_System_nint_System_nint_bool + 23468280 (UIPickerView.g.cs:216)
12  [AppName]iOS                   0x00000001043cfaa8 Uno_UI_Windows_UI_Xaml_Controls_Picker_OnSelectedItemChangedPartial_object_object + 33372840 (D:\a\1\s\src\Uno.UI\UI\Xaml\Controls\Picker\Picker.iOS.cs:139)
13  [AppName]iOS                   0x00000001043d6770 Uno_UI_Windows_UI_Xaml_Controls_Picker__c___cctorb__325_1_Windows_UI_Xaml_DependencyObject_Windows_UI_Xaml_DependencyPropertyChangedEventArgs + 33400688 (D:\a\1\s\src\Uno.UI\Mixins\DependencyPropertyMixins.g.cs:434)
14  [AppName]iOS                   0x0000000104289728 Uno_UI_Windows_UI_Xaml_DependencyObjectStore_InvokeCallbacks_Windows_UI_Xaml_DependencyObject_Windows_UI_Xaml_DependencyProperty_Windows_UI_Xaml_DependencyPropertyDetails_object_Windows_UI_Xaml_DependencyPropertyValuePrecedences_object_Windows_UI_Xaml_DependencyPropertyValuePrecedences_bool + 32036648 (D:\a\1\s\src\Uno.UI\UI\Xaml\DependencyObjectStore.cs:1383)
15  [AppName]iOS                   0x00000001042894e8 Uno_UI_Windows_UI_Xaml_DependencyObjectStore_RaiseCallbacks_Windows_UI_Xaml_DependencyObject_Windows_UI_Xaml_DependencyPropertyDetails_object_Windows_UI_Xaml_DependencyPropertyValuePrecedences_object_Windows_UI_Xaml_DependencyPropertyValuePrecedences + 32036072 (D:\a\1\s\src\Uno.UI\UI\Xaml\DependencyObjectStore.cs:1315)
16  [AppName]iOS                   0x00000001042873b0 Uno_UI_Windows_UI_Xaml_DependencyObjectStore_InnerSetValue_Windows_UI_Xaml_DependencyProperty_object_Windows_UI_Xaml_DependencyPropertyValuePrecedences_Windows_UI_Xaml_DependencyPropertyDetails + 32027568 (D:\a\1\s\src\Uno.UI\UI\Xaml\DependencyObjectStore.cs:459)
17  [AppName]iOS                   0x0000000104286e34 Uno_UI_Windows_UI_Xaml_DependencyObjectStore_SetValue_Windows_UI_Xaml_DependencyProperty_object_Windows_UI_Xaml_DependencyPropertyValuePrecedences_Windows_UI_Xaml_DependencyPropertyDetails + 32026164 (D:\a\1\s\src\Uno.UI\UI\Xaml\DependencyObjectStore.cs:398)
18  [AppName]iOS                   0x0000000104286d0c Uno_UI_Windows_UI_Xaml_DependencyObjectStore_SetValue_Windows_UI_Xaml_DependencyProperty_object + 32025868 (D:\a\1\s\src\Uno.UI\UI\Xaml\DependencyObjectStore.cs:360)
19  [AppName]iOS                   0x00000001043cf958 Uno_UI_Windows_UI_Xaml_Controls_Picker_set_SelectedItem_object + 33372504 (D:\a\1\s\src\Uno.UI\Mixins\DependencyPropertyMixins.g.cs:423)
20  [AppName]iOS                   0x00000001043cf5bc Uno_UI_Windows_UI_Xaml_Controls_Picker_OnItemSourceChanged_object_System_Collections_Specialized_NotifyCollectionChangedEventArgs + 33371580 (D:\a\1\s\src\Uno.UI\UI\Xaml\Controls\Picker\Picker.iOS.cs:106)
```

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://github.com/unoplatform/private/issues/115