### PR TITLE
Image from bytes

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -17,8 +17,8 @@
     <PackageReference Update="Uno.SourceGeneration" Version="1.32.0" />
     <PackageReference Update="Uno.Core" Version="1.29.0" />
     <PackageReference Update="Uno.Core.Build" Version="1.29.0" />
-    <PackageReference Update="Uno.Wasm.Bootstrap" Version="1.0.10" />
-    <DotNetCliToolReference Update="Uno.Wasm.Bootstrap.Cli" Version="1.0.10" />
+    <PackageReference Update="Uno.Wasm.Bootstrap" Version="1.1.0-dev.433" />
+    <DotNetCliToolReference Update="Uno.Wasm.Bootstrap.Cli" Version="1.1.0-dev.433" />
     <PackageReference Update="xamarin.build.download" Version="0.4.11" />
     <PackageReference Update="Uno.MonoAnalyzers" Version="1.0.0-dev.4" PrivateAssets="all" />
     <PackageReference Update="System.Memory" Version="4.5.2" />

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -23,6 +23,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Logging;
 
 namespace SamplesApp
 {
@@ -109,6 +110,7 @@ namespace SamplesApp
 
 				// Place the frame in the current Window
 				Windows.UI.Xaml.Window.Current.Content = rootFrame;
+				Console.WriteLine($"RootFrame: {rootFrame}");
 			}
 
 			if (e.PrelaunchActivated == false)
@@ -160,8 +162,13 @@ namespace SamplesApp
 			deferral.Complete();
 		}
 
