### PR TITLE
[Wasm] Fix ComboBox should not stretch to the full window width

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -95,6 +95,7 @@
 - #2570 [Android/iOS] fixed ObjectDisposedException in BindingPath
 - #2107 [iOS] fixed ContentDialog doesn't block touch for background elements
 - #2108 [iOS/Android] fixed ContentDialog background doesn't change
+- #2680 [Wasm] Fix ComboBox should not stretch to the full window width
 
 ## Release 2.0
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
@@ -98,5 +98,24 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			// compensates for a possible change of origins with android popups.
 			Assert.AreEqual(popupLocationDifference - sampleControlResultExtended.Rect.Y, popupLocationDifferenceExtended);
 		}
+
+
+		[Test]
+		[AutoRetry]
+		public void ComboBoxTests_Stretch()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Stretch");
+
+			var combo01 = _app.Marked("combo01");
+			var sampleControl = _app.Marked("sampleControl");
+
+			var sampleControlResult = _app.WaitForElement(sampleControl).First();
+
+			_app.FastTap(combo01);
+
+			var popupResult = _app.WaitForElement("PopupBorder").First();
+
+			Assert.IsTrue(popupResult.Rect.Width < sampleControlResult.Rect.Width / 2, "The popup should not stretch to the width of the screen");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -521,6 +521,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Stretch.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_VisibleBounds.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3335,6 +3339,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_DropDownPlacement.xaml.cs">
       <DependentUpon>ComboBox_DropDownPlacement.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Stretch.xaml.cs">
+      <DependentUpon>ComboBox_Stretch.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_VisibleBounds.xaml.cs">
       <DependentUpon>ComboBox_VisibleBounds.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Stretch.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Stretch.xaml
@@ -1,0 +1,31 @@
+﻿<Page x:Class="UITests.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Stretch"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ComboBox"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+		  Width="100"
+		  HorizontalAlignment="Center"
+		  VerticalAlignment="Center">
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<ComboBox x:Name="combo01"
+				  Grid.Row="0"
+				  HorizontalAlignment="Stretch">
+			<x:String>Item 1</x:String>
+			<x:String>Item 2 Item 2</x:String>
+			<x:String>Item 3 Item 3 Item 3</x:String>
+			<x:String>Item 4 Item 4 Item 4 Item 4</x:String>
+		</ComboBox>
+		<ComboBox x:Name="combo02"
+				  Grid.Row="1" />
+	</Grid>
+
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Stretch.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Stretch.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.ComboBox
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo("ComboBox")]
+	sealed partial class ComboBox_Stretch : Page
+	{
+		public ComboBox_Stretch()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.cs
@@ -13,6 +13,14 @@ namespace Windows.UI.Xaml.Controls
 {
 	abstract partial class VirtualizingPanelLayout : IScrollSnapPointsInfo
 	{
+		/// <summary>
+		/// Determines if the owner Panel is inside a popup. Used to determine
+		/// if the computation of the breadth should be using the parent's stretch
+		/// modes.
+		/// Related: https://github.com/unoplatform/uno/issues/135
+		/// </summary>
+		private bool IsInsidePopup { get; set; }
+
 		protected enum RelativeHeaderPlacement { Inline, Adjacent }
 
 		/// <summary>
@@ -122,6 +130,11 @@ namespace Windows.UI.Xaml.Controls
 				if (XamlParent == null)
 				{
 					return true;
+				}
+
+				if (IsInsidePopup)
+				{
+					return false;
 				}
 
 				if (ScrollOrientation == Orientation.Vertical)

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.wasm.cs
@@ -138,6 +138,15 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
+			var hasPopupPanelParent = OwnerPanel.FindFirstParent<PopupPanel>() != null;
+			var hasListViewParent = OwnerPanel.FindFirstParent<ListViewBase>() != null;
+			IsInsidePopup = hasPopupPanelParent && !hasListViewParent;
+
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug($"Calling {GetMethodTag()} hasPopupPanelParent={hasPopupPanelParent} hasListViewParent={hasListViewParent}");
+			}
+
 			if (
 				ItemsControl == null
 				&& OwnerPanel.TemplatedParent is ItemsControl popupItemsControl
@@ -398,7 +407,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{
-				this.Log().LogDebug($"{GetMethodTag()} => {extent} -> {ret} {ScrollOrientation} {_availableSize.Height} {double.IsInfinity(_availableSize.Height)} AvailableBreadth:{AvailableBreadth}");
+				this.Log().LogDebug($"{GetMethodTag()} => {extent} -> {ret} {ScrollOrientation} {_availableSize.Height} {double.IsInfinity(_availableSize.Height)} ShouldBreadthStretch:{ShouldBreadthStretch} XamlParent:{XamlParent} AvailableBreadth:{AvailableBreadth}");
 			}
 
 			return ret;


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #2680

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

A `ComboBox` with `HorizontalAlignment` set to `Stretch` stretches the content of its drop down to the width of the screen.

## What is the new behavior?

The ComboBox dropdown does not stretch.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
