### PR TITLE
[Android] Fix ProgressRing fails to display

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -47,6 +47,7 @@
 - [Android] Add support for non-native `Popup` by default. Can be enabled through `FeatureConfiguration.Popup.UseNativePopup` set to false (See #2533 for more details)
 - Add template tags for the VS2019 VSIX template search experience
 - [iOS] #2746 Fix border thickness when a corner radius is set
+- [Android] #2762 ProgressRing wasn't displaying inside a StackPanel
 
 ### Breaking changes
 - `IconElement.AddIconElementView` is now `internal` so it is not accessible from outside.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ProgressRing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ProgressRing.cs
@@ -9,12 +9,40 @@ using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using MUXControlsTestApp.Utilities;
+using Private.Infrastructure;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
 	[TestClass]
 	class Given_ProgressRing
 	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_ProgressRing_Visible()
+		{
+			const int expectedSize =
+#if __ANDROID__
+				48; //Natively set as 48 for Android; 20 for other platforms
+#else
+				20;
+#endif
+
+			var panel = new StackPanel();
+			var ring = new ProgressRing() { IsActive = true };
+			panel.Children.Add(ring);
+			var border = new Border();
+			border.Child = panel;
+
+			TestServices.WindowHelper.WindowContent = border;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			border.Measure(new Size(1000, 1000));
+			border.Arrange(new Rect(0, 0, 1000, 1000));
+
+			Assert.AreEqual(expectedSize, Math.Round(ring.ActualWidth));
+			Assert.AreEqual(expectedSize, Math.Round(ring.ActualHeight));
+		}
+
 		[TestMethod]
 		public Task When_ProgressRing_Collapsed() =>
 			RunOnUIThread.Execute(() =>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ProgressRing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ProgressRing.cs
@@ -39,7 +39,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			border.Measure(new Size(1000, 1000));
 			border.Arrange(new Rect(0, 0, 1000, 1000));
 
-			Assert.AreEqual(expectedSize, Math.Round(ring.ActualWidth));
 			Assert.AreEqual(expectedSize, Math.Round(ring.ActualHeight));
 		}
 

--- a/src/Uno.UI/Mixins/Android/FrameworkElementMixins.tt
+++ b/src/Uno.UI/Mixins/Android/FrameworkElementMixins.tt
@@ -3,14 +3,14 @@
 #if XAMARIN_ANDROID
 <# 
 	AddClass("Uno.UI.Controls.Legacy", "GridView");
-	AddClass("Windows.UI.Xaml", "FrameworkElement", overridesAttachedToWindow:true, overridesOnLayout: false, isUnoMotionTarget: true);
+	AddClass("Windows.UI.Xaml", "FrameworkElement", overridesAttachedToWindow:true, overridesOnLayout: false, isUnoMotionTarget: true, hasLayouter: true);
 	AddClass("Uno.UI.Controls.Legacy", "ListView");
-	AddClass("Windows.UI.Xaml.Controls", "Image", hasNewMaxWidthHeight: true, hasAutomationPeer: true);
+	AddClass("Windows.UI.Xaml.Controls", "Image", hasNewMaxWidthHeight: true, hasAutomationPeer: true, hasLayouter: true);
 	AddClass("Uno.UI.Controls.Legacy", "HorizontalGridView");
 	AddClass("Uno.UI.Controls.Legacy", "HorizontalListView");
 	AddClass("Windows.UI.Xaml.Controls", "ProgressRing");
-	AddClass("Windows.UI.Xaml.Controls", "ScrollContentPresenter", callsBaseOnLayout: false);
-	AddClass("Windows.UI.Xaml.Controls", "NativePagedView");
+	AddClass("Windows.UI.Xaml.Controls", "ScrollContentPresenter", callsBaseOnLayout: false, hasLayouter: true);
+	AddClass("Windows.UI.Xaml.Controls", "NativePagedView", hasLayouter: true);
 	AddClass("Windows.UI.Xaml.Controls", "TextBoxView", hasNewMinWidthHeight: true, hasNewMaxWidthHeight: true);
 	AddClass("Windows.UI.Xaml.Controls", "NativeListViewBase", isUnoMotionTarget: true);
 #> 

--- a/src/Uno.UI/Mixins/iOS/FrameworkElementMixins.tt
+++ b/src/Uno.UI/Mixins/iOS/FrameworkElementMixins.tt
@@ -4,8 +4,8 @@
 <# 
 	AddClass("Windows.UI.Xaml.Controls", "SinglelineTextBoxView", isUIControl: true, hasAttachedToWindow: true, overridesAttachedToWindow: false, isNewBackground: true);
 	AddClass("Windows.UI.Xaml.Controls", "MultilineTextBoxView", isUIControl: false, hasAttachedToWindow: true, overridesAttachedToWindow: false, isNewBackground: false);
-	AddClass("Windows.UI.Xaml", "FrameworkElement", defineSetNeedsLayout: false, defineLayoutSubviews: false, hasAttachedToWindow: false, overridesAttachedToWindow: true);
-	AddClass("Windows.UI.Xaml.Controls", "Image", defineLayoutSubviews: false, overridesAttachedToWindow: false, hasAutomationPeer: true);
+	AddClass("Windows.UI.Xaml", "FrameworkElement", defineSetNeedsLayout: false, defineLayoutSubviews: false, hasAttachedToWindow: false, overridesAttachedToWindow: true, hasLayouter: true);
+	AddClass("Windows.UI.Xaml.Controls", "Image", defineLayoutSubviews: false, overridesAttachedToWindow: false, hasAutomationPeer: true, hasLayouter: true);
 	AddClass("Windows.UI.Xaml.Controls", "NativeListViewBase", hasAttachedToWindow: false, overridesAttachedToWindow: true, defineSetNeedsLayout: false, defineLayoutSubviews: false);
 	AddClass("Uno.UI.Controls.Legacy", "ListViewBase", hasAttachedToWindow: false, overridesAttachedToWindow: true, defineSetNeedsLayout: false, defineLayoutSubviews: false);
 	AddClass("Windows.UI.Xaml.Controls", "ProgressRing", hasAttachedToWindow: false, overridesAttachedToWindow: true);

--- a/src/Uno.UI/Mixins/macOS/FrameworkElementMixins.tt
+++ b/src/Uno.UI/Mixins/macOS/FrameworkElementMixins.tt
@@ -2,8 +2,8 @@
 <#@output extension="g.cs" #>
 #if __MACOS__
 <# 
-	AddClass("Windows.UI.Xaml", "FrameworkElement", defineSetNeedsLayout: false, defineLayoutSubviews: false, hasAttachedToWindow: false, overridesAttachedToWindow: true);
-	AddClass("Windows.UI.Xaml.Controls", "Image", overridesAttachedToWindow: false, hasAutomationPeer: true);
+	AddClass("Windows.UI.Xaml", "FrameworkElement", defineSetNeedsLayout: false, defineLayoutSubviews: false, hasAttachedToWindow: false, overridesAttachedToWindow: true, hasLayouter: true);
+	AddClass("Windows.UI.Xaml.Controls", "Image", overridesAttachedToWindow: false, hasAutomationPeer: true, hasLayouter: true);
 
 	// TODO
 	// AddClass("Windows.UI.Xaml.Controls", "ScrollContentPresenter", defineSetNeedsLayout: false, defineLayoutSubviews: false, hasAttachedToWindow: false, overridesAttachedToWindow: false);

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
@@ -1,5 +1,4 @@
-﻿#if XAMARIN_ANDROID
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -120,4 +119,3 @@ namespace Windows.UI.Xaml.Controls
 		}
 	}
 }
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -415,7 +415,6 @@ namespace Windows.UI.Xaml.Controls
 
 			return ret;
 		}
