### PR TITLE
Fix ListView selection mode changed

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
@@ -19,6 +19,9 @@ namespace Uno.UI.Tests.ListViewBaseTests
 	public class Given_ListViewBase
 	{
 #if !NETFX_CORE
+		// Make sure to have a valid custom theme set, so it won't try to read it from the Application.Current(<<== null).RequestedTheme
+		[TestInitialize] public void Init() => global::Uno.UI.ApplicationHelper.RequestedCustomTheme = "HighContrast";
+
 		[TestMethod]
 		public void When_MultiSelectedItem()
 		{
@@ -233,7 +236,7 @@ namespace Uno.UI.Tests.ListViewBaseTests
 			{
 				Assert.Fail("Container should be a ListViewItem");
 			}
-	}
+		}
 
 		[TestMethod]
 		public void When_Single_SelectionChanged_And_SelectorItem_IsSelected_Changed()
@@ -483,6 +486,49 @@ namespace Uno.UI.Tests.ListViewBaseTests
 			}
 
 			Assert.AreEqual(2, SUT.SelectedItems.Count);
+		}
+
+		[TestMethod]
+		public void When_Multi_SelectionModeChanged()
+		{
+			var SUT = new ListView()
+			{
+				ItemsPanel = new ItemsPanelTemplate(() => new StackPanel()),
+				ItemContainerStyle = BuildBasicContainerStyle(),
+				Template = new ControlTemplate(() => new ItemsPresenter()),
+				SelectionMode = ListViewSelectionMode.Multiple,
+			};
+
+			SUT.ForceLoaded();
+
+			var source = Enumerable.Range(0, 10).Select(v => v.ToString()).ToArray();
+			SUT.ItemsSource = source;
+
+			Assert.IsNull(SUT.SelectedItem);
+
+			if (SUT.ContainerFromIndex(2) is ListViewItem s1)
+			{
+				s1.IsSelected = true;
+			}
+			else
+			{
+				Assert.Fail("Container should be a ListViewItem");
+			}
+
+			if (SUT.ContainerFromIndex(3) is ListViewItem s2)
+			{
+				s2.IsSelected = true;
+			}
+			else
+			{
+				Assert.Fail("Container should be a ListViewItem");
+			}
+
+			Assert.AreEqual(2, SUT.SelectedItems.Count);
+
+			SUT.SelectionMode = ListViewSelectionMode.None;
+
+			Assert.AreEqual(0, SUT.SelectedItems.Count);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -346,7 +346,7 @@ namespace Windows.UI.Xaml.Controls
 		partial void OnSelectionModeChangedPartial(ListViewSelectionMode oldSelectionMode, ListViewSelectionMode newSelectionMode)
 		{
 			SelectedIndex = -1;
-			foreach (var item in SelectedItems)
+			foreach (var item in SelectedItems.ToList())
 			{
 				SetSelectedState(IndexFromItem(item), false);
 			}


### PR DESCRIPTION
GitHub Issue: fixes https://github.com/unoplatform/uno/issues/2839

## Bugfix
Invalid visual state when changing a `ListView`'s selectuion mode while one or more items are selected.

## What is the current behavior?
When the `SelectionMode` is changed to `None` while at least on item is selected, the `ListView` tries to un-select them, but doing this it alter the collection that it is enumerating.

## What is the new behavior?
We create a clone of the selected items collection.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

