### PR TITLE
feat(DisplayRequest): macOS support

### DIFF
--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Display/DisplayRequest.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Display/DisplayRequest.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System.Display
 {
-	#if false || false || NET461 || __WASM__ || __MACOS__
+	#if false || false || NET461 || __WASM__ || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class DisplayRequest 
 	{
-		#if false || false || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || false
 		[global::Uno.NotImplemented]
 		public DisplayRequest() 
 		{
@@ -15,14 +15,14 @@ namespace Windows.System.Display
 		}
 		#endif
 		// Forced skipping of method Windows.System.Display.DisplayRequest.DisplayRequest()
-		#if false || false || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || false
 		[global::Uno.NotImplemented]
 		public  void RequestActive()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.System.Display.DisplayRequest", "void DisplayRequest.RequestActive()");
 		}
 		#endif
-		#if false || false || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || false
 		[global::Uno.NotImplemented]
 		public  void RequestRelease()
 		{

--- a/src/Uno.UWP/Helpers/IOKit.macOS.cs
+++ b/src/Uno.UWP/Helpers/IOKit.macOS.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using CoreFoundation;
+
+namespace Uno.Helpers
+{
+    internal static class IOKit
+    {
+        private const string IOKitLibrary = "/System/Library/Frameworks/IOKit.framework/IOKit";
+        private const uint kIOPMAssertionLevelOn = 255;
+
+        private static readonly CFString kIOPMAssertionTypePreventUserIdleDisplaySleep = "PreventUserIdleDisplaySleep";
+
+        [DllImport(IOKitLibrary)]
+        static extern uint IOPMAssertionCreateWithName(IntPtr type, uint level, IntPtr name, out uint id);
+
+        [DllImport(IOKitLibrary)]
+        static extern uint IOPMAssertionRelease(uint id);
+
+        internal static bool PreventUserIdleDisplaySleep(CFString name, out uint id)
+        {
+            var result = IOPMAssertionCreateWithName(
+                kIOPMAssertionTypePreventUserIdleDisplaySleep.Handle,
+                kIOPMAssertionLevelOn,
+                name.Handle,
+                out var newId);
+
+            id = result == 0 ? newId : 0;
+
+            return result == 0;
+        }
+
+        internal static bool AllowUserIdleDisplaySleep(uint id)
+        {
+            var result = IOPMAssertionRelease(id);
+            return result == 0;
+        }
+    }
+}

--- a/src/Uno.UWP/System/Display/DisplayRequest.cs
+++ b/src/Uno.UWP/System/Display/DisplayRequest.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__ || __IOS__
+﻿#if __ANDROID__ || __IOS__ || __MACOS__
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Uno.UWP/System/Display/DisplayRequest.macOS.cs
+++ b/src/Uno.UWP/System/Display/DisplayRequest.macOS.cs
@@ -1,0 +1,21 @@
+﻿#if __MACOS__
+using Uno.Helpers;
+
+namespace Windows.System.Display
+{
+	public partial class DisplayRequest
+	{
+		private uint _displayRequestId;
+
+		partial void ActivateScreenLock()
+		{
+			IOKit.PreventUserIdleDisplaySleep("DisplayRequest", out _displayRequestId);
+		}
+
+		partial void DeactivateScreenLock()
+		{
+			IOKit.AllowUserIdleDisplaySleep(_displayRequestId);
+		}
+	}
+}
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): #626, closes #2987 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`DisplayRequest` is not supported on macOS.

## What is the new behavior?

`DisplayRequest` supported on macOS.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.