### PR TITLE
Make sure to not crash if receiving a pointer event for a disposed UIElement

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Android.cs
@@ -54,12 +54,9 @@ namespace Windows.UI.Xaml
 
 		protected sealed override bool OnNativeMotionEvent(MotionEvent nativeEvent, View originalSource, bool isInView)
 		{
-			if (nativeEvent.PointerCount > 1
-				&& this.Log().IsEnabled(LogLevel.Information))
+			if (IsPointersSuspended)
 			{
-				this.Log().Info(
-					"Multi touches are not supported yet by UNO pointer events. You will receive event only for the first pointer. " +
-					"Note: This is only for pointers events, scalling using pin and pan gestures in the ScrollViewer does work properly.");
+				return false;
 			}
 
 			if (!(originalSource is UIElement srcElement))

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -88,6 +88,14 @@ namespace Windows.UI.Xaml
 
 		private /* readonly but partial */ Lazy<GestureRecognizer> _gestures;
 
+		/// <summary>
+		/// Validates that this element is able to manage pointer events.
+		/// If this element is only the shadow of a ghost native view that was instantiated for marshalling purposes by Xamarin,
+		/// the _gestures will be null and trying to interpret a native pointer event might crash the app.
+		/// This flag should be checked when receiving a pointer related event from the native view to prevent this case.
+		/// </summary>
+		private bool IsPointersSuspended => _gestures == null;
+
 		// ctor
 		private void InitializePointers()
 		{

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.iOS.cs
@@ -27,6 +27,11 @@ namespace Windows.UI.Xaml
 		#region Native touch handling (i.e. source of the pointer / gesture events)
 		public override void TouchesBegan(NSSet touches, UIEvent evt)
 		{
+			if (IsPointersSuspended)
+			{
+				return; // Will also prevent subsequents events
+			}
+
 			/* Note: Here we have a mismatching behavior with UWP, if the events bubble natively we're going to get
 					 (with Ctrl_02 is a child of Ctrl_01):
 							Ctrl_02: Entered

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.macOS.cs
@@ -46,6 +46,11 @@ namespace Windows.UI.Xaml
 
 		public override void MouseDown(NSEvent evt)
 		{
+			if (IsPointersSuspended)
+			{
+				return;
+			}
+
 			try
 			{
 				// evt.AllTouches raises a invalid selector exception
@@ -67,6 +72,11 @@ namespace Windows.UI.Xaml
 
 		public override void MouseMoved(NSEvent evt)
 		{
+			if (IsPointersSuspended)
+			{
+				return;
+			}
+
 			try
 			{
 				// evt.AllTouches raises a invalid selector exception
@@ -88,6 +98,11 @@ namespace Windows.UI.Xaml
 
 		public override void MouseEntered(NSEvent evt)
 		{
+			if (IsPointersSuspended)
+			{
+				return;
+			}
+
 			try
 			{
 				var args = new PointerRoutedEventArgs(null, evt, this);
@@ -108,6 +123,11 @@ namespace Windows.UI.Xaml
 
 		public override void MouseExited(NSEvent evt)
 		{
+			if (IsPointersSuspended)
+			{
+				return;
+			}
+
 			try
 			{
 				// evt.AllTouches raises a invalid selector exception
@@ -129,6 +149,11 @@ namespace Windows.UI.Xaml
 
 		public override void MouseUp(NSEvent evt)
 		{
+			if (IsPointersSuspended)
+			{
+				return;
+			}
+
 			try
 			{
 				// evt.AllTouches raises a invalid selector exception
@@ -150,6 +175,11 @@ namespace Windows.UI.Xaml
 
 		public override void MouseDragged(NSEvent evt)
 		{
+			if (IsPointersSuspended)
+			{
+				return;
+			}
+
 			try
 			{
 				// evt.AllTouches raises a invalid selector exception


### PR DESCRIPTION
GitHub Issue: 
https://github.com/unoplatform/uno/issues/2656

## Stability enhancement
Make sure to not crash if receiving a pointer event for a disposed `UIElement`

## What is the current behavior?
If a `UIElement` is explicitly disposed by application code, we might receive pointer events on non-initialized element, which causes `NullRefException`

## What is the new behavior?
We silently dismiss all native event received on non initialized `UIElement`

## PR Checklist
- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
