### PR TITLE
[Android] Include Margin when measuring from LayoutManager

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -51,7 +51,8 @@
 - Add template tags for the VS2019 VSIX template search experience
 - [iOS] #2746 Fix border thickness when a corner radius is set
 - [Android] #2762 ProgressRing wasn't displaying inside a StackPanel
-- #2797 Stack overflow in ListView when changing SelectedItem to and from invalid valu
+- #2797 Stack overflow in ListView when changing SelectedItem to and from invalid value
+- [Android] #2761 Control with AreDimensionsConstrained and Margin set not measured correctly
 
 ### Breaking changes
 - `IconElement.AddIconElementView` is now `internal` so it is not accessible from outside.

--- a/src/Uno.UI/Services/LayoutManager.Android.cs
+++ b/src/Uno.UI/Services/LayoutManager.Android.cs
@@ -49,7 +49,7 @@ namespace Uno.UI.Services
 				{
 					typeof(LayoutManager).Log().LogDebug($"Measuring {view} with {GetAncestorCount(view)} ancestors in visual tree.");
 				}
-				IFrameworkElementHelper.Measure(view, view.ActualSize);
+				IFrameworkElementHelper.Measure(view, view.ActualSize.Add(view.Margin));
 			}
 			foreach (var view in queue)
 			{


### PR DESCRIPTION
The LayoutManager is used when `AreDimensionsConstrained = true` for a particular view, which can be set manually as an optimization if it's known that a view's size will never change. It wasn't taking the Margin into account when measuring the view, which was causing errors after layouting changes.

GitHub Issue (If applicable): fixes #2761

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
