### PR TITLE
[Android] Added support for IsScreenCaptureEnabled

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -1,6 +1,8 @@
 # Release notes
 
 ### Features
+
+- Support for `ApplicationView.IsScreenCaptureEnabled` on Android
 - Add support for `StorageFile.DeleteAsync()`
 - Support for `PointerDown`, `PointerUp` `PointerEntered`, `PointerExited` and `PointerMoved` events on macOS
 - Support for `Launcher` API on macOS, support for special URIs

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -201,6 +201,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_ViewManagement\IsScreenCaptureEnabledTests.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_ViewManagement\TitleBarColorTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3035,6 +3039,9 @@
       <DependentUpon>JumpListTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_StartScreen\JumpListTestsViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_ViewManagement\IsScreenCaptureEnabledTests.xaml.cs">
+      <DependentUpon>IsScreenCaptureEnabledTests.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_ViewManagement\TitleBarColorTests.xaml.cs">
       <DependentUpon>TitleBarColorTests.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml
@@ -1,16 +1,21 @@
-﻿<UserControl
-    x:Class="UITests.Shared.Windows_UI_ViewManagement.IsScreenCaptureEnabledTests"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UITests.Shared.Windows_UI_ViewManagement"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    d:DesignHeight="300"
-    d:DesignWidth="400">
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_ViewManagement.IsScreenCaptureEnabledTests"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_ViewManagement"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
 
 	<StackPanel>
-		<CheckBox Content="Is screen capture enabled" x:Name="CaptureCheckBox" Checked="CaptureCheckBoxChanged" Unchecked="CaptureCheckBoxChanged" />
-		<TextBlock x:Name="InfoMessage" Text="Screen capture is disabled now, you should not be able to take screenshots" Visibility="Collapsed" Foreground="Red" />
+		<CheckBox Content="Is screen capture enabled"
+				  x:Name="CaptureCheckBox"
+				  Checked="CaptureCheckBoxChanged"
+				  Unchecked="CaptureCheckBoxChanged" />
+		<TextBlock x:Name="InfoMessage"
+				   Text="Screen capture is disabled now, you should not be able to take screenshots"
+				   Visibility="Collapsed"
+				   Foreground="Red" />
 	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_ViewManagement.IsScreenCaptureEnabledTests"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_ViewManagement"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <StackPanel>
+		<CheckBox Content="Is screen capture enabled" x:Name="CaptureCheckBox" IsThreeState="False" Checked="CaptureCheckBoxChanged" Unchecked="CaptureCheckBoxChanged" />
+		<TextBlock x:Name="InfoMessage" Text="Screen capture is disabled now, you should not be able to take screenshots" Visibility="Collapsed" Foreground="Red" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml
@@ -9,8 +9,8 @@
     d:DesignHeight="300"
     d:DesignWidth="400">
 
-    <StackPanel>
-		<CheckBox Content="Is screen capture enabled" x:Name="CaptureCheckBox" IsThreeState="False" Checked="CaptureCheckBoxChanged" Unchecked="CaptureCheckBoxChanged" />
+	<StackPanel>
+		<CheckBox Content="Is screen capture enabled" x:Name="CaptureCheckBox" Checked="CaptureCheckBoxChanged" Unchecked="CaptureCheckBoxChanged" />
 		<TextBlock x:Name="InfoMessage" Text="Screen capture is disabled now, you should not be able to take screenshots" Visibility="Collapsed" Foreground="Red" />
 	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml.cs
