### PR TITLE
.Tap() -> .FastTap()

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/NumberBoxTests/Given_NumberBox.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/NumberBoxTests/Given_NumberBox.cs
@@ -27,11 +27,11 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 			var downButton = numBox.Descendant().Marked("DownSpinButton");
 
 			Console.WriteLine("Assert that up button increases value by 1");
-			upButton.Tap();
+			upButton.FastTap();
 			Assert.AreEqual(1, numBox.GetDependencyPropertyValue<double>("Value"));
 
 			Console.WriteLine("Assert that down button decreases value by 1");
-			downButton.Tap();
+			downButton.FastTap();
 			Assert.AreEqual(0, numBox.GetDependencyPropertyValue<double>("Value"));
 
 			Console.WriteLine("Change SmallChange value to 5");
@@ -39,28 +39,28 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 			smallChangeNumBox.SetDependencyPropertyValue("Text", "5");
 
 			Console.WriteLine("Assert that up button increases value by 5");
-			upButton.Tap();
+			upButton.FastTap();
 			Assert.AreEqual(5, numBox.GetDependencyPropertyValue<double>("Value"));
 
-			_app.Tap("MinCheckBox");
-			_app.Tap("MaxCheckBox");
+			_app.FastTap("MinCheckBox");
+			_app.FastTap("MaxCheckBox");
 
 			numBox.SetDependencyPropertyValue("Value", "100");
-			_app.Tap("WrapCheckBox");
+			_app.FastTap("WrapCheckBox");
 
 			Console.WriteLine("Assert that when wrapping is on, and value is at max, clicking the up button wraps to the min value.");
-			upButton.Tap();
+			upButton.FastTap();
 			Assert.AreEqual(0, numBox.GetDependencyPropertyValue<double>("Value"));
 
 			Console.WriteLine("Assert that when wrapping is on, clicking the down button wraps to the max value.");
-			downButton.Tap();
+			downButton.FastTap();
 			Assert.AreEqual(100, numBox.GetDependencyPropertyValue<double>("Value"));
 
 			Console.WriteLine("Assert that incrementing after typing in a value validates the text first.");
 			numBox.ClearText();
 			numBox.EnterText("50");
 			_app.PressEnter();
-			upButton.Tap();
+			upButton.FastTap();
 			Assert.AreEqual(55, numBox.GetDependencyPropertyValue<double>("Value"));
 		}
 
