### PR TITLE
Add support of the Holding event

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -607,6 +607,15 @@
 				<Member
 					fullName="System.Void Windows.UI.Input.RightTappedEventArgs..ctor()"
 					reason="Not part of the WinUI API."/>
+				<Member
+					fullName="System.Boolean Windows.UI.Xaml.Input.HoldingRoutedEventArgs.get_Handled()"
+					reason="Auto property"/>
+				<Member
+					fullName="System.Void Windows.UI.Xaml.Input.HoldingRoutedEventArgs.set_Handled(System.Boolean value)"
+					reason="Auto property"/>
+				<Member
+					fullName="System.Void Windows.UI.Input.HoldingEventArgs..ctor()"
+					reason="Not part of the WinUI API."/>
             </Methods>
 		</IgnoreSet>
 	</IgnoreSets>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -616,6 +616,12 @@
 				<Member
 					fullName="System.Void Windows.UI.Input.HoldingEventArgs..ctor()"
 					reason="Not part of the WinUI API."/>
+				<Member
+					fullName="System.Void Windows.System.DispatcherQueue..ctor()"
+					reason="Not part of the WinUI API."/>
+				<Member
+					fullName="System.Void Windows.System.DispatcherQueueTimer..ctor()"
+					reason="Not part of the WinUI API."/>
             </Methods>
 		</IgnoreSet>
 	</IgnoreSets>

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -17,6 +17,7 @@
 - Multiple pointers at same time on screen (a.k.a. Multi-touch) are now supported
 - Add support for WinUI 2.3 [`NumberBox`](https://docs.microsoft.com/en-us/uwp/api/microsoft.ui.xaml.controls.numberbox?view=winui-2.3)
 - Add support of the `UIElement.RightTapped` event
+- Add support of the `UIElement.Holding` event
 
 ### Breaking changes
 -

--- a/doc/articles/features/routed-events.md
+++ b/doc/articles/features/routed-events.md
@@ -31,8 +31,8 @@
 | _gesture events_         
 | `Tapped`                      | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.tapped) |
 | `DoubleTapped`                | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.doubletapped) |
-| `RightTapped`                 | No      | No      | No      | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.righttapped) |
-| `Holding`                     | No      | No      | No      | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.holding) |
+| `RightTapped`                 | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.righttapped) |
+| `Holding`                     | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.holding) |
 
 Notes:
 
@@ -169,10 +169,8 @@ These _routed events_ are not implemented yet in Uno:
 * `DragLeave`
 * `DragOver`
 * `Drop`
-* `Holding`
 * `ManipulationInertiaStarting`
 * `PointerWheelChanged`
-* `RightTapped`
 
 ### Property `OriginalSource` might not be accurate on _RoutedEventArgs_
 
@@ -242,6 +240,8 @@ As those events are tightly coupled to the native events, Uno has to make some c
 * On WASM, if you touch the screen with the pen **then** you press the barrel button (still while touching the screen), the pointer events will
   have the `IsRightButtonPressed` set (in addition of the `IsBarrelButtonPressed`). On WinUI and Android you get this flag only if the barrel 
   button was pressed at the moment where you touched the screen, otherwise you will have the `IsLeftButtonPressed` and the `IsBarrelButtonPressed`.
+* The `Holding` event is not raised after a given delay like on WinUI, but instead we rely on the fact that we usually 
+  get a lot of moves for pens and fingers, so we raise the event only when we get a move that exceed defined thresholds for holding.
 
 ### Pointer capture
 
@@ -259,5 +259,4 @@ will never be fired. The `Velocities` properties of event args are not implement
 
 They are generated from the PointerXXX events (using the `Windows.UI.Input.GestureRecognizer`) and are bubbling in managed only.
 
-Currently only the `Tapped` and `DoubleTapped` gestures are supported. Note that those events are not linked in any way to a native equivalent, 
-but are fully interpreted in managed code.
+Note that `Tapped` and `DoubleTapped` are not linked in any way to a native equivalent, but are fully interpreted in managed code.

--- a/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
@@ -23,7 +23,7 @@ namespace SamplesApp.UITests
 			Run("SamplesApp.Samples.UnitTests.UnitTestsPage");
 
 			var runButton = _app.Marked("runButton");
-			var failedTests = _app.Marked("failedTests");
+			var failedTests = _app.Marked("failedTestCount");
 			var runTestCount = _app.Marked("runTestCount");
 
 			bool IsTestExecutionDone()

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/GestureResult.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/GestureResult.cs
@@ -13,7 +13,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		public static GestureResult Parse(string text)
 		{
-			var regex = new Regex(@"(?<elt>[\w_]+)@(?<x>[\d\.]+),(?<y>[\d\.]+)");
+			var regex = new Regex(@"(?<elt>[\w_]+)(-(?<state>\w+))?@(?<x>[\d\.]+),(?<y>[\d\.]+)");
 			var result = regex.Match(text);
 			if (!result.Success)
 			{
@@ -23,15 +23,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			return new GestureResult(
 				result.Groups["elt"].Value,
 				float.Parse(result.Groups["x"].Value, CultureInfo.InvariantCulture),
-				float.Parse(result.Groups["y"].Value, CultureInfo.InvariantCulture));
+				float.Parse(result.Groups["y"].Value, CultureInfo.InvariantCulture),
+				result.Groups["state"].Value);
 		}
 
-		private GestureResult(string element, float x, float y)
+		private GestureResult(string element, float x, float y, string state)
 		{
 			Element = element;
 			X = x;
 			Y = y;
+			State = state;
 		}
