### PR TITLE
fix(pointers): [WASM] Misc PointerWheelChanged fixes

### DIFF
--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -350,8 +350,8 @@ declare namespace Uno.UI {
          * @param evt
          */
         private pointerEventExtractor;
-        private _wheelLineSize;
-        private readonly WheelLineSize;
+        private static _wheelLineSize;
+        private static readonly wheelLineSize;
         /**
          * keyboard event extractor to be used with registerEventOnView
          * @param evt

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -298,7 +298,6 @@ var Uno;
                 this.loadingElementId = loadingElementId;
                 this.allActiveElementsById = {};
                 this.uiElementRegistrations = {};
-                this._wheelLineSize = undefined;
                 this.initDom();
             }
             /**
@@ -1006,8 +1005,9 @@ var Uno;
                     wheelDeltaY = evt.deltaY;
                     switch (evt.deltaMode) {
                         case WheelEvent.DOM_DELTA_LINE: // Actually this is supported only by FF
-                            wheelDeltaX *= this.WheelLineSize;
-                            wheelDeltaY *= this.WheelLineSize;
+                            const lineSize = WindowManager.wheelLineSize;
+                            wheelDeltaX *= lineSize;
+                            wheelDeltaY *= lineSize;
                             break;
                         case WheelEvent.DOM_DELTA_PAGE:
                             wheelDeltaX *= document.documentElement.clientWidth;
@@ -1024,7 +1024,7 @@ var Uno;
                 }
                 return `${pointerId};${evt.clientX};${evt.clientY};${(evt.ctrlKey ? "1" : "0")};${(evt.shiftKey ? "1" : "0")};${evt.buttons};${evt.button};${pointerType};${srcHandle};${evt.timeStamp};${pressure};${wheelDeltaX};${wheelDeltaY}`;
             }
-            get WheelLineSize() {
+            static get wheelLineSize() {
                 // In web browsers, scroll might happen by pixels, line or page.
                 // But WinUI works only with pixels, so we have to convert it before send the value to the managed code.
                 // The issue is that there is no easy way get the "size of a line", instead we have to determine the CSS "line-height"
@@ -1711,6 +1711,7 @@ var Uno;
             WindowManager.initMethods();
             UI.HtmlDom.initPolyfills();
         })();
+        WindowManager._wheelLineSize = undefined;
         WindowManager.MAX_WIDTH = `${Number.MAX_SAFE_INTEGER}vw`;
         WindowManager.MAX_HEIGHT = `${Number.MAX_SAFE_INTEGER}vh`;
         UI.WindowManager = WindowManager;

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -925,8 +925,9 @@ namespace Uno.UI {
 
 				switch (evt.deltaMode) {
 					case WheelEvent.DOM_DELTA_LINE: // Actually this is supported only by FF
-						wheelDeltaX *= this.WheelLineSize;
-						wheelDeltaY *= this.WheelLineSize;
+						const lineSize = WindowManager.wheelLineSize;
+						wheelDeltaX *= lineSize;
+						wheelDeltaY *= lineSize;
 						break;
 					case WheelEvent.DOM_DELTA_PAGE:
 						wheelDeltaX *= document.documentElement.clientWidth;
@@ -944,8 +945,8 @@ namespace Uno.UI {
 			return `${pointerId};${evt.clientX};${evt.clientY};${(evt.ctrlKey ? "1" : "0")};${(evt.shiftKey ? "1" : "0")};${evt.buttons};${evt.button};${pointerType};${srcHandle};${evt.timeStamp};${pressure};${wheelDeltaX};${wheelDeltaY}`;
 		}
 
-		private _wheelLineSize : number = undefined;
-		private get WheelLineSize(): number {
+		private static _wheelLineSize : number = undefined;
+		private static get wheelLineSize(): number {
 			// In web browsers, scroll might happen by pixels, line or page.
 			// But WinUI works only with pixels, so we have to convert it before send the value to the managed code.
 			// The issue is that there is no easy way get the "size of a line", instead we have to determine the CSS "line-height"

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -138,7 +138,8 @@ namespace Windows.UI.Xaml
 				}
 				if (args.wheelDeltaY != 0)
 				{
-					handled |= target.OnNativePointerWheel(ToPointerArgs(target, args, wheel: (false, args.wheelDeltaY), isInContact: null /* maybe */));
+					// Note: Vertical scrolling is inverted between web browser and WinUI!
+					handled |= target.OnNativePointerWheel(ToPointerArgs(target, args, wheel: (false, -args.wheelDeltaY), isInContact: null /* maybe */));
 				}
 				return handled;
 			}


### PR DESCRIPTION
## Bug fixes
Minor fixes for the `PointerWheelChanged` event for WASM

## What is the current behavior?
1. The `PointerWheelChanged` event is not raised on Firefox
2. When scrolling down, the content is scrolling up

## What is the new behavior?
🙃

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).~~
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
