### PR TITLE
[Android] Support for `ToastNotification` (with test)

### DIFF
--- a/Doc/articles/features/toasts.md
+++ b/Doc/articles/features/toasts.md
@@ -1,0 +1,7 @@
+# Uno Support for Windows.UI.Notifications.Toast*
+
+## Limitations
+
+**Android**
+Currently, from XML, only toast.launch attribute and text elements are supported.
+First text element is converted to Android notification title, and subsequent text elements - to notification text. But on Android < 14, new lines within texts are ignored; on newer Android versions, new lines are ignored in first text (title).

--- a/Doc/articles/features/toasts.md
+++ b/Doc/articles/features/toasts.md
@@ -6,3 +6,5 @@
 Currently, from XML, only toast.launch attribute and text elements are supported.
 First text element is converted to Android notification title, and subsequent text elements - to notification text. But on Android < 14, new lines within texts are ignored; on newer Android versions, new lines are ignored in first text (title).
 You have to set icon in Android manifest file (on Android, all Notifications are required to have icons).
+
+Toasts wouldn't work if app has no default icon. Make sure to set one in Android manifest file (application/@android:icon)

--- a/Doc/articles/features/toasts.md
+++ b/Doc/articles/features/toasts.md
@@ -5,3 +5,4 @@
 **Android**
 Currently, from XML, only toast.launch attribute and text elements are supported.
 First text element is converted to Android notification title, and subsequent text elements - to notification text. But on Android < 14, new lines within texts are ignored; on newer Android versions, new lines are ignored in first text (title).
+You have to set icon in Android manifest file (on Android, all Notifications are required to have icons).

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -200,6 +200,8 @@
               href: features/windows-ui-markup-extensions.md
             - name: WinAppSDK Specifics
               href: features/winapp-sdk-specifics.md
+            - name: Toasts
+              href: features/toasts.md
         - name: WinUI Controls
           items:
             - name: ComboBox

--- a/src/SamplesApp/SamplesApp.Droid/Properties/AndroidManifest.xml
+++ b/src/SamplesApp/SamplesApp.Droid/Properties/AndroidManifest.xml
@@ -17,7 +17,7 @@
 		</intent>
 	</queries>-->
 	<uses-permission android:name="android.permission.READ_CALENDAR" />
-	<application android:label="SamplesApp" android:usesCleartextTraffic="true">
+	<application android:label="SamplesApp" android:usesCleartextTraffic="true" android:icon="@drawable/Icon">
 		<!-- Set an API key locally to test the MapControl - https://developers.google.com/maps/documentation/android-sdk/get-api-key -->
 		<meta-data android:name="com.google.android.geo.API_KEY" android:value="YOUR API KEY" />
 

--- a/src/SamplesApp/SamplesApp.netcoremobile/Android/AndroidManifest.xml
+++ b/src/SamplesApp/SamplesApp.netcoremobile/Android/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="uno.platform.unosampleapp" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
   <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="30" />
   <!-- NOTE: Add permissions in AssemblyInfo.cs -->
-  <application android:label="SamplesApp" android:usesCleartextTraffic="true">
+  <application android:label="SamplesApp" android:usesCleartextTraffic="true" android:icon="@drawable/Icon">
 	<!-- Set an API key locally to test the MapControl - https://developers.google.com/maps/documentation/android-sdk/get-api-key -->
 	<meta-data android:name="com.google.android.geo.API_KEY" android:value="YOUR API KEY" />
   </application>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -802,6 +802,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Notifications\ToastNotification.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_StartScreen\JumpListTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5623,6 +5627,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Notifications\BadgeNotificationTests.xaml.cs">
       <DependentUpon>BadgeNotificationTests.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Notifications\ToastNotification.xaml.cs">
+      <DependentUpon>TestNotification.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_StartScreen\JumpListTests.xaml.cs">
       <DependentUpon>JumpListTests.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Notifications.ToastNotification"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:UITests.Windows_ApplicationModel.Contacts"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:contacts="using:Windows.ApplicationModel.Contacts"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+	<StackPanel Padding="20">
+		<TextBlock Text="This would work only if app has icon defined" />
+		<TextBox x:Name="toastLine1" Header="Toast message line 1" />
+		<TextBox x:Name="toastLine2" Header="Toast message line 2"/>
+		<Button Click="sendToast_Click">Send toast</Button>
+		<TextBlock Text="" Foreground="Red" Name="errorMsg"/>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml
@@ -12,6 +12,7 @@
 		<TextBlock Text="This would work only if app has icon defined" />
 		<TextBox x:Name="uiToastLine1" Header="Toast message line 1" />
 		<TextBox x:Name="uiToastLine2" Header="Toast message line 2"/>
