### PR TITLE
[Wasm] Fix double arrange margin

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -19,6 +19,7 @@ resources:
 
 jobs:
 - template: build/ci/.azure-devops-windows.yml
+- template: build/ci/.azure-devops-unit-tests.yml
 - template: build/ci/.azure-devops-docs.yml
 - template: build/ci/.azure-devops-wasm-uitests.yml
 - template: build/ci/.azure-devops-macos.yml

--- a/build/ci/.azure-devops-unit-tests.yml
+++ b/build/ci/.azure-devops-unit-tests.yml
@@ -1,0 +1,53 @@
+parameters:
+  pool: ''
+
+jobs:
+- job: Unit_Tests
+  timeoutInMinutes: 90
+
+  pool:
+    vmImage: 'vs2017-win2016'
+
+  variables:
+    CombinedConfiguration: Release|Any CPU
+    CI_Build: true
+
+    # This is required to be able to use hard links as much as possible
+    NUGET_PACKAGES: $(Agent.WorkFolder)\.nuget
+
+  steps:
+  - checkout: self
+    clean: true
+
+  - template: templates/nuget-cache.yml
+    parameters:
+      nugetPackages: $(NUGET_PACKAGES)
+
+  - template: templates/gitversion.yml
+   
+  - task: NuGetToolInstaller@0
+    inputs:
+      versionSpec: 4.9.1
+      checkLatest: false
+
+  - task: MSBuild@1
+    inputs:
+      solution: src/**/*.Tests.csproj
+      msbuildArguments: /r /p:CheckExclusions=True /p:Configuration=Release /nodeReuse:true /detailedsummary /m # /bl:$(build.artifactstagingdirectory)\build.binlog
+
+  - task: VisualStudioTestPlatformInstaller@1
+
+  - task: VSTest@2
+    inputs:
+      testAssemblyVer2: |
+        **\*test*.dll
+        !**\obj\**
+        !**\*Wasm.Test*.dll
+        !**\*UITests.dll
+        !**\*.RuntimeTests.dll
+      vstestLocationMethod: version
+      vsTestVersion: latest
+      testSelector: testAssemblies
+      batchingBasedOnAgentsOption: customBatchSize
+      rerunFailedTests: 'true'
+      customBatchSizeValue: 200 # test count / 10 (https://developercommunity.visualstudio.com/content/problem/891803/vstestconsoleadapter-fails-with-outofmemory.html?childToView=896206#comment-896206)

--- a/build/ci/.azure-devops-windows.yml
+++ b/build/ci/.azure-devops-windows.yml
@@ -49,23 +49,6 @@ jobs:
       logProjectEvents: false
       createLogFile: false
 
-  - task: VisualStudioTestPlatformInstaller@1
-
-  - task: VSTest@2
-    inputs:
-      testAssemblyVer2: |
-        **\*test*.dll
-        !**\obj\**
-        !**\*Wasm.Test*.dll
-        !**\*UITests.dll
-        !**\*.RuntimeTests.dll
-      vstestLocationMethod: version
-      vsTestVersion: latest
-      testSelector: testAssemblies
-      batchingBasedOnAgentsOption: customBatchSize
-      rerunFailedTests: 'true'
-      customBatchSizeValue: 200 # test count / 10 (https://developercommunity.visualstudio.com/content/problem/891803/vstestconsoleadapter-fails-with-outofmemory.html?childToView=896206#comment-896206)
-
   - task: CopyFiles@2
     inputs:
       SourceFolder: $(build.sourcesdirectory)/Build

--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -42,7 +42,7 @@ else
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml.FocusManagerDirectionTests' or \
 		namespace = 'SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.PivotTests' or \	
+		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.PivotTests' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media_Animation.DoubleAnimation_Tests'
 	"
 fi

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions;
+using Uno.UI.RuntimeTests;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI;
@@ -175,7 +176,8 @@ namespace Uno.UI.Samples.Tests
 							continue;
 						}
 
