### PR TITLE
Add fallback condition if IDBFS is not available

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -39,6 +39,7 @@
 - [#2398] Fully qualify the `MethodName` value for `CreateFromStringAttribute' if it's not fully qualified it the code
 - [WASM] Fix bug where changing a property could remove the required clipping on a view
 - [Android] Fix unconstrained Image loading issue when contained in a ContentControl template
+- [Wasm] Fail gracefully if IDBFS is not enabled in emscripten
 
 ## Release 2.0
 

--- a/src/Uno.UI.Wasm/ts/Windows/Storage/StorageFolder.ts
+++ b/src/Uno.UI.Wasm/ts/Windows/Storage/StorageFolder.ts
@@ -43,9 +43,16 @@
 				return;
 			}
 
+			if (typeof IDBFS === 'undefined') {
+				console.warn(`IDBFS is not enabled in mono's configuration, peristence is disabled`);
+
+				return;
+			}
+
 			console.debug("Making persistent: " + path);
 
 			FS.mkdir(path);
+
 			FS.mount(IDBFS, {}, path);
 			// Request an initial sync to populate the file system
 			const that = this;

--- a/src/Uno.UI.Wasm/ts/Windows/Storage/StorageFolder.ts
+++ b/src/Uno.UI.Wasm/ts/Windows/Storage/StorageFolder.ts
@@ -44,7 +44,7 @@
 			}
 
 			if (typeof IDBFS === 'undefined') {
-				console.warn(`IDBFS is not enabled in mono's configuration, peristence is disabled`);
+				console.warn(`IDBFS is not enabled in mono's configuration, persistence is disabled`);
 
 				return;
 			}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fail gracefully if IDBFS support is not enabled in emscripten.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