-		static void ConfigureFilters(ILoggerFactory factory)
+		void ConfigureFilters(ILoggerFactory factory)
 		{
+#if HAS_UNO
+			System.Threading.Tasks.TaskScheduler.UnobservedTaskException += (s, e) => typeof(App).Log().Error("UnobservedTaskException", e.Exception);
+			AppDomain.CurrentDomain.UnhandledException += (s, e) => typeof(App).Log().Error("UnhandledException", e.ExceptionObject as Exception);
+#endif
+
 			factory
 				.WithFilter(new FilterLoggerSettings
 					{

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup> 
-		<PackageReference Include="FluentAssertions" Version="5.10.2" />
+		<PackageReference Include="FluentAssertions" Version="5.10.3" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" /> 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
@@ -324,6 +324,32 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 
 		[Test]
 		[AutoRetry]
+		public void ContentDialog_Closing_PrimaryDialogCancelClosing()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Closing");
+
+			var showDialog = _app.Marked("PrimaryDialogCancelClosing");
+			var resultText = _app.Marked("ResultTextBlock");
+			var closedText = _app.Marked("DidCloseTextBlock");
+			var closeButton = _app.Marked("CloseButton");
+			var primaryButton = _app.Marked("PrimaryButton");
+
+			_app.WaitForElement(showDialog);
+			_app.FastTap(showDialog);
+
+			_app.WaitForElement(primaryButton);
+			_app.FastTap(primaryButton);
+
+			_app.WaitForDependencyPropertyValue(resultText, "Text", "Primary");
+			_app.WaitForDependencyPropertyValue(closedText, "Text", "Not closed");
+
+			_app.FastTap(closeButton);
+
+			_app.WaitForDependencyPropertyValue(closedText, "Text", "Closed");
+		}
+
+		[Test]
+		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] //TODO: https://github.com/unoplatform/uno/issues/1583
 		public void ContentDialog_ComboBox()
 		{

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -37,6 +37,12 @@
 	<ItemGroup>
 		<LinkerDescriptor Include="LinkerConfig.xml" />
 	</ItemGroup>
+	
+	<ItemGroup>
+		<!-- Required to enable IDBFS (https://github.com/emscripten-core/emscripten/blob/d2148d096e2b5f3ec4886f93e24312ef88976020/ChangeLog.md#v1391-10302019) -->
+		<WasmShellExtraEmccFlags Include="-lidbfs.js" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<!--
 		This item group is required by the project templace because of the

--- a/src/SamplesApp/SamplesApp.Wasm/WasmScripts/AppManifest.js
+++ b/src/SamplesApp/SamplesApp.Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 ﻿var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.scale-200.png",
-    splashScreenColor: "#00f",
+    splashScreenColor: "#0078D7",
     displayName: "SamplesApp"
 
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -709,6 +709,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\LoadFromBytes.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Margin_On_Container.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3486,6 +3490,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_UseTargetSizeLate.xaml.cs">
       <DependentUpon>Image_UseTargetSizeLate.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\LoadFromBytes.xaml.cs">
+      <DependentUpon>LoadFromBytes.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Margin_On_Container.xaml.cs">
       <DependentUpon>ListView_Margin_On_Container.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Closing.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Closing.xaml
@@ -21,6 +21,9 @@
 			<Button x:Name="PrimaryDialog"
 					Content="Show dialog with Primary button"
 					Click="PrimaryDialog_Click" />
+			<Button x:Name="PrimaryDialogCancelClosing"
+					Content="Show dialog with Primary button and cancel closing"
+					Click="PrimaryDialogCancelClosing_Click" />
 			<TextBlock x:Name="ResultTextBlock"
 					   Margin="50" />
 			<TextBlock x:Name="DidCloseTextBlock"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Closing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Closing.xaml.cs
@@ -111,5 +111,26 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests
 			var dummy = dialog.ShowAsync();
 		}
 
+		private void PrimaryDialogCancelClosing_Click(object sender, RoutedEventArgs args)
+		{
+			DidCloseTextBlock.Text = "Not closed";
+			var dialog = new ContentDialog { CloseButtonText = "Close", PrimaryButtonText = "Primo" };
+			dialog.Closing += (o, e) =>
+			  {
+				  ResultTextBlock.Text = e.Result.ToString();
+
+				  if (e.Result == ContentDialogResult.Primary)
+				  {
+					  e.Cancel = true;
+				  }
+			  };
+
+			dialog.Closed += (o, e) =>
+			{
+				DidCloseTextBlock.Text = "Closed";
+			};
+
+			var dummy = dialog.ShowAsync();
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/LoadFromBytes.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/LoadFromBytes.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="Uno.UI.Samples.UITests.ImageTestsControl.LoadFromBytes"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+			 d:DesignHeight="2000"
+			 d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="Image loaded from bytes"/>
+		<Image x:Name="MyImage" Width="400" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/LoadFromBytes.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/LoadFromBytes.xaml.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace Uno.UI.Samples.UITests.ImageTestsControl
+{
+	[SampleControlInfo("Image", "LoadFromBytes")]
+	public sealed partial class LoadFromBytes : UserControl
+	{
+		private readonly string _imageUrl = "https://www.spriters-resource.com/resources/sheet_icons/30/32521.png";
+
+		public LoadFromBytes()
+		{
+			InitializeComponent();
+			Loaded += OnLoaded;
+		}
+
+		private async void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			var client = new HttpClient(new CorsByPassHandler());
+
+			var result = await client.GetAsync(_imageUrl);
+			var stream = await result.Content.ReadAsStreamAsync();
+
+
+			var bitmap = new BitmapImage();
+#if !NETFX_CORE
+			await bitmap.SetSourceAsync(stream);
+#else
+				var memStream = new MemoryStream();
+				await stream.CopyToAsync(memStream);
+				memStream.Position = 0;
+				using (memStream)
+				{
+					await bitmap.SetSourceAsync(memStream.AsRandomAccessStream());
+				}
+#endif
+			MyImage.Source = bitmap;
+
+		}
+
+		public class CorsByPassHandler : DelegatingHandler
+		{
+			public CorsByPassHandler()
+			{
+				InnerHandler = new HttpClientHandler();
+			}
+
+			protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+			{
+				var builder = new UriBuilder(request.RequestUri)
+				{
+					Host = "cors-anywhere.herokuapp.com",
+				};
+
+				builder.Path = request.RequestUri.Host + builder.Path;
+
+				return base.SendAsync(new HttpRequestMessage(request.Method, builder.Uri)
+				{
+					Headers = { { "origin", "" } },
+				}, cancellationToken);
+			}
+		}
+	}
+}

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoQuickStart.Wasm/WasmScripts/AppManifest.js
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoQuickStart.Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 ﻿var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.scale-200.png",
-    splashScreenColor: "#00f",
+    splashScreenColor: "#0078D7",
     displayName: "UnoQuickStart"
 
 }

--- a/src/SolutionTemplate/UnoSolutionTemplate/Wasm/WasmScripts/AppManifest.js
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 ﻿var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.png",
-    splashScreenColor: "#00f",
+    splashScreenColor: "#0078D7",
     displayName: "$ext_safeprojectname$"
 
 }