+		<TextBox x:Name="uiToastLaunchArg" Header="Toast launch argument"/>
 		<Button Click="sendToast_Click">Send toast</Button>
 		<TextBlock Text="" Foreground="Red" Name="uiErrorMsg"/>
 	</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml
@@ -3,16 +3,16 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:UITests.Windows_ApplicationModel.Contacts"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:contacts="using:Windows.ApplicationModel.Contacts"
+    xmlns:local="using:UITests.Windows_UI_Notifications"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
 	<StackPanel Padding="20">
 		<TextBlock Text="This would work only if app has icon defined" />
-		<TextBox x:Name="toastLine1" Header="Toast message line 1" />
-		<TextBox x:Name="toastLine2" Header="Toast message line 2"/>
+		<TextBox x:Name="uiToastLine1" Header="Toast message line 1" />
+		<TextBox x:Name="uiToastLine2" Header="Toast message line 2"/>
 		<Button Click="sendToast_Click">Send toast</Button>
-		<TextBlock Text="" Foreground="Red" Name="errorMsg"/>
+		<TextBlock Text="" Foreground="Red" Name="uiErrorMsg"/>
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml
@@ -14,6 +14,6 @@
 		<TextBox x:Name="uiToastLine2" Header="Toast message line 2"/>
 		<TextBox x:Name="uiToastLaunchArg" Header="Toast launch argument"/>
 		<Button Click="sendToast_Click">Send toast</Button>