-						var runsOnUIThread = testMethod.GetCustomAttribute(typeof(Uno.UI.RuntimeTests.RunsOnUIThreadAttribute)) != null;
+						var runsOnUIThread = HasCustomAttribute<RunsOnUIThreadAttribute>(testMethod)
+							|| HasCustomAttribute<RunsOnUIThreadAttribute>(testMethod.DeclaringType);
 						var expectedException = testMethod.GetCustomAttributes<ExpectedExceptionAttribute>().SingleOrDefault();
 						var dataRows = testMethod.GetCustomAttributes<DataRowAttribute>();
 						if (dataRows.Any())
@@ -293,6 +295,9 @@ namespace Uno.UI.Samples.Tests
 				ReportTestsResults(counters);
 			}
 		}
+
+		private bool HasCustomAttribute<T>(MemberInfo testMethod)
+			=> testMethod.GetCustomAttribute(typeof(T)) != null;
 
 		private bool IsIgnored(MethodInfo testMethod, out string ignoreMessage)
 		{

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -31,6 +31,21 @@
     <UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
   </ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)'!='uap10.0.17763'">
+		<Compile Include="$(MSBuildThisFileDirectory)..\Uno.UI.Tests\Windows_UI_Xaml\FrameworkElementTests\*.cs">
+			<Link>UnitTests\Windows_UI_Xaml\FrameworkElementTests\%(RecursiveDir)%(FileName)%(Extension)</Link>
+		</Compile>
+		<Compile Include="$(MSBuildThisFileDirectory)..\Uno.UI.Tests\Windows_UI_XAML_Controls\GridTests\Given_Grid_And_Min_Max.cs">
+			<Link>UnitTests\Windows_UI_Xaml_Controls\GridTests\%(RecursiveDir)%(FileName)%(Extension)</Link>
+		</Compile>
+		<Compile Include="$(MSBuildThisFileDirectory)..\Uno.UI.Tests\Windows_UI_XAML_Controls\GridTests\Context.cs">
+			<Link>UnitTests\Windows_UI_Xaml_Controls\GridTests\%(RecursiveDir)%(FileName)%(Extension)</Link>
+		</Compile>
+		<Compile Include="$(MSBuildThisFileDirectory)..\Uno.UI.Tests\Windows_UI_XAML_Controls\BorderTests\*.cs">
+			<Link>UnitTests\Windows_UI_Xaml_Controls\BorderTests\%(RecursiveDir)%(FileName)%(Extension)</Link>
+		</Compile>
+	</ItemGroup>
+
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
 		<EmbeddedResource Include="LinkerDefinition.Wasm.xml">
 			<LogicalName>$(AssemblyName).xml</LogicalName>

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.DynamicObject.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.DynamicObject.cs
@@ -16,15 +16,6 @@ namespace Uno.UI.Tests.BinderTests
 	[TestClass]
 	public partial class Given_Binder_DynamicObject
 	{
-		[TestInitialize]
-		public void Init()
-		{
-			Uno.Extensions.LogExtensionPoint
-				.AmbientLoggerFactory
-				.AddConsole(LogLevel.Debug)
-				.AddDebug(LogLevel.Debug);
-		}
-
 		[TestMethod]
 		public void When_ReadValue()
 		{

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.Expando.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.Expando.cs
@@ -16,15 +16,6 @@ namespace Uno.UI.Tests.BinderTests
 	[TestClass]
 	public partial class Given_Binder_Expando
 	{
-		[TestInitialize]
-		public void Init()
-		{
-			Uno.Extensions.LogExtensionPoint
-				.AmbientLoggerFactory
-				.AddConsole(LogLevel.Debug)
-				.AddDebug(LogLevel.Debug);
-		}
-
 		[TestMethod]
 		public void When_ReadValue()
 		{

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.TargetNullValue.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.TargetNullValue.cs
@@ -15,15 +15,6 @@ namespace Uno.UI.Tests.BinderTests
 	[TestClass]
 	public partial class Given_Binder_TestNullValue
 	{
-		[TestInitialize]
-		public void Init()
-		{
-			Uno.Extensions.LogExtensionPoint
-				.AmbientLoggerFactory
-				.AddConsole(LogLevel.Debug)
-				.AddDebug(LogLevel.Debug);
-		}
-
 		[TestMethod]
 		public void When_Converted_Value_NotNull()
 		{

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
@@ -27,15 +27,6 @@ namespace Uno.UI.Tests.BinderTests
 	[TestClass]
 	public partial class Given_Binder
 	{
-		[TestInitialize]
-		public void Init()
-		{
-			Uno.Extensions.LogExtensionPoint
-				.AmbientLoggerFactory
-				.AddConsole(LogLevel.Debug)
-				.AddDebug(LogLevel.Debug);
-		}
-
 		[TestMethod]
 		public void When_Inherited_data_Context()
 		{

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
@@ -30,11 +30,6 @@ namespace Uno.UI.Tests.BinderTests.Propagation
 		[TestInitialize]
 		public void Init()
 		{
-			Uno.Extensions.LogExtensionPoint
-				.AmbientLoggerFactory
-				.AddConsole(LogLevel.Debug)
-				.AddDebug(LogLevel.Debug);
-
 			global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(SubObject).TypeHandle);
 			global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(MyObject).TypeHandle);
 		}

--- a/src/Uno.UI.Tests/Global.cs
+++ b/src/Uno.UI.Tests/Global.cs
@@ -15,10 +15,17 @@ namespace Uno.UI.Tests
 			Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
 			Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
+#if DEBUG
 			Uno.Extensions.LogExtensionPoint
 				.AmbientLoggerFactory
-				.AddConsole(LogLevel.Debug)
-				.AddDebug(LogLevel.Debug);
+				.AddConsole(LogLevel.Information)
+				.AddDebug(LogLevel.Information);
+#else
+			Uno.Extensions.LogExtensionPoint
+				.AmbientLoggerFactory
+				.AddConsole(LogLevel.Warning)
+				.AddDebug(LogLevel.Warning);
+#endif
 		}
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/BorderTests/Given_Border.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/BorderTests/Given_Border.cs
@@ -58,6 +58,9 @@ namespace Uno.UI.Tests.BorderTests
         }
 
 		[TestMethod]
+#if __IOS__
+		[Ignore("Layout engine on ios needs actual layout pass")]
+#endif
 		public void When_Child_Has_Fixed_Size_Smaller_than_Parent()
 		{
 			var parentSize = new Windows.Foundation.Size(100, 100);
@@ -88,6 +91,9 @@ namespace Uno.UI.Tests.BorderTests
 		}
 
 		[TestMethod]
+#if __IOS__
+		[Ignore("Layout engine on ios needs actual layout pass")]
+#endif
 		public void When_Child_Is_Stretch()
 		{
 			var parentSize = new Windows.Foundation.Size(500, 500);
@@ -111,8 +117,8 @@ namespace Uno.UI.Tests.BorderTests
 		}
 
 		[TestMethod]
-#if NET461
-		[Ignore("Layout engine is incomplete on net461 for arrange")]
+#if NET461 || __IOS__
+		[Ignore("Layout engine is incomplete on net461 for arrange, ios needs actual layout pass")]
 #endif
 		public void When_Top_Align_Nested_With_Margin()
 		{

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/BorderTests/Given_Border.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/BorderTests/Given_Border.cs
@@ -17,6 +17,9 @@ using Windows.Foundation;
 namespace Uno.UI.Tests.BorderTests
 {
 	[TestClass]
+#if !NET461
+	[RuntimeTests.RunsOnUIThread]
+#endif
 	public class Given_Border : Context
 	{
 		[TestMethod]

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/BorderTests/Given_Border.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/BorderTests/Given_Border.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using Uno;
 using Uno.Extensions;
 using Uno.Logging;
@@ -7,12 +6,13 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using Uno.Disposables;
 using System.Text;
 using System.Threading.Tasks;
 using View = Windows.UI.Xaml.FrameworkElement;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.Foundation;
 
 namespace Uno.UI.Tests.BorderTests
 {
@@ -72,14 +72,16 @@ namespace Uno.UI.Tests.BorderTests
 				Height = childSize.Height
 			};
 
-			SUT.AddChild(child);
+			SUT.Child = child;
 
 			SUT.Measure(new Windows.Foundation.Size(100, 100));
 			var measuredSize = SUT.DesiredSize;
 			SUT.Arrange(new Windows.Foundation.Rect(0, 0,100, 100));
 
-			Assert.AreEqual(parentSize, measuredSize);
-			Assert.AreEqual(new Windows.Foundation.Rect(0, 0, parentSize.Width, parentSize.Height), child.Arranged);
+			Assert.AreEqual(parentSize, measuredSize, $"(parentSize:{parentSize}) != (measuredSize:{measuredSize})");
+			var expectedArrange = new Windows.Foundation.Rect(0, 0, parentSize.Width, parentSize.Height);
+			var layoutSlot = LayoutInformation.GetLayoutSlot(child);
+			Assert.AreEqual(expectedArrange, layoutSlot, $"(expectedArrange:{expectedArrange}) != (layoutSlot: {layoutSlot})");
 		}
 
 		[TestMethod]
@@ -95,14 +97,53 @@ namespace Uno.UI.Tests.BorderTests
 
 			var child = new View();
 
-			SUT.AddChild(child);
+			SUT.Child = child;
 
 			SUT.Measure(new Windows.Foundation.Size(500, 500));
 			var measuredSize = SUT.DesiredSize;
 			SUT.Arrange(new Windows.Foundation.Rect(0, 0,500, 500));
 
 			Assert.AreEqual(parentSize, measuredSize);
-			Assert.AreEqual(new Windows.Foundation.Rect(0, 0, parentSize.Width, parentSize.Height), child.Arranged);
+			Assert.AreEqual(new Windows.Foundation.Rect(0, 0, parentSize.Width, parentSize.Height), LayoutInformation.GetLayoutSlot(child));
+		}
+
+		[TestMethod]
+#if NET461
+		[Ignore("Layout engine is incomplete on net461 for arrange")]
+#endif
+		public void When_Top_Align_Nested_With_Margin()
+		{
+			var border1 = new Border()
+			{
+				Height = 34,
+			};
+
+			var border2 = new Border()
+			{
+				VerticalAlignment = VerticalAlignment.Top,
+				Margin = new Thickness(15, 5, 0, 7)
+			};
+
+			var border3 = new Border()
+			{
+				Width = 50,
+				Height = 30,
+			};
+
+			border1.Child = border2;
+			border2.Child = border3;
+
+			border1.Measure(new Windows.Foundation.Size(500, 500));
+			var measuredSize = border1.DesiredSize;
+			border1.Arrange(new Rect(0, 0, measuredSize.Width, measuredSize.Height));
+
+			var slot1 = LayoutInformation.GetLayoutSlot(border1);
+			var slot2 = LayoutInformation.GetLayoutSlot(border2);
+			var slot3 = LayoutInformation.GetLayoutSlot(border3);
+
+			Assert.AreEqual(new Rect(0, 0, 65, 34), slot1, "slot1");
+			Assert.AreEqual(new Rect(0, 0, 65, 34), slot2, "slot2");
+			Assert.AreEqual(new Rect(0, 0, 50, 22), slot3, "slot3");
 		}
 
 		[TestMethod]
@@ -116,20 +157,20 @@ namespace Uno.UI.Tests.BorderTests
 				Height = parentSize.Height
 			};
 
-			var child = new View()
+			var child = new Border()
 			{
 				HorizontalAlignment = HorizontalAlignment.Left,
 				VerticalAlignment = VerticalAlignment.Top
 			};
 
-			SUT.AddChild(child);
+			SUT.Child = child;
 
 			SUT.Measure(new Windows.Foundation.Size(500, 500));
 			var measuredSize = SUT.DesiredSize;
-			SUT.Arrange(new Windows.Foundation.Rect(0, 0,500, 500));
+			SUT.Arrange(new Windows.Foundation.Rect(0, 0, 500, 500));
 
 			Assert.AreEqual(parentSize, measuredSize);
-			Assert.AreEqual(new Windows.Foundation.Rect(0, 0, 0, 0), child.Arranged);
+			Assert.AreEqual(new Size(0, 0), new Size(child.LayoutSlotWithMarginsAndAlignments.Width, child.LayoutSlotWithMarginsAndAlignments.Height));
 		}
 
 		[TestMethod]
@@ -144,20 +185,20 @@ namespace Uno.UI.Tests.BorderTests
 				Height = parentSize.Height
 			};
 
-			var child = new View()
+			var child = new Border()
 			{
 				MaxWidth = maxSize.Width,
 				MaxHeight = maxSize.Height
 			};
 
-			SUT.AddChild(child);
+			SUT.Child = child;
 
 			SUT.Measure(new Windows.Foundation.Size(500, 500));
 			var measuredSize = SUT.DesiredSize;
 			SUT.Arrange(new Windows.Foundation.Rect(0, 0,500, 500));
 
 			Assert.AreEqual(parentSize, measuredSize);
-			Assert.AreEqual(new Windows.Foundation.Rect((SUT.Width - maxSize.Width)/2, (SUT.Height - maxSize.Height) / 2, maxSize.Width, maxSize.Height), child.Arranged);
+			Assert.AreEqual(new Windows.Foundation.Rect((SUT.Width - maxSize.Width) / 2, (SUT.Height - maxSize.Height) / 2, maxSize.Width, maxSize.Height), child.LayoutSlotWithMarginsAndAlignments);
 		}
 
 		[TestMethod]
@@ -180,14 +221,14 @@ namespace Uno.UI.Tests.BorderTests
 				VerticalAlignment = VerticalAlignment.Top
 			};
 
