### PR TITLE
fix(layouting): Ensure negative Margin doesn't push DesiredSize below 0

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
@@ -350,6 +350,36 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.AreEqual(setHeight, Math.Round(innerView.ActualHeight));
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Negative_Margin_NonZero_Size()
+		{
+			var SUT = new Grid { VerticalAlignment = VerticalAlignment.Top, Margin = new Thickness(0, -16, 0, 0), Height = 120 };
+
+			var hostPanel = new Grid();
+			hostPanel.Children.Add(SUT);
+
+			TestServices.WindowHelper.WindowContent = hostPanel;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(104d, Math.Round(SUT.DesiredSize.Height));
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Negative_Margin_Zero_Size()
+		{
+			var SUT = new Grid { VerticalAlignment = VerticalAlignment.Top, Margin = new Thickness(0, -16, 0, 0) };
+
+			var hostPanel = new Grid();
+			hostPanel.Children.Add(SUT);
+
+			TestServices.WindowHelper.WindowContent = hostPanel;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0d, Math.Round(SUT.DesiredSize.Height));
+		}
 	}
 
 	public partial class MyControl01 : FrameworkElement

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -128,7 +128,9 @@ namespace Windows.UI.Xaml.Controls
 
 				var clippedDesiredSize = desiredSize
 					.AtMost(frameworkAvailableSize)
-					.Add(marginSize);
+					.Add(marginSize)
+					// Margin may be negative
+					.AtLeastZero();
 
 				// DesiredSize must include margins
 				// TODO: on UWP, it's not clipped. See test When_MinWidth_SmallerThan_AvailableSize

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.wasm.cs
@@ -104,7 +104,9 @@ namespace Windows.UI.Xaml
 
 			var clippedDesiredSize = desiredSize
 				.AtMost(availableSize)
-				.Add(marginSize);
+				.Add(marginSize)
+				// Margin may be negative
+				.AtLeastZero();
 
 			// DesiredSize must include margins
 			SetDesiredSize(clippedDesiredSize);


### PR DESCRIPTION
Bring influence of negative Margin on DesiredSize in line with Windows: it reduces the DesiredSize, but never below 0.

This fixes a bug on Android where setting a negative native MeasuredDimension overflows to a very large desired size, causing an empty view with negative margins to request all available space.

GitHub Issue (If applicable): fixes unoplatform/private#129

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
