### PR TITLE
Fix erratic animations on Android and iOS

### DIFF
--- a/src/Uno.UI/Media/NativeRenderTransformAdapter.Android.cs
+++ b/src/Uno.UI/Media/NativeRenderTransformAdapter.Android.cs
@@ -52,7 +52,7 @@ namespace Uno.UI.Media
 			{
 				this.Log().Error(
 					$"A RenderTransform was set on '{Owner}', but its parent is not a BindableView ({newParent.GetType().Name}), "
-					+ $"so the transform won't have any effect.");
+					+ "so the transform won't have any effect.");
 			}
 		}
 

--- a/src/Uno.UI/Media/NativeRenderTransformAdapter.iOSmacOS.cs
+++ b/src/Uno.UI/Media/NativeRenderTransformAdapter.iOSmacOS.cs
@@ -30,9 +30,14 @@ namespace Uno.UI.Media
 			{
 				// While animating the transform, we let the Animator apply the transform by itself, so do not update the Transform
 #if __IOS__
-				Owner.Layer.AnchorPoint = GPUFloatValueAnimator.GetAnchorForAnimation(Transform, CurrentOrigin, CurrentSize);
+				if (!_wasAnimating)
+				{
+					// At the beginning of the animation make sure we disable all properties of the transform
+					Owner.Layer.AnchorPoint = GPUFloatValueAnimator.GetAnchorForAnimation(Transform, CurrentOrigin, CurrentSize);
+					Owner.Layer.Transform = CoreAnimation.CATransform3D.Identity;
 
-				_wasAnimating = true;
+					_wasAnimating = true;
+				}
 
 				return;
 #else

--- a/src/Uno.UI/UI/Xaml/Media/Transform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Transform.Android.cs
@@ -28,8 +28,18 @@ namespace Windows.UI.Xaml.Media
 				{
 					_isAnimating = value;
 
-					MatrixCore = ToMatrix(new Point(0, 0));
-					NotifyChanged();
+					if (_isAnimating)
+					{
+						// We don't use the NotifyChanged() since it filters out change notifications when IsAnimating.
+						// Note: we also bypass the MatrixCore update which is actually irrelevant until animation completes.
+						Changed?.Invoke(this, EventArgs.Empty);
+					}
+					else
+					{
+						// Notify a change so the result matrix will be updated (as updates were ignored due to 'Animations' DP precedence),
+						// and the NativeRenderTransformAdapter will then apply this final matrix.
+						NotifyChanged();
+					}
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Media/Transform.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Transform.iOSmacOS.cs
@@ -30,10 +30,9 @@ namespace Windows.UI.Xaml.Media
 			// will update the 'AnchorPoint' using current 'RenderOrigin' and current size.
 			if (++_runningAnimations == 1)
 			{
-				// While animating, we disable other properties of the transform
-				View.Layer.Transform = CoreAnimation.CATransform3D.Identity;
-
-				NotifyChanged();
+				// We don't use the NotifyChanged() since it will filters out changes when IsAnimating
+				// Note: we also bypass the MatrixCore update which is actually irrelevant until animation completes.
+				Changed?.Invoke(this, EventArgs.Empty);
 			}
 		}
 
@@ -41,13 +40,10 @@ namespace Windows.UI.Xaml.Media
 		{
 			if (--_runningAnimations == 0)
 			{
-				// First update the result matrix (as updates were ignored due to 'Animations' DP precedence)
-				MatrixCore = ToMatrix(new Point(0, 0));
-
+				// Notify a change so the result matrix will be updated (as updates were ignored due to 'Animations' DP precedence),
+				// and the NativeRenderTransformAdapter will then apply this final matrix.
 				NotifyChanged();
 
-				// Let the RenderTransformAdapter restore the 'AnchorPoint' to the 'RenderOrigin' and set the updated 'Transform'.
-				View.InvalidateArrange();
 			}
 		}
 	}


### PR DESCRIPTION
GitHub Issue:
fixes https://github.com/unoplatform/uno/issues/2695
fixes https://github.com/unoplatform/uno/issues/2723

## Fixes animations
The managed `RenderTransform` was not properly cleared before starting a native animation of the `Transform`.

## What is the current behavior?
We invoked the `NotifyChanged()` method on the `Transform` right after setting the `IsAnimating` flag, but the `NotifyChanged()` was aborted while `IsAnimating` (in order to not update itself on each frame of an animation)

## What is the new behavior?
We bypass the `NotifyChanged()` and we directly invoke the `Changed`  event, so the `RenderTransformAdapter` receives the update and disables itself.

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md)~~ _regression_
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ _no way to properly test animations_
- [ ] ~~[Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [ ] ~~Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)~~ _regression_
- [x] Associated with an issue (GitHub or internal)

## Other information
Internal Issue:
https://dev.azure.com/nventive/Umbrella/_workitems/edit/175311
https://dev.azure.com/nventive/Umbrella/_workitems/edit/175740
