### PR TITLE
[Android] Ensure Image scaling takes Width/Height into account

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+using Windows.Foundation;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	public class Given_Image
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Fixed_Height_And_Stretch_Uniform()
+		{
+			var image = new Image { Height = 30, Stretch = Stretch.Uniform, Source = new BitmapImage(new Uri("ms-appx:///Assets/storelogo.png")) };
+			var innerGrid = new Grid { HorizontalAlignment = HorizontalAlignment.Left, VerticalAlignment = VerticalAlignment.Center };
+			var outerGrid = new Grid { Height = 750, Width = 430 };
+			innerGrid.Children.Add(image);
+			outerGrid.Children.Add(innerGrid);
+
+			TestServices.WindowHelper.WindowContent = outerGrid;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			outerGrid.Measure(new Size(1000, 1000));
+			var desiredContainer = innerGrid.DesiredSize;
+
+			Assert.AreEqual(30, Math.Round(desiredContainer.Width));
+			Assert.AreEqual(30, Math.Round(desiredContainer.Height));
+
+			TestServices.WindowHelper.WindowContent = null;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Image/ImageSizeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/ImageSizeHelper.cs
@@ -197,7 +197,7 @@ namespace Windows.UI.Xaml.Controls
 		[Pure]
 		public static Size AdjustSize(this Image image, Size availableSize, Size measuredSize)
 		{
-			return AdjustSize(image.Stretch, availableSize, measuredSize);
+			return AdjustSize(image.Stretch, image.ApplySizeConstraints(availableSize), measuredSize);
 		}
 
 		[Pure]


### PR DESCRIPTION
This fixes bug where image requests all available size, even when it has a fixed dimension and aspect ratio.

GitHub Issue (If applicable): fixes #2541 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
