### PR TITLE
fix(point): Fix comparing a Point to null NRE

### DIFF
--- a/src/Uno.Foundation/Point.cs
+++ b/src/Uno.Foundation/Point.cs
@@ -52,12 +52,21 @@ namespace Windows.Foundation
 
 		public static implicit operator Point(string point)
 		{
-			var parts = point
-				.Split(new[] { ',' })
-				.Select(value => double.Parse(value, CultureInfo.InvariantCulture))
-				.ToArray();
+			if (string.IsNullOrEmpty(point))
+			{
+				// Marker to enable null-comparison if the string comparer
+				// has been called with null.
+				return new Point(double.NaN, double.NaN);
+			}
+			else
+			{
+				var parts = point
+					.Split(new[] { ',' })
+					.Select(value => double.Parse(value, CultureInfo.InvariantCulture))
+					.ToArray();
 
-			return new Point(parts[0], parts[1]);
+				return new Point(parts[0], parts[1]);
+			}
 		}
 
 		public override int GetHashCode() => X.GetHashCode() ^ Y.GetHashCode();

--- a/src/Uno.UI.Tests/Foundation/Given_Point.cs
+++ b/src/Uno.UI.Tests/Foundation/Given_Point.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Uno.UI.Tests.Foundation
+{
+	[TestClass]
+	public class Given_Point
+	{
+		[TestMethod]
+		public void When_NullComparison()
+		{
+			var p = new Point(0, 0);
+			Assert.IsTrue(p != null);
+
+			var p2 = new Point(1, 0);
+			Assert.IsTrue(p2 != null);
+		}
+	}
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Comparing a `Point` with null does not fail with an NRE.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
