### PR TITLE
Fix FindName cannot dig into UIElement.ContextFlyout and Button.Flyout

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1118,7 +1118,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					if (appThemes.Any())
 					{
 						writer.AppendLineInvariant("// Element's RequestedTheme not supported yet. Fallback on Application's RequestedTheme.");
-						writer.AppendLineInvariant("var currentTheme = global::Windows.UI.Xaml.Application.Current.RequestedTheme;");
+						writer.AppendLineInvariant("var currentTheme = global::Windows.UI.Xaml.Application.Current?.RequestedTheme;");
 						using (writer.BlockInvariant($"switch(currentTheme)"))
 						{
 							foreach (var theme in appThemes)

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FindName.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FindName.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+using Windows.UI.Xaml.Controls;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
+{
+	[TestClass]
+#if !NET461
+	[RuntimeTests.RunsOnUIThread]
+#endif
+	public class Given_FindName
+	{
+		[TestInitialize] public void Init() => global::Uno.UI.ApplicationHelper.RequestedCustomTheme = "HighContrast";
+
+		[TestMethod]
+		public void When_SimpleElement()
+		{
+			var SUT = new Grid();
+
+			SUT.Children.Add(new Border { Name = "test" });
+
+			Assert.AreEqual(SUT.Children.First(), SUT.FindName("test"));
+		}
+
+		[TestMethod]
+		public void When_ContextFlyout()
+		{
+			var SUT = new Grid();
+
+			var test1 = new MenuFlyoutItem { Name = "test1" };
+			var test2 = new MenuFlyoutItem { Name = "test2" };
+
+			SUT.ContextFlyout = new MenuFlyout
+			{
+				Items = {
+					test1,
+					test2
+				}
+			};
+
+			Assert.AreEqual(test1, SUT.FindName("test1"));
+			Assert.AreEqual(test2, SUT.FindName("test2"));
+		}
+
+		[TestMethod]
+		public void When_ButtonFlyout()
+		{
+			var SUT = new Grid();
+			var button = new Button() { Style = new Style() };
+
+			SUT.Children.Add(button);
+
+			var test1 = new MenuFlyoutItem { Name = "test1" };
+			var test2 = new MenuFlyoutItem { Name = "test2" };
+
+			button.Flyout = new MenuFlyout
+			{
+				Items = {
+					test1,
+					test2
+				}
+			};
+
+			Assert.AreEqual(test1, SUT.FindName("test1"));
+			Assert.AreEqual(test2, SUT.FindName("test2"));
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FindName.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FindName.cs
@@ -18,8 +18,6 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
 #endif
 	public class Given_FindName
 	{
-		[TestInitialize] public void Init() => global::Uno.UI.ApplicationHelper.RequestedCustomTheme = "HighContrast";
-
 		[TestMethod]
 		public void When_SimpleElement()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -329,6 +329,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			}
 		}
 
-		internal Control GetPresenter() => _popup.Child as Control;
+		internal Control GetPresenter() => _popup?.Child as Control;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
@@ -252,8 +252,25 @@ namespace Windows.UI.Xaml
 				}
 			}
 
+			if(e is UIElement uiElement && uiElement.ContextFlyout is Controls.Primitives.FlyoutBase contextFlyout)
+			{
+				return FindInFlyout(name, contextFlyout);
+			}
+
+			if (e is Button button && button.Flyout is Controls.Primitives.FlyoutBase buttonFlyout)
+			{
+				return FindInFlyout(name, buttonFlyout);
+			}
+
 			return null;
 		}
+
+		private static IFrameworkElement FindInFlyout(string name, Controls.Primitives.FlyoutBase flyoutBase)
+			=> flyoutBase switch
+			{
+				MenuFlyout f => f.Items.Select(i => i.FindName(name)).Trim().FirstOrDefault(),
+				Controls.Primitives.FlyoutBase fb => fb.GetPresenter()?.FindName(name)
+			};
 
 		public static CGSize Measure(this IFrameworkElement element, _Size availableSize)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #2995

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

`FindName` for MenuItems in a ContextFlyout cannot be found

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
