### PR TITLE
Prevent the context menu on wasm while not in a TextBox

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -18,7 +18,7 @@
 - `TransformToVisual` now returns a real transform to convert coordinates between views (was only returning a translate transform to offset the origin of controls)
 - Multiple pointers at same time on screen (a.k.a. Multi-touch) are now supported
 - Add support for WinUI 2.3 [`NumberBox`](https://docs.microsoft.com/en-us/uwp/api/microsoft.ui.xaml.controls.numberbox?view=winui-2.3)
-- Add support of the `UIElement.RightTapped` event
+- Add support of the `UIElement.RightTapped` event (The context menu won't appear anymore on WASM, except for the `TextBox`)
 - Add support of the `UIElement.Holding` event
 
 ### Breaking changes

--- a/doc/articles/features/routed-events.md
+++ b/doc/articles/features/routed-events.md
@@ -260,3 +260,7 @@ will never be fired. The `Velocities` properties of event args are not implement
 They are generated from the PointerXXX events (using the `Windows.UI.Input.GestureRecognizer`) and are bubbling in managed only.
 
 Note that `Tapped` and `DoubleTapped` are not linked in any way to a native equivalent, but are fully interpreted in managed code.
+
+In order to match the WinUI behavior, on WASM the default "Context menu" of the browser is disabled (except for the `TextBox`), 
+no matter if you use / handle the `RightTapped` event or not.
+Be aware that on some browser (Firefox), user can still request to get the "Context menu" on right click.

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -1539,6 +1539,11 @@ var Uno;
                     document.body.appendChild(this.containerElement);
                 }
                 window.addEventListener("resize", x => this.resize());
+                window.addEventListener("contextmenu", x => {
+                    if (!(x.target instanceof HTMLInputElement)) {
+                        x.preventDefault();
+                    }
+                });
             }
             removeLoading() {
                 if (!this.loadingElementId) {
@@ -2355,6 +2360,10 @@ var Windows;
                 }
                 if (!this.isIndexDBAvailable()) {
                     console.warn("IndexedDB is not available (private mode or uri starts with file:// ?), changes will not be persisted.");
+                    return;
+                }
+                if (typeof IDBFS === 'undefined') {
+                    console.warn(`IDBFS is not enabled in mono's configuration, persistence is disabled`);
                     return;
                 }
                 console.debug("Making persistent: " + path);

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -1601,6 +1601,11 @@
 			}
 
 			window.addEventListener("resize", x => this.resize());
+			window.addEventListener("contextmenu", x => {
+				if (!(x.target instanceof HTMLInputElement)) {
+					x.preventDefault();
+				}
+			})
 		}
 
 		private removeLoading() {


### PR DESCRIPTION
GitHub issue: https://github.com/unoplatform/uno/issues/2423

## Feature
Disable the context menu on WASM

## What is the current behavior?
Application has to disable it themselves, or has to handle proper pointer events.

## What is the new behavior?
Context menu is disabled by default

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~[Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~ _(We cannot automate right tapped UI test yet)_
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