-			SUT.AddChild(child);
+			SUT.Child = child;
 
 			SUT.Measure(new Windows.Foundation.Size(500, 500));
 			var measuredSize = SUT.DesiredSize;
 			SUT.Arrange(new Windows.Foundation.Rect(0, 0,500, 500));
 
 			Assert.AreEqual(parentSize, measuredSize);
-			Assert.AreEqual(new Windows.Foundation.Rect(0, 0, minSize.Width, minSize.Height), child.Arranged);
+			Assert.AreEqual(minSize, new Size(child.LayoutSlotWithMarginsAndAlignments.Width, child.LayoutSlotWithMarginsAndAlignments.Height));
 		}
 
 		[TestMethod]
@@ -203,7 +244,7 @@ namespace Uno.UI.Tests.BorderTests
 				Height = parentSize.Height
 			};
 
-			var child = new View()
+			var child = new Border()
 			{
 				MaxWidth = maxSize.Width,
 				MaxHeight = maxSize.Height,
@@ -211,14 +252,14 @@ namespace Uno.UI.Tests.BorderTests
 				MinHeight = minSize.Height
 			};
 
-			SUT.AddChild(child);
+			SUT.Child = child;
 
 			SUT.Measure(new Windows.Foundation.Size(500, 500));
 			var measuredSize = SUT.DesiredSize;
 			SUT.Arrange(new Windows.Foundation.Rect(0, 0,500, 500));
 
