### PR TITLE
Correct template version

### DIFF
--- a/doc/articles/get-started-vscode-wasm.md
+++ b/doc/articles/get-started-vscode-wasm.md
@@ -9,7 +9,7 @@ This guide will walk you through the set-up process for building WebAssembly app
 
 1. Launch Code, then in the terminal type the following to install the Uno Platform templates:
 ```bash
-dotnet new -i Uno.ProjectTemplates.Dotnet::2.3.0-dev.2
+dotnet new -i Uno.ProjectTemplates.Dotnet::2.2.0
 ```
 1. In the terminal type the following to create a new project:
 ```bash

--- a/doc/articles/get-started-vscode-wasm.md
+++ b/doc/articles/get-started-vscode-wasm.md
@@ -9,7 +9,7 @@ This guide will walk you through the set-up process for building WebAssembly app
 
 1. Launch Code, then in the terminal type the following to install the Uno Platform templates:
 ```bash
-dotnet new -i Uno.ProjectTemplates.Dotnet::2.2.0-dev.489
+dotnet new -i Uno.ProjectTemplates.Dotnet::2.3.0-dev.2
 ```
 1. In the terminal type the following to create a new project:
 ```bash


### PR DESCRIPTION
## PR Type

- Documentation content changes 

## What is the current behavior?

The template version to install was incorrect and did not contain `unoapp`

## What is the new behavior?

Updated to the latest stable version.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


## Other information

-

Internal Issue (If applicable):
-