-		<TextBlock Text="" Foreground="Red" Name="uiErrorMsg"/>
+		<TextBlock Text="" Foreground="Red" Name="uiErrorMsg" TextWrapping="Wrap"/>
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Data.Xml.Dom;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Notifications;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Notifications
+{
+	[SampleControlInfo("Windows.UI.Notifications")]
+	[ActivePlatforms(Platform.Android)]
+	public sealed partial class ToastNotification : Page
+    {
+        public ToastNotification()
+        {
+            this.InitializeComponent();
+        }
+
+
+		public sealed partial class BadgeNotificationTests : Page
+		{
+			public BadgeNotificationTests()
+			{
+				this.InitializeComponent();
+			}
+
+			private void sendToast_Click(object sender, RoutedEventArgs e)
+			{
+				string toastLine1 = toastLine1.Text;
+				string toastLine2 = toastLine2.Text;
+
+				if (string.IsNullOrEmpty(toastLine1))
+				{
+					errorMsg.Text = "First string cannot be empty!";
+					return;
+				}
+
+				var sXml = "<visual><binding template='ToastGeneric'><text>" + toastLine1;
+				if (!string.IsNullOrEmpty(toastLine2))
+				{
+					sXml = sXml + "</text><text>" + toastLine2;
+				}
+				sXml = sXml + "</text></binding></visual>";
+				var oXml = new Windows.Data.Xml.Dom.XmlDocument();
+				oXml.LoadXml("<toast>" + sXml + "</toast>");
+
+				try
+				{
+					var oToast = new Windows.UI.Notifications.ToastNotification(oXml);
+					Windows.UI.Notifications.ToastNotificationManager.CreateToastNotifier().Show(oToast);
+				}
+				catch (Exception ex)
+				{
+					errorMsg.Text = "Catched exception: " + ex.Message;
+				}
+
+			}
+
+		}
+
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml.cs
@@ -47,8 +47,8 @@ namespace UITests.Windows_UI_Notifications
 			}
 			sXml = sXml + "</text></binding></visual>";
 			var oXml = new Windows.Data.Xml.Dom.XmlDocument();
-			oXml.LoadXml("<toast>" + sXml + "</toast>");
-
+			oXml.LoadXml("<toast launch=\"" + uiToastLaunchArg.Text + "\"> " + sXml + "</toast>");
+			
 			try
 			{
 				var oToast = new Windows.UI.Notifications.ToastNotification(oXml);

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml.cs
@@ -20,56 +20,47 @@ using Windows.UI.Xaml.Navigation;
 
 namespace UITests.Windows_UI_Notifications
 {
-	[SampleControlInfo("Windows.UI.Notifications")]
-	[ActivePlatforms(Platform.Android)]
+	[SampleControlInfo("Windows.UI.Notifications", "Toast")]
 	public sealed partial class ToastNotification : Page
-    {
-        public ToastNotification()
-        {
-            this.InitializeComponent();
-        }
-
-
-		public sealed partial class BadgeNotificationTests : Page
+	{
+		public ToastNotification()
 		{
-			public BadgeNotificationTests()
+			this.InitializeComponent();
+		}
+
+
+		private void sendToast_Click(object sender, RoutedEventArgs e)
+		{
+			string toastLine1 = uiToastLine1.Text;
+			string toastLine2 = uiToastLine2.Text;
+
+			if (string.IsNullOrEmpty(toastLine1))
 			{
-				this.InitializeComponent();
+				uiErrorMsg.Text = "First string cannot be empty!";
+				return;
 			}
 
-			private void sendToast_Click(object sender, RoutedEventArgs e)
+			var sXml = "<visual><binding template='ToastGeneric'><text>" + toastLine1;
+			if (!string.IsNullOrEmpty(toastLine2))
 			{
-				string toastLine1 = toastLine1.Text;
-				string toastLine2 = toastLine2.Text;
+				sXml = sXml + "</text><text>" + toastLine2;
+			}
+			sXml = sXml + "</text></binding></visual>";
+			var oXml = new Windows.Data.Xml.Dom.XmlDocument();
+			oXml.LoadXml("<toast>" + sXml + "</toast>");
 
-				if (string.IsNullOrEmpty(toastLine1))
-				{
-					errorMsg.Text = "First string cannot be empty!";
-					return;
-				}
-
-				var sXml = "<visual><binding template='ToastGeneric'><text>" + toastLine1;
-				if (!string.IsNullOrEmpty(toastLine2))
-				{
-					sXml = sXml + "</text><text>" + toastLine2;
-				}
-				sXml = sXml + "</text></binding></visual>";
-				var oXml = new Windows.Data.Xml.Dom.XmlDocument();
-				oXml.LoadXml("<toast>" + sXml + "</toast>");
-
-				try
-				{
-					var oToast = new Windows.UI.Notifications.ToastNotification(oXml);
-					Windows.UI.Notifications.ToastNotificationManager.CreateToastNotifier().Show(oToast);
-				}
-				catch (Exception ex)
-				{
-					errorMsg.Text = "Catched exception: " + ex.Message;
-				}
-
+			try
+			{
+				var oToast = new Windows.UI.Notifications.ToastNotification(oXml);
+				Windows.UI.Notifications.ToastNotificationManager.CreateToastNotifier().Show(oToast);
+			}
+			catch (Exception ex)
+			{
+				uiErrorMsg.Text = "Caught exception: " + ex.Message;
 			}
 
 		}
 
 	}
+
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Notifications/ToastNotification.xaml.cs
@@ -48,7 +48,7 @@ namespace UITests.Windows_UI_Notifications
 			sXml = sXml + "</text></binding></visual>";
 			var oXml = new Windows.Data.Xml.Dom.XmlDocument();
 			oXml.LoadXml("<toast launch=\"" + uiToastLaunchArg.Text + "\"> " + sXml + "</toast>");
-			
+
 			try
 			{
 				var oToast = new Windows.UI.Notifications.ToastNotification(oXml);

--- a/src/Uno.UI/UI/Xaml/NativeApplication.cs
+++ b/src/Uno.UI/UI/Xaml/NativeApplication.cs
@@ -64,15 +64,22 @@ namespace Windows.UI.Xaml
 
 				_app.InitializationCompleted();
 
-				var handled = TryHandleIntent(activity.Intent);
-
-				// default to normal launch
-				if (!handled && !_isRunning)
+				if (activity.Intent?.GetDoubleExtra("Uno.internal.IntentType", 0) == (int)ActivationKind.ToastNotification)
 				{
-					_app.OnLaunched(new LaunchActivatedEventArgs());
+					var toastActivated = new ToastNotificationActivatedEventArgs(activity.Intent.GetStringExtra("Uno.internal.ToastArgument"));
+					_app.OnActivated(toastActivated as IActivatedEventArgs);
 				}
+				else
+				{
+					var handled = TryHandleIntent(activity.Intent);
 
-				_isRunning = true;
+					// default to normal launch
+					if (!handled && !_isRunning)
+					{
+						_app.OnLaunched(new LaunchActivatedEventArgs());
+					}
+					_isRunning = true;
+				}
 			}
 		}
 

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Notifications/ToastNotificationManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Notifications/ToastNotificationManager.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Notifications
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public static partial class ToastNotificationManager 
@@ -39,7 +39,7 @@ namespace Windows.UI.Notifications
 		}
 		#endif
 		// Forced skipping of method Windows.UI.Notifications.ToastNotificationManager.History.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Notifications.ToastNotifier CreateToastNotifier()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Notifications/ToastNotifier.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Notifications/ToastNotifier.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Notifications
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ToastNotifier 
@@ -17,7 +17,7 @@ namespace Windows.UI.Notifications
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Show( global::Windows.UI.Notifications.ToastNotification notification)
 		{

--- a/src/Uno.UWP/UI/Notifications/ToastNotificationManager.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotificationManager.Android.cs
@@ -1,0 +1,19 @@
+﻿#if __ANDROID__
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Windows.UI.Notifications
+{
+	public partial class ToastNotificationManager
+	{
+		public static ToastNotifier CreateToastNotifier()
+		{
+			return new ToastNotifier();
+		}
+	}
+}
+
+#endif 

--- a/src/Uno.UWP/UI/Notifications/ToastNotificationManager.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotificationManager.Android.cs
@@ -1,5 +1,4 @@
-﻿#if __ANDROID__
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,5 +14,3 @@ namespace Windows.UI.Notifications
 		}
 	}
 }