--- a/src/Uno.Foundation/Point.cs
+++ b/src/Uno.Foundation/Point.cs
@@ -52,12 +52,21 @@ namespace Windows.Foundation
 
 		public static implicit operator Point(string point)
 		{
-			var parts = point
-				.Split(new[] { ',' })
-				.Select(value => double.Parse(value, CultureInfo.InvariantCulture))
-				.ToArray();
+			if (string.IsNullOrEmpty(point))
+			{
+				// Marker to enable null-comparison if the string comparer
+				// has been called with null.
+				return new Point(double.NaN, double.NaN);
+			}
+			else
+			{
+				var parts = point
+					.Split(new[] { ',' })
+					.Select(value => double.Parse(value, CultureInfo.InvariantCulture))
+					.ToArray();
 
-			return new Point(parts[0], parts[1]);
+				return new Point(parts[0], parts[1]);
+			}
 		}
 
 		public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode();

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="5.10.2" />
+		<PackageReference Include="FluentAssertions" Version="5.10.3" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
 		<PackageReference Include="Uno.SourceGenerationTasks" />
 		<ProjectReference Include="..\Uno.UI.Toolkit\Uno.UI.Toolkit.csproj" />

--- a/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
+++ b/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
@@ -36,7 +36,7 @@
       <Version>1.3</Version>
     </PackageReference>
     <PackageReference Include="FluentAssertions">
-      <Version>5.10.2</Version>
+      <Version>5.10.3</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.13.1</Version>

