### PR TITLE
UI Tests chat box, Text box and Button

### DIFF
--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -42,8 +42,10 @@ else
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml.FocusManagerDirectionTests' or \
 		namespace = 'SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.PivotTests' or \	
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media_Animation.DoubleAnimation_Tests'
+		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media_Animation.DoubleAnimation_Tests' or \
+		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.PivotTests' or \
+		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ChatBoxTests' or \
+		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.Button_Tests'
 	"
 fi
 

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
@@ -390,7 +390,7 @@ namespace SamplesApp.UITests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.iOS, Platform.Browser)] // Android is disabled https://github.com/unoplatform/uno/issues/1630
+		[ActivePlatforms(Platform.iOS)] // WASM & Android are disabled https://github.com/unoplatform/uno/issues/1630
 		public void TextBox_Disable()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Disabled");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_IsEnabled_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_IsEnabled_Automated.cs
@@ -281,7 +281,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 			var button01 = _app.Marked("button01");
 
 			// Click on button01 and verify text and number of clicks in all text blocks
-			button01.Tap();
+			button01.FastTap();
 			VerifyTextBlockText("Button button01 Clicked (1)", "Button button01 Tapped (1)", "Command Button 01 (1)");
 
 			// Again click on button01 and verify text and number of clicks in all text blocks

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_IsEnabled_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_IsEnabled_Automated.cs
@@ -257,6 +257,96 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 			Check(true, "Assert after another double click while myCheckBox should stay checked");
 		}
 
