### PR TITLE
Support DesignMode2Enabled

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -19,6 +19,7 @@
 -
 
 ### Bug fixes
+- [#2506] `DesignMode.DesignMode2Enabled` no longer throws (is always `false` on non-UWP platforms)
 - [#915] FontFamily values are now properly parsed on WebAssembly, updated docs with new info
 - [#2213] Fixed `ApplicationData` on MacOS, added support for `LocalSettings`
 - Made macOS Samples app skeleton runnable (temporarily removed ApplicationData check on startup, fixed reference), added xamarinmacos20 to crosstargeting_override sample

--- a/src/Uno.UWP/ApplicationModel/DesignMode.cs
+++ b/src/Uno.UWP/ApplicationModel/DesignMode.cs
@@ -7,5 +7,7 @@ namespace Windows.ApplicationModel
 	public static partial class DesignMode
 	{
 		public static bool DesignModeEnabled => false;
+
+		public static bool DesignMode2Enabled => false;
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/DesignMode.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/DesignMode.cs
@@ -8,16 +8,7 @@ namespace Windows.ApplicationModel
 	public  partial class DesignMode 
 	{
 		// Skipping already declared property DesignModeEnabled
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static bool DesignMode2Enabled
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool DesignMode.DesignMode2Enabled is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property DesignMode2Enabled
 		// Forced skipping of method Windows.ApplicationModel.DesignMode.DesignMode2Enabled.get
 		// Forced skipping of method Windows.ApplicationModel.DesignMode.DesignModeEnabled.get
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): #2506 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`DesignMode2Enabled` throws.

## What is the new behavior?

`DesignMode2Enabled` always returns `false`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)