### PR TITLE
feat: [WASM] Using Uno blue accent color for splash

### DIFF
--- a/src/SamplesApp/SamplesApp.Wasm/WasmScripts/AppManifest.js
+++ b/src/SamplesApp/SamplesApp.Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 ﻿var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.scale-200.png",
-    splashScreenColor: "#00f",
+    splashScreenColor: "#0078D7",
     displayName: "SamplesApp"
 
 }

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoQuickStart.Wasm/WasmScripts/AppManifest.js
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoQuickStart.Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 ﻿var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.scale-200.png",
-    splashScreenColor: "#00f",
+    splashScreenColor: "#0078D7",
     displayName: "UnoQuickStart"
 
 }

--- a/src/SolutionTemplate/UnoSolutionTemplate/Wasm/WasmScripts/AppManifest.js
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 ﻿var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.png",
-    splashScreenColor: "#00f",
+    splashScreenColor: "#0078D7",
     displayName: "$ext_safeprojectname$"
 
 }


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #2857 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Pure blue used for WASM splash screen.

## What is the new behavior?

Default Uno accent color (#0078D7) used for WASM splash screen.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