+		private void VerifyTextBlockText(string text1, string text2, string text3)
+		{
+			var result = _app.Marked("result");
+			var resultTapped = _app.Marked("resultTapped");
+			var resultCommand = _app.Marked("resultCommand");
+
+			Assert.AreEqual(text1, result.GetDependencyPropertyValue("Text")?.ToString());
+			Assert.AreEqual(text2, resultTapped.GetDependencyPropertyValue("Text")?.ToString());
+			Assert.AreEqual(text3, resultCommand.GetDependencyPropertyValue("Text")?.ToString());
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Uno.UITest.Helpers.Queries.Platform.iOS, Uno.UITest.Helpers.Queries.Platform.Android)] // Wasm is disabled https://github.com/unoplatform/uno/issues/2664
+		public void ButtonNative_Button01_Validation()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.Buttons_Native");
+
+			// Verify text of all text blocks initially
+			VerifyTextBlockText("No value", "No value", "No command");
+
+			var button01 = _app.Marked("button01");
+
+			// Click on button01 and verify text and number of clicks in all text blocks
+			button01.Tap();
+			VerifyTextBlockText("Button button01 Clicked (1)", "Button button01 Tapped (1)", "Command Button 01 (1)");
+
+			// Again click on button01 and verify text and number of clicks in all text blocks
+			button01.Tap();
+			VerifyTextBlockText("Button button01 Clicked (2)", "Button button01 Tapped (2)", "Command Button 01 (2)");
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Uno.UITest.Helpers.Queries.Platform.iOS, Uno.UITest.Helpers.Queries.Platform.Android)] // Wasm is disabled https://github.com/unoplatform/uno/issues/2664
+		public void ButtonNative_Button02_Validation()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.Buttons_Native");
+
+			// Verify text of all text blocks initially
+			VerifyTextBlockText("No value", "No value", "No command");
+
+			var button02 = _app.Marked("button02");
+			var enableButton02 = _app.Marked("enableButton02");
+
+			// Click on button02 and verify text- It should not change as button 02 is not enabled
+			button02.Tap();
+			VerifyTextBlockText("No value", "No value", "No command");
+
+			enableButton02.Tap();
+			VerifyTextBlockText("No value", "No value", "No command");
+
+			// Again click on button02 and verify text and number of clicks in all text blocks
+			button02.Tap();
+			VerifyTextBlockText("Button button02 Clicked (1)", "Button button02 Tapped (1)", "Command Button 02 (1)");
+
+			// Again click on button02 and verify text and number of clicks in all text blocks
+			button02.Tap();
+			VerifyTextBlockText("Button button02 Clicked (2)", "Button button02 Tapped (2)", "Command Button 02 (2)");
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Uno.UITest.Helpers.Queries.Platform.iOS, Uno.UITest.Helpers.Queries.Platform.Android)] // Wasm is disabled https://github.com/unoplatform/uno/issues/2664
+		public void ButtonNative_ToggleSwitch_Validation()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.Buttons_Native");
+
+			// Verify text of all text blocks initially
+			VerifyTextBlockText("No value", "No value", "No command");
+
+			var toggleSwitch02 = _app.Marked("toggleSwitch02");
+			var enableToggleSwitch02 = _app.Marked("enableToggleSwitch02");
+
+			// Click on toggleSwitch02 and verify text- It should not change as toggleSwitch02 is not enabled
+			toggleSwitch02.Tap();
+			VerifyTextBlockText("No value", "No value", "No command");
+
+			enableToggleSwitch02.Tap();
+			VerifyTextBlockText("No value", "No value", "No command");
+
+			// Again click on toggleSwitch02 and verify text and number of clicks in all text blocks
+			toggleSwitch02.Tap();
+			VerifyTextBlockText("ToggleSwitch toggleSwitch02 Toggled True (1)", "No value", "No command");
+
+			// Again click on toggleSwitch02 and verify text and number of clicks in all text blocks
+			toggleSwitch02.Tap();
+			VerifyTextBlockText("ToggleSwitch toggleSwitch02 Toggled False (2)", "No value", "No command");
+		}
+
 		[Test]
 		[AutoRetry]
 		public void Button_NestedButtons_Validation()

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ChatBoxTests/UnoSamples_Tests.ChatBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ChatBoxTests/UnoSamples_Tests.ChatBoxTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ChatBoxTests
+{
+	[TestFixture]
+	public partial class ChatBoxTests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void ChatBoxTest_Validation()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ChatBox.ChatBox");
+
+			var clicksCountTextBlock = _app.Marked("ClicksCountTextBlock");
+			var clickButton = _app.Marked("ClickButton");
+			var textBox = _app.Marked("TextBox");
+
+			// Validate number of clicks
+			Assert.AreEqual("You clicked 0 times", clicksCountTextBlock.GetDependencyPropertyValue("Text")?.ToString());
+			clickButton.Tap();
+			Assert.AreEqual("You clicked 1 times", clicksCountTextBlock.GetDependencyPropertyValue("Text")?.ToString());
+			clickButton.Tap();
+			Assert.AreEqual("You clicked 2 times", clicksCountTextBlock.GetDependencyPropertyValue("Text")?.ToString());
+
+			// Validate text box
+			textBox.Tap();
+			textBox.ClearText();
+			textBox.EnterText("Testing");
+			Assert.AreEqual("Testing", textBox.GetDependencyPropertyValue("Text")?.ToString());
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -414,5 +414,61 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			Assert.AreEqual("Testing text property", textChangedTextBlock.GetDependencyPropertyValue("Text")?.ToString());
 			Assert.AreEqual("Testing text property", lostFocusTextBlock.GetDependencyPropertyValue("Text")?.ToString());
 		}
