### PR TITLE
feat: (macOS) Add support for Orientation on DisplayInformation

### DIFF
--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.macOS.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.macOS.cs
@@ -13,6 +13,7 @@ namespace Windows.Graphics.Display
 		{
 			UpdateLogicalProperties();
 			UpdateRawProperties();
+			UpdateNativeOrientation();
 		}
 
 		private void UpdateLogicalProperties()
@@ -32,6 +33,14 @@ namespace Windows.Graphics.Display
 			ScreenHeightInRawPixels = (uint)(screenSize.Height * scale);
 			ScreenWidthInRawPixels = (uint)(screenSize.Width * scale);
 			RawPixelsPerViewPixel = NSScreen.MainScreen.BackingScaleFactor;
+		}
+
+		/// <summary>
+		/// Sets the NativeOrientation property 		
+		/// </summary>
+		private void UpdateNativeOrientation()
+		{
+			NativeOrientation = DisplayOrientations.Landscape;
 		}
 	}
 }

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.macOS.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.macOS.cs
@@ -14,6 +14,7 @@ namespace Windows.Graphics.Display
 			UpdateLogicalProperties();
 			UpdateRawProperties();
 			UpdateNativeOrientation();
+			UpdateCurrentOrientation();
 		}
 
 		private void UpdateLogicalProperties()
@@ -41,6 +42,18 @@ namespace Windows.Graphics.Display
 		private void UpdateNativeOrientation()
 		{
 			NativeOrientation = DisplayOrientations.Landscape;
+		}
+
+		private void UpdateCurrentOrientation()
+		{
+			if (NSScreen.MainScreen.Frame.Width > NSScreen.MainScreen.Frame.Height)
+			{
+				CurrentOrientation = DisplayOrientations.Landscape;
+			}
+			else
+			{
+				CurrentOrientation = DisplayOrientations.Portrait;
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://github.com/unoplatform/uno/issues/2907

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
macOS does not support Orientation on the 

## What is the new behavior?
Basic orientation will be supported to match with other platforms.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
closes #2907 

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issues if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