-			Assert.AreEqual(parentSize, measuredSize);
-			Assert.AreEqual(new Windows.Foundation.Rect((SUT.Width - maxSize.Width) / 2, (SUT.Height - maxSize.Height) / 2, maxSize.Width, maxSize.Height), child.Arranged);
+			Assert.AreEqual(parentSize, measuredSize, "parentSize != measuredSize");
+			Assert.AreEqual(new Windows.Foundation.Rect((SUT.Width - maxSize.Width) / 2, (SUT.Height - maxSize.Height) / 2, maxSize.Width, maxSize.Height), child.LayoutSlotWithMarginsAndAlignments);
 
 			child.HorizontalAlignment = HorizontalAlignment.Left;
 			child.VerticalAlignment = VerticalAlignment.Top;
@@ -228,7 +269,7 @@ namespace Uno.UI.Tests.BorderTests
 			SUT.Arrange(new Windows.Foundation.Rect(0, 0,500, 500));
 
 			Assert.AreEqual(parentSize, measuredSize);
-			Assert.AreEqual(new Windows.Foundation.Rect(0, 0, minSize.Width, minSize.Height), child.Arranged);
+			Assert.AreEqual(minSize, new Size(child.LayoutSlotWithMarginsAndAlignments.Width, child.LayoutSlotWithMarginsAndAlignments.Height));
 		}
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid_And_Min_Max.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid_And_Min_Max.cs
@@ -11,6 +11,9 @@ using Windows.UI.Xaml.Controls;
 namespace Uno.UI.Tests.Windows_UI_XAML_Controls.GridTests
 {
 	[TestClass]
+#if !NET461
+	[RuntimeTests.RunsOnUIThread]
+#endif
 	public class Given_Grid_And_Min_Max
 	{
 		[TestMethod]

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid_And_Min_Max.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid_And_Min_Max.cs
@@ -204,8 +204,7 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.GridTests
 			sut.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLengthHelper.Auto });
 			sut.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star), MinWidth = 48 });
 
