### PR TITLE
Fix android ScrollViewer invalid clipping on update

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.SymbolStore;
+using System.Drawing;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Text;
@@ -57,6 +59,33 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 			validate.FastTap();
 			TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 			_app.WaitForDependencyPropertyValue(result, "Text", "SUCCESS");
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Android)] // IsIntermediate is not supported on Wasm yet
+		public void ScrollViewer_Clipping()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ScrollViewerTests.ScrollViewer_Clipping");
+
+			var sut = _app.WaitForElement(_app.Marked("scrollViewer1")).Single();
+			var updateButton = _app.Marked("UpdateButton");
+
+			var updateButtonRect = _app.WaitForElement(_app.Marked("intentionallyBlank")).Single().Rect;
+
+			updateButton.FastTap();
+
+			//Drag upward
+			_app.DragCoordinates(sut.Rect.CenterX, sut.Rect.CenterY, sut.Rect.CenterX, sut.Rect.CenterY - (sut.Rect.Height / 2));
+
+			var res = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+
+			ImageAssert.AreNotEqual(
+				expected: res,
+				expectedRect: new Rectangle((int)sut.Rect.X, (int)sut.Rect.Bottom - 20, (int)updateButtonRect.Width, (int)updateButtonRect.Height),
+				actual: res,
+				actualRect: new Rectangle((int)updateButtonRect.X, (int)updateButtonRect.Y, (int)updateButtonRect.Width, (int)updateButtonRect.Height)
+			);
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -765,6 +765,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Clipping.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Padding.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3475,6 +3479,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\RepeatButton\RepeatButton_Automated.xaml.cs">
       <DependentUpon>RepeatButton_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Clipping.xaml.cs">
+      <DependentUpon>ScrollViewer_Clipping.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Padding.xaml.cs">
       <DependentUpon>ScrollViewer_Padding.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Clipping.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Clipping.xaml
@@ -1,0 +1,24 @@
+﻿<Page x:Class="UITests.Windows_UI_Xaml_Controls.ScrollViewerTests.ScrollViewer_Clipping"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ScrollViewerTests"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<StackPanel>
+			<ScrollViewer x:Name="scrollViewer1" Height="200">
+				<TextBlock x:Name="myContent"
+						   TextWrapping="WrapWholeWords"
+						   Text="None" />
+			</ScrollViewer>
+			<Border x:Name="intentionallyBlank"
+					Width="100"
+					Height="40" />
+			<Button x:Name="UpdateButton" Content="Update"
+					Click="OnClick" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Clipping.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Clipping.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo("ScrollViewer")]
+	public sealed partial class ScrollViewer_Clipping : Page
+	{
+		public ScrollViewer_Clipping()
+		{
+			this.InitializeComponent();
+		}
+
+		private void OnClick(object sender, object args)
+		{
+			myContent.Text = string.Join(" ", Enumerable.Range(0, 1000).Select(i => $"String {i}"));
+		}
+	}
+}

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoTwoDScrollView.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoTwoDScrollView.java
@@ -1193,7 +1193,6 @@ public class UnoTwoDScrollView extends FrameLayout {
 
 	@Override
 	protected void onLayout(boolean changed, int l, int t, int r, int b) {
-		super.onLayout(changed, l, t, r, b);
 		mIsLayoutDirty = false;
 		// Give a child focus if it needs it
 		if (mChildToScrollTo != null && isViewDescendantOf(mChildToScrollTo, this)) {

--- a/src/Uno.UI/Mixins/Android/FrameworkElementMixins.tt
+++ b/src/Uno.UI/Mixins/Android/FrameworkElementMixins.tt
@@ -9,7 +9,7 @@
 	AddClass("Uno.UI.Controls.Legacy", "HorizontalGridView");
 	AddClass("Uno.UI.Controls.Legacy", "HorizontalListView");
 	AddClass("Windows.UI.Xaml.Controls", "ProgressRing");
-	AddClass("Windows.UI.Xaml.Controls", "ScrollContentPresenter");
+	AddClass("Windows.UI.Xaml.Controls", "ScrollContentPresenter", callsBaseOnLayout: false);
 	AddClass("Windows.UI.Xaml.Controls", "NativePagedView");
 	AddClass("Windows.UI.Xaml.Controls", "TextBoxView", hasNewMinWidthHeight: true, hasNewMaxWidthHeight: true);
 	AddClass("Windows.UI.Xaml.Controls", "NativeListViewBase", isUnoMotionTarget: true);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Android.cs
@@ -143,7 +143,6 @@ namespace Windows.UI.Xaml.Controls
 			IFrameworkElementHelper.OnMeasureOverride(this);
 		}
 
-		//TODO generated code
 		partial void OnLayoutPartial(bool changed, int left, int top, int right, int bottom)
 		{
 			var newSize = new Rect(0, 0, right - left, bottom - top).PhysicalToLogicalPixels();
@@ -154,6 +153,9 @@ namespace Windows.UI.Xaml.Controls
 			// the child at an invalid location when the visibility changes.
 
 			_layouter.Arrange(newSize);
+
+			// base.OnLayout is not invoked in the mixin to allow for the clipping algorithms
+			base.OnLayout(changed, left, top, right, bottom);
 		}
 
 		private void UpdateScrollSettings()

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -860,7 +860,10 @@ namespace <#= mixin.NamespaceName #>
 			var newSize = new Size(right - left, bottom - top).PhysicalToLogicalPixels();
 			var previousSize = _actualSize;
 
+#if <#= mixin.CallsBaseOnLayout #>
 			base.OnLayout(changed, left, top, right, bottom);
+#endif
+
 			OnLayoutPartial(changed, left, top, right, bottom);
 
 			_actualSize = newSize;
@@ -965,6 +968,7 @@ namespace <#= mixin.NamespaceName #>
 		bool isFocusable = false,
 		bool isUnoMotionTarget = false,
 		bool overridesOnLayout = true,
+		bool callsBaseOnLayout = true,
 		bool hasAutomationPeer = false
 	)
 	{
@@ -981,6 +985,7 @@ namespace <#= mixin.NamespaceName #>
 				OverridesOnLayout = overridesOnLayout ? "true" : "false",
 				IsFrameworkElement = className == "FrameworkElement" ? "true" : "false",
 				HasAutomationPeer = hasAutomationPeer ? "true" : "false",
+				CallsBaseOnLayout = callsBaseOnLayout ? "true" : "false",
 			}
 		);
 	}
@@ -998,6 +1003,7 @@ namespace <#= mixin.NamespaceName #>
 		public string OverridesOnLayout;
 		public string IsFrameworkElement;
 		public string HasAutomationPeer;
+		public string CallsBaseOnLayout;
 	}
 
 	private List<MixinParams> _mixins = new List<MixinParams>();


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/2714

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

ScrollViewer content may be clipped incorrectly when updated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