-
-#endif 

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -1,0 +1,266 @@
+﻿#if __ANDROID__
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Windows.UI.Notifications
+{
+	public partial class ToastNotifier
+	{
+		private string _channelID = "PlatformUno"; 
+		private Android.App.NotificationManager _notificationManager;
+
+		public ToastNotifier()
+		{
+			_notificationManager = Android.App.NotificationManager.FromContext(Android.App.Application.Context);
+
+			if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.O)
+			{	// none of this strings would be visible for user
+				var channel = new Android.App.NotificationChannel(_channelID, "PlatformUnoChannel", Android.App.NotificationImportance.Default); ; // deprecated: Android.App.NotificationManager.ImportanceDefault
+				_notificationManager.CreateNotificationChannel(channel);
+			}
+
+		}
+
+		private string ConvertToastTextToString(string toasttext)
+		{
+			// "When using the "ms-resource" prefix, the string identifier is referenced in the app's Resources.resw file."
+			if (!toasttext.StartsWith("ms-resource:"))
+			{
+				return toasttext;
+			}
+
+			toasttext = toasttext.Substring(12); // skipping prefix "ms-resource:"
+			var retVal = Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView()?.GetString(toasttext);
+			if(retVal is null)
+			{	// we have no such string
+				return toasttext;
+			}
+			return retVal;
+		}
+
+		private Android.App.Notification.Builder GetToastBuilder()
+		{
+			// if API < 11, then another version...
+			if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.O)
+			{
+				return new Android.App.Notification.Builder(Android.App.Application.Context, _channelID);
+			}
+
+#pragma warning disable CS0618 // Type or member is obsolete - compilation is for newer SDK, but runtime is on older SDK
+				return new Android.App.Notification.Builder(Android.App.Application.Context);
+#pragma warning restore CS0618
+
+		}
+
+		private int GetIconId(string packageName)
+		{
+			Android.Content.PM.ApplicationInfo info = null;
+			info = Android.App.Application.Context?.ApplicationContext?.PackageManager?.GetApplicationInfo(packageName, 0);
+
+			int iconId;
+			if (info != null)
+			{
+				iconId = info.Icon;
+			}
+			else
+			{
+				// try another method - using more resources (CPU and memory), as Intent is involved
+				Android.Content.Intent intent = Android.App.Application.Context.PackageManager.GetLaunchIntentForPackage(Android.App.Application.Context.PackageName);
+				Android.Content.PM.ResolveInfo resolveInfo = Android.App.Application.Context.PackageManager.ResolveActivity(intent, Android.Content.PM.PackageInfoFlags.MatchDefaultOnly);
+				iconId = resolveInfo.IconResource;
+			}
+
+			return iconId;
+
+		}
+
+
+		public void Show(ToastNotification notification)
+		{
+			var androidNotification = new Android.App.Notification();
+			androidNotification.Category = Android.App.Notification.CategoryMessage;
+
+			Android.App.Notification.Builder builder = GetToastBuilder();
+
+			#region "setting Toast texts"
+			// extract <text> nodes from XML
+
+			string toastTitleText = "";
+			string toastText = "";
+
+			// we use XmlDocument for retrieving text items and launch attribute (many lines below)
+			// Windows.Data.Xml.Dom is almost not implemented, so we have to use System.Xml
+			var xmlDoc = new XmlDocument();
+			xmlDoc.LoadXml(notification.Content.GetXml());  
+
+			var childToast = xmlDoc.GetElementsByTagName("text");
+			if(childToast.Count > 0)
+			{
+				// first text - bigger text (title)
+				toastTitleText = ConvertToastTextToString(childToast.Item(0).InnerText);
+
+				if (childToast.Count > 1)
+				{
+					toastText = ConvertToastTextToString(childToast.Item(1).InnerText);
+
+					for (int loopCnt = 2; loopCnt < childToast.Count; loopCnt++)
+					{	// in most scenarios, this loop will never iterate
+						// separate lines with space and \n: \n as line splitting for newer Android, space - for older
+						toastText = toastText + " \n" + ConvertToastTextToString(childToast.Item(loopCnt).InnerText);
+					}
+				}
+			}
+
+
+			// now, we have set toastTitleText, and maybe toastText.
+
+			if (!string.IsNullOrEmpty(toastTitleText))
+			{
+				builder.SetContentTitle(toastTitleText);
+			}
+
+			if (!string.IsNullOrEmpty(toastText))
+			{ // Android toasts doesn't support new line character in standard toasts
+
+				if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.JellyBean)
+				{
+					// too old Android... we can't do anything with it
+					builder.SetContentText(toastText);
+				}
+				else
+				{ // since API 16, we can try to emulate multiline toast's text
+					var msgLines = toastText.Split("\n");
+					if (msgLines.Count() < 2)
+					{
+						// single line of text
+						builder.SetContentText(toastText);
+					}
+					else
+					{
+						if (msgLines.Count() > 6)
+						{
+							// too many lines for InboxStyle - show in expandable form
+							var expandableToast = new Android.App.Notification.BigTextStyle().BigText(toastText);
+							builder.SetStyle(expandableToast);
+						}
+						else
+						{
+							// between 2 and 6 lines - use InboxStyle
+							var inboxToast = new Android.App.Notification.InboxStyle();
+							foreach(var oneLine in msgLines)
+							{
+								inboxToast.AddLine(oneLine.Trim());
+							}
+
+							builder.SetStyle(inboxToast);
+						}
+					}
+				}
+
+				builder.SetContentText(toastText);
+			}
+			#endregion
+
+
+			// we have to set icon ("This is the only user-visible content that's required", says doc).
+			string packageName = Android.App.Application.Context.PackageName;
+
+			int iconId = GetIconId(packageName);
+			if(iconId == 0)
+			{
+				throw new ArgumentException("ToastNotifier: cannot get iconId, probably you didn't set icon in Android manifest file");
+			}
+
+			builder.SetSmallIcon(iconId);
+
+
+			// for somewhat older Android, we need to set Priority (deprecated in API26 - in newer Android priorities are defined in channels)
+
+			if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.O)
+			{
+#pragma warning disable CS0618 // Type or member is obsolete
+				builder.SetPriority(0); // PRIORITY_DEFAULT
+#pragma warning restore CS0618 // Type or member is obsolete
+			}
+
+
+			// mirroring / bridging of notification
+			builder.SetLocalOnly((notification.NotificationMirroring == NotificationMirroring.Disabled));
+
+			// expiration time
+			if((notification.ExpirationTime != null) && (notification.ExpirationTime.HasValue) )
+			{
+				int seconds = (int)(notification.ExpirationTime.Value - DateTime.Now).TotalSeconds;
+				if(seconds > 0)
+				{
+					builder.SetTimeoutAfter(seconds * 1000);
+				}
+
+			}
+
+			// we want notification time to be shown
+			// "For apps targeting Build.VERSION_CODES.N and above, this time is not shown anymore by default and must be opted into by using setShowWhen(boolean)"
+			// but SetShowWhen is since API 17...
+			if (Android.OS.Build.VERSION.SdkInt > Android.OS.BuildVersionCodes.M)
+			{
+				builder.SetShowWhen(true);
+			}
+
+
+			// action - opening app from tap on Toast (App.OnActivated)
+			var intentAction = Android.App.Application.Context.PackageManager.GetLaunchIntentForPackage(packageName);
+			intentAction.SetPackage(packageName);
+			// according to doc:
+			// The name must include a package prefix, for example the app com.android.contacts would use names like "com.android.contacts.ShowAll"
+			// but it works also in this way, and getting package name in background app can be difficult.
+			intentAction.PutExtra("Uno.internal.IntentType", (double)ApplicationModel.Activation.ActivationKind.ToastNotification);
+
+			string toastArgument = "";
+			childToast = xmlDoc.GetElementsByTagName("toast");
+			if (childToast.Count == 1)
+			{
+				var childLaunch = childToast.Item(0)?.Attributes?.GetNamedItem("launch");
+				if (childLaunch != null)
+				{
+					toastArgument = childLaunch.Value;
+				}
+			}
+
+			intentAction.PutExtra("Uno.internal.ToastArgument", toastArgument);
+
+			// we should have intent.data field different for different toast arguments,
+			// else - next intent would overwrite previous.
+			// it can be any URI, e.g. http://dummy.com/dummy?arg=  
+			var data = Android.Net.Uri.Parse("http://unotask.com/toast?arg=" + Android.Net.Uri.Encode(toastArgument));
+			intentAction.SetData(data);
+
+			// 12345: arbitrary number, it can be any value (as it is not used in Uno code anywhere)
+			var pendingIntent = Android.App.PendingIntent.GetActivity(Android.App.Application.Context, 12345, intentAction, 0); // 12345=requestCode
+			builder.SetContentIntent(pendingIntent);
+
+			builder.SetAutoCancel(true);
+
+
+			// another 'must' - uniq Tag/id pair
+
+			string notifTag = notification.Tag;
+			if (string.IsNullOrEmpty(notifTag))
+			{
+				notifTag = Guid.NewGuid().ToString();
+			}
+
+			// everything ready, show notification
+			// but, it will disappear when app will be closed
+
+			_notificationManager.Notify(notifTag, 12345, builder.Build());	// 12345: arbitrary number
+		}
+
+	}
+}
+
+#endif

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -116,7 +116,7 @@ namespace Windows.UI.Notifications
 			StringBuilder toastText = new StringBuilder("");
 
 			var childToast = xmlDoc.GetElementsByTagName("text");
