### PR TITLE
chore: Update Uno.Core to 2.0.0-dev.5

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -15,8 +15,8 @@
   <ItemGroup>
     <PackageReference Update="Uno.SourceGenerationTasks" Version="2.0.0-dev.304" />
     <PackageReference Update="Uno.SourceGeneration" Version="2.0.0-dev.304" />
-    <PackageReference Update="Uno.Core" Version="1.29.0" />
-    <PackageReference Update="Uno.Core.Build" Version="1.29.0" />
+    <PackageReference Update="Uno.Core" Version="2.0.0-dev.5" />
+    <PackageReference Update="Uno.Core.Build" Version="2.0.0-dev.5" />
     <PackageReference Update="Uno.Wasm.Bootstrap" Version="1.1.0-dev.433" />
     <DotNetCliToolReference Update="Uno.Wasm.Bootstrap.Cli" Version="1.1.0-dev.433" />
     <PackageReference Update="xamarin.build.download" Version="0.4.11" />

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Behaviors/WebViewBehavior.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Behaviors/WebViewBehavior.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Practices.ServiceLocation;
 using Uno.Logging;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/src/SourceGenerators/Uno.UI.Tasks/app.config
+++ b/src/SourceGenerators/Uno.UI.Tasks/app.config
@@ -19,10 +19,6 @@
         <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
       </dependentAssembly>

--- a/src/Uno.UI.RemoteControl.Host/ServiceLocatorAdapter.cs
+++ b/src/Uno.UI.RemoteControl.Host/ServiceLocatorAdapter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Uno.UI.RemoteControl.Host
 {

--- a/src/Uno.UI.RemoteControl.Host/Startup.cs
+++ b/src/Uno.UI.RemoteControl.Host/Startup.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Uno.UI.RemoteControl.Host
 {

--- a/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
+++ b/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
@@ -31,10 +31,6 @@
     <PackageReference Include="MSTest.TestFramework">
       <Version>2.1.0</Version>
     </PackageReference>
-
-    <PackageReference Include="CommonServiceLocator">
-      <Version>1.3</Version>
-    </PackageReference>
     <PackageReference Include="FluentAssertions">
       <Version>5.10.3</Version>
     </PackageReference>

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.DependencyPropertyPath.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.DependencyPropertyPath.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.FastConvert.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.FastConvert.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyObjectCollection.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyObjectCollection.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.AttachedPropagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.AttachedPropagation.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DataContext.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DataContext.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Inversion.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Inversion.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.UI.Xaml.Data;
 using System;

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.ManualPropagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.ManualPropagation.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.StandardProperty.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.StandardProperty.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.TemplatedParent.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.TemplatedParent.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Weak.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Weak.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
+﻿using CommonServiceLocator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Uno.Logging;

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -33,10 +33,6 @@
     <PackageReference Include="MSTest.TestFramework">
       <Version>2.1.0</Version>
     </PackageReference>
-
-    <PackageReference Include="CommonServiceLocator">
-      <Version>1.3</Version>
-    </PackageReference>
     <PackageReference Include="FluentAssertions">
       <Version>5.10.3</Version>
     </PackageReference>

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/BorderTests/Context.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/BorderTests/Context.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Practices.ServiceLocation;
 
 namespace Uno.UI.Tests.BorderTests
 {

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Context.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Context.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Practices.ServiceLocation;
 
 namespace Uno.UI.Tests.GridTests
 {

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/RelativePanelTests/Context.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/RelativePanelTests/Context.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 using System.Linq;
 using Uno.Extensions;
 

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/StackPanelTest/Context.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/StackPanelTest/Context.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Uno.UI.Tests.StackPanelTest
 {

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Context.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Context.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Practices.ServiceLocation;
+using CommonServiceLocator;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 {

--- a/src/Uno.UI.Tests/app.config
+++ b/src/Uno.UI.Tests/app.config
@@ -3,10 +3,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Practices.ServiceLocation" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Practices.Unity" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>

--- a/src/Uno.UI/Controls/BindableNSView.macOS.cs
+++ b/src/Uno.UI/Controls/BindableNSView.macOS.cs
@@ -1,5 +1,4 @@
 ﻿using Uno.Collections;
-using Microsoft.Practices.ServiceLocation;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Uno.UI/Controls/BindableUIView.iOS.cs
+++ b/src/Uno.UI/Controls/BindableUIView.iOS.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;

--- a/src/Uno.UI/Mock/ImageSource.net.cs
+++ b/src/Uno.UI/Mock/ImageSource.net.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
-using Uno.Extensions;
+﻿using Uno.Extensions;
 using Uno.Logging;
 using System;
 using System.Collections.Generic;

--- a/src/Uno.UI/Mock/ImageSource.wasm.cs
+++ b/src/Uno.UI/Mock/ImageSource.wasm.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Practices.ServiceLocation;
-using Uno.Extensions;
+﻿using Uno.Extensions;
 using Uno.Logging;
 using System;
 using System.Collections.Generic;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/Legacy/ListViewBaseSource.Legacy.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/Legacy/ListViewBaseSource.Legacy.iOS.cs
@@ -9,7 +9,6 @@ using Windows.UI.Xaml.Data;
 using Uno.UI.Converters;
 using Uno.Client;
 using System.Threading.Tasks;
-using Microsoft.Practices.ServiceLocation;
 using Uno.Diagnostics.Eventing;
 using Uno.UI.Controls;
 using Windows.UI.Core;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -9,7 +9,6 @@ using Windows.UI.Xaml.Data;
 using Uno.UI.Converters;
 using Uno.Client;
 using System.Threading.Tasks;
-using Microsoft.Practices.ServiceLocation;
 using Uno.Diagnostics.Eventing;
 using Uno.UI.Controls;
 using Windows.UI.Core;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

This update of Uno.Core updates the `CommonServiceLocator` dependency to 2.0.

BREAKING CHANGE: The namespace of the ServiceLocator class has changed, and dependencies that rely on this type must adjust to this newer version.

To upgrade, replace all Microsoft.Practices.ServiceLocation by CommonServiceLocator.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
