### PR TITLE
ios flyout coverage workaround

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -96,6 +96,13 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		{
 			if (_popup.Child is FrameworkElement child)
 			{
+#if __IOS__
+				// workaround for #2984
+				var availableSize = ApplicationView.GetForCurrentView().VisibleBounds.Size;
+				child.MaxHeight = availableSize.Height;
+				child.MaxWidth = availableSize.Width;
+#endif
+
 				SizeChangedEventHandler handler = (_, __) => SetPopupPositionPartial(Target, _popupPositionInTarget);
 
 				child.SizeChanged += handler;

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
@@ -158,13 +158,13 @@ namespace Windows.UI.Xaml.Controls
 					case FlyoutPlacementMode.Full:
 						desiredSize = visibleBounds.Size.AtMost(maxSize);
 						finalPosition = new Point(
-							x: (visibleBounds.Width - desiredSize.Width) / 2.0,
-							y: (visibleBounds.Height - desiredSize.Height) / 2.0);
+							x: visibleBounds.Left + (visibleBounds.Width - desiredSize.Width) / 2.0,
+							y: visibleBounds.Top + (visibleBounds.Height - desiredSize.Height) / 2.0);
 						break;
 					default: // Other unsupported placements
 						finalPosition = new Point(
-							x: (visibleBounds.Width - desiredSize.Width) / 2.0,
-							y: (visibleBounds.Height - desiredSize.Height) / 2.0);
+							x: visibleBounds.Left + (visibleBounds.Width - desiredSize.Width) / 2.0,
+							y: visibleBounds.Top + (visibleBounds.Height - desiredSize.Height) / 2.0);
 						break;
 				}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #2984

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

On iOS, flyout will be able to fully cover the screen


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
