### PR TITLE
[iOS] Fix bug with padding on ScrollViewer

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -761,6 +761,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Padding.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Simple.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3464,6 +3468,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\RepeatButton\RepeatButton_Automated.xaml.cs">
       <DependentUpon>RepeatButton_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Padding.xaml.cs">
+      <DependentUpon>ScrollViewer_Padding.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Decorations.xaml.cs">
       <DependentUpon>TextBlock_Decorations.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Options.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Options.xaml.cs
@@ -5,7 +5,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests
 {
-	[SampleControlInfo("ScrollViewer", nameof(ScrollViewer_Options))]
+	[SampleControlInfo(category: "ScrollViewer")]
 	public sealed partial class ScrollViewer_Options : Page
 	{
 		private static string[] Sizes = new[] {"Small", "Large"};

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Padding.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Padding.xaml
@@ -1,0 +1,36 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.ScrollViewerTests.ScrollViewer_Padding"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="2*" />
+			<ColumnDefinition Width="3*" />
+		</Grid.ColumnDefinitions>
+
+		<Grid Padding="50" BorderBrush="Blue" BorderThickness="2">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+
+			<ScrollViewer HorizontalScrollMode="Enabled"
+					  HorizontalScrollBarVisibility="Hidden"
+					  VerticalScrollBarVisibility="Disabled"
+					  Padding="0,10">
+				<StackPanel Orientation="Horizontal">
+					<Button Content="Hello 1!"
+						Margin="0,0,15,0" />
+					<Button Content="Hello 2!"
+						Margin="0,0,15,0" />
+				</StackPanel>
+			</ScrollViewer>
+		</Grid>
+
+		<TextBlock TextWrapping="Wrap" x:Name="layout" Grid.Column="1" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Padding.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Padding.xaml
@@ -6,10 +6,11 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d">
 
-	<Grid>
+	<Grid BorderBrush="Red" BorderThickness="2">
 		<Grid.ColumnDefinitions>
-			<ColumnDefinition Width="2*" />
 			<ColumnDefinition Width="3*" />
+			<ColumnDefinition Width="3*" />
+			<ColumnDefinition Width="7*" />
 		</Grid.ColumnDefinitions>
 
 		<Grid Padding="50" BorderBrush="Blue" BorderThickness="2">
@@ -21,8 +22,11 @@
 			<ScrollViewer HorizontalScrollMode="Enabled"
 					  HorizontalScrollBarVisibility="Hidden"
 					  VerticalScrollBarVisibility="Disabled"
-					  Padding="0,10">
-				<StackPanel Orientation="Horizontal">
+					  Padding="0,10"
+					  x:Name="Scroll1"
+					  Background="Pink">
+				<StackPanel Orientation="Horizontal"
+				            Background="Turquoise">
 					<Button Content="Hello 1!"
 						Margin="0,0,15,0" />
 					<Button Content="Hello 2!"
@@ -31,6 +35,27 @@
 			</ScrollViewer>
 		</Grid>
 
-		<TextBlock TextWrapping="Wrap" x:Name="layout" Grid.Column="1" />
+		<Grid Padding="50" BorderBrush="Green" BorderThickness="2" Grid.Column="1">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+
+			<ScrollViewer HorizontalScrollMode="Enabled"
+			              HorizontalScrollBarVisibility="Hidden"
+			              VerticalScrollBarVisibility="Disabled"
+			              x:Name="Scroll2"
+			              Background="Pink">
+				<StackPanel Orientation="Horizontal"
+				            Background="Turquoise">
+					<Button Content="Hello 1!"
+					        Margin="0,0,15,0" />
+					<Button Content="Hello 2!"
+					        Margin="0,0,15,0" />
+				</StackPanel>
+			</ScrollViewer>
+		</Grid>
+
+		<TextBlock TextWrapping="Wrap" x:Name="layout" Grid.Column="2" />
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Padding.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Padding.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using UIKit;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
+{
+	[SampleControlInfo(category: "ScrollViewer")]
+	public sealed partial class ScrollViewer_Padding : Page
+	{
+		public ScrollViewer_Padding()
+		{
+			this.InitializeComponent();
+
+			Loaded += OnLoaded;
+		}
+
+		private async void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			await Task.Delay(300);
+			layout.Text = this.ShowLocalVisualTree();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Padding.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Padding.xaml.cs
@@ -24,7 +24,7 @@ namespace UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 		private async void OnLoaded(object sender, RoutedEventArgs e)
 		{
 			await Task.Delay(300);
-#if HAS_UNO
+#if HAS_UNO && !__WASM__
 			layout.Text = this.ShowLocalVisualTree();
 #endif
 		}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Padding.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Padding.xaml.cs
@@ -1,7 +1,12 @@
 ﻿using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+#if __IOS__
 using UIKit;
+#elif __MACOS__
+using AppKit;
+#endif
+using Uno.UI;
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
@@ -19,7 +24,9 @@ namespace UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 		private async void OnLoaded(object sender, RoutedEventArgs e)
 		{
 			await Task.Delay(300);
+#if HAS_UNO
 			layout.Text = this.ShowLocalVisualTree();
+#endif
 		}
 	}
 }

--- a/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
@@ -581,6 +581,8 @@ namespace AppKit
 				var name = (innerView as IFrameworkElement)?.Name;
 				var namePart = string.IsNullOrEmpty(name) ? "" : $"-'{name}'";
 
+				var uiElement = innerView as UIElement;
+
 				return sb
 						.Append(spacing)
 						.Append(innerView == viewOfInterest ? "*>" : ">")
@@ -590,6 +592,7 @@ namespace AppKit
 #if __IOS__
 						.Append($" {(innerView.Hidden ? "Hidden" : "Visible")}")
 #endif
+						.Append(uiElement?.NeedsClipToSlot ?? false ? " CLIPPED_TO_SLOT" : "")
 						.AppendLine();
 			}
 		}

