### PR TITLE
[macOS] Support for ShowComposeSmsMessageAsync

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- Support for `ShowComposeSmsMessageAsync` on macOS
 - Support for `Flyout` on macOS
 - Support for `HingeAngleSensor` for Surface Duo
 - Support for `Geolocator` on macOS

--- a/doc/articles/features/windows-applicationmodel-chat.md
+++ b/doc/articles/features/windows-applicationmodel-chat.md
@@ -1,0 +1,8 @@
+# Uno Support for Windows.ApplicationModel.Chat
+
+## `ChatMessageManager`
+
+### Limitations
+
+**macOS**
+`ShowComposeSmsMessageAsync` method is implemented but due to limitations of iMessage `sms:` scheme implementation, it doesn't support multiple `Recipients` (will only use the first one)

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -76,6 +76,8 @@
     href: features\windows-applicationmodel.md
   - name: Windows.ApplicationModel.Calls
     href: features\windows-applicationmodel-calls.md
+  - name: Windows.ApplicationModel.Chat
+    href: features\windows-applicationmodel-chat.md
   - name: Windows.ApplicationModel.Email
     href: features\windows-applicationmodel-email.md
   - name: Windows.Devices.Lights

--- a/src/Uno.UWP/ApplicationModel/Chat/ChatMessageManager.macOS.cs
+++ b/src/Uno.UWP/ApplicationModel/Chat/ChatMessageManager.macOS.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AppKit;
+using Foundation;
+using Windows.Foundation;
+
+namespace Windows.ApplicationModel.Chat
+{
+	public partial class ChatMessageManager
+	{
+		public static IAsyncAction ShowComposeSmsMessageAsync(ChatMessage message)
+		{
+			if (message == null)
+			{
+				throw new ArgumentNullException(nameof(message));
+			}
+
+			var firstNumber = message.Recipients.First();
+			var uri = $"sms:{firstNumber}";
+
+			if(!string.IsNullOrEmpty(message.Body))
+			{
+				uri += $"&body={Uri.EscapeDataString(message.Body)}";
+			}
+
+			var result = NSWorkspace.SharedWorkspace.OpenUrl(new NSUrl(uri));
+
+			return Task.FromResult(result).AsAsyncAction();
+		}
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Chat/ChatMessageManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Chat/ChatMessageManager.cs
@@ -42,7 +42,7 @@ namespace Windows.ApplicationModel.Chat
 			throw new global::System.NotImplementedException("The member IAsyncOperation<ChatMessageStore> ChatMessageManager.RequestStoreAsync() is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || false
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncAction ShowComposeSmsMessageAsync( global::Windows.ApplicationModel.Chat.ChatMessage message)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #2640 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`ShowComposeSmsMessageAsync` is not implemented.

## What is the new behavior?

Implemented.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)