### PR TITLE
fix: Transform to visual ignores render origin

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.TransformToVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.TransformToVisual.cs
@@ -136,5 +136,34 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			}
 		}
 #endif
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_TransformToVisual_WithTransformOrigin()
+		{
+			var sut = new Border
+			{
+				Width = 100,
+				Height = 10,
+				RenderTransform = new RotateTransform { Angle = 90 },
+				RenderTransformOrigin = new Point(.5, .5),
+				HorizontalAlignment = HorizontalAlignment.Center,
+				VerticalAlignment = VerticalAlignment.Center
+			};
+			var testRoot = new Grid
+			{
+				Height = 300,
+				Width = 300,
+				Children = { sut }
+			};
+
+			TestServices.WindowHelper.WindowContent = testRoot;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var result = sut.TransformToVisual(testRoot).TransformPoint(new Point(1, 1));
+
+			Assert.AreEqual(154, result.X);
+			Assert.AreEqual(101, result.Y);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -178,10 +178,15 @@ namespace Windows.UI.Xaml
 				}
 				else
 				{
+					var origin = elt.RenderTransformOrigin;
+					var transformMatrix = origin == default
+						? transform.MatrixCore
+						: transform.ToMatrix(origin, layoutSlot.Size);
+
 					// First apply any pending arrange offset that would have been impacted by this RenderTransform (eg. scaled)
 					// Friendly reminder: Matrix multiplication is usually not commutative ;)
 					matrix *= Matrix3x2.CreateTranslation((float)offsetX, (float)offsetY);
-					matrix *= transform.MatrixCore;
+					matrix *= transformMatrix;
 
 					offsetX = layoutSlot.X;
 					offsetY = layoutSlot.Y;
@@ -221,7 +226,7 @@ namespace Windows.UI.Xaml
 			return matrix;
 		}
 
-#if !__IOS__ && !__ANDROID__ // This is the default implementation, but is can be customized per platform
+#if !__IOS__ && !__ANDROID__ // This is the default implementation, but it can be customized per platform
 		/// <summary>
 		/// Note: Offsets are only an approximation which does not take in consideration possible transformations
 		///	applied by a 'UIView' between this element and its parent UIElement.


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/2913

## Bugfix
The `TransformOrigin` was not taken in consideration by `TransformToVisual` 

## What is the current behavior?
You you click on a button that is rotated by 90 degrees, the click event it not fired. 

That's because before raising the `click` event, the `ButtonBase` checks if the pointer is over the button in the `OnPointerReleased`, but as the `RenderOrigin` was ignored the computed pointer location was invalid.

## What is the new behavior?
The pointer's location is computed properly, so the click event is fired.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
