### PR TITLE
feat: [android] FileOpenPicker

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3250,6 +3250,9 @@
       <Member
 			  fullName="System.Void Microsoft.UI.Xaml.Controls.TabView.set_TabItems(System.Collections.Generic.IList`1&lt;System.Object&gt; value)"
 			  reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Pickers.FilePickerSelectedFilesArray..ctor()"
+				reason="No public ctor exist in UWP"/>
 		</Methods>
 		<Fields>
 			<Member

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Pickers/Given_FileOpenPicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Pickers/Given_FileOpenPicker.cs
@@ -1,0 +1,26 @@
+﻿#if __ANDROID__
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Storage.Pickers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Storage.Pickers
+{
+	[TestClass]
+	public class Given_FileOpenPicker
+	{
+		[TestMethod]
+		public void When_No_FileTypeFilter_For_PickSingleFileAsync()
+		{
+			var fileOpenPicker = new FileOpenPicker();
+			Assert.ThrowsException<InvalidOperationException>(() => fileOpenPicker.PickSingleFileAsync());
+		}
+
+		[TestMethod]
+		public void When_No_FileTypeFilter_For_PickMultipleFilesAsync()
+		{
+			var fileOpenPicker = new FileOpenPicker();
+			Assert.ThrowsException<InvalidOperationException>(() => fileOpenPicker.PickMultipleFilesAsync());
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FileOpenPicker.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FileOpenPicker.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Pickers
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class FileOpenPicker 
@@ -21,7 +21,7 @@ namespace Windows.Storage.Pickers
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Storage.Pickers.PickerLocationId SuggestedStartLocation
 		{
@@ -35,7 +35,7 @@ namespace Windows.Storage.Pickers
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string SettingsIdentifier
 		{
@@ -63,7 +63,7 @@ namespace Windows.Storage.Pickers
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Collections.Generic.IList<string> FileTypeFilter
 		{
@@ -93,7 +93,7 @@ namespace Windows.Storage.Pickers
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public FileOpenPicker() 
 		{
@@ -116,7 +116,7 @@ namespace Windows.Storage.Pickers
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.Pickers.FileOpenPicker", "void FileOpenPicker.PickMultipleFilesAndContinue()");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> PickSingleFileAsync( string pickerOperationId)
 		{
@@ -132,14 +132,14 @@ namespace Windows.Storage.Pickers
 		// Forced skipping of method Windows.Storage.Pickers.FileOpenPicker.CommitButtonText.get
 		// Forced skipping of method Windows.Storage.Pickers.FileOpenPicker.CommitButtonText.set
 		// Forced skipping of method Windows.Storage.Pickers.FileOpenPicker.FileTypeFilter.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> PickSingleFileAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> FileOpenPicker.PickSingleFileAsync() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyList<global::Windows.Storage.StorageFile>> PickMultipleFilesAsync()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FilePickerSelectedFilesArray.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FilePickerSelectedFilesArray.cs
@@ -2,13 +2,13 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Pickers
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class FilePickerSelectedFilesArray : global::System.Collections.Generic.IReadOnlyList<global::Windows.Storage.StorageFile>,global::System.Collections.Generic.IEnumerable<global::Windows.Storage.StorageFile>
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  uint Size
 		{
 			get
@@ -23,8 +23,8 @@ namespace Windows.Storage.Pickers
 		// Forced skipping of method Windows.Storage.Pickers.FilePickerSelectedFilesArray.GetMany(uint, Windows.Storage.StorageFile[])
 		// Forced skipping of method Windows.Storage.Pickers.FilePickerSelectedFilesArray.First()
 		// Processing: System.Collections.Generic.IReadOnlyList<Windows.Storage.StorageFile>
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public global::Windows.Storage.StorageFile this[int index]
 		{
 			get
@@ -38,7 +38,7 @@ namespace Windows.Storage.Pickers
 		}
 		#endif
 		// Processing: System.Collections.Generic.IEnumerable<Windows.Storage.StorageFile>
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
 		// DeclaringType: System.Collections.Generic.IEnumerable<Windows.Storage.StorageFile>
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public global::System.Collections.Generic.IEnumerator<global::Windows.Storage.StorageFile> GetEnumerator()
@@ -47,7 +47,7 @@ namespace Windows.Storage.Pickers
 		}
 		#endif
 		// Processing: System.Collections.IEnumerable
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
 		// DeclaringType: System.Collections.IEnumerable
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		 global::System.Collections.IEnumerator global::System.Collections.IEnumerable.GetEnumerator()
@@ -56,7 +56,7 @@ namespace Windows.Storage.Pickers
 		}
 		#endif
 		// Processing: System.Collections.Generic.IReadOnlyCollection<Windows.Storage.StorageFile>
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public int Count
 		{

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
@@ -1,0 +1,215 @@
+﻿#if __ANDROID__
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Android.Content;
+using Android.Provider;
+using Android.Webkit;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+using Uno.Storage.Pickers.Internal;
+using Uno.UI;
+using AndroidUri = Android.Net.Uri;
+
+#pragma warning disable CS0618
+namespace Windows.Storage.Pickers
+{
+	public partial class FileOpenPicker
+	{
+		private const string StorageIdentifierFormatString = "Uno.FileOpenPicker.{0}";
+
+		private TaskCompletionSource<IReadOnlyList<StorageFile>> _pickCompletionSource;
+		private string _docUri = "";
+
+		partial void Init()
+		{
+			if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.Kitkat)
+			{
+				throw new NotSupportedException("FileOpenPicker requires Android KitKat (API level 19) or newer");
+			}
+			GetInitialUri();
+
+			if(!Windows.Extensions.PermissionsHelper.IsDeclaredInManifest(Android.Manifest.Permission.ReadExternalStorage))
+			{
+				throw new NotSupportedException("FileOpenPicker requires ReadExternalStorage permission defined in Android Manifest");
+			}
+		}
+
+		private async Task<StorageFile> PickSingleFileAsyncTask()
+		{
+			var pickedFiles = await PickFilesAsync(false);
+			if (pickedFiles.Count == 0)
+			{
+				return null;
+			}
+
+			return pickedFiles[0];
+		}
+
+		private async Task<IReadOnlyList<StorageFile>> PickMultipleFilesAsyncTask() => await PickFilesAsync(true);
+
+		private string GetInitialUri()
+		{
+			var settingName = string.Format(StorageIdentifierFormatString, SettingsIdentifier);
+
+			if (ApplicationData.Current.RoamingSettings.Values.ContainsKey(settingName))
+			{
+				var uri = ApplicationData.Current.LocalSettings.Values[settingName].ToString();
+				return uri;
+			}
+
+			switch (SuggestedStartLocation)
+			{
+				// see also Windows.Storage.KnownFolders
+				case PickerLocationId.DocumentsLibrary:
+					return "file://" + Android.OS.Environment.GetExternalStoragePublicDirectory(Android.OS.Environment.DirectoryDocuments).CanonicalPath;
+				case PickerLocationId.MusicLibrary:
+					return "file://" + Android.OS.Environment.GetExternalStoragePublicDirectory(Android.OS.Environment.DirectoryMusic).CanonicalPath;
+				case PickerLocationId.PicturesLibrary:
+					return "file://" + Android.OS.Environment.GetExternalStoragePublicDirectory(Android.OS.Environment.DirectoryPictures).CanonicalPath;
+				case PickerLocationId.Downloads:
+					return "file://" + Android.OS.Environment.GetExternalStoragePublicDirectory(Android.OS.Environment.DirectoryDownloads).CanonicalPath;
+				case PickerLocationId.VideosLibrary:
+					return "file://" + Android.OS.Environment.GetExternalStoragePublicDirectory(Android.OS.Environment.DirectoryMovies).CanonicalPath;
+				case PickerLocationId.Unspecified:
+					return string.Empty;
+				default:
+					if (this.Log().IsEnabled(LogLevel.Warning))
+					{
+						this.Log().LogWarning($"{SuggestedStartLocation} is not supported for Android FileOpenPicker");
+					}
+					return string.Empty;
+			}
+		}
+
+		private string PathFromUri(AndroidUri fileUri)
+		{
+			// basic file
+			if (fileUri.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase))
+			{
+				return fileUri.Path;
+			}
+
+			// more complicated Uris ("content://")
+			if (!DocumentsContract.IsDocumentUri(Android.App.Application.Context, fileUri))
+			{
+				throw new NotSupportedException("FileOpenPicker - unsupported document type");
+			}
+
+			if (fileUri.Authority.Equals("com.microsoft.skydrive.content.StorageAccessProvider"))
+			{
+				throw new NotSupportedException("FileOpenPicker - OneDrive documents are not implemented yet");
+			}
+
+			string dataColumnName = MediaStore.Files.FileColumns.Data;
+			string[] projection = { dataColumnName };
+
+			using (var cursor = Android.App.Application.Context.ContentResolver.Query(fileUri, projection, null, null, null))
+			{
+				if (cursor is null)
+				{
+					throw new InvalidOperationException("FileOpenPicker - cannot get cursor");
+				}
+
+				if (!cursor.MoveToFirst())
+				{
+					throw new InvalidOperationException("FileOpenPicker - cannot MoveToFirst");
+				}
+
+				int columnNo = cursor.GetColumnIndex(dataColumnName);
+				if (columnNo < 0)
+				{
+					throw new InvalidOperationException("FileOpenPicker - column with data doesn't exist?");
+				}
+
+				string filePath = cursor.GetString(columnNo);
+				cursor.Close();
+
+				if (!string.IsNullOrEmpty(filePath))
+				{
+					return filePath;
+				}
+			}
+			return null;
+		}
+
+		private Task<IReadOnlyList<StorageFile>> PickFilesAsync(bool allowMultiple)
+		{
+			var intent = new Intent(ContextHelper.Current, typeof(FileOpenPickerActivity));
+
+			intent.PutExtra(Intent.ExtraAllowMultiple, allowMultiple);
+			intent.PutExtra(DocumentsContract.ExtraInitialUri, _docUri);
+			intent.PutExtra(Intent.ExtraMimeTypes, GetMimeTypesFilter());
+
+			// wrap it in Task
+			_pickCompletionSource = new TaskCompletionSource<IReadOnlyList<StorageFile>>();
+			FileOpenPickerActivity.FilePicked += FilePickerHandler;
+
+			ContextHelper.Current.StartActivity(intent);
+
+			async void FilePickerHandler(object sender, List<Android.Net.Uri> list)
+			{
+				FileOpenPickerActivity.FilePicked -= FilePickerHandler;
+
+				// convert list of Uris tolist of StorageFiles
+				var storageFiles = new List<StorageFile>();
+
+				if (list.Count > 0)
+				{
+					var settingName = string.Format(StorageIdentifierFormatString, SettingsIdentifier);
+					ApplicationData.Current.LocalSettings.Values[settingName] = list.ElementAt(0).ToString();
+				}
+
+				foreach (var fileUri in list)
+				{
+					Android.App.Application.Context.ContentResolver.TakePersistableUriPermission(
+						fileUri, ActivityFlags.GrantReadUriPermission);
+
+					string filePath = PathFromUri(fileUri);
+					if (!string.IsNullOrEmpty(filePath))
+					{
+						var storageFile = await StorageFile.GetFileFromPathAsync(filePath);
+						storageFiles.Add(storageFile);
+					}
+
+				}
+				_pickCompletionSource.SetResult(new FilePickerSelectedFilesArray(storageFiles.ToArray()));
+			}
+
+			return _pickCompletionSource.Task;
+		}
+
+		private string[] GetMimeTypesFilter()
+		{
+			var mimeTypes = new HashSet<string>();
+			foreach (var fileType in FileTypeFilter)
+			{
+				if (fileType == "*")
+				{
+					// Special handling for wildcard
+					mimeTypes.Clear();
+					mimeTypes.Add("*/*");
+					return mimeTypes.ToArray();
+				}
+
+				string mimeType = fileType;
+
+				if (fileType.StartsWith("."))
+				{
+					// Supported format from UWP, e.g. ".jpg"
+					mimeType = MimeTypeMap.Singleton.GetMimeTypeFromExtension(fileType.Substring(1));
+				}
+
+				if (mimeType != null && !mimeTypes.Contains(mimeType))
+				{
+					mimeTypes.Add(mimeType);
+				}
+			}
+
+			return mimeTypes.ToArray();
+		}
+	}
+}
+#pragma warning restore CS0618
+#endif

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
@@ -12,6 +12,8 @@ using Uno.Storage.Pickers.Internal;
 using Uno.UI;
 using AndroidUri = Android.Net.Uri;
 
+// small, innocent change to force build restart.
+
 #pragma warning disable CS0618
 namespace Windows.Storage.Pickers
 {

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
@@ -12,8 +12,6 @@ using Uno.Storage.Pickers.Internal;
 using Uno.UI;
 using AndroidUri = Android.Net.Uri;
 
-// small, innocent change to force build restart.
-
 #pragma warning disable CS0618
 namespace Windows.Storage.Pickers
 {

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.cs
@@ -1,0 +1,78 @@
+﻿#if __ANDROID__
+using System;
+using System.Collections.Generic;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+namespace Windows.Storage.Pickers
+{
+	/// <summary>
+	/// Represents a UI element that lets the user choose and open files.
+	/// </summary>
+	public partial class FileOpenPicker
+    {
+		/// <summary>
+		/// Creates a new instance of a FileOpenPicker.
+		/// </summary>
+		public FileOpenPicker() => Init();
+
+		/// <summary>
+		/// Gets or sets the initial location where the file open picker looks for files to present to the user.
+		/// </summary>
+		public PickerLocationId SuggestedStartLocation { get; set; } = PickerLocationId.DocumentsLibrary;
+
+		/// <summary>
+		/// Gets or sets the settings identifier associated with the state of the file open picker.
+		/// </summary>
+		public string SettingsIdentifier { get; set; } = "";
+
+		/// <summary>
+		/// Gets the collection of file types that the file open picker displays.
+		/// Examples - ".png", ".jpg". Use "*" for any.
+		/// </summary>
+		public IList<string> FileTypeFilter { get; } = new NonNullList<string>();
+
+		partial void Init();
+
+		/// <summary>
+		/// Shows the file picker so that the user can pick one file.
+		/// </summary>
+		/// <returns>When the call to this method completes successfully,
+		/// it returns a StorageFile object that represents the file that the user picked.</returns>
+		public IAsyncOperation<StorageFile> PickSingleFileAsync()
+		{
+			ValidatePicker();
+			return PickSingleFileAsyncTask().AsAsyncOperation();
+		}
+
+		/// <summary>
+		/// Shows the file picker so that the user can pick one file.
+		/// </summary>
+		/// <param name="pickerOperationId">This argument is ignored and has no effect.</param>
+		/// <returns>When the call to this method completes successfully,
+		/// it returns a StorageFile object that represents the file that the user picked.</returns>
+		public IAsyncOperation<StorageFile> PickSingleFileAsync(string pickerOperationId) => PickSingleFileAsync();
+
+		/// <summary>
+		/// Shows the file picker so that the user can pick multiple files. (UWP app).
+		/// </summary>
+		/// <returns>When the call to this method completes successfully, it returns
+		/// a FilePickerSelectedFilesArray object that contains all the files that were
+		/// picked by the user. Picked files in this array are represented by StorageFile objects.</returns>
+		public IAsyncOperation<IReadOnlyList<StorageFile>> PickMultipleFilesAsync()
+		{
+			ValidatePicker();
+			return PickMultipleFilesAsyncTask().AsAsyncOperation();
+		}
+
+		private void ValidatePicker()
+		{
+			if (FileTypeFilter.Count == 0)
+			{
+				throw new InvalidOperationException(
+					$"At least one file type or wildcard (*) must be specified in {nameof(FileTypeFilter)}.");
+			}
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/Storage/Pickers/FilePickerSelectedFilesArray.cs
+++ b/src/Uno.UWP/Storage/Pickers/FilePickerSelectedFilesArray.cs
@@ -1,0 +1,48 @@
+#if __MACOS__ || __ANDROID__
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Windows.Storage.Pickers
+{
+	/// <summary>
+	/// Represents a collection of storage files that the user has selected by using a file picker.
+	/// </summary>
+	public partial class FilePickerSelectedFilesArray : IReadOnlyList<StorageFile>, IEnumerable<StorageFile>
+	{
+		private readonly IList<StorageFile> _files;
+
+		internal FilePickerSelectedFilesArray(StorageFile[] files)
+		{
+			_files = files ?? throw new ArgumentNullException(nameof(files));
+		}
+
+		/// <summary>
+		/// Gets the number of StorageFile objects in the collection.
+		/// </summary>
+		public uint Size => (uint)_files.Count;
+
+		public StorageFile this[int index]
+		{
+			get => _files[index];
+			set
+			{
+				throw new InvalidOperationException("The list is read-only");
+			}
+		}
+
+		public IEnumerator<StorageFile> GetEnumerator() => _files.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		public int Count
+		{
+			get => _files.Count;
+			set
+			{
+				throw new InvalidOperationException("The list is read-only");
+			}
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/Storage/Pickers/Internal/FileOpenPickerActivity.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/Internal/FileOpenPickerActivity.Android.cs
@@ -1,0 +1,119 @@
+﻿#if __ANDROID__
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Android.App;
+using Android.Content.PM;
+using Android.OS;
+using Android.Provider;
+using Android.Content;
+using AndroidUri = Android.Net.Uri;
+
+namespace Uno.Storage.Pickers.Internal
+{
+	[Activity(ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
+	internal class FileOpenPickerActivity : Activity
+	{
+		internal static event EventHandler<List<AndroidUri>> FilePicked;
+
+		private bool _multiple;
+		
+		protected override void OnCreate(Bundle savedInstanceState)
+		{
+			base.OnCreate(savedInstanceState);
+
+			var caller = base.Intent.Extras;
+			_multiple = caller.GetBoolean(Intent.ExtraAllowMultiple, false);
+
+			var intent = CreateIntent(_multiple,
+				caller.GetStringArray(Intent.ExtraMimeTypes).ToList(),
+				caller.GetString(DocumentsContract.ExtraInitialUri, "")
+				);
+
+			intent.SetType("*/*");
+			intent.AddFlags(ActivityFlags.GrantPersistableUriPermission);
+
+			// StartActivityForResult(Android.Content.Intent.CreateChooser(intent, "Select file"),10);
+			StartActivityForResult(intent, 10);
+		}
+
+		protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)
+		{
+			base.OnActivityResult(requestCode, resultCode, data);
+
+			var pickedFiles = new List<AndroidUri>();
+
+			if (resultCode != Result.Canceled)
+			{
+				if (_multiple)
+				{
+					// multiple files - ClipData
+					if (data?.ClipData != null)
+					{
+						for (int i = 0; i < data.ClipData.ItemCount; i++)
+						{
+							var item = data.ClipData.GetItemAt(i);
+							pickedFiles.Add(item.Uri);
+						}
+					}
+				}
+				else
+				{
+					// single file - Data
+					if (data?.Data != null)
+					{
+						pickedFiles.Add(data.Data);
+					}
+
+				}
+			}
+
+			FilePicked?.Invoke(null, pickedFiles);
+			Finish();
+		}
+
+		private Intent CreateIntent(bool multiple, List<string> mimeTypes, string initialDir)
+		{
+			var intent = new Intent(Intent.ActionOpenDocument);
+
+			// file ext / mimetypes
+			if (mimeTypes.Count < 1)
+			{  // if none is given, then use all types
+				intent.SetType("*/*");  
+			}
+			else
+			{
+				if (mimeTypes.Count < 2)
+				{
+					intent.SetType(mimeTypes.ElementAt(0));
+				}
+				else
+				{
+					intent.SetType("*/*");
+					intent.PutExtra(Intent.ExtraMimeTypes, mimeTypes.ToArray());
+				}
+			}
+
+			// multiple selection
+			if (multiple)
+			{
+				intent.PutExtra(Intent.ExtraAllowMultiple, true);
+			}
+
+			// initial dir
+			if (Build.VERSION.SdkInt >= BuildVersionCodes.O && !string.IsNullOrEmpty(initialDir))
+			{
+				intent.PutExtra(DocumentsContract.ExtraInitialUri, initialDir);
+			}
+
+			// maybe also
+			// intent.AddCategory(Android.Content.Intent.CategoryOpenable);
+			// "openable" means: ContentResolver#openFileDescriptor(Uri, String) // string: rwt (t:can truncate)
+
+			return intent;
+		}
+	}
+}
+
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4016 

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
FileOpenPicker is not implemented on Android

## What is the new behavior?
FileOpenPicker is implemented on Android


## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.