### PR TITLE
[Android] TextBox.IsReadOnly bugfixes

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -917,6 +917,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_IsReadOnly_AcceptsReturn.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_MaxLength.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3700,6 +3704,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Margin.xaml.cs">
       <DependentUpon>TextBox_Margin.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_IsReadOnly_AcceptsReturn.xaml.cs">
+      <DependentUpon>TextBox_IsReadOnly_AcceptsReturn.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_MaxLength.xaml.cs">
       <DependentUpon>TextBox_MaxLength.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly_AcceptsReturn.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly_AcceptsReturn.xaml
@@ -1,0 +1,27 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_IsReadOnly_AcceptsReturn"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+		<StackPanel Orientation="Horizontal">
+			<TextBlock Text="IsReadOnly:" />
+			<CheckBox x:Name="IsReadOnlyCheckBox" IsChecked="{Binding ElementName=TargetTextBox, Path=IsReadOnly, Mode=TwoWay}" />
+		</StackPanel>
+		<StackPanel Orientation="Horizontal">
+			<TextBlock Text="AcceptsReturn:" />
+			<CheckBox x:Name="AcceptsReturnCheckBox" IsChecked="{Binding ElementName=TargetTextBox, Path=AcceptsReturn, Mode=TwoWay}" />
+		</StackPanel>
+
+		<TextBox x:Name="TargetTextBox"
+				 Text="lorem&#x0a;ipsum&#x0a;asd&#x0a;asd&#x0a;asd"
+				 AcceptsReturn="True"
+				 IsReadOnly="True" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly_AcceptsReturn.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly_AcceptsReturn.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
+{
+	[SampleControlInfo("TextBox", description: "#2700: Setting IsReadOnly=True breaks AcceptReturns=True on android")]
+	public sealed partial class TextBox_IsReadOnly_AcceptsReturn : UserControl
+    {
+        public TextBox_IsReadOnly_AcceptsReturn()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -322,24 +322,7 @@ namespace Windows.UI.Xaml.Controls
 					inputType |= InputTypes.TextFlagMultiLine;
 				}
 
-				if (IsReadOnly)
-				{
-					_textBoxView.InputType = InputTypes.Null;
-
-					// Clear the listener so the inputs have no effect.
-					// Setting the input type to InputTypes.Null is not enough.
-					_listener = _textBoxView.KeyListener;
-					_textBoxView.KeyListener = null;
-				}
-				else
-				{
-					if (_listener != null)
-					{
-						_textBoxView.KeyListener = _listener;
-					}
-
-					_textBoxView.InputType = inputType;
-				}
+				_textBoxView.InputType = inputType;
 			}
 		}
 
@@ -407,7 +390,26 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (_textBoxView != null)
 			{
-				UpdateInputScope(InputScope);
+				var isReadOnly = IsReadOnly;
+
+				_textBoxView.Focusable = !isReadOnly;
+				_textBoxView.FocusableInTouchMode = !isReadOnly;
+				_textBoxView.Clickable = !isReadOnly;
+				_textBoxView.LongClickable = !isReadOnly;
+				_textBoxView.SetCursorVisible(!isReadOnly);
+
+				if (isReadOnly)
+				{
+					_listener = _textBoxView.KeyListener;
+					_textBoxView.KeyListener = null;
+				}
+				else
+				{
+					if (_listener != null)
+					{
+						_textBoxView.KeyListener = _listener;
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #2700

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
`TextBox IsReadOnly="true"` ignores line changes in text.

## What is the new behavior?
`TextBox IsReadOnly="true"` makes TextBox read-only (and nothing else).

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)