### PR TITLE
feat(commandbar): Fix support for CommandBar content horizontal alignment on Android

### DIFF
--- a/doc/articles/controls/CommandBar.md
+++ b/doc/articles/controls/CommandBar.md
@@ -73,20 +73,22 @@ On **iOS**, tapping the back button automatically triggers a back navigation on 
 
 ## Properties
 
-| Property                              | Windows | iOS | Android | Comments                                                        |
-|---------------------------------------|:-------:|:---:|:-------:|------------------------------------------------------           |
-| Background                            | x       | x   | x       |                                                                 |
-| Content                               | x       | x   | x       |                                                                 |
-| Foreground                            | x       | x   | x       |                                                                 |
-| Height                                | x       | -   | -       | **iOS** and **Android**: Fixed and can't be changed.            |
-| HorizontalAlignment                   | x       | -   | x       | **iOS**: Always use `HorizontalAlignment.Stretch`.              |
-| Opacity                               | x       | x   | x       |                                                                 |
-| Padding                               | x       | x   | x       | **iOS** and **Android**: Please refer to the `Padding` section. |
-| PrimaryCommands                       | x       | x   | x       |                                                                 |
-| SecondaryCommands                     | x       | -   | x       | **iOS**: Not supported.                                         |
-| VerticalAlignment                     | x       | -   | x       | **iOS**: Always use `VerticalAlignment.Top`.                    |
-| Visibility                            | x       | x   | x       |                                                                 |
-| Width                                 | x       | -   | x       | **iOS**: Always use `double.NaN`.                               |
+| Property                              | Windows | iOS | Android | Comments                                                                                                               |
+|---------------------------------------|:-------:|:---:|:-------:|------------------------------------------------------                                                                  |
+| Background                            | x       | x   | x       |                                                                                                                        |
+| Content                               | x       | x   | x       |                                                                                                                        |
+| Foreground                            | x       | x   | x       |                                                                                                                        |
+| Height                                | x       | -   | -       | **iOS** and **Android**: Fixed and can't be changed.                                                                   |
+| HorizontalAlignment                   | x       | -   | x       | **iOS**: Always use `HorizontalAlignment.Stretch`.                                                                     |
+| Opacity                               | x       | x   | x       |                                                                                                                        |
+| Padding                               | x       | x   | x       | **iOS** and **Android**: Please refer to the `Padding` section.                                                        |
+| PrimaryCommands                       | x       | x   | x       |                                                                                                                        |
+| SecondaryCommands                     | x       | -   | x       | **iOS**: Not supported.                                                                                                |
+| VerticalAlignment                     | x       | -   | x       | **iOS**: Always use `VerticalAlignment.Top`.                                                                           |
+| Visibility                            | x       | x   | x       |                                                                                                                        |
+| Width                                 | x       | -   | x       | **iOS**: Always use `double.NaN`.                                                                                      |
+| HorizontalContentAlignment            | x       | -   | x       | **Android**: Stretch and Left are supported. **Windows**: Set `IsDynamicOverflowEnabled="False"` for proper behavior.  |
+| VerticalContentAlignment              | x       | -   | -       | Only supported on Windows. **Android**: Alignment needs to be done through the content itself.                         |
 
 *If it's not listed, assume it's not supported.*
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
@@ -27,5 +27,40 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			_app.WaitForText(result, "Clicked!");
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android)]
+		public void NativeCommandBar_Content_Alignment_Automated()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.CommandBar.CommandBar_Native_With_TextBox");
+
+			var verticalValue = _app.Marked("verticalValue");
+			var horizontalValue = _app.Marked("horizontalValue");
+			var innerTextBox = _app.Marked("InnerTextBox");
+			var innerTextBlock = _app.Marked("InnerTextBlock");
+			var myCommandBar = _app.Marked("MyCommandBar");
+
+			var myCommandBarResult = _app.Query(myCommandBar).First();
+
+			TakeScreenshot("Default");
+
+			var innerTextBoxResult = _app.Query(innerTextBox).First();
+			Assert.IsTrue(innerTextBoxResult.Rect.Width <= myCommandBarResult.Rect.Width / 2, "TextBox Width is too large");
+
+			horizontalValue.SetDependencyPropertyValue("SelectedItem", "Stretch");
+
+			TakeScreenshot("Stretch");
+
+			innerTextBoxResult = _app.Query(innerTextBox).First();
+			Assert.IsTrue(innerTextBoxResult.Rect.Width > myCommandBarResult.Rect.Width * .75, "TextBox Width is not large enough");
+
+			horizontalValue.SetDependencyPropertyValue("SelectedItem", "Left");
+
+			innerTextBoxResult = _app.Query(innerTextBox).First();
+			Assert.IsTrue(innerTextBoxResult.Rect.Width <= myCommandBarResult.Rect.Width / 2, "TextBox Width is too large");
+
+			TakeScreenshot("Left");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -549,6 +549,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Native_With_TextBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Xaml_Automated.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3400,6 +3404,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Native_With_Content.xaml.cs">
       <DependentUpon>CommandBar_Native_With_Content.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Native_With_TextBox.xaml.cs">
+      <DependentUpon>CommandBar_Native_With_TextBox.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Xaml_Automated.xaml.cs">
       <DependentUpon>CommandBar_Xaml_Automated.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Native_With_TextBox.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Native_With_TextBox.xaml
