### PR TITLE
fix: [Wasm] Fixes #2834 -Symbol icon Home not shown

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/SymbolIcon/SymbolIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SymbolIcon/SymbolIcon.cs
@@ -12,15 +12,14 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private FontIcon _icon;
 
-		public SymbolIcon()
+		public SymbolIcon() : this(Symbol.Emoji)
 		{
-			_icon = new FontIcon();
-
-			AddIconElementView(_icon);
 		}
 
-		public SymbolIcon(Symbol symbol) : this()
+		public SymbolIcon(Symbol symbol)
 		{
+			_icon = new FontIcon();
+			AddIconElementView(_icon);
 			_icon.Glyph = new string((char)symbol, 1);
 		}
 
@@ -31,13 +30,13 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty SymbolProperty { get; } =
-			DependencyProperty.Register("Symbol", typeof(Symbol), typeof(SymbolIcon), new PropertyMetadata(Symbol.Home, OnSymbolChanged));
+			DependencyProperty.Register("Symbol", typeof(Symbol), typeof(SymbolIcon), new PropertyMetadata(Symbol.Emoji, OnSymbolChanged));
 
 		private static void OnSymbolChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
 			var symbol = dependencyObject as SymbolIcon;
 
-			if(symbol != null)
+			if (symbol != null)
 			{
 				symbol._icon.Glyph = new string((char)symbol.Symbol, 1);
 			}


### PR DESCRIPTION
GitHub Issue : #2834

## PR Type
- Bugfix

## What is the current behavior?

The symbol icon **Home** is not shown in WASM (**Home** is set as the default symbol in the **Symbol** dependency property but the inner **FontIcon.Glyph** property is not set).

## What is the new behavior?

The symbol icon **Home** is now shown in WASM, and the default symbol is now **Emoji** (like in UWP **SymbolIcon** class).


## PR Checklist

- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).