### PR TITLE
Misc Fixes

### DIFF
--- a/doc/ReleaseNotes/LegacyReleaseNotes.md
+++ b/doc/ReleaseNotes/LegacyReleaseNotes.md
@@ -56,6 +56,8 @@
 
 ### Breaking changes
 - `IconElement.AddIconElementView` is now `internal` so it is not accessible from outside.
+- `Thumb.DragStarted.<Horizontal|Vertical>Offset` are now fullfilled (was always 0)
+- `Thumb.Drag<Delta|Completed>.<Horizontal|Vertical>` are now relative to the last event (was cummulative / relative to the started)
 - On iOS, the parent of the `ListViwItem` is now the `NativeListViewBase` (was the `ListView` it self) as described here https://github.com/unoplatform/uno/blob/master/doc/articles/controls/ListViewBase.md#difference-in-the-visual-tree
 
 ### Bug fixes
@@ -102,6 +104,13 @@
 - [Android] Adjust `TextBlock.TextDecorations` is not updating properly
 - Adjust `XamlBindingHelper` for `GridLength` and `TimeSpan`
 - Add missing `ListView` resources
+- [WASM] Setting null to the Fill no longer fill shapes in black
+- Shapes was not able to receive pointer events
+- [WASM] Invisble Shapes no longer prevent sub-elements to receive the pointer events
+- `Thumb.DragStarted.<Horizontal|Vertical>Offset` are now fullfilled (was always 0)
+- `Thumb.Drag<Delta|Completed>.<Horizontal|Vertical>` are now relative to the last event (was cummulative / relative to the started)
+- Thumb now handles the PointyerPressed event (like WinUI)
+- [WASM] Inserting an element at index 0 was appending the element instead of prepending it.
 - #2570 [Android/iOS] fixed ObjectDisposedException in BindingPath
 - #2107 [iOS] fixed ContentDialog doesn't block touch for background elements
 - #2108 [iOS/Android] fixed ContentDialog background doesn't change

--- a/doc/articles/features/routed-events.md
+++ b/doc/articles/features/routed-events.md
@@ -242,6 +242,7 @@ As those events are tightly coupled to the native events, Uno has to make some c
   button was pressed at the moment where you touched the screen, otherwise you will have the `IsLeftButtonPressed` and the `IsBarrelButtonPressed`.
 * The `Holding` event is not raised after a given delay like on WinUI, but instead we rely on the fact that we usually 
   get a lot of moves for pens and fingers, so we raise the event only when we get a move that exceed defined thresholds for holding.
+* On WASM, Shapes must have a non null Fill to receive pointer events (setting the Stroke is not sufficient).
 
 ### Pointer capture
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SliderTests/UnoSamples_Tests.Slider_Vertical_Tap.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SliderTests/UnoSamples_Tests.Slider_Vertical_Tap.cs
@@ -27,16 +27,16 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.SliderTests
 				y: sliderRect.CenterY + (sliderRect.Height * 0.3f));
 
 			var tbSliderValue = _app.Marked("mySlider2Value");
-			getSliderValue(tbSliderValue).Should().BeLessThan(50, "Below 50% Value");
+			GetSliderValue(tbSliderValue).Should().BeLessThan(50, "Below 50% Value");
 
 			_app.TapCoordinates(
 				x: sliderRect.CenterX,
 				y: sliderRect.CenterY - (sliderRect.Height * 0.3f));
 
-			getSliderValue(tbSliderValue).Should().BeGreaterThan(50, "Above 50% Value");
+			GetSliderValue(tbSliderValue).Should().BeGreaterThan(50, "Above 50% Value");
 		}
 
