### PR TITLE
fix(ContentDialog): Content dialog can be closed if Closing event was canceled

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
@@ -324,6 +324,32 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 
 		[Test]
 		[AutoRetry]
+		public void ContentDialog_Closing_PrimaryDialogCancelClosing()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Closing");
+
+			var showDialog = _app.Marked("PrimaryDialogCancelClosing");
+			var resultText = _app.Marked("ResultTextBlock");
+			var closedText = _app.Marked("DidCloseTextBlock");
+			var closeButton = _app.Marked("CloseButton");
+			var primaryButton = _app.Marked("PrimaryButton");
+
+			_app.WaitForElement(showDialog);
+			_app.FastTap(showDialog);
+
+			_app.WaitForElement(primaryButton);
+			_app.FastTap(primaryButton);
+
+			_app.WaitForDependencyPropertyValue(resultText, "Text", "Primary");
+			_app.WaitForDependencyPropertyValue(closedText, "Text", "Not closed");
+
+			_app.FastTap(closeButton);
+
+			_app.WaitForDependencyPropertyValue(closedText, "Text", "Closed");
+		}
+
+		[Test]
+		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] //TODO: https://github.com/unoplatform/uno/issues/1583
 		public void ContentDialog_ComboBox()
 		{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Closing.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Closing.xaml
@@ -21,6 +21,9 @@
 			<Button x:Name="PrimaryDialog"
 					Content="Show dialog with Primary button"
 					Click="PrimaryDialog_Click" />
+			<Button x:Name="PrimaryDialogCancelClosing"
+					Content="Show dialog with Primary button and cancel closing"
+					Click="PrimaryDialogCancelClosing_Click" />
 			<TextBlock x:Name="ResultTextBlock"
 					   Margin="50" />
 			<TextBlock x:Name="DidCloseTextBlock"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Closing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Closing.xaml.cs
@@ -111,5 +111,26 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests
 			var dummy = dialog.ShowAsync();
 		}
 
+		private void PrimaryDialogCancelClosing_Click(object sender, RoutedEventArgs args)
+		{
+			DidCloseTextBlock.Text = "Not closed";
+			var dialog = new ContentDialog { CloseButtonText = "Close", PrimaryButtonText = "Primo" };
+			dialog.Closing += (o, e) =>
+			  {
+				  ResultTextBlock.Text = e.Result.ToString();
+
+				  if (e.Result == ContentDialogResult.Primary)
+				  {
+					  e.Cancel = true;
+				  }
+			  };
+
+			dialog.Closed += (o, e) =>
+			{
+				DidCloseTextBlock.Text = "Closed";
+			};
+
+			var dummy = dialog.ShowAsync();
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -12,7 +12,8 @@ using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public partial class ContentDialog : ContentControl
+	public partial class 
+		ContentDialog : ContentControl
 	{
 		internal readonly Popup _popup;
 		private TaskCompletionSource<ContentDialogResult> _tcs;
@@ -73,7 +74,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public void Hide() => Hide(ContentDialogResult.None);
-		private void Hide(ContentDialogResult result)
+		private bool Hide(ContentDialogResult result)
 		{
 			void Complete(ContentDialogClosingEventArgs args)
 			{
@@ -97,6 +98,8 @@ namespace Windows.UI.Xaml.Controls
 			{
 				closingArgs.EventRaiseCompleted();
 			}
+
+			return !closingArgs.Cancel;
 		}
 
 		protected override void OnApplyTemplate()
@@ -260,9 +263,13 @@ namespace Windows.UI.Xaml.Controls
 				if (!a.Cancel)
 				{
 					const ContentDialogResult result = ContentDialogResult.None;
-					_tcs.SetResult(result);
+
 					CloseButtonCommand.ExecuteIfPossible(CloseButtonCommandParameter);
-					Hide(result);
+
+					if (Hide(result))
+					{
+						_tcs.SetResult(result);
+					}
 				}
 			}
 
@@ -282,9 +289,11 @@ namespace Windows.UI.Xaml.Controls
 				if (!a.Cancel)
 				{
 					const ContentDialogResult result = ContentDialogResult.Secondary;
-					_tcs.SetResult(result);
 					SecondaryButtonCommand.ExecuteIfPossible(SecondaryButtonCommandParameter);
-					Hide(result);
+					if (Hide(result))
+					{
+						_tcs.SetResult(result);
+					}
 				}
 			}
 
@@ -305,10 +314,12 @@ namespace Windows.UI.Xaml.Controls
 				if (!a.Cancel)
 				{
 					const ContentDialogResult result = ContentDialogResult.Primary;
-					_tcs.SetResult(result);
 					PrimaryButtonCommand.ExecuteIfPossible(PrimaryButtonCommandParameter);
 
-					Hide(result);
+					if(Hide(result))
+					{
+						_tcs.SetResult(result);
+					}
 				}
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/2805

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

When a `ContentDialog.Closing` is canceled, using the dialog's button now properly handle actions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