+
+		[Test]
+		[AutoRetry]
+		public void TextBox_DisabledWithAlphabet_Validation()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Disabled");
+
+			// Tap in text box and verify the disability with alphabet
+			var disableOnfTextBox = _app.Marked("DisableOnfTextBox");
+			disableOnfTextBox.Tap();
+			disableOnfTextBox.EnterText("Text box is not disabled");
+			Assert.AreEqual("Text box is not disabled", disableOnfTextBox.GetDependencyPropertyValue("Text")?.ToString());
+			disableOnfTextBox.ClearText();
+			disableOnfTextBox.EnterText("Disabled with f");
+			Assert.AreEqual("Disabled with ", disableOnfTextBox.GetDependencyPropertyValue("Text")?.ToString());
+		}
+
+		[Test]
+		[AutoRetry]
+		public void TextBox_DisabledWithCheckBox_Validation()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Disabled");
+
+			var disabledWithCheckboxTextBox = _app.Marked("DisabledWithCheckboxTextBox");
+			var enabledCheckBox = _app.Marked("EnabledCheckBox");
+
+			// Tap in text box and verify the disability with Checkbox
+			disabledWithCheckboxTextBox.Tap();
+			disabledWithCheckboxTextBox.EnterText("Text box is not disabled");
+			Assert.AreEqual("Text box is not disabled", disabledWithCheckboxTextBox.GetDependencyPropertyValue("Text")?.ToString());
+			enabledCheckBox.Tap();
+
+			disabledWithCheckboxTextBox.ClearText();
+			Assert.AreNotEqual(string.Empty, disabledWithCheckboxTextBox.GetDependencyPropertyValue("Text")?.ToString());
+			Assert.AreEqual("Text box is not disabled", disabledWithCheckboxTextBox.GetDependencyPropertyValue("Text")?.ToString());
+		}
+
+		[Test]
+		[AutoRetry]
+		public void TextBox_DisabledWithToggleButton_Validation()
+		{
+			Run("Uno.UI.Samples.Content.UITests.TextBoxControl.TextBox_Disabled_State");
+
+			var toggleSwitch = _app.Marked("ToggleSwitch");
+			var toggleControlledTextBox = _app.Marked("ToggleControlledTextBox");
+
+			// Tap in text box and verify the disability with toggle button
+			toggleControlledTextBox.Tap();
+			toggleControlledTextBox.EnterText("Text box is not disabled");
+			Assert.AreEqual("Text box is not disabled", toggleControlledTextBox.GetDependencyPropertyValue("Text")?.ToString());
+			toggleSwitch.Tap();
+
+			toggleControlledTextBox.ClearText();
+			Assert.AreNotEqual(string.Empty, toggleControlledTextBox.GetDependencyPropertyValue("Text")?.ToString());
+			Assert.AreEqual("Text box is not disabled", toggleControlledTextBox.GetDependencyPropertyValue("Text")?.ToString());
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ChatBox/ChatBox.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ChatBox/ChatBox.xaml
@@ -12,27 +12,30 @@
 	<controls:SampleControl SampleDescription="Translate the content above the keyboard after opening it (like a chat app). ">
 		<controls:SampleControl.SampleContent>
 			<DataTemplate>
-				<Grid extensions:InputPanelExtensions.IsPanIntoView="True">					
+				<Grid extensions:InputPanelExtensions.IsPanIntoView="True">
 					<StackPanel VerticalAlignment="Bottom">
 						<TextBlock Text="Known issue : On iOS only - When focusing the TextBox, the keyboard appears and our animation is played to translate upwards the content (the whole grid). But when clicking on a button (i.e : send  a message), the focus is lost, the keyboard hidden, and the tap is triggered. The tap should be triggered before the animation hide the keyboard."
 							   TextWrapping="Wrap"
 							   HorizontalAlignment="Center"
 							   Margin="20"/>
-						
-						<TextBlock HorizontalAlignment="Center">
-								<Run Text="You clicked" />							
-								<Run Text="{Binding ClickCount}" />						
-								<Run Text=" times" />
+
+						<TextBlock x:Name="ClicksCountTextBlock"
+									HorizontalAlignment="Center">
+									<Run Text="You clicked" />
+									<Run Text="{Binding ClickCount}" />
+									<Run Text="times" />
 						</TextBlock>
 
 						<StackPanel  Orientation="Horizontal" VerticalAlignment="Bottom"
 									  HorizontalAlignment="Center"
-									  Background="Aquamarine">					
-							<TextBox Text="TextBox"
+									  Background="Aquamarine">
+							<TextBox x:Name="TextBox"
+									 Text="TextBox"
 									 AcceptsReturn="True"
 									 Margin="20" />
 
-							<Button Content="Click on me"
+							<Button x:Name="ClickButton"
+									Content="Click on me"
 									Command="{Binding [ToggleHeader]}"
 									Margin="20" />
 						</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Disabled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Disabled.xaml
@@ -1,22 +1,23 @@
-﻿<UserControl
-    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Disabled"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBox"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    d:DesignHeight="300"
-    d:DesignWidth="400">
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Disabled"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
 
 	<StackPanel Margin="50">
 		<TextBox PlaceholderText="disables on letter f..."
-					 x:Name="DisableOnf"
-					 BeforeTextChanging="DisableOnf_BeforeTextChanging" />
-			<TextBox />
-			<TextBox IsEnabled="False" />
-			<TextBox IsEnabled="{Binding ElementName=EnabledCheckBox, Path=IsChecked}" />
-			<CheckBox x:Name="EnabledCheckBox" Content="Is last TextBox enabled?"
-					  IsChecked="True" />
-		</StackPanel>
+				 x:Name="DisableOnfTextBox"
+				 BeforeTextChanging="DisableOnf_BeforeTextChanging" />
+		<TextBox />
+		<TextBox IsEnabled="False" />
+		<TextBox x:Name="DisabledWithCheckboxTextBox"
+				 IsEnabled="{Binding ElementName=EnabledCheckBox, Path=IsChecked}" />
+		<CheckBox x:Name="EnabledCheckBox"
+				  Content="Is last TextBox enabled?"
+				  IsChecked="True" />
+	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Disabled_State.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Disabled_State.xaml
@@ -1,28 +1,29 @@
-<UserControl
-	x:Class="Uno.UI.Samples.Content.UITests.TextBoxControl.TextBox_Disabled_State"
-	xmlns:controls="using:Uno.UI.Samples.Controls"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:ios="http://uno.ui/ios"
-	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:android="http://uno.ui/android"
-	mc:Ignorable="d ios android"
-	d:DesignHeight="2000"
-	d:DesignWidth="400">
+<UserControl x:Class="Uno.UI.Samples.Content.UITests.TextBoxControl.TextBox_Disabled_State"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:ios="http://uno.ui/ios"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:android="http://uno.ui/android"
+			 mc:Ignorable="d ios android"
+			 d:DesignHeight="2000"
+			 d:DesignWidth="400">
 
 	<controls:SampleControl SampleDescription="Description for sample of TextBox_Disabled_State">
 		<controls:SampleControl.SampleContent>
 			<DataTemplate>
 				<StackPanel>
 					<ToggleSwitch IsOn="{Binding [IsEnabled], Mode=TwoWay}"
-                                  OnContent="TextBox is Enabled"
-                                  OffContent="TextBox is Disabled"/>
-                    <TextBlock Text="When TextBox is disabled and we should not be able to use it." />
-					<TextBlock Text="Enter your Name"/>
-                    <TextBox IsEnabled="{Binding [IsEnabled]}"
-                             PlaceholderText="Name"/>
+								  OnContent="TextBox is Enabled"
+								  OffContent="TextBox is Disabled"
+								  x:Name="ToggleSwitch" />
+					<TextBlock Text="When TextBox is disabled and we should not be able to use it." />
+					<TextBlock Text="Enter your Name" />
+					<TextBox IsEnabled="{Binding [IsEnabled]}"
+							 PlaceholderText="Name"
+							 x:Name="ToggleControlledTextBox" />
 				</StackPanel>
 			</DataTemplate>
 		</controls:SampleControl.SampleContent>


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

UI Tests related to chat box, Text box and Button.


## What is the current behavior?
UI tests doen not exists.

## What is the new behavior?
Added new UI tests.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_sprints/taskboard/Umbrella%20Team/Umbrella/2020/Sprint%202?workitem=172736
https://nventive.visualstudio.com/Umbrella/_sprints/taskboard/Umbrella%20Team/Umbrella/2020/Sprint%202?workitem=172616
https://nventive.visualstudio.com/Umbrella/_sprints/taskboard/Umbrella%20Team/Umbrella/2020/Sprint%202?workitem=173200