### PR TITLE
feat: OpenStreamForReadAsync without token

### DIFF
--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -130,8 +130,9 @@ namespace Windows.Storage
             public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer) => throw new NotImplementedException();
         }
 
+		public IAsyncOperation<Stream> OpenStreamForReadAsync() => OpenStreamForReadAsync(CancellationToken.None).AsAsyncOperation<Stream>();
 
-        public async Task<Stream> OpenStreamForReadAsync(CancellationToken ct)
+		public async Task<Stream> OpenStreamForReadAsync(CancellationToken ct)
 		{
 			switch (Scheme)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
There is method `OpenStreamForReadAsync(CancellationToken ct)`, but no method `OpenStreamForReadAsync()` .

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Method `OpenStreamForReadAsync()` is implemented.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
I hope I would not be required to create test for this method.
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

