### PR TITLE
fix: [Wasm] Adjust linker settings for FocusManager.ReceiveFocusNative

### DIFF
--- a/src/Uno.UI/LinkerDefinition.Wasm.xml
+++ b/src/Uno.UI/LinkerDefinition.Wasm.xml
@@ -10,6 +10,9 @@
     <type fullname="Uno.Media.GeometryConverter" />
     <type fullname="Windows.UI.Xaml.ThicknessConverter" />
     <type fullname="Windows.UI.Xaml.ObservableVectorWrapper" />
+	<type fullname="Windows.UI.Xaml.Input.FocusManager">
+	  <method name="ReceiveFocusNative" />
+	</type>
   </assembly>
   
   <assembly fullname="Uno">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

`dotnet.js:1 Uncaught Error: Could not find method: ReceiveFocusNative`

## What is the new behavior?

The ReceiveFocusNative is excluded from the wasm linker.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
