### PR TITLE
[WASM] Fix pointers for elt nested in manip aware content

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
@@ -13,7 +13,7 @@ using Uno.UITest.Helpers.Queries;
 
 namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 {
-	public class Manipulation_Tests : SampleControlUITestBase
+	public partial class Manipulation_Tests : SampleControlUITestBase
 	{
 		[Test]
 		[AutoRetry]
@@ -42,6 +42,20 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			var result = Parse(resultStr);
 
 			Assert.AreEqual(2.0, result.cumulative.Scale);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void Manipulation_WithNestedElement()
+		{
+			Run("UITests.Windows_UI_Input.GestureRecognizerTests.Manipulation_WithNestedElement");
+
+			var rect = _app.WaitForElement("_target").Single().Rect;
+			_app.DragCoordinates(rect.X + 10, rect.Y + 10, rect.Right - 10, rect.Bottom - 10);
+
+			var result = _app.Marked("_result").GetDependencyPropertyValue<string>("Text");
+
+			Assert.IsTrue(result.Contains("[PARENT] Manip delta\r\n[CHILD] Pointer moved\r\n[PARENT] Manip delta\r\n[CHILD] Pointer moved\r\n"));
 		}
 
 		private static (Point position, ManipulationDelta delta, ManipulationDelta cumulative) Parse(string raw)

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
@@ -54,8 +54,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			_app.DragCoordinates(rect.X + 10, rect.Y + 10, rect.Right - 10, rect.Bottom - 10);
 
 			var result = _app.Marked("_result").GetDependencyPropertyValue<string>("Text");
+			result = result.Replace("\r", "").Replace("\n", "");
 
-			Assert.IsTrue(result.Contains("[PARENT] Manip delta\r\n[CHILD] Pointer moved\r\n[PARENT] Manip delta\r\n[CHILD] Pointer moved\r\n"));
+			Assert.IsTrue(result.Contains("[PARENT] Manip delta[CHILD] Pointer moved[PARENT] Manip delta[CHILD] Pointer moved"));
 		}
 
 		private static (Point position, ManipulationDelta delta, ManipulationDelta cumulative) Parse(string raw)

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -169,6 +169,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\Manipulation_WithNestedElement.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\RightTappedTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3236,6 +3240,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\Manipulation_WhenInScrollViewer.xaml.cs">
       <DependentUpon>Manipulation_WhenInScrollViewer.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\Manipulation_WithNestedElement.xaml.cs">
+      <DependentUpon>Manipulation_WithNestedElement.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\RightTappedTests.xaml.cs">
       <DependentUpon>RightTappedTests.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_WithNestedElement.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_WithNestedElement.xaml
@@ -26,6 +26,7 @@
 			ManipulationDelta="OnParentManipDelta"
 			ManipulationCompleted="OnParentManipCompleted">
 			<Border
+				x:Name="_target"
 				Width="100"
 				Height="100"
 				VerticalAlignment="Center"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_WithNestedElement.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_WithNestedElement.xaml
@@ -1,0 +1,50 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Input.GestureRecognizerTests.Manipulation_WithNestedElement"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Input.GestureRecognizerTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition />
+		</Grid.ColumnDefinitions>
+
+		<Border
+			Background="DeepPink"
+			Margin="10"
+			Width="300"
+			Height="300"
+			HorizontalAlignment="Left"
+			VerticalAlignment="Top"
+			ManipulationMode="All"
+			ManipulationStarted="OnParentManipStarted"
+			ManipulationDelta="OnParentManipDelta"
+			ManipulationCompleted="OnParentManipCompleted">
+			<Border
+				Width="100"
+				Height="100"
+				VerticalAlignment="Center"
+				HorizontalAlignment="Center"
+				Background="DeepSkyBlue"
+				PointerPressed="OnChildPointerPressed"
+				PointerMoved="OnChildPointerMoved"
+				PointerReleased="OnChildPointerReleased">
+				<TextBlock Text="The touch target" />
+			</Border>
+		</Border>
+
+		<StackPanel Grid.Column="1">
+			<TextBlock
+				Text="Drag and drop the blue square, you should get a mix of ''[PARENT] Manip delta'' ** AND ** ''[CHILD] Pointer moved''."
+				TextWrapping="Wrap"/>
+			<TextBlock
+				x:Name="_result"
+				TextWrapping="Wrap"/>
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_WithNestedElement.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_WithNestedElement.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Input.GestureRecognizerTests
+{
+	[Sample("Gesture recognizer")]
+	public sealed partial class Manipulation_WithNestedElement : Page
+	{
+		public Manipulation_WithNestedElement()
+		{
+			this.InitializeComponent();
+		}
+
+		private void OnParentManipStarted(object sender, ManipulationStartedRoutedEventArgs e)
+			=> _result.Text += "[PARENT] Manip started\r\n";
+
+		private void OnParentManipDelta(object sender, ManipulationDeltaRoutedEventArgs e)
+			=> _result.Text += "[PARENT] Manip delta\r\n";
+
+		private void OnParentManipCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
+			=> _result.Text += "[PARENT] Manip completed\r\n";
+
+		private void OnChildPointerPressed(object sender, PointerRoutedEventArgs e)
+			=> _result.Text += "[CHILD] Pointer pressed\r\n";
+
+		private void OnChildPointerMoved(object sender, PointerRoutedEventArgs e)
+			=> _result.Text += "[CHILD] Pointer moved\r\n";
+
+		private void OnChildPointerReleased(object sender, PointerRoutedEventArgs e)
+			=> _result.Text += "[CHILD] Pointer released\r\n";
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.PointerCapture.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.PointerCapture.cs
@@ -110,7 +110,7 @@ namespace Windows.UI.Xaml
 					}
 					else
 					{
-						// Add the new king to the target
+						// Add the new kind to the target
 						target.Kind |= kind;
 					}
 				}
@@ -245,7 +245,7 @@ namespace Windows.UI.Xaml
 				}
 				else if (IsImplicitOnly)
 				{
-					// If the capture is implicit, we should not filter out events for child elements.
+					// If the capture is implicit, we should not filter out events for children elements.
 
 					return true;
 				}


### PR DESCRIPTION
GitHub Issue: fixes#https://github.com/unoplatform/uno/issues/2843

## Bugfix
Fix pointers event for elements that are nested in an element that has enabled manipulations.

## What is the current behavior?
When a manipulation stars on an element, it will implicitly capture the pointer to make sure to receive all updates even when pointer moves out of the range of this element. But this will prevent any nested child to receive pointer events (instead they will receive a 'pointerleave' on capture and a 'pointerenter' when releasing capture ... for mouse).

## What is the new behavior?
For implicit captures we use the `OriginalSource` (if possible) instead of the element that is actually capturing the pointer, so event will still bubble up from the lowest layer.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
