### PR TITLE
fix: [WASM] Fix clearing the Data of a Path

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.ClearData.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.ClearData.cs
@@ -1,0 +1,50 @@
+﻿using System.Drawing;
+using System.Linq;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
+{
+	public partial class Shapes_Tests
+	{
+		private const string _clearDataSample = "UITests.Windows_UI_Xaml_Shapes.Path_ClearData";
+
+		private static readonly ScreenshotOptions _opts = new ScreenshotOptions {IgnoreInSnapshotCompare = true};
+
+		[Test]
+		[AutoRetry]
+		public void Path_ClearData_When_Control()
+		{
+			Run(_clearDataSample, skipInitialScreenshot: true);
+
+			var sut = _app.WaitForElement("ControlDataParent").Single().Rect;
+			var result = TakeScreenshot("result", _opts);
+
+			ImageAssert.HasColorAt(result, sut.CenterX, sut.CenterY, Color.Green);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void Path_ClearData_When_ClearData()
+		{
+			Run(_clearDataSample);
+
+			var sut = _app.WaitForElement("ClearedDataParent").Single().Rect;
+			var result = TakeScreenshot("result", _opts);
+
+			ImageAssert.HasColorAt(result, sut.CenterX, sut.CenterY, Color.White);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void Path_ClearData_When_NoData()
+		{
+			Run(_clearDataSample);
+
+			var sut = _app.WaitForElement("NoDataShape").Single().Rect;
+			var result = TakeScreenshot("result", _opts);
+
+			ImageAssert.HasColorAt(result, sut.CenterX, sut.CenterY, Color.White);
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
@@ -12,7 +12,7 @@ using Uno.UITest.Helpers.Queries;
 
 namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 {
-	public class Shapes_Tests : SampleControlUITestBase
+	public partial class Shapes_Tests : SampleControlUITestBase
 	{
 		[Test]
 		[AutoRetry]

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3097,6 +3097,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Path_ClearData.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PolygonPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4822,6 +4826,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PathTestsControl\Test3.xaml.cs">
       <DependentUpon>Test3.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Path_ClearData.xaml.cs">
+      <DependentUpon>Path_ClearData.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PolygonPage.xaml.cs">
       <DependentUpon>PolygonPage.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_ClearData.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_ClearData.xaml
@@ -1,0 +1,62 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Shapes.Path_ClearData"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Shapes"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Background="White">
+
+		<TextBlock Text="You should see only one pink D (but 3 blue containers)" />
+
+		<Border
+			Background="White"
+			Height="150"
+			Width="150"
+			BorderBrush="DeepSkyBlue"
+			BorderThickness="3"
+			Margin="5"
+			x:Name="ControlDataParent">
+			<Path
+				Data="M25,25 L25,125 L75,125 C125,125 125,25 75,25 L25,25 Z"
+				Height="150"
+				Width="150"
+				Fill="Green" />
+		</Border>
+
+		<Border
+			Background="White"
+			Height="150"
+			Width="150"
+			BorderBrush="DeepSkyBlue"
+			BorderThickness="3"
+			Margin="5"
+			x:Name="ClearedDataParent">
+			<Path
+				x:Name="ClearedData"
+				Data="M25,25 L25,125 L75,125 C125,125 125,25 75,25 L25,25 Z"
+				Height="150"
+				Width="100"
+				Fill="Red"
+				Loaded="ClearData" />
+		</Border>
+
+		<Border
+			Background="White"
+			Height="150"
+			Width="150"
+			BorderBrush="DeepSkyBlue"
+			BorderThickness="3"
+			Margin="5"
+			x:Name="NoDataShape">
+			<Path
+				Height="150"
+				Width="100"
+				Fill="Red"
+				Loaded="ClearData" />
+		</Border>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_ClearData.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_ClearData.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Shapes
+{
+	[Sample("Shapes", IgnoreInSnapshotTests = true, Description = "Automated test which validates that when we clear the Path.Data, it's no longer visible. You should see only one pink D (but 3 blue containers).")]
+	public sealed partial class Path_ClearData : Page
+	{
+		public Path_ClearData()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ClearData(object sender, RoutedEventArgs e)
+		{
+			((Windows.UI.Xaml.Shapes.Path)sender).Data = null;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Shapes/Path.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Path.wasm.cs
@@ -37,6 +37,9 @@ namespace Windows.UI.Xaml.Shapes
 				case PathGeometry pg:
 					_path.SetAttribute(("d", ToStreamGeometry(pg)));
 					break;
+				case null:
+					_path.RemoveAttribute("d");
+					break;
 			}
 		}
 		/// <summary>


### PR DESCRIPTION
GitHub Issue: _private, see below_

## Bugfix
WASM: Impossible to clear the Data of a Path

## What is the current behavior?
When you set `null` on a `Path.Data` the path remains visible

## What is the new behavior?
The `d` property of the native svg element is now clear

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