-		private int getSliderValue(QueryEx mark)
+		private int GetSliderValue(QueryEx mark)
 		{
 			_app.Wait(0.15f); // give time to app to execute the action
 			var valueString = mark.GetDependencyPropertyValue("Text") as string;

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ThumbTests/UnoSamples_Tests.Thumb.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ThumbTests/UnoSamples_Tests.Thumb.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ThumbTests
+{
+	[TestFixture]
+	public partial class ThumbTests : SampleControlUITestBase
+	{
+		private const string _sample = "UITests.Windows_UI_Xaml_Controls.ThumbTests.Thumb_DragEvents";
+
+		[Test]
+		[AutoRetry]
+		public void When_DragAndDrop()
+		{
+			Run(_sample);
+
+			var originalLocation = _app.WaitForElement("TheThumb").Single().Rect;
+			var dpiScale = originalLocation.Width / 20;
+
+			_app.DragCoordinates(
+				originalLocation.CenterX,
+				originalLocation.CenterY,
+				originalLocation.CenterX + 100 * dpiScale,
+				originalLocation.CenterY + 100 * dpiScale);
+
+			var start = GetResult("DragStartedOutput").Single().Value;
+			var lastDelta = GetResult("DragDeltaOutput")["Δ"];
+			var total = GetResult("DragCompletedOutput")["Σ"];
+
+			IsCloseTo(start, 50, 50).Should().BeTrue();
+			IsCloseTo(lastDelta, 1, 1, tolerance: 15).Should().BeTrue();
+			IsCloseTo(total, 100, 100, tolerance: dpiScale * 1.5).Should().BeTrue();
+		}
+
+		public IDictionary<string, (double x, double y)> GetResult(string resultElementName)
+		{
+			var regex = new Regex(@"(?<value>(?<name>.)x=(?<x>\d+.\d{0,2}),.y=(?<y>\d+.\d{0,2}))");
+			var raw = _app.Marked(resultElementName).GetDependencyPropertyValue<string>("Text");
+			var result = regex.Match(raw);
+
+			if (!result.Success)
+			{
+				throw new InvalidOperationException("Cannot parse result: " + result);
+			}
+
+			return GetValues().ToDictionary(x => x.name, x => x.value);
+
+			IEnumerable<(string name, (double x, double y) value)> GetValues()
+			{
+				while(result.Success)
+				{
+					var x = double.Parse(result.Groups["x"].Value, CultureInfo.InvariantCulture);
+					var y = double.Parse(result.Groups["y"].Value, CultureInfo.InvariantCulture);
+
+					yield return (result.Groups["name"].Value, (x, y));
+
+					result = result.NextMatch();
+				}
+			}
+		}
+
+		private bool IsCloseTo((double x, double y) value, double x, double y, double tolerance = 1.5)
+			=> Math.Abs(value.x - x) < tolerance
+			&& Math.Abs(value.y - y) < tolerance;
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Shapes_Tests.cs
@@ -23,21 +23,21 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 		[Test] [AutoRetry] public void When_LineFilled() => RunFilledTest();
 		[Ignore("Path does not render with Uno")] [Test] [AutoRetry] public void When_PathFilled() => RunFilledTest();
 		[Test] [AutoRetry] public void When_PolygonFilled() => RunFilledTest(offsetY: 10);
-		[Test] [AutoRetry] public void When_PolylineFilled() => RunFilledTest(offsetY: 10);
+		[Test] [AutoRetry] public void When_PolylineFilled() => RunFilledTest(offsetY: 20);
 
 		[Test] [AutoRetry] public void When_RectangleNotFilled() => RunNotFilledTest();
 		[Test] [AutoRetry] public void When_EllipseNotFilled() => RunNotFilledTest();
 		[ActivePlatforms(Platform.Browser, Platform.iOS)] [Test] [AutoRetry] public void When_LineNotFilled() => RunNotFilledTest();
 		[Ignore("Path does not render with Uno")] [Test] [AutoRetry] public void When_PathNotFilled() => RunNotFilledTest();
 		[Test] [AutoRetry] public void When_PolygonNotFilled() => RunNotFilledTest(offsetY: 10);
-		[Test] [AutoRetry] public void When_PolylineNotFilled() => RunNotFilledTest(offsetY: 10);
+		[Test] [AutoRetry] public void When_PolylineNotFilled() => RunNotFilledTest(offsetY: 20);
 
 		[Test] [AutoRetry] public void When_RectangleHidden() => RunHiddenTest();
 		[Test] [AutoRetry] public void When_EllipseHidden() => RunHiddenTest();
 		[Test] [AutoRetry] public void When_LineHidden() => RunHiddenTest();
 		[Ignore("Path does not render with Uno")] [Test] [AutoRetry] public void When_PathHidden() => RunHiddenTest();
 		[Test] [AutoRetry] public void When_PolygonHidden() => RunHiddenTest(offsetY: 10);
-		[Test] [AutoRetry] public void When_PolylineHidden() => RunHiddenTest(offsetY: 10);
+		[Test] [AutoRetry] public void When_PolylineHidden() => RunHiddenTest(offsetY: 20);
 
 
 		private void RunFilledTest(int offsetX = 0, int offsetY = 0, [CallerMemberName] string testName = null)

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Shapes_Tests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Input
+{
+	[TestFixture]
+	public partial class HitTest_Shapes_Tests : SampleControlUITestBase
+	{
+		private const string _sample = "UITests.Windows_UI_Input.PointersTests.HitTest_Shapes";
+
+		[Test] [AutoRetry] public void When_RectangleFilled() => RunFilledTest();
+		[Test] [AutoRetry] public void When_EllipseFilled() => RunFilledTest();
+		[Test] [AutoRetry] public void When_LineFilled() => RunFilledTest();
+		[Ignore("Path does not render with Uno")] [Test] [AutoRetry] public void When_PathFilled() => RunFilledTest();
+		[Test] [AutoRetry] public void When_PolygonFilled() => RunFilledTest(offsetY: 10);
+		[Test] [AutoRetry] public void When_PolylineFilled() => RunFilledTest(offsetY: 10);
+
+		[Test] [AutoRetry] public void When_RectangleNotFilled() => RunNotFilledTest();
+		[Test] [AutoRetry] public void When_EllipseNotFilled() => RunNotFilledTest();
+		[ActivePlatforms(Platform.Browser, Platform.iOS)] [Test] [AutoRetry] public void When_LineNotFilled() => RunNotFilledTest();
+		[Ignore("Path does not render with Uno")] [Test] [AutoRetry] public void When_PathNotFilled() => RunNotFilledTest();
+		[Test] [AutoRetry] public void When_PolygonNotFilled() => RunNotFilledTest(offsetY: 10);
+		[Test] [AutoRetry] public void When_PolylineNotFilled() => RunNotFilledTest(offsetY: 10);
+
+		[Test] [AutoRetry] public void When_RectangleHidden() => RunHiddenTest();
+		[Test] [AutoRetry] public void When_EllipseHidden() => RunHiddenTest();
+		[Test] [AutoRetry] public void When_LineHidden() => RunHiddenTest();
+		[Ignore("Path does not render with Uno")] [Test] [AutoRetry] public void When_PathHidden() => RunHiddenTest();
+		[Test] [AutoRetry] public void When_PolygonHidden() => RunHiddenTest(offsetY: 10);
+		[Test] [AutoRetry] public void When_PolylineHidden() => RunHiddenTest(offsetY: 10);
+
+
+		private void RunFilledTest(int offsetX = 0, int offsetY = 0, [CallerMemberName] string testName = null)
+			=> RunTest(offsetX, offsetY, testName.Substring("When_".Length), testName.Substring("When_".Length));
+
+		private void RunNotFilledTest(int offsetX = 0, int offsetY = 0, [CallerMemberName] string testName = null)
+			=> RunTest(offsetX, offsetY, testName.Substring("When_".Length), "Root");
+
+		private void RunHiddenTest(int offsetX = 0, int offsetY = 0, [CallerMemberName] string testName = null)
+			=> RunTest(offsetX, offsetY, testName.Substring("When_".Length) + "SubElement", testName.Substring("When_".Length) + "SubElement");
+
+		private void RunTest(int offsetX, int offsetY, string element, string expected)
+		{
+			Run(_sample);
+
+			var target = _app.WaitForElement(element).Single().Rect;
+			
+			_app.TapCoordinates(target.CenterX, target.CenterY);
+
+			var result = new QueryEx(q => q.All().Marked("LastPressed")).GetDependencyPropertyValue<string>("Text");
+
+			result.Should().Be(expected);
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Shapes_Tests.cs
@@ -22,22 +22,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 		[Test] [AutoRetry] public void When_EllipseFilled() => RunFilledTest();
 		[Test] [AutoRetry] public void When_LineFilled() => RunFilledTest();
 		[Ignore("Path does not render with Uno")] [Test] [AutoRetry] public void When_PathFilled() => RunFilledTest();
-		[Test] [AutoRetry] public void When_PolygonFilled() => RunFilledTest(offsetY: 10);
-		[Test] [AutoRetry] public void When_PolylineFilled() => RunFilledTest(offsetY: 20);
+		[Test] [AutoRetry] public void When_PolygonFilled() => RunFilledTest(offsetY: 5);
+		[Test] [AutoRetry] public void When_PolylineFilled() => RunFilledTest(offsetY: 10);
 
 		[Test] [AutoRetry] public void When_RectangleNotFilled() => RunNotFilledTest();
 		[Test] [AutoRetry] public void When_EllipseNotFilled() => RunNotFilledTest();
 		[ActivePlatforms(Platform.Browser, Platform.iOS)] [Test] [AutoRetry] public void When_LineNotFilled() => RunNotFilledTest();
 		[Ignore("Path does not render with Uno")] [Test] [AutoRetry] public void When_PathNotFilled() => RunNotFilledTest();
-		[Test] [AutoRetry] public void When_PolygonNotFilled() => RunNotFilledTest(offsetY: 10);
-		[Test] [AutoRetry] public void When_PolylineNotFilled() => RunNotFilledTest(offsetY: 20);
+		[Test] [AutoRetry] public void When_PolygonNotFilled() => RunNotFilledTest(offsetY: 5);
+		[Test] [AutoRetry] public void When_PolylineNotFilled() => RunNotFilledTest(offsetY: 10);
 
 		[Test] [AutoRetry] public void When_RectangleHidden() => RunHiddenTest();
 		[Test] [AutoRetry] public void When_EllipseHidden() => RunHiddenTest();
 		[Test] [AutoRetry] public void When_LineHidden() => RunHiddenTest();
 		[Ignore("Path does not render with Uno")] [Test] [AutoRetry] public void When_PathHidden() => RunHiddenTest();
-		[Test] [AutoRetry] public void When_PolygonHidden() => RunHiddenTest(offsetY: 10);
-		[Test] [AutoRetry] public void When_PolylineHidden() => RunHiddenTest(offsetY: 20);
+		[Test] [AutoRetry] public void When_PolygonHidden() => RunHiddenTest(offsetY: 5);
+		[Test] [AutoRetry] public void When_PolylineHidden() => RunHiddenTest(offsetY: 10);
 
 
 		private void RunFilledTest(int offsetX = 0, int offsetY = 0, [CallerMemberName] string testName = null)
@@ -54,8 +54,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			Run(_sample);
 
 			var target = _app.WaitForElement(element).Single().Rect;
+			var dpiScale = target.Width / 50;
 			
-			_app.TapCoordinates(target.CenterX, target.CenterY);
+			_app.TapCoordinates(target.CenterX + offsetX * dpiScale, target.CenterY + offsetY * dpiScale);
 
 			var result = _app.Marked("LastPressed").GetDependencyPropertyValue<string>("Text");
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Shapes_Tests.cs
@@ -57,7 +57,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			
 			_app.TapCoordinates(target.CenterX, target.CenterY);
 
-			var result = new QueryEx(q => q.All().Marked("LastPressed")).GetDependencyPropertyValue<string>("Text");
+			var result = _app.Marked("LastPressed").GetDependencyPropertyValue<string>("Text");
 
 			result.Should().Be(expected);
 		}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -889,6 +889,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\UIElementCollectionTests\UIElementCollection_Insert.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ViewBoxTests\ViewBox_Alignment.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3580,6 +3584,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\TimePicker_Flyout_Automated.xaml.cs">
       <DependentUpon>TimePicker_Flyout_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\UIElementCollectionTests\UIElementCollection_Insert.xaml.cs">
+      <DependentUpon>UIElementCollection_Insert.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ViewBoxTests\ViewBox_Alignment.xaml.cs">
       <DependentUpon>ViewBox_Alignment.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -189,6 +189,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_Shapes.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\VisualStatesTests\Buttons.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3187,6 +3191,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Capture.xaml.cs">
       <DependentUpon>Capture.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_Shapes.xaml.cs">
+      <DependentUpon>HitTest_Shapes.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\VisualStatesTests\TextBox_VisualStates.xaml.cs">
       <DependentUpon>TextBox_VisualStates.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -865,6 +865,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ThumbTests\Thumb_DragEvents.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\ToggleSwitch_TemplateReuse.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3564,6 +3568,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_TextChanging.xaml.cs">
       <DependentUpon>TextBox_TextChanging.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ThumbTests\Thumb_DragEvents.xaml.cs">
+      <DependentUpon>Thumb_DragEvents.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\ToggleSwitch_TemplateReuse.xaml.cs">
       <DependentUpon>ToggleSwitch_TemplateReuse.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Shapes.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Shapes.xaml
@@ -265,7 +265,10 @@
 			Visibility="Collapsed"
 			Points="0,0 0,50 50,50"/>
 
-		<StackPanel Orientation="Horizontal">
+		<StackPanel
+			Grid.Row="6"
+			Grid.ColumnSpan="3"
+			Orientation="Horizontal">
 			<TextBlock Text="Last pressed: " />
 			<TextBlock x:Name="LastPressed" Text="__none__" />
 		</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Shapes.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Shapes.xaml
@@ -1,0 +1,273 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Input.PointersTests.HitTest_Shapes"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Input.PointersTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid x:Name="Root" Background="Transparent">
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition />
+			<RowDefinition />
+			<RowDefinition />
+			<RowDefinition />
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition />
+			<ColumnDefinition />
+			<ColumnDefinition />
+		</Grid.ColumnDefinitions>
+
+		<Rectangle
+			x:Name="RectangleFilled"
+			Grid.Row="0"
+			Grid.Column="0"
+			Width="50"
+			Height="50"
+			Fill="#A0FF0000"
+			Stroke="#FF0000"
+			StrokeThickness="6" />
+		<Rectangle
+			x:Name="RectangleNotFilled"
+			Grid.Row="0"
+			Grid.Column="1"
+			Width="50"
+			Height="50"
+			Fill="{x:Null}"
+			Stroke="#FF0000"
+			StrokeThickness="6"/>
+		<Border
+			x:Name="RectangleHiddenSubElement"
+			Grid.Row="0"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Background="LightGray" />
+		<Rectangle
+			x:Name="RectangleHidden"
+			Grid.Row="0"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Fill="#A0FF0000"
+			Stroke="#FF0000"
+			StrokeThickness="6"
+			Visibility="Collapsed" />
+
+		<Ellipse
+			x:Name="EllipseFilled"
+			Grid.Row="1"
+			Grid.Column="0"
+			Width="50"
+			Height="50"
+			Fill="#A0FF8000"
+			Stroke="#FF8000"
+			StrokeThickness="6"/>
+		<Ellipse
+			x:Name="EllipseNotFilled"
+			Grid.Row="1"
+			Grid.Column="1"
+			Width="50"
+			Height="50"
+			Fill="{x:Null}"
+			Stroke="#FF8000"
+			StrokeThickness="6" />
+		<Border
+			x:Name="EllipseHiddenSubElement"
+			Grid.Row="1"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Background="LightGray" />
+		<Ellipse
+			x:Name="EllipseHidden"
+			Grid.Row="1"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Fill="#A0FF8000"
+			Stroke="#FF8000"
+			StrokeThickness="6"
+			Visibility="Collapsed" />
+
+		<Line
+			x:Name="LineFilled"
+			Grid.Row="2"
+			Grid.Column="0"
+			Width="50"
+			Height="50"
+			Stroke="#FFFF00"
+			StrokeThickness="20"
+			X1="0" Y1="0" X2="50" Y2="50" />
+		<Line
+			x:Name="LineNotFilled"
+			Grid.Row="2"
+			Grid.Column="1"
+			Width="50"
+			Height="50"
+			Stroke="{x:Null}"
+			StrokeThickness="20"
+			X1="0" Y1="0" X2="50" Y2="50"/>
+		<Border
+			x:Name="LineHiddenSubElement"
+			Grid.Row="2"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Background="LightGray" />
+		<Line
+			x:Name="LineHidden"
+			Grid.Row="2"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Stroke="#FFFF00"
+			StrokeThickness="20"
+			Visibility="Collapsed"
+			X1="0" Y1="0" X2="50" Y2="50"/>
+
+		<Path
+			x:Name="PathFilled"
+			Grid.Row="3"
+			Grid.Column="0"
+			Width="50"
+			Height="50"
+			Fill="#A0008000"
+			Stroke="#008000"
+			StrokeThickness="6">
+			<Path.Data>
+				<GeometryGroup>
+					<EllipseGeometry Center="50,50" RadiusX="50" RadiusY="50"/>
+				</GeometryGroup>
+			</Path.Data>
+		</Path>
+		<Path
+			x:Name="PathNotFilled"
+			Grid.Row="3"
+			Grid.Column="1"
+			Width="50"
+			Height="50"
+			Fill="{x:Null}"
+			Stroke="#008000"
+			StrokeThickness="6">
+			<Path.Data>
+				<GeometryGroup>
+					<EllipseGeometry Center="50,50" RadiusX="50" RadiusY="50"/>
+				</GeometryGroup>
+			</Path.Data>
+		</Path>
+		<Border
+			x:Name="PathHiddenSubElement"
+			Grid.Row="3"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Background="LightGray" />
+		<Path
+			x:Name="PathHidden"
+			Grid.Row="3"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Fill="#008000"
+			Stroke="#008000"
+			StrokeThickness="6"
+			Visibility="Collapsed">
+			<Path.Data>
+				<GeometryGroup>
+					<EllipseGeometry Center="50,50" RadiusX="50" RadiusY="50"/>
+				</GeometryGroup>
+			</Path.Data>
+		</Path>
+
+		<Polygon
+			x:Name="PolygonFilled"
+			Grid.Row="4"
+			Grid.Column="0"
+			Width="50"
+			Height="50"
+			Fill="#A00000FF"
+			Stroke="#0000FF"
+			StrokeThickness="6"
+			Points="0,0 0,50 50,50"/>
+		<Polygon
+			x:Name="PolygonNotFilled"
+			Grid.Row="4"
+			Grid.Column="1"
+			Width="50"
+			Height="50"
+			Fill="{x:Null}"
+			Stroke="#0000FF"
+			StrokeThickness="6"
+			Points="0,0 0,50 50,50"/>
+		<Border
+			x:Name="PolygonHiddenSubElement"
+			Grid.Row="4"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Background="LightGray" />
+		<Polygon
+			x:Name="PolygonHidden"
+			Grid.Row="4"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Fill="#A00000FF"
+			Stroke="#0000FF"
+			StrokeThickness="6"
+			Visibility="Collapsed"
+			Points="0,0 0,50 50,50"/>
+
+		<Polyline
+			x:Name="PolylineFilled"
+			Grid.Row="5"
+			Grid.Column="0"
+			Width="50"
+			Height="50"
+			Fill="#A0A000C0"
+			Stroke="#A000C0"
+			StrokeThickness="6"
+			Points="0,0 0,50 50,50"/>
+		<Polyline
+			x:Name="PolylineNotFilled"
+			Grid.Row="5"
+			Grid.Column="1"
+			Width="50"
+			Height="50"
+			Fill="{x:Null}"
+			Stroke="#A000C0"
+			StrokeThickness="6"
+			Points="0,0 0,50 50,50"/>
+		<Border
+			x:Name="PolylineHiddenSubElement"
+			Grid.Row="5"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Background="LightGray" />
+		<Polyline
+			x:Name="PolylineHidden"
+			Grid.Row="5"
+			Grid.Column="2"
+			Width="50"
+			Height="50"
+			Fill="#A0A000C0"
+			Stroke="#A000C0"
+			StrokeThickness="6"
+			Visibility="Collapsed"
+			Points="0,0 0,50 50,50"/>
+
+		<StackPanel Orientation="Horizontal">
+			<TextBlock Text="Last pressed: " />
+			<TextBlock x:Name="LastPressed" Text="__none__" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Shapes.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Shapes.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Input.PointersTests
+{
+	[Sample("Pointers", "Shapes")]
+	public sealed partial class HitTest_Shapes : Page
+	{
+		public HitTest_Shapes()
+		{
+			this.InitializeComponent();
+
+			foreach (var elt in GetElements())
+			{
+				elt.PointerPressed += (snd, e) =>
+				{
+					e.Handled = true;
+					LastPressed.Text = elt.Name;
+				};
+			}
+		}
+
+		private IEnumerable<FrameworkElement> GetElements()
+		{
+			yield return Root;
+
+			yield return RectangleFilled;
+			yield return RectangleNotFilled;
+			yield return RectangleHidden;
+			yield return RectangleHiddenSubElement;
+
+			yield return EllipseFilled;
+			yield return EllipseNotFilled;
+			yield return EllipseHidden;
+			yield return EllipseHiddenSubElement;
+
+			yield return LineFilled;
+			yield return LineNotFilled;
+			yield return LineHidden;
+			yield return LineHiddenSubElement;
+
+			yield return PathFilled;
+			yield return PathNotFilled;
+			yield return PathHidden;
+			yield return PathHiddenSubElement;
+
+			yield return PolygonFilled;
+			yield return PolygonNotFilled;
+			yield return PolygonHidden;
+			yield return PolygonHiddenSubElement;
+
+			yield return PolylineFilled;
+			yield return PolylineNotFilled;
+			yield return PolylineHidden;
+			yield return PolylineHiddenSubElement;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_DragEvents.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_DragEvents.xaml
@@ -1,0 +1,46 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.ThumbTests.Thumb_DragEvents"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ThumbTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<StackPanel
+			VerticalAlignment="Top"
+			HorizontalAlignment="Left">
+			<TextBlock Text="Start:" />
+			<TextBlock x:Name="DragStartedOutput" />
+			<TextBlock Text="Delta:" />
+			<TextBlock x:Name="DragDeltaOutput" />
+			<TextBlock Text="End:" />
+			<TextBlock x:Name="DragCompletedOutput" />
+		</StackPanel>
+
+		<Grid
+			Width="100"
+			Height="100"
+			VerticalAlignment="Center"
+			HorizontalAlignment="Center"
+			Background="Red">
+			<Thumb
+				x:Name="TheThumb"
+				Width="20"
+				Height="20"
+				VerticalAlignment="Center"
+				HorizontalAlignment="Center"
+				DragStarted="OnThumbDragStarted"
+				DragDelta="OnThumbDragDelta"
+				DragCompleted="OnThumbDragCompleted">
+				<Thumb.Template>
+					<ControlTemplate>
+						<Border Background="Blue" />
+					</ControlTemplate>
+				</Thumb.Template>
+			</Thumb>
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_DragEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_DragEvents.xaml.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.ThumbTests
+{
+	[Sample]
+	public sealed partial class Thumb_DragEvents : Page
+	{
+		public Thumb_DragEvents()
+		{
+			this.InitializeComponent();
+		}
+
+		private void OnThumbDragStarted(object sender, DragStartedEventArgs e)
+		{
+			DragStartedOutput.Text = $"@x={e.HorizontalOffset:F2},@y={e.VerticalOffset:F2}";
+		}
+
+		private void OnThumbDragDelta(object sender, DragDeltaEventArgs e)
+		{
+#if XAMARIN // Total properties are uno only
+			DragDeltaOutput.Text = $"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx={e.TotalHorizontalChange:F2},Σy={e.TotalVerticalChange:F2}";
+#else
+			DragDeltaOutput.Text = $"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx=0.0,Σy=0.0";
+#endif
+		}
+
+		private void OnThumbDragCompleted(object sender, DragCompletedEventArgs e)
+		{
+#if XAMARIN // Total properties are uno only
+			DragCompletedOutput.Text = $"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx={e.TotalHorizontalChange:F2},Σy={e.TotalVerticalChange:F2}";
+#else
+			DragCompletedOutput.Text = $"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx=0.0,Σy=0.0";
+#endif
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_DragEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_DragEvents.xaml.cs
@@ -21,7 +21,7 @@ namespace UITests.Windows_UI_Xaml_Controls.ThumbTests
 
 		private void OnThumbDragDelta(object sender, DragDeltaEventArgs e)
 		{
-#if XAMARIN // Total properties are uno only
+#if XAMARIN || __WASM__ // Total properties are uno only
 			DragDeltaOutput.Text = $"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx={e.TotalHorizontalChange:F2},Σy={e.TotalVerticalChange:F2}";
 #else
 			DragDeltaOutput.Text = $"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx=0.0,Σy=0.0";
@@ -30,7 +30,7 @@ namespace UITests.Windows_UI_Xaml_Controls.ThumbTests
 
 		private void OnThumbDragCompleted(object sender, DragCompletedEventArgs e)
 		{
-#if XAMARIN // Total properties are uno only
+#if XAMARIN || __WASM__ // Total properties are uno only
 			DragCompletedOutput.Text = $"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx={e.TotalHorizontalChange:F2},Σy={e.TotalVerticalChange:F2}";
 #else
 			DragCompletedOutput.Text = $"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx=0.0,Σy=0.0";

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/UIElementCollectionTests/UIElementCollection_Insert.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/UIElementCollectionTests/UIElementCollection_Insert.xaml
@@ -1,0 +1,45 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.UIElementCollectionTests.UIElementCollection_Insert"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.UIElementCollectionTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+
+		<Grid x:Name="When_Insert_First" Grid.Row="0">
+			<!--Inserted element:  <Border Margin="0" Background="#FF0000" />-->
+			<Border Margin="10,0" Background="#FF8000" />
+			<Border Margin="20,0" Background="#FFFF00" />
+			<Border Margin="30,0" Background="#008000" />
+			<Border Margin="40,0" Background="#0000FF" />
+			<Border Margin="50,0" Background="#A000C0" />
+		</Grid>
+
+		<Grid x:Name="When_Insert_Middle" Grid.Row="1">
+			<Border Margin="0" Background="#FF0000" />
+			<Border Margin="10,0" Background="#FF8000" />
+			<Border Margin="20,0" Background="#FFFF00" />
+			<!--Inserted element: <Border Margin="30,0" Background="#008000" />-->
+			<Border Margin="40,0" Background="#0000FF" />
+			<Border Margin="50,0" Background="#A000C0" />
+		</Grid>
+
+		<Grid x:Name="When_Insert_Last" Grid.Row="2">
+			<Border Margin="0" Background="#FF0000" />
+			<Border Margin="10,0" Background="#FF8000" />
+			<Border Margin="20,0" Background="#FFFF00" />
+			<Border Margin="30,0" Background="#008000" />
+			<Border Margin="40,0" Background="#0000FF" />
+			<!--Inserted element: <Border Margin="50,0" Background="#A000C0" />-->
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/UIElementCollectionTests/UIElementCollection_Insert.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/UIElementCollectionTests/UIElementCollection_Insert.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.UIElementCollectionTests
+{
+	[Sample(
+		Description= "This test asserts that an element inserted after the first draw is really inserted at the right place",
+		IgnoreInSnapshotTests=false)]
+	public sealed partial class UIElementCollection_Insert : Page
+	{
+		public UIElementCollection_Insert()
+		{
+			this.InitializeComponent();
+
+			Loaded += (snd, e) =>
+			{
+				When_Insert_First.Children.Insert(0, new Border
+				{
+					Background = new SolidColorBrush(Color.FromArgb(0xff, 0xff, 0x00, 0x00)),
+					Margin = new Thickness(0),
+				});
+
+				When_Insert_Middle.Children.Insert(3, new Border
+				{
+					Background = new SolidColorBrush(Color.FromArgb(0xff, 0x00, 0x80, 0x00)),
+					Margin = new Thickness(30, 0, 30, 0),
+				});
+
+				When_Insert_Last.Children.Add(new Border
+				{
+					Background = new SolidColorBrush(Color.FromArgb(0xff, 0xa0, 0x00, 0xc0)),
+					Margin = new Thickness(50, 0, 50, 0),
+				});
+			};
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
@@ -38,6 +38,15 @@ body {
   transform: translate(0, 0);
 }
 
+svg.uno-uielement {
+  /*
+    The SVG elements are not intended to be a touch target (they are only a holder collection of child shapes),
+    instead it's their child SvgElement that should be the target of the pointer.
+    This also ensure that we are HitTestVisible only for shapes that has a fill.
+  */
+  pointer-events: none;
+}
+
 .uno-frameworkelement.uno-clippedToBounds {
   /*
     This CSS class is applied when a control is a _clipping mode_:

--- a/src/Uno.UI/UI/Xaml/BatchCollectionWrapper.cs
+++ b/src/Uno.UI/UI/Xaml/BatchCollectionWrapper.cs
@@ -16,6 +16,12 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private readonly DependencyObject _owner;
 
+		/// <summary>
+		/// The owner of this collection.
+		/// This is intended to be used to redispatch to a specific instance in ** static ** CollectionChanged handlers.
+		/// </summary>
+		internal DependencyObject Owner => _owner;
+
 		public BatchCollection(DependencyObject owner)
 		{
 			_owner = owner;

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/DragCompletedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/DragCompletedEventArgs.cs
@@ -13,12 +13,14 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			VerticalChange = verticalChange;
 		}
 
-		public DragCompletedEventArgs(object originalSource, double horizontalChange, double verticalChange, bool canceled)
+		public DragCompletedEventArgs(object originalSource, double horizontalChange, double verticalChange, double totalHorizontalChange, double totalVerticalChange, bool canceled)
 			: base(originalSource)
 		{
 			Canceled = canceled;
 			HorizontalChange = horizontalChange;
 			VerticalChange = verticalChange;
+			TotalHorizontalChange = totalHorizontalChange;
+			TotalVerticalChange = totalVerticalChange;
 		}
 
 		public bool Canceled { get; }
@@ -26,5 +28,17 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		public double HorizontalChange { get; }
 
 		public double VerticalChange { get; }
+
+		/// <summary>
+		/// Internal helper property that contains the total horizontal change since the DragStarted event
+		/// </summary>
+		/// <remarks>Be aware that this property will be filled only when the args are built internally by Uno</remarks>
+		internal double TotalHorizontalChange { get; }
+
+		/// <summary>
+		/// Internal helper property that contains the total vertical change since the DragStarted event
+		/// </summary>
+		/// <remarks>Be aware that this property will be filled only when the args are built internally by Uno</remarks>
+		internal double TotalVerticalChange { get; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/DragDeltaEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/DragDeltaEventArgs.cs
@@ -12,16 +12,30 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			VerticalChange = verticalChange;
 		}
 
-		internal DragDeltaEventArgs(object originalSource, double horizontalChange, double verticalChange)
+		internal DragDeltaEventArgs(object originalSource, double horizontalChange, double verticalChange, double totalHorizontalChange, double totalVerticalChange)
 			: base(originalSource)
 		{
 			HorizontalChange = horizontalChange;
 			VerticalChange = verticalChange;
+			TotalHorizontalChange = totalHorizontalChange;
+			TotalVerticalChange = totalVerticalChange;
 		}
 
 		public double HorizontalChange { get; }
-
+		
 		public double VerticalChange { get; }
+
+		/// <summary>
+		/// Internal helper property that contains the total horizontal change since the DragStarted event
+		/// </summary>
+		/// <remarks>Be aware that this property will be filled only when the args are built internally by Uno</remarks>
+		internal double TotalHorizontalChange { get; }
+
+		/// <summary>
+		/// Internal helper property that contains the total vertical change since the DragStarted event
+		/// </summary>
+		/// <remarks>Be aware that this property will be filled only when the args are built internally by Uno</remarks>
+		internal double TotalVerticalChange { get; }
 
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Thumb.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Thumb.cs
@@ -7,6 +7,7 @@ using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI.Xaml.Input;
+using Uno.Extensions;
 
 namespace Windows.UI.Xaml.Controls.Primitives
 {
@@ -71,16 +72,27 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		//		 however there is probably no good reason to not use the GestureRecognizer.
 		private Point _startLocation, _lastLocation;
 
-		internal void StartDrag(Point absoluteLocation)
+		internal void StartDrag(PointerRoutedEventArgs args)
 		{
+			// Note: Position MUST be absolute as the element might move
+			var absoluteLocation = args.GetCurrentPoint(null).Position;
+
 			_startLocation = _lastLocation = absoluteLocation;
 
 			IsDragging = true;
-			DragStarted?.Invoke(this, new DragStartedEventArgs(this, 0, 0));
+
+			var handler = DragStarted;
+			if (Parent is UIElement elt && handler != null)
+			{
+				var locationRelativeToParent = args.GetCurrentPoint(elt).Position;
+				DragStarted?.Invoke(this, new DragStartedEventArgs(this, locationRelativeToParent.X, locationRelativeToParent.Y));
+			}
 		}
 
-		internal void DeltaDrag(Point absoluteLocation)
+		internal void DeltaDrag(PointerRoutedEventArgs args)
 		{
+			// Note: Position MUST be absolute as the element might have moved
+			var absoluteLocation = args.GetCurrentPoint(null).Position;
 			var deltaX = absoluteLocation.X - _lastLocation.X;
 			var deltaY = absoluteLocation.Y - _lastLocation.Y;
 			var totalX = absoluteLocation.X - _startLocation.X;
@@ -91,10 +103,12 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			DragDelta?.Invoke(this, new DragDeltaEventArgs(this, deltaX, deltaY, totalX, totalY));
 		}
 
-		internal void CompleteDrag(Point absoluteLocation)
+		internal void CompleteDrag(PointerRoutedEventArgs args)
 		{
 			IsDragging = false;
 
+			// Note: Position MUST be absolute as the element might have moved
+			var absoluteLocation = args.GetCurrentPoint(null).Position;
 			var deltaX = absoluteLocation.X - _lastLocation.X;
 			var deltaY = absoluteLocation.Y - _lastLocation.Y;
 			var totalX = absoluteLocation.X - _startLocation.X;
@@ -112,7 +126,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				return;
 			}
 
-			// Note: Position MUST be absolute as the element might have moved
 			var point = args.GetCurrentPoint(null);
 			if (!point.Properties.IsLeftButtonPressed
 				|| !CapturePointer(args.Pointer))
@@ -124,7 +137,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			// Note2: Handling this event causes an issue in parent controls (like ToggleSwitch) that has a pressed visual state.
 			//		  In order to fix that, parents controls are expected to also listen for handled events too, and update their visual state in case.
 			args.Handled = true;
-			StartDrag(point.Position);
+			StartDrag(args);
 		}
 
 		protected override void OnPointerMoved(PointerRoutedEventArgs args)
@@ -134,8 +147,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			if (IsCaptured(args.Pointer))
 			{
 				// Note: We don't handle event as UWP does not, and otherwise it will prevent parent control to update its visual state
-				// Note2: Position MUST be absolute as the element might have moved
-				DeltaDrag(args.GetCurrentPoint(null).Position);
+				DeltaDrag(args);
 			}
 		}
 
@@ -144,8 +156,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			base.OnPointerCaptureLost(args);
 
 			// Note: We don't handle event as UWP does not, and otherwise it will prevent parent control to update its visual state
-			// Note2: Position MUST be absolute as the element might have moved
-			CompleteDrag(args.GetCurrentPoint(null).Position);
+			CompleteDrag(args);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
@@ -340,37 +340,30 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnSliderContainerPressed(object sender, PointerRoutedEventArgs e)
 		{
-			var container = sender as FrameworkElement;
-			if (container.CapturePointer(e.Pointer))
+			if (sender is FrameworkElement container && container.CapturePointer(e.Pointer))
 			{
-				var point = e.GetCurrentPoint(null).Position;
+				var point = e.GetCurrentPoint(container).Position;
 				var newOffset = Orientation == Orientation.Horizontal
 					? point.X / container.ActualWidth
 					: 1 - (point.Y / container.ActualHeight);
 
 				ApplySlideToValue(newOffset);
-				Thumb?.StartDrag(point);
+				Thumb?.StartDrag(e.GetCurrentPoint(null).Position);
 			}
 		}
 
 		private void OnSliderContainerMoved(object sender, PointerRoutedEventArgs e)
 		{
-			var container = sender as FrameworkElement;
-			if (container.IsCaptured(e.Pointer))
+			if (sender is FrameworkElement container && container.IsCaptured(e.Pointer))
 			{
-				var point = e.GetCurrentPoint(null).Position;
-
-				Thumb?.DeltaDrag(point);
+				Thumb?.DeltaDrag(e.GetCurrentPoint(null).Position);
 			}
 		}
 
 		private void OnSliderContainerCaptureLost(object sender, PointerRoutedEventArgs e)
 		{
-			var container = sender as FrameworkElement;
-			var point = e.GetCurrentPoint(null).Position;
-
 			ApplyValueToSlide();
-			Thumb?.CompleteDrag(point);
+			Thumb?.CompleteDrag(e.GetCurrentPoint(null).Position);
 		}
 
 		#region IsTrackerEnabled DependencyProperty

--- a/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
@@ -169,7 +169,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 					var maxWidth = ActualWidth - _horizontalThumb.ActualWidth;
 
-					_horizontalDecreaseRect.Width = Math.Min(Math.Max(0, _horizontalInitial + (float)e.HorizontalChange), maxWidth);
+					_horizontalDecreaseRect.Width = Math.Min(Math.Max(0, _horizontalInitial + (float)e.TotalHorizontalChange), maxWidth);
 
 					ApplySlideToValue(_horizontalDecreaseRect.Width / maxWidth);
 				}
@@ -177,7 +177,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 					var maxHeight = ActualHeight - _horizontalThumb.ActualHeight;
 
-					_verticalDecreaseRect.Height = Math.Min(Math.Max(0, _verticalInitial - (float)e.VerticalChange), (float)maxHeight);
+					_verticalDecreaseRect.Height = Math.Min(Math.Max(0, _verticalInitial - (float)e.TotalVerticalChange), (float)maxHeight);
 
 					ApplySlideToValue(_verticalDecreaseRect.Height / maxHeight);
 				}
@@ -343,7 +343,7 @@ namespace Windows.UI.Xaml.Controls
 			var container = sender as FrameworkElement;
 			if (container.CapturePointer(e.Pointer))
 			{
-				var point = e.GetCurrentPoint(container).Position;
+				var point = e.GetCurrentPoint(null).Position;
 				var newOffset = Orientation == Orientation.Horizontal
 					? point.X / container.ActualWidth
 					: 1 - (point.Y / container.ActualHeight);
@@ -358,7 +358,7 @@ namespace Windows.UI.Xaml.Controls
 			var container = sender as FrameworkElement;
 			if (container.IsCaptured(e.Pointer))
 			{
-				var point = e.GetCurrentPoint(container).Position;
+				var point = e.GetCurrentPoint(null).Position;
 
 				Thumb?.DeltaDrag(point);
 			}
@@ -367,7 +367,7 @@ namespace Windows.UI.Xaml.Controls
 		private void OnSliderContainerCaptureLost(object sender, PointerRoutedEventArgs e)
 		{
 			var container = sender as FrameworkElement;
-			var point = e.GetCurrentPoint(container).Position;
+			var point = e.GetCurrentPoint(null).Position;
 
 			ApplyValueToSlide();
 			Thumb?.CompleteDrag(point);

--- a/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
@@ -338,32 +338,32 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private void OnSliderContainerPressed(object sender, PointerRoutedEventArgs e)
+		private void OnSliderContainerPressed(object sender, PointerRoutedEventArgs args)
 		{
-			if (sender is FrameworkElement container && container.CapturePointer(e.Pointer))
+			if (sender is FrameworkElement container && container.CapturePointer(args.Pointer))
 			{
-				var point = e.GetCurrentPoint(container).Position;
+				var point = args.GetCurrentPoint(container).Position;
 				var newOffset = Orientation == Orientation.Horizontal
 					? point.X / container.ActualWidth
 					: 1 - (point.Y / container.ActualHeight);
 
 				ApplySlideToValue(newOffset);
-				Thumb?.StartDrag(e.GetCurrentPoint(null).Position);
+				Thumb?.StartDrag(args);
 			}
 		}
 
-		private void OnSliderContainerMoved(object sender, PointerRoutedEventArgs e)
+		private void OnSliderContainerMoved(object sender, PointerRoutedEventArgs args)
 		{
-			if (sender is FrameworkElement container && container.IsCaptured(e.Pointer))
+			if (sender is FrameworkElement container && container.IsCaptured(args.Pointer))
 			{
-				Thumb?.DeltaDrag(e.GetCurrentPoint(null).Position);
+				Thumb?.DeltaDrag(args);
 			}
 		}
 
-		private void OnSliderContainerCaptureLost(object sender, PointerRoutedEventArgs e)
+		private void OnSliderContainerCaptureLost(object sender, PointerRoutedEventArgs args)
 		{
 			ApplyValueToSlide();
-			Thumb?.CompleteDrag(e.GetCurrentPoint(null).Position);
+			Thumb?.CompleteDrag(args);
 		}
 
 		#region IsTrackerEnabled DependencyProperty

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch.cs
@@ -245,9 +245,9 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnDragDelta(object sender, DragDeltaEventArgs e)
 		{
-			var dragDistance = Math.Abs(e.HorizontalChange);
+			var dragDistance = Math.Abs(e.TotalHorizontalChange);
 			_maxDragDistance = Math.Max(dragDistance, _maxDragDistance);
-			UpdateSwitchKnobPosition(e.HorizontalChange);
+			UpdateSwitchKnobPosition(e.TotalHorizontalChange);
 		}
 
 		private void OnDragCompleted(object sender, DragCompletedEventArgs e)
@@ -262,7 +262,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else
 			{
-				var isOn = GetAbsoluteOffset(e.HorizontalChange) > (GetMaxOffset() / 2);
+				var isOn = GetAbsoluteOffset(e.TotalHorizontalChange) > (GetMaxOffset() / 2);
 				if (isOn == IsOn)
 				{
 					UpdateSwitchKnobPosition(0);

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.wasm.cs
@@ -56,7 +56,7 @@ namespace Windows.UI.Xaml.Shapes
 			var translate = Matrix3x2.CreateTranslation((float)measurements.translateX, (float)measurements.translateY);
 			var matrix = translate * scale;
 
-			foreach (FrameworkElement child in GetChildren())
+			foreach (var child in GetChildren())
 			{
 				if (child is DefsSvgElement)
 				{
@@ -148,7 +148,7 @@ namespace Windows.UI.Xaml.Shapes
 		{
 			var bbox = Rect.Empty;
 
-			foreach (FrameworkElement child in GetChildren())
+			foreach (var child in GetChildren())
 			{
 				if (child is DefsSvgElement)
 				{
@@ -170,7 +170,7 @@ namespace Windows.UI.Xaml.Shapes
 			return bbox;
 		}
 
-		private Rect GetBBoxWithStrokeThickness(FrameworkElement element)
+		private Rect GetBBoxWithStrokeThickness(UIElement element)
 		{
 			var bbox = element.GetBBox();
 			if (Stroke == null || StrokeThickness < double.Epsilon)

--- a/src/Uno.UI/UI/Xaml/Shapes/Rectangle.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Rectangle.wasm.cs
@@ -25,16 +25,6 @@ namespace Windows.UI.Xaml.Shapes
 			return _rectangle;
 		}
 
-		protected override Size MeasureOverride(Size availableSize)
-		{
-			var strokeThickness = ActualStrokeThickness;
-
-			_rectangle.Width = Width - strokeThickness;
-			_rectangle.Height = Height - strokeThickness;
-
-			return base.MeasureOverride(availableSize);
-		}
-
 		protected override Size ArrangeOverride(Size finalSize)
 		{
 			var strokeThickness = ActualStrokeThickness;

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
@@ -169,6 +169,6 @@ namespace Windows.UI.Xaml.Shapes
 		protected virtual void RefreshShape(bool forceRefresh = false) { }
 
 		internal override bool IsViewHit()
-			=> Fill != null; // Do not invoke base.IsViewHit(): We don't have to have de FramewokrElement.Background to be hit testable!
+			=> Fill != null; // Do not invoke base.IsViewHit(): We don't have to have de FrameworkElement.Background to be hit testable!
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
@@ -169,6 +169,6 @@ namespace Windows.UI.Xaml.Shapes
 		protected virtual void RefreshShape(bool forceRefresh = false) { }
 
 		internal override bool IsViewHit()
-			=> Fill != null || base.IsViewHit();
+			=> Fill != null; // Do not invoke base.IsViewHit(): We don't have to have de FramewokrElement.Background to be hit testable!
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.wasm.cs
@@ -29,6 +29,7 @@ namespace Windows.UI.Xaml.Shapes
 		protected Shape() : base("svg", isSvg: true)
 		{
 			SvgChildren = new UIElementCollection(this);
+			SvgChildren.CollectionChanged += OnSvgChildrenChanged;
 
 			OnStretchUpdatedPartial();
 		}
@@ -42,6 +43,18 @@ namespace Windows.UI.Xaml.Shapes
 		}
 
 		protected abstract SvgElement GetMainSvgElement();
+
+		private static readonly NotifyCollectionChangedEventHandler OnSvgChildrenChanged = (object sender, NotifyCollectionChangedEventArgs args) =>
+		{
+			if (sender is UIElementCollection children && children.Owner is Shape shape)
+			{
+				shape.OnChildrenChanged();
+			}
+		};
+
+		protected virtual void OnChildrenChanged()
+		{
+		}
 
 		partial void OnFillUpdatedPartial()
 		{

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.wasm.cs
@@ -33,21 +33,6 @@ namespace Windows.UI.Xaml.Shapes
 			OnStretchUpdatedPartial();
 		}
 
-		private void OnSvgChildrenChanged(object sender, NotifyCollectionChangedEventArgs e)
-			=> OnChildrenChanged();
-
-		protected override void OnLoaded()
-		{
-			base.OnLoaded();
-			SvgChildren.CollectionChanged += OnSvgChildrenChanged;
-		}
-
-		protected override void OnUnloaded()
-		{
-			base.OnUnloaded();
-			SvgChildren.CollectionChanged -= OnSvgChildrenChanged;
-		}
-
 		protected void InitCommonShapeProperties() // Should be called from base class constructor
 		{
 			// Initialize
@@ -57,10 +42,6 @@ namespace Windows.UI.Xaml.Shapes
 		}
 
 		protected abstract SvgElement GetMainSvgElement();
-
-		protected virtual void OnChildrenChanged()
-		{
-		}
 
 		partial void OnFillUpdatedPartial()
 		{
@@ -162,6 +143,12 @@ namespace Windows.UI.Xaml.Shapes
 			}
 
 			return _defs.Defs;
+		}
+
+		private protected override void OnHitTestVisibilityChanged(HitTestVisibility oldValue, HitTestVisibility newValue)
+		{
+			// We don't invoke the base, so we stay at the default "pointer-events: none" defined in Uno.UI.css in class svg.uno-uielement.
+			// This is required to avoid this SVG element (which is actually only a collection) to stoll pointer events.
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/SvgElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/SvgElement.wasm.cs
@@ -2,7 +2,7 @@
 
 namespace Windows.UI.Xaml.Wasm
 {
-	public partial class SvgElement : FrameworkElement
+	public partial class SvgElement : UIElement
 	{
 		public SvgElement(string svgTag) : base(svgTag, isSvg: true)
 		{

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -171,7 +171,7 @@ namespace Windows.UI.Xaml
 				{
 					return ctrl.IsLoaded && ctrl.IsEnabled;
 				}
-				else if (this is Windows.UI.Xaml.Controls.Control fwElt)
+				else if (this is Windows.UI.Xaml.FrameworkElement fwElt)
 				{
 					return fwElt.IsLoaded;
 				}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -202,7 +202,7 @@ namespace Windows.UI.Xaml
 			this.CoerceValue(HitTestVisibilityProperty);
 		}
 
-		private enum HitTestVisibility
+		private protected enum HitTestVisibility
 		{
 			/// <summary>
 			/// The element and its children can't be targeted by hit-testing.
@@ -280,27 +280,34 @@ namespace Windows.UI.Xaml
 
 		private static void OnHitTestVisibilityChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
-			if (dependencyObject is UIElement element && args.NewValue is HitTestVisibility hitTestVisibility)
+			if (dependencyObject is UIElement element
+				&& args.OldValue is HitTestVisibility oldValue
+				&& args.NewValue is HitTestVisibility newValue)
 			{
-				if (hitTestVisibility == HitTestVisibility.Visible)
-				{
-					// By default, elements have 'pointer-event' set to 'auto' (see Uno.UI.css .uno-uielement class).
-					// This means that they can be the target of hit-testing and will raise pointer events when interacted with.
-					// This is aligned with HitTestVisibilityProperty's default value of Visible.
-					element.SetStyle("pointer-events", "auto");
-				}
-				else
-				{
-					// If HitTestVisibilityProperty is calculated to Invisible or Collapsed,
-					// we don't want to be the target of hit-testing and raise any pointer events.
-					// This is done by setting 'pointer-events' to 'none'.
-					element.SetStyle("pointer-events", "none");
-				}
+				element.OnHitTestVisibilityChanged(oldValue, newValue);
+			}
+		}
 
-				if (FeatureConfiguration.UIElement.AssignDOMXamlProperties)
-				{
-					element.UpdateDOMProperties();
-				}
+		private protected virtual void OnHitTestVisibilityChanged(HitTestVisibility oldValue, HitTestVisibility newValue)
+		{
+			if (newValue == HitTestVisibility.Visible)
+			{
+				// By default, elements have 'pointer-event' set to 'auto' (see Uno.UI.css .uno-uielement class).
+				// This means that they can be the target of hit-testing and will raise pointer events when interacted with.
+				// This is aligned with HitTestVisibilityProperty's default value of Visible.
+				SetStyle("pointer-events", "auto");
+			}
+			else
+			{
+				// If HitTestVisibilityProperty is calculated to Invisible or Collapsed,
+				// we don't want to be the target of hit-testing and raise any pointer events.
+				// This is done by setting 'pointer-events' to 'none'.
+				SetStyle("pointer-events", "none");
+			}
+
+			if (FeatureConfiguration.UIElement.AssignDOMXamlProperties)
+			{
+				UpdateDOMProperties();
 			}
 		}
 		#endregion

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -423,15 +423,7 @@ namespace Windows.UI.Xaml
 			OnAddingChild(child);
 
 			_children.Add(child);
-
-			if (index.HasValue)
-			{
-				Uno.UI.Xaml.WindowManagerInterop.AddView(HtmlId, child.HtmlId, index);
-			}
-			else
-			{
-				Uno.UI.Xaml.WindowManagerInterop.AddView(HtmlId, child.HtmlId);
-			}
+			Uno.UI.Xaml.WindowManagerInterop.AddView(HtmlId, child.HtmlId, index);
 
 			OnChildAdded(child);
 


### PR DESCRIPTION
GitHub Issue: _private_

## Bug fixes
1. `HorizontalChange` and `VerticalChange` of event args raised by `Thumb.Drag<Delta|Complete>` 
1. `Shape` are no longer target of pointers
1. `SvgElement` can now be hit testable

## What is the current behavior?
1. `HorizontalChange` and `VerticalChange` of event args raised by `Thumb.Drag<Delta|Completed>` are cummulative since the `DragStarted` event
1. A hidden `Shape` can stole the pointer events as it's inheriting the default CSS `pointer-events: auto` from `UIElement`
1. As the `SvgElement` inherits from `FrameworkElement`, they are required to have a `Background` to be hit testable.

## What is the new behavior?
1. They should contains only the delta since the last `Thumb.Drag<Started|Delta>`
1. As on WASM a `Shape` is only a collection of `SvgElement` that are the real implementation of the shape, all HTML-SVG elements that are also a `UIElement` (i.e. `Shape`) are now `pointer-events: none`
1. `SvgElement` is now inheriting from `UIElement`, so it's hit testability is directly inherited from it's parent `Shape`.

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~ (`Drag<Delta|Completed>EventArgs.<Horizontal|Vertical>Change` are no longer cummulative)
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