-		//public static bool _debugTemp1 = true;
 
 		/// <summary>
 		/// Arranges the location a child in the current panel

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -271,7 +271,7 @@ namespace Windows.UI.Xaml.Controls
 
 		protected Size MeasureChild(View view, Size slotSize)
 		{
-			var frameworkElement = view as IFrameworkElement;
+			var frameworkElement = view as IFrameworkElementInternal;
 			var ret = default(Size);
 
 			// NaN values are accepted as input for MeasureOverride, but are treated as Infinity.
@@ -404,7 +404,8 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
-			if (frameworkElement == null || frameworkElement.Visibility == Visibility.Collapsed)
+			var hasLayouter = frameworkElement?.HasLayouter ?? false;
+			if (!hasLayouter || frameworkElement.Visibility == Visibility.Collapsed)
 			{
 				// For native controls only - because it's already set in Layouter.Measure()
 				// for Uno's managed controls
@@ -414,6 +415,7 @@ namespace Windows.UI.Xaml.Controls
 
 			return ret;
 		}
+		//public static bool _debugTemp1 = true;
 
 		/// <summary>
 		/// Arranges the location a child in the current panel

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.iOS.cs
@@ -1,5 +1,4 @@
-﻿#if XAMARIN_IOS
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -147,4 +146,3 @@ namespace Windows.UI.Xaml.Controls
 		}
 	}
 }
