### PR TITLE
[Android] BorderLayerRenderer - restore BorderThickness adjustment

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -34,6 +34,7 @@
 - [#2033] Add Missing `LostFocus` Value to `UpdateSourceTrigger` Enum
 - [Android] Fix Image margin calculation on fixed size
 - [Android] Native views weren't clipped correctly
+- [Android] Border thickness was incorrect when CornerRadius was set
 - [iOS] #2361 ListView would measure children with infinite width
 - [iOS] Fix crash when using ComboBox template with native Picker and changing ItemsSource to null after SelectedItem was set
 - [#2398] Fully qualify the `MethodName` value for `CreateFromStringAttribute' if it's not fully qualified it the code

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
@@ -65,14 +65,14 @@ namespace SamplesApp.UITests.TestFramework
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
-		/// (ie, neither the A, R, G, or B values differ by more than the permitted error for any pixel).
+		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
 		public static void AreAlmostEqual(FileInfo expected, FileInfo actual, IAppRect rect, int permittedPixelError)
 			=> AreAlmostEqual(expected, actual, new Rectangle((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height), permittedPixelError);
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
-		/// (ie, neither the A, R, G, or B values differ by more than the permitted error for any pixel).
+		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
 		public static void AreAlmostEqual(FileInfo expected, FileInfo actual, Rectangle? rect = null, int permittedPixelError = 5)
 		{
@@ -82,7 +82,7 @@ namespace SamplesApp.UITests.TestFramework
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
-		/// (ie, neither the A, R, G, or B values differ by more than the permitted error for any pixel).
+		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
 		public static void AreAlmostEqual(FileInfo expected, IAppRect expectedRect, FileInfo actual, IAppRect actualRect, int permittedPixelError)
 			=> AreAlmostEqual(
@@ -94,7 +94,7 @@ namespace SamplesApp.UITests.TestFramework
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
-		/// (ie, neither the A, R, G, or B values differ by more than the permitted error for any pixel).
+		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
 		public static void AreAlmostEqual(FileInfo expected, Rectangle expectedRect, FileInfo actual, Rectangle actualRect, int permittedPixelError)
 		{
@@ -129,11 +129,12 @@ namespace SamplesApp.UITests.TestFramework
 							continue;
 						}
 
-						if (Abs(expectedPixel.R - actualPixel.R) > permittedPixelError
-							|| Abs(expectedPixel.G - actualPixel.G) > permittedPixelError
-							|| Abs(expectedPixel.B - actualPixel.B) > permittedPixelError
-							|| Abs(expectedPixel.A - actualPixel.A) > permittedPixelError
-						)
+						var cumulativeError = Abs(expectedPixel.R - actualPixel.R)
+							+ Abs(expectedPixel.G - actualPixel.G)
+							+ Abs(expectedPixel.B - actualPixel.B)
+							+ Abs(expectedPixel.A - actualPixel.A);
+
+						if (cumulativeError > permittedPixelError)
 						{
 							Assert.Fail($"Difference between expected={expectedPixel} and actual={actualPixel} at {x},{y} exceeds permitted error of {permittedPixelError}");
 						}

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Uno.UITest;
+using static System.Math;
 
 namespace SamplesApp.UITests.TestFramework
 {
@@ -52,13 +53,91 @@ namespace SamplesApp.UITests.TestFramework
 				);
 
 				for (var x = 0; x < width; x++)
-				for (var y = 0; y < height; y++)
-				{
-					Assert.AreEqual(
-						expectedBitmap.GetPixel(x + expectedOffset.x, y + expectedOffset.y),
-						actualBitmap.GetPixel(x + actualOffset.x, y + actualOffset.y),
-						$"Pixel {x},{y}");
-				}
+					for (var y = 0; y < height; y++)
+					{
+						Assert.AreEqual(
+							expectedBitmap.GetPixel(x + expectedOffset.x, y + expectedOffset.y),
+							actualBitmap.GetPixel(x + actualOffset.x, y + actualOffset.y),
+							$"Pixel {x},{y}");
+					}
+			}
+		}
+
+		/// <summary>
+		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
+		/// (ie, neither the A, R, G, or B values differ by more than the permitted error for any pixel).
+		/// </summary>
+		public static void AreAlmostEqual(FileInfo expected, FileInfo actual, IAppRect rect, int permittedPixelError)
+			=> AreAlmostEqual(expected, actual, new Rectangle((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height), permittedPixelError);
+
+		/// <summary>
+		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
+		/// (ie, neither the A, R, G, or B values differ by more than the permitted error for any pixel).
+		/// </summary>
+		public static void AreAlmostEqual(FileInfo expected, FileInfo actual, Rectangle? rect = null, int permittedPixelError = 5)
+		{
+			rect = rect ?? new Rectangle(0, 0, int.MaxValue, int.MaxValue);
+			AreAlmostEqual(expected, rect.Value, actual, rect.Value, permittedPixelError);
+		}
+
+		/// <summary>
+		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
+		/// (ie, neither the A, R, G, or B values differ by more than the permitted error for any pixel).
+		/// </summary>
+		public static void AreAlmostEqual(FileInfo expected, IAppRect expectedRect, FileInfo actual, IAppRect actualRect, int permittedPixelError)
+			=> AreAlmostEqual(
+				expected,
+				new Rectangle((int)expectedRect.X, (int)expectedRect.Y, (int)expectedRect.Width, (int)expectedRect.Height),
+				actual,
+				new Rectangle((int)actualRect.X, (int)actualRect.Y, (int)actualRect.Width, (int)actualRect.Height),
+				permittedPixelError);
+
+		/// <summary>
+		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
+		/// (ie, neither the A, R, G, or B values differ by more than the permitted error for any pixel).
+		/// </summary>
+		public static void AreAlmostEqual(FileInfo expected, Rectangle expectedRect, FileInfo actual, Rectangle actualRect, int permittedPixelError)
+		{
+			Assert.AreEqual(expectedRect.Width, actualRect.Width, "Rect Width");
+			Assert.AreEqual(expectedRect.Height, actualRect.Height, "Rect Height");
+
+			using (var expectedBitmap = new Bitmap(expected.FullName))
+			using (var actualBitmap = new Bitmap(actual.FullName))
+			{
+				Assert.AreEqual(expectedBitmap.Size.Width, actualBitmap.Size.Width, "Screenshot Width");
+				Assert.AreEqual(expectedBitmap.Size.Height, actualBitmap.Size.Height, "Screenshot Height");
+
+				var width = Math.Min(expectedRect.Width, expectedBitmap.Size.Width);
+				var height = Math.Min(expectedRect.Height, expectedBitmap.Size.Height);
+
+				(int x, int y) expectedOffset = (
+					expectedRect.X < 0 ? expectedBitmap.Size.Width + expectedRect.X : expectedRect.X,
+					expectedRect.Y < 0 ? expectedBitmap.Size.Height + expectedRect.Y : expectedRect.Y
+				);
+				(int x, int y) actualOffset = (
+					actualRect.X < 0 ? actualBitmap.Size.Width + actualRect.X : actualRect.X,
+					actualRect.Y < 0 ? actualBitmap.Size.Height + actualRect.Y : actualRect.Y
+				);
+
+				for (var x = 0; x < width; x++)
+					for (var y = 0; y < height; y++)
+					{
+						var expectedPixel = expectedBitmap.GetPixel(x + expectedOffset.x, y + expectedOffset.y);
+						var actualPixel = actualBitmap.GetPixel(x + actualOffset.x, y + actualOffset.y);
+						if (expectedPixel == actualPixel)
+						{
+							continue;
+						}
+
+						if (Abs(expectedPixel.R - actualPixel.R) > permittedPixelError
+							|| Abs(expectedPixel.G - actualPixel.G) > permittedPixelError
+							|| Abs(expectedPixel.B - actualPixel.B) > permittedPixelError
+							|| Abs(expectedPixel.A - actualPixel.A) > permittedPixelError
+						)
+						{
+							Assert.Fail($"Difference between expected={expectedPixel} and actual={actualPixel} at {x},{y} exceeds permitted error of {permittedPixelError}");
+						}
+					}
 			}
 		}
 
@@ -101,13 +180,13 @@ namespace SamplesApp.UITests.TestFramework
 				);
 
 				for (var x = 0; x < width; x++)
-				for (var y = 0; y < height; y++)
-				{
-					if (expectedBitmap.GetPixel(x + expectedOffset.x, y + expectedOffset.y) != actualBitmap.GetPixel(x + actualOffset.x, y + actualOffset.y))
+					for (var y = 0; y < height; y++)
 					{
-						return;
+						if (expectedBitmap.GetPixel(x + expectedOffset.x, y + expectedOffset.y) != actualBitmap.GetPixel(x + actualOffset.x, y + actualOffset.y))
+						{
+							return;
+						}
 					}
-				}
 
 				Assert.Fail("Screenshots are equals.");
 			}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BorderTests/Border_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BorderTests/Border_Tests.cs
@@ -30,5 +30,27 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests
 
 			ImageAssert.AreEqual(before, after);
 		}
+
+		[Test]
+		[AutoRetry]
+		public void Check_CornerRadius_Border()
+		{
+			// Verify that border is drawn with the same thickness with/without CornerRadius
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.BorderTests.Border_CornerRadius_Toggle");
+
+			_app.WaitForElement("SubjectBorder");
+
+			var verificationRect = _app.GetRect("SnapshotBorder");
+
+			var scrBefore = TakeScreenshot("No CornerRadius");
+
+			_app.Tap("ToggleCornerRadiusButton");
+
+			_app.WaitForText("StatusTextBlock", "5");
+
+			var scrAfter = TakeScreenshot("CornerRadius=5");
+
+			ImageAssert.AreAlmostEqual(scrBefore, scrAfter, verificationRect, permittedPixelError: 5);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -425,6 +425,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\Border_CornerRadius_Toggle.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Buttons_Native.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3126,6 +3130,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\Border_Clipped_Change_Property.xaml.cs">
       <DependentUpon>Border_Clipped_Change_Property.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\Border_CornerRadius_Toggle.xaml.cs">
+      <DependentUpon>Border_CornerRadius_Toggle.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Buttons_Native.xaml.cs">
       <DependentUpon>Buttons_Native.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/Border_CornerRadius_Toggle.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/Border_CornerRadius_Toggle.xaml
@@ -1,0 +1,36 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.BorderTests.Border_CornerRadius_Toggle"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.BorderTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<StackPanel Background="Beige" Spacing="15">
+		<Grid HorizontalAlignment="Center"
+			  VerticalAlignment="Top">
+			<Border x:Name="SubjectBorder"
+					BorderBrush="Green"
+					BorderThickness="1"
+					Background="Yellow"
+					Width="100"
+					Height="40">
+				<Border BorderBrush="Blue"
+						BorderThickness="1"
+						HorizontalAlignment="Stretch"
+						VerticalAlignment="Stretch" />
+			</Border>
+			<Border x:Name="SnapshotBorder"
+					Width="40"
+					Height="40"
+					VerticalAlignment="Center" />
+		</Grid>
+		<Button x:Name="ToggleCornerRadiusButton"
+				Content="Toggle CornerRadius (current=0)"
+				Click="ToggleCornerRadius" />
+		<TextBlock x:Name="StatusTextBlock"
+				   Text="0" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/Border_CornerRadius_Toggle.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/Border_CornerRadius_Toggle.xaml.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.BorderTests
+{
+	[SampleControlInfo("Border", description: "Outline should look the same (aside from corners) with/without CornerRadius")]
+	public sealed partial class Border_CornerRadius_Toggle : UserControl
+	{
+		public Border_CornerRadius_Toggle()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ToggleCornerRadius(object sender, RoutedEventArgs args)
+		{
+			var currentRadius = SubjectBorder.CornerRadius;
+			var newRadius = currentRadius.TopLeft == 0 ?
+				new CornerRadius(5) :
+				default(CornerRadius);
+			SubjectBorder.CornerRadius = newRadius;
+			ToggleCornerRadiusButton.Content = $"Toggle CornerRadius (current={newRadius.TopLeft})";
+			StatusTextBlock.Text = newRadius.TopLeft.ToString();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/BorderLayerRenderer.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/BorderLayerRenderer.Android.cs
@@ -63,12 +63,12 @@ namespace Windows.UI.Xaml.Controls
 
 					// Clear previous value anyway in order to make sure the previous values are unset before the new ones.
 					// This prevents the case where a second update would set a new background and then set the background to null when disposing the previous.
-					_layerDisposable.Disposable = null; 
+					_layerDisposable.Disposable = null;
 				}
 
 				Action onImageSet = null;
 				var disposable = InnerCreateLayers(view, drawArea, background, borderThickness, borderBrush, cornerRadius, () => onImageSet?.Invoke());
-				
+
 				// Most of the time we immediately dispose the previous layer. In the case where we're using an ImageBrush,
 				// and the backing image hasn't changed, we dispose the previous layer at the moment the new background is applied,
 				// to prevent a visible flicker.
@@ -118,7 +118,10 @@ namespace Windows.UI.Xaml.Controls
 
 			if (cornerRadius != 0)
 			{
-				using (var path = cornerRadius.GetOutlinePath(drawArea.ToRectF()))
+				var adjustedLineWidth = physicalBorderThickness.Top; // TODO: handle non-uniform BorderThickness correctly
+				var adjustedArea = drawArea;
+				adjustedArea.Inflate(-adjustedLineWidth / 2, -adjustedLineWidth / 2);
+				using (var path = cornerRadius.GetOutlinePath(adjustedArea.ToRectF()))
 				{
 					path.SetFillType(Path.FillType.EvenOdd);
 
@@ -354,12 +357,12 @@ namespace Windows.UI.Xaml.Controls
 
 					if (physicalBorderThickness.Top != 0)
 					{
-						var adjustY = (float)physicalBorderThickness.Top / 2;						
+						var adjustY = (float)physicalBorderThickness.Top / 2;
 
 						using (var line = new Path())
-						{						
-							line.MoveTo((float)physicalBorderThickness.Left, (float)adjustY); 
-							line.LineTo(viewSize.Width - (float)physicalBorderThickness.Right, (float)adjustY); 
+						{
+							line.MoveTo((float)physicalBorderThickness.Left, (float)adjustY);
+							line.LineTo(viewSize.Width - (float)physicalBorderThickness.Right, (float)adjustY);
 							line.Close();
 
 							var lineDrawable = new PaintDrawable();
@@ -399,7 +402,7 @@ namespace Windows.UI.Xaml.Controls
 					if (physicalBorderThickness.Bottom != 0)
 					{
 						var adjustY = physicalBorderThickness.Bottom / 2;
-						
+
 						using (var line = new Path())
 						{
 							line.MoveTo((float)physicalBorderThickness.Left, (float)(viewSize.Height - adjustY));


### PR DESCRIPTION
When calculating the fill path for a control with a non-zero CornerRadius, ensure to adjust the fill area for the BorderThickness. This adjustment was erroneously removed when CornerRadius handling was refactored in #2190.

GitHub Issue (If applicable): fixes #2263

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
