### PR TITLE
fix(elevatedview): Patch a TemplateBinding problem.

### DIFF
--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -16,7 +16,7 @@ using _View = AppKit.NSView;
 
 namespace Uno.UI.Toolkit
 {
-	[ContentProperty(Name = "Content")]
+	[ContentProperty(Name = "ElevatedContent")]
 	[TemplatePart(Name = "PART_Border", Type = typeof(Border))]
 	public sealed partial class ElevatedView : Control
 #if !NETFX_CORE
@@ -41,7 +41,7 @@ namespace Uno.UI.Toolkit
 		 *
 		 */
 
-		private Border _border = new Border();
+		private Border _border;
 
 		public ElevatedView()
 		{
@@ -77,13 +77,13 @@ namespace Uno.UI.Toolkit
 			set => SetValue(ShadowColorProperty, value);
 		}
 
-		public static readonly DependencyProperty ContentProperty = DependencyProperty.Register(
-			"Content", typeof(object), typeof(ElevatedView), new PropertyMetadata(default(object)));
+		public static readonly DependencyProperty ElevatedContentProperty = DependencyProperty.Register(
+			"ElevatedContent", typeof(object), typeof(ElevatedView), new PropertyMetadata(default(object)));
 
-		public object Content
+		public object ElevatedContent
 		{
-			get => GetValue(ContentProperty);
-			set => SetValue(ContentProperty, value);
+			get => GetValue(ElevatedContentProperty);
+			set => SetValue(ElevatedContentProperty, value);
 		}
 
 #if !NETFX_CORE

--- a/src/Uno.UI.Toolkit/Themes/Generic.xaml
+++ b/src/Uno.UI.Toolkit/Themes/Generic.xaml
@@ -13,7 +13,7 @@
 						BorderBrush="{TemplateBinding BorderBrush}"
 						BorderThickness="{TemplateBinding BorderThickness}"
 						CornerRadius="{TemplateBinding CornerRadius}"
-						Child="{TemplateBinding Content}" />
+						Child="{TemplateBinding ElevatedContent}" />
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>


### PR DESCRIPTION
## Bugfix

Occurs when the `TemplateParent` binding could be confused and bind to the wrong parent. It should be resolved at parse time, but it's resoved at runtime, so a required context is lost, leading to this problem.

Has been fixed by renaming the content property from `Content` to `ElevatedContent`.

Fix #2853
Unblock https://nventive.visualstudio.com/Umbrella/_workitems/edit/168664

## PR Checklist

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
