### PR TITLE
Fix ContentDialog overlay bugfixes

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -91,6 +91,8 @@
 - Adjust `XamlBindingHelper` for `GridLength` and `TimeSpan`
 - Add missing `ListView` resources
 - #2570 [Android/iOS] fixed ObjectDisposedException in BindingPath
+- #2107 [iOS] fixed ContentDialog doesn't block touch for background elements
+- #2108 [iOS/Android] fixed ContentDialog background doesn't change
 
 ## Release 2.0
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -8,6 +8,7 @@ using Uno.Disposables;
 using Uno.Extensions;
 using Windows.Foundation;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -19,7 +20,15 @@ namespace Windows.UI.Xaml.Controls
 
 		public ContentDialog() : base()
 		{
-			_popup = new Popup();
+			_popup = new Popup()
+			{
+				LightDismissOverlayMode = LightDismissOverlayMode.On,
+				LightDismissOverlayBackground = Resources["ContentDialogLightDismissOverlayBackground"] as Brush ??
+					// This is normally a no-op - the above line should retrieve the framework-level resource. This is purely to fail the build when
+					// Resources/Styles are overhauled (and the above will no longer be valid)
+					Uno.UI.GlobalStaticResources.ContentDialogLightDismissOverlayBackground as Brush,
+			};
+
 			_popup.PopupPanel = new ContentDialogPopupPanel(this);
 			_popup.Opened += (s, e) =>
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.md
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.md
@@ -1,0 +1,9 @@
+# ContentDialog
+Represents a dialog box that can be customized to contain checkboxes, hyperlinks, buttons and any other XAML content.
+
+## Overlay Background (ios/android)
+You can override the overlay background by adding the following resources to the application resources:
+```xml
+<SolidColorBrush x:Key="ContentDialogLightDismissOverlayBackground" Color="#99000000" />
+```
+> note: There is no specific key to override for this other than `SystemControlPageBackgroundMediumAltMediumBrush` on window, see: https://stackoverflow.com/a/40397576.

--- a/src/Uno.UI/UI/Xaml/Style/Generic/SystemResources.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/SystemResources.xaml
@@ -1035,6 +1035,7 @@
 			<StaticResource x:Key="CalendarDatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="ComboBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<!--<StaticResource x:Key="CommandBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />-->
+			<StaticResource x:Key="ContentDialogLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="DatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="FlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="MenuFlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
@@ -2051,6 +2052,7 @@
 			<StaticResource x:Key="CalendarDatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="ComboBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<!--<StaticResource x:Key="CommandBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />-->
+			<StaticResource x:Key="ContentDialogLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="DatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="FlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="MenuFlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
@@ -3065,6 +3067,7 @@
 			<StaticResource x:Key="CalendarDatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="ComboBoxLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<!--<StaticResource x:Key="CommandBarLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />-->
+			<StaticResource x:Key="ContentDialogLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="DatePickerLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="FlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
 			<StaticResource x:Key="MenuFlyoutLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />


### PR DESCRIPTION
GitHub Issue (If applicable): #2107, #2108

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
iOS: ContentDialog doesn't block touch for background elements.
iOS/Android: ContentDialog overlay background cannot be changed.

## What is the new behavior?
ContentDialog overlay blocks touch.
ContentDialog overlay background can be changed via application resource key: `ContentDialogLightDismissOverlayBackground` (Brush)

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
closes: #2107, #2108