### PR TITLE
TextBox - only update binding after edits, fix iOS UI tests whitelist

### DIFF
--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -31,7 +31,7 @@ else
 	export TEST_FILTERS=" \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests' or \
 		namespace = 'SamplesApp.UITests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Input.VisualState_Tests' or \
+		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Input' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests' or \

--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -39,7 +39,8 @@ else
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ControlTests' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests' or \
 		namespace = 'SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests'
+		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests' or \
+		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests'
 	"
 fi
 

--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -31,7 +31,7 @@ else
 	export TEST_FILTERS=" \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests' or \
 		namespace = 'SamplesApp.UITests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Input' or \
+		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Input.VisualState_Tests' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests' or \

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -50,6 +50,7 @@
 - [iOS] Fix crash when using ComboBox template with native Picker and changing ItemsSource to null after SelectedItem was set
 - [#2398] Fully qualify the `MethodName` value for `CreateFromStringAttribute' if it's not fully qualified it the code
 - [WASM] Fix bug where changing a property could remove the required clipping on a view
+- #2294 Fix TextBox text binding is updated by simply unfocusing
 - [Android] Fix unconstrained Image loading issue when contained in a ContentControl template
 - Enable partial `NavigationView.ItemSource` scenario (https://github.com/unoplatform/uno/issues/2477)
 - [Wasm] Fail gracefully if IDBFS is not enabled in emscripten

--- a/src/SamplesApp/SamplesApp.UITests/QueryExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/QueryExtensions.cs
@@ -49,5 +49,15 @@ namespace SamplesApp.UITests
 		{
 			return app.WaitForElement(elementName).Single().Rect;
 		}
+
+		/// <summary>
+		/// Wait for the named element to have received focus (ie after being tapped).
+		/// </summary>
+		public static void WaitForFocus(this IApp app, string elementName)
+		{
+			var element = app.Marked(elementName);
+			app.WaitForElement(element);
+			app.WaitForDependencyPropertyValue(element, "FocusState", "Pointer");
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -221,5 +221,55 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			text2.Should().Be(text1, because: "Text content should not change at max length.");
 			text3.Should().Be("TextChanged: 1");
 		}
+
+		[Test]
+		[AutoRetry]
+		public void TextBox_No_Text_Entered()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxControl.TextBox_Binding_Null");
+
+			const string MappedText = "MappedText";
+			const string TextBox = "TargetTextBox";
+			const string DummyButton = "DummyButton";
+
+			string GetMappedText() => _app.GetText(MappedText);
+
+			void DefocusTextBox()
+			{
+				_app.Tap(DummyButton);
+
+				_app.WaitForFocus(DummyButton);
+			}
+
+			Assert.AreEqual("initial", GetMappedText());
+
+			_app.Tap(TextBox);
+
+			_app.WaitForFocus(TextBox);
+
+			DefocusTextBox();
+
+			Assert.AreEqual("initial", GetMappedText()); //Binding not pushed on losing focus
+
+			_app.Tap(TextBox);
+
+			_app.EnterText("fleep");
+
+			DefocusTextBox();
+
+			Assert.AreEqual("fleep", GetMappedText());
+
+			_app.Tap("ResetButton");
+
+			_app.WaitForText(MappedText, "reset");
+
+			_app.Tap(TextBox);
+
+			_app.WaitForFocus(TextBox);
+
+			DefocusTextBox();
+
+			Assert.AreEqual("reset", GetMappedText());
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -729,6 +729,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Binding_Null.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_DeleteButton_Automated.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3334,6 +3338,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_BeforeTextChanging.xaml.cs">
       <DependentUpon>TextBox_BeforeTextChanging.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Binding_Null.xaml.cs">
+      <DependentUpon>TextBox_Binding_Null.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_DeleteButton_Automated.xaml.cs">
       <DependentUpon>TextBox_DeleteButton_Automated.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Binding_Null.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Binding_Null.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxControl.TextBox_Binding_Null"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<StackPanel Spacing="15">
+		<Button x:Name="DummyButton"
+				Content="Dummy" />
+		<TextBox x:Name="TargetTextBox"
+				 Text="{Binding MyString, Mode=TwoWay}"
+				 PlaceholderText="enter..." />
+		<TextBlock x:Name="MappedText"
+				   Text="initial" />
+		<Button x:Name="ResetButton"
+				Content="Reset text"
+				Click="OnClick" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Binding_Null.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Binding_Null.xaml.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxControl
+{
+	[SampleControlInfo("TextBox", description: "Demonstrates that TextBox shouldn't push binding on losing focus unless user has edited text")]
+	public sealed partial class TextBox_Binding_Null : UserControl
+	{
+		public TextBox_Binding_Null()
+		{
+			this.InitializeComponent();
+
+			TargetTextBox.DataContext = this;
+		}
+
+		private void OnClick(object sender, RoutedEventArgs args)
+		{
+			MappedText.Text = "reset";
+		}
+
+		public string MyString
+		{
+			get { return (string)GetValue(MyStringProperty); }
+			set { SetValue(MyStringProperty, value); }
+		}
+
+		public static readonly DependencyProperty MyStringProperty =
+			DependencyProperty.Register("MyString", typeof(string), typeof(TextBox_Binding_Null), new PropertyMetadata(null, OnMyStringChanged));
+
+		private static void OnMyStringChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var ctrl = d as TextBox_Binding_Null;
+
+			var newValue = (string)e.NewValue;
+			ctrl.MappedText.Text = newValue == "" ?
+				"[empty]" :
+				newValue ?? "[null]";
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #2294

Upon losing focus, only push a new value to the two-way binding if user edits have occurred, in alignment with UWP behavior. This avoids overwriting null with an empty string if the user focuses and then defocuses the TextBox.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
