### PR TITLE
fix(elevatedview): Make sure the `ElevatedView` propagates its `TemplatedParent`.

### DIFF
--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -106,7 +106,34 @@ namespace Uno.UI.Toolkit
 		}
 #endif
 
+		protected internal override void OnTemplatedParentChanged(DependencyPropertyChangedEventArgs e)
+		{
+			base.OnTemplatedParentChanged(e);
+
+			// This is required to ensure that FrameworkElement.FindName can dig through the tree after
+			// the control has been created.
+			SynchronizeContentTemplatedParent();
+		}
+
+		protected override void OnLoaded()
+		{
+			base.OnLoaded();
+
+			SynchronizeContentTemplatedParent();
+		}
+
 		private static void OnChanged(DependencyObject snd, DependencyPropertyChangedEventArgs evt) => ((ElevatedView)snd).UpdateElevation();
+
+		private void SynchronizeContentTemplatedParent()
+		{
+			// Manual propagation of the templated parent to the content property
+			// until we get the propagation running properly
+			if (ElevatedContent is IFrameworkElement content)
+			{
+				content.TemplatedParent = this.TemplatedParent;
+			}
+		}
+
 
 		private void UpdateElevation()
 		{
@@ -114,6 +141,8 @@ namespace Uno.UI.Toolkit
 			{
 				return; // not initialized yet
 			}
+
+			SynchronizeContentTemplatedParent();
 
 			if (Background == null)
 			{

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -46,6 +46,10 @@ namespace Uno.UI.Toolkit
 		public ElevatedView()
 		{
 			DefaultStyleKey = typeof(ElevatedView);
+
+#if !NETFX_CORE
+			Loaded += (snd, evt) => SynchronizeContentTemplatedParent();
+#endif
 		}
 
 		protected override void OnApplyTemplate()
@@ -104,7 +108,6 @@ namespace Uno.UI.Toolkit
 			get => (CornerRadius)GetValue(CornerRadiusProperty);
 			set => SetValue(CornerRadiusProperty, value);
 		}
-#endif
 
 		protected internal override void OnTemplatedParentChanged(DependencyPropertyChangedEventArgs e)
 		{
@@ -115,15 +118,6 @@ namespace Uno.UI.Toolkit
 			SynchronizeContentTemplatedParent();
 		}
 
-		protected override void OnLoaded()
-		{
-			base.OnLoaded();
-
-			SynchronizeContentTemplatedParent();
-		}
-
-		private static void OnChanged(DependencyObject snd, DependencyPropertyChangedEventArgs evt) => ((ElevatedView)snd).UpdateElevation();
-
 		private void SynchronizeContentTemplatedParent()
 		{
 			// Manual propagation of the templated parent to the content property
@@ -133,7 +127,9 @@ namespace Uno.UI.Toolkit
 				content.TemplatedParent = this.TemplatedParent;
 			}
 		}
+#endif
 
+		private static void OnChanged(DependencyObject snd, DependencyPropertyChangedEventArgs evt) => ((ElevatedView)snd).UpdateElevation();
 
 		private void UpdateElevation()
 		{
@@ -142,7 +138,9 @@ namespace Uno.UI.Toolkit
 				return; // not initialized yet
 			}
 
+#if !NETFX_CORE
 			SynchronizeContentTemplatedParent();
+#endif
 
 			if (Background == null)
 			{


### PR DESCRIPTION
# Bugfix
When the `ElevatedView` itself was placed into an `ControlTemplate`, the `TemplatedParent` were not the right one, leading to unexpected behavior in the result.

This is a patch and reproduce a behavior already patched in `ContentControl`. A better fix would required architectural changes in Uno, which is not is the scope of this bug fix.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).

## Internal Issue (If applicable):
* fix https://github.com/unoplatform/uno/issues/2891

