### PR TITLE
feat: (macOS) Add support for DisplayInformation

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_Graphics_Display/DisplayInformation/DisplayInformation_Properties.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Graphics_Display/DisplayInformation/DisplayInformation_Properties.xaml
@@ -1,5 +1,5 @@
-﻿<UserControl
-    x:Class="UITests.Shared.Windows_Graphics_Display.DisplayInformation.DisplayInformation_Properties"
+﻿<Page
+    x:Class="UITests.Shared.Windows_Graphics_Display.DisplayInformation.DisplayInformation_Properties"	
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -29,4 +29,4 @@
         </ListView>
     </Grid>
 	
-</UserControl>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_Graphics_Display/DisplayInformation/DisplayInformation_Properties.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Graphics_Display/DisplayInformation/DisplayInformation_Properties.xaml.cs
@@ -8,7 +8,7 @@ using DisplayInfo = Windows.Graphics.Display.DisplayInformation;
 namespace UITests.Shared.Windows_Graphics_Display.DisplayInformation
 {
 	[SampleControlInfo("DisplayInformation", "DisplayInformation_Properties", description: "Shows the values from DisplayInformation class properties. N/A for not implemented.")]
-	public sealed partial class DisplayInformation_Properties : UserControl
+	public sealed partial class DisplayInformation_Properties : Page
 	{
 		public DisplayInformation_Properties()
 		{

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.macOS.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.macOS.cs
@@ -1,0 +1,37 @@
+﻿using AppKit;
+
+namespace Windows.Graphics.Display
+{
+	public sealed partial class DisplayInformation
+	{
+		partial void Initialize()
+		{			
+			UpdateProperties();
+		}
+
+		private void UpdateProperties()
+		{
+			UpdateLogicalProperties();
+			UpdateRawProperties();
+		}
+
+		private void UpdateLogicalProperties()
+		{
+			// Scale of 1 is considered @1x, which is the equivalent of 96.0 or 100% for UWP.
+			LogicalDpi = (float)(NSScreen.MainScreen.BackingScaleFactor * 96.0f);
+			ResolutionScale = (ResolutionScale)(int)(NSScreen.MainScreen.BackingScaleFactor * 100.0);
+		}
+
+		/// <summary>
+		/// Sets ScreenHeightInRawPixels, ScreenWidthInRawPixels and RawPixelsPerViewPixel
+		/// </summary>
+		private void UpdateRawProperties()
+		{
+			var screenSize = NSScreen.MainScreen.Frame.Size;
+			var scale = NSScreen.MainScreen.BackingScaleFactor;
+			ScreenHeightInRawPixels = (uint)(screenSize.Height * scale);
+			ScreenWidthInRawPixels = (uint)(screenSize.Width * scale);
+			RawPixelsPerViewPixel = NSScreen.MainScreen.BackingScaleFactor;
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://github.com/unoplatform/uno/issues/2907

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
macOS does not support the `DisplayInformation`

## What is the new behavior?
macOS does support the `DisplayInformation`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).

- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

Internal Issue (If applicable):
