### PR TITLE
Fixed CommandBar doc for the elevation property

### DIFF
--- a/doc/articles/controls/CommandBar.md
+++ b/doc/articles/controls/CommandBar.md
@@ -601,7 +601,9 @@ Gets or sets a value indicating whether the user can interact with the control.
 - > How can I add an elevation shadow to the CommandBar on Android?
   
   ```xml
-  <CommandBar toolkit:CommandBarExtensions.Elevation="4" />
+  xmlns:toolkit="using:Uno.UI.Toolkit"
+  ...
+  <CommandBar toolkit:UIElementExtensions.Elevation="4" />
   ```
   
 - > How can I use a Path for the AppBarButton Icon?


### PR DESCRIPTION
## PR Type 

What kind of change does this PR introduce?
- Documentation content changes

## What is the current behavior?

CommandBar documentation is not up to date for the elevation property

## What is the new behavior?

CommandBar documentation is not up to date for the elevation property


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


