### PR TITLE
[iOS] Fix for margin on TextBox

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -817,6 +817,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Margin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_MaxLength.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3496,6 +3500,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Formatting_Flicker.xaml.cs">
       <DependentUpon>TextBox_Formatting_Flicker.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Margin.xaml.cs">
+      <DependentUpon>TextBox_Margin.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_MaxLength.xaml.cs">
       <DependentUpon>TextBox_MaxLength.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Margin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Margin.xaml
@@ -1,0 +1,36 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_Margin"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="10">
+		<TextBlock FontSize="15">
+			They should be identical:
+		</TextBlock>
+		<StackPanel Orientation="Horizontal" Spacing="10">
+			<StackPanel Width="100">
+				<StackPanel>
+					<TextBox Margin="0,12" Height="35" />
+				</StackPanel>
+				<Border Height="4" Background="Green" />
+			</StackPanel>
+
+			<StackPanel Width="100">
+				<TextBox Margin="0,12" Height="35" />
+				<Border Height="4" Background="Green" />
+			</StackPanel>
+
+			<StackPanel Width="100">
+				<Border Height="12" />
+				<TextBox Height="35" />
+				<Border Height="12" />
+				<Border Height="4" Background="Green" />
+			</StackPanel>
+		</StackPanel>
+
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Margin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Margin.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBox
+{
+	[SampleControlInfo(category: "TextBox")]
+	public sealed partial class TextBox_Margin : Page
+	{
+		public TextBox_Margin()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
@@ -29,13 +29,6 @@ namespace Windows.UI.Xaml.Controls
 			OnKeyboardAppearanceChanged(KeyboardAppearance);
 		}
 
-		public override CGSize SizeThatFits(CGSize size)
-		{
-			size = base.SizeThatFits(size);
-			size = IFrameworkElementHelper.SizeThatFits(this, size);
-			return size;
-		}
-
 		partial void OnFocusStateChangedPartial(FocusState focusState)
 		{
 			if (_textBoxView != null)


### PR DESCRIPTION
Margin were wrongly calculated on TextBox on iOS because of legacy code.

Fixes https://github.com/unoplatform/uno/issues/2705

# Bugfix
The `TextBox.SizeThatFits` was using an old legacy pattern causing problem with margins calculations.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
