### PR TITLE
ci: Fix invalid android platform-tools path

### DIFF
--- a/build/android-uitest-run.sh
+++ b/build/android-uitest-run.sh
@@ -26,6 +26,12 @@ echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'extras;android;m2reposi
 echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-28;google_apis;x86' | tr '\r' '\n' | uniq
 echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "system-images;android-$ANDROID_SIMULATOR_APILEVEL;google_apis;x86" | tr '\r' '\n' | uniq
 
+if [[ -f $ANDROID_HOME/platform-tools/platform-tools/adb ]]
+then
+	# It appears that the platform-tools 29.0.6 are extracting into an incorrect path
+    mv $ANDROID_HOME/platform-tools/platform-tools/* $ANDROID_HOME/platform-tools
+fi
+
 # Create emulator
 echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n xamarin_android_emulator -k "system-images;android-$ANDROID_SIMULATOR_APILEVEL;google_apis;x86" --sdcard 128M --force
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?

When install the android SDK adb (in the `platform-tools` 29.0.6 package) is installed in an incorrect folder by the sdk-manager

## What is the new behavior?

This update moves the incorrect directory to the correct location

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
