### PR TITLE
[Android/iOS] Images with margins were returning wrong measure size.

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Margins.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Margins.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
+{
+	public partial class UnoSamples_Tests
+	{
+		[Test]
+		[AutoRetry]
+		public void Image_Margins_Identical()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ImageTests.Image_Margins");
+
+			_app.WaitForElement("rect4");
+
+			var imageRects = new[] {"img0", "img1", "img2", "img3", "img4"}
+				.Select(x => _app.GetRect(x))
+				.ToArray();
+
+			var rects = new[] { "rect0", "rect1", "rect2", "rect3", "rect4" }
+				.Select(x => _app.GetRect(x))
+				.ToArray();
+
+			using (new AssertionScope())
+			{
+				var y = imageRects[0].Y;
+				var w = imageRects[0].Width;
+				var h = imageRects[0].Height;
+
+				imageRects[1].Y.Should().Be(y);
+				imageRects[2].Y.Should().Be(y);
+				imageRects[3].Y.Should().Be(y);
+				imageRects[4].Y.Should().Be(y);
+				imageRects[1].Width.Should().Be(w);
+				imageRects[2].Width.Should().Be(w);
+				imageRects[3].Width.Should().Be(w);
+				imageRects[4].Width.Should().Be(w);
+				imageRects[1].Height.Should().Be(h);
+				imageRects[2].Height.Should().Be(h);
+				imageRects[3].Height.Should().Be(h);
+				imageRects[4].Height.Should().Be(h);
+			}
+
+			using (new AssertionScope())
+			{
+				var y = rects[0].Y;
+				var h = rects[0].Height;
+
+				rects[1].Y.Should().Be(y);
+				rects[2].Y.Should().Be(y);
+				rects[3].Y.Should().Be(y);
+				rects[4].Y.Should().Be(y);
+				rects[1].Height.Should().Be(h);
+				rects[2].Height.Should().Be(h);
+				rects[3].Height.Should().Be(h);
+				rects[4].Height.Should().Be(h);
+			}
+
+			// Take screenshot
+			TakeScreenshot("WriteableBitmap_Invalidate - Result");
+		}
+
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Margins.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Margins.cs
@@ -21,7 +21,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 			_app.WaitForElement("rect4");
 
-			var imageRects = new[] {"img0", "img1", "img2", "img3", "img4"}
+			var imageRects = new[] { "img0", "img1", "img2", "img3", "img4" }
 				.Select(x => _app.GetRect(x))
 				.ToArray();
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -673,6 +673,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Margins.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Margin_Large.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3449,6 +3453,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Margin.xaml.cs">
       <DependentUpon>Image_Margin.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Margins.xaml.cs">
+      <DependentUpon>Image_Margins.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Margin_Large.xaml.cs">
       <DependentUpon>Image_Margin_Large.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margins.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margins.xaml
@@ -1,0 +1,40 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.ImageTests.Image_Margins"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<StackPanel Spacing="10">
+		<TextBlock>Those 5 should all look-like identical:</TextBlock>
+		<StackPanel Orientation="Horizontal" Background="LightBlue">
+			<StackPanel>
+				<Image x:Name="img0" Source="ms-appx:///Assets/test_image_100_100.pngg" Height="45" Margin="20" />
+				<Rectangle x:Name="rect0" Fill="Red" Width="45" Height="45" />
+			</StackPanel>
+			<StackPanel>
+				<Border>
+					<Image x:Name="img1" Source="ms-appx:///Assets/test_image_100_100.png" Height="45" Margin="20" />
+				</Border>
+				<Rectangle x:Name="rect1" Fill="Red" Width="45" Height="45" />
+			</StackPanel>
+			<StackPanel>
+				<Border Height="45" Margin="20">
+					<Image x:Name="img2" Source="ms-appx:///Assets/test_image_100_100.png" />
+				</Border>
+				<Rectangle x:Name="rect2" Fill="Red" Width="45" Height="45" />
+			</StackPanel>
+			<StackPanel>
+				<Image x:Name="img3" Source="ms-appx:///Assets/test_image_100_100.png" Height="45" Margin="20" />
+				<Rectangle x:Name="rect3" Fill="Red" Width="45" Height="45" />
+			</StackPanel>
+			<StackPanel>
+				<Border Padding="20">
+					<Image x:Name="img4" Source="ms-appx:///Assets/test_image_100_100.png" Height="45" />
+				</Border>
+				<Rectangle x:Name="rect4" Fill="Red" Width="45" Height="45" />
+			</StackPanel>
+		</StackPanel>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margins.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margins.xaml
@@ -10,31 +10,32 @@
 		<TextBlock>Those 5 should all look-like identical:</TextBlock>
 		<StackPanel Orientation="Horizontal" Background="LightBlue">
 			<StackPanel>
-				<Image x:Name="img0" Source="ms-appx:///Assets/test_image_100_100.pngg" Height="45" Margin="20" />
+				<Image x:Name="img0" Source="ms-appx:///Assets/test_image_100_100.png" Height="45" Margin="12" />
 				<Rectangle x:Name="rect0" Fill="Red" Width="45" Height="45" />
 			</StackPanel>
 			<StackPanel>
 				<Border>
-					<Image x:Name="img1" Source="ms-appx:///Assets/test_image_100_100.png" Height="45" Margin="20" />
+					<Image x:Name="img1" Source="ms-appx:///Assets/test_image_100_100.png" Height="45" Margin="12" />
 				</Border>
 				<Rectangle x:Name="rect1" Fill="Red" Width="45" Height="45" />
 			</StackPanel>
 			<StackPanel>
-				<Border Height="45" Margin="20">
+				<Border Height="45" Margin="12">
 					<Image x:Name="img2" Source="ms-appx:///Assets/test_image_100_100.png" />
 				</Border>
 				<Rectangle x:Name="rect2" Fill="Red" Width="45" Height="45" />
 			</StackPanel>
 			<StackPanel>
-				<Image x:Name="img3" Source="ms-appx:///Assets/test_image_100_100.png" Height="45" Margin="20" />
+				<Image x:Name="img3" Source="ms-appx:///Assets/test_image_100_100.png" Height="45" Margin="12" />
 				<Rectangle x:Name="rect3" Fill="Red" Width="45" Height="45" />
 			</StackPanel>
 			<StackPanel>
-				<Border Padding="20">
+				<Border Padding="12">
 					<Image x:Name="img4" Source="ms-appx:///Assets/test_image_100_100.png" Height="45" />
 				</Border>
 				<Rectangle x:Name="rect4" Fill="Red" Width="45" Height="45" />
 			</StackPanel>
 		</StackPanel>
+		<TextBlock x:Name="tree" TextWrapping="WrapWholeWords" FontSize="14" />
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margins.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margins.xaml.cs
@@ -1,9 +1,12 @@
 ﻿using Windows.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using System;
+using System.Threading.Tasks;
 
 namespace UITests.Windows_UI_Xaml_Controls.ImageTests
 {
-	[Sample("Image")]
+	[SampleControlInfo(category: "Image")]
 	public sealed partial class Image_Margins : Page
 	{
 		public Image_Margins()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margins.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Margins.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.ImageTests
+{
+	[Sample("Image")]
+	public sealed partial class Image_Margins : Page
+	{
+		public Image_Margins()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Stretch.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Stretch.xaml.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Samples.UITests.Image
 {
-	[SampleControlInfo]
+	[SampleControlInfo("Image")]
 	public sealed partial class Image_Stretch : Page
 	{
 		public Image_Stretch()

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
@@ -105,15 +105,17 @@ namespace Windows.UI.Xaml.Controls
 				measuredSize = this.AdjustSize(availableSize, measuredSize);
 			}
 
-			measuredSize = measuredSize.LogicalToPhysicalPixels();
+			var physicalMeasuredSize = measuredSize
+				.LogicalToPhysicalPixels();
 
 			// Report our final dimensions.
-			SetMeasuredDimension(
-				(int)measuredSize.Width,
-				(int)measuredSize.Height
-			);
+			var width = (int)physicalMeasuredSize.Width;
+			var height = (int)physicalMeasuredSize.Height;
 
-			IFrameworkElementHelper.OnMeasureOverride(this);
+			SetMeasuredDimension(width, height);
+
+			IFrameworkElementHelper
+				.SizeThatFits(this, new Size(width, height).PhysicalToLogicalPixels());
 		}
 
 		partial void OnLayoutPartial(bool changed, int left, int top, int right, int bottom)

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
@@ -63,10 +63,7 @@ namespace Windows.UI.Xaml.Controls
 			var ret = Uno.UI.Controls.BindableView.GetNativeMeasuredDimensionsFast(view)
 				.PhysicalToLogicalPixels();
 
-			ret.Width = Math.Min(slotSize.Width, ret.Width);
-			ret.Height = Math.Min(slotSize.Height, ret.Height);
-
-			return ret;
+			return ret.AtMost(slotSize);
 		}
 
 		protected abstract void MeasureChild(View view, int widthSpec, int heightSpec);

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.iOS.cs
@@ -80,10 +80,13 @@ namespace Windows.UI.Xaml.Controls
 
 			if (!(view is FrameworkElement) && view is IFrameworkElement ife)
 			{
-				// If the child is not a FrameworkElement, part of the "Measure"
-				// phase must be done by the parent element's layouter.
-				// Here, it means adding the margin to the measured size.
-				ret = ret.Add(ife.Margin);
+				if(!(view is Image)) // Except for Image
+				{
+					// If the child is not a FrameworkElement, part of the "Measure"
+					// phase must be done by the parent element's layouter.
+					// Here, it means adding the margin to the measured size.
+					ret = ret.Add(ife.Margin);
+				}
 			}
 
 			var w = nfloat.IsNaN((nfloat)ret.Width) ? double.PositiveInfinity : Math.Min(slotSize.Width, ret.Width);


### PR DESCRIPTION
# Bugfix
In situations where the measured size is required in the arranged phase, the measure value was reported without the margins, leading to broken layout in some situations.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


Internal Issue (If applicable):
* https://dev.azure.com/nventive/Umbrella/_workitems/edit/177045 Android / Button is cut off
* https://dev.azure.com/nventive/Umbrella/_workitems/edit/177339 /#2836 iOS / Button content is cut off
