### PR TITLE
Prevent flicker of animation on iOS 

### DIFF
--- a/src/Uno.UWP/UI/Composition/CoreAnimation.iOS.cs
+++ b/src/Uno.UWP/UI/Composition/CoreAnimation.iOS.cs
@@ -159,7 +159,9 @@ namespace Windows.UI.Composition
 
 			animation.Duration = durationMilliseconds / __millisecondsPerSecond;
 			animation.FillMode = CAFillMode.Forwards;
-			animation.RemovedOnCompletion = true;
+			// Let the 'OnAnimationStop' forcefully apply the final value before removing the animation.
+			// That's required for Storyboards that animating multiple properties of the same object at once.
+			animation.RemovedOnCompletion = false; 
 			animation.AnimationStarted += OnAnimationStarted(animation);
 			animation.AnimationStopped += OnAnimationStopped(animation);
 
@@ -285,6 +287,11 @@ namespace Windows.UI.Composition
 				if (_stop.reason == StopReason.Completed)
 				{
 					Debug.Assert(args.Finished);
+
+					// We have to remove the animation only in case of 'StopReason.Completed',
+					// for other cases it's what we actually did to request the stop.
+					layer?.RemoveAnimation(_key);
+
 					_onCompleted();
 				}
 			}


### PR DESCRIPTION
## Bugfix
Prevent flicker of animation on iOS when animating multiple properties of the same target

## What is the current behavior?
At the end of a storyboard that animates multiple properties of a `Transform`, we can notice a flicker

## What is the new behavior?
No flicker

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ _No way to detect flicker in UI tests_
- [ ] ~~[Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~
- [ ] ~~Associated with an issue (GitHub or internal)~~

## Other information
Fixes regression introduced by https://github.com/unoplatform/uno/pull/2532