-			var inner = new Border();
-			inner.RequestedDesiredSize = new Size(343, 0);
+			var inner = new Border() { Width = 343, Height = 0 };
 
 			sut.Children.Add(inner);
 
@@ -221,8 +220,7 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.GridTests
 			sut.RowDefinitions.Add(new RowDefinition() { Height = GridLengthHelper.Auto });
 			sut.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(1, GridUnitType.Star), MinHeight = 48 });
 
-			var inner = new Border();
-			inner.RequestedDesiredSize = new Size(0, 343);
+			var inner = new Border() { Width = 0, Height = 343 };
 
 			sut.Children.Add(inner);
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FrameworkElement.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FrameworkElement.cs
@@ -10,6 +10,9 @@ using Windows.UI.Xaml.Controls;
 namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
 {
 	[TestClass]
+#if !NET461
+	[RuntimeTests.RunsOnUIThread]
+#endif
 	public class Given_FrameworkElement
 	{
 		[TestMethod]

--- a/src/Uno.UI/Mock/Layouter.net.cs
+++ b/src/Uno.UI/Mock/Layouter.net.cs
@@ -9,6 +9,7 @@ using Uno.Extensions;
 using Uno;
 using Uno.Logging;
 using View = Windows.UI.Xaml.UIElement;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -24,6 +25,8 @@ namespace Windows.UI.Xaml.Controls
 		protected void ArrangeChildOverride(View view, Rect frame)
 		{
 			view.Arranged = frame;
+			view.LayoutSlotWithMarginsAndAlignments = frame;
+			view.LayoutSlot = frame;
 		}
 
 		protected Size DesiredChildSize(View view)

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.wasm.cs
@@ -55,14 +55,14 @@ namespace Windows.UI.Xaml
 
 				using (traceActivity)
 				{
-					InnerMeasureCore(availableSize.Subtract(Margin));
+					InnerMeasureCore(availableSize);
 				}
 			}
 			else
 			{
 				// This method is split in two functions to avoid the dynCalls
 				// invocations generation for mono-wasm AOT inside of try/catch/finally blocks.
-				InnerMeasureCore(availableSize.Subtract(Margin));
+				InnerMeasureCore(availableSize);
 			}
 		}
 
