### PR TITLE
[macOS] Update measure/arrange passes

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
@@ -578,12 +578,12 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 
 			private void WriteDispose(INamedTypeSymbol typeSymbol, IndentedStringBuilder builder)
 			{
-				var hasDispose = typeSymbol.Is(_androidViewSymbol) || typeSymbol.Is(_iosViewSymbol);
+				var hasDispose = typeSymbol.Is(_androidViewSymbol) || typeSymbol.Is(_iosViewSymbol) || typeSymbol.Is(_macosViewSymbol);
 
 				if (hasDispose)
 				{
 					builder.AppendLine($@"
-#if __IOS__
+#if __IOS__ || __MACOS__
 					private bool _isDisposed;
 
 					[SuppressMessage(
@@ -625,7 +625,11 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 						}}
 					}}
 
+#if __IOS__
 					private void RequestCollect(UIKit.UIView[] subviews)
+#elif __MACOS__
+					private void RequestCollect(AppKit.NSView[] subviews)
+#endif
 					{{
 						if(subviews.Length != 0)
 						{{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/NativeCtor/NativeCtorsGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/NativeCtor/NativeCtorsGenerator.cs
@@ -20,8 +20,9 @@ namespace Uno.UI.SourceGenerators.NativeCtor
 		private class SerializationMethodsGenerator : SymbolVisitor
 		{ 
 			private readonly SourceGeneratorContext _context; 
-			private readonly Compilation _comp; 
-			private readonly INamedTypeSymbol _iosViewSymbol; 
+			private readonly Compilation _comp;
+			private readonly INamedTypeSymbol _iosViewSymbol;
+			private readonly INamedTypeSymbol _macosViewSymbol;
 			private readonly INamedTypeSymbol _androidViewSymbol; 
 			private readonly INamedTypeSymbol _intPtrSymbol; 
 			private readonly INamedTypeSymbol _jniHandleOwnershipSymbol;
@@ -39,7 +40,7 @@ using System;
 
 namespace {0}
 {{
-#if __IOS__
+#if __IOS__ || __MACOS__
 	[global::Foundation.Register]
 #endif
 	partial class {1}
@@ -58,7 +59,7 @@ namespace {0}
 		/// </remarks>
 		public {3}(IntPtr javaReference, global::Android.Runtime.JniHandleOwnership transfer) : base (javaReference, transfer) {{ }}
 #endif
-#if __IOS__
+#if __IOS__ || __MACOS__
 		/// <summary>
 		/// Native constructor, do not use explicitly.
 		/// </summary>
@@ -79,6 +80,7 @@ namespace {0}
 				_comp = context.Compilation;
 
 				_iosViewSymbol = context.Compilation.GetTypeByMetadataName("UIKit.UIView");
+				_macosViewSymbol = context.Compilation.GetTypeByMetadataName("AppKit.NSView");
 				_androidViewSymbol = context.Compilation.GetTypeByMetadataName("Android.Views.View");
 				_intPtrSymbol = context.Compilation.GetTypeByMetadataName("System.IntPtr");
 				_jniHandleOwnershipSymbol = context.Compilation.GetTypeByMetadataName("Android.Runtime.JniHandleOwnership");
@@ -117,10 +119,11 @@ namespace {0}
 			private void ProcessType(INamedTypeSymbol typeSymbol)
 			{
 				var isiOSView = typeSymbol.Is(_iosViewSymbol);
+				var ismacOSView = typeSymbol.Is(_macosViewSymbol);
 				var isAndroidView = typeSymbol.Is(_androidViewSymbol);
 				var smallSymbolName = typeSymbol.ToString().Replace(typeSymbol.ContainingNamespace + ".", "");
 
-				if (isiOSView)
+				if (isiOSView || ismacOSView)
 				{
 					var nativeCtor = typeSymbol
 						.GetMethods()

--- a/src/Uno.UI/DataBinding/BinderCollector.iOSmacOS.cs
+++ b/src/Uno.UI/DataBinding/BinderCollector.iOSmacOS.cs
@@ -1,5 +1,4 @@
-﻿#if XAMARIN_IOS
-using Windows.UI.Core;
+﻿using Windows.UI.Core;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -48,4 +47,3 @@ namespace Uno.UI.DataBinding
         }
     }
 }
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.macOS.cs
@@ -29,7 +29,7 @@ namespace Windows.UI.Xaml.Controls
 		private void SetUpdateTemplate()
 		{
 			UpdateContentTemplateRoot();
-			this.SetNeedsLayout();
+			this.InvalidateMeasure();
 		}
 
 		partial void RegisterContentTemplateRoot()

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.macOS.cs
@@ -209,7 +209,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else
 			{
-				this.SetNeedsLayout();
+				this.InvalidateMeasure();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/MenuBar/NativeMenuBarPresenter.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuBar/NativeMenuBarPresenter.macOS.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public class NativeMenuBarPresenter : FrameworkElement
+	public partial class NativeMenuBarPresenter : FrameworkElement
 	{
 		private MenuBar _menuBar;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.macOS.cs
@@ -54,13 +54,13 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnBorderThicknessChangedPartial(Thickness oldValue, Thickness newValue)
 		{
-			NeedsLayout = true;
+			InvalidateMeasure();
 			UpdateBackground();
 		}
 
 		partial void OnPaddingChangedPartial(Thickness oldValue, Thickness newValue)
 		{
-			NeedsLayout = true;
+			InvalidateMeasure();
 		}
 
 		protected override void OnBackgroundChanged(DependencyPropertyChangedEventArgs args)
@@ -114,7 +114,7 @@ namespace Windows.UI.Xaml.Controls
 
 		protected virtual void OnChildrenChanged()
 		{
-			NeedsLayout = true;
+			InvalidateMeasure();
 		}
 
 		protected override void OnAfterArrange()

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.macOS.cs
@@ -22,6 +22,8 @@ namespace Windows.UI.Xaml.Controls
 			InitializeScrollContentPresenter();
 
 			Notifications.ObserveDidLiveScroll(this, OnLiveScroll);
+
+			DrawsBackground = false;
 		}
 
 		public nfloat ZoomScale {

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.macOS.cs
@@ -128,7 +128,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 					// This measures the height correctly, even if the Text is null or empty
 					// This matches Windows where empty TextBlocks still have a height (especially useful when measuring ListView items with no DataContext)
-					var font = NSFontHelper.TryGetFont((float)FontSize, FontWeight, FontStyle, FontFamily);
+					var font = NSFontHelper.TryGetFont((float)FontSize*2, FontWeight, FontStyle, FontFamily);
 
 					var str = new NSAttributedString(Text, font);
 
@@ -333,15 +333,16 @@ namespace Windows.UI.Xaml.Controls
 				_textContainer.LineFragmentPadding = 0;
 				_textContainer.LineBreakMode = GetLineBreakMode();
 				_textContainer.MaximumNumberOfLines = (nuint)GetLines();
-				
+
+				// Configure textStorage
+				_textStorage = new NSTextStorage();
+				_textStorage.SetString(_attributedString);
+
 				// Configure layoutManager
 				_layoutManager = new NSLayoutManager();
 				_layoutManager.AddTextContainer(_textContainer);
 
-				// Configure textStorage
-				_textStorage = new NSTextStorage();
 				_textStorage.AddLayoutManager(_layoutManager);
-				_textStorage.SetString(_attributedString);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.macOS.cs
@@ -33,15 +33,38 @@ namespace Windows.UI.Xaml
 					base.NeedsLayout = value;
 				}
 
-				RequiresMeasure = true;
-				RequiresArrange = true;
-
 				if (ShouldInterceptInvalidate)
 				{
 					return;
 				}
+			}
+		}
 
-				SetSuperviewNeedsLayout();
+		protected internal override void OnInvalidateMeasure()
+		{
+			base.OnInvalidateMeasure();
+
+			// Note that the reliance on NSView.NeedsLayout to invalidate the measure / arrange phases for
+			// self and parents.NeedsLayout is set to true when NSView.Frame is different from iOS, causing
+			// a chain of multiple unneeded updates for the element and its parents. OnInvalidateMeasure
+			// sets NeedsLayout to true and propagates to the parent but NeedsLayout by itself does not.
+
+			if (!RequiresMeasure)
+			{
+				RequiresArrange = true;
+				RequiresMeasure = true;
+
+				if (Parent is FrameworkElement fe)
+				{
+					if (!fe.RequiresMeasure)
+					{
+						fe.InvalidateMeasure();
+					}
+				}
+				else if (Parent is IFrameworkElement ife)
+				{
+					ife.InvalidateMeasure();
+				}
 			}
 		}
 
@@ -60,33 +83,33 @@ namespace Windows.UI.Xaml
 		{
 			try
 			{
-				try
+				_inLayoutSubviews = true;
+
+				if (RequiresMeasure)
 				{
-					_inLayoutSubviews = true;
-
-					if (RequiresMeasure)
-					{
-						XamlMeasure(Bounds.Size);
-					}
-
-					OnBeforeArrange();
-
-					var size = SizeFromUISize(Bounds.Size);
-					_layouter.Arrange(new Rect(0, 0, size.Width, size.Height));
-
-					OnAfterArrange();
+					XamlMeasure(Bounds.Size);
 				}
-				finally
-				{
-					_inLayoutSubviews = false;
-					RequiresArrange = false;
-				}
+
+				OnBeforeArrange();
+
+				var size = SizeFromUISize(Bounds.Size);
+
+				_layouter.Arrange(new Rect(0, 0, size.Width, size.Height));
+
+				OnAfterArrange();
 			}
 			catch (Exception e)
 			{
 				this.Log().Error($"Layout failed in {GetType()}", e);
 			}
+			finally
+			{
+				_inLayoutSubviews = false;
+				RequiresMeasure = false;
+				RequiresArrange = false;
+			}
 		}
+
 		/// <summary>
 		/// Called before Arrange is called, this method will be deprecated
 		/// once OnMeasure/OnArrange will be implemented completely
@@ -107,7 +130,7 @@ namespace Windows.UI.Xaml
 
 		}
 
-		private CGSize? XamlMeasure(CGSize availableSize)
+		internal CGSize? XamlMeasure(CGSize availableSize)
 		{
 			// If set layout has not been called, we can 
 			// return a previously cached result for the same available size.

--- a/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
@@ -266,7 +266,7 @@ namespace Windows.UI.Xaml
 			}
 			else if (element is FrameworkElement fe)
 			{
-				fe.Measure(new Size(availableSize.Width, availableSize.Height));
+				fe.XamlMeasure(new CoreGraphics.CGSize(availableSize.Width, availableSize.Height));
 				var desiredSize = fe.DesiredSize;
 				return new CGSize(desiredSize.Width, desiredSize.Height);
 			}
@@ -298,7 +298,7 @@ namespace Windows.UI.Xaml
 			}
 			else if (element is FrameworkElement fe)
 			{
-				fe.Measure(new Size(availableSize.Width, availableSize.Height));
+				fe.XamlMeasure(new Size(availableSize.Width, availableSize.Height));
 				var desiredSize = fe.DesiredSize;
 				return new CGSize(desiredSize.Width, desiredSize.Height);
 			}

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
@@ -189,10 +189,14 @@ namespace <#= mixin.NamespaceName #>
 		{
 			// Resolve the property only once, to avoid paying the cost of the interop.
 			var actualSuperview = Superview;
-
-			if (actualSuperview != null)
+            
+            if(actualSuperview is FrameworkElement fe)
+            {
+                fe.InvalidateMeasure();
+            }
+			else if (actualSuperview is IFrameworkElement ife)
 			{
-				actualSuperview.NeedsLayout = true;
+				ife.InvalidateMeasure();
 			}
 		}
 
@@ -576,7 +580,7 @@ namespace <#= mixin.NamespaceName #>
 			base.ViewDidMoveToSuperview();
 			OnViewDidMoveToSuperview();
 
-			this.SetNeedsLayout();
+			this.InvalidateMeasure();
 		}
 
 		partial void OnViewDidMoveToSuperview();
@@ -599,7 +603,7 @@ namespace <#= mixin.NamespaceName #>
 		{
 			IsLoaded = true;
 
-			this.SetNeedsLayout();
+			this.InvalidateMeasure();
 			OnLoadedPartial();
 
 			Loaded?.Invoke(this, new RoutedEventArgs(this));
@@ -706,7 +710,7 @@ namespace <#= mixin.NamespaceName #>
 			if (base.Hidden != newVisibility.IsHidden())
 			{
 				base.Hidden = newVisibility.IsHidden();
-				this.SetNeedsLayout();
+				this.InvalidateMeasure();
 
 				if (newVisibility == Visibility.Visible)
 				{
@@ -990,7 +994,18 @@ namespace <#= mixin.NamespaceName #>
 		private static void OnGenericPropertyUpdated(object dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
 			OnGenericPropertyUpdatedPartial(dependencyObject, args);
-			((NSView)dependencyObject).SetNeedsLayout();
+            
+#if <#= mixin.IsFrameworkElement #>
+            if(dependencyObject is FrameworkElement fe)
+            {
+                fe.InvalidateMeasure();
+            }
+#else
+            if(dependencyObject is IFrameworkElement ife)
+            {
+                ife.InvalidateMeasure();
+            }
+#endif
 		}
 
 		static partial void OnGenericPropertyUpdatedPartial(object dependencyObject, DependencyPropertyChangedEventArgs args);

--- a/src/Uno.UI/UI/Xaml/Shapes/Path.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Path.iOSmacOS.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Shapes
 
 		partial void OnDataChanged()
 		{
-			this.SetNeedsLayout();
+			this.InvalidateMeasure();
 		}
 	}
 }

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -44,18 +44,19 @@
 
 	<ItemGroup>
 		<Compile Remove="Mixins\**\*.cs" />
+		<None Include="Mixins\**\*.cs" />
 
-		<Compile Include="Mixins\Android\BaseActivity.Callbacks.g.cs">
+		<Compile Include="Mixins\Android\BaseActivity.Callbacks.g.cs" Condition="$(IsMonoAndroid)">
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 			<DependentUpon>BaseActivity.Callbacks.tt</DependentUpon>
 		</Compile>
-		<Compile Include="Mixins\Android\FrameworkElementMixins.g.cs">
+		<Compile Include="Mixins\Android\FrameworkElementMixins.g.cs" Condition="$(IsMonoAndroid)">
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 			<DependentUpon>FrameworkElementMixins.tt</DependentUpon>
 		</Compile>
-		<Compile Include="Mixins\Android\VisualStatesMixins.g.cs">
+		<Compile Include="Mixins\Android\VisualStatesMixins.g.cs" Condition="$(IsMonoAndroid)">
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 			<DependentUpon>VisualStatesMixins.tt</DependentUpon>
@@ -65,32 +66,32 @@
 			<AutoGen>True</AutoGen>
 			<DependentUpon>DependencyPropertyMixins.tt</DependentUpon>
 		</Compile>
-		<Compile Include="Mixins\macOS\FrameworkElementMixins.g.cs">
+		<Compile Include="Mixins\macOS\FrameworkElementMixins.g.cs" Condition="$(IsXamarinMac)">
 			<DependentUpon>FrameworkElementMixins.tt</DependentUpon>
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 		</Compile>
-		<Compile Include="Mixins\macOS\VisualStatesMixins.g.cs">
+		<Compile Include="Mixins\macOS\VisualStatesMixins.g.cs" Condition="$(IsXamarinMac)">
 			<DependentUpon>VisualStatesMixins.tt</DependentUpon>
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 		</Compile>
-		<Compile Include="Mixins\iOS\FrameworkElementMixins.g.cs">
+		<Compile Include="Mixins\iOS\FrameworkElementMixins.g.cs" Condition="$(IsXamarinIOS)">
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 			<DependentUpon>FrameworkElementMixins.tt</DependentUpon>
 		</Compile>
-		<Compile Include="Mixins\iOS\VisualStatesMixins.g.cs">
+		<Compile Include="Mixins\iOS\VisualStatesMixins.g.cs" Condition="$(IsXamarinIOS)">
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 			<DependentUpon>VisualStatesMixins.tt</DependentUpon>
 		</Compile>
-		<Compile Include="Mixins\net461\VisualStatesMixins.g.cs">
+		<Compile Include="Mixins\net461\VisualStatesMixins.g.cs" Condition="'$(TargetFramework)'=='net461'">
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 			<DependentUpon>VisualStatesMixins.tt</DependentUpon>
 		</Compile>
-		<Compile Include="Mixins\Wasm\VisualStatesMixins.g.cs">
+		<Compile Include="Mixins\Wasm\VisualStatesMixins.g.cs" Condition="'$(TargetFramework)'=='netstandard2.0'">
 			<DesignTime>True</DesignTime>
 			<AutoGen>True</AutoGen>
 			<DependentUpon>VisualStatesMixins.tt</DependentUpon>
@@ -156,11 +157,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.SourceGenerationTasks" />
-		<PackageReference Include="Uno.Core" />
-		<PackageReference Include="Uno.Core.Build" />
-		<PackageReference Include="Uno.MonoAnalyzers" />
-		<PackageReference Include="System.Memory" />
+		<PackageReference Include="Uno.SourceGenerationTasks" Version="2.0.0-dev.304" />
+		<PackageReference Include="Uno.Core" Version="2.0.0-dev.5" />
+		<PackageReference Include="Uno.Core.Build" Version="2.0.0-dev.5" />
+		<PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+		  <PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="System.Memory" Version="4.5.2" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
@@ -176,7 +179,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xamarin.build.download" />
+		<PackageReference Include="xamarin.build.download" Version="0.4.11" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -200,32 +203,32 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<MixinInput Include=".\Mixins\Android\BaseActivity.Callbacks.tt" />
-		<MixinInput Include=".\Mixins\Android\FrameworkElementMixins.tt" />
-		<MixinInput Include=".\Mixins\Android\VisualStatesMixins.tt" />
+		<MixinInput Include=".\Mixins\Android\BaseActivity.Callbacks.tt" Condition="$(IsMonoAndroid)" />
+		<MixinInput Include=".\Mixins\Android\FrameworkElementMixins.tt" Condition="$(IsMonoAndroid)" />
+		<MixinInput Include=".\Mixins\Android\VisualStatesMixins.tt" Condition="$(IsMonoAndroid)" />
 		<MixinInput Include=".\Mixins\DependencyPropertyMixins.tt" />
 		<MixinInput Include=".\UI\Xaml\DependencyPropertiesImplementation.tt" />
 		<MixinInput Include=".\UI\Xaml\Controls\VisualStatesImplementation.tt" />
-		<MixinInput Include=".\UI\Xaml\IFrameworkElementImplementation.Android.tt" />
-		<MixinInput Include=".\Mixins\iOS\FrameworkElementMixins.tt" />
-		<MixinInput Include=".\Mixins\iOS\VisualStatesMixins.tt" />
-		<MixinInput Include=".\Mixins\macOS\FrameworkElementMixins.tt" />
-		<MixinInput Include=".\Mixins\macOS\VisualStatesMixins.tt" />
-		<MixinInput Include=".\Mixins\Wasm\VisualStatesMixins.tt" />
-		<MixinInput Include=".\Mixins\net461\VisualStatesMixins.tt" />
-		<MixinInput Include=".\UI\Xaml\IFrameworkElementImplementation.iOS.tt" />
-		<MixinInput Include=".\UI\Xaml\IFrameworkElementImplementation.macOS.tt" />
+		<MixinInput Include=".\UI\Xaml\IFrameworkElementImplementation.Android.tt" Condition="$(IsMonoAndroid)" />
+		<MixinInput Include=".\Mixins\iOS\FrameworkElementMixins.tt" Condition="$(IsXamarinIOS)" />
+		<MixinInput Include=".\Mixins\iOS\VisualStatesMixins.tt" Condition="$(IsXamarinIOS)" />
+		<MixinInput Include=".\Mixins\macOS\FrameworkElementMixins.tt" Condition="$(IsXamarinMac)" />
+		<MixinInput Include=".\Mixins\macOS\VisualStatesMixins.tt" Condition="$(IsXamarinMac)" />
+		<MixinInput Include=".\Mixins\Wasm\VisualStatesMixins.tt" Condition="'$(TargetFramework)'=='netstandard2.0'" />
+		<MixinInput Include=".\Mixins\net461\VisualStatesMixins.tt" Condition="'$(TargetFramework)'=='net461'" />
+		<MixinInput Include=".\UI\Xaml\IFrameworkElementImplementation.iOS.tt" Condition="$(IsXamarinIOS)" />
+		<MixinInput Include=".\UI\Xaml\IFrameworkElementImplementation.macOS.tt" Condition="$(IsXamarinMac)" />
 
-		<MixinOutput Include=".\Mixins\Android\BaseActivity.Callbacks.g.cs" />
-		<MixinOutput Include=".\Mixins\Android\FrameworkElementMixins.g.cs" />
-		<MixinOutput Include=".\Mixins\Android\VisualStatesMixins.g.cs" />
+		<MixinOutput Include=".\Mixins\Android\BaseActivity.Callbacks.g.cs" Condition="$(IsMonoAndroid)" />
+		<MixinOutput Include=".\Mixins\Android\FrameworkElementMixins.g.cs" Condition="$(IsMonoAndroid)" />
+		<MixinOutput Include=".\Mixins\Android\VisualStatesMixins.g.cs" Condition="$(IsMonoAndroid)" />
 		<MixinOutput Include=".\Mixins\DependencyPropertyMixins.g.cs" />
-		<MixinOutput Include=".\Mixins\iOS\FrameworkElementMixins.g.cs" />
-		<MixinOutput Include=".\Mixins\iOS\VisualStatesMixins.g.cs" />
-		<MixinOutput Include=".\Mixins\macOS\FrameworkElementMixins.g.cs" />
-		<MixinOutput Include=".\Mixins\macOS\VisualStatesMixins.g.cs" />
-		<MixinOutput Include=".\Mixins\Wasm\VisualStatesMixins.g.cs" />
-		<MixinOutput Include=".\Mixins\net461\VisualStatesMixins.g.cs" />
+		<MixinOutput Include=".\Mixins\iOS\FrameworkElementMixins.g.cs" Condition="$(IsXamarinIOS)" />
+		<MixinOutput Include=".\Mixins\iOS\VisualStatesMixins.g.cs" Condition="$(IsXamarinIOS)" />
+		<MixinOutput Include=".\Mixins\macOS\FrameworkElementMixins.g.cs" Condition="$(IsXamarinMac)" />
+		<MixinOutput Include=".\Mixins\macOS\VisualStatesMixins.g.cs" Condition="$(IsXamarinMac)" />
+		<MixinOutput Include=".\Mixins\Wasm\VisualStatesMixins.g.cs" Condition="'$(TargetFramework)'=='netstandard2.0'" />
+		<MixinOutput Include=".\Mixins\net461\VisualStatesMixins.g.cs" Condition="'$(TargetFramework)'=='net461'" />
 	</ItemGroup>
 
 	<!--
@@ -235,40 +238,37 @@
 	<Target Name="GenerateMixins" Inputs="@(MixinInput)" Outputs="@(MixinOutput)" BeforeTargets="DispatchToInnerBuilds;Build;_UnoSourceGenerator" DependsOnTargets="_OptimizeT4Generator" Condition="'$(DesignTimeBuild)' != 'true'">
 
 		<ItemGroup>
-			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
+			<MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsMonoAndroid)">
 				<Properties>InputFile=.\Mixins\Android\BaseActivity.Callbacks.tt;OutputPath=.\Mixins\Android;Configuration=$(Configuration);Platform=$(Platform)</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
+			<MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsMonoAndroid)">
 				<Properties>InputFile=.\Mixins\Android\FrameworkElementMixins.tt;OutputPath=.\Mixins\Android;Configuration=$(Configuration);Platform=$(Platform)</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
+			<MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsMonoAndroid)">
 				<Properties>InputFile=.\Mixins\Android\VisualStatesMixins.tt;OutputPath=.\Mixins\Android;Configuration=$(Configuration);Platform=$(Platform)</Properties>
 			</MixinDefinition>
 			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
 				<Properties>InputFile=.\Mixins\DependencyPropertyMixins.tt;OutputPath=.\Mixins;Configuration=$(Configuration);Platform=$(Platform)</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
+			<MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsXamarinIOS)">
 				<Properties>InputFile=.\Mixins\iOS\FrameworkElementMixins.tt;OutputPath=.\Mixins\iOS;Configuration=$(Configuration);Platform=$(Platform)</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
