### PR TITLE
fix(android): Fix for bug #2879

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -421,6 +421,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Layout_Bug2879.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Layout_Constrains.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3333,6 +3337,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_ArrangeOverride_Alignment.xaml.cs">
       <DependentUpon>UIElement_ArrangeOverride_Alignment.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Layout_Bug2879.xaml.cs">
+      <DependentUpon>UIElement_Layout_Bug2879.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Layout_Constrains.xaml.cs">
       <DependentUpon>UIElement_Layout_Constrains.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ButtonClipping652.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ButtonClipping652.xaml.cs
@@ -3,7 +3,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Windows_UI_Xaml.Clipping
 {
-	[SampleControlInfo]
+	[Sample("Clipping", "GH Bugs")]
 	public sealed partial class ButtonClipping652 : Page
 	{
 		public ButtonClipping652()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Layout_Bug2879.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Layout_Bug2879.xaml
@@ -1,0 +1,82 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml.UIElementTests.UIElement_Layout_Bug2879"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel VerticalAlignment="Center" Spacing="8" MaxWidth="350">
+		<TextBlock>
+			This is an illustration of
+			<Hyperlink NavigateUri="https://github.com/unoplatform/uno/issues/2879">Bug #2879</Hyperlink>.
+			To trigger the bug, press few times on the follow button:
+		</TextBlock>
+		<ToggleButton Background="LightGray"
+					  x:Name="toggle"
+					  HorizontalAlignment="Center">Change State</ToggleButton>
+		<Grid Background="Gray"
+					Margin="8,3,8,15"
+					Padding="0,6,0,13"
+					CornerRadius="13"
+					MinHeight="80">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="Auto" />
+			</Grid.ColumnDefinitions>
+
+			<StackPanel Background="Gold"
+			            Padding="20,5">
+				<TextBlock FontSize="20" Text="qwertyuiopasdfghjklxcvbnmqwertyu" HorizontalAlignment="Left" TextWrapping="Wrap" />
+			</StackPanel>
+
+			<StackPanel Background="Red"
+			            Visibility="{Binding IsChecked, ElementName=toggle}"
+			            Grid.Column="1"
+			            Width="100" />
+		</Grid>
+		<TextBlock>State OFF (should be like this when unpressed)</TextBlock>
+		<Grid Background="Gray"
+		      Margin="8,3,8,15"
+		      Padding="0,6,0,13"
+		      CornerRadius="13"
+		      MinHeight="80">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="Auto" />
+			</Grid.ColumnDefinitions>
+
+			<StackPanel Background="Gold"
+			            Padding="20,5">
+				<TextBlock FontSize="20" Text="qwertyuiopasdfghjklxcvbnmqwertyu" HorizontalAlignment="Left" TextWrapping="Wrap" />
+			</StackPanel>
+
+			<StackPanel Background="Red"
+			            Visibility="Collapsed"
+			            Grid.Column="1"
+			            Width="100" />
+		</Grid>
+		<TextBlock>State ON (should be like this when pressed)</TextBlock>
+		<Grid Background="Gray"
+		      Margin="8,3,8,15"
+		      Padding="0,6,0,13"
+		      CornerRadius="13"
+		      MinHeight="80">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="Auto" />
+			</Grid.ColumnDefinitions>
+
+			<StackPanel Background="Gold"
+			            Padding="20,5">
+				<TextBlock FontSize="20" Text="qwertyuiopasdfghjklxcvbnmqwertyu" HorizontalAlignment="Left" TextWrapping="Wrap" />
+			</StackPanel>
+
+			<StackPanel Background="Red"
+			            Grid.Column="1"
+			            Width="100" />
+		</Grid>
+
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Layout_Bug2879.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Layout_Bug2879.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml.UIElementTests
+{
+	[Sample("UIElement", "GH Bugs")]
+	public sealed partial class UIElement_Layout_Bug2879 : Page
+	{
+		public UIElement_Layout_Bug2879()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_MinWidthColumns.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_MinWidthColumns.xaml.cs
@@ -3,7 +3,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.GridTestsControl
 {
-	[SampleControlInfo(category: "GridTestsControl")]
+	[Sample("GridTestsControl", "GH Bugs")]
 	public sealed partial class Grid_with_MinWidthColumns : Page
 	{
 		public Grid_with_MinWidthColumns()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageAlignment2541.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageAlignment2541.xaml.cs
@@ -3,7 +3,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Windows_UI_Xaml_Controls.ImageTests
 {
-	[SampleControlInfo(category: "Image")]
+	[Sample("Image", "GH Bugs")]
 	public sealed partial class ImageAlignment2541 : Page
 	{
 		public ImageAlignment2541()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/EllipseAlignment2542_2547.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/EllipseAlignment2542_2547.xaml.cs
@@ -3,7 +3,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Windows_UI_Xaml_Shapes
 {
-	[SampleControlInfo("Shapes")]
+	[Sample("Shapes", "GH Bugs")]
 	public sealed partial class EllipseAlignment2542_2547 : Page
 	{
 		public EllipseAlignment2542_2547()

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
@@ -58,6 +58,8 @@ namespace Windows.UI.Xaml.Controls
 			var widthSpec = ViewHelper.SpecFromLogicalSize(slotSize.Width);
 			var heightSpec = ViewHelper.SpecFromLogicalSize(slotSize.Height);
 
+			view.ForceLayout(); // Bypass Android cache, to ensure the Child's Measure() is actually invoked.
+
 			MeasureChild(view, widthSpec, heightSpec);
 			
 			var ret = Uno.UI.Controls.BindableView.GetNativeMeasuredDimensionsFast(view)

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
@@ -58,7 +58,20 @@ namespace Windows.UI.Xaml.Controls
 			var widthSpec = ViewHelper.SpecFromLogicalSize(slotSize.Width);
 			var heightSpec = ViewHelper.SpecFromLogicalSize(slotSize.Height);
 
-			view.ForceLayout(); // Bypass Android cache, to ensure the Child's Measure() is actually invoked.
+			var previousDesiredSize = DesiredChildSize(view);
+
+			if (previousDesiredSize.Width > slotSize.Width || previousDesiredSize.Height > slotSize.Height)
+			{
+				// Bypass Android cache, to ensure the Child's Measure() is actually invoked.
+				view.ForceLayout();
+
+				// We must do this here because we're using the MeasureSpecMode.AtMost mode to force Android to
+				// behave like the UWP's measure phase.
+
+				// We can't use MeasureSpecMode.Exactly because native controls would take all available space.
+
+				// Issue: https://github.com/unoplatform/uno/issues/2879
+			}
 
 			MeasureChild(view, widthSpec, heightSpec);
 			

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
@@ -58,17 +58,13 @@ namespace Windows.UI.Xaml.Controls
 			var widthSpec = ViewHelper.SpecFromLogicalSize(slotSize.Width);
 			var heightSpec = ViewHelper.SpecFromLogicalSize(slotSize.Height);
 
-			var previousDesiredSize = DesiredChildSize(view);
-
-			if (previousDesiredSize.Width > slotSize.Width || previousDesiredSize.Height > slotSize.Height)
+			if (double.IsPositiveInfinity(slotSize.Width) || double.IsPositiveInfinity(slotSize.Height))
 			{
 				// Bypass Android cache, to ensure the Child's Measure() is actually invoked.
 				view.ForceLayout();
 
-				// We must do this here because we're using the MeasureSpecMode.AtMost mode to force Android to
-				// behave like the UWP's measure phase.
-
-				// We can't use MeasureSpecMode.Exactly because native controls would take all available space.
+				// This could occur when one of the dimension is _Infinite_: Android will cache the
+				// value, which is not something we want. Specially when the container is a <StackPanel>.
 
 				// Issue: https://github.com/unoplatform/uno/issues/2879
 			}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -64,10 +64,6 @@ namespace Windows.UI.Xaml
 		private bool _styleChanging = false;
 		private bool _defaultStyleApplied = false;
 
-		internal bool RequiresArrange { get; private set; }
-
-		internal bool RequiresMeasure { get; private set; }
-
 		/// <summary>
 		/// Sets whether constraint-based optimizations are used to limit redrawing of the entire visual tree on Android. This can be
 		/// globally set to false if it is causing visual errors (eg views not updating properly). Note: this can still be overridden by

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -20,6 +20,10 @@ namespace Windows.UI.Xaml
 
 		partial void Initialize();
 
+		internal bool RequiresArrange { get; private set; }
+
+		internal bool RequiresMeasure { get; private set; }
+
 		public override void SetNeedsLayout()
 		{
 			if (!_inLayoutSubviews)

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.macOS.cs
@@ -20,6 +20,10 @@ namespace Windows.UI.Xaml
 
 		partial void Initialize();
 
+		internal bool RequiresArrange { get; private set; }
+
+		internal bool RequiresMeasure { get; private set; }
+
 		public override bool NeedsLayout
 		{
 			set

--- a/src/Uno.UI/UI/Xaml/Shapes/Polygon.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polygon.Android.cs
@@ -9,7 +9,7 @@ namespace Windows.UI.Xaml.Shapes
 		{
 			var coords = Points;
 
-			if (coords == null)
+			if (coords == null || coords.Count <= 1)
 			{
 				return null;
 			}

--- a/src/Uno.UI/UI/Xaml/Shapes/Polyline.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polyline.Android.cs
@@ -9,7 +9,7 @@ namespace Windows.UI.Xaml.Shapes
 		{
 			var coords = Points;
 
-			if (coords == null)
+			if (coords == null || coords.Count <= 1)
 			{
 				return null;
 			}


### PR DESCRIPTION
# Bugfix

The problem was caused by a cache in Android layout system. Was appearing when the `DesiredSize` is required to layout an element, like in the `<StackPanel>`. In this case, the `Measure()` were not properly called at the right time, causing the panel (`<StackPanel>` here) to use the previous (wrong) measured/desired size.

The fix is to call `ForceLayout()`, causing Android to bypass the cache during the `Measure()` phase.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

Internal Issue (If applicable):
* Fix #2879 
* Fix https://nventive.visualstudio.com/Umbrella/_workitems/edit/177488