-			if (childToast.Count > 0)
+			if ((childToast != null) && childToast.Count > 0)
 			{
 				// first text - bigger text (title)
 				toastTitleText = ConvertToastTextToString(childToast[0].InnerText);
@@ -128,7 +128,7 @@ namespace Windows.UI.Notifications
 					for (int childIndex = 2; childIndex < childToast.Count; childIndex++)
 					{   // in most scenarios, this loop will never iterate
 						// separate lines with space and \n: \n as line splitting for newer Android, space - for older
-						toastText.Append(" \n" + ConvertToastTextToString(childToast[childIndex].InnerText));
+						toastText.Append(" \n" + ConvertToastTextToString(childToast[childIndex].InnerText!));
 					}
 				}
 			}
@@ -228,7 +228,7 @@ namespace Windows.UI.Notifications
 				var childLaunch = childToast[0]?.Attributes?.GetNamedItem("launch");
 				if (childLaunch != null)
 				{
-					toastArgument = childLaunch.Value;
+					toastArgument = childLaunch!.Value!;
 				}
 			}
 

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -115,8 +115,9 @@ namespace Windows.UI.Notifications
 				var childNode0 = childToast[0];
 				if (childNode0 is null)
 				{
-					throw new InvalidOperationException("Invalid document notification document"); 
+					throw new InvalidOperationException("Invalid document notification document");
 				}
