### PR TITLE
Improve focus compatibility

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -682,6 +682,12 @@
 				<Member
 					fullName="System.Void Uno.UI.Toolkit.UIElementExtensions.SetElevation(Windows.UI.Xaml.UIElement element, System.Double Elevation)"
 					reason="Naming uniformization, not a binary breaking change." />
+				<Member
+					fullName="System.Void Windows.UI.Xaml.Controls.Control.OnFocusStateChanged(Windows.UI.Xaml.FocusState oldValue, Windows.UI.Xaml.FocusState newValue)"
+					reason="Not part of the WinUI API, Uno-specific implementation detail." />
+				<Member
+					fullName="System.Boolean Windows.UI.Xaml.Controls.TextBox.FocusTextView()"
+					reason="Not part of the WinUI API, Uno-specific implementation detail." />
 			</Methods>
 			<Properties>
 				<Member

--- a/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
@@ -29,7 +29,7 @@ namespace SamplesApp.UITests
 			var runTestCount = _app.Marked("runTestCount");
 
 			bool IsTestExecutionDone()
-				=> runningState.GetDependencyPropertyValue<string>("Text").Equals("Finished", StringComparison.OrdinalIgnoreCase);
+				=> runningState.GetDependencyPropertyValue("Text")?.ToString().Equals("Finished", StringComparison.OrdinalIgnoreCase) ?? false;
 
 			_app.WaitForElement(runButton);
 
