### PR TITLE
[Android] Fix elements may not be arranged properly

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FrameworkElement.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FrameworkElement.cs
@@ -55,8 +55,18 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
 
 			using (new AssertionScope())
 			{
+#if __ANDROID__
+				// Android has an issue where LayoutUpdate is called twice, caused by the presence
+				// of two calls to arrange (Arrange, ArrangeElement(this)) in FrameworkElement.
+				// Failing to call the first Arrange makes some elements fail to have a proper size in
+				// some yet unknown conditions.
+				// Issue: https://github.com/unoplatform/uno/issues/2769
+				sutLayoutUpdate1.Should().Be(2, "sut-before");
+				sutLayoutUpdate2.Should().Be(4, "sut-after");
+#else
 				sutLayoutUpdate1.Should().Be(1, "sut-before");
 				sutLayoutUpdate2.Should().Be(2, "sut-after");
+#endif
 
 #if __ANDROID__
 				item1LayoutUpdate1.Should().Be(1, "item1-before");

--- a/src/Uno.UI/UI/Xaml/Controls/StackPanel/StackPanel.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/StackPanel/StackPanel.Layout.cs
@@ -87,7 +87,10 @@ namespace Windows.UI.Xaml.Controls
 			var isHorizontal = Orientation == Windows.UI.Xaml.Controls.Orientation.Horizontal;
 			var previousChildSize = 0.0;
 
-			this.Log().Debug($"StackPanel/{Name}: Arranging {Children.Count} children.");
+			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+			{
+				this.Log().Debug($"StackPanel/{Name}: Arranging {Children.Count} children.");
+			}
 
 			// Shadow variables for evaluation performance
 			var spacing = Spacing;

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -187,9 +187,7 @@ namespace Windows.UI.Xaml
 		/// <param name="finalRect">The final size that the parent computes for the child in layout, provided as a <see cref="Windows.Foundation.Rect"/> value.</param>
 		public override void Arrange(Rect finalRect)
 		{
-#if !__ANDROID__ // On Android .ArrangeChild() will call .Arrange() in its flow.
 			_layouter.Arrange(finalRect);
-#endif
 			_layouter.ArrangeChild(this, finalRect);
 		}
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #2767

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

[Android] Fix elements may not be arranged properly, caused by a missing Arrange pass. There is no clear repro case that could be created at this time.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Related Issue : https://github.com/unoplatform/uno/issues/2769