@@ -1,0 +1,105 @@
+﻿<Page x:Class="UITests.Windows_UI_Xaml_Controls.CommandBar.CommandBar_Native_With_TextBox"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:android="http://uno.ui/android"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Windows_UI_Xaml_Controls.CommandBar"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d android"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<android:Style x:Key="MyNativeDefaultCommandBar"
+					   TargetType="CommandBar">
+			<Setter Property="Background"
+					Value="{x:Null}" />
+			<Setter Property="Foreground"
+					Value="{x:Null}" />
+			<Setter Property="HorizontalAlignment"
+					Value="Stretch" />
+			<Setter Property="VerticalAlignment"
+					Value="Top" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="CommandBar">
+						<NativeCommandBarPresenter Height="44" />
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</android:Style>
+
+		<android:Style x:Key="CommandBarTypo"
+					   TargetType="TextBlock">
+			<Setter Property="FontWeight"
+					Value="Bold" />
+			<Setter Property="Foreground"
+					Value="Black" />
+			<Setter Property="TextTrimming"
+					Value="CharacterEllipsis" />
+			<Setter Property="VerticalAlignment"
+					Value="Center" />
+		</android:Style>
+	</Page.Resources>
+
+	<Grid>
+		<StackPanel Margin="0,150,0,0">
+			<ComboBox x:Name="verticalValue"
+					  Header="Vertical Alignment"
+					  SelectedItem="Top">
+				<x:String>Top</x:String>
+				<x:String>Bottom</x:String>
+				<x:String>Center</x:String>
+				<x:String>Stretch</x:String>
+			</ComboBox>
+			<ComboBox x:Name="horizontalValue"
+					  Header="Horizontal Alignment"
+					  SelectedItem="Left">
+				<x:String>Left</x:String>
+				<x:String>Right</x:String>
+				<x:String>Center</x:String>
+				<x:String>Stretch</x:String>
+			</ComboBox>
+			<TextBlock>
+				<Run Text="v:" />
+				<Run Text="{x:Bind MyCommandBar.VerticalContentAlignment, Mode=OneWay}" />
+				<Run Text="h:" />
+				<Run Text="{x:Bind MyCommandBar.HorizontalContentAlignment, Mode=OneWay}" />
+			</TextBlock>
+		</StackPanel>
+		<StackPanel>
+			<CommandBar x:Name="MyCommandBar"
+						IsDynamicOverflowEnabled="False"
+						android:Style="{StaticResource MyNativeDefaultCommandBar}"
+						VerticalContentAlignment="{Binding SelectedItem, ElementName=verticalValue, Mode=TwoWay}"
+						HorizontalContentAlignment="{Binding SelectedItem, ElementName=horizontalValue, Mode=TwoWay}"
+						Background="Gray">
+				<CommandBar.Content>
+					<TextBox Text="Hello Title 2 !"
+							 Foreground="Black"
+							 x:Name="InnerTextBox" />
+				</CommandBar.Content>
+				<CommandBar.PrimaryCommands>
+					<AppBarButton Content="Hello">
+					</AppBarButton>
+				</CommandBar.PrimaryCommands>
+			</CommandBar>
+			<CommandBar x:Name="TextBlockCommandBar"
+						IsDynamicOverflowEnabled="False"
+						android:Style="{StaticResource MyNativeDefaultCommandBar}"
+						VerticalContentAlignment="{Binding SelectedItem, ElementName=verticalValue, Mode=TwoWay}"
+						HorizontalContentAlignment="{Binding SelectedItem, ElementName=horizontalValue, Mode=TwoWay}"
+						Background="Gray">
+				<CommandBar.Content>
+					<TextBlock Text="Hello Title 2 !"
+							   Foreground="Black"
+							   VerticalAlignment="Center"
+							   x:Name="InnerTextBlock" />
+				</CommandBar.Content>
+				<CommandBar.PrimaryCommands>
+					<AppBarButton Content="Hello">
+					</AppBarButton>
+				</CommandBar.PrimaryCommands>
+			</CommandBar>
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Native_With_TextBox.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Native_With_TextBox.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.CommandBar
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo("CommandBar")]
+	public sealed partial class CommandBar_Native_With_TextBox : Page
+	{
+		public CommandBar_Native_With_TextBox()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/Controls/CommandBarRenderer.Android.cs
+++ b/src/Uno.UI/Controls/CommandBarRenderer.Android.cs
@@ -123,6 +123,9 @@ namespace Uno.UI.Controls
 				new[] { CommandBar.VisibilityProperty },
 				new[] { CommandBar.PaddingProperty },
 				new[] { CommandBar.OpacityProperty },
+				new[] { CommandBar.HorizontalContentAlignmentProperty },
+				new[] { CommandBar.VerticalContentAlignmentProperty },
+				new[] { CommandBar.OpacityProperty },
 				new[] { SubtitleProperty },
 				new[] { NavigationCommandProperty },
 				new[] { BackButtonVisibilityProperty },
@@ -149,6 +152,8 @@ namespace Uno.UI.Controls
 			// Content
 			Native.Title = Element.Content as string;
 			_contentContainer.Child = Element.Content as View;
+			_contentContainer.VerticalAlignment = Element.VerticalContentAlignment;
+			_contentContainer.HorizontalAlignment = Element.HorizontalContentAlignment;
 			_contentContainer.Visibility = Element.Content is View
 				? Visibility.Visible
 				: Visibility.Collapsed;


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #2838, Fixes #2837

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Horizontal alignment for custom `CommandBar` content is not possible.

## What is the new behavior?

`CommandBar.HorizontalContentAlignment` is now supported to change the alignment.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