@@ -259,6 +259,8 @@ namespace Windows.UI.Xaml
 			{
 				ArrangeNative(offset);
 			}
+
+			OnLayoutUpdated();
 		}
 
 		internal Thickness GetThicknessAdjust()

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.net.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.net.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Windows.Foundation;
 using View = Windows.UI.Xaml.UIElement;
 using System.Collections;
+using Uno.UI;
 
 namespace Windows.UI.Xaml
 {
@@ -77,6 +78,11 @@ namespace Windows.UI.Xaml
 			{
 				DesiredSize = RequestedDesiredSize.Value;
 			}
+		}
+
+		internal void InternalArrange(Rect frame)
+		{
+			_layouter.Arrange(frame);
 		}
 
 		static partial void OnGenericPropertyUpdatedPartial(object dependencyObject, DependencyPropertyChangedEventArgs args);


### PR DESCRIPTION
Included more Unit Tests in Runtime Tests

GitHub Issue (If applicable): Fixes #2637


## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Arranged elements with margins are not getting double margins during the Arrange phase (introduced here https://github.com/unoplatform/uno/commit/28d78c7c5f50cb7b9b5fd017dba58448e63785f4#diff-1e50ceb3ff0d84d3d58ddd3548fcfb41R58)
- Add missing support for LayoutUpdated
- Cross-include Unit Tests as Runtime Tests

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~ (regression)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
