### PR TITLE
fix: [Android/iOS] Layouter - Clipping were not properly applied.

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -17,6 +17,7 @@ using Uno.UI;
 using static System.Double;
 using static System.Math;
 using static Uno.UI.LayoutHelper;
+using System.Diagnostics.Contracts;
 
 #if XAMARIN_ANDROID
 using Android.Views;
@@ -51,8 +52,6 @@ namespace Windows.UI.Xaml.Controls
 		private readonly Size MaxSize = new Size(double.PositiveInfinity, double.PositiveInfinity);
 
 		internal Size _unclippedDesiredSize;
-
-		private const double SIZE_EPSILON = 0.05d;
 
 		public IFrameworkElement Panel { get; }
 
@@ -140,9 +139,17 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		[Pure]
+		private static bool IsCloseReal(double a, double b)
+		{
+			var x = Abs((a - b) / (b == 0d ? 1d : b));
+			return x < 1.85e-3d;
+		}
+
+		[Pure]
 		private static bool IsLessThanAndNotCloseTo(double a, double b)
 		{
-			return a < b - SIZE_EPSILON;
+			return (a < b) && !IsCloseReal(a, b);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Changed how the IsLessThanAndNotCloseTo is calculated
The EPSILON is replaced by something dynamic

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](https://github.com/unoplatform/uno/blob/master/README.md#uno-features)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/unoplatform/uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
* Internal issue, no link available here.