### PR TITLE
[Android] Fix toolbar height with custom content

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
+{
+	[TestFixture]
+	public partial class NativeCommandBar_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void NativeCommandBar_Automated()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.CommandBar.CommandBar_Native_With_Content");
+
+			var myButton = _app.Marked("myButton");
+			var result = _app.Marked("result");
+
+			myButton.Tap();
+
+			_app.WaitForText(result, "Clicked!");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -533,6 +533,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Native_With_Content.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Xaml_Automated.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3360,6 +3364,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_VisibleBounds.xaml.cs">
       <DependentUpon>ComboBox_VisibleBounds.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Native_With_Content.xaml.cs">
+      <DependentUpon>CommandBar_Native_With_Content.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Xaml_Automated.xaml.cs">
       <DependentUpon>CommandBar_Xaml_Automated.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Native_With_Content.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Native_With_Content.xaml
@@ -1,0 +1,69 @@
+﻿<Page x:Class="UITests.Windows_UI_Xaml_Controls.CommandBar.CommandBar_Native_With_Content"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:android="http://uno.ui/android"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Windows_UI_Xaml_Controls.CommandBar"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d android"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<android:Style x:Key="MyNativeDefaultCommandBar"
+					   TargetType="CommandBar">
+			<Setter Property="Background"
+					Value="{x:Null}" />
+			<Setter Property="Foreground"
+					Value="{x:Null}" />
+			<Setter Property="HorizontalAlignment"
+					Value="Stretch" />
+			<Setter Property="VerticalAlignment"
+					Value="Top" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="CommandBar">
+						<NativeCommandBarPresenter Height="44" />
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</android:Style>
+
+		<android:Style x:Key="CommandBarTypo"
+					   TargetType="TextBlock">
+			<Setter Property="FontWeight"
+					Value="Bold" />
+			<Setter Property="Foreground"
+					Value="Black" />
+			<Setter Property="TextTrimming"
+					Value="CharacterEllipsis" />
+			<Setter Property="VerticalAlignment"
+					Value="Center" />
+		</android:Style>
+	</Page.Resources>
+
+	<Grid>
+		<StackPanel VerticalAlignment="Center">
+			<Button x:Name="myButton"
+					Content="Click me (Android only)"
+					Click="OnClick"
+					Height="50" />
+			<TextBlock x:Name="result" Text="none" />
+		</StackPanel>
+
+		<android:CommandBar x:Name="MyCommandBar"
+							Style="{StaticResource MyNativeDefaultCommandBar}"
+							Background="Gray">
+			<CommandBar.Content>
+				<TextBlock Text="Hello Title 2 !"
+						   VerticalAlignment="Center"
+						   Foreground="Black"
+						   Style="{StaticResource CommandBarTypo}"
+						   x:Name="InnerTextBlock" />
+			</CommandBar.Content>
+			<CommandBar.PrimaryCommands>
+				<AppBarButton Content="Hello">
+				</AppBarButton>
+			</CommandBar.PrimaryCommands>
+		</android:CommandBar>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Native_With_Content.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Native_With_Content.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.CommandBar
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo("CommandBar")]
+	public sealed partial class CommandBar_Native_With_Content : Page
+	{
+		public CommandBar_Native_With_Content()
+		{
+			this.InitializeComponent();
+		}
+
+		private void OnClick(object sender, object args)
+		{
+			result.Text = "Clicked!";
+		}
+	}
+}

--- a/src/Uno.UI/Controls/CommandBarRenderer.Android.cs
+++ b/src/Uno.UI/Controls/CommandBarRenderer.Android.cs
@@ -79,7 +79,15 @@ namespace Uno.UI.Controls
 				// According to Google's Material Design Guidelines, the Toolbar must have a minimum height of 48.
 				// https://material.io/guidelines/layout/structure.html
 				Height = 48,
+				Name = "CommandBarRendererContentHolder",
+
+				// Set the alignment so that the measured sized
+				// returned is size of the child, not the available
+				// size provided to the ToolBar view.
+				VerticalAlignment = VerticalAlignment.Top,
+				HorizontalAlignment = HorizontalAlignment.Left,
 			};
+
 			_contentContainer.SetParent(Element);
 			Native.AddView(_contentContainer);
 			yield return Disposable.Create(() => Native.RemoveView(_contentContainer));


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #2763 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Custom content in a CommandBar is stretching the CommandBar to the available space.

## What is the new behavior?

The Content is properly sized to the CommandBar height.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
