### PR TITLE
[macOS] Support for Flyout

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- Support for `Flyout` on macOS
 - Support for `Geolocator` on macOS
 - Support for `Clipboard` get/set Text content on macOS
 - Support for `ApplicationView.Title` on Android and macOS

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.iOSmacOS.cs
@@ -2,8 +2,12 @@
 using System.Collections.Generic;
 using System.Text;
 using CoreGraphics;
-using UIKit;
 using Uno.UI;
+#if __IOS__
+using UIKit;
+#else
+using AppKit;
+#endif
 
 namespace Windows.UI.Xaml.Controls.Primitives
 { 
@@ -15,7 +19,17 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			{
 				Visibility = Visibility.Collapsed,
 				Background = SolidColorBrushHelper.Transparent,
+#if __IOS__
 				AutoresizingMask = UIViewAutoresizing.All,
+#else
+				AutoresizingMask =
+					NSViewResizingMask.HeightSizable |
+					NSViewResizingMask.WidthSizable |
+					NSViewResizingMask.MinXMargin |
+					NSViewResizingMask.MaxXMargin |
+					NSViewResizingMask.MinYMargin |
+					NSViewResizingMask.MaxYMargin,
+#endif
 				Frame = new CGRect(CGPoint.Empty, ViewHelper.GetScreenSize())
 			};
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.macOS.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CoreGraphics;
+using Uno.Extensions;
+using AppKit;
+using System.Linq;
+using System.Drawing;
+using Windows.UI.Xaml.Input;
+using Uno.Disposables;
+using Windows.UI.Xaml.Media;
+using Uno.UI;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class Popup
+	{
+		private NSView _mainWindowContent;
+
+		public NSView MainWindowContent
+		{
+			get
+			{
+				if (_mainWindowContent == null)
+				{
+					_mainWindowContent = NSApplication.SharedApplication.KeyWindow?.ContentView;
+				}
+
+				return _mainWindowContent;
+			}
+		}
+
+		partial void OnPopupPanelChangedPartial(PopupPanel previousPanel, PopupPanel newPanel)
+		{
+			if (previousPanel?.Superview != null)
+			{
+				// Remove the current child, if any.
+				previousPanel.Children.Clear();
+
+				previousPanel.RemoveFromSuperview();
+			}
+
+			if (newPanel != null)
+			{
+				if (Child != null)
+				{
+					// Make sure that the child does not find itself without a TemplatedParent
+					if (newPanel.TemplatedParent == null)
+					{
+						newPanel.TemplatedParent = TemplatedParent;
+					}
+
+					newPanel.AddSubview(Child);
+				}
+
+				newPanel.Background = GetPanelBackground();
+
+				RegisterPopupPanel();
+			}
+		}
+
+		protected override void OnLoaded()
+		{
+			base.OnLoaded();
+
+			RegisterPopupPanel();
+		}
+
+		private void RegisterPopupPanel()
+		{
+			if (PopupPanel == null)
+			{
+				PopupPanel = new PopupPanel(this);
+			}			
+
+			if (PopupPanel.Superview == null)
+			{
+				MainWindowContent?.AddSubview(PopupPanel);
+			}
+		}
+
+		protected override void OnUnloaded()
+		{
+			base.OnUnloaded();
+
+			PopupPanel?.RemoveFromSuperview();
+		}
+
+		protected override void OnChildChanged(NSView oldChild, NSView newChild)
+		{
+			base.OnChildChanged(oldChild, newChild);
+
+			if (PopupPanel != null)
+			{
+				if (oldChild != null)
+				{
+					PopupPanel.RemoveChild(oldChild);
+				}
+
+				if (newChild != null)
+				{
+					PopupPanel.AddSubview(newChild);
+				}
+			}
+		}
+
+		protected override void OnIsOpenChanged(bool oldIsOpen, bool newIsOpen)
+		{
+			base.OnIsOpenChanged(oldIsOpen, newIsOpen);
+
+			RegisterPopupPanel();
+
+			UpdateLightDismissLayer(newIsOpen);
+
+			EnsureForward();
+		}
+
+		protected override void OnIsLightDismissEnabledChanged(bool oldIsLightDismissEnabled, bool newIsLightDismissEnabled)
+		{
+			base.OnIsLightDismissEnabledChanged(oldIsLightDismissEnabled, newIsLightDismissEnabled);
+
+			RegisterPopupPanel();
+
+			if (PopupPanel != null)
+			{
+				PopupPanel.Background = GetPanelBackground();
+			}
+		}
+
+		private void UpdateLightDismissLayer(bool newIsOpen)
+		{
+			if (PopupPanel != null && PopupPanel.Superview != null)
+			{
+				if (newIsOpen)
+				{
+					if (PopupPanel.Bounds != MainWindowContent.Bounds)
+					{
+						// If the Bounds are different, the screen has probably been rotated.
+						// We always want the light dismiss layer to have the same bounds (and frame) as the window.
+						PopupPanel.Frame = MainWindowContent.Frame;
+						PopupPanel.Bounds = MainWindowContent.Bounds;						
+					}
+
+					PopupPanel.Visibility = Visibility.Visible;
+				}
+				else
+				{
+					PopupPanel.Visibility = Visibility.Collapsed;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Ensure that Popup panel is forward-most in the window. This ensures it isn't hidden behind the main content, which can happen when
+		/// the Popup is created during initial launch.
+		/// </summary>
+		private void EnsureForward()
+		{
+			//macOS does not have BringSubviewToFront,
+			//solution based on https://stackoverflow.com/questions/4236304/os-x-version-of-bringsubviewtofront
+			if (PopupPanel.Layer.SuperLayer != null)
+			{
+				var superlayer = PopupPanel.Layer.SuperLayer;
+				PopupPanel.Layer.RemoveFromSuperLayer();
+				superlayer.AddSublayer(PopupPanel.Layer);
+			}
+			else
+			{
+				var superview = PopupPanel.Superview;
+				PopupPanel.RemoveFromSuperview();
+				superview.AddSubview(PopupPanel);
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Style/Generic/GenericStyles.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/GenericStyles.iOSmacOS.cs
@@ -1,7 +1,6 @@
 ﻿using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
-using Uno.UI.Views.Controls;
 using Uno.Extensions;
 using System;
 using System.Collections.Generic;
@@ -16,6 +15,12 @@ using Windows.UI.Xaml.Media;
 using UIKit;
 #elif XAMARIN_IOS
 using MonoTouch.UIKit;
+#elif __MACOS__
+using AppKit;
+#endif
+
+#if !__MACOS__
+using Uno.UI.Views.Controls;
 #endif
 
 namespace Windows.UI.Xaml
@@ -55,7 +60,8 @@ namespace Windows.UI.Xaml
 
 		private static void InitDatePicker()
         {
-            var style = new Style(typeof(Windows.UI.Xaml.Controls.DatePicker))
+#if !__MACOS__
+			var style = new Style(typeof(Windows.UI.Xaml.Controls.DatePicker))
             {
                 Setters =  {
                     new Setter<DatePicker>("Template", t =>
@@ -65,10 +71,12 @@ namespace Windows.UI.Xaml
             };
 
 			Style.RegisterDefaultStyleForType(typeof(Windows.UI.Xaml.Controls.DatePicker), style);
+#endif
 		}
 
 		private static void InitDatePickerSelector()
 		{
+#if !__MACOS__
 			var style = new Style(typeof(Windows.UI.Xaml.Controls.DatePickerSelector))
 			{
 				Setters =  {
@@ -88,6 +96,7 @@ namespace Windows.UI.Xaml
 			};
 
 			Style.RegisterDefaultStyleForType(typeof(Windows.UI.Xaml.Controls.DatePickerSelector), style);
+#endif
 		}
 
 #if !IS_UNO
@@ -196,6 +205,7 @@ namespace Windows.UI.Xaml
 
 		private static void InitWebView()
 		{
+#if !__MACOS__
 			var style = new Style(typeof(Windows.UI.Xaml.Controls.WebView))
 			{
 				Setters =  {
@@ -207,6 +217,7 @@ namespace Windows.UI.Xaml
 			};
 
 			Style.RegisterDefaultStyleForType(typeof(Windows.UI.Xaml.Controls.WebView), style);
+#endif
 		}
 
 		private static void InitItemsControl()
@@ -228,6 +239,7 @@ namespace Windows.UI.Xaml
 
 		private static void InitFlipView()
 		{
+#if !__MACOS__
 			var style = new Style(typeof(Windows.UI.Xaml.Controls.FlipView))
 			{
 				Setters =  {
@@ -247,6 +259,7 @@ namespace Windows.UI.Xaml
 			};
 
 			Style.RegisterDefaultStyleForType(typeof(Windows.UI.Xaml.Controls.FlipView), style);
+#endif
 		}
 
 #if !IS_UNO

--- a/src/Uno.UI/UI/Xaml/Window.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.macOS.cs
@@ -21,6 +21,7 @@ namespace Windows.UI.Xaml
 		private static Window _current;
 		private RootViewController _mainController;
 		private UIElement _content;
+		private object _windowResizeNotificationObject;
 
 		/// <summary>
 		/// A function to generate a custom view controller which inherits from <see cref="RootViewController"/>.
@@ -45,19 +46,20 @@ namespace Windows.UI.Xaml
 			CoreWindow = new CoreWindow(_window);
 
 			InitializeCommon();
-		}
+		}		
 
 		private void ObserveOrientationAndSize()
 		{
-			//_window.FrameChanged +=
-			//	() => RaiseNativeSizeChanged(ViewHelper.GetScreenSize());
+			_windowResizeNotificationObject = NSNotificationCenter.DefaultCenter.AddObserver(
+				new NSString("NSWindowDidResizeNotification"), ResizeObserver, null);
 
-			// TODO macOS
-			//var statusBar = StatusBar.GetForCurrentView();
-			//statusBar.Showing += (o, e) => UpdateCoreBounds();
-			//statusBar.Hiding += (o, e) => UpdateCoreBounds();
+			RaiseNativeSizeChanged(new CGSize(_window.Frame.Width, _window.Frame.Height));
 
-			RaiseNativeSizeChanged(ViewHelper.GetScreenSize());
+		}
+
+		private void ResizeObserver(NSNotification obj)
+		{
+			RaiseNativeSizeChanged(new CGSize(_window.Frame.Width, _window.Frame.Height));
 		}
 
 		partial void InternalActivate()
@@ -119,6 +121,6 @@ namespace Windows.UI.Xaml
 			{
 				applicationView.SetCoreBounds(_window, Bounds);
 			}
-		}
+		}		
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #626 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`Flyout` is not supported.

## What is the new behavior?

`Flyout` is supported. There are still issues with its layout when the default presenter is used, but that is caused by some `ScrollViewer` layout issues.

<img width="371" alt="Screenshot 2020-02-10 at 21 16 32" src="https://user-images.githubusercontent.com/1075116/74186548-22e65500-4c4b-11ea-9cb1-e37a68224460.png">

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)