@@ -70,8 +70,8 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 		{
 			Run("UITests.Shared.Microsoft_UI_Xaml_Controls.NumberBoxTests.MUX_Test");
 
-			_app.Tap("MinCheckBox");
-			_app.Tap("MaxCheckBox");
+			_app.FastTap("MinCheckBox");
+			_app.FastTap("MaxCheckBox");
 
 			var numBox = _app.Marked("TestNumberBox");
 			Assert.AreEqual(0, numBox.GetDependencyPropertyValue<double>("Minimum"));
@@ -122,8 +122,8 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 			var upButton = numBox.Descendant().Marked("UpSpinButton");
 			var downButton = numBox.Descendant().Marked("DownSpinButton");
 
-			_app.Tap("MinCheckBox");
-			_app.Tap("MaxCheckBox");
+			_app.FastTap("MinCheckBox");
+			_app.FastTap("MaxCheckBox");
 
 			Console.WriteLine("Assert that when Value is at Minimum, the down spin button is disabled.");
 			Assert.IsTrue(upButton.GetDependencyPropertyValue<bool>("IsEnabled"));
@@ -136,10 +136,10 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 			Assert.IsTrue(downButton.GetDependencyPropertyValue<bool>("IsEnabled"));
 
 			Console.WriteLine("Assert that when wrapping is enabled, spin buttons are enabled.");
-			_app.Tap("WrapCheckBox");
+			_app.FastTap("WrapCheckBox");
 			Assert.IsTrue(upButton.GetDependencyPropertyValue<bool>("IsEnabled"));
 			Assert.IsTrue(downButton.GetDependencyPropertyValue<bool>("IsEnabled"));
-			_app.Tap("WrapCheckBox");
+			_app.FastTap("WrapCheckBox");
 
 			Console.WriteLine("Assert that when Maximum is updated the up button is updated also.");
 			var maxBox = _app.Marked("MaxNumberBox");
@@ -180,7 +180,7 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 			_app.EnterText(numBox, "5 + 3");
 			Assert.AreEqual("0", numBox.GetText());
 
-			_app.Tap("ExpressionCheckBox");
+			_app.FastTap("ExpressionCheckBox");
 
 			int numErrors = 0;
 			const double resetValue = double.NaN;

--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/NumberBoxTests/Given_NumberBox.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/NumberBoxTests/Given_NumberBox.cs
@@ -180,7 +180,7 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 			_app.EnterText(numBox, "5 + 3");
 			Assert.AreEqual("0", numBox.GetText());
 
-			_app.FastTap("ExpressionCheckBox");
+			_app.Tap("ExpressionCheckBox");
 
 			int numErrors = 0;
 			const double resetValue = double.NaN;

--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/TwoPaneViewTests/Given_TwoPaneView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/TwoPaneViewTests/Given_TwoPaneView.cs
@@ -168,7 +168,7 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 				SetComboBox("SimulateComboBox", "LeftRight");
 
 				var marginCheckbox = _app.Marked("AddMarginCheckBox");
-				marginCheckbox.Tap();
+				marginCheckbox.FastTap();
 				// Wait.ForIdle();
 
 				AssertViewMode(ViewMode.LeftRight);
@@ -197,7 +197,7 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 				SetComboBox("SimulateComboBox", "LeftRight");
 
 				var marginCheckbox = _app.Marked("OneSideCheckBox");
-				marginCheckbox.Tap();
+				marginCheckbox.FastTap();
 				// Wait.ForIdle();
 
 				AssertViewMode(ViewMode.Pane1Only);

--- a/src/SamplesApp/SamplesApp.UITests/QueryExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/QueryExtensions.cs
@@ -49,6 +49,38 @@ namespace SamplesApp.UITests
 		{
 			return app.WaitForElement(elementName).Single().Rect;
 		}
+		public static IAppRect GetRect(this IApp app, QueryEx query)
+		{
+			return app.WaitForElement(query).Single().Rect;
+		}
+		public static IAppRect GetRect(this IApp app, Func<IAppQuery, IAppQuery> query)
+		{
+			return app.WaitForElement(query).Single().Rect;
+		}
+
+		public static void FastTap(this IApp app, string elementName)
+		{
+			var tapPosition = app.GetRect(elementName);
+			app.TapCoordinates(tapPosition.CenterX, tapPosition.Y);
+		}
+
+		public static void FastTap(this IApp app, QueryEx query)
+		{
+			var tapPosition = app.GetRect(query);
+			app.TapCoordinates(tapPosition.CenterX, tapPosition.Y);
+		}
+
+		public static void FastTap(this IApp app, Func<IAppQuery, IAppQuery> query)
+		{
+			var tapPosition = app.GetRect(query);
+			app.TapCoordinates(tapPosition.CenterX, tapPosition.Y);
+		}
+
+		public static QueryEx FastTap(this QueryEx query)
+		{
+			Helpers.App.FastTap(query);
+			return query;
+		}
 
 		/// <summary>
 		/// Wait for the named element to have received focus (ie after being tapped).

--- a/src/SamplesApp/SamplesApp.UITests/QueryExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/QueryExtensions.cs
@@ -61,19 +61,19 @@ namespace SamplesApp.UITests
 		public static void FastTap(this IApp app, string elementName)
 		{
 			var tapPosition = app.GetRect(elementName);
-			app.TapCoordinates(tapPosition.CenterX, tapPosition.Y);
+			app.TapCoordinates(tapPosition.CenterX, tapPosition.CenterY);
 		}
 
 		public static void FastTap(this IApp app, QueryEx query)
 		{
 			var tapPosition = app.GetRect(query);
-			app.TapCoordinates(tapPosition.CenterX, tapPosition.Y);
+			app.TapCoordinates(tapPosition.CenterX, tapPosition.CenterY);
 		}
 
 		public static void FastTap(this IApp app, Func<IAppQuery, IAppQuery> query)
 		{
 			var tapPosition = app.GetRect(query);
-			app.TapCoordinates(tapPosition.CenterX, tapPosition.Y);
+			app.TapCoordinates(tapPosition.CenterX, tapPosition.CenterY);
 		}
 
 		public static QueryEx FastTap(this QueryEx query)

--- a/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
@@ -31,7 +31,7 @@ namespace SamplesApp.UITests
 
 			_app.WaitForElement(runButton);
 
-			_app.Tap(runButton);
+			_app.FastTap(runButton);
 
 			var lastChange = DateTimeOffset.Now;
 			var lastValue = "";

--- a/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.Elevation.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.Elevation.cs
@@ -30,7 +30,7 @@ namespace SamplesApp.UITests.Toolkit
 			// Take ScreenShot with no elevation
 			var screenshot_NoElevation = TakeScreenshot("Elevation - No Elevation");
 
-			turnElevation_ON_Button.Tap();
+			turnElevation_ON_Button.FastTap();
 
 			// Take ScreenShot of with elevation
 			var screenshot_WithElevation = TakeScreenshot("Elevation - With Elevation");

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.ContentControl.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.ContentControl.cs
@@ -25,14 +25,14 @@ namespace SamplesApp.UITests
 			var tb2 = _app.Marked("innerText2");
 			Assert.AreEqual("ContentControl:  DataContext", tb2.GetDependencyPropertyValue("Text").ToString());
 
-			_app.Marked("actionButton").Tap();
+			_app.Marked("actionButton").FastTap();
 
 			var tb3 = _app.Marked("innerText");
 			Assert.AreEqual("ContentPresenter:  42", tb3.GetDependencyPropertyValue("Text").ToString());
 			var tb4 = _app.Marked("innerText2");
 			Assert.AreEqual("ContentControl:  42", tb4.GetDependencyPropertyValue("Text").ToString());
 
-			_app.Marked("actionButton").Tap();
+			_app.Marked("actionButton").FastTap();
 
 			Assert.IsFalse(_app.Marked("innerText").HasResults());
 			Assert.IsFalse(_app.Marked("innerText2").HasResults());
@@ -46,7 +46,7 @@ namespace SamplesApp.UITests
 
 			Assert.IsFalse(_app.Marked("ContentViewBorder").HasResults());
 
-			_app.Tap(c => c.Marked("ToggleTemplateButton"));
+			_app.FastTap(c => c.Marked("ToggleTemplateButton"));
 
 			Assert.IsTrue(_app.Marked("ContentViewBorder").HasResults());
 
@@ -60,7 +60,7 @@ namespace SamplesApp.UITests
 
 			Assert.IsFalse(_app.Marked("ContentViewBorder").HasResults());
 
-			_app.Tap(c => c.Marked("ToggleTemplateButton"));
+			_app.FastTap(c => c.Marked("ToggleTemplateButton"));
 
 			Assert.IsTrue(_app.Marked("ContentViewBorder").HasResults());
 

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
@@ -41,7 +41,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on normalTextBox
-				_app.Tap(normalTextBox);
+				_app.FastTap(normalTextBox);
 				_app.Wait(1);
 				TakeScreenshot("0 - Focus on normalTextBox ", ignoreInSnapshotCompare: true);
 
@@ -53,7 +53,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on normalTextBox
-				_app.Tap(filledTextBox);
+				_app.FastTap(filledTextBox);
 				_app.Wait(1);
 				TakeScreenshot("1 - Focus on filledTextBox", ignoreInSnapshotCompare: true);
 
@@ -65,7 +65,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on placeholderTextTextBox
-				_app.Tap(placeholderTextTextBox);
+				_app.FastTap(placeholderTextTextBox);
 				_app.Wait(1);
 				TakeScreenshot("2 - Focus on placeholderTextTextBox", ignoreInSnapshotCompare: true);
 
@@ -77,7 +77,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on disabledTextBox
-				_app.Tap(disabledTextBox);
+				_app.FastTap(disabledTextBox);
 				_app.Wait(1);
 				TakeScreenshot("3 - Focus on disabledTextBox", ignoreInSnapshotCompare: true);
 
@@ -89,7 +89,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on multilineTextBox
-				_app.Tap(multilineTextBox);
+				_app.FastTap(multilineTextBox);
 				_app.Wait(1);
 				TakeScreenshot("4 - Focus on multilineTextBox", ignoreInSnapshotCompare: true);
 
@@ -101,7 +101,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on numberTextBox
-				_app.Tap(numberTextBox);
+				_app.FastTap(numberTextBox);
 				_app.Wait(1);
 				TakeScreenshot("5 - Focus on numberTextBox", ignoreInSnapshotCompare: true);
 
@@ -137,7 +137,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on normalTextBox
-				_app.Tap(normalTextBox);
+				_app.FastTap(normalTextBox);
 				_app.Wait(1);
 				TakeScreenshot("0 - Focus on normalTextBox", ignoreInSnapshotCompare: true);
 
@@ -149,7 +149,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on normalTextBox
-				_app.Tap(filledTextBox);
+				_app.FastTap(filledTextBox);
 				_app.Wait(1);
 				TakeScreenshot("1 - Focus on filledTextBox", ignoreInSnapshotCompare: true);
 
@@ -161,7 +161,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on placeholderTextTextBox
-				_app.Tap(placeholderTextTextBox);
+				_app.FastTap(placeholderTextTextBox);
 				_app.Wait(1);
 				TakeScreenshot("2 - Focus on placeholderTextTextBox", ignoreInSnapshotCompare: true);
 
@@ -173,7 +173,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on disabledTextBox
-				_app.Tap(disabledTextBox);
+				_app.FastTap(disabledTextBox);
 				_app.Wait(1);
 				TakeScreenshot("3 - Focus on disabledTextBox", ignoreInSnapshotCompare: true);
 
@@ -185,7 +185,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on multilineTextBox
-				_app.Tap(multilineTextBox);
+				_app.FastTap(multilineTextBox);
 				_app.Wait(1);
 				TakeScreenshot("4 - Focus on multilineTextBox", ignoreInSnapshotCompare: true);
 
@@ -197,7 +197,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on numberTextBox
-				_app.Tap(numberTextBox);
+				_app.FastTap(numberTextBox);
 				_app.Wait(1);
 				TakeScreenshot("5 - Focus on numberTextBox", ignoreInSnapshotCompare: true);
 
@@ -226,7 +226,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on normalTextBox
-				_app.Tap(normalTextBox);
+				_app.FastTap(normalTextBox);
 				_app.Wait(1);
 
 				// Writing in normalTextBox 
@@ -240,7 +240,7 @@ namespace SamplesApp.UITests
 
 			{
 				// Setting focus on disabledTextBox
-				_app.Tap(disabledTextBox);
+				_app.FastTap(disabledTextBox);
 				_app.Wait(1);
 
 				// Writing in disabledTextBox 
@@ -409,7 +409,7 @@ namespace SamplesApp.UITests
 		{
 			var tb = _app.Marked(textBoxName);
 			_app.WaitForElement(tb);
-			_app.Tap(tb);
+			_app.FastTap(tb);
 			_app.EnterText(tb, inputText);
 			_app.WaitFor(() => expectedText == GetText(tb));
 			return tb;
@@ -433,7 +433,7 @@ namespace SamplesApp.UITests
 
 			var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
 
-			singleTextBox.Tap();
+			singleTextBox.FastTap();
 			_app.Wait(2);
 
 			// Click on AppBar Button

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Popup.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Popup.cs
@@ -34,7 +34,7 @@ namespace SamplesApp.UITests
 			TakeScreenshot("Popup - Dismissable - 1 - InitialState");
 			Assert.AreEqual(null, PopupText.GetDependencyPropertyValue("Text")?.ToString());
 
-			OpenDismissablePopupButton.Tap();
+			OpenDismissablePopupButton.FastTap();
 
 			_app.WaitForElement(PopupText, timeout: TimeSpan.FromSeconds(5));
 
@@ -67,8 +67,8 @@ namespace SamplesApp.UITests
 			TakeScreenshot("Popup - Non Dismissable - 1 - InitialState");
 			Assert.AreEqual(null, PopupText.GetDependencyPropertyValue("Text")?.ToString());
 
-			OpenNonDismissablePopupButton.Tap();
-			OpenNonDismissablePopupButton.Tap();
+			OpenNonDismissablePopupButton.FastTap();
+			OpenNonDismissablePopupButton.FastTap();
 
 			_app.WaitForElement(PopupText, timeout: TimeSpan.FromSeconds(5));
 
@@ -101,7 +101,7 @@ namespace SamplesApp.UITests
 			TakeScreenshot("Popup - No Fixed Height - 1 - InitialState");
 			Assert.AreEqual(null, PopupText.GetDependencyPropertyValue("Text")?.ToString());
 
-			OpenNoFixedHeightPopupButton.Tap();
+			OpenNoFixedHeightPopupButton.FastTap();
 
 			_app.WaitForElement(PopupText, timeout: TimeSpan.FromSeconds(5));
 

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.RadioButton.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.RadioButton.cs
@@ -30,20 +30,20 @@ namespace SamplesApp.UITests
 			// Assert initial state 
 			Assert.AreEqual("None", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
-			myRadioButton_1.Tap();
+			myRadioButton_1.FastTap();
 
 			// Assert after clicking once while radio buttons are enabled
 			Assert.AreEqual("Radio Button 1", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
 
-			myRadioButtonDisabler.Tap();
-			myRadioButton_2.Tap();
+			myRadioButtonDisabler.FastTap();
+			myRadioButton_2.FastTap();
 
 			// Assert after clicking once while radio buttons are disabled
 			Assert.AreEqual("Radio Button 1", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
-			myRadioButtonDisabler.Tap();
-			myRadioButton_2.Tap();
+			myRadioButtonDisabler.FastTap();
+			myRadioButton_2.FastTap();
 
 			// Assert after clicking once while radio buttons are enabled
 			Assert.AreEqual("Radio Button 2", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
@@ -65,21 +65,21 @@ namespace SamplesApp.UITests
 			// Assert initial state 
 			Assert.AreEqual("None", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
-			myRadioButton_1.Tap();
+			myRadioButton_1.FastTap();
 
 			// Assert after clicking once while radio buttons are enabled
 			Assert.AreEqual("Radio Button 1", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
-			myRadioButton_1.Tap();
+			myRadioButton_1.FastTap();
 
 			// Assert after clicking twice while radio buttons are enabled
 			Assert.AreEqual("Radio Button 1", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
-			myRadioButton_2.Tap();
+			myRadioButton_2.FastTap();
 
 			// Assert after clicking once while radio buttons are enabled
 			Assert.AreEqual("Radio Button 2", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
-			myRadioButton_2.Tap();
+			myRadioButton_2.FastTap();
 
 			// Assert after clicking twice while radio buttons are enabled
 			Assert.AreEqual("Radio Button 2", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
@@ -101,24 +101,24 @@ namespace SamplesApp.UITests
 			// Assert initial state 
 			Assert.AreEqual("None", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
-			myRadioButton_1.Tap();
+			myRadioButton_1.FastTap();
 
 			// Assert after clicking once while radio buttons are enabled
 			Assert.AreEqual("Radio Button 1", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
-			myRadioButtonDisabler.Tap();
+			myRadioButtonDisabler.FastTap();
 			// Assert after clicking once while radio buttons are disabled
 			Assert.AreEqual("Radio Button 1", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
-			myRadioButtonDisabler.Tap();
+			myRadioButtonDisabler.FastTap();
 
 			Assert.AreEqual("Radio Button 1", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
-			myRadioButton_2.Tap();
+			myRadioButton_2.FastTap();
 			// Assert after clicking once while radio buttons are enabled
 			Assert.AreEqual("Radio Button 2", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 
-			myRadioButtonDisabler.Tap();
+			myRadioButtonDisabler.FastTap();
 			// Assert after clicking once while radio buttons are disabled
 			Assert.AreEqual("Radio Button 2", currentRadioButton.GetDependencyPropertyValue("Text")?.ToString());
 		}

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Touch.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Touch.cs
@@ -40,7 +40,7 @@ namespace SamplesApp.UITests
 				var button = _app.Marked("button_border_on_top");
 				var border = _app.Marked("button_border_on_top_border");
 
-				border.Tap();
+				border.FastTap();
 
 				var position = button.FirstResult().Rect;
 				_app.TapCoordinates(position.X + 2, position.Y + 2);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_Devices/GyrometerTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_Devices/GyrometerTests.cs
@@ -38,7 +38,7 @@ namespace SamplesApp.UITests.Windows_Devices
 
 			try
 			{
-				_app.Tap("AttachReadingButton");
+				_app.FastTap("AttachReadingButton");
 
 				_app.Wait(TimeSpan.FromMilliseconds(500));
 
@@ -48,7 +48,7 @@ namespace SamplesApp.UITests.Windows_Devices
 			}
 			finally
 			{
-				_app.Tap("DetachReadingButton");
+				_app.FastTap("DetachReadingButton");
 			}
 		}
 
@@ -63,7 +63,7 @@ namespace SamplesApp.UITests.Windows_Devices
 
 			try
 			{
-				_app.Tap("AttachReadingButton");
+				_app.FastTap("AttachReadingButton");
 
 				_app.Wait(TimeSpan.FromMilliseconds(500));
 				var firstTimestampSnapshot = _app.GetText("TimestampRun");
@@ -76,7 +76,7 @@ namespace SamplesApp.UITests.Windows_Devices
 			}
 			finally
 			{
-				_app.Tap("DetachReadingButton");
+				_app.FastTap("DetachReadingButton");
 			}
 		}
 
@@ -91,9 +91,9 @@ namespace SamplesApp.UITests.Windows_Devices
 
 			try
 			{
-				_app.Tap("AttachReadingButton");
+				_app.FastTap("AttachReadingButton");
 				_app.Wait(TimeSpan.FromMilliseconds(500));
-				_app.Tap("DetachReadingButton");
+				_app.FastTap("DetachReadingButton");
 
 				//wait a bit to make sure last invoke finishes
 				_app.Wait(TimeSpan.FromMilliseconds(250));
@@ -107,7 +107,7 @@ namespace SamplesApp.UITests.Windows_Devices
 			}
 			finally
 			{
-				_app.Tap("DetachReadingButton");
+				_app.FastTap("DetachReadingButton");
 			}
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ContentControlTests/ContentControlBehaviorTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ContentControlTests/ContentControlBehaviorTests.cs
@@ -24,7 +24,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ContentControlTests
 
 			void TabWaitAndThenScreenshot(string buttonName)
 			{
-				_app.Marked(buttonName).Tap();
+				_app.Marked(buttonName).FastTap();
 				TakeScreenshot($"ContentControlNoTemplateNoContent - {buttonName}");
 			}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerTests/UnoSamples_Tests.FocusManager.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerTests/UnoSamples_Tests.FocusManager.cs
@@ -26,13 +26,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyBorder");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - Border - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
@@ -50,13 +50,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyButton");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - Button - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyButton");
@@ -74,13 +74,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyButton");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - LostFocus - Button - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyButton");
 
 			_app.TapCoordinates(20, 100);
@@ -101,13 +101,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyCheckBox");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - CheckBox - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyCheckBox");
@@ -125,13 +125,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyCheckBox");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>"); ;
 			TakeScreenshot("FocusManager - LostFocus - CheckBox - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyCheckBox");
 
 			_app.TapCoordinates(20, 100);
@@ -152,13 +152,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyGrid");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - Grid - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
@@ -176,13 +176,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyHyperlinkButton");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - HyperlinkButton - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyHyperlinkButton");
 
 			_app.TapCoordinates(20, 100);
@@ -203,13 +203,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyHyperlinkButton");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - LostFocus - HyperlinkButton - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyHyperlinkButton");
 
 			_app.TapCoordinates(20, 100);
@@ -230,13 +230,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyImage");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - Image - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
@@ -254,13 +254,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyRectangle");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - Rectangle - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
@@ -278,13 +278,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyTextBlock");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - TextBlock - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
@@ -302,13 +302,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("TextBoxMultiLine");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - TextBoxMultiLine - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "TextBoxMultiLine");
 
 			// Assert After Selection 
@@ -327,13 +327,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("TextBoxMultiLine");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - LostFocus - TextBoxMultiLine - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "TextBoxMultiLine");
 
 			_app.TapCoordinates(20, 100);
@@ -354,13 +354,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("TextBoxSingleLine");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - TextBoxSingleLine - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "TextBoxSingleLine");
@@ -378,13 +378,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("TextBoxSingleLine");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - LostFocus - TextBoxSingleLine - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "TextBoxSingleLine");
 
 			_app.TapCoordinates(20, 100);
@@ -405,13 +405,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyToggleButton");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - ToggleButton - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyToggleButton");
@@ -429,13 +429,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var frameworkElement = _app.Marked("MyToggleButton");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - LostFocus - ToggleButton - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyToggleButton");
 
 			_app.TapCoordinates(20, 100);
@@ -456,13 +456,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var combo = _app.Marked("MyComboBox");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - ComboBox - 1 - Initial State");
 
-			combo.Tap();
+			combo.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyComboBox");
@@ -483,13 +483,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var txtCurrentFocused = _app.Marked("TxtCurrentFocused");
 			var combo = _app.Marked("MyComboBox");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - LostFocus - ComboBox - 1 - Initial State");
 
-			combo.Tap();
+			combo.FastTap();
 
 			_app.TapCoordinates(20, 100); // Close the  combo
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyComboBox");
@@ -513,16 +513,16 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var comboBox = _app.Marked("MyComboBox");
 			var frameworkElement = _app.Marked("MyComboBoxItem_1");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - ComboBoxItem - 1 - Initial State");
 
-			comboBox.Tap();
+			comboBox.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyComboBox");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyComboBoxItem_1");
@@ -541,16 +541,16 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var comboBox = _app.Marked("MyComboBox");
 			var item1 = _app.Marked("MyComboBoxItem_1");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - LostFocus - ComboBoxItem - 1 - Initial State");
 
-			comboBox.Tap();
+			comboBox.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyComboBox");
 
-			item1.Tap();
+			item1.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyComboBoxItem_1");
 
 			_app.TapCoordinates(20, 100);
@@ -572,13 +572,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var scrollViewer = _app.Marked("ScrollViewer");
 			var frameworkElement = _app.Marked("MyScrollViewerElement");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - ScrollViewer - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
@@ -597,13 +597,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			var listView = _app.Marked("MyListView");
 			var frameworkElement = _app.Marked("MyListViewItem");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - GetFocusedElement - ListViewItem - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyListViewItem");
@@ -622,13 +622,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 			//var listView = _app.Marked("MyListView");
 			var frameworkElement = _app.Marked("MyListViewItem");
 
-			_app.Tap(txtCurrentFocused);
+			_app.FastTap(txtCurrentFocused);
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
 			TakeScreenshot("FocusManager - LostFocus - ListViewItem - 1 - Initial State");
 
-			frameworkElement.Tap();
+			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyListViewItem");
 
 			_app.TapCoordinates(20, 100);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/VisualStateManagerTests/VisualStateManagerTest.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/VisualStateManagerTests/VisualStateManagerTest.cs
@@ -26,7 +26,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.VisualStateManagerTests
 			var border02 = _app.Marked("border02");
 			var border03 = _app.Marked("border03");
 
-			_app.Tap(changeState);
+			_app.FastTap(changeState);
 
 			_app.WaitForDependencyPropertyValue(border01_bound, "Background", "[SolidColorBrush [Color: 000000FF;000000FF;00000000;00000000]]");
 			_app.WaitForDependencyPropertyValue(border02, "Background", "[SolidColorBrush [Color: 000000FF;00000080;00000000;00000080]]");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Automation/AutomationId_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Automation/AutomationId_Tests.cs
@@ -27,7 +27,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Automation
 			{
 				var itemName = $"Item{i:00}";
 				_app.WaitForElement(itemName);
-				_app.Tap(itemName);
+				_app.FastTap(itemName);
 				_app.WaitForDependencyPropertyValue(result, "Text", $"Item {i:00}");
 			}
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BitmapIconTests/UnoSamples_Tests.BitmapIcon.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BitmapIconTests/UnoSamples_Tests.BitmapIcon.cs
@@ -27,7 +27,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.BitmapIconTests
 
 			TakeScreenshot("Initial");
 
-			_app.Tap(colorChange);
+			_app.FastTap(colorChange);
 
 			var color1 = icon1.GetDependencyPropertyValue<string>("Foreground");
 			var color2 = icon2.GetDependencyPropertyValue<string>("Foreground");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BorderTests/Border_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BorderTests/Border_Tests.cs
@@ -22,7 +22,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests
 
 			var before = TakeScreenshot("Before property change");
 
-			_app.Tap("ClippedBorder");
+			_app.FastTap("ClippedBorder");
 
 			_app.WaitForDependencyPropertyValue(_app.Marked("ClippedBorder"), "ManipulationMode", "None");
 
@@ -44,7 +44,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests
 
 			var scrBefore = TakeScreenshot("No CornerRadius");
 
-			_app.Tap("ToggleCornerRadiusButton");
+			_app.FastTap("ToggleCornerRadiusButton");
 
 			_app.WaitForText("StatusTextBlock", "5");
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Test_NativeButtons.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Test_NativeButtons.cs
@@ -30,36 +30,36 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 
 			_app.WaitForElement(button01);
 
-			_app.Tap(button01);
+			_app.FastTap(button01);
 			_app.WaitForText(result, "Button button01 Clicked (1)");
 			_app.WaitForText(resultTapped, "Button button01 Tapped (1)");
 			_app.WaitForText(resultCommand, "Command Button 01 (1)");
 
-			_app.Tap(button02);
+			_app.FastTap(button02);
 			_app.WaitForText(result, "Button button01 Clicked (1)");
 			_app.WaitForText(resultTapped, "Button button01 Tapped (1)");
 			_app.WaitForText(resultCommand, "Command Button 01 (1)");
 
-			_app.Tap(enableButton02);
-			_app.Tap(button02);
+			_app.FastTap(enableButton02);
+			_app.FastTap(button02);
 			_app.WaitForText(result, "Button button02 Clicked (2)");
 			_app.WaitForText(resultTapped, "Button button02 Tapped (2)");
 			_app.WaitForText(resultCommand, "Command Button 02 (2)");
 
-			_app.Tap(toggleSwitch01);
+			_app.FastTap(toggleSwitch01);
 			_app.WaitForText(result, "ToggleSwitch toggleSwitch01 Toggled True (1)");
 
-			_app.Tap(toggleSwitch01);
+			_app.FastTap(toggleSwitch01);
 			_app.WaitForText(result, "ToggleSwitch toggleSwitch01 Toggled False (2)");
 
-			_app.Tap(toggleSwitch02);
+			_app.FastTap(toggleSwitch02);
 			_app.WaitForText(result, "ToggleSwitch toggleSwitch01 Toggled False (2)");
 
-			_app.Tap(enableToggleSwitch02);
-			_app.Tap(toggleSwitch02);
+			_app.FastTap(enableToggleSwitch02);
+			_app.FastTap(toggleSwitch02);
 			_app.WaitForText(result, "ToggleSwitch toggleSwitch02 Toggled True (3)");
 
-			_app.Tap(toggleSwitch02);
+			_app.FastTap(toggleSwitch02);
 			_app.WaitForText(result, "ToggleSwitch toggleSwitch02 Toggled False (4)");
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_IsEnabled_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_IsEnabled_Automated.cs
@@ -31,13 +31,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 			// Assert initial state
 			Assert.AreEqual("0", totalClicksText.GetDependencyPropertyValue("Text")?.ToString());
 
-			clickingButton.Tap();
+			clickingButton.FastTap();
 
 			// Assert after clicking once while clickingButton enabled
 			Assert.AreEqual("1", totalClicksText.GetDependencyPropertyValue("Text")?.ToString());
 
-			toggleClickingButtonIsEnable.Tap();
-			clickingButton.Tap();
+			toggleClickingButtonIsEnable.FastTap();
+			clickingButton.FastTap();
 
 			// Assert after clicking once while clickingButton disabled
 			Assert.AreEqual("1", totalClicksText.GetDependencyPropertyValue("Text")?.ToString());
@@ -58,19 +58,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 			// Assert initial state
 			Assert.AreEqual("False", checkBoxIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
 
-			myCheckBox.Tap();
+			myCheckBox.FastTap();
 
 			// Assert after clicking once while myCheckBox enabled
 			Assert.AreEqual("True", checkBoxIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
 
-			myCheckBoxDisabler.Tap();
-			myCheckBox.Tap();
+			myCheckBoxDisabler.FastTap();
+			myCheckBox.FastTap();
 
 			// Assert after clicking once while myCheckBox disabled
 			Assert.AreEqual("True", checkBoxIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
 
-			myCheckBoxDisabler.Tap();
-			myCheckBox.Tap();
+			myCheckBoxDisabler.FastTap();
+			myCheckBox.FastTap();
 
 			// Assert after clicking once while myCheckBox enabled
 			Assert.AreEqual("False", checkBoxIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
@@ -91,19 +91,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 			// Assert initial state
 			Assert.AreEqual("False", toggleButtonIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
 
-			myToggleButton.Tap();
+			myToggleButton.FastTap();
 
 			// Assert after clicking once while myToggleButton enabled
 			Assert.AreEqual("True", toggleButtonIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
 
-			myToggleButtonDisabler.Tap();
-			myToggleButton.Tap();
+			myToggleButtonDisabler.FastTap();
+			myToggleButton.FastTap();
 
 			// Assert after clicking once while myToggleButton disabled
 			Assert.AreEqual("True", toggleButtonIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
 
-			myToggleButtonDisabler.Tap();
-			myToggleButton.Tap();
+			myToggleButtonDisabler.FastTap();
+			myToggleButton.FastTap();
 
 			// Assert after clicking once while myToggleButton enabled
 			Assert.AreEqual("False", toggleButtonIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
@@ -124,12 +124,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 			Assert.AreEqual("ToggleSwitch_1 is OFF", toggleSwitch_1_IsOn.GetDependencyPropertyValue("Text")?.ToString());
 			Assert.AreEqual("ToggleSwitch_2 is OFF", toggleSwitch_2_IsOn.GetDependencyPropertyValue("Text")?.ToString());
 
-			myToggleSwitch_1.Tap();
+			myToggleSwitch_1.FastTap();
 
 			// Assert after clicking once while radio buttons are enabled
 			Assert.AreEqual("ToggleSwitch_1 is ON", toggleSwitch_1_IsOn.GetDependencyPropertyValue("Text")?.ToString());
 
-			myToggleSwitch_2.Tap();
+			myToggleSwitch_2.FastTap();
 
 			// Assert after clicking once while radio buttons are disabled
 			Assert.AreEqual("ToggleSwitch_2 is OFF", toggleSwitch_2_IsOn.GetDependencyPropertyValue("Text")?.ToString());
@@ -150,13 +150,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 			// Assert initial state
 			Assert.AreEqual("0", totalClicksText.GetDependencyPropertyValue("Text")?.ToString());
 
-			clickingButton.Tap();
+			clickingButton.FastTap();
 
 			// Assert after clicking once while clickingButton enabled
 			Assert.AreEqual("1", totalClicksText.GetDependencyPropertyValue("Text")?.ToString());
 
-			toggleClickingButtonIsEnable.Tap();
-			clickingButton.Tap();
+			toggleClickingButtonIsEnable.FastTap();
+			clickingButton.FastTap();
 
 			// Assert after clicking once while clickingButton disabled
 			Assert.AreEqual("1", totalClicksText.GetDependencyPropertyValue("Text")?.ToString());
@@ -178,24 +178,24 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 			// Assert initial state
 			Assert.AreEqual("False", checkBoxIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
 
-			myCheckBoxDisabler.Tap();
+			myCheckBoxDisabler.FastTap();
 
 			// Assert after disabling the check box
 			Assert.AreEqual("False", checkBoxIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
 
 			//Enable state preservation
 
-			myCheckBoxDisabler.Tap();
+			myCheckBoxDisabler.FastTap();
 
 			// Assert initial state
 			Assert.AreEqual("False", checkBoxIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
 
-			myCheckBox.Tap();
+			myCheckBox.FastTap();
 
 			// Assert after clicking once while myCheckBox enabled
 			Assert.AreEqual("True", checkBoxIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
 
-			myCheckBoxDisabler.Tap();
+			myCheckBoxDisabler.FastTap();
 
 			// Assert after disabling the check box
 			Assert.AreEqual("True", checkBoxIsCheckedState.GetDependencyPropertyValue("Text")?.ToString());
@@ -248,7 +248,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 
 			Check(false, "Assert after fist double click while myCheckBox is not checked");
 
-			myCheckBox.Tap();
+			myCheckBox.FastTap();
 			Check(true, "Assert after single tap myCheckBox should be checked");
 
 			myCheckBox.DoubleTap();

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_Opacity_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ButtonTests/UnoSamples_Tests.Button_Opacity_Automated.cs
@@ -31,31 +31,31 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 			Assert.AreEqual("1", valueOfOpacity.GetDependencyPropertyValue("Text")?.ToString());
 
 			// When user click on Button ClickingButtonToChangeOpacity for the first time
-			buttonToIncrementNumber.Tap();
+			buttonToIncrementNumber.FastTap();
 			
 			// Assert after clicking once while clickingButton enabled
 			Assert.AreEqual("1", totalClicks.GetDependencyPropertyValue("Text")?.ToString());
 
-			valueOfOpacity.Tap();
+			valueOfOpacity.FastTap();
 			_app.ClearText(valueOfOpacity);
 			_app.EnterText("0.5");
 
-			applyOpacityButton.Tap();
+			applyOpacityButton.FastTap();
 
 			// When user click on Button ClickingButtonToChangeOpacity for the seconde time
-			buttonToIncrementNumber.Tap();
+			buttonToIncrementNumber.FastTap();
 
 			// Assert after clicking once while clickingButton add
 			Assert.AreEqual("2", totalClicks.GetDependencyPropertyValue("Text")?.ToString());
 
-			valueOfOpacity.Tap();
+			valueOfOpacity.FastTap();
 			_app.ClearText(valueOfOpacity);
 			_app.EnterText("0");
 
-			applyOpacityButton.Tap();
+			applyOpacityButton.FastTap();
 
 			// When user click on Button ClickingButtonToChangeOpacity for the third time
-			buttonToIncrementNumber.Tap();
+			buttonToIncrementNumber.FastTap();
 
 			// Assert after clicking once while clickingButton add again
 			Assert.AreEqual("3", totalClicks.GetDependencyPropertyValue("Text")?.ToString());

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CheckBoxTests/UnoSamples_CheckBox.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CheckBoxTests/UnoSamples_CheckBox.cs
@@ -21,13 +21,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 
 			_app.WaitForElement(twoState01);
 
-			_app.Tap(twoState01);
+			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Checked twoState01 True");
 
-			_app.Tap(twoState01);
+			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Unchecked twoState01 False");
 
-			_app.Tap(twoState01);
+			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Checked twoState01 True");
 		}
 
@@ -42,22 +42,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 
 			_app.WaitForElement(twoState01);
 
-			_app.Tap(twoState01);
+			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Checked threeState01 True");
 
 			TakeScreenshot("Checked");
 
-			_app.Tap(twoState01);
+			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Indeterminate threeState01 ");
 
 			TakeScreenshot("Indeterminate");
 
-			_app.Tap(twoState01);
+			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Unchecked threeState01 False");
 
 			TakeScreenshot("Unchecked");
 
-			_app.Tap(twoState01);
+			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Checked threeState01 True");
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
@@ -40,17 +40,17 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			var presenter = _app.FindWithin(marked: "ContentPresenter", within: comboBox);
 
 			var button = _app.Marked("ChangeSelectionButton");
-			_app.Tap(button);
+			_app.FastTap(button);
 
 			var first = _app.FindWithin("_tb1", presenter);
 			Assert.AreEqual("Item 1", first.GetDependencyPropertyValue<string>("Text"));
 
-			_app.Tap(comboBox);
+			_app.FastTap(comboBox);
 			_app.TapCoordinates(300, 100);
 			first = _app.FindWithin("_tb1", presenter);
 			Assert.AreEqual("Item 1", first.GetDependencyPropertyValue<string>("Text"));
 
-			_app.Tap(button);
+			_app.FastTap(button);
 			var second = _app.FindWithin("_tb2", presenter);
 			Assert.AreEqual("Item 2", second.GetDependencyPropertyValue<string>("Text"));
 
@@ -73,7 +73,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			var resourcesFilterResult = _app.WaitForElement(combo01).First();
 			var sampleControlResult = _app.WaitForElement(sampleControl).First();
 
-			_app.Tap(combo01);
+			_app.FastTap(combo01);
 
 			var popupResult = _app.WaitForElement("PopupBorder").First();
 
@@ -81,12 +81,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			_app.TapCoordinates(popupResult.Rect.Y - 10, popupResult.Rect.X);
 
-			_app.Tap(changeExtended);
+			_app.FastTap(changeExtended);
 
 			var resourcesFilterResultExtended = _app.WaitForElement(combo01).First();
 			var sampleControlResultExtended = _app.WaitForElement(sampleControl).First();
 
-			_app.Tap(combo01);
+			_app.FastTap(combo01);
 
 			var popupResultExtended = _app.WaitForElement("PopupBorder").First();
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.XamlCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.XamlCommandBar.cs
@@ -30,18 +30,18 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			TakeScreenshot("Initial");
 
-			_app.Tap(shuffleButton);
+			_app.FastTap(shuffleButton);
 			_app.WaitForDependencyPropertyValue(shuffleButton, "IsChecked", true);
 			_app.WaitForDependencyPropertyValue(clickResult, "Text", "Shuffle");
 
 			TakeScreenshot("AfterShuffle");
 
-			_app.Tap(playButton);
+			_app.FastTap(playButton);
 			_app.WaitForDependencyPropertyValue(clickResult, "Text", "Play");
 
 			TakeScreenshot("AfterPlay");
 
-			_app.Tap(appBarContentButton);
+			_app.FastTap(appBarContentButton);
 			_app.WaitForDependencyPropertyValue(clickResult, "Text", "Click me");
 
 			TakeScreenshot("AfterClickMe");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
@@ -36,14 +36,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			// Assert initial state 
 			Assert.AreEqual("Undefined", dialogResult.GetDependencyPropertyValue("Text")?.ToString());
 
-			_app.Tap(showDialog1);
+			_app.FastTap(showDialog1);
 
 			var primaryButton = _app.Marked("PrimaryButton");
 			_app.WaitForElement(primaryButton);
 
 			CurrentTestTakeScreenShot("Primary Button");
 
-			_app.Tap(primaryButton);
+			_app.FastTap(primaryButton);
 
 			_app.WaitForDependencyPropertyValue(dialogResult, "Text", "Primary");
 		}
@@ -63,25 +63,25 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			// Assert initial state 
 			Assert.AreEqual("Undefined", dialogResult.GetDependencyPropertyValue("Text")?.ToString());
 
-			_app.Tap(showDialog6);
+			_app.FastTap(showDialog6);
 
 			var primaryButton = _app.Marked("PrimaryButton");
 			_app.WaitForElement(primaryButton);
 
 			CurrentTestTakeScreenShot("Primary Button");
 
-			_app.Tap(primaryButton);
+			_app.FastTap(primaryButton);
 
 			_app.WaitForDependencyPropertyValue(dialogResult, "Text", "Primary");
 
-			_app.Tap(showDialog6);
+			_app.FastTap(showDialog6);
 
 			var secondaryButton = _app.Marked("SecondaryButton");
 			_app.WaitForElement(secondaryButton);
 
 			CurrentTestTakeScreenShot("Secondary Button");
 
-			_app.Tap(secondaryButton);
+			_app.FastTap(secondaryButton);
 
 			_app.WaitForDependencyPropertyValue(dialogResult, "Text", "Secondary");
 		}
@@ -101,14 +101,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			// Assert initial state 
 			Assert.AreEqual("Undefined", dialogResult.GetDependencyPropertyValue("Text")?.ToString());
 
-			_app.Tap(showDialog1);
+			_app.FastTap(showDialog1);
 
 			var primaryButton = _app.Marked("PrimaryButton");
 			_app.WaitForElement(primaryButton);
 
 			CurrentTestTakeScreenShot("Primary Button");
 
-			_app.Tap(primaryButton);
+			_app.FastTap(primaryButton);
 
 			_app.WaitForDependencyPropertyValue(dialogResult, "Text", "Undefined");
 
@@ -117,7 +117,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 
 			CurrentTestTakeScreenShot("Secondary Button");
 
-			_app.Tap(secondaryButton);
+			_app.FastTap(secondaryButton);
 
 			CurrentTestTakeScreenShot("Closed");
 		}
@@ -137,14 +137,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			// Assert initial state 
 			Assert.AreEqual("Undefined", dialogResult.GetDependencyPropertyValue("Text")?.ToString());
 
-			_app.Tap(showDialog1);
+			_app.FastTap(showDialog1);
 
 			var secondaryButton = _app.Marked("SecondaryButton");
 			_app.WaitForElement(secondaryButton);
 
 			CurrentTestTakeScreenShot("Secondary Button");
 
-			_app.Tap(secondaryButton);
+			_app.FastTap(secondaryButton);
 
 			_app.WaitForDependencyPropertyValue(dialogResult, "Text", "Secondary");
 		}
@@ -165,14 +165,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			// Assert initial state 
 			Assert.AreEqual("Undefined", dialogResult.GetDependencyPropertyValue("Text")?.ToString());
 
-			_app.Tap(showDialog1);
+			_app.FastTap(showDialog1);
 
 			var primaryButton = _app.Marked("PrimaryButton");
 			_app.WaitForElement(primaryButton);
 
 			CurrentTestTakeScreenShot("Primary Button");
 
-			_app.Tap(primaryButton);
+			_app.FastTap(primaryButton);
 
 			_app.WaitForDependencyPropertyValue(dialogResult, "Text", "Primary");
 			_app.WaitForDependencyPropertyValue(dialogCommand, "Text", "primaryCommand");
@@ -193,14 +193,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			// Assert initial state 
 			Assert.AreEqual("Undefined", dialogResult.GetDependencyPropertyValue("Text")?.ToString());
 
-			_app.Tap(showDialog1);
+			_app.FastTap(showDialog1);
 
 			var closeButton = _app.Marked("CloseButton");
 			_app.WaitForElement(closeButton);
 
 			CurrentTestTakeScreenShot("Close Button");
 
-			_app.Tap(closeButton);
+			_app.FastTap(closeButton);
 
 			_app.WaitForDependencyPropertyValue(dialogResult, "Text", "None");
 		}
@@ -220,20 +220,20 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			// Assert initial state 
 			Assert.AreEqual("Undefined", dialogResult.GetDependencyPropertyValue("Text")?.ToString());
 
-			_app.Tap(showDialog1);
+			_app.FastTap(showDialog1);
 
 			var dialogInnerButton = _app.Marked("dialogInnerButton");
 			_app.WaitForElement(dialogInnerButton);
 
 			CurrentTestTakeScreenShot("Secondary Button");
 
-			_app.Tap(dialogInnerButton);
+			_app.FastTap(dialogInnerButton);
 
 			var buttonClickResult = _app.Marked("buttonClickResult");
 			_app.WaitForDependencyPropertyValue(buttonClickResult, "Text", "OnDialogInnerButtonClick");
 
 			var dialogTb = _app.Marked("dialogTb");
-			_app.Tap(dialogTb);
+			_app.FastTap(dialogTb);
 			_app.EnterText("This is some text");
 
 			var dialogTextBinding = _app.Marked("dialogTextBinding");
@@ -242,7 +242,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			CurrentTestTakeScreenShot("Secondary Button");
 
 			var primaryButton = _app.Marked("SecondaryButton");
-			_app.Tap(primaryButton);
+			_app.FastTap(primaryButton);
 
 			_app.WaitForDependencyPropertyValue(dialogResult, "Text", "Secondary");
 		}
@@ -257,7 +257,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 
 			_app.WaitForElement(showDialog);
 
-			_app.Tap(showDialog);
+			_app.FastTap(showDialog);
 
 			var resultText = _app.Marked("ResultTextBlock");
 			var closedText = _app.Marked("DidCloseTextBlock");
@@ -277,22 +277,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 
 			_app.WaitForElement(showDialog);
 
-			_app.Tap(showDialog);
+			_app.FastTap(showDialog);
 
 			var closeButton = _app.Marked("CloseButton");
 			_app.WaitForElement(closeButton);
 
-			_app.Tap(closeButton);
+			_app.FastTap(closeButton);
 
 			var resultText = _app.Marked("ResultTextBlock");
 			var closedText = _app.Marked("DidCloseTextBlock");
 
 			var defer1 = _app.Marked("Complete1Button");
-			_app.Tap(defer1);
+			_app.FastTap(defer1);
 			_app.WaitForDependencyPropertyValue(resultText, "Text", "First complete called");
 
 			var defer2 = _app.Marked("Complete2Button");
-			_app.Tap(defer2);
+			_app.FastTap(defer2);
 			_app.WaitForDependencyPropertyValue(resultText, "Text", "Second complete called");
 
 			_app.WaitForDependencyPropertyValue(closedText, "Text", "Closed");
@@ -308,12 +308,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 
 			_app.WaitForElement(showDialog);
 
-			_app.Tap(showDialog);
+			_app.FastTap(showDialog);
 
 			var closeButton = _app.Marked("PrimaryButton");
 			_app.WaitForElement(closeButton);
 
-			_app.Tap(closeButton);
+			_app.FastTap(closeButton);
 
 			var resultText = _app.Marked("ResultTextBlock");
 			var closedText = _app.Marked("DidCloseTextBlock");
@@ -331,15 +331,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 
 			var showDialog = _app.Marked("ShowComboBoxDialog");
 			_app.WaitForElement(showDialog);
-			_app.Tap(showDialog);
+			_app.FastTap(showDialog);
 
 			var comboBox = _app.Marked("InnerComboBox");
 			_app.WaitForElement(comboBox);
-			_app.Tap(comboBox);
+			_app.FastTap(comboBox);
 
 			var item = _app.Marked("ComboElement4");
 			_app.WaitForElement(item);
-			_app.Tap(item);
+			_app.FastTap(item);
 
 			var resultsText = _app.Marked("ResultsTextBlock");
 			_app.WaitForDependencyPropertyValue(resultsText, "Text", "Item 4");
@@ -348,7 +348,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var closeButton = _app.Marked("CloseButton");
 			_app.WaitForElement(closeButton);
 
-			_app.Tap(closeButton);
+			_app.FastTap(closeButton);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ControlTests/Control_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ControlTests/Control_Tests.cs
@@ -19,15 +19,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ControlTests
 
 			_app.WaitForText("CounterTextBlock", "0");
 
-			_app.Tap("ButtonUnderTest");
+			_app.FastTap("ButtonUnderTest");
 
 			_app.WaitForText("CounterTextBlock", "0");
 
-			_app.Tap("ToggleEnabledButton");
+			_app.FastTap("ToggleEnabledButton");
 
 			_app.WaitForText("IsEnabledTextBlock", "True");
 
-			_app.Tap("ButtonUnderTest");
+			_app.FastTap("ButtonUnderTest");
 
 			_app.WaitForText("CounterTextBlock", "1");
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -32,7 +32,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			_app.WaitForDependencyPropertyValue(theDatePicker, "DataContext", "UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.Models.DatePickerViewModel");
 
 			// Open flyout
-			theDatePicker.Tap();
+			theDatePicker.FastTap();
 
 			_app.WaitForElement(datePickerFlyout);
 
@@ -54,7 +54,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			var datePickerFlyout = _app.CreateQuery(q => q.WithClass("Windows_UI_Xaml_Controls_DatePickerFlyoutPresenter"));
 
 			// Open flyout
-			theDatePicker.Tap();
+			theDatePicker.FastTap();
 
 			_app.WaitForDependencyPropertyValue(datePickerFlyout, "Content", "Windows.UI.Xaml.Controls.DatePickerSelector");
 
@@ -74,7 +74,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 
 			_app.WaitForElement(button);
 
-			button.Tap();
+			button.FastTap();
 
 			TakeScreenshot("DatePicker - Flyout", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Status bar appears with clock*/);
 
@@ -97,7 +97,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			var minYear = theDatePicker.GetDependencyPropertyValue<string>("MinYear");
 
 			// Open flyout
-			theDatePicker.Tap();
+			theDatePicker.FastTap();
 
 			_app.WaitFor(() => datePickerFlyout.GetDependencyPropertyValue<string>("MinYear") == minYear);
 
@@ -120,7 +120,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 			var maxYear = theDatePicker.GetDependencyPropertyValue<string>("MaxYear");
 
 			// Open flyout
-			theDatePicker.Tap();
+			theDatePicker.FastTap();
 
 			//Assert
 			_app.WaitFor(() => datePickerFlyout.GetDependencyPropertyValue<string>("MaxYear") == maxYear);
@@ -140,7 +140,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 
 			_app.WaitForElement(TestDatePickerFlyoutButton);
 
-			TestDatePickerFlyoutButton.Tap();
+			TestDatePickerFlyoutButton.FastTap();
 
 			_app.WaitForElement(datePickerFlyout);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -26,7 +26,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 
 			// Can't find popup that is outside of page.
 			//var button = _app.Marked("FlyoutToBottomButton");
-			//_app.Tap(button);
+			//_app.FastTap(button);
 
 			//_app.Wait(1);
 			//_app.WaitForElement(_app.Marked("BottomFlyout"));
@@ -47,12 +47,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			var dataBoundText = _app.Marked("DataBoundText");
 
 			_app.WaitForElement(flyoutButton);
-			_app.Tap(flyoutButton);
+			_app.FastTap(flyoutButton);
 
 			_app.WaitForElement(dataBoundButton);
 			Assert.AreEqual("Button not clicked", dataBoundText.GetText());
 
-			_app.Tap(dataBoundButton);
+			_app.FastTap(dataBoundButton);
 			Assert.AreEqual("Button was clicked", dataBoundText.GetText());
 			
 			_app.TapCoordinates(10, 100);
@@ -75,7 +75,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			{
 				var target1Result = _app.WaitForElement(target1).First();
 
-				_app.Tap(target1);
+				_app.FastTap(target1);
 
 				var innerContentResult = _app.WaitForElement(innerContent).First();
 
@@ -88,7 +88,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			{
 				var target2Result = _app.WaitForElement(target2).First();
 
-				_app.Tap(target2);
+				_app.FastTap(target2);
 
 				var innerContentResult = _app.WaitForElement(innerContent).First();
 
@@ -99,7 +99,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			}
 
 			{
-				_app.Tap(flyoutFull);
+				_app.FastTap(flyoutFull);
 
 				var innerContentResult = _app.WaitForElement(innerContent).First();
 
@@ -126,10 +126,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			var outerButton = _app.Marked("outerButton");
 			var innerButton = _app.Marked("innerButton");
 
-			_app.Tap(outerButton);
+			_app.FastTap(outerButton);
 			_app.WaitForElement(innerButton);
 
-			_app.Tap(innerButton);
+			_app.FastTap(innerButton);
 
 			_app.WaitForNoElement(outerButton);
 			_app.WaitForNoElement(innerButton);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.BitmapSource.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.BitmapSource.cs
@@ -30,7 +30,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			_app.WaitForDependencyPropertyValue(loadStateElement, "Text", "none");
 
 			_app.WaitForElement(button);
-			button.Tap();
+			button.FastTap();
 
 			_app.WaitForDependencyPropertyValue(bitmapWidthElement, "Text", "1252");
 			_app.WaitForDependencyPropertyValue(bitmapHeightElement, "Text", "836");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -22,7 +22,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			// Request to render
 			var button = _app.Marked("_update");
 			_app.WaitForElement(button);
-			button.Tap();
+			button.FastTap();
 
 			// Take screenshot
 			TakeScreenshot("WriteableBitmap_Invalidate - Result");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
@@ -67,7 +67,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 			void TabWaitAndThenScreenshot(string buttonName)
 			{
-				_app.Marked(buttonName).Tap();
+				_app.Marked(buttonName).FastTap();
 				_app.Wait(TimeSpan.FromSeconds(2));
 				TakeScreenshot($"ListView_ItemPanel_HotSwap - {buttonName}");
 			}
@@ -79,7 +79,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Controls.ListView.ListView_VirtualizePanelAdaptaterIdCache");
 
-			_app.Tap("MyButton");
+			_app.FastTap("MyButton");
 
 			var textResult = _app.Marked("TextResult");
 			_app.WaitForText(textResult, "Success");
@@ -95,7 +95,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ListView_Header_DataContextChanging");
 
 			_app.WaitForText("MyTextBlock", "InitialText InitialDataContext");
-			_app.Marked("MyButton").Tap();
+			_app.Marked("MyButton").FastTap();
 			_app.WaitForText("MyTextBlock", "InitialText InitialDataContext UpdatedDataContext");
 		}
 
@@ -113,7 +113,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			var measureTextBefore = _app.GetText("MeasureCountTextBlock");
 			var initialMeasureCount = int.Parse(measureTextBefore);
 
-			_app.Tap("ChangeViewButton");
+			_app.FastTap("ChangeViewButton");
 
 			_app.WaitForText("ResultTextBlock", "Scrolled");
 
@@ -153,7 +153,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			var heightStrBefore = _app.GetText("HeightTextBlock");
 			var heightBefore = int.Parse(heightStrBefore);
 
-			_app.Tap("AddItemsButton");
+			_app.FastTap("AddItemsButton");
 
 			_app.WaitForText("StatusTextBlock", "Finished");
 
@@ -179,13 +179,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 			{
 				var firstItem = _app.Marked("itemsStackPanelList").Descendant().Marked("1");
-				_app.Tap(firstItem);
+				_app.FastTap(firstItem);
 				_app.WaitForText("itemsStackPanelListSelectedItem", "1");
 			}
 
 			{
 				var firstItem = _app.Marked("stackPanelList").Descendant().Marked("1");
-				_app.Tap(firstItem);
+				_app.FastTap(firstItem);
 				_app.WaitForText("itemsStackPanelListSelectedItem", "1");
 			}
 
@@ -198,36 +198,36 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Controls.ListView.ListViewSelectedItems");
 
-			_app.Tap("Right 0");
+			_app.FastTap("Right 0");
 			_app.WaitForText("_selectedItem", "Selected item: 0");
 			_app.WaitForText("SelectionChangedTextBlock", "SelectionChanged event: AddedItems=(0, ), RemovedItems=()");
 
-			_app.Tap("Left 0");
+			_app.FastTap("Left 0");
 			_app.WaitForText("_selectedItem", "Selected item: ");
 			_app.WaitForText("SelectionChangedTextBlock", "SelectionChanged event: AddedItems=(), RemovedItems=(0, )");
 
-			_app.Tap("Left 0");
+			_app.FastTap("Left 0");
 			_app.WaitForText("_selectedItem", "Selected item: 0");
 			_app.WaitForText("SelectionChangedTextBlock", "SelectionChanged event: AddedItems=(0, ), RemovedItems=()");
 
-			_app.Tap("Left 1");
+			_app.FastTap("Left 1");
 			_app.WaitForText("_selectedItem", "Selected item: 0");
 			_app.WaitForText("SelectionChangedTextBlock", "SelectionChanged event: AddedItems=(1, ), RemovedItems=()");
 
-			_app.Tap("Left 2");
+			_app.FastTap("Left 2");
 			_app.WaitForText("_selectedItem", "Selected item: 0");
 			_app.WaitForText("SelectionChangedTextBlock", "SelectionChanged event: AddedItems=(2, ), RemovedItems=()");
 
-			_app.Tap("Center 3");
+			_app.FastTap("Center 3");
 			_app.WaitForText("_selectedItem", "Selected item: 3");
 			_app.WaitForText("SelectionChangedTextBlock", "SelectionChanged event: AddedItems=(3, ), RemovedItems=(0, 1, 2, )");
 
-			_app.Tap("Right 0");
-			_app.Tap("Right 1");
-			_app.Tap("Right 2");
+			_app.FastTap("Right 0");
+			_app.FastTap("Right 1");
+			_app.FastTap("Right 2");
 			_app.WaitForText("SelectionChangedTextBlock", "SelectionChanged event: AddedItems=(2, ), RemovedItems=()");
 
-			_app.Tap("ClearSelectedItemButton");
+			_app.FastTap("ClearSelectedItemButton");
 
 			_app.WaitForText("SelectionChangedTextBlock", "SelectionChanged event: AddedItems=(), RemovedItems=(3, 0, 1, 2, )");
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/MenuFlyoutItemTests/UnoSamples_Test_Click.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/MenuFlyoutItemTests/UnoSamples_Test_Click.cs
@@ -26,12 +26,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutItemTests
 			TakeScreenshot("Initial");
 
 			// step 1: press button to show menu
-			_app.Tap(_app.Marked("mfiButton"));
+			_app.FastTap(_app.Marked("mfiButton"));
 
 			TakeScreenshot("menuShown", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Menu animation is midflight*/);
 
 			// step 2: click MenuFlyoutItem
-			_app.Tap(_app.Marked("mfiItem"));
+			_app.FastTap(_app.Marked("mfiItem"));
 
 			// step 3: check result
 			_app.WaitForText(_app.Marked("mfiResult"), "success");  

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
@@ -32,7 +32,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", false);
 
-			toggleButton.Tap();
+			toggleButton.FastTap();
 
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", true);
 
@@ -40,7 +40,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 
 			_app.WaitForElement(popupContent);
 
-			popupContent.Tap();
+			popupContent.FastTap();
 
 			_app.Wait(0.25f);
 
@@ -78,14 +78,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", false);
 
 			// 1. Open the popup
-			toggleButton.Tap();
+			toggleButton.FastTap();
 			_app.Wait(0.25f);
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", true);
 			_app.WaitForElement(popupContent);
 			TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup opened");
 
 			// 2. Tap on content should keep the popup opened
-			popupContent.Tap();
+			popupContent.FastTap();
 			_app.Wait(0.25f);
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", true);
 			TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup stays open when tap on content");
@@ -98,7 +98,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 			TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup stays open when tap out of popup");
 
 			// 3. Close the popup (to make sure to not pollute other tests)
-			toggleButton.Tap(); // should dismiss here
+			toggleButton.FastTap(); // should dismiss here
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", false);
 			TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup closed"); // We add a screen shot in order to make sure that the check of the bool IsChecked is valid!
 		}
@@ -113,7 +113,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 			var rect = _app.GetRect("LocatorRectangle");
 			ImageAssert.HasColorAt(before, rect.CenterX, rect.CenterY, Color.Blue);
 
-			_app.Tap("PopupCheckBox");
+			_app.FastTap("PopupCheckBox");
 
 			_app.WaitForElement("PopupChild");
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
@@ -27,12 +27,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 			var validate = _app.Marked("_validate");
 			var result = _app.Marked("_result");
 
-			selectMode.Tap();
+			selectMode.FastTap();
 
 			//Drag upward
 			_app.DragCoordinates(sut.Rect.X + 10, sut.Rect.Y + 110, sut.Rect.X + 10, sut.Rect.Y + 10);
 
-			validate.Tap();
+			validate.FastTap();
 			TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 			_app.WaitForDependencyPropertyValue(result, "Text", "SUCCESS");
 		}
@@ -49,12 +49,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 			var validate = _app.Marked("_validate");
 			var result = _app.Marked("_result");
 
-			selectMode.Tap();
+			selectMode.FastTap();
 
 			//Drag upward
 			_app.DragCoordinates(sut.Rect.X + 10, sut.Rect.Y + 110, sut.Rect.X + 10, sut.Rect.Y + 10);
 
-			validate.Tap();
+			validate.FastTap();
 			TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 			_app.WaitForDependencyPropertyValue(result, "Text", "SUCCESS");
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -66,7 +66,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			var blueBefore = TakeScreenshot("Before - blue");
 
-			_app.Tap("ChangeTextBlockButton");
+			_app.FastTap("ChangeTextBlockButton");
 
 			var blackBefore = TakeScreenshot("Before - black");
 
@@ -74,11 +74,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			ImageAssert.AreNotEqual(blueBefore, blackBefore, textRect);
 
-			_app.Tap("ChangeTextBlockButton");
+			_app.FastTap("ChangeTextBlockButton");
 
 			//_app.WaitForNoElement("FunnyTextBlock"); // This times out on WASM because view is considered to be still there when collapsed - https://github.com/unoplatform/Uno.UITest/issues/25
 
-			_app.Tap("ChangeTextBlockButton");
+			_app.FastTap("ChangeTextBlockButton");
 
 			_app.WaitForElement("FunnyTextBlock");
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Linq;
 using FluentAssertions;
@@ -146,6 +146,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 		[Test]
 		[AutoRetry]
+        [ActivePlatforms(Platform.Browser, Platform.Android)] // unstable test on iOS
 		public void TextBox_Readonly()
 		{
 			Run("Uno.UI.Samples.UITests.TextBoxControl.TextBox_IsReadOnly");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -45,10 +45,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			var tb1 = _app.Marked("tb1");
 			var tb2 = _app.Marked("tb2");
 
-			tb1.Tap();
+			tb1.FastTap();
 			TakeScreenshot("tb1 focused", ignoreInSnapshotCompare: true);
 
-			tb2.Tap();
+			tb2.FastTap();
 			TakeScreenshot("tb2 focused", ignoreInSnapshotCompare: true);
 		}
 
@@ -64,12 +64,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			var textBox1Result_Before = _app.Query(textBox1).First();
 			var textBox2Result_Before = _app.Query(textBox2).First();
 
-			textBox1.Tap();
+			textBox1.FastTap();
 			textBox1.EnterText("hello 01");
 
 			_app.WaitForText(textBox1, "hello 01");
 
-			textBox2.Tap();
+			textBox2.FastTap();
 			textBox2.EnterText("hello 02");
 
 			_app.WaitForText(textBox2, "hello 02");
@@ -92,12 +92,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			var textBox1 = _app.Marked("textBox1");
 			var textBox2 = _app.Marked("textBox2");
 
-			textBox1.Tap();
+			textBox1.FastTap();
 			textBox1.EnterText("hello 01");
 
 			_app.WaitForText(textBox1, "hello 01");
 
-			textBox2.Tap();
+			textBox2.FastTap();
 			textBox2.EnterText("hello 02");
 
 			_app.WaitForText(textBox2, "hello 02");
@@ -106,7 +106,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			var textBox2Result = _app.Query(textBox2).First();
 
 			// Focus the first textbox
-			textBox1.Tap();
+			textBox1.FastTap();
 
 			var deleteButton1 = FindDeleteButton(textBox1Result);
 
@@ -118,7 +118,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			_app.WaitForText(textBox1, "");
 
 			// Focus the first textbox
-			textBox2.Tap();
+			textBox2.FastTap();
 
 			var deleteButton2 = FindDeleteButton(textBox2Result);
 
@@ -159,15 +159,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			_app.EnterText(txt, "ERROR1");
 			_app.WaitForText(txt, initialText);
 
-			tglReadonly.Tap();
+			tglReadonly.FastTap();
 			_app.EnterText(txt, "Hello!");
 			_app.WaitForText(txt, initialText + "Hello!");
 
-			tglReadonly.Tap();
+			tglReadonly.FastTap();
 			_app.EnterText(txt, "ERROR2");
 			_app.WaitForText(txt, initialText + "Hello!");
 
-			tglReadonly.Tap();
+			tglReadonly.FastTap();
 			_app.EnterText(txt, " Works again!");
 			_app.WaitForText(txt, initialText + "Hello! Works again!");
 		}
@@ -236,14 +236,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			void DefocusTextBox()
 			{
-				_app.Tap(DummyButton);
+				_app.FastTap(DummyButton);
 
 				_app.WaitForFocus(DummyButton);
 			}
 
 			Assert.AreEqual("initial", GetMappedText());
 
-			_app.Tap(TextBox);
+			_app.FastTap(TextBox);
 
 			_app.WaitForFocus(TextBox);
 
@@ -251,7 +251,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			Assert.AreEqual("initial", GetMappedText()); //Binding not pushed on losing focus
 
-			_app.Tap(TextBox);
+			_app.FastTap(TextBox);
 
 			_app.EnterText("fleep");
 
@@ -259,11 +259,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			Assert.AreEqual("fleep", GetMappedText());
 
-			_app.Tap("ResetButton");
+			_app.FastTap("ResetButton");
 
 			_app.WaitForText(MappedText, "reset");
 
-			_app.Tap(TextBox);
+			_app.FastTap(TextBox);
 
 			_app.WaitForFocus(TextBox);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
@@ -36,7 +36,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 				_app.SetOrientationPortrait();
 
 				// Open and dismiss flyout
-				myTimePicker.Tap();
+				myTimePicker.FastTap();
 				var myDevice = _app.Device.GetType();
 				if (_app.Device.GetType().Name.Contains("Android"))
 				{
@@ -44,7 +44,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 					_app.Wait(2);
 					_app.TapCoordinates(988, 1625);
 
-					_app.Find("Cancel").Tap();
+					_app.Find("Cancel").FastTap();
 					_app.Wait(2);
 				}
 				else
@@ -82,7 +82,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 				_app.SetOrientationPortrait();
 
 				// Open, change ime and click on ok to apply changes and to close flyout
-				myTimePicker.Tap();
+				myTimePicker.FastTap();
 				var myDevice = _app.Device.GetType();
 				if (_app.Device.GetType().Name.Contains("Android"))
 				{
@@ -90,7 +90,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 					_app.Wait(2);
 					_app.TapCoordinates(988, 1625);
 
-					_app.Find("OK").Tap();
+					_app.Find("OK").FastTap();
 					_app.Wait(2);
 
 					//Assert final state
@@ -140,7 +140,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 			var timePickerFlyout = theTimePicker.Child;
 
 			// Open flyout
-			theTimePicker.Tap();
+			theTimePicker.FastTap();
 
 			//Assert
 			Assert.IsNotNull(theTimePicker.GetDependencyPropertyValue("DataContext"));
@@ -163,7 +163,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 			var timePickerFlyout = theTimePicker.Child;
 
 			// Open flyout
-			theTimePicker.Tap();
+			theTimePicker.FastTap();
 
 			//Assert
 			Assert.IsNotNull(timePickerFlyout.GetDependencyPropertyValue("Content"));
@@ -183,7 +183,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 
 			_app.WaitForElement(picker);
 
-			picker.Tap();
+			picker.FastTap();
 
 			TakeScreenshot("TimePicker - Flyout", ignoreInSnapshotCompare: true);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToggleSwitchTests/UnoSamples_Tests.ToggleSwitch.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToggleSwitchTests/UnoSamples_Tests.ToggleSwitch.cs
@@ -30,8 +30,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ToggleSwitchTests
 			Assert.AreEqual("False", toggleSwitchGroup.GetDependencyPropertyValue("IsOn")?.ToString());
 			Assert.AreEqual("True", separatedToggleSwitch.GetDependencyPropertyValue("IsOn")?.ToString());
 
-			unloadButton.Tap();
-			reloadButton.Tap();
+			unloadButton.FastTap();
+			reloadButton.FastTap();
 
 			//Assert final state
 			Assert.AreEqual("False", toggleSwitchGroup.GetDependencyPropertyValue("IsOn")?.ToString());

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToolTipTests/ToolTip_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToolTipTests/ToolTip_Tests.cs
@@ -20,17 +20,17 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ToolTipTests
 
 			_app.Marked("richToolTip").FirstResult().Should().BeNull("Initial state");
 
-			_app.Marked("rect2").Tap();
+			_app.Marked("rect2").FastTap();
 
 			_app.Marked("richToolTip").FirstResult().Should().BeNull("Right after first click");
 
 			Thread.Sleep(1200);
 
-			_app.Marked("rect1").Tap();
+			_app.Marked("rect1").FastTap();
 
 			Thread.Sleep(200);
 
-			_app.Marked("rect2").Tap();
+			_app.Marked("rect2").FastTap();
 
 			_app.Marked("richToolTip").FirstResult().Should().BeNull("Right after second click");
 
@@ -44,7 +44,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ToolTipTests
 
 			_app.Marked("richToolTip").FirstResult().Should().BeNull("tooltip delay expired");
 
-			_app.Marked("rect1").Tap();
+			_app.Marked("rect1").FastTap();
 
 			Thread.Sleep(1200);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WebViewTests/UnoSamples_Test_NavigateToString.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WebViewTests/UnoSamples_Test_NavigateToString.cs
@@ -29,12 +29,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.WebViewTests
 			var clickResult = _app.Marked("WebView_NavigateToStringResult");
 
 			// step 1: generate long string
-			_app.Tap(startButton);
+			_app.FastTap(startButton);
 
 			_app.WaitForText(clickResult, "string ready");  // timeout here means: add wait
 
 			// step 2: NavigateTo
-			_app.Tap(startButton);
+			_app.FastTap(startButton);
 			_app.WaitForText(clickResult, "success");   // timeout here means: bug reappear
 
 			TakeScreenshot("AfterSuccess");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Data/UnoSamples_Tests.XBind.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Data/UnoSamples_Tests.XBind.cs
@@ -100,7 +100,7 @@ namespace SamplesApp.UITests
 			var _DataTemplate_MyProperty_Formatted_OneWay = _app.Marked("_DataTemplate_MyProperty_Formatted_OneWay");
 			Assert.AreEqual("Formatted Initial", _DataTemplate_MyProperty_Formatted_OneWay.GetText());
 
-			updateTemplateButton.Tap();
+			updateTemplateButton.FastTap();
 
 			Assert.AreEqual("NEW UPDATE", _DataTemplate_MyProperty_Function_OneWay.GetText());
 			Assert.AreEqual("Formatted new update", _DataTemplate_MyProperty_Formatted_OneWay.GetText());

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Capture_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Capture_Tests.cs
@@ -42,7 +42,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			=> RunTest("NestedIsEnabled");
 
 
-		private readonly Action<QueryEx> TouchAndHold = element => /*element.TouchAndHold() not implemented ... we can use tap instead */ element.Tap();
+		private readonly Action<QueryEx> TouchAndHold = element => /*element.TouchAndHold() not implemented ... we can use tap instead */ element.FastTap();
 		private void TouchAndMoveOut(QueryEx element)
 		{
 			var rect = _app.WaitForElement(element).Single().Rect;

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/EventSequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/EventSequence_Tests.cs
@@ -42,7 +42,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 		public void TestListView()
 			=> RunSequence("ListView", TapSomewhereInElement);
 
-		private readonly Action<QueryEx> TapElement = element => element.Tap();
+		private readonly Action<QueryEx> TapElement = element => element.FastTap();
 		private void TranslateOverElement(QueryEx element)
 		{
 			var rect = _app.WaitForElement(element).Single().Rect;
@@ -66,9 +66,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			var result = _app.Marked($"Test{testName}Result");
 
 			_app.WaitForElement(target);
-			reset.Tap();
+			reset.FastTap();
 			tap(target);
-			validate.Tap();
+			validate.FastTap();
 
 			TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Opacity.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Opacity.cs
@@ -65,7 +65,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 			var initial = TakeScreenshot("Initial", ignoreInSnapshotCompare: true);
 			var element = _app.WaitForElement($"{type}AnimationHost_{fill}").Single().Rect;
 
-			_app.Marked("StartButton").Tap();
+			_app.Marked("StartButton").FastTap();
 			_app.WaitForDependencyPropertyValue(_app.Marked("Status"), "Text", "Completed");
 
 			// Assert

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Transforms.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Transforms.cs
@@ -69,7 +69,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 			expectedDelta *= scale;
 			tolerance *= scale;
 
-			_app.Marked("StartButton").Tap();
+			_app.Marked("StartButton").FastTap();
 			_app.WaitForDependencyPropertyValue(_app.Marked("Status"), "Text", "Completed");
 
 			// Assert

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
@@ -25,7 +25,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 
 			void TabWaitAndThenScreenshot(string buttonName)
 			{
-				_app.Marked(buttonName).Tap();
+				_app.Marked(buttonName).FastTap();
 				_app.WaitForElement("DPolyline");
 				TakeScreenshot($"PolylinePage - {buttonName}");
 			}
@@ -42,7 +42,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 
 			void TabWaitAndThenScreenshot(string buttonName)
 			{
-				_app.Marked(buttonName).Tap();
+				_app.Marked(buttonName).FastTap();
 				_app.WaitForElement("DPolygon");
 				TakeScreenshot($"PolygonPage - {buttonName}");
 			}
@@ -55,10 +55,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			Run("SamplesApp.Windows_UI_Xaml_Shapes.PolygonPage");
 
 			_app.WaitForElement("DPolygon");
-			_app.Marked("ClearShape").Tap();
+			_app.Marked("ClearShape").FastTap();
 			TakeScreenshot($"PolygonPage - ClearShape");
 
-			_app.Marked("ChangeShape").Tap();
+			_app.Marked("ChangeShape").FastTap();
 			var widthzize = _app.Query(_app.Marked("DPolygon")).First().Rect.Width;
 
 			if (widthzize == 0)
@@ -74,10 +74,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			Run("SamplesApp.Windows_UI_Xaml_Shapes.PolylinePage");
 
 			_app.WaitForElement("DPolyline");
-			_app.Marked("ClearShape").Tap();
+			_app.Marked("ClearShape").FastTap();
 			TakeScreenshot($"PolylinePage - ClearShape");
 
-			_app.Marked("ChangeShape").Tap();
+			_app.Marked("ChangeShape").FastTap();
 			var widthzize = _app.Query(_app.Marked("DPolyline")).First().Rect.Width;
 
 			if(widthzize == 0)


### PR DESCRIPTION
# Feature
UI tests: .FastTap() instead of .Tap()

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