--- a/src/Uno.UI.Tests/Foundation/Given_Point.cs
+++ b/src/Uno.UI.Tests/Foundation/Given_Point.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Uno.UI.Tests.Foundation
+{
+	[TestClass]
+	public class Given_Point
+	{
+		[TestMethod]
+		public void When_NullComparison()
+		{
+			var p = new Point(0, 0);
+			Assert.IsTrue(p != null);
+
+			var p2 = new Point(1, 0);
+			Assert.IsTrue(p2 != null);
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -39,7 +39,7 @@
       <Version>1.3</Version>
     </PackageReference>
     <PackageReference Include="FluentAssertions">
-      <Version>5.10.2</Version>
+      <Version>5.10.3</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.13.1</Version>

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -12,7 +12,8 @@ using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public partial class ContentDialog : ContentControl
+	public partial class 
+		ContentDialog : ContentControl
 	{
 		internal readonly Popup _popup;
 		private TaskCompletionSource<ContentDialogResult> _tcs;
@@ -73,7 +74,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public void Hide() => Hide(ContentDialogResult.None);
-		private void Hide(ContentDialogResult result)
+		private bool Hide(ContentDialogResult result)
 		{
 			void Complete(ContentDialogClosingEventArgs args)
 			{
@@ -97,6 +98,8 @@ namespace Windows.UI.Xaml.Controls
 			{
 				closingArgs.EventRaiseCompleted();
 			}
+
+			return !closingArgs.Cancel;
 		}
 
 		protected override void OnApplyTemplate()
@@ -260,9 +263,13 @@ namespace Windows.UI.Xaml.Controls
 				if (!a.Cancel)
 				{
 					const ContentDialogResult result = ContentDialogResult.None;
-					_tcs.SetResult(result);
+
 					CloseButtonCommand.ExecuteIfPossible(CloseButtonCommandParameter);
-					Hide(result);
+
+					if (Hide(result))
+					{
+						_tcs.SetResult(result);
+					}
 				}
 			}
 
@@ -282,9 +289,11 @@ namespace Windows.UI.Xaml.Controls
 				if (!a.Cancel)
 				{
 					const ContentDialogResult result = ContentDialogResult.Secondary;
-					_tcs.SetResult(result);
 					SecondaryButtonCommand.ExecuteIfPossible(SecondaryButtonCommandParameter);
-					Hide(result);
+					if (Hide(result))
+					{
+						_tcs.SetResult(result);
+					}
 				}
 			}
 
@@ -305,10 +314,12 @@ namespace Windows.UI.Xaml.Controls
 				if (!a.Cancel)
 				{
 					const ContentDialogResult result = ContentDialogResult.Primary;
-					_tcs.SetResult(result);
 					PrimaryButtonCommand.ExecuteIfPossible(PrimaryButtonCommandParameter);
 
-					Hide(result);
+					if(Hide(result))
+					{
+						_tcs.SetResult(result);
+					}
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.wasm.cs
@@ -40,6 +40,7 @@ namespace Windows.UI.Xaml.Controls
 		private void UpdateBorder()
 		{
 			SetBorder(BorderThickness, BorderBrush, CornerRadius);
+			SetBackgroundBrush(Background);
 		}
 
 		partial void OnPaddingChangedPartial(Thickness oldValue, Thickness newValue)

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Globalization;
+using System.IO;
 using Windows.Foundation;
 using Windows.UI.Xaml.Media;
-using Uno.Diagnostics.Eventing;
 using Uno.Extensions;
 using Uno.Foundation;
 using Uno.Logging;
@@ -102,7 +101,15 @@ namespace Windows.UI.Xaml.Controls
 
 			_lastMeasuredSize = _zeroSize;
 
-			if (source is WriteableBitmap wb)
+			var stream = source?.Stream;
+			if (stream != null)
+			{
+				stream.Seek(0, SeekOrigin.Begin);
+				var encodedBytes = Convert.ToBase64String(stream.ReadBytes());
+				var url = "data:application/octet-stream;base64," + encodedBytes;
+				SetImageUrl(url);
+			}
+			else if (source is WriteableBitmap wb)
 			{
 				void setImageContent()
 				{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
@@ -118,7 +118,7 @@ namespace Windows.UI.Xaml
 			SetBackgroundBrush(brush);
 		}
 
-		private void SetBackgroundBrush(Brush brush)
+		private protected void SetBackgroundBrush(Brush brush)
 		{
 			switch (brush)
 			{


### PR DESCRIPTION
GitHub Issue: https://github.com/unoplatform/uno/issues/2856

# Adds the ability to load images from bytes in WASM heads.

This is my first PR, so please, be patient. I don't expect this to be merged soon, because it surely will need refinement and maybe important changes

Basically, I've edited src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs to handle the use case when ImageSource.Stream isn't null. I don't know if this condition is enough to guarantee that the ImageSource should be loaded from the Stream, but it worked for me.

In case we are loading the image from the ImageSource.Stream, I read it using ImageSharp.
I know this introduces a 3rd party library, but I found no better option to load the pixel data, since I don't have enough knowledge about how this scenarios are handled inside Uno. Feel free to suggest/edit/criticize and I will refine the PR until it meets the conditions to be merged.

Thanks for your understanding :)