-#endif

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -29,7 +29,7 @@ using View = Windows.UI.Xaml.UIElement;
 
 namespace Windows.UI.Xaml
 {
-	public partial class FrameworkElement : UIElement, IFrameworkElement, ILayoutConstraints
+	public partial class FrameworkElement : UIElement, IFrameworkElement, IFrameworkElementInternal, ILayoutConstraints
 	{
 		public
 			static class TraceProvider

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.net.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.net.cs
@@ -10,6 +10,8 @@ namespace Windows.UI.Xaml
 {
 	public partial class FrameworkElement : IEnumerable
 	{
+		bool IFrameworkElementInternal.HasLayouter => true;
+
 		internal List<View> _children = new List<View>();
 
 		partial void OnLoadingPartial();

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
@@ -20,6 +20,8 @@ namespace Windows.UI.Xaml
 {
 	public partial class FrameworkElement : IEnumerable
 	{
+		bool IFrameworkElementInternal.HasLayouter => true;
+
 		partial void OnLoadingPartial();
 
 		/*

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -35,7 +35,7 @@ using Point = Windows.Foundation.Point;
 
 namespace <#= mixin.NamespaceName #>
 {
-	public partial class <#= mixin.ClassName #> : IFrameworkElement, IXUidProvider
+	public partial class <#= mixin.ClassName #> : IFrameworkElement, IXUidProvider, IFrameworkElementInternal
 	{
 		private readonly static IEventProvider _trace = Tracing.Get(FrameworkElement.TraceProvider.Id);
 
@@ -50,6 +50,8 @@ namespace <#= mixin.NamespaceName #>
 		public event SizeChangedEventHandler SizeChanged;
 
 		string IXUidProvider.Uid { get; set; }
+
+		bool IFrameworkElementInternal.HasLayouter => <#= mixin.HasLayouter #>;
 
 		public IFrameworkElement FindName(string name)
 		{
@@ -969,7 +971,8 @@ namespace <#= mixin.NamespaceName #>
 		bool isUnoMotionTarget = false,
 		bool overridesOnLayout = true,
 		bool callsBaseOnLayout = true,
-		bool hasAutomationPeer = false
+		bool hasAutomationPeer = false,
+		bool hasLayouter = false
 	)
 	{
 		_mixins.Add(
@@ -986,6 +989,7 @@ namespace <#= mixin.NamespaceName #>
 				IsFrameworkElement = className == "FrameworkElement" ? "true" : "false",
 				HasAutomationPeer = hasAutomationPeer ? "true" : "false",
 				CallsBaseOnLayout = callsBaseOnLayout ? "true" : "false",
+				HasLayouter = hasLayouter ? "true" : "false"
 			}
 		);
 	}
@@ -1004,6 +1008,7 @@ namespace <#= mixin.NamespaceName #>
 		public string IsFrameworkElement;
 		public string HasAutomationPeer;
 		public string CallsBaseOnLayout;
+		public string HasLayouter;
 	}
 
 	private List<MixinParams> _mixins = new List<MixinParams>();

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -30,9 +30,11 @@ using Windows.UI.Xaml.Automation;
 
 namespace <#= mixin.NamespaceName #>
 {
-	public partial class <#= mixin.ClassName #> : IFrameworkElement, IXUidProvider
+	public partial class <#= mixin.ClassName #> : IFrameworkElement, IXUidProvider, IFrameworkElementInternal
 	{		
 		string IXUidProvider.Uid { get; set; }
+
+		bool IFrameworkElementInternal.HasLayouter => <#= mixin.HasLayouter #>;
 
 #if !<#= mixin.IsFrameworkElement #>
 		/// <summary>
@@ -1132,7 +1134,8 @@ namespace <#= mixin.NamespaceName #>
 		bool hasAttachedToWindow = true,
 		bool overridesAttachedToWindow = false,
 		bool isNewBackground = false,
-		bool hasAutomationPeer = false
+		bool hasAutomationPeer = false,
+		bool hasLayouter = false
 	)
 	{
 		_mixins.Add(
@@ -1147,6 +1150,7 @@ namespace <#= mixin.NamespaceName #>
 				IsNewBackground = isNewBackground ? "new" : "",
 				IsFrameworkElement = className == "FrameworkElement" ? "true" : "false",
 				HasAutomationPeer = hasAutomationPeer ? "true" : "false",
+				HasLayouter = hasLayouter ? "true" : "false"
 			}
 		);
 	}
@@ -1163,6 +1167,7 @@ namespace <#= mixin.NamespaceName #>
 		public string IsNewBackground;
 		public string IsFrameworkElement;
 		public string HasAutomationPeer;
+		public string HasLayouter;
 	}
 
 	private List<MixinParams> _mixins = new List<MixinParams>();

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
@@ -30,9 +30,12 @@ using Windows.UI.Xaml.Automation;
 
 namespace <#= mixin.NamespaceName #>
 {
-	public partial class <#= mixin.ClassName #> : IFrameworkElement, IXUidProvider
-	{		
+	public partial class <#= mixin.ClassName #> : IFrameworkElement, IXUidProvider, IFrameworkElementInternal
+	{
 		string IXUidProvider.Uid { get; set; }
+
+		bool IFrameworkElementInternal.HasLayouter => <#= mixin.HasLayouter #>;
+
 
 #if !<#= mixin.IsFrameworkElement #>
 		/// <summary>
@@ -1110,7 +1113,8 @@ namespace <#= mixin.NamespaceName #>
 		bool hasAttachedToWindow = true,
 		bool overridesAttachedToWindow = false,
 		bool isNewBackground = false,
-		bool hasAutomationPeer = false
+		bool hasAutomationPeer = false,
+		bool hasLayouter = false
 	)
 	{
 		_mixins.Add(
@@ -1125,6 +1129,7 @@ namespace <#= mixin.NamespaceName #>
 				IsNewBackground = isNewBackground ? "new" : "",
 				IsFrameworkElement = className == "FrameworkElement" ? "true" : "false",
 				HasAutomationPeer = hasAutomationPeer ? "true" : "false",
+				HasLayouter = hasLayouter ? "true" : "false"
 			}
 		);
 	}
@@ -1141,6 +1146,7 @@ namespace <#= mixin.NamespaceName #>
 		public string IsNewBackground;
 		public string IsFrameworkElement;
 		public string HasAutomationPeer;
+		public string HasLayouter;
 	}
 
 	private List<MixinParams> _mixins = new List<MixinParams>();

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementInternal.cs
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementInternal.cs
@@ -1,0 +1,12 @@
+using Windows.UI.Xaml.Controls;
+
+namespace Windows.UI.Xaml
+{
+	internal interface IFrameworkElementInternal : IFrameworkElement
+	{
+		/// <summary>
+		/// True if this <see cref="IFrameworkElement"/> implementation has a <see cref="Layouter"/> associated with it.
+		/// </summary>
+		bool HasLayouter { get; }
+	}
+}


### PR DESCRIPTION
ProgressRing inside a StackPanel was failing to display because its desired size wasn't set. Fix this by introducing a flag to distinguish between managed views that have their own Layouter, and those that don't (like ProgressRing).

GitHub Issue (If applicable): fixes #2762 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
