### PR TITLE
Improve BitmapImage.SetSource()

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -80,7 +80,7 @@
 - Enable partial `NavigationView.ItemSource` scenario (https://github.com/unoplatform/uno/issues/2477)
 - [Wasm] Fail gracefully if IDBFS is not enabled in emscripten
 - [#2513] Fix `TransformGroup` not working
-- [#1956] Fis iOS invalid final state when switching visual state before current state's animation is completed.
+- [#1956] Fix iOS invalid final state when switching visual state before current state's animation is completed.
 - Fix `Selector` support for IsSelected (#1606)
 - [Android] 164249 fixed TextBox.Text flickering when using custom IInputFilter with MaxLength set
 - [MacOS] Fix exceptions when modifying UIElementCollection, layouting view with null `Layer`
@@ -89,6 +89,7 @@
 - [Android] Adjust `TextBlock.TextDecorations` is not updating properly
 - Adjust `XamlBindingHelper` for `GridLength` and `TimeSpan`
 - Add missing `ListView` resources
+- [#2377] Improve BitmapImage.SetSource to better handle the provided stream
 
 ## Release 2.0
 

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapSource.cs
@@ -60,7 +60,9 @@ namespace Windows.UI.Xaml.Media.Imaging
 			PixelWidth = 0;
 			PixelHeight = 0;
 
-			Stream = streamSource;
+			MemoryStream copy = new MemoryStream();
+			streamSource.CopyTo(copy);
+			Stream = copy;
 		}
 
 		public async Task SetSourceAsync(Stream streamSource)

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapSource.cs
@@ -59,10 +59,18 @@ namespace Windows.UI.Xaml.Media.Imaging
 		{
 			PixelWidth = 0;
 			PixelHeight = 0;
-
-			MemoryStream copy = new MemoryStream();
-			streamSource.CopyTo(copy);
-			Stream = copy;
+			
+			if (streamSource != null)
+			{
+				MemoryStream copy = new MemoryStream();
+				streamSource.CopyTo(copy);
+				Stream = copy;
+			}
+			else
+			{
+				//Same behavior as windows, although the documentation does not mention it!!!
+				throw new ArgumentException(nameof(streamSource));
+			}
 		}
 
 		public async Task SetSourceAsync(Stream streamSource)


### PR DESCRIPTION
GitHub Issue (If applicable): #2377 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
BitmapImage.SetSource Needs Access to the provided stream, Which makes it difficult to handle. It should be in line with SetSourceAsync.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
BitmapImage.SetSource makes a local copy of the provided stream and therefore manges it in ist own.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