@@ -14,7 +14,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
-
+using Windows.Foundation.Metadata;
 
 namespace UITests.Shared.Windows_UI_ViewManagement
 {

--- a/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+
+namespace UITests.Shared.Windows_UI_ViewManagement
+{
+	[SampleControlInfo("Windows.UI.ViewManagement", "IsScreenCaptureEnabled", description: "Allows disabling screen capture (currently available on Android only)")]
+	public sealed partial class IsScreenCaptureEnabledTests : UserControl
+    {
+        public IsScreenCaptureEnabledTests()
+        {
+            this.InitializeComponent();
+#if __ANDROID__ || WINDOWS_UWP
+			CaptureCheckBox.IsChecked = ApplicationView.GetForCurrentView().IsScreenCaptureEnabled;
+#else
+			InfoMessage.Text = "API not supported on this platform.";
+			CaptureCheckBox.IsEnabled = false;
+#endif
+		}
+
+		private void CaptureCheckBoxChanged(object sender, RoutedEventArgs e)
+		{
+			var checkBox = (CheckBox)sender;
+			var enabled = checkBox.IsChecked ?? false;
+			ApplicationView.GetForCurrentView().IsScreenCaptureEnabled = enabled;
+			InfoMessage.Visibility = enabled ? Visibility.Collapsed : Visibility.Visible;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml.cs
@@ -20,16 +20,19 @@ namespace UITests.Shared.Windows_UI_ViewManagement
 {
 	[SampleControlInfo("Windows.UI.ViewManagement", "IsScreenCaptureEnabled", description: "Allows disabling screen capture (currently available on Android only)")]
 	public sealed partial class IsScreenCaptureEnabledTests : UserControl
-    {
-        public IsScreenCaptureEnabledTests()
-        {
-            this.InitializeComponent();
-#if __ANDROID__ || WINDOWS_UWP
-			CaptureCheckBox.IsChecked = ApplicationView.GetForCurrentView().IsScreenCaptureEnabled;
-#else
-			InfoMessage.Text = "API not supported on this platform.";
-			CaptureCheckBox.IsEnabled = false;
-#endif
+	{
+		public IsScreenCaptureEnabledTests()
+		{
+			this.InitializeComponent();
+			if (ApiInformation.IsPropertyPresent("Windows.UI.ViewManagement.ApplicationView", "IsScreenCaptureEnabled"))
+			{
+				CaptureCheckBox.IsChecked = ApplicationView.GetForCurrentView().IsScreenCaptureEnabled;
+			}
+			else
+			{
+				InfoMessage.Text = "API not supported on this platform.";
+				CaptureCheckBox.IsEnabled = false;
+			}
 		}
 
 		private void CaptureCheckBoxChanged(object sender, RoutedEventArgs e)

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.ViewManagement/ApplicationView.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.ViewManagement/ApplicationView.cs
@@ -21,7 +21,7 @@ namespace Windows.UI.ViewManagement
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  bool IsScreenCaptureEnabled
 		{

--- a/src/Uno.UWP/UI/ViewManagement/ApplicationView.Android.cs
+++ b/src/Uno.UWP/UI/ViewManagement/ApplicationView.Android.cs
@@ -1,4 +1,5 @@
 ﻿#if __ANDROID__
+using System;
 using Android.App;
 using Android.Views;
 using Uno.Extensions;
@@ -11,6 +12,33 @@ namespace Windows.UI.ViewManagement
 {
 	partial class ApplicationView
 	{
+		public bool IsScreenCaptureEnabled
+		{
+			get
+			{
+				if (!(ContextHelper.Current is Activity activity))
+				{
+					throw new InvalidOperationException($"{nameof(IsScreenCaptureEnabled)} API must be called when Activity is created");
+				}
+				return !activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.Secure);
+			}
+			set
+			{
+				if (!(ContextHelper.Current is Activity activity))
+				{
+					throw new InvalidOperationException($"{nameof(IsScreenCaptureEnabled)} API must be called when Activity is created");
+				}
+				if (value)
+				{
+					activity.Window.ClearFlags(WindowManagerFlags.Secure);
+				}
+				else
+				{
+					activity.Window.SetFlags(WindowManagerFlags.Secure, WindowManagerFlags.Secure);
+				}
+			}
+		}
+
 		internal void SetVisibleBounds(Rect newVisibleBounds)
 		{
 			if (newVisibleBounds != VisibleBounds)


### PR DESCRIPTION
GitHub Issue (If applicable): #2524 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`IsScreenCaptureEnabled` is not supported.

## What is the new behavior?

`IsScreenCaptureEnabled` is supported on Android.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)