--- a/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
@@ -582,13 +582,14 @@ namespace AppKit
 				var namePart = string.IsNullOrEmpty(name) ? "" : $"-'{name}'";
 
 				var uiElement = innerView as UIElement;
+				var desiredSize = uiElement?.DesiredSize.ToString() ?? "<native/unk>";
 
 				return sb
 						.Append(spacing)
 						.Append(innerView == viewOfInterest ? "*>" : ">")
 						.Append(innerView.ToString() + namePart)
 						.Append($"-({innerView.Frame.Width}x{innerView.Frame.Height})@({innerView.Frame.X},{innerView.Frame.Y})")
-
+						.Append($" d:{desiredSize}")
 #if __IOS__
 						.Append($" {(innerView.Hidden ? "Hidden" : "Visible")}")
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.iOS.cs
@@ -85,7 +85,6 @@ namespace Windows.UI.Xaml.Controls
 				// phase must be done by the parent element's layouter.
 				// Here, it means adding the margin to the measured size.
 				ret = ret.Add(ife.Margin);
-				SetDesiredChildSize(view, ret);
 			}
 
 			var w = nfloat.IsNaN((nfloat)ret.Width) ? double.PositiveInfinity : Math.Min(slotSize.Width, ret.Width);

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.iOS.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private static UnsafeWeakAttachedDictionary<View, string> _layoutProperties = new UnsafeWeakAttachedDictionary<View, string>();
+		private static readonly UnsafeWeakAttachedDictionary<View, string> _layoutProperties = new UnsafeWeakAttachedDictionary<View, string>();
 
 		protected Size MeasureChildOverride(View view, Size slotSize)
 		{
@@ -79,12 +79,19 @@ namespace Windows.UI.Xaml.Controls
 				ret.ToString();
 			}
 
+			if (!(view is FrameworkElement) && view is IFrameworkElement ife)
+			{
+				// If the child is not a FrameworkElement, part of the "Measure"
+				// phase must be done by the parent element's layouter.
+				// Here, it means adding the margin to the measured size.
+				ret = ret.Add(ife.Margin);
+				SetDesiredChildSize(view, ret);
+			}
 
+			var w = nfloat.IsNaN((nfloat)ret.Width) ? double.PositiveInfinity : Math.Min(slotSize.Width, ret.Width);
+			var h = nfloat.IsNaN((nfloat)ret.Height) ? double.PositiveInfinity : Math.Min(slotSize.Height, ret.Height);
 
-			ret.Width = nfloat.IsNaN((nfloat)ret.Width) ? double.PositiveInfinity : Math.Min(slotSize.Width, ret.Width);
-			ret.Height = nfloat.IsNaN((nfloat)ret.Height) ? double.PositiveInfinity : Math.Min(slotSize.Height, ret.Height);
-
-			return ret;
+			return new Size(w, h);
 		}
 
 		protected void ArrangeChildOverride(View view, Rect frame)


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/2703
# Bugfix

## What is the current behavior?
If the `generic.xaml` of Uno, the `<ScrollViewer>` control template will convert the `Padding` into a `Margin` applied to the inner `<ScrollContentPresenter>`: https://github.com/unoplatform/uno/blob/3e231f1db2d4be5f7334d1bb74adf6ffa758c53d/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml#L4716

But this `Margin` is not getting included in the `DesiredSize` as the output of the _Measure_ phase. This happend because `<ScrollContentPresenter>` is **NOT** a `FrameworkElement`, on iOS, it's a `UIScrollView` (native control). So there's no layouter in it and the _desired size_ must be calculated by the parent element's layouter.

## What is the new behavior?
After calling `.SizeThatFits()` on a native, non-`FrameworkElement` control, the `.Margin` is applied and stored as the _desired size_ for the control.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
