### PR TITLE
fixed sample for TextBox InputScope=Number

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Input_InputScope_Number.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Input_InputScope_Number.xaml
@@ -14,6 +14,7 @@
 	<TextBox Header="Enter number:"
 	         PlaceholderText="placeHolder"
 	         Text="{Binding [MyInput], Mode=TwoWay}"
+	         InputScope="Number"
 	         AcceptsReturn="False" />
 
 </UserControl>


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type
What kind of change does this PR introduce?
- Other: Sample

## What is the current behavior?
The "TextBox -> Input_InputScope_Number" sample doesn't have `InputScope` assigned.

## What is the new behavior?
Added `InputScope=Number` to the sample.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)