@@ -40,7 +40,7 @@ namespace SamplesApp.UITests
 
 			while(DateTimeOffset.Now - lastChange < TestRunTimeout)
 			{
-				var newValue = runTestCount.GetDependencyPropertyValue<string>("Text");
+				var newValue = runTestCount.GetDependencyPropertyValue("Text")?.ToString();
 
 				if (lastValue != newValue)
 				{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -430,5 +430,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			Assert.AreEqual("Testing text property", textChangedTextBlock.GetDependencyPropertyValue("Text")?.ToString());
 			Assert.AreEqual("Testing text property", lostFocusTextBlock.GetDependencyPropertyValue("Text")?.ToString());
 		}
+
+		[Test]
+		[AutoRetry]
+		public void Focus_Programmatic()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_Focus_Programmatic");
+
+			_app.WaitForElement("SetFocus");
+
+			_app.FastTap("SetFocus");
+
+			_app.WaitForText("StatusText", "Got focus");
+
+			_app.EnterText("orangutan");
+
+			_app.WaitForText("TargetTextBox", "orangutan");
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Focus_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Focus_Tests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Input
+{
+	public class Focus_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void Test_FocusState_Interactive()
+		{
+			Run("UITests.Windows_UI_Xaml.FocusManager.Focus_FocusState");
+
+			_app.WaitForElement("YeButton");
+
+			string GetButtonFocusState() => _app.GetText("ButtonFocusStatus");
+			string GetContentControlFocusState() => _app.GetText("ContentControlFocusStatus");
+			string GetTextBoxFocusState() => _app.GetText("TextBoxFocusStatus");
+
+			Assert.AreEqual("Unfocused", GetButtonFocusState());
+			Assert.AreEqual("Unfocused", GetContentControlFocusState());
+			Assert.AreEqual("Unfocused", GetTextBoxFocusState());
+
+			_app.FastTap("YeButton");
+
+			_app.WaitForText("ButtonFocusStatus", "Pointer");
+			Assert.AreEqual("Unfocused", GetContentControlFocusState());
+			Assert.AreEqual("Unfocused", GetTextBoxFocusState());
+
+			_app.FastTap("YeTextBox");
+			_app.WaitForText("TextBoxFocusStatus", "Pointer");
+			Assert.AreEqual("Unfocused", GetButtonFocusState());
+			Assert.AreEqual("Unfocused", GetContentControlFocusState());
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
@@ -103,6 +103,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // Failing on WASM: https://github.com/unoplatform/uno/issues/2905
 		public void TestListViewReleasedOut()
 		{
 			Run("UITests.Shared.Windows_UI_Input.VisualStatesTests.ListViewItem");

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -317,6 +317,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FocusManager\Focus_FocusState.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_NativeLayout.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -862,6 +866,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Disabled.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Focus_Programmatic.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -3114,6 +3122,7 @@
       <DependentUpon>Elevation.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)ValueConverters\BoolNegationValueConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ValueConverters\StringConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_ApplicationModel\Calls\PhoneCallManagerTests.xaml.cs">
       <DependentUpon>PhoneCallManagerTests.xaml</DependentUpon>
     </Compile>
@@ -3271,6 +3280,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FocusManager\FocusManager_GetFocus_Automated.xaml.cs">
       <DependentUpon>FocusManager_GetFocus_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FocusManager\Focus_FocusState.xaml.cs">
+      <DependentUpon>Focus_FocusState.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_NativeLayout.xaml.cs">
       <DependentUpon>FrameworkElement_NativeLayout.xaml</DependentUpon>
@@ -3600,6 +3612,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Disabled.xaml.cs">
       <DependentUpon>TextBox_Disabled.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Focus_Programmatic.xaml.cs">
+      <DependentUpon>TextBox_Focus_Programmatic.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Formatting_Flicker.xaml.cs">
       <DependentUpon>TextBox_Formatting_Flicker.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/ValueConverters/StringConverter.cs
+++ b/src/SamplesApp/UITests.Shared/ValueConverters/StringConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml.Data;
+
+namespace UITests.ValueConverters
+{
+	// This converter is extraneous on Uno, but on UWP displays a readable version of the .NET-mapped type, where without the converter it
+	// would otherwise display an (unreadable) string output of the underlying WinRT type
+	public class StringConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			string str = value?.ToString();
+			return str;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FocusManager/Focus_FocusState.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FocusManager/Focus_FocusState.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml.FocusManager.Focus_FocusState"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:converters="using:UITests.ValueConverters"
+			 xmlns:local="using:UITests.Windows_UI_Xaml.FocusManager"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+	<UserControl.Resources>
+		<converters:StringConverter x:Key="StringConverter" />
+	</UserControl.Resources>
+
+	<Grid>
+		<StackPanel>
+			<Button Content="Dummy" />
+			<Button Content="Is button"
+					x:Name="YeButton" />
+			<TextBlock x:Name="ButtonFocusStatus"
+					   Text="{Binding ElementName=YeButton, Path=FocusState, Converter={StaticResource StringConverter}}" />
+			<ContentControl x:Name="YeContentControl">
+				<Border Background="Pink">
+					<TextBlock Text="Is ContentControl" />
+				</Border>
+			</ContentControl>
+			<TextBlock x:Name="ContentControlFocusStatus"
+					   Text="{Binding ElementName=YeContentControl, Path=FocusState, Converter={StaticResource StringConverter}}" />
+			<TextBox Text="Is TextBox"
+					 x:Name="YeTextBox" />
+			<TextBlock x:Name="TextBoxFocusStatus"
+					   Text="{Binding ElementName=YeTextBox, Path=FocusState, Converter={StaticResource StringConverter}}" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FocusManager/Focus_FocusState.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FocusManager/Focus_FocusState.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml.FocusManager
+{
+	[Sample]
+	public sealed partial class Focus_FocusState : UserControl
+	{
+		public Focus_FocusState()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Focus_Programmatic.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Focus_Programmatic.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_Focus_Programmatic"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<StackPanel>
+			<Button Content="Dummy" />
+			<Button x:Name="SetFocus"
+					Content="Set TextBox focus"
+					Click="SetFocus_Click" />
+			<TextBox x:Name="TargetTextBox"
+					 PlaceholderText="enter..."
+					 GotFocus="TargetTextBox_GotFocus" />
+			<TextBlock x:Name="StatusText" />
+		</StackPanel >
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Focus_Programmatic.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Focus_Programmatic.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBox
+{
+	[Sample]
+	public sealed partial class TextBox_Focus_Programmatic : UserControl
+	{
+		public TextBox_Focus_Programmatic()
+		{
+			this.InitializeComponent();
+		}
+
+		private void SetFocus_Click(object sender, RoutedEventArgs e)
+		{
+			TargetTextBox.Focus(FocusState.Programmatic);
+		}
+
+		private void TargetTextBox_GotFocus(object sender, RoutedEventArgs e)
+		{
+			StatusText.Text = "Got focus";
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
+{
+	[TestClass]
+	public class Given_FocusManager
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task GotLostFocus()
+		{
+			try
+			{
+				var panel = new StackPanel();
+				var wasEventRaised = false;
+
+				var receivedGotFocus = new bool[4];
+				var receivedLostFocus = new bool[4];
+
+				var buttons = new Button[4];
+				for (int i = 0; i < 4; i++)
+				{
+					var button = new Button
+					{
+						Content = $"Button {i}",
+						Name = $"Button{i}"
+					};
+
+					panel.Children.Add(button);
+					buttons[i] = button;
+				}
+
+				TestServices.WindowHelper.WindowContent = panel;
+
+				await TestServices.WindowHelper.WaitForIdle();
+
+				const int tries = 10;
+				var initialSuccess = false;
+				for (int i = 0; i < tries; i++)
+				{
+					initialSuccess = buttons[0].Focus(FocusState.Programmatic);
+					if (initialSuccess)
+					{
+						break;
+					}
+					//await TestServices.WindowHelper.WaitForIdle(); //
+					await Task.Delay(50); //
+				}
+				
+				Assert.IsTrue(initialSuccess);
+				AssertHasFocus(buttons[0]);
+				await TestServices.WindowHelper.WaitForIdle();
+
+				AssertHasFocus(buttons[0]);
+
+				for (int i = 0; i < 4; i++)
+				{
+					var inner = i;
+					buttons[i].GotFocus += (o, e) =>
+					{
+						receivedGotFocus[inner] = true;
+						wasEventRaised = true;
+						Assert.IsNotNull(FocusManager.GetFocusedElement());
+					};
+
+					buttons[i].LostFocus += (o, e) =>
+					{
+						receivedLostFocus[inner] = true;
+						wasEventRaised = true;
+						Assert.IsNotNull(FocusManager.GetFocusedElement());
+					};
+				}
+
+				FocusManager.GotFocus += (o, e) =>
+				{
+					Assert.IsNotNull(FocusManager.GetFocusedElement());
+					wasEventRaised = true;
+				};
+				FocusManager.LostFocus += (o, e) =>
+				{
+					Assert.IsNotNull(FocusManager.GetFocusedElement());
+					wasEventRaised = true;
+				};
+
+				buttons[1].Focus(FocusState.Programmatic);
+				buttons[3].Focus(FocusState.Programmatic);
+				buttons[2].Focus(FocusState.Programmatic);
+
+				AssertHasFocus(buttons[2]);
+				Assert.IsFalse(wasEventRaised);
+				await TestServices.WindowHelper.WaitForIdle();
+				AssertHasFocus(buttons[2]);
+				Assert.IsTrue(wasEventRaised);
+
+				Assert.IsFalse(receivedGotFocus[0]);
+				Assert.IsTrue(receivedGotFocus[1]);
+				Assert.IsTrue(receivedGotFocus[2]);
+				Assert.IsTrue(receivedGotFocus[3]);
+
+				Assert.IsTrue(receivedLostFocus[0]);
+				Assert.IsTrue(receivedLostFocus[1]);
+				Assert.IsFalse(receivedLostFocus[2]);
+				Assert.IsTrue(receivedLostFocus[3]);
+				;
+			}
+			finally
+			{
+				TestServices.WindowHelper.WindowContent = null;
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task IsTabStop_False_Check_Inner()
+		{
+			var outerControl = new ContentControl() { IsTabStop = false };
+			var innerControl = new Button { Content = "Inner" };
+			var contentRoot = new Border
+			{
+				Child = new Grid
+				{
+					Children =
+					{
+						new TextBlock {Text = "Spinach"},
+						innerControl
+					}
+				}
+			};
+			outerControl.Content = contentRoot;
+
+			TestServices.WindowHelper.WindowContent = outerControl;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			outerControl.Focus(FocusState.Programmatic);
+			AssertHasFocus(innerControl);
+			Assert.AreEqual(FocusState.Unfocused, outerControl.FocusState);
+
+			TestServices.WindowHelper.WindowContent = null;
+		}
+
+		private void AssertHasFocus(Control control)
+		{
+			Assert.IsNotNull(control);
+			var focused = FocusManager.GetFocusedElement();
+			Assert.IsNotNull(focused);
+			Assert.AreEqual(focused, control);
+			Assert.AreNotEqual(FocusState.Unfocused, control.FocusState);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
@@ -110,7 +110,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 				Assert.IsTrue(receivedLostFocus[1]);
 				Assert.IsFalse(receivedLostFocus[2]);
 				Assert.IsTrue(receivedLostFocus[3]);
-				;
 			}
 			finally
 			{

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -153,6 +153,7 @@ declare namespace Uno.UI {
         private allActiveElementsById;
         private static resizeMethod;
         private static dispatchEventMethod;
+        private static focusInMethod;
         private static getDependencyPropertyValueMethod;
         private static setDependencyPropertyValueMethod;
         private constructor();
@@ -520,6 +521,7 @@ declare namespace Uno.UI {
         private initDom;
         private removeLoading;
         private resize;
+        private onfocusin;
         private dispatchEvent;
         private getIsConnectedToRootElement;
         setCursor(cssCursor: string): string;

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -522,6 +522,7 @@ declare namespace Uno.UI {
         private removeLoading;
         private resize;
         private onfocusin;
+        private onWindowBlur;
         private dispatchEvent;
         private getIsConnectedToRootElement;
         setCursor(cssCursor: string): string;

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -1548,6 +1548,7 @@ var Uno;
                         x.preventDefault();
                     }
                 });
+                window.addEventListener("blur", this.onWindowBlur);
             }
             removeLoading() {
                 if (!this.loadingElementId) {
@@ -1578,6 +1579,15 @@ var Uno;
                     const handle = newFocus.getAttribute("XamlHandle");
                     const htmlId = handle ? Number(handle) : -1; // newFocus may not be an Uno element
                     WindowManager.focusInMethod(htmlId);
+                }
+            }
+            onWindowBlur() {
+                if (WindowManager.isHosted) {
+                    console.warn("Focus not supported in hosted mode");
+                }
+                else {
+                    // Unset managed focus when Window loses focus
+                    WindowManager.focusInMethod(-1);
                 }
             }
             dispatchEvent(element, eventName, eventPayload = null) {

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -1529,6 +1529,9 @@ var Uno;
                     if (!WindowManager.dispatchEventMethod) {
                         WindowManager.dispatchEventMethod = Module.mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.UIElement:DispatchEvent");
                     }
+                    if (!WindowManager.focusInMethod) {
+                        WindowManager.focusInMethod = Module.mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Input.FocusManager:ReceiveFocusNative");
+                    }
                 }
             }
             initDom() {
@@ -1536,8 +1539,9 @@ var Uno;
                 if (!this.containerElement) {
                     // If not found, we simply create a new one.
                     this.containerElement = document.createElement("div");
-                    document.body.appendChild(this.containerElement);
                 }
+                document.body.addEventListener("focusin", this.onfocusin);
+                document.body.appendChild(this.containerElement);
                 window.addEventListener("resize", x => this.resize());
                 window.addEventListener("contextmenu", x => {
                     if (!(x.target instanceof HTMLInputElement)) {
@@ -1563,6 +1567,17 @@ var Uno;
                 }
                 else {
                     WindowManager.resizeMethod(document.documentElement.clientWidth, document.documentElement.clientHeight);
+                }
+            }
+            onfocusin(event) {
+                if (WindowManager.isHosted) {
+                    console.warn("Focus not supported in hosted mode");
+                }
+                else {
+                    const newFocus = event.target;
+                    const handle = newFocus.getAttribute("XamlHandle");
+                    const htmlId = handle ? Number(handle) : -1; // newFocus may not be an Uno element
+                    WindowManager.focusInMethod(htmlId);
                 }
             }
             dispatchEvent(element, eventName, eventPayload = null) {

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -1612,6 +1612,7 @@
 					x.preventDefault();
 				}
 			})
+			window.addEventListener("blur", this.onWindowBlur);
 		}
 
 		private removeLoading() {
@@ -1649,6 +1650,16 @@
 				const handle = (newFocus as HTMLElement).getAttribute("XamlHandle");
 				const htmlId = handle ? Number(handle) : -1; // newFocus may not be an Uno element
 				WindowManager.focusInMethod(htmlId);
+			}
+		}
+
+		private onWindowBlur() {
+			if (WindowManager.isHosted) {
+				console.warn("Focus not supported in hosted mode");
+			}
+			else {
+				// Unset managed focus when Window loses focus
+				WindowManager.focusInMethod(-1);
 			}
 		}
 

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -134,6 +134,7 @@
 
 		private static resizeMethod: any;
 		private static dispatchEventMethod: any;
+		private static focusInMethod: any;
 		private static getDependencyPropertyValueMethod: any;
 		private static setDependencyPropertyValueMethod: any;
 
@@ -1589,6 +1590,10 @@
 				if (!WindowManager.dispatchEventMethod) {
 					WindowManager.dispatchEventMethod = (<any>Module).mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.UIElement:DispatchEvent");
 				}
+
+				if (!WindowManager.focusInMethod) {
+					WindowManager.focusInMethod = (<any>Module).mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Input.FocusManager:ReceiveFocusNative");
+				}
 			}
 		}
 
@@ -1597,8 +1602,9 @@
 			if (!this.containerElement) {
 				// If not found, we simply create a new one.
 				this.containerElement = document.createElement("div");
-				document.body.appendChild(this.containerElement);
 			}
+			document.body.addEventListener("focusin", this.onfocusin);
+			document.body.appendChild(this.containerElement);
 
 			window.addEventListener("resize", x => this.resize());
 			window.addEventListener("contextmenu", x => {
@@ -1631,6 +1637,18 @@
 			}
 			else {
 				WindowManager.resizeMethod(document.documentElement.clientWidth, document.documentElement.clientHeight);
+			}
+		}
+
+		private onfocusin(event: Event) {
+			if (WindowManager.isHosted) {
+				console.warn("Focus not supported in hosted mode");
+			}
+			else {
+				const newFocus = event.target;
+				const handle = (newFocus as HTMLElement).getAttribute("XamlHandle");
+				const htmlId = handle ? Number(handle) : -1; // newFocus may not be an Uno element
+				WindowManager.focusInMethod(htmlId);
 			}
 		}
 

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/FocusManager.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/FocusManager.cs
@@ -71,7 +71,7 @@ namespace Windows.UI.Xaml.Input
 			throw new global::System.NotImplementedException("The member DependencyObject FocusManager.FindNextElement(FocusNavigationDirection focusNavigationDirection, FindNextElementOptions focusNavigationOptions) is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || false || false
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.UIElement FindNextFocusableElement( global::Windows.UI.Xaml.Input.FocusNavigationDirection focusNavigationDirection)
 		{
@@ -85,14 +85,14 @@ namespace Windows.UI.Xaml.Input
 			throw new global::System.NotImplementedException("The member UIElement FocusManager.FindNextFocusableElement(FocusNavigationDirection focusNavigationDirection, Rect hintRect) is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || false || false
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public static bool TryMoveFocus( global::Windows.UI.Xaml.Input.FocusNavigationDirection focusNavigationDirection)
 		{
 			throw new global::System.NotImplementedException("The member bool FocusManager.TryMoveFocus(FocusNavigationDirection focusNavigationDirection) is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || false || false
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public static object GetFocusedElement()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.Android.cs
@@ -50,21 +50,5 @@ namespace Windows.UI.Xaml.Controls
 		{
 			return this.GetChildren()?.FirstOrDefault() as IFrameworkElement;
 		}
-
-		partial void OnFocusStateChangedPartial(FocusState oldValue, FocusState newValue)
-		{
-			if (newValue == FocusState.Pointer && Focusable)
-			{
-				//Set native focus to this view
-				RequestFocus();
-			}
-		}
-
-		protected virtual bool RequestFocus(FocusState state)
-		{
-			FocusState = state;
-
-			return true;
-		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -146,7 +146,7 @@ namespace Windows.UI.Xaml.Controls
 
 				if (value != null)
 				{
-					if(_templatedRoot is IDependencyObjectStoreProvider provider)
+					if (_templatedRoot is IDependencyObjectStoreProvider provider)
 					{
 						provider.Store.SetValue(provider.Store.TemplatedParentProperty, this, DependencyPropertyValuePrecedences.Local);
 					}
@@ -310,7 +310,7 @@ namespace Windows.UI.Xaml.Controls
 				&& NameScope.GetNameScope(root) is INameScope nameScope
 				&& nameScope.FindName(name) is DependencyObject element
 				// Doesn't currently support ElementStub (fallbacks to other FindName implementation)
-				&& !(element is ElementStub) 
+				&& !(element is ElementStub)
 					? element
 					: null;
 		}
@@ -363,7 +363,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			if (
-				!FeatureConfiguration.FrameworkElement.UseLegacyApplyStylePhase && 
+				!FeatureConfiguration.FrameworkElement.UseLegacyApplyStylePhase &&
 				FeatureConfiguration.FrameworkElement.ClearPreviousOnStyleChange
 			)
 			{
@@ -610,8 +610,7 @@ namespace Windows.UI.Xaml.Controls
 				typeof(FocusState),
 				typeof(Control),
 				new PropertyMetadata(
-					(FocusState)FocusState.Unfocused,
-					(s, e) => ((Control)s)?.OnFocusStateChanged((FocusState)e.OldValue, (FocusState)e.NewValue)
+					(FocusState)FocusState.Unfocused
 				)
 			);
 
@@ -668,11 +667,13 @@ namespace Windows.UI.Xaml.Controls
 				throw new ArgumentException("Value does not fall within the expected range.", nameof(value));
 			}
 
-#if __WASM__
-			return Visibility == Visibility.Visible && IsEnabled && RequestFocus(value);
-#else
-			return IsFocusable && RequestFocus(value);
-#endif
+			return RequestFocus(value);
+		}
+
+
+		protected virtual bool RequestFocus(FocusState state)
+		{
+			return FocusManager.SetFocusedElement(this, FocusNavigationDirection.None, state);
 		}
 
 		internal void Unfocus()
@@ -736,29 +737,12 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnBorderBrushChangedPartial(Brush oldValue, Brush newValue);
 
-		protected virtual void OnFocusStateChanged(FocusState oldValue, FocusState newValue)
+		internal virtual void UpdateFocusState(FocusState focusState)
 		{
-			if (newValue == FocusState.Unfocused && oldValue == newValue)
-			{
-				return;
-			}
-
-			OnFocusStateChangedPartial(oldValue, newValue);
-#if XAMARIN || __WASM__
-			FocusManager.OnFocusChanged(this, newValue);
-#endif
-
-			if (newValue == FocusState.Unfocused)
-			{
-				RaiseEvent(LostFocusEvent, new RoutedEventArgs(this));
-			}
-			else
-			{
-				RaiseEvent(GotFocusEvent, new RoutedEventArgs(this));
-			}
+			FocusState = focusState;
 		}
 
-		partial void OnFocusStateChangedPartial(FocusState oldValue, FocusState newValue);
+		partial void UpdateFocusStatePartial(FocusState focusState);
 
 		protected virtual void OnPointerPressed(PointerRoutedEventArgs args) { }
 		protected virtual void OnPointerReleased(PointerRoutedEventArgs args) { }

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.iOSmacOS.cs
@@ -60,13 +60,6 @@ namespace Windows.UI.Xaml.Controls
 
 			AddSubview(child);
 		}
-
-		protected virtual bool RequestFocus(FocusState state)
-		{
-			FocusState = state;
-
-			return true;
-		}
 	}
 }
 

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.net.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.net.cs
@@ -41,21 +41,5 @@ namespace Windows.UI.Xaml.Controls
 		{
 			return this.GetChildren()?.FirstOrDefault() as IFrameworkElement;
 		}
-
-		protected virtual bool RequestFocus(FocusState state)
-		{
-			FocusState = state;
-
-			return true;
-		}
-
-		partial void OnFocusStateChangedPartial(FocusState oldValue, FocusState newValue)
-		{
-			//if (newValue == FocusState.Pointer && Focusable)
-			//{
-			//	//Set native focus to this view
-			//	RequestFocus();
-			//}
-		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.wasm.cs
@@ -18,7 +18,7 @@ namespace Windows.UI.Xaml.Controls
 	{
 		/// This binary compatibility workaround that can be removed
 		public new static DependencyProperty IsEnabledProperty => FrameworkElement.IsEnabledProperty;
-		
+
 		public Control(string htmlTag = "div") : base(htmlTag)
 		{
 			InitializeControl();
@@ -46,15 +46,6 @@ namespace Windows.UI.Xaml.Controls
 			return this.GetChildren()?.FirstOrDefault() as IFrameworkElement;
 		}
 
-		partial void OnFocusStateChangedPartial(FocusState oldValue, FocusState newValue)
-		{
-			//if (newValue == FocusState.Pointer && Focusable)
-			//{
-			//	//Set native focus to this view
-			//	RequestFocus();
-			//}
-		}
-
 		partial void OnIsFocusableChanged()
 		{
 			var isFocusable = IsFocusable && !IsDelegatingFocusToTemplateChild();
@@ -63,40 +54,5 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		protected virtual bool IsDelegatingFocusToTemplateChild() => false;
-
-		private FocusState? _pendingFocusRequestState;
-		protected virtual bool RequestFocus(FocusState state)
-		{
-			try
-			{
-				_pendingFocusRequestState = state;
-				return FocusManager.Focus(this);
-			}
-			finally
-			{
-				_pendingFocusRequestState = null;
-			}
-		}
-
-		internal bool SetFocused(bool isFocused)
-		{
-			if (isFocused)
-			{
-				if (IsFocusable)
-				{
-					FocusState = _pendingFocusRequestState ?? FocusState.Pointer;
-					return true;
-				}
-				else
-				{
-					return false;
-				}
-			}
-			else
-			{
-				Unfocus();
-				return true;
-			}
-		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -71,14 +71,14 @@ namespace Windows.UI.Xaml.Controls
 			if (_textBoxView != null)
 			{
 				_textBoxView.OnFocusChangeListener = null;
-			}
 
-			// We always force lose the focus when unloading the control.
-			// This is required as the FocusChangedListener may not be called
-			// when the unloaded propagation is done on the .NET side (see
-			// FeatureConfiguration.FrameworkElement.AndroidUseManagedLoadedUnloaded for
-			// more details.
-			ProcessFocusChanged(false);
+				// We always force lose the focus when unloading the control.
+				// This is required as the FocusChangedListener may not be called
+				// when the unloaded propagation is done on the .NET side (see
+				// FeatureConfiguration.FrameworkElement.AndroidUseManagedLoadedUnloaded for
+				// more details.
+				ProcessFocusChanged(false);
+			}
 		}
 
 		protected override void OnLoaded()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -19,6 +19,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.Foundation;
 using Windows.UI.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -153,7 +154,8 @@ namespace Windows.UI.Xaml.Controls
 		public string Text
 		{
 			get => (string)this.GetValue(TextProperty);
-			set {
+			set
+			{
 				if (value == null)
 				{
 					throw new ArgumentNullException();
@@ -581,12 +583,15 @@ namespace Windows.UI.Xaml.Controls
 
 		#endregion
 
-		protected override void OnFocusStateChanged(FocusState oldValue, FocusState newValue)
-			=> OnFocusStateChanged(oldValue, newValue, initial: false);
+		internal override void UpdateFocusState(FocusState focusState)
+		{
+			var oldValue = FocusState;
+			base.UpdateFocusState(focusState);
+			OnFocusStateChanged(oldValue, focusState, initial: false);
+		}
 
 		private void OnFocusStateChanged(FocusState oldValue, FocusState newValue, bool initial)
 		{
-			base.OnFocusStateChanged(oldValue, newValue);
 			OnFocusStateChangedPartial(newValue);
 
 			if (!initial && newValue == FocusState.Unfocused && _hasTextChangedThisFocusSession)
@@ -646,6 +651,11 @@ namespace Windows.UI.Xaml.Controls
 
 		private void UpdateButtonStates()
 		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug(nameof(UpdateButtonStates));
+			}
+
 			if (Text.HasValue()
 				&& FocusState != FocusState.Unfocused
 				&& !IsReadOnly

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -12,7 +12,7 @@ namespace Windows.UI.Xaml.Controls
 		protected override bool IsDelegatingFocusToTemplateChild() => true; // _textBoxView
 		protected override bool RequestFocus(FocusState state) => FocusTextView();
 		partial void OnTextClearedPartial() => FocusTextView();
-		protected virtual bool FocusTextView() => FocusManager.Focus(_textBoxView);
+		protected virtual bool FocusTextView() => FocusManager.FocusNative(_textBoxView);
 
 		private void UpdateTextBoxView()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -10,9 +10,8 @@ namespace Windows.UI.Xaml.Controls
 		private TextBoxView _textBoxView;
 		
 		protected override bool IsDelegatingFocusToTemplateChild() => true; // _textBoxView
-		protected override bool RequestFocus(FocusState state) => FocusTextView();
 		partial void OnTextClearedPartial() => FocusTextView();
-		protected virtual bool FocusTextView() => FocusManager.FocusNative(_textBoxView);
+		internal bool FocusTextView() => FocusManager.FocusNative(_textBoxView);
 
 		private void UpdateTextBoxView()
 		{

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.Android.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Windows.UI.Xaml.Controls;
 using Android.Graphics;
+using Windows.UI.ViewManagement;
 
 namespace Windows.UI.Xaml.Input
 {
@@ -38,7 +39,7 @@ namespace Windows.UI.Xaml.Input
 				var inputManager = activity?.GetSystemService(Android.Content.Context.InputMethodService) as Android.Views.InputMethods.InputMethodManager;
 				inputManager?.HideSoftInputFromWindow(activity?.CurrentFocus?.WindowToken, Android.Views.InputMethods.HideSoftInputFlags.None);
 			}
-			
+
 			return nextFocused?.RequestFocus(FocusSearchDirection.Forward) ?? false;
 		}
 
@@ -210,6 +211,17 @@ namespace Windows.UI.Xaml.Input
 
 				default:
 					return null;
+			}
+		}
+
+		private static void FocusNative(Control control)
+		{
+			control.RequestFocus();
+
+			// Forcefully try to bring the control into view when keyboard is open to accommodate adjust nothing mode
+			if (InputPane.GetForCurrentView().Visible)
+			{
+				control.StartBringIntoView();
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.cs
@@ -1,5 +1,4 @@
-﻿#if XAMARIN || __WASM__
-using Windows.UI.Xaml.Input;
+﻿using Windows.UI.Xaml.Input;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -146,4 +145,3 @@ namespace Windows.UI.Xaml.Input
 
 	}
 }
-#endif

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.cs
@@ -18,10 +18,6 @@ namespace Windows.UI.Xaml.Input
 
 		private static object _focusedElement;
 
-		// We keep a _fallbackFocused as backup if an element is unfocused and try move focus is called right after
-		// It is currently the case in ContextualCommand.
-		private static object _fallbackFocusedElement;
-
 		/// <summary>
 		/// Get the currently focused element, if any
 		/// </summary>
@@ -144,8 +140,6 @@ namespace Windows.UI.Xaml.Input
 
 			CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.Normal, OnGotFocus); // event is rescheduled, as on UWP
 		}
-
-		internal static object GetFocusedElement(bool useFallback) => GetFocusedElement() ?? _fallbackFocusedElement;
 
 		public static event EventHandler<FocusManagerGotFocusEventArgs> GotFocus;
 		public static event EventHandler<FocusManagerLostFocusEventArgs> LostFocus;

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.cs
@@ -102,9 +102,15 @@ namespace Windows.UI.Xaml.Input
 
 			FocusNative(newFocus as Control);
 
-			RaiseLostFocusEvent(oldFocusedElement);
+			if (oldFocusedElement != null)
+			{
+				RaiseLostFocusEvent(oldFocusedElement);
+			}
 
-			RaiseGotFocusEvent(_focusedElement);
+			if (_focusedElement != null)
+			{
+				RaiseGotFocusEvent(_focusedElement);
+			}
 
 			return true;
 		}

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.iOS.cs
@@ -12,7 +12,7 @@ namespace Windows.UI.Xaml.Input
 	{
 		private static bool InnerTryMoveFocus(FocusNavigationDirection focusNavigationDirection)
 		{
-			var focusedView = GetFocusedElement(true) as UIView;
+			var focusedView = GetFocusedElement() as UIView;
 
 			if (focusedView == null)
 			{
@@ -102,7 +102,7 @@ namespace Windows.UI.Xaml.Input
 
 		public static UIView InnerFindNextFocusableElement(FocusNavigationDirection focusNavigationDirection)
 		{
-			var focusedView = GetFocusedElement(true) as UIView;
+			var focusedView = GetFocusedElement() as UIView;
 			var absoluteFocusedFrame = focusedView.ConvertRectToView(focusedView.Bounds, UIApplication.SharedApplication.KeyWindow);
 			
 			var focusableViews = SearchOtherFocusableViews(focusedView);

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.iOS.cs
@@ -208,6 +208,8 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 
+		private static void FocusNative(Control control) => control.BecomeFirstResponder();
+
 		//We need to validate this difference because focused elements don't have the same absolute position once focused
 		private static bool IsInBetweenOrEqual(nfloat number, nfloat lowerlimit, nfloat highlimit)
 		{

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.macOS.cs
@@ -213,6 +213,8 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 
+		private static void FocusNative(Control control) => control.BecomeFirstResponder();
+
 		//We need to validate this difference because focused elements don't have the same absolute position once focused
 		private static bool IsInBetweenOrEqual(nfloat number, nfloat lowerlimit, nfloat highlimit)
 		{

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.macOS.cs
@@ -12,7 +12,7 @@ namespace Windows.UI.Xaml.Input
 	{
 		private static bool InnerTryMoveFocus(FocusNavigationDirection focusNavigationDirection)
 		{
-			var focusedView = GetFocusedElement(true) as NSView;
+			var focusedView = GetFocusedElement() as NSView;
 
 			if (focusedView == null)
 			{
@@ -107,7 +107,7 @@ namespace Windows.UI.Xaml.Input
 
 		public static NSView InnerFindNextFocusableElement(FocusNavigationDirection focusNavigationDirection)
 		{
-			var focusedView = GetFocusedElement(true) as NSView;
+			var focusedView = GetFocusedElement() as NSView;
 			var absoluteFocusedFrame = focusedView.ConvertRectToView(focusedView.Bounds, NSApplication.SharedApplication.KeyWindow.ContentView);
 			
 			var focusableViews = SearchOtherFocusableViews(focusedView);

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.net.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.net.cs
@@ -49,5 +49,7 @@ namespace Windows.UI.Xaml.Input
 		{
 			throw new NotImplementedException();
 		}
+
+		private static void FocusNative(object toFocus) { }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -10,43 +10,25 @@ namespace Windows.UI.Xaml.Input
 {
 	public partial class FocusManager
 	{
-		private static readonly RoutedEventHandler OnControlFocused
-			= (control, args) => ProcessControlFocus(control, args);
-
-		/// <remarks>
-		/// This method is extracted to allow for the mono-wasm to set breakpoints.
-		/// </remarks>
-		private static void ProcessControlFocus(object control, RoutedEventArgs args)
+		internal static void ProcessControlFocused(Control control)
 		{
 			if (
-				// Only act if the origin of the event is the control itself
-				ReferenceEquals(control, args.OriginalSource)
-
 				// Don't change the focus if the control already has the focus
-				&& !ReferenceEquals(control, _focusedElement))
+				!ReferenceEquals(control, _focusedElement))
 			{
 				// Make sure that the managed UI knowns that the element was unfocused, no matter if the new focused element can be focused or not
 				(_focusedElement as Control)?.SetFocused(false);
 
 				// Then set the new control as focused
-				((Control)control).SetFocused(true);
+				control.SetFocused(true);
 			}
 		}
 
-		private static readonly RoutedEventHandler OnElementFocused
-			= (element, args) => ProcessElementFocused(element, args);
-
-		/// <remarks>
-		/// This method is extracted to allow for the mono-wasm to set breakpoints.
-		/// </remarks>
-		private static void ProcessElementFocused(object element, RoutedEventArgs args)
+		internal static void ProcessElementFocused(UIElement element)
 		{
 			if (
-				// Only act if the origin of the event is the element itself
-				ReferenceEquals(element, args.OriginalSource)
-
 				// Don't change the focus if the element already has the focus
-				&& !ReferenceEquals(element, _focusedElement))
+				!ReferenceEquals(element, _focusedElement))
 			{
 				// Try to find the first focusable parent and set it as focused, otherwise just keep it for reference (GetFocusedElement())
 				var ownerControl = element.GetParents().OfType<Control>().Where(control => control.IsFocusable).FirstOrDefault();
@@ -68,15 +50,6 @@ namespace Windows.UI.Xaml.Input
 					}
 				}
 			}
-		}
-
-		internal static void Track(UIElement element)
-		{
-			var handler = element is Control
-				? OnControlFocused
-				: OnElementFocused;
-
-			element.GotFocus += handler;
 		}
 
 		internal static bool Focus(UIElement element)

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Uno.Foundation;
+using Microsoft.Extensions.Logging;
 
 namespace Windows.UI.Xaml.Input
 {
@@ -12,48 +13,33 @@ namespace Windows.UI.Xaml.Input
 	{
 		internal static void ProcessControlFocused(Control control)
 		{
-			if (
-				// Don't change the focus if the control already has the focus
-				!ReferenceEquals(control, _focusedElement))
+			if (_log.Value.IsEnabled(LogLevel.Debug))
 			{
-				// Make sure that the managed UI knowns that the element was unfocused, no matter if the new focused element can be focused or not
-				(_focusedElement as Control)?.SetFocused(false);
-
-				// Then set the new control as focused
-				control.SetFocused(true);
+				_log.Value.LogDebug($"{nameof(ProcessControlFocused)}() _focusedElement={_focusedElement}, control={control}");
 			}
+
+			UpdateFocus(control, FocusNavigationDirection.None, FocusState.Pointer);
 		}
 
 		internal static void ProcessElementFocused(UIElement element)
 		{
-			if (
-				// Don't change the focus if the element already has the focus
-				!ReferenceEquals(element, _focusedElement))
+			if (_log.Value.IsEnabled(LogLevel.Debug))
 			{
-				// Try to find the first focusable parent and set it as focused, otherwise just keep it for reference (GetFocusedElement())
-				var ownerControl = element.GetParents().OfType<Control>().Where(control => control.IsFocusable).FirstOrDefault();
-				if (ownerControl == null)
-				{
-					// Make sure that the managed UI knows that the element was unfocused, no matter if the new focused element can be focused or not
-					(_focusedElement as Control)?.SetFocused(false);
-
-					_focusedElement = element;
-				}
-				else if (!ReferenceEquals(ownerControl, _focusedElement))
-				{
-					// Make sure that the managed UI knows that the element was unfocused, no matter if the new focused element can be focused or not
-					(_focusedElement as Control)?.SetFocused(false);
-
-					if (ownerControl.SetFocused(true))
-					{
-						_fallbackFocusedElement = element;
-					}
-				}
+				_log.Value.LogDebug($"{nameof(ProcessElementFocused)}() _focusedElement={_focusedElement}, element={element}");
 			}
+
+			// Try to find the first focusable parent and set it as focused, otherwise just keep it for reference (GetFocusedElement())
+			var ownerControl = element.GetParents().OfType<Control>().Where(control => control.IsFocusable).FirstOrDefault();
+			UpdateFocus(ownerControl, FocusNavigationDirection.None, FocusState.Pointer);
 		}
 
-		internal static bool Focus(UIElement element)
+		internal static bool FocusNative(UIElement element)
 		{
+			if (_log.Value.IsEnabled(LogLevel.Debug))
+			{
+				_log.Value.LogDebug($"{nameof(FocusNative)}(element: {element})");
+			}
+
 			if (element == null)
 			{
 				return false;

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -6,11 +6,17 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Uno.Foundation;
 using Microsoft.Extensions.Logging;
+using Uno;
 
 namespace Windows.UI.Xaml.Input
 {
 	public partial class FocusManager
 	{
+		/// <summary>
+		/// True during a call to native focusView().
+		/// </summary>
+		private static bool _isCallingFocusNative;
+
 		internal static void ProcessControlFocused(Control control)
 		{
 			if (_log.Value.IsEnabled(LogLevel.Debug))
@@ -50,10 +56,52 @@ namespace Windows.UI.Xaml.Input
 				return textBox.FocusTextView();
 			}
 
+			_isCallingFocusNative = true;
 			var command = $"Uno.UI.WindowManager.current.focusView({element.HtmlId});";
 			WebAssemblyRuntime.InvokeJS(command);
+			_isCallingFocusNative = false;
 
 			return true;
+		}
+
+		[Preserve]
+		public static void ReceiveFocusNative(int handle)
+		{
+			if (_isCallingFocusNative)
+			{
+				// We triggered this callback by calling focusView() ourselves, ignore it so we don't overwrite the FocusState
+				return;
+			}
+			var focused = GetFocusElementFromHandle(handle);
+			if (_log.Value.IsEnabled(LogLevel.Debug))
+			{
+				_log.Value.LogDebug($"{nameof(ReceiveFocusNative)}({focused?.ToString() ?? "[null]"})");
+			}
+
+			if (focused is Control control)
+			{
+				ProcessControlFocused(control);
+			}
+			else if (focused != null)
+			{
+				ProcessElementFocused(focused);
+			}
+			else
+			{
+				// This might occur if a non-Uno element receives focus
+				UpdateFocus(null, FocusNavigationDirection.None, FocusState.Pointer);
+			}
+		}
+
+		private static UIElement GetFocusElementFromHandle(int handle)
+		{
+
+			if (handle == -1)
+			{
+				// 
+				return null;
+			}
+			return UIElement.GetElementFromHandle(handle);
 		}
 
 		private static bool InnerTryMoveFocus(FocusNavigationDirection focusNavigationDirection)

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -45,6 +45,11 @@ namespace Windows.UI.Xaml.Input
 				return false;
 			}
 
+			if (element is TextBox textBox)
+			{
+				return textBox.FocusTextView();
+			}
+
 			var command = $"Uno.UI.WindowManager.current.focusView({element.HtmlId});";
 			WebAssemblyRuntime.InvokeJS(command);
 

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -102,8 +102,6 @@ namespace Windows.UI.Xaml
 
 			InitializePointers();
 			UpdateHitTest();
-
-			TrackFocus();
 		}
 
 		~UIElement()
@@ -573,36 +571,6 @@ namespace Windows.UI.Xaml
 
 		// We keep track of registered routed events to avoid registering the same one twice (mainly because RemoveHandler is not implemented)
 		private RoutedEventFlag _registeredRoutedEvents;
-
-		/// <summary>
-		/// Initialize handler for native focus event.
-		/// </summary>
-		private void TrackFocus()
-		{
-			var handler = this is Control ? (Func<bool>)ProcessControlFocused : ProcessElementFocused;
-
-			RegisterEventHandler(
-				eventName: "focus",
-				handler: new RoutedEventHandlerWithHandled((snd, args) => handler()),
-				onCapturePhase: false,
-				canBubbleNatively: true,
-				eventFilter: HtmlEventFilter.Default,
-				eventExtractor: HtmlEventExtractor.FocusEventExtractor,
-				payloadConverter: PayloadToFocusArgs
-			);
-
-			bool ProcessControlFocused()
-			{
-				FocusManager.ProcessControlFocused(this as Control);
-				return true;
-			}
-
-			bool ProcessElementFocused()
-			{
-				FocusManager.ProcessElementFocused(this);
-				return true;
-			}
-		}
 
 		partial void AddKeyHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo)
 		{

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -55,7 +55,7 @@ namespace Windows.UI.Input
 			{
 				if (_log.IsEnabled(LogLevel.Error))
 				{
-					this.Log().Error("Inconsistent state, we already have a pending gesture for a pointer that is going down. Abort the previous gesture.");
+					this.Log().Error($"{Owner} Inconsistent state, we already have a pending gesture for a pointer that is going down. Abort the previous gesture.");
 				}
 				previousGesture.ProcessComplete();
 			}
@@ -104,7 +104,7 @@ namespace Windows.UI.Input
 				{
 					// debug: We might get some PointerMove for mouse even if not pressed,
 					//		  or if gesture was completed by user / other gesture recognizers.
-					_log.Debug("Received a 'Move' for a pointer which was not considered as down. Ignoring event.");
+					_log.Debug($"{Owner} Received a 'Move' for a pointer which was not considered as down. Ignoring event.");
 				}
 			}
 
@@ -132,7 +132,7 @@ namespace Windows.UI.Input
 			{
 				// debug: We might get some PointerMove for mouse even if not pressed,
 				//		  or if gesture was completed by user / other gesture recognizers.
-				_log.Debug("Received a 'Up' for a pointer which was not considered as down. Ignoring event.");
+				_log.Debug($"{Owner} Received a 'Up' for a pointer which was not considered as down. Ignoring event.");
 			}
 
 			_manipulation?.Remove(value);


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #2845, fixes #2846, fixes #1037 

Brings focus handling closer in line with Windows behaviour:
 - `UIElement.GotFocus` and `.LostFocus` are raised asynchronously, and `FocusManager.GetFocusedElement()` always returns correct current value
 - `Control.Focus()` checks all children until it finds one focusable
 - WASM: managed focus is updated when browser window loses focus

Perf improvement for WASM: Native focus event is only handled on the top-level body instead of every element, improving element creation time

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
 - [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
