### PR TITLE
ListView - fix stack overflow when changing SelectedItem

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -51,6 +51,7 @@
 - Add template tags for the VS2019 VSIX template search experience
 - [iOS] #2746 Fix border thickness when a corner radius is set
 - [Android] #2762 ProgressRing wasn't displaying inside a StackPanel
+- #2797 Stack overflow in ListView when changing SelectedItem to and from invalid valu
 
 ### Breaking changes
 - `IconElement.AddIconElementView` is now `internal` so it is not accessible from outside.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -12,6 +12,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 	public class Given_ListViewBase
 	{
 		[TestMethod]
+		[RunsOnUIThread]
 		public void ValidSelectionChange()
 		{
 			var source = Enumerable.Range(0, 10).ToArray();
@@ -23,6 +24,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[RunsOnUIThread]
 		public void InvalidSelectionChangeValidPrevious()
 		{
 			var source = Enumerable.Range(0, 10).ToArray();
@@ -34,6 +36,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[RunsOnUIThread]
 		public void InvalidSelectionChangeInvalidPrevious()
 		{
 			var source = Enumerable.Range(0, 10).ToArray();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	public class Given_ListViewBase
+	{
+		[TestMethod]
+		public void ValidSelectionChange()
+		{
+			var source = Enumerable.Range(0, 10).ToArray();
+			var list = new ListView { ItemsSource = source };
+			list.SelectedItem = 3;
+			Assert.AreEqual(list.SelectedItem, 3);
+			list.SelectedItem = 5;
+			Assert.AreEqual(list.SelectedItem, 5);
+		}
+
+		[TestMethod]
+		public void InvalidSelectionChangeValidPrevious()
+		{
+			var source = Enumerable.Range(0, 10).ToArray();
+			var list = new ListView { ItemsSource = source };
+			list.SelectedItem = 3;
+			Assert.AreEqual(list.SelectedItem, 3);
+			list.SelectedItem = 17;
+			Assert.AreEqual(list.SelectedItem, 3);
+		}
+
+		[TestMethod]
+		public void InvalidSelectionChangeInvalidPrevious()
+		{
+			var source = Enumerable.Range(0, 10).ToArray();
+			var list = new ListView { ItemsSource = source };
+			list.SelectedItem = 3;
+			Assert.AreEqual(list.SelectedItem, 3);
+			source[3] = 13;
+			list.SelectedItem = 17;
+#if NETFX_CORE
+			Assert.AreEqual(list.SelectedItem, 3);
+#else
+			Assert.IsNull(list.SelectedItem);
+#endif
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -68,7 +68,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		{
 			var wasSelectionUnset = oldSelectedItem == null && (!GetItems()?.Contains(null) ?? false);
 			var isSelectionUnset = false;
-			if (!GetItems()?.Contains(selectedItem) ?? false)
+			var items = GetItems();
+			if (!items?.Contains(selectedItem) ?? false)
 			{
 				if (selectedItem == null)
 				{
@@ -76,18 +77,24 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				}
 				else
 				{
+					var selectionToReset = items?.Contains(oldSelectedItem) ?? false ?
+						oldSelectedItem
+						// Note: in this scenario (previous SelectedItem no longer in collection either), Windows still leaves it at the
+						// previous value. We don't try to reproduce this behaviour, amongst other reasons because under Uno's DP system
+						// this would push an invalid value back through any 2-way binding.
+						: null;
 					try
 					{
 						_disableRaiseSelectionChanged = true;
 
 						//Prevent SelectedItem being set to an invalid value
-						SelectedItem = oldSelectedItem;
+						SelectedItem = selectionToReset;
 					}
 					finally
 					{
 						_disableRaiseSelectionChanged = false;
 					}
-						
+
 					return;
 				}
 			}
@@ -143,7 +150,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		{
 			if (SelectedValuePath.HasValue())
 			{
-				if(_path?.Path != SelectedValuePath)
+				if (_path?.Path != SelectedValuePath)
 				{
 					_path = new Uno.UI.DataBinding.BindingPath(SelectedValuePath, null);
 				}
@@ -271,7 +278,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		private void IsSynchronizedWithCurrentItemChanged(bool? oldValue, bool? newValue)
 		{
-			if(newValue == true)
+			if (newValue == true)
 			{
 				throw new ArgumentOutOfRangeException("True is not a supported value for this property");
 			}


### PR DESCRIPTION
When changing SelectedItem to an invalid value, if the current value had already become invalid, an infinite ping-pong from one value to the other would ensue.

This change interrupts the process by setting the value to null instead, which is a little different from Windows where the original value is retained even if invalid.

GitHub Issue (If applicable): fixes #2797 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