+
 				toastTitleText = ConvertToastTextToString(childNode0.InnerText);
 
 				if (childToast.Count > 1)

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -120,7 +120,7 @@ namespace Windows.UI.Notifications
 					for (int childIndex = 2; childIndex < childToast.Count; childIndex++)
 					{   // in most scenarios, this loop will never iterate
 						// separate lines with space and \n: \n as line splitting for newer Android, space - for older
-						toastText.Append(" \n" + ConvertToastTextToString(childToast[childIndex]!.InnerText!));
+						toastText.Append(" \n" + ConvertToastTextToString(childToast[childIndex].InnerText!));
 					}
 				}
 			}
@@ -220,7 +220,7 @@ namespace Windows.UI.Notifications
 				var childLaunch = childToast[0]?.Attributes?.GetNamedItem("launch");
 				if (childLaunch != null)
 				{
-					toastArgument = childLaunch!.Value!;
+					toastArgument = childLaunch.Value!;
 				}
 			}
 

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -34,23 +34,15 @@ namespace Windows.UI.Notifications
 
 		private string ConvertToastTextToString(string toasttext)
 		{
-			var uri = Android.Net.Uri.Parse(toasttext);
-			if(uri is null)
-			{
-				throw new ArgumentException("ToastNotifier:ConvertToastTextToString, toastText cannot be converted to Uri");
-			}
-			// "When using the "ms-resource" prefix, the string identifier is referenced in the app's Resources.resw file."
-			if (uri.Scheme == "ms-resource")
+			// this is simple text, e.g. "dummy" or "1"
+			if (!toasttext.StartsWith("ms-resource:"))
 			{
 				return toasttext;
 			}
 
-			var resName = uri.SchemeSpecificPart;
-			if (resName is null)
-			{
-				throw new ArgumentException("ToastNotifier:ConvertToastTextToString, empty SchemeSpecificPart (within Scheme ms-resource)");
-			}
-			toasttext = resName; 
+			// it is text with prefix, directing us to resources
+			toasttext = toasttext.Substring("ms-resource:".Length);
+
 			var retVal = Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView()?.GetString(toasttext);
 			if (retVal is null)
 			{   // we have no such string
@@ -113,7 +105,7 @@ namespace Windows.UI.Notifications
 		private void SetToastTexts(Android.App.Notification.Builder builder, XmlDocument xmlDoc)
 		{
 			string toastTitleText = "";
-			StringBuilder toastText = new StringBuilder("");
+			StringBuilder toastText = new ("");
 
 			var childToast = xmlDoc.GetElementsByTagName("text");
 			if ((childToast != null) && childToast.Count > 0)
@@ -159,7 +151,7 @@ namespace Windows.UI.Notifications
 					}
 					else
 					{
-						if (msgLines.Count() > 6)
+						if (msgLines.Length > 6)
 						{
 							// too many lines for InboxStyle - show in expandable form
 							var expandableToast = new Android.App.Notification.BigTextStyle().BigText(toastText.ToString());

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -111,16 +111,16 @@ namespace Windows.UI.Notifications
 			if ((childToast != null) && childToast.Count > 0)
 			{
 				// first text - bigger text (title)
-				toastTitleText = ConvertToastTextToString(childToast![0]!.InnerText);
+				toastTitleText = ConvertToastTextToString(childToast[0]!.InnerText);
 
 				if (childToast.Count > 1)
 				{
-					toastText.Append(ConvertToastTextToString(childToast![1]!.InnerText));
+					toastText.Append(ConvertToastTextToString(childToast[1]!.InnerText));
 
 					for (int childIndex = 2; childIndex < childToast.Count; childIndex++)
 					{   // in most scenarios, this loop will never iterate
 						// separate lines with space and \n: \n as line splitting for newer Android, space - for older
-						toastText.Append(" \n" + ConvertToastTextToString(childToast![childIndex]!.InnerText!));
+						toastText.Append(" \n" + ConvertToastTextToString(childToast[childIndex]!.InnerText!));
 					}
 				}
 			}

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -116,7 +116,7 @@ namespace Windows.UI.Notifications
 				var childNode0 = childToast[0];
 				if (childNode0 is null)
 				{
-					throw new Exception("It cannot happen, but to keep compiler happy...");
+					throw new InvalidOperationException("Invalid document notification document"); 
 				}
 				toastTitleText = ConvertToastTextToString(childNode0.InnerText);
 
@@ -126,7 +126,7 @@ namespace Windows.UI.Notifications
 					var childNode1 = childToast[1];
 					if (childNode1 is null)
 					{
-						throw new Exception("It cannot happen, but to keep compiler happy...");
+						throw new InvalidOperationException("Invalid document notification document");
 					}
 					toastText.Append(ConvertToastTextToString(childNode1.InnerText));
 
@@ -138,7 +138,7 @@ namespace Windows.UI.Notifications
 						var childNode = childToast[childIndex];
 						if(childNode is null )
 						{
-							throw new Exception("It cannot happen, but to keep compiler happy...");
+							throw new InvalidOperationException("Invalid document notification document");
 						}
 						toastText.Append(" \n" + ConvertToastTextToString(childNode.InnerText));
 					}

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -111,16 +111,36 @@ namespace Windows.UI.Notifications
 			if ((childToast != null) && childToast.Count > 0)
 			{
 				// first text - bigger text (title)
-				toastTitleText = ConvertToastTextToString(childToast[0]!.InnerText);
+
+				// to keep compiler happy
+				var childNode0 = childToast[0];
+				if (childNode0 is null)
+				{
+					throw new Exception("It cannot happen, but to keep compiler happy...");
+				}
+				toastTitleText = ConvertToastTextToString(childNode0.InnerText);
 
 				if (childToast.Count > 1)
 				{
-					toastText.Append(ConvertToastTextToString(childToast[1]!.InnerText));
+					// to keep compiler happy
+					var childNode1 = childToast[1];
+					if (childNode1 is null)
+					{
+						throw new Exception("It cannot happen, but to keep compiler happy...");
+					}
+					toastText.Append(ConvertToastTextToString(childNode1.InnerText));
 
 					for (int childIndex = 2; childIndex < childToast.Count; childIndex++)
 					{   // in most scenarios, this loop will never iterate
 						// separate lines with space and \n: \n as line splitting for newer Android, space - for older
-						toastText.Append(" \n" + ConvertToastTextToString(childToast[childIndex].InnerText!));
+
+						// to keep compiler happy
+						var childNode = childToast[childIndex];
+						if(childNode is null )
+						{
+							throw new Exception("It cannot happen, but to keep compiler happy...");
+						}
+						toastText.Append(" \n" + ConvertToastTextToString(childNode.InnerText));
 					}
 				}
 			}
@@ -220,7 +240,12 @@ namespace Windows.UI.Notifications
 				var childLaunch = childToast[0]?.Attributes?.GetNamedItem("launch");
 				if (childLaunch != null)
 				{
-					toastArgument = childLaunch.Value!;
+					var launchValue = childLaunch.Value;
+					if (launchValue is null)
+					{
+						throw new Exception("It cannot happen, but to keep compiler happy...");
+					}
+					toastArgument = launchValue;
 				}
 			}
 

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -119,16 +119,16 @@ namespace Windows.UI.Notifications
 			if ((childToast != null) && childToast.Count > 0)
 			{
 				// first text - bigger text (title)
-				toastTitleText = ConvertToastTextToString(childToast[0].InnerText);
+				toastTitleText = ConvertToastTextToString(childToast![0]!.InnerText);
 
 				if (childToast.Count > 1)
 				{
-					toastText.Append(ConvertToastTextToString(childToast[1].InnerText));
+					toastText.Append(ConvertToastTextToString(childToast![1]!.InnerText));
 
 					for (int childIndex = 2; childIndex < childToast.Count; childIndex++)
 					{   // in most scenarios, this loop will never iterate
 						// separate lines with space and \n: \n as line splitting for newer Android, space - for older
-						toastText.Append(" \n" + ConvertToastTextToString(childToast[childIndex].InnerText!));
+						toastText.Append(" \n" + ConvertToastTextToString(childToast![childIndex]!.InnerText!));
 					}
 				}
 			}

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -24,7 +24,7 @@ namespace Windows.UI.Notifications
 			_notificationManager = notifManager;
 
 			if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.O)
-			{   // none of this strings would be visible for user
+			{   // none of these strings would be visible to the user
 				var channel = new Android.App.NotificationChannel(_channelID, "PlatformUnoChannel", Android.App.NotificationImportance.Default); ; // deprecated: Android.App.NotificationManager.ImportanceDefault
 				_notificationManager.CreateNotificationChannel(channel);
 			}
@@ -153,7 +153,7 @@ namespace Windows.UI.Notifications
 			}
 
 			if (toastText.Length > 0)
-			{ // Android toasts doesn't support new line character in standard toasts
+			{ // Android toasts don't support new line character in standard toasts
 
 				if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.JellyBean)
 				{
@@ -274,7 +274,7 @@ namespace Windows.UI.Notifications
 
 			Android.App.Notification.Builder builder = GetToastBuilder();
 
-			// we use XmlDocument for retrieving text items and launch attribute
+			// we use XmlDocument for retrieving text items and 'launch' attribute
 			var xmlDoc = new XmlDocument();
 			xmlDoc.LoadXml(notification.Content.GetXml());
 

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -254,7 +254,7 @@ namespace Windows.UI.Notifications
 			// we should have intent.data field different for different toast arguments,
 			// else - next intent would overwrite previous.
 			// it can be any URI, e.g. http://dummy.com/dummy?arg=  
-			var data = Android.Net.Uri.Parse("http://unotask.com/toast?arg=" + Android.Net.Uri.Encode(toastArgument));
+			var data = Android.Net.Uri.Parse("http://android-toast.platform.uno/toast?arg=" + Android.Net.Uri.Encode(toastArgument));
 			intentAction.SetData(data);
 
 			// 12345: arbitrary number, it can be any value (as it is not used in Uno code anywhere)

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -34,7 +34,7 @@ namespace Windows.UI.Notifications
 		private string ConvertToastTextToString(string toasttext)
 		{
 			// this is simple text, e.g. "dummy" or "1"
-			if (!toasttext.StartsWith("ms-resource:"))
+			if (!toasttext.StartsWith("ms-resource:", StringComparison.Ordinal))
 			{
 				return toasttext;
 			}

--- a/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
+++ b/src/Uno.UWP/UI/Notifications/ToastNotifier.Android.cs
@@ -1,5 +1,4 @@
-﻿#if __ANDROID__
-#nullable enable
+﻿#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -18,7 +17,7 @@ namespace Windows.UI.Notifications
 		public ToastNotifier()
 		{
 			var notifManager = Android.App.NotificationManager.FromContext(Android.App.Application.Context);
-			if(notifManager is null)
+			if (notifManager is null)
 			{
 				throw new InvalidOperationException("ToastNotifier: cannot get _notificationManager");
 			}
@@ -105,7 +104,7 @@ namespace Windows.UI.Notifications
 		private void SetToastTexts(Android.App.Notification.Builder builder, XmlDocument xmlDoc)
 		{
 			string toastTitleText = "";
-			StringBuilder toastText = new ("");
+			StringBuilder toastText = new("");
 
 			var childToast = xmlDoc.GetElementsByTagName("text");
 			if ((childToast != null) && childToast.Count > 0)
@@ -136,7 +135,7 @@ namespace Windows.UI.Notifications
 
 						// to keep compiler happy
 						var childNode = childToast[childIndex];
-						if(childNode is null )
+						if (childNode is null)
 						{
 							throw new InvalidOperationException("Invalid document notification document");
 						}
@@ -340,4 +339,3 @@ namespace Windows.UI.Notifications
 	}
 }
 
-#endif


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
 No support of Toasts.

## What is the new behavior?
 Support for just-text Toasts 


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
It implements:
* Windows.UI.Notifications.ToastNotification, fields for Android only
* Windows.UI.Notifications.ToastNotificationManager (CreateToastNotifier), for Android only
* Windows.UI.Notifications.ToastNotifier (constructor, and Show), for Android only.

It uses app default icon, but this icon has same problems as on AppBar - should not have transparency defined.
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
Part of my app https://github.com/pkar70/EnviroStatus
 