### PR TITLE
Support for Windows.System.Launcher on macOS

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -1,6 +1,7 @@
-﻿# Release notes
+# Release notes
 
 ### Features
+- Support for `Launcher` API on macOS, support for special URIs
 - Support for `EmailManager.ShowComposeNewEmailAsync`
 - Add support for `StorageFolder.CreateFileAsync(string path)`
 - Add support for ApplicationViewTitleBar.BackgroundColor on WASM

--- a/doc/articles/features/windows-system.md
+++ b/doc/articles/features/windows-system.md
@@ -4,9 +4,9 @@
 
 ### `LaunchUriAsync` 
 
-This API is supported on iOS, Android and WASM.
+This API is supported on iOS, Android, WASM and macOS.
 
-On iOS and Android, the `ms-settings:` special URI is supported. 
+On iOS, Android and macOS the `ms-settings:` special URI is supported. 
 
 In case of iOS, any such URI opens the main page of system settings (there is no settings deep-linking available on iOS).
 
@@ -52,6 +52,46 @@ In case of Android, we support the following nested URIs.
 | `ms-settings:developers` | `Settings.ActionApplicationDevelopmentSettings` |
 
 
+In case of macOS, we support the following nested URIs, mapped to Preference Panes (/System/Library/PreferencePanes)
+
+| Settings URI | macOS Mapping |
+|--------------|----------|
+| `ms-settings:signinoptions-launchfaceenrollment` | `TouchID` |
+| `ms-settings:launchfingerprintenrollment` | `TouchID` |
+| `ms-settings:signinoptions ` | `Accounts` |
+| `ms-settings:emailandaccounts` | `InternetAccounts` |
+| `ms-settings:appsforwebsites` | `Settings.ActionManageDefaultAppsSettings` |
+| `ms-settings:tabletmode` | `Expose` |
+| `ms-settings:personalization-start` | `Expose` |
+| `ms-settings:personalization-background` | `DesktopScreenEffectsPref` |
+| `ms-settings:personalization` | `Appearance` |
+| `ms-settings:bluetooth` | `Bluetooth` |
+| `ms-settings:dateandtime` | `DateAndTime` |
+| `ms-settings:region` | `Localization` |
+| `ms-settings:typing` | `Keyboard` |
+| `ms-settings:display` | `Displays` |
+| `ms-settings:screenrotation` | `Displays` |
+| `ms-settings:taskbar` | `Dock` |
+| `ms-settings:batterysaver` | `EnergySaver` |
+| `ms-settings:powersleep` | `EnergySaver` |
+| `ms-settings:otherusers` | `FamilySharingPrefPane` |
+| `ms-settings:mousetouchpad` | `Mouse` |
+| `ms-settings:devices-touchpad` | `Trackpad` |
+| `ms-settings:network` | `Network` |
+| `ms-settings:privacy-notifications` | `Notifications` |
+| `ms-settings:printers` | `PrintAndFax` |
+| `ms-settings:privacy` | `Security` |
+| `ms-settings:crossdevice` | `SharingPref` |
+| `ms-settings:quiethours` | `ScreenTime` |
+| `ms-settings:quietmomentshome` | `ScreenTime` |
+| `ms-settings:sound` | `Sound` |
+| `ms-settings:windowsupdate` | `SoftwareUpdate` |
+| `ms-settings:cortana-windowssearch` | `Spotlight` |
+| `ms-settings:cortana` | `Speech` |
+| `ms-settings:storage` | `StartupDisk` |
+| `ms-settings:backup` | `TimeMachine` |
+| `ms-settings:easeofaccess` | `UniversalAccessPref` |
+
 #### Exceptions
 
 - When `uri` argument is `null`, `NullReferenceException` is thrown. Note this differs from UWP where `AccessViolationException` is thrown.
@@ -61,7 +101,7 @@ Exceptions are in line with UWP.
 
 ### `QueryUriSupportAsync` 
 
-This API is supported on iOS and Android and the implementation does not respect the `LaunchQuerySupportType` parameter yet. It also reports the aforementioned special `ms-settings` URIs on Android and iOS as supported.
+This API is supported on iOS, Android and macOS, and the implementation does not respect the `LaunchQuerySupportType` parameter yet. It also reports the aforementioned special `ms-settings` URIs on Android and iOS as supported.
 
 #### Exceptions
 

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System/Launcher.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System/Launcher.cs
@@ -148,7 +148,7 @@ namespace Windows.System
 			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> Launcher.LaunchUriAsync(Uri uri, LauncherOptions options, ValueSet inputData) is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || false
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.System.LaunchQuerySupportStatus> QueryUriSupportAsync( global::System.Uri uri,  global::Windows.System.LaunchQuerySupportType launchQuerySupportType)
 		{

--- a/src/Uno.UWP/System/Launcher.cs
+++ b/src/Uno.UWP/System/Launcher.cs
@@ -17,7 +17,7 @@ namespace Windows.System
 
 		public static Task<bool> LaunchUriAsync(Uri uri)
 		{
-#if __IOS__ || __ANDROID__ || __WASM__
+#if __IOS__ || __ANDROID__ || __WASM__ || __MACOS__
 
 			if (uri == null)
 			{
@@ -48,7 +48,7 @@ namespace Windows.System
 #endif
 		}
 
-#if __ANDROID__ || __IOS__
+#if __ANDROID__ || __IOS__ || __MACOS__
 		public static IAsyncOperation<LaunchQuerySupportStatus> QueryUriSupportAsync(
 			Uri uri,
 			LaunchQuerySupportType launchQuerySupportType)

--- a/src/Uno.UWP/System/Launcher.iOSmacOS.cs
+++ b/src/Uno.UWP/System/Launcher.iOSmacOS.cs
@@ -1,7 +1,12 @@
-﻿#if __IOS__
+﻿#if __IOS__ || __MACOS__
 using System;
 using System.Threading.Tasks;
+#if __IOS__
 using UIKit;
+#else
+using AppKit;
+using Foundation;
+#endif
 using AppleUrl = global::Foundation.NSUrl;
 
 namespace Windows.System
@@ -15,20 +20,30 @@ namespace Windows.System
 				return await HandleSpecialUriAsync(uri);
 			}
 
+			var appleUrl = new AppleUrl(uri.OriginalString);
+#if __IOS__
 			return UIApplication.SharedApplication.OpenUrl(
-				new AppleUrl(uri.OriginalString));
+				appleUrl);
+#else
+			return NSWorkspace.SharedWorkspace.OpenUrl(
+				appleUrl);
+#endif
 		}
 
 
 		public static Task<LaunchQuerySupportStatus> QueryUriSupportPlatformAsync(
 			Uri uri,
 			LaunchQuerySupportType launchQuerySupportType)
-		{            
+		{
 			bool canOpenUri;
 			if (!IsSpecialUri(uri))
 			{
+#if __IOS__
 				canOpenUri = UIApplication.SharedApplication.CanOpenUrl(
 					new AppleUrl(uri.OriginalString));
+#else
+				canOpenUri = NSWorkspace.SharedWorkspace.UrlForApplication(new NSUrl(uri.AbsoluteUri)) != null;
+#endif
 			}
 			else
 			{

--- a/src/Uno.UWP/System/Launcher.macOS.SpecialUris.cs
+++ b/src/Uno.UWP/System/Launcher.macOS.SpecialUris.cs
@@ -1,0 +1,103 @@
+﻿#if __MACOS__
+using Foundation;
+using AppKit;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Windows.System
+{
+	public static partial class Launcher
+	{
+		private const string MicrosoftSettingsUri = "ms-settings";
+
+		private static readonly Lazy<Dictionary<string, string>> _settingsHandlers = new Lazy<Dictionary<string, string>>(() =>
+		{
+			var settings = new Dictionary<string, string>()
+			{
+				{ "signinoptions-launchfaceenrollment", "TouchID" },
+				{ "signinoptions-launchfingerprintenrollment", "TouchID" },
+				{ "signinoptions", "Accounts" },
+				{ "emailandaccounts", "InternetAccounts" },
+				{ "tabletmode", "Expose" },
+				{ "personalization-start", "Expose" },
+				{ "personalization-background", "DesktopScreenEffectsPref" },
+				{ "personalization", "Appearance" },
+				{ "bluetooth", "Bluetooth" },
+				{ "dateandtime", "DateAndTime" },
+				{ "region", "Localization" },
+				{ "typing", "Keyboard" },
+				{ "display", "Displays" },
+				{ "screenrotation", "Displays" },
+				{ "taskbar", "Dock" },
+				{ "batterysaver", "EnergySaver" },
+				{ "powersleep", "EnergySaver" },
+				{ "otherusers", "FamilySharingPrefPane" },
+				{ "mousetouchpad", "Mouse" },
+				{ "devices-touchpad", "Trackpad" },
+				{ "network", "Network" },
+				{ "privacy-notifications", "Notifications" },
+				{ "printers", "PrintAndFax" },
+				{ "privacy", "Security" },
+				{ "crossdevice", "SharingPref" },
+				{ "quiethours", "ScreenTime" },
+				{ "quietmomentshome", "ScreenTime" },
+				{ "sound", "Sound" },
+				{ "windowsupdate", "SoftwareUpdate" },
+				{ "cortana-windowssearch", "Spotlight" },
+				{ "cortana", "Speech" },
+				{ "storage", "StartupDisk" },
+				{ "backup", "TimeMachine" },
+				{ "easeofaccess", "UniversalAccessPref" }
+			};
+			return settings;
+		});
+
+		private static bool CanHandleSpecialUri(Uri uri)
+		{
+			switch (uri.Scheme.ToLowerInvariant())
+			{
+				case MicrosoftSettingsUri: return true;
+				default: return false;
+			}
+		}
+
+		private static Task<bool> HandleSpecialUriAsync(Uri uri)
+		{
+			switch (uri.Scheme.ToLowerInvariant())
+			{
+				case MicrosoftSettingsUri: return HandleSettingsUriAsync(uri);
+				default: throw new InvalidOperationException("This special URI is not supported on iOS");
+			}
+		}
+
+		private static Task<bool> HandleSettingsUriAsync(Uri uri)
+		{
+			var settingsString = uri.AbsolutePath.ToLowerInvariant();
+			//get exact match first
+			_settingsHandlers.Value.TryGetValue(settingsString, out var launchAction);
+			if (string.IsNullOrEmpty(launchAction))
+			{
+				var secondaryMatch = _settingsHandlers.Value
+					.Where(handler =>
+						settingsString.StartsWith(handler.Key, StringComparison.InvariantCultureIgnoreCase))
+					.Select(handler => handler.Value)
+					.FirstOrDefault();
+				launchAction = secondaryMatch;
+			}
+			NSUrl url;
+			if (string.IsNullOrEmpty(launchAction))
+			{
+				url = NSUrl.CreateFileUrl(new string[] { "/System/Applications/System Preferences.app" });
+			}
+			else
+			{
+				url = NSUrl.CreateFileUrl(new string[] { $@"/System/Library/PreferencePanes/{launchAction}.prefPane" });
+			}
+			NSWorkspace.SharedWorkspace.OpenUrl(url);
+			return Task.FromResult(true);
+		}	
+	}
+}
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): #2499

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Launcher API is not supported on macOS.


## What is the new behavior?

Launcher API is supported on macOS and on par with iOS/Android. Includes support for Query and many special preference URIs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
