### PR TITLE
[Android] KnownFolders.CameraRoll, DocumentsLibrary, and permission check

### DIFF
--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/KnownFolders.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/KnownFolders.cs
@@ -7,7 +7,7 @@ namespace Windows.Storage
 	#endif
 	public  partial class KnownFolders 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Storage.StorageFolder CameraRoll
 		{
@@ -37,7 +37,7 @@ namespace Windows.Storage
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Storage.StorageFolder DocumentsLibrary
 		{

--- a/src/Uno.UWP/Storage/KnownFolders.Android.cs
+++ b/src/Uno.UWP/Storage/KnownFolders.Android.cs
@@ -1,9 +1,46 @@
 ﻿#if __ANDROID__
 
+using System;
+using System.IO;
+using Android.OS;
+
 namespace Windows.Storage
 {
 	public static partial class KnownFolders
 	{
+		internal static void AndroidQRemediationCheck()
+		{
+			// first, check if workaround is needed - if not, return 
+			if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.Q)
+			{
+				return;
+			}
+
+
+			Android.Content.Context context = context = Android.App.Application.Context;
+			var apkInfo = context.PackageManager.GetPackageInfo(context.PackageName, 0);
+
+			// check if workaround is "timeouted", as stated in documentation:
+			// https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage
+			// After you update your app to target Android 11 (API level 30), the system ignores the requestLegacyExternalStorage attribute when your app is running on Android 11 devices
+			if (Android.OS.Build.VERSION.SdkInt > Android.OS.BuildVersionCodes.Q)
+			{ 
+				var apkSdkVers = apkInfo.ApplicationInfo.TargetSdkVersion;
+				if(apkSdkVers > Android.OS.BuildVersionCodes.Q)
+				{
+					// sorry, our workaround would not work
+					throw new UnauthorizedAccessException("KnownFolders: On apps targetting Android 11+, on Android 11+, requestLegacyExternalStorage doesn't work");
+				}
+			}
+
+			// and now, we should check if workaround is in place, i.e.
+			// do we have
+			// android:requestLegacyExternalStorage="true"
+			// defined in `<application ` node in Manifest file
+
+			// assume we have...
+		}
+
 
 		internal static void CheckPermission()
 		{
@@ -14,12 +51,12 @@ namespace Windows.Storage
 
 			string permissionName = "";
 
-			if(Windows.Extensions.PermissionHelper.IsDeclaredInManifest(Android.Manifest.Permission.ReadExternalStorage))
+			if(Windows.Extensions.PermissionsHelper.IsDeclaredInManifest(Android.Manifest.Permission.ReadExternalStorage))
 			{
 					permissionName = Android.Manifest.Permission.ReadExternalStorage;
 			}
 
-			if(Windows.Extensions.PermissionHelper.IsDeclaredInManifest(Android.Manifest.Permission.WriteExternalStorage)
+			if(Windows.Extensions.PermissionsHelper.IsDeclaredInManifest(Android.Manifest.Permission.WriteExternalStorage))
 			{
 					permissionName = Android.Manifest.Permission.WriteExternalStorage; // // READ is included in WRITE
 			}
@@ -41,9 +78,13 @@ namespace Windows.Storage
 
 		internal static StorageFolder FolderFromAndroidName(string name, bool createDir)
 		{
+
+			AndroidQRemediationCheck();
+
 			// createDir = true if directory should be created if doesn't exist. All UWP libraries exist by definition, on Android - such folders could not exist.
 			CheckPermission();
 
+			// since Android 10 (Q), it would not work
 #pragma warning disable CS0618 // Type or member is obsolete
 			string folderPath = Android.OS.Environment.GetExternalStoragePublicDirectory(name).CanonicalPath;
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -56,16 +97,45 @@ namespace Windows.Storage
 			return new StorageFolder(folderPath);
 		}
 
-		public static StorageFolder MusicLibrary => FolderFromAndroidName(Android.OS.Environment.DirectoryMusic, true); 
+		/// <remarks>
+		/// This method would work only on Android < 11,
+		/// It requires ReadExternalStorage or WriteExternalStorage permission in Manifest
+		/// For Android 10, also add `<application android:requestLegacyExternalStorage="true"` to Manifest 
+		/// </remarks>
+		public static StorageFolder MusicLibrary => FolderFromAndroidName(Android.OS.Environment.DirectoryMusic, true);
+		/// <remarks>
+		/// This method would work only on Android < 11,
+		/// It requires ReadExternalStorage or WriteExternalStorage permission in Manifest
+		/// For Android 10, also add `<application android:requestLegacyExternalStorage="true"` to Manifest 
+		/// </remarks>
 		public static StorageFolder VideosLibrary => FolderFromAndroidName(Android.OS.Environment.DirectoryMovies, true);
+		/// <remarks>
+		/// This method would work only on Android < 11,
+		/// It requires ReadExternalStorage or WriteExternalStorage permission in Manifest
+		/// For Android 10, also add `<application android:requestLegacyExternalStorage="true"` to Manifest 
+		/// </remarks>
 		public static StorageFolder DocumentsLibrary { get => FolderFromAndroidName(Android.OS.Environment.DirectoryDocuments, true); }
+		/// <remarks>
+		/// This method would work only on Android < 11,
+		/// It requires ReadExternalStorage or WriteExternalStorage permission in Manifest
+		/// For Android 10, also add `<application android:requestLegacyExternalStorage="true"` to Manifest 
+		/// </remarks>
 		public static StorageFolder CameraRoll { get => GetCameraFolder(); }
 
 		internal static StorageFolder GetCameraFolder()
 		{
+
+			AndroidQRemediationCheck();
+
 			CheckPermission();
 
+			// getExternalStoragePublicDirectory(String type)
+			// This method was deprecated in API level 29.
+			// When an app targets Build.VERSION_CODES.Q, the path returned from this method is no longer directly accessible to apps.
+
+#pragma warning disable CS0618 // Type or member is obsolete
 			var dcimFolder = Android.OS.Environment.GetExternalStoragePublicDirectory(Android.OS.Environment.DirectoryDcim);
+#pragma warning restore CS0618 // Type or member is obsolete
 			string dcimCanonicalPath = dcimFolder.CanonicalPath;
 
 			foreach (var folderName in Directory.GetDirectories(dcimCanonicalPath))

--- a/src/Uno.UWP/Storage/KnownFolders.Android.cs
+++ b/src/Uno.UWP/Storage/KnownFolders.Android.cs
@@ -4,15 +4,84 @@ namespace Windows.Storage
 {
 	public static partial class KnownFolders
 	{
-		internal static StorageFolder FolderFromAndroidName(string name)
+
+		internal static void CheckPermission()
+		{
+			if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.M)
+            {	// older Android - permission is not required
+				return;
+			}
+
+			string permissionName = "";
+
+			if(Windows.Extensions.PermissionHelper.IsDeclaredInManifest(Android.Manifest.Permission.ReadExternalStorage))
+			{
+					permissionName = Android.Manifest.Permission.ReadExternalStorage;
+			}
+
+			if(Windows.Extensions.PermissionHelper.IsDeclaredInManifest(Android.Manifest.Permission.WriteExternalStorage)
+			{
+					permissionName = Android.Manifest.Permission.WriteExternalStorage; // // READ is included in WRITE
+			}
+
+			if (string.IsNullOrEmpty(permissionName))
+			{
+				throw new UnauthorizedAccessException("KnownFolders: you have to request at least one (Read or Write ExternalStorage) permission in Manifest");
+			}
+
+			// have to re-implement Windows.Extensions.PermissionHelper.CheckPermission without async/await
+			Android.Content.Context context = Android.App.Application.Context;
+			if (context.PackageManager.CheckPermission(permissionName, context.PackageName) != Android.Content.PM.Permission.Granted)
+			{
+				// should ask for it - but asking for this requires async/await, and UWP API is not async here (MusicLibrary, not MusicLibraryAsync)
+				throw new NotImplementedException("KnownFolders: permission is not granted - asking for it is unimplemented (yet)");
+			}
+
+		}
+
+		internal static StorageFolder FolderFromAndroidName(string name, bool createDir)
+		{
+			// createDir = true if directory should be created if doesn't exist. All UWP libraries exist by definition, on Android - such folders could not exist.
+			CheckPermission();
+
 #pragma warning disable CS0618 // Type or member is obsolete
-			=> new StorageFolder(Android.OS.Environment.GetExternalStoragePublicDirectory(name).CanonicalPath);
+			string folderPath = Android.OS.Environment.GetExternalStoragePublicDirectory(name).CanonicalPath;
 #pragma warning restore CS0618 // Type or member is obsolete
 
-		public static StorageFolder MusicLibrary => FolderFromAndroidName(Android.OS.Environment.DirectoryMusic); 
-		public static StorageFolder VideosLibrary => FolderFromAndroidName(Android.OS.Environment.DirectoryMovies); 
+			if (createDir && !Directory.Exists(folderPath))
+			{
+				Directory.CreateDirectory(folderPath);
+			}
+
+			return new StorageFolder(folderPath);
+		}
+
+		public static StorageFolder MusicLibrary => FolderFromAndroidName(Android.OS.Environment.DirectoryMusic, true); 
+		public static StorageFolder VideosLibrary => FolderFromAndroidName(Android.OS.Environment.DirectoryMovies, true);
+		public static StorageFolder DocumentsLibrary { get => FolderFromAndroidName(Android.OS.Environment.DirectoryDocuments, true); }
+		public static StorageFolder CameraRoll { get => GetCameraFolder(); }
+
+		internal static StorageFolder GetCameraFolder()
+		{
+			CheckPermission();
+
+			var dcimFolder = Android.OS.Environment.GetExternalStoragePublicDirectory(Android.OS.Environment.DirectoryDcim);
+			string dcimCanonicalPath = dcimFolder.CanonicalPath;
+
+			foreach (var folderName in Directory.GetDirectories(dcimCanonicalPath))
+			{
+				if(folderName.ToLower().EndsWith("/camera"))
+				{
+					return new StorageFolder(folderName);
+				}
+			}
+
+			// UWP: "If the Camera Roll folder doesn't exist, reading the value of this property creates it"
+			Directory.CreateDirectory(dcimCanonicalPath + "/Camera");
+			return new StorageFolder(dcimCanonicalPath + "/Camera");
+		}
 
 	}
 }
 
-#endif 
+#endif

--- a/src/Uno.UWP/Storage/KnownFolders.Android.cs
+++ b/src/Uno.UWP/Storage/KnownFolders.Android.cs
@@ -11,7 +11,10 @@ namespace Windows.Storage
 		internal static void AndroidQRemediationCheck()
 		{
 			// first, check if workaround is needed - if not, return 
-			if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.Q)
+			// should be `if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.Q)`
+			// correct in VStudio/Intellisense, but CI reports
+			// Error CS0117: 'BuildVersionCodes' does not contain a definition for 'Q'
+			if (Android.OS.Build.VERSION.SdkInt <= Android.OS.BuildVersionCodes.P)
 			{
 				return;
 			}
@@ -23,10 +26,12 @@ namespace Windows.Storage
 			// check if workaround is "timeouted", as stated in documentation:
 			// https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage
 			// After you update your app to target Android 11 (API level 30), the system ignores the requestLegacyExternalStorage attribute when your app is running on Android 11 devices
-			if (Android.OS.Build.VERSION.SdkInt > Android.OS.BuildVersionCodes.Q)
+			// should be `if (Android.OS.Build.VERSION.SdkInt > Android.OS.BuildVersionCodes.Q)`
+			if ((int)Android.OS.Build.VERSION.SdkInt > 29)
 			{ 
 				var apkSdkVers = apkInfo.ApplicationInfo.TargetSdkVersion;
-				if(apkSdkVers > Android.OS.BuildVersionCodes.Q)
+				// same as above, `if(apkSdkVers > Android.OS.BuildVersionCodes.Q)`
+				if ((int)apkSdkVers > 29)
 				{
 					// sorry, our workaround would not work
 					throw new UnauthorizedAccessException("KnownFolders: On apps targetting Android 11+, on Android 11+, requestLegacyExternalStorage doesn't work");


### PR DESCRIPTION
GitHub Issue (If applicable): #1187 (partly)

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature
- Bugfix

## What is the current behavior?
No support for KnownFolders.CameraRoll, DocumentsLibrary.
Existing KnownFolders doesn't check permission.
Bad behaviour on Android 10.

## What is the new behavior?
Support for KnownFolders.CameraRoll, DocumentsLibrary.
Checking permission before returning KnownFolder.
Corrections for Android 10 (using workaround, but it is guaranteed to work till OS and targetSDK changes to Android 11+)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
Permission check should, as last resort, display system dialog asking for permission. But this is impossible in current Uno, see also: #2024, #2575, #2544
 Part of my app BackupSMS.

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