+
+		public string State { get; }
 
 		public string Element { get; }
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Holding_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Holding_Tests.cs
@@ -1,0 +1,269 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+using Uno.UITests.Helpers;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Input
+{
+	public class Holding_Tests : SampleControlUITestBase
+	{
+		private const string _xamlTestPage = "UITests.Shared.Windows_UI_Input.GestureRecognizerTests.HoldingTests";
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // No WASM as Holding is not raise for mouse pointers
+		public void When_Basic()
+		{
+			Run(_xamlTestPage);
+
+			const string targetName = "Basic_Target";
+			const int tapX = 10, tapY = 10;
+
+			// Tap and hold the target
+			var target = _app.WaitForElement(targetName).Single().Rect;
+			Hold(target.X + tapX, target.Y + tapY);
+
+			var result = GestureResult.Get(_app.Marked("LastHeld"));
+			result.Element.Should().Be(targetName);
+			result.State.Should().Be("Completed");
+			((int)result.X).Should().Be(tapX);
+			((int)result.Y).Should().Be(tapY);
+		}
+
+		[Test]
+		[AutoRetry]
+		[Ignore("Currently there is no available gesture to test cancel")]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // No WASM as Holding is not raise for mouse pointers
+		public void When_Basic_Canceled()
+		{
+			Run(_xamlTestPage);
+
+			const string targetName = "Basic_Target";
+			const int tapX = 10, tapY = 10;
+
+			// Tap and hold the target
+			var target = _app.WaitForElement(targetName).Single().Rect;
+			HoldAndCancel(target.X + tapX, target.Y + tapY);
+
+			var result = GestureResult.Get(_app.Marked("LastHeld"));
+			result.Element.Should().Be(targetName);
+			result.State.Should().Be("Canceled");
+			((int)result.X).Should().Be(tapX);
+			((int)result.Y).Should().Be(tapY);
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)] // No WASM as Holding is not raise for mouse pointers + Disabled on Android: The test engine is not able to find "Transformed_Target"
+		public void When_Transformed()
+		{
+			Run(_xamlTestPage);
+
+			const string parentName = "Transformed_Parent";
+			const string targetName = "Transformed_Target";
+
+			var parent = _app.WaitForElement(parentName).Single().Rect;
+			var target = _app.WaitForElement(targetName).Single().Rect;
+
+			// Tap and hold the target
+			Hold(parent.Right - target.Width, parent.Bottom - 3);
+
+			var result = GestureResult.Get(_app.Marked("LastHeld"));
+			result.Element.Should().Be(targetName);
+			result.State.Should().Be("Completed");
+		}
+
+		[Test]
+		[AutoRetry]
+		[Ignore("Currently there is no available gesture to test cancel")]
+		[ActivePlatforms(Platform.iOS)] // No WASM as Holding is not raise for mouse pointers + Disabled on Android: The test engine is not able to find "Transformed_Target"
+		public void When_Transformed_Canceled()
+		{
+			Run(_xamlTestPage);
+
+			const string parentName = "Transformed_Parent";
+			const string targetName = "Transformed_Target";
+
+			var parent = _app.WaitForElement(parentName).Single().Rect;
+			var target = _app.WaitForElement(targetName).Single().Rect;
+
+			// Tap and hold the target
+			HoldAndCancel(parent.Right - target.Width, parent.Bottom - 3);
+
+			var result = GestureResult.Get(_app.Marked("LastHeld"));
+			result.Element.Should().Be(targetName);
+			result.State.Should().Be("Canceled");
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // No WASM as Holding is not raise for mouse pointers
+		public void When_InScroll()
+		{
+			Run(_xamlTestPage);
+
+			const string targetName = "InScroll_Target";
+			const int tapX = 10, tapY = 10;
+
+			// Scroll to make the target visible
+			var scroll = _app.WaitForElement("InScroll_ScrollViewer").Single().Rect;
+			_app.DragCoordinates(scroll.Right - 3, scroll.Bottom - 3, 0, 0);
+
+			// Tap and hold the target
+			var target = _app.WaitForElement(targetName).Single();
+			Hold(target.Rect.X + tapX, target.Rect.Y + tapY);
+
+			var result = GestureResult.Get(_app.Marked("LastHeld"));
+			result.Element.Should().Be(targetName);
+			result.State.Should().Be("Completed");
+			((int)result.X).Should().Be(tapX);
+			((int)result.Y).Should().Be(tapY);
+		}
+
+		[Test]
+		[AutoRetry]
+		[Ignore("Currently there is no available gesture to test cancel")]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // No WASM as Holding is not raise for mouse pointers
+		public void When_InScroll_Canceled()
+		{
+			Run(_xamlTestPage);
+
+			const string targetName = "InScroll_Target";
+			const int tapX = 10, tapY = 10;
+
+			// Scroll to make the target visible
+			var scroll = _app.WaitForElement("InScroll_ScrollViewer").Single().Rect;
+			_app.DragCoordinates(scroll.Right - 3, scroll.Bottom - 3, 0, 0);
+
+			// Tap and hold the target
+			var target = _app.WaitForElement(targetName).Single();
+			HoldAndCancel(target.Rect.X + tapX, target.Rect.Y + tapY);
+
+			var result = GestureResult.Get(_app.Marked("LastHeld"));
+			result.Element.Should().Be(targetName);
+			result.State.Should().Be("Canceled");
+			((int)result.X).Should().Be(tapX);
+			((int)result.Y).Should().Be(tapY);
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // No WASM as Holding is not raise for mouse pointers
+		public void When_InListViewWithItemClick()
+		{
+			Run(_xamlTestPage);
+
+			const string targetName = "ListViewWithItemClick";
+
+			// Scroll a bit in the ListView
+			var target = _app.WaitForElement(targetName).Single().Rect;
+			_app.DragCoordinates(target.CenterX, target.Bottom - 3, target.CenterX, target.Y + 3);
+
+			// Tap and hold an item
+			Hold(target.CenterX, target.CenterY - 5);
+
+			var result = GestureResult.Get(_app.Marked("LastHeld"));
+			var expectedItem = AppInitializer.GetLocalPlatform() == Platform.Browser
+				? "none" // Long press not supported with mouse
+				: "Item_3";
+			result.Element.Should().Be(expectedItem);
+			result.State.Should().Be("Completed");
+		}
+
+		[Test]
+		[AutoRetry]
+		[Ignore("Currently there is no available gesture to test cancel")]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // No WASM as Holding is not raise for mouse pointers
+		public void When_InListViewWithItemClick_Canceled()
+		{
+			Run(_xamlTestPage);
+
+			const string targetName = "ListViewWithItemClick";
+
+			// Scroll a bit in the ListView
+			var target = _app.WaitForElement(targetName).Single().Rect;
+			_app.DragCoordinates(target.CenterX, target.Bottom - 3, target.CenterX, target.Y + 3);
+
+			// Tap and hold an item
+			HoldAndCancel(target.CenterX, target.CenterY - 5);
+
+			var result = GestureResult.Get(_app.Marked("LastHeld"));
+			var expectedItem = AppInitializer.GetLocalPlatform() == Platform.Browser
+				? "none" // Long press not supported with mouse
+				: "Item_3";
+			result.Element.Should().Be(expectedItem);
+			result.State.Should().Be("Canceled");
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // No WASM as Holding is not raise for mouse pointers
+		public void When_InListViewWithoutItemClick()
+		{
+			Run(_xamlTestPage);
+
+			const string targetName = "ListViewWithoutItemClick";
+
+			// Scroll a bit in the ListView
+			var target = _app.WaitForElement(targetName).Single().Rect;
+			_app.DragCoordinates(target.CenterX, target.Bottom - 3, target.CenterX, target.Y + 3);
+
+			// Tap and hold an item
+			Hold(target.CenterX, target.CenterY - 5);
+
+			var result = GestureResult.Get(_app.Marked("LastHeld"));
+			var expectedItem = AppInitializer.GetLocalPlatform() == Platform.Browser
+				? "none" // Long press not supported with mouse
+				: "Item_3";
+			result.Element.Should().Be(expectedItem);
+			result.State.Should().Be("Completed");
+		}
+
+		[Test]
+		[AutoRetry]
+		[Ignore("Currently there is no available gesture to test cancel")]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // No WASM as Holding is not raise for mouse pointers
+		public void When_InListViewWithoutItemClick_Canceled()
+		{
+			Run(_xamlTestPage);
+
+			const string targetName = "ListViewWithoutItemClick";
+
+			// Scroll a bit in the ListView
+			var target = _app.WaitForElement(targetName).Single().Rect;
+			_app.DragCoordinates(target.CenterX, target.Bottom - 3, target.CenterX, target.Y + 3);
+
+			// Tap and hold an item
+			HoldAndCancel(target.CenterX, target.CenterY - 5);
+
+			var result = GestureResult.Get(_app.Marked("LastHeld"));
+			var expectedItem = AppInitializer.GetLocalPlatform() == Platform.Browser
+				? "none" // Long press not supported with mouse
+				: "Item_3";
+			result.Element.Should().Be(expectedItem);
+			result.State.Should().Be("Canceled");
+		}
+
+		private void Hold(float x, float y)
+		{
+			// Note:  We use DragCoordinates to simulate the real behavior of user which
+			// moves a bit its finger over the screen
+			_app.DragCoordinates(x, y, x + 2, y + 2);
+		}
+
+		private void HoldAndCancel(float x, float y)
+		{
+			// Note:  We use DragCoordinates to simulate the real behavior of user which
+			// moves a bit its finger over the screen
+			_app.DragCoordinates(x, y, x + 40, y + 40);
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -176,6 +176,7 @@ namespace Uno.UI.Samples.Tests
 						ReportRunTestCount($"Run tests: {++runTests}");
 
 						var runsOnUIThread = testMethod.GetCustomAttribute(typeof(Uno.UI.RuntimeTests.RunsOnUIThreadAttribute)) != null;
+						var expectedException = testMethod.GetCustomAttributes<ExpectedExceptionAttribute>().SingleOrDefault();
 						var dataRows = testMethod.GetCustomAttributes<DataRowAttribute>();
 						if (dataRows.Any())
 						{
@@ -227,7 +228,15 @@ namespace Uno.UI.Samples.Tests
 										throw resultingTask.Exception;
 									}
 								}
-								ReportTestResult(fullTestName, TestResult.Sucesss);
+
+								if (expectedException == null)
+								{
+									ReportTestResult(fullTestName, TestResult.Sucesss);
+								}
+								else
+								{
+									ReportTestResult(fullTestName, TestResult.Failed, message: $"Test did not throw the excepted exception of type {expectedException.ExceptionType.Name}");
+								}
 							}
 							catch (Exception e)
 							{
@@ -242,7 +251,14 @@ namespace Uno.UI.Samples.Tests
 									e = tie.InnerException;
 								}
 
-								ReportTestResult(fullTestName, TestResult.Failed, e);
+								if (expectedException == null || !expectedException.ExceptionType.IsInstanceOfType(e))
+								{
+									ReportTestResult(fullTestName, TestResult.Failed, e);
+								}
+								else
+								{
+									ReportTestResult(fullTestName, TestResult.Sucesss, e);
+								}
 							}
 
 						}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
@@ -18,13 +18,27 @@
 			<ColumnDefinition Width="*"/>
 		</Grid.ColumnDefinitions>
 		<StackPanel Grid.Row="0">
-			<Button x:Name="runButton"
-			  Content="Run"
-			  Click="OnRunTests" />
-			<TextBlock x:Name="runStatus"
-				 Text="Not initialized" />
-			<TextBlock x:Name="failedTests" Text="Pending..." />
-			<TextBlock x:Name="runTestCount" Text="None" />
+			<Button
+				x:Name="runButton"
+				Content="Run"
+				Click="OnRunTests" />
+
+			<StackPanel Orientation="Horizontal">
+				<TextBlock Text="Status: " />
+				<TextBlock x:Name="runStatus" Text="Not initialized" />
+			</StackPanel>
+
+			<StackPanel Orientation="Horizontal">
+				<TextBlock Text="Run: " />
+				<TextBlock x:Name="runTestCount" Text="None" />
+				<TextBlock Text=" | Ignored: " />
+				<TextBlock x:Name="ignoredTestCount" Text="None" />
+				<TextBlock Text=" | Succeeded: " />
+				<TextBlock x:Name="succeededTestCount" Text="None" />
+				<TextBlock Text=" | Failed: " />
+				<TextBlock x:Name="failedTestCount" Text="None" />
+			</StackPanel>
+			
 			<ScrollViewer Height="100">
 				<TextBlock x:Name="failedTestDetails" Opacity="0.5" />
 			</ScrollViewer>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -137,6 +137,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\HoldingTests.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\ManipulationEvents.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2989,6 +2993,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\GestureEventsCommons.xaml.cs">
       <DependentUpon>GestureEventsCommons.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\HoldingTests.xaml.cs">
+      <DependentUpon>HoldingTests.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\ManipulationEvents.xaml.cs">
       <DependentUpon>ManipulationEvents.xaml</DependentUpon>
     </Compile>
@@ -2999,7 +3006,7 @@
       <DependentUpon>Manipulation_WhenInScrollViewer.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\RightTappedTests.xaml.cs">
-      <DependentUpon>$fileinputname$.xaml</DependentUpon>
+      <DependentUpon>RightTappedTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\TappedTest.xaml.cs">
       <DependentUpon>TappedTest.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/HoldingTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/HoldingTests.xaml
@@ -1,0 +1,207 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Input.GestureRecognizerTests.HoldingTests"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Input.GestureRecognizerTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition />
+			<ColumnDefinition />
+		</Grid.ColumnDefinitions>
+
+		<TextBlock
+			Text="Long press (touch), right click (mouse), use barrel button (pen) on each zones. Last right tapped:"
+			TextWrapping="Wrap"
+			Grid.Row="0"
+			Grid.ColumnSpan="2"/>
+		<TextBlock
+			x:Name="LastHeld"
+			Text="__none__"
+			Grid.Row="1"
+			Grid.ColumnSpan="2"/>
+
+		<TextBlock
+			Text="Basic"
+			Grid.Row="2"
+			Grid.Column="0"
+			HorizontalAlignment="Center"/>
+		<Border
+			x:Name="Basic_Target"
+			Grid.Row="3"
+			Grid.Column="0"
+			Width="150"
+			Height="150"
+			Background="#FF0018"
+			Holding="TargetHeld" />
+
+		<TextBlock
+			Text="With transformation"
+			Grid.Row="2"
+			Grid.Column="1" 
+			HorizontalAlignment="Center"/>
+		<Border
+			Grid.Row="3"
+			Grid.Column="1"
+			Width="150"
+			Height="150"
+			Background="#FFA52C"
+			x:Name="Transformed_Parent">
+			<Border
+				x:Name="Transformed_Target"
+				HorizontalAlignment="Left"
+				VerticalAlignment="Top"
+				Width="50"
+				Height="50"
+				Background="#33000000"
+				Holding="TargetHeld">
+				<Border.RenderTransform>
+					<CompositeTransform Rotation="45" TranslateX="100" TranslateY="100" />
+				</Border.RenderTransform>
+			</Border>
+		</Border>
+
+		<TextBlock
+			Text="In ScrollViewer"
+			Grid.Row="4"
+			Grid.Column="0" 
+			HorizontalAlignment="Center"/>
+		<Border
+			Grid.Row="5"
+			Grid.Column="0"
+			Width="150"
+			Height="150"
+			Background="#FFFF41">
+			<ScrollViewer
+				VerticalScrollMode="Enabled"
+				VerticalScrollBarVisibility="Visible"
+				HorizontalScrollMode="Enabled"
+				HorizontalScrollBarVisibility="Visible"
+				x:Name="InScroll_ScrollViewer">
+				<Grid
+					Width="300"
+					Height="300">
+					<Border
+						x:Name="InScroll_Target"
+						Width="100"
+						Height="100"
+						HorizontalAlignment="Right"
+						VerticalAlignment="Bottom"
+						Background="#33000000"
+						Holding="TargetHeld" />
+				</Grid>
+			</ScrollViewer>
+		</Border>
+
+		<TextBlock
+			Text="In button"
+			Grid.Row="4"
+			Grid.Column="1" 
+			HorizontalAlignment="Center"/>
+		<Button
+			Grid.Row="5"
+			Grid.Column="1"
+			Width="150"
+			Height="150"
+			HorizontalAlignment="Center"
+			VerticalAlignment="Center"
+			Background="#008018">
+			<Border
+				x:Name="InButton_Target"
+				Width="100"
+				Height="100"
+				HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				Background="#33000000"
+				Holding="TargetHeld" />
+		</Button>
+
+		<TextBlock
+			Text="ListView"
+			Grid.Row="6"
+			Grid.Column="0" 
+			HorizontalAlignment="Center"/>
+		<Border
+			Grid.Row="7"
+			Grid.Column="0"
+			Width="150"
+			Height="150"
+			Background="#0000F9">
+			<ListView
+				ItemsSource="0123456789abcdef"
+				IsItemClickEnabled="True"
+				SelectionMode="Single"
+				x:Name="ListViewWithItemClick">
+				<ListView.ItemTemplate>
+					<DataTemplate>
+						<Border
+							Height="50"
+							Width="125"
+							Background="#11000000"
+							BorderBrush="#33000000"
+							BorderThickness="3"
+							Margin="3"
+							Holding="ItemHeld">
+							<TextBlock
+								VerticalAlignment="Center"
+								HorizontalAlignment="Center"
+								Text="{Binding}" />
+						</Border>
+					</DataTemplate>
+				</ListView.ItemTemplate>
+			</ListView>
+		</Border>
+
+
+		<TextBlock
+			Text="ListView item click disabled"
+			Grid.Row="6"
+			Grid.Column="1" 
+			HorizontalAlignment="Center"/>
+		<Border
+			Grid.Row="7"
+			Grid.Column="1"
+			Width="150"
+			Height="150"
+			Background="#86007D">
+			<ListView
+				ItemsSource="0123456789abcdef"
+				IsItemClickEnabled="False"
+				SelectionMode="None"
+				x:Name="ListViewWithoutItemClick">
+				<ListView.ItemTemplate>
+					<DataTemplate>
+						<Border
+							Height="50"
+							Width="125"
+							Background="#11000000"
+							BorderBrush="#33000000"
+							BorderThickness="3"
+							Margin="3"
+							Holding="ItemHeld">
+							<TextBlock
+								VerticalAlignment="Center"
+								HorizontalAlignment="Center"
+								Text="{Binding}" />
+						</Border>
+					</DataTemplate>
+				</ListView.ItemTemplate>
+			</ListView>
+		</Border>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/HoldingTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/HoldingTests.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Uno.UI;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
+{
+	[SampleControlInfo("Gesture recognizer")]
+	public sealed partial class HoldingTests : Page
+	{
+		public HoldingTests()
+		{
+			this.InitializeComponent();
+		}
+
+		private void TargetHeld(object sender, HoldingRoutedEventArgs e)
+		{
+			var target = (FrameworkElement)sender;
+			var position = e.GetPosition(target).LogicalToPhysicalPixels();
+
+			LastHeld.Text = $"{target.Name}-{e.HoldingState}@{position.X:F2},{position.Y:F2}";
+		}
+
+		private void ItemHeld(object sender, HoldingRoutedEventArgs e)
+		{
+			var target = (FrameworkElement)sender;
+			var position = e.GetPosition(target).LogicalToPhysicalPixels();
+
+			LastHeld.Text = $"Item_{target.DataContext}-{e.HoldingState}@{position.X:F2},{position.Y:F2}";
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueue.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueue.cs
@@ -18,10 +18,12 @@ namespace Uno.UI.RuntimeTests.Tests.System
 			Assert.IsNotNull(DispatcherQueue.GetForCurrentThread());
 		}
 
+#if !__WASM__ // Wasm does not have bg threads yet ...
 		[TestMethod]
 		public void When_GetForCurrentThreadFromBackgroundThread()
 		{
 			Assert.IsNull(DispatcherQueue.GetForCurrentThread());
 		}
+#endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueue.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueue.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Tests.System
+{
+	[TestClass]
+	public class Given_DispatcherQueue
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_GetForCurrentThreadFromDispatcher()
+		{
+			Assert.IsNotNull(DispatcherQueue.GetForCurrentThread());
+		}
+
+		[TestMethod]
+		public void When_GetForCurrentThreadFromBackgroundThread()
+		{
+			Assert.IsNull(DispatcherQueue.GetForCurrentThread());
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
@@ -74,6 +74,7 @@ namespace Uno.UI.RuntimeTests.Tests.System
 			}
 		}
 
+#if !WINDOWS_UWP
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_Tick_Then_RunningOnDispatcher()
@@ -102,6 +103,7 @@ namespace Uno.UI.RuntimeTests.Tests.System
 				timer.Stop();
 			}
 		}
+#endif
 
 		[TestMethod]
 		[RunsOnUIThread]

--- a/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
@@ -15,7 +15,6 @@ namespace Uno.UI.RuntimeTests.Tests.System
 	{
 		[TestMethod]
 		[RunsOnUIThread]
-		[Ignore] // This test is disabled on the CI as depending of the server's load it might fail randomly
 		public async Task When_ScheduleWorkItem()
 		{
 			var tcs = new TaskCompletionSource<object>();
@@ -30,7 +29,7 @@ namespace Uno.UI.RuntimeTests.Tests.System
 
 				Assert.IsTrue(timer.IsRunning);
 
-				await Task.WhenAny(tcs.Task, Task.Delay(10000));
+				await Task.WhenAny(tcs.Task, Task.Delay(30000));
 
 				Assert.IsTrue(tcs.Task.IsCompleted);
 			}
@@ -42,7 +41,6 @@ namespace Uno.UI.RuntimeTests.Tests.System
 
 		[TestMethod]
 		[RunsOnUIThread]
-		[Ignore] // This test is disabled on the CI as depending of the server's load it might fail randomly
 		public async Task When_ScheduleRepeatingWorkItem()
 		{
 			var tcs = new TaskCompletionSource<object>();
@@ -65,7 +63,7 @@ namespace Uno.UI.RuntimeTests.Tests.System
 				Assert.IsTrue(timer.IsRunning);
 				Assert.IsTrue(timer.IsRepeating);
 
-				await Task.WhenAny(tcs.Task, Task.Delay(10000));
+				await Task.WhenAny(tcs.Task, Task.Delay(30000));
 
 				Assert.IsTrue(tcs.Task.IsCompleted);
 				Assert.AreEqual(count, 3);

--- a/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.System;
+using Windows.UI.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Tests.System
+{
+	[TestClass]
+	public class Given_DispatcherQueueTimer
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_ScheduleWorkItem()
+		{
+			var tcs = new TaskCompletionSource<object>();
+			var timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+			try
+			{
+				timer.Interval = TimeSpan.FromMilliseconds(100);
+				timer.Tick += (snd, e) => tcs.SetResult(default);
+
+				timer.Start();
+
+				Assert.IsTrue(timer.IsRunning);
+
+				await Task.WhenAny(tcs.Task, Task.Delay(1000));
+
+				Assert.IsTrue(tcs.Task.IsCompleted);
+			}
+			finally
+			{
+				timer.Stop();
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_ScheduleRepeatingWorkItem()
+		{
+			var tcs = new TaskCompletionSource<object>();
+			var timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+			var count = 0;
+
+			try
+			{
+				timer.Interval = TimeSpan.FromMilliseconds(100);
+				timer.Tick += (snd, e) =>
+				{
+					if (++count >= 3)
+					{
+						tcs.SetResult(default);
+					}
+				};
+
+				timer.Start();
+
+				Assert.IsTrue(timer.IsRunning);
+				Assert.IsTrue(timer.IsRepeating);
+
+				await Task.WhenAny(tcs.Task, Task.Delay(1000));
+
+				Assert.IsTrue(tcs.Task.IsCompleted);
+				Assert.AreEqual(count, 3);
+			}
+			finally
+			{
+				timer.Stop();
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Tick_Then_RunningOnDispatcher()
+		{
+			var tcs = new TaskCompletionSource<object>();
+			var timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+			var hasThreadAccess = false;
+
+			try
+			{
+				timer.Interval = TimeSpan.FromMilliseconds(100);
+				timer.Tick += (snd, e) =>
+				{
+					hasThreadAccess = CoreDispatcher.Main.HasThreadAccess;
+					tcs.SetResult(default);
+				};
+
+				timer.Start();
+
+				await Task.WhenAny(tcs.Task, Task.Delay(1000));
+
+				Assert.IsTrue(hasThreadAccess);
+			}
+			finally
+			{
+				timer.Stop();
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_StartAndStopFromBackgroundThread()
+		{
+			var timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+			try
+			{
+				timer.Interval = TimeSpan.FromMilliseconds(100);
+
+				Assert.IsFalse(timer.IsRunning);
+				await Task.Run(() => timer.Start());
+				Assert.IsTrue(timer.IsRunning);
+				await Task.Run(() => timer.Stop());
+				Assert.IsFalse(timer.IsRunning);
+			}
+			finally
+			{
+				timer.Stop();
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[ExpectedException(typeof(ArgumentException))]
+		public async Task When_SetNegativeInterval()
+		{
+			var tcs = new TaskCompletionSource<object>();
+			var timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
+			timer.Interval = TimeSpan.FromMilliseconds(-100);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
@@ -15,6 +15,7 @@ namespace Uno.UI.RuntimeTests.Tests.System
 	{
 		[TestMethod]
 		[RunsOnUIThread]
+		[Ignore] // This test is disabled on the CI as depending of the server's load it might fail randomly
 		public async Task When_ScheduleWorkItem()
 		{
 			var tcs = new TaskCompletionSource<object>();
@@ -41,6 +42,7 @@ namespace Uno.UI.RuntimeTests.Tests.System
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[Ignore] // This test is disabled on the CI as depending of the server's load it might fail randomly
 		public async Task When_ScheduleRepeatingWorkItem()
 		{
 			var tcs = new TaskCompletionSource<object>();

--- a/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
@@ -74,7 +74,7 @@ namespace Uno.UI.RuntimeTests.Tests.System
 			}
 		}
 
-#if !WINDOWS_UWP
+#if !WINDOWS_UWP && !__WASM__ // CoreDispatcher.Main.HasThreadAccess is always false on WASM ...
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_Tick_Then_RunningOnDispatcher()

--- a/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/System/Given_DispatcherQueueTimer.cs
@@ -22,14 +22,14 @@ namespace Uno.UI.RuntimeTests.Tests.System
 
 			try
 			{
-				timer.Interval = TimeSpan.FromMilliseconds(100);
+				timer.Interval = TimeSpan.FromMilliseconds(10);
 				timer.Tick += (snd, e) => tcs.SetResult(default);
 
 				timer.Start();
 
 				Assert.IsTrue(timer.IsRunning);
 
-				await Task.WhenAny(tcs.Task, Task.Delay(1000));
+				await Task.WhenAny(tcs.Task, Task.Delay(10000));
 
 				Assert.IsTrue(tcs.Task.IsCompleted);
 			}
@@ -49,7 +49,7 @@ namespace Uno.UI.RuntimeTests.Tests.System
 
 			try
 			{
-				timer.Interval = TimeSpan.FromMilliseconds(100);
+				timer.Interval = TimeSpan.FromMilliseconds(10);
 				timer.Tick += (snd, e) =>
 				{
 					if (++count >= 3)
@@ -63,7 +63,7 @@ namespace Uno.UI.RuntimeTests.Tests.System
 				Assert.IsTrue(timer.IsRunning);
 				Assert.IsTrue(timer.IsRepeating);
 
-				await Task.WhenAny(tcs.Task, Task.Delay(1000));
+				await Task.WhenAny(tcs.Task, Task.Delay(10000));
 
 				Assert.IsTrue(tcs.Task.IsCompleted);
 				Assert.AreEqual(count, 3);

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Control.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Control.cs
@@ -560,7 +560,7 @@ namespace Windows.UI.Xaml.Controls
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Control", "void Control.OnDoubleTapped(DoubleTappedRoutedEventArgs e)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		protected virtual void OnHolding( global::Windows.UI.Xaml.Input.HoldingRoutedEventArgs e)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/HoldingRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/HoldingRoutedEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class HoldingRoutedEventArgs : global::Windows.UI.Xaml.RoutedEventArgs
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  bool Handled
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.HoldingState HoldingState
 		{
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Input.PointerDeviceType PointerDeviceType
 		{
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public HoldingRoutedEventArgs() : base()
 		{
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Input
 		// Forced skipping of method Windows.UI.Xaml.Input.HoldingRoutedEventArgs.HoldingState.get
 		// Forced skipping of method Windows.UI.Xaml.Input.HoldingRoutedEventArgs.Handled.get
 		// Forced skipping of method Windows.UI.Xaml.Input.HoldingRoutedEventArgs.Handled.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Point GetPosition( global::Windows.UI.Xaml.UIElement relativeTo)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
@@ -596,7 +596,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.RoutedEvent HoldingEvent
 		{
@@ -1507,7 +1507,7 @@ namespace Windows.UI.Xaml
 		}
 		#endif
 		// Skipping already declared event Windows.UI.Xaml.UIElement.GotFocus
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.UI.Xaml.Input.HoldingEventHandler Holding
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -237,6 +237,11 @@ namespace Windows.UI.Xaml.Controls
 				RightTapped += OnRightTappedHandler;
 			}
 
+			if (implementedEvents.HasFlag(RoutedEventFlag.Holding))
+			{
+				Holding += OnHoldingHandler;
+			}
+
 			if (implementedEvents.HasFlag(RoutedEventFlag.KeyDown))
 			{
 				KeyDown += OnKeyDownHandler;
@@ -761,6 +766,7 @@ namespace Windows.UI.Xaml.Controls
 		protected virtual void OnTapped(TappedRoutedEventArgs e) { }
 		protected virtual void OnDoubleTapped(DoubleTappedRoutedEventArgs e) { }
 		protected virtual void OnRightTapped(RightTappedRoutedEventArgs e) { }
+		protected virtual void OnHolding(HoldingRoutedEventArgs e) { }
 		protected virtual void OnKeyDown(KeyRoutedEventArgs args) { }
 		protected virtual void OnKeyUp(KeyRoutedEventArgs args) { }
 		protected virtual void OnGotFocus(RoutedEventArgs e) { }
@@ -811,6 +817,9 @@ namespace Windows.UI.Xaml.Controls
 		private static readonly RightTappedEventHandler OnRightTappedHandler =
 			(object sender, RightTappedRoutedEventArgs args) => ((Control)sender).OnRightTapped(args);
 
+		private static readonly HoldingEventHandler OnHoldingHandler =
+			(object sender, HoldingRoutedEventArgs args) => ((Control)sender).OnHolding(args);
+
 		private static readonly KeyEventHandler OnKeyDownHandler =
 			(object sender, KeyRoutedEventArgs args) => ((Control)sender).OnKeyDown(args);
 
@@ -830,6 +839,7 @@ namespace Windows.UI.Xaml.Controls
 		private static readonly Type[] _tappedArgsType = new[] { typeof(TappedRoutedEventArgs) };
 		private static readonly Type[] _doubleTappedArgsType = new[] { typeof(DoubleTappedRoutedEventArgs) };
 		private static readonly Type[] _rightTappedArgsType = new[] { typeof(RightTappedRoutedEventArgs) };
+		private static readonly Type[] _holdingArgsType = new[] { typeof(HoldingRoutedEventArgs) };
 		private static readonly Type[] _keyArgsType = new[] { typeof(KeyRoutedEventArgs) };
 		private static readonly Type[] _routedArgsType = new[] { typeof(RoutedEventArgs) };
 		private static readonly Type[] _manipStartingArgsType = new[] { typeof(ManipulationStartingRoutedEventArgs) };
@@ -929,6 +939,11 @@ namespace Windows.UI.Xaml.Controls
 			if (GetIsEventOverrideImplemented(type, nameof(OnRightTapped), _rightTappedArgsType))
 			{
 				result |= RoutedEventFlag.RightTapped;
+			}
+
+			if (GetIsEventOverrideImplemented(type, nameof(OnHolding), _holdingArgsType))
+			{
+				result |= RoutedEventFlag.Holding;
 			}
 
 			if (GetIsEventOverrideImplemented(type, nameof(OnKeyDown), _keyArgsType))

--- a/src/Uno.UI/UI/Xaml/Input/HoldingRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/HoldingRoutedEventArgs.cs
@@ -1,0 +1,50 @@
+using Windows.Devices.Input;
+using Windows.Foundation;
+using Windows.UI.Input;
+
+namespace Windows.UI.Xaml.Input
+{
+	public  partial class HoldingRoutedEventArgs : RoutedEventArgs
+	{
+		private readonly UIElement _originalSource;
+		private readonly Point _position;
+
+		public HoldingRoutedEventArgs() { }
+		internal HoldingRoutedEventArgs(UIElement originalSource, HoldingEventArgs args)
+			: base(originalSource)
+		{
+			_originalSource = originalSource;
+			_position = args.Position;
+			PointerId = args.PointerId;
+			PointerDeviceType = args.PointerDeviceType;
+			HoldingState = args.HoldingState;
+		}
+
+		/// <summary>
+		/// Used internally to prevent multiple holding events due to routed event bubbling for the same pointer
+		/// </summary>
+		internal uint PointerId { get; }
+
+		public bool Handled { get; set; }
+
+		public PointerDeviceType PointerDeviceType { get; }
+
+		public HoldingState HoldingState { get; }
+
+		public Point GetPosition(UIElement relativeTo)
+		{
+			if (_originalSource == null)
+			{
+				return default; // Required for the default public ctor ...
+			}
+			else if (relativeTo == _originalSource)
+			{
+				return _position;
+			}
+			else
+			{
+				return _originalSource.GetPosition(_position, relativeTo);
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/RoutedEventFlag.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEventFlag.cs
@@ -56,7 +56,7 @@ namespace Uno.UI.Xaml
 		Tapped = 1UL << 48,
 		DoubleTapped = 1UL << 49,
 		RightTapped = 1UL << 50,
-		// Holding = 1UL << 51, => Reserved for future usage 
+		Holding = 1UL << 51, 
 
 		// Context menu
 		// ContextRequested = 1UL << 61, => Reserved for future usage 
@@ -100,8 +100,8 @@ namespace Uno.UI.Xaml
 		private const RoutedEventFlag _isGesture = // 0b0000_0000_0001_1111___0000_0000_0000_0000___0000_0000_0000_0000___0000_0000_0000_0000
 			RoutedEventFlag.Tapped
 			| RoutedEventFlag.DoubleTapped
-			| RoutedEventFlag.RightTapped;
-			//| RoutedEventFlag.Holding;
+			| RoutedEventFlag.RightTapped
+			| RoutedEventFlag.Holding;
 
 		private const RoutedEventFlag _isContextMenu = (RoutedEventFlag)0b0011_0000_0000_0000___0000_0000_0000_0000___0000_0000_0000_0000___0000_0000_0000_0000;
 			//   RoutedEventFlag.ContextRequested

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -374,9 +374,16 @@ namespace Windows.UI.Xaml
 		partial void PrepareManagedGestureEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
 		{
 			// When we bubble a gesture event from a child, we make sure to abort any pending gesture/manipulation on the current element
-			if (_gestures.IsValueCreated)
+			if (routedEvent == HoldingEvent)
 			{
-				_gestures.Value.CompleteGesture();
+				if (_gestures.IsValueCreated)
+				{
+					_gestures.Value.AbortHolding();
+				}
+			}
+			else
+			{
+				CompleteGesture(); // Make sure to set the flag _isGestureCompleted, so won't try to recognize double tap
 			}
 		}
 
@@ -506,7 +513,7 @@ namespace Windows.UI.Xaml
 				// We need to process only events that are bubbling natively to this control,
 				// if they are bubbling in managed it means that they were handled by a child control,
 				// so we should not use them for gesture recognition.
-				_gestures.Value.ProcessMoveEvents(args.GetIntermediatePoints(this), isManagedBubblingEvent || isOverOrCaptured);
+				_gestures.Value.ProcessMoveEvents(args.GetIntermediatePoints(this), !isManagedBubblingEvent || isOverOrCaptured);
 			}
 
 			return handledInManaged;
@@ -530,7 +537,7 @@ namespace Windows.UI.Xaml
 				// We need to process only events that are bubbling natively to this control (i.e. isOverOrCaptured == true),
 				// if they are bubbling in managed it means that they where handled a child control,
 				// so we should not use them for gesture recognition.
-				_gestures.Value.ProcessUpEvent(args.GetCurrentPoint(this), isManagedBubblingEvent || isOverOrCaptured);
+				_gestures.Value.ProcessUpEvent(args.GetCurrentPoint(this), !isManagedBubblingEvent || isOverOrCaptured);
 			}
 
 			// We release the captures on up but only after the released event and processed the gesture

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -228,6 +228,12 @@ namespace Windows.UI.Xaml
 			var that = (UIElement)sender.Owner;
 			that.SafeRaiseEvent(RightTappedEvent, new RightTappedRoutedEventArgs(that, args));
 		};
+
+		private static readonly TypedEventHandler<GestureRecognizer, HoldingEventArgs> OnRecognizerHolding = (sender, args) =>
+		{
+			var that = (UIElement)sender.Owner;
+			that.SafeRaiseEvent(HoldingEvent, new HoldingRoutedEventArgs(that, args));
+		};
 		#endregion
 
 		private bool _isGestureCompleted;
@@ -243,6 +249,7 @@ namespace Windows.UI.Xaml
 			recognizer.ManipulationCompleted += OnRecognizerManipulationCompleted;
 			recognizer.Tapped += OnRecognizerTapped;
 			recognizer.RightTapped += OnRecognizerRightTapped;
+			recognizer.Holding += OnRecognizerHolding;
 
 			// Allow partial parts to subscribe to pointer events (WASM)
 			OnGestureRecognizerInitialized(recognizer);
@@ -330,6 +337,10 @@ namespace Windows.UI.Xaml
 			else if (routedEvent == RightTappedEvent)
 			{
 				_gestures.Value.GestureSettings |= GestureSettings.RightTap;
+			}
+			else if (routedEvent == HoldingEvent)
+			{
+				_gestures.Value.GestureSettings |= GestureSettings.Hold; // Note: We do not set GestureSettings.HoldWithMouse as WinUI never raises Holding for mouse pointers
 			}
 		}
 		#endregion

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -378,11 +378,13 @@ namespace Windows.UI.Xaml
 			{
 				if (_gestures.IsValueCreated)
 				{
-					_gestures.Value.AbortHolding();
+					_gestures.Value.PreventHolding(((HoldingRoutedEventArgs) args).PointerId);
 				}
 			}
 			else
 			{
+				// Note: Here we should prevent only the same gesture ... but actually currently supported gestures
+				// are mutually exclusive, so if a child element detected a gesture, it's safe to prevent all of them.
 				CompleteGesture(); // Make sure to set the flag _isGestureCompleted, so won't try to recognize double tap
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -107,6 +107,8 @@ namespace Windows.UI.Xaml
 
 		public static RoutedEvent RightTappedEvent { get; } = new RoutedEvent(RoutedEventFlag.RightTapped);
 
+		public static RoutedEvent HoldingEvent { get; } = new RoutedEvent(RoutedEventFlag.Holding);
+
 		public static RoutedEvent KeyDownEvent { get; } = new RoutedEvent(RoutedEventFlag.KeyDown);
 
 		public static RoutedEvent KeyUpEvent { get; } = new RoutedEvent(RoutedEventFlag.KeyUp);
@@ -303,6 +305,12 @@ namespace Windows.UI.Xaml
 		{
 			add => AddHandler(RightTappedEvent, value, false);
 			remove => RemoveHandler(RightTappedEvent, value);
+		}
+
+		public event HoldingEventHandler Holding
+		{
+			add => AddHandler(HoldingEvent, value, false);
+			remove => RemoveHandler(HoldingEvent, value);
 		}
 
 #if __MACOS__
@@ -671,6 +679,9 @@ namespace Windows.UI.Xaml
 					break;
 				case RightTappedEventHandler rightTappedEventHandler:
 					rightTappedEventHandler(this, (RightTappedRoutedEventArgs)args);
+					break;
+				case HoldingEventHandler holdingEventHandler:
+					holdingEventHandler(this, (HoldingRoutedEventArgs)args);
 					break;
 				case KeyEventHandler keyEventHandler:
 					keyEventHandler(this, (KeyRoutedEventArgs)args);

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System/DispatcherQueue.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System/DispatcherQueue.cs
@@ -7,7 +7,7 @@ namespace Windows.System
 	#endif
 	public  partial class DispatcherQueue 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.System.DispatcherQueueTimer CreateTimer()
 		{
@@ -32,7 +32,7 @@ namespace Windows.System
 		// Forced skipping of method Windows.System.DispatcherQueue.ShutdownStarting.remove
 		// Forced skipping of method Windows.System.DispatcherQueue.ShutdownCompleted.add
 		// Forced skipping of method Windows.System.DispatcherQueue.ShutdownCompleted.remove
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.System.DispatcherQueue GetForCurrentThread()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System/DispatcherQueueTimer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System/DispatcherQueueTimer.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class DispatcherQueueTimer 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  bool IsRepeating
 		{
@@ -21,7 +21,7 @@ namespace Windows.System
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::System.TimeSpan Interval
 		{
@@ -35,7 +35,7 @@ namespace Windows.System
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  bool IsRunning
 		{
@@ -50,14 +50,14 @@ namespace Windows.System
 		// Forced skipping of method Windows.System.DispatcherQueueTimer.IsRunning.get
 		// Forced skipping of method Windows.System.DispatcherQueueTimer.IsRepeating.get
 		// Forced skipping of method Windows.System.DispatcherQueueTimer.IsRepeating.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  void Start()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.System.DispatcherQueueTimer", "void DispatcherQueueTimer.Start()");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  void Stop()
 		{
@@ -66,7 +66,7 @@ namespace Windows.System
 		#endif
 		// Forced skipping of method Windows.System.DispatcherQueueTimer.Tick.add
 		// Forced skipping of method Windows.System.DispatcherQueueTimer.Tick.remove
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.System.DispatcherQueueTimer, object> Tick
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/GestureRecognizer.cs
@@ -387,7 +387,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Input.GestureRecognizer, global::Windows.UI.Input.HoldingEventArgs> Holding
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/HoldingEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/HoldingEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class HoldingEventArgs 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Input.HoldingState HoldingState
 		{
@@ -17,7 +17,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Devices.Input.PointerDeviceType PointerDeviceType
 		{
@@ -27,7 +27,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Point Position
 		{

--- a/src/Uno.UWP/System/DispatcherQueue.cs
+++ b/src/Uno.UWP/System/DispatcherQueue.cs
@@ -1,0 +1,30 @@
+using System;
+using Windows.UI.Core;
+
+namespace Windows.System
+{
+	public partial class DispatcherQueue
+	{
+		[ThreadStatic]
+		private static DispatcherQueue _current;
+
+		private DispatcherQueue()
+		{
+		}
+
+		public DispatcherQueueTimer CreateTimer()
+			=> new DispatcherQueueTimer();
+
+		public static DispatcherQueue GetForCurrentThread()
+		{
+			CoreDispatcher.CheckThreadAccess();
+
+			if (_current == null)
+			{
+				_current = new DispatcherQueue();
+			}
+
+			return _current;
+		}
+	}
+}

--- a/src/Uno.UWP/System/DispatcherQueue.cs
+++ b/src/Uno.UWP/System/DispatcherQueue.cs
@@ -19,10 +19,13 @@ namespace Windows.System
 		{
 			if (_current == null) // Do not even check for thread access if we already have a value!
 			{
+#if !__WASM__
+				// This check is disabled on WASM until threading support is enabled, since HasThreadAccess is currently user-configured (and defaults to false).
 				if (!CoreDispatcher.Main.HasThreadAccess)
 				{
 					return default;
 				}
+#endif
 
 				_current = new DispatcherQueue();
 			}

--- a/src/Uno.UWP/System/DispatcherQueue.cs
+++ b/src/Uno.UWP/System/DispatcherQueue.cs
@@ -17,10 +17,13 @@ namespace Windows.System
 
 		public static DispatcherQueue GetForCurrentThread()
 		{
-			CoreDispatcher.CheckThreadAccess();
-
-			if (_current == null)
+			if (_current == null) // Do not even check for thread access if we already have a value!
 			{
+				if (!CoreDispatcher.Main.HasThreadAccess)
+				{
+					return default;
+				}
+
 				_current = new DispatcherQueue();
 			}
 

--- a/src/Uno.UWP/System/DispatcherQueueTimer.Android.cs
+++ b/src/Uno.UWP/System/DispatcherQueueTimer.Android.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Android.OS;
+using Java.Lang;
+
+namespace Windows.System
+{
+	partial class DispatcherQueueTimer
+	{
+		private Handler _handler;
+		private TickRunnable _runnable;
+
+		partial void NativeCtor()
+		{
+			_handler = new Handler(Looper.MainLooper);
+			_runnable = new TickRunnable(this);
+		}
+
+		private void StartNative(TimeSpan interval)
+		{
+			var longInterval = (long)interval.TotalMilliseconds;
+
+			_runnable.Interval = longInterval;
+			_handler.PostDelayed(_runnable, longInterval);
+		}
+
+		private void StartNative(TimeSpan dueTime, TimeSpan interval)
+		{
+			_runnable.Interval = (long)interval.TotalMilliseconds;
+			_handler.PostDelayed(_runnable, (long)dueTime.TotalMilliseconds);
+		}
+
+		private void StopNative()
+		{
+			_runnable.Interval = -1;
+			_handler.RemoveCallbacks(_runnable);
+		}
+
+		private class TickRunnable : Java.Lang.Object, IRunnable
+		{
+			private readonly DispatcherQueueTimer _timer;
+
+			public long Interval { get; set; }
+
+			public TickRunnable(DispatcherQueueTimer timer)
+			{
+				_timer = timer;
+			}
+
+			public void Run()
+			{
+				var interval = Interval;
+				if (interval >= 0)
+				{
+					_timer.RaiseTick();
+
+					interval = Interval;
+					if (interval >= 0) // be sure to not self restart if the timer was Stopped by the Tick event handler
+					{
+						_timer._handler.PostDelayed(this, interval);
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/System/DispatcherQueueTimer.cs
+++ b/src/Uno.UWP/System/DispatcherQueueTimer.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Threading;
+using Windows.Foundation;
+
+namespace Windows.System
+{
+	public partial class DispatcherQueueTimer 
+	{
+		private static class States
+		{
+			public const int Idle = 0;
+			public const int Running = 1;
+		}
+
+		private int _state = States.Idle;
+		private TimeSpan _interval;
+		private DateTimeOffset _lastTick;
+
+		public event TypedEventHandler<DispatcherQueueTimer, object> Tick;
+
+		public TimeSpan Interval
+		{
+			get => _interval;
+			set
+			{
+				if (_interval != value)
+				{
+					_interval = value;
+					if (IsRunning)
+					{
+						Restart(value);
+					}
+				}
+			}
+		}
+
+		public bool IsRunning => _state == States.Running;
+
+		public bool IsRepeating
+		{
+			get => true;
+			[global::Uno.NotImplemented]
+			set => global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.System.DispatcherQueueTimer", "bool DispatcherQueueTimer.IsRepeating");
+		}
+
+		/// <summary>
+		/// An internal state that can be used to store a value in order to prevent a closure in the click handler.
+		/// </summary>
+		internal object State { get; set; }
+
+		internal DispatcherQueueTimer()
+		{
+			NativeCtor();
+		}
+
+		partial void NativeCtor();
+
+		public void Start()
+		{
+			if (Interlocked.CompareExchange(ref _state, States.Running, States.Idle) == States.Idle)
+			{
+				StartNative(Interval);
+			}
+			else
+			{
+				// As of 2018-04-24: "If the timer has already started, then it is restarted."
+				// https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.dispatchertimer.start#Windows_UI_Xaml_DispatcherTimer_Start
+				StopNative();
+				StartNative(Interval);
+			}
+		}
+
+		/// <summary>
+		/// Stops the DispatcherTimer.
+		/// </summary>
+		public void Stop()
+		{
+			if (Interlocked.Exchange(ref _state, States.Idle) == States.Running)
+			{
+				StopNative();
+			}
+		}
+
+		/*
+		 * Note: When we change the Interval on a timer while it's running, the new delay is applied immediately.
+		 * This means that :
+		 *  - if the new Interval is lower that delay since the last Tick, a Tick will occurs immediately
+		 *  - if the new Interval is greater, next Tick will occur after the end of the new Interval.
+		 */
+		private void Restart(TimeSpan interval)
+		{
+			var now = DateTimeOffset.Now;
+
+			// First be sure to stop the pending timer
+			StopNative();
+
+			var elapsed = now - _lastTick;
+			if (elapsed >= interval)
+			{
+				RaiseTick();
+
+				if (IsRunning) // be sure to not self restart if the timer was Stopped by the Tick event handler
+				{
+					StartNative(interval);
+				}
+			}
+			else
+			{
+				StartNative(interval - elapsed, interval);
+			}
+		}
+
+		private void RaiseTick()
+		{
+			if (IsRunning)
+			{
+				_lastTick = DateTimeOffset.UtcNow;
+
+				Tick?.Invoke(this, null);
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/System/DispatcherQueueTimer.cs
+++ b/src/Uno.UWP/System/DispatcherQueueTimer.cs
@@ -124,5 +124,10 @@ namespace Windows.System
 				Tick?.Invoke(this, null);
 			}
 		}
+
+		~DispatcherQueueTimer()
+		{
+			Stop();
+		}
 	}
 }

--- a/src/Uno.UWP/System/DispatcherQueueTimer.cs
+++ b/src/Uno.UWP/System/DispatcherQueueTimer.cs
@@ -23,6 +23,11 @@ namespace Windows.System
 			get => _interval;
 			set
 			{
+				if (value < TimeSpan.Zero)
+				{
+					throw new ArgumentException(nameof(value)); // WinUI throws a ArgumentException, not and ArgumentOutOfRangeException
+				}
+
 				if (_interval != value)
 				{
 					_interval = value;

--- a/src/Uno.UWP/System/DispatcherQueueTimer.iOSmacOS.cs
+++ b/src/Uno.UWP/System/DispatcherQueueTimer.iOSmacOS.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using Foundation;
+
+namespace Windows.System
+{
+    partial class DispatcherQueueTimer
+	{
+		private NSTimer _timer;
+
+		private void StartNative(TimeSpan interval)
+		{
+			Start(NSTimer.CreateScheduledTimer(interval.TotalSeconds, repeats: true, block: OnRecurentTick));
+		}
+
+		private void StartNative(TimeSpan dueTime, TimeSpan interval)
+		{
+			Start(NSTimer.CreateScheduledTimer(dueTime.TotalSeconds, repeats: false, block: OnUniqueTick));
+		}
+
+		private void Start(NSTimer timer)
+		{
+			Interlocked.Exchange(ref _timer, timer)?.Invalidate();
+			NSRunLoop.Main.AddTimer(timer, NSRunLoopMode.Common);
+		}
+
+		private void StopNative()
+		{
+			Interlocked.Exchange(ref _timer, null)?.Invalidate();
+		}
+
+		private void OnUniqueTick(NSTimer timer)
+		{
+			if (_timer == timer)
+			{
+				RaiseTick();
+
+				if (_timer == timer) // be sure to not self restart if the timer was Stopped by the Tick event handler
+				{
+					StartNative(Interval);
+				}
+			}
+		}
+
+		private void OnRecurentTick(NSTimer timer)
+		{
+			if (_timer == timer)
+			{
+				RaiseTick();
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/System/DispatcherQueueTimer.net.cs
+++ b/src/Uno.UWP/System/DispatcherQueueTimer.net.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.System.Threading;
+
+namespace Windows.System
+{
+	partial class DispatcherQueueTimer
+	{
+		private void StartNative(TimeSpan interval)
+		{
+			throw new NotImplementedException("DispatcherQueueTimer not supported on .net");
+		}
+
+		private void StartNative(TimeSpan dueTime, TimeSpan interval)
+		{
+			throw new NotImplementedException("DispatcherQueueTimer not supported on .net");
+		}
+
+		private void StopNative()
+		{
+			throw new NotImplementedException("DispatcherQueueTimer not supported on .net");
+		}
+	}
+}

--- a/src/Uno.UWP/System/DispatcherQueueTimer.wasm.cs
+++ b/src/Uno.UWP/System/DispatcherQueueTimer.wasm.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Windows.System
+{
+	partial class DispatcherQueueTimer
+	{
+		Timer _timer;
+
+		private void StartNative(TimeSpan interval)
+		{
+			if(_timer == null)
+			{
+				_timer = new Timer(_ => RaiseTick());
+			}
+
+			_timer.Change(interval, interval);
+		}
+
+		private void StartNative(TimeSpan dueTime, TimeSpan interval)
+		{
+			if (_timer == null)
+			{
+				_timer = new Timer(_ => RaiseTick());
+			}
+
+			_timer.Change(dueTime, interval);
+		}
+
+		private void StopNative()
+		{
+			_timer.Dispose();
+			_timer = null;
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -15,7 +15,7 @@ namespace Windows.UI.Input
 		/// <summary>
 		/// This is the state machine which handles the gesture ([Double|Right]Tapped and Holding gestures)
 		/// </summary>
-		private class Gestur
+		private class Gesture
 		{
 			private readonly GestureRecognizer _recognizer;
 			private DispatcherQueueTimer _holdingTimer;

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Windows.Devices.Input;
+using Windows.System;
+using Microsoft.Extensions.Logging;
+using Uno.Logging;
+
+namespace Windows.UI.Input
+{
+	public partial class GestureRecognizer
+	{
+		/// <summary>
+		/// This is the state machine which handles the gesture ([Double|Right]Tapped and Holding gestures)
+		/// </summary>
+		private class Gesture : List<PointerPoint>
+		{
+			private readonly GestureRecognizer _recognizer;
+			private DispatcherQueueTimer _holdingTimer;
+			private GestureSettings _settings;
+			private HoldingState? _holdingState;
+
+			public ulong PointerIdentifier { get; }
+
+			public PointerDeviceType PointerType { get; }
+
+			public PointerPoint Down { get; }
+
+			public PointerPoint Up { get; private set; }
+
+			public bool IsCompleted { get; private set; }
+
+			public Gesture(GestureRecognizer recognizer, PointerPoint down)
+				: base(16)
+			{
+				_recognizer = recognizer;
+				_settings = recognizer._gestureSettings | GestureSettings.Tap; // On WinUI, Tap is always raised no matter the flag set on the recognizer
+
+				Down = down;
+				PointerIdentifier = GetPointerIdentifier(down);
+				PointerType = down.PointerDevice.PointerDeviceType;
+
+				// This is how WinUI behaves: it will fire the double tap
+				// on Down for a double tap instead of the Up.
+				if (TryRecognizeMultiTap())
+				{
+					IsCompleted = true;
+				}
+				else
+				{
+					StartHoldingTimer();
+				}
+			}
+
+			public void ProcessMove(PointerPoint point)
+			{
+				if (IsCompleted)
+				{
+					return;
+				}
+
+				// Update internal state
+				Add(point);
+
+				// Process the pointer
+				TryStartHolding(point);
+			}
+
+			public void ProcessUp(PointerPoint up)
+			{
+				if (IsCompleted)
+				{
+					return;
+				}
+
+				// Update internal state
+				IsCompleted = true;
+				Up = up;
+
+				// Process the pointer
+				TryEndHolding(HoldingState.Completed);
+				TryRecognize();
+			}
+
+			public void ProcessComplete()
+			{
+				if (IsCompleted)
+				{
+					return;
+				}
+
+				// Update internal state
+				IsCompleted = true;
+
+				// Process the pointer
+				TryEndHolding(HoldingState.Canceled);
+				TryRecognize();
+			}
+
+			public void PreventTap()
+			{
+				_settings &= ~GestureSettings.Tap;
+				if ((_settings & GestureSettingsHelper.SupportedGestures) == GestureSettings.None)
+				{
+					IsCompleted = true;
+				}
+			}
+
+			public void PreventDoubleTap()
+			{
+				_settings &= ~GestureSettings.DoubleTap;
+				if ((_settings & GestureSettingsHelper.SupportedGestures) == GestureSettings.None)
+				{
+					IsCompleted = true;
+				}
+			}
+
+			public void PreventRightTap()
+			{
+				_settings &= ~GestureSettings.RightTap;
+				if ((_settings & GestureSettingsHelper.SupportedGestures) == GestureSettings.None)
+				{
+					IsCompleted = true;
+				}
+			}
+
+			public void PreventHolding()
+			{
+				StopHoldingTimer();
+				_settings &= ~(GestureSettings.Hold | GestureSettings.HoldWithMouse);
+				if ((_settings & GestureSettingsHelper.SupportedGestures) == GestureSettings.None)
+				{
+					IsCompleted = true;
+				}
+			}
+
+			private void TryRecognize()
+			{
+				if (Count == 0)
+				{
+					return;
+				}
+
+				var recognized = TryRecognizeRightTap() // We check right tap first as for touch a right tap is a press and hold of the finger :)
+					|| TryRecognizeTap();
+
+				if (!recognized && _recognizer._log.IsEnabled(LogLevel.Information))
+				{
+					_recognizer._log.Info("No gesture recognized");
+				}
+			}
+
+			private bool TryRecognizeTap()
+			{
+				if (_settings.HasFlag(GestureSettings.Tap) && IsTapGesture(LeftButton, this, out _))
+				{
+					// Note: Up cannot be 'null' here!
+
+					_recognizer._lastSingleTap = (PointerIdentifier, Up.Timestamp, Up.Position);
+					_recognizer.Tapped?.Invoke(_recognizer, new TappedEventArgs(PointerType, Down.Position, tapCount: 1));
+
+					return true;
+				}
+				else
+				{
+					return false;
+				}
+			}
+
+			private bool TryRecognizeMultiTap()
+			{
+				if (_settings.HasFlag(GestureSettings.DoubleTap) && IsMultiTapGesture(_recognizer._lastSingleTap, Down))
+				{
+					_recognizer._lastSingleTap = default; // The Recognizer supports only double tap, even on UWP
+					_recognizer.Tapped?.Invoke(_recognizer, new TappedEventArgs(PointerType, Down.Position, tapCount: 2));
+
+					return true;
+				}
+				else
+				{
+					return false;
+				}
+			}
+
+			private bool TryRecognizeRightTap()
+			{
+				if (_settings.HasFlag(GestureSettings.RightTap) && IsRightTapGesture(this, out var isLongPress))
+				{
+					_recognizer.RightTapped?.Invoke(_recognizer, new RightTappedEventArgs(PointerType, Down.Position));
+
+					return true;
+				}
+				else
+				{
+					return false;
+				}
+			}
+
+			private void TryStartHolding(PointerPoint current = null, bool timeElapsed = false)
+			{
+				Debug.Assert(timeElapsed || current != null);
+
+				if (SupportsHolding()
+					&& !_holdingState.HasValue
+					&& (timeElapsed || IsLongPress(this, current))
+					&& IsBeginningTapGesture(LeftButton, this, out _))
+				{
+					StopHoldingTimer();
+
+					_holdingState = HoldingState.Started;
+					_recognizer.Holding?.Invoke(_recognizer, new HoldingEventArgs(Down.PointerId, PointerType, Down.Position, HoldingState.Started));
+				}
+			}
+
+			private void TryEndHolding(HoldingState state)
+			{
+				Debug.Assert(state != HoldingState.Started);
+
+				StopHoldingTimer();
+
+				if (_holdingState == HoldingState.Started)
+				{
+					_holdingState = state;
+					_recognizer.Holding?.Invoke(_recognizer, new HoldingEventArgs(Down.PointerId, PointerType, Down.Position, state));
+				}
+			}
+
+			#region Holding timer
+			private bool SupportsHolding()
+			{
+				switch (PointerType)
+				{
+					case PointerDeviceType.Mouse: return _settings.HasFlag(GestureSettings.HoldWithMouse);
+					default: return _settings.HasFlag(GestureSettings.Hold);
+				}
+			}
+
+			private bool NeedsHoldingTimer()
+			{
+				// When possible we don't start a timer for the Holding event, instead we rely on the fact that
+				// we get a lot of small moves due to the lack of precision of the capture device.
+
+				switch (PointerType)
+				{
+					case PointerDeviceType.Mouse: return _settings.HasFlag(GestureSettings.HoldWithMouse);
+					default: return false;
+				}
+			}
+
+			private void StartHoldingTimer()
+			{
+				if (NeedsHoldingTimer())
+				{
+					_holdingTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+					_holdingTimer.Interval = TimeSpan.FromTicks(HoldMinDelayTicks);
+					_holdingTimer.State = this;
+					_holdingTimer.Tick += OnHoldTimerTick;
+					_holdingTimer.Start();
+				}
+			}
+
+			private void StopHoldingTimer()
+			{
+				_holdingTimer?.Stop();
+				_holdingTimer = null;
+			}
+
+			private static void OnHoldTimerTick(DispatcherQueueTimer timer, object _)
+			{
+				timer.Stop();
+				((Gesture)timer.State).TryStartHolding(timeElapsed: true);
+			}
+			#endregion
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -116,7 +116,7 @@ namespace Windows.UI.Input
 		internal void ProcessUpEvent(PointerPoint value, bool isRelevant)
 		{
 #if NET461 || __WASM__
-			if (_gestures.TryGetValue(value.PointerId, out var points))
+			if (_gestures.TryGetValue(value.PointerId, out var gesture))
 			{
 				_gestures.Remove(value.PointerId);
 #else

--- a/src/Uno.UWP/UI/Input/GestureSettings.cs
+++ b/src/Uno.UWP/UI/Input/GestureSettings.cs
@@ -17,10 +17,8 @@ namespace Windows.UI.Input
 		/// <summary>Enable support for the double-tap gesture.</summary>
 		DoubleTap = 2U,
 		/// <summary>Enable support for the press and hold gesture (from a single touch or pen/stylus contact). The Holding event is raised if a time threshold is crossed before the contact is lifted, an additional contact is detected, or a gesture is started.</summary>
-		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		Hold = 4U,
 		/// <summary>Enable support for the press and hold gesture through the left button on a mouse. The Holding event is raised if a time threshold is crossed before the left button is released or a gesture is started.This gesture can be used to display a context menu.</summary>
-		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		HoldWithMouse = 8U,
 		/// <summary>Enable support for a right-tap interaction. The RightTapped event is raised when the contact is lifted or the mouse button released.</summary>
 		RightTap = 16U,
@@ -86,6 +84,16 @@ namespace Windows.UI.Input
 			| GestureSettings.HoldWithMouse
 			| GestureSettings.RightTap
 			| GestureSettings.CrossSlide;
+
+		/// <summary>
+		/// A combination of all "gesture" flags that can be raised by the GestureRecognizer
+		/// </summary>
+		public const GestureSettings SupportedGestures =
+			GestureSettings.Tap
+			| GestureSettings.DoubleTap
+			| GestureSettings.Hold
+			| GestureSettings.HoldWithMouse
+			| GestureSettings.RightTap;
 
 		/// <summary>
 		/// A combination of all "drag and drop" flags

--- a/src/Uno.UWP/UI/Input/HoldingEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/HoldingEventArgs.cs
@@ -1,0 +1,24 @@
+using Windows.Devices.Input;
+using Windows.Foundation;
+
+namespace Windows.UI.Input
+{
+	public partial class HoldingEventArgs 
+	{
+		internal HoldingEventArgs(uint pointerId, PointerDeviceType type, Point position, HoldingState state)
+		{
+			PointerId = pointerId;
+			PointerDeviceType = type;
+			Position = position;
+			HoldingState = state;
+		}
+
+		internal uint PointerId { get; }
+
+		public PointerDeviceType PointerDeviceType { get; }
+
+		public Point Position { get; }
+
+		public HoldingState HoldingState { get; }
+	}
+}


### PR DESCRIPTION
GitHub Issue: https://github.com/unoplatform/uno/issues/2423

## Feature
Add support of the `UIElement.Holding` event.

## What is the current behavior?
`UIElement.Holding` event is never raised

## What is the new behavior?
`UIElement.Holding` event is raised

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