+			<MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsXamarinIOS)">
 				<Properties>InputFile=.\Mixins\iOS\VisualStatesMixins.tt;OutputPath=.\Mixins\iOS;Configuration=$(Configuration);Platform=$(Platform)</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
+			<MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsXamarinMac)">
 				<Properties>InputFile=.\Mixins\macOS\FrameworkElementMixins.tt;OutputPath=.\Mixins\macOS;Configuration=$(Configuration);Platform=$(Platform)</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
+			<MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsXamarinMac)">
 				<Properties>InputFile=.\Mixins\macOS\VisualStatesMixins.tt;OutputPath=.\Mixins\macOS;Configuration=$(Configuration);Platform=$(Platform)</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
+			<MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="'$(TargetFramework)'=='netstandard2.0'">
 				<Properties>InputFile=.\Mixins\Wasm\VisualStatesMixins.tt;OutputPath=.\Mixins\Wasm;Configuration=$(Configuration);Platform=$(Platform)</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
+			<MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="'$(TargetFramework)'=='net461'">
 				<Properties>InputFile=.\Mixins\net461\VisualStatesMixins.tt;OutputPath=.\Mixins\net461;Configuration=$(Configuration);Platform=$(Platform)</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileFullPath)">
-				<Properties>InputFile=.\Mixins\DependencyPropertyMixins.tt;OutputPath=.\Mixins;Configuration=$(Configuration);Platform=$(Platform)</Properties>
-			</MixinDefinition>
-		</ItemGroup>
+    </ItemGroup>
 
 		<Message Text="Generating mixins" Importance="high" />
 
@@ -278,7 +278,7 @@
 
 	<Target Name="_OptimizeT4Generator" Condition="$([MSBuild]::IsOSUnixLike())">
 		<ItemGroup>
-			<_T4AOTFiles Include="$(T4Path)/*.dll" />
+			<_T4AOTFiles Include="$(T4Path)/*.dll" Exclude="$(T4Path)/System.Text.Encoding.CodePages.dll" />
 		</ItemGroup>
 		
 		<Exec ContinueOnError="WarnAndContinue" Command="mono --aot &quot;$(T4Bin)&quot;" Condition="!exists('$(T4Bin).dylib')" />
@@ -319,7 +319,7 @@
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
 		<EmbeddedResource Include="LinkerDefinition.Wasm.xml">
-			<LogicalName>$(AssemblyName).xml</LogicalName>
+			<LogicalName>Uno.UI.xml</LogicalName>
 		</EmbeddedResource>
 	</ItemGroup>
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Slow layout performance.

## What is the new behavior?

This change removes the reliance on NSView.NeedsLayout to invalidate the measure/arrange phases for self and parents. NeedsLayout is set to true when NSView.Frame is changed, causing a chain of multiple unneeded updates for the element and its parents.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Related to #626