### PR TITLE
fix(pointers): [iOS] Fix the DoubleTap

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -29,10 +29,10 @@
     <PackageReference Update="Microsoft.TypeScript.MSBuild" Version="3.1.5" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.16.0" />
-    <PackageReference Update="Uno.UITest" Version="1.0.0-dev.107" />
-    <PackageReference Update="Uno.UITest.Selenium" Version="1.0.0-dev.107" />
-    <PackageReference Update="Uno.UITest.Xamarin" Version="1.0.0-dev.107" />
-    <PackageReference Update="Uno.UITest.Helpers" Version="1.0.0-dev.107" />
+    <PackageReference Update="Uno.UITest" Version="1.0.0-dev.113" />
+    <PackageReference Update="Uno.UITest.Selenium" Version="1.0.0-dev.113" />
+    <PackageReference Update="Uno.UITest.Xamarin" Version="1.0.0-dev.113" />
+    <PackageReference Update="Uno.UITest.Helpers" Version="1.0.0-dev.113" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
     <PackageReference Update="Xamarin.DuoSdk" Version="0.0.3.4" />
   </ItemGroup>

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DoubleTappedTapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DoubleTappedTapped_Tests.cs
@@ -13,7 +13,6 @@ using Uno.UITests.Helpers;
 
 namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 {
-	[Ignore("DoubleTapCoordinates is not implemented yet https://github.com/unoplatform/Uno.UITest/issues/29")] 
 	public class DoubleTapped_Tests : SampleControlUITestBase
 	{
 		private const string _xamlTestPage = "UITests.Shared.Windows_UI_Input.GestureRecognizerTests.DoubleTappedTests";
@@ -37,10 +36,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			((int)result.Y).Should().Be(tapY);
 		}
 
-
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Browser, Platform.iOS)] // Disabled on Android: The test engine is not able to find "Transformed_Target"
 		public void When_Transformed()
 		{
 			Run(_xamlTestPage);
@@ -48,8 +45,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			const string parentName = "Transformed_Parent";
 			const string targetName = "Transformed_Target";
 
-			var parent = _app.WaitForElement(parentName).Single().Rect;
-			var target = _app.WaitForElement(targetName).Single().Rect;
+			var parent = _app.Query(q => q.All().Marked(parentName)).Single().Rect;
+			var target = _app.Query(q => q.All().Marked(targetName)).Single().Rect;
 
 			// Double tap the target
 			_app.DoubleTapCoordinates(parent.Right - target.Width, parent.Bottom - 3);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DoubleTappedTapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DoubleTappedTapped_Tests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
+using Uno.UITest;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 using Uno.UITests.Helpers;
@@ -45,8 +46,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			const string parentName = "Transformed_Parent";
 			const string targetName = "Transformed_Target";
 
-			var parent = _app.Query(q => q.All().Marked(parentName)).Single().Rect;
-			var target = _app.Query(q => q.All().Marked(targetName)).Single().Rect;
+			IAppRect parent, target;
+			if (AppInitializer.TestEnvironment.CurrentPlatform == Platform.Browser)
+			{
+				// Workaournd until https://github.com/unoplatform/Uno.UITest/pull/35 is merged
+
+				parent = _app.Query(q => q.Marked(parentName)).Single().Rect;
+				target = _app.Query(q => q.Marked(targetName)).Single().Rect;
+			}
+			else
+			{
+				parent = _app.Query(q => q.All().Marked(parentName)).Single().Rect;
+				target = _app.Query(q => q.All().Marked(targetName)).Single().Rect;
+			}
 
 			// Double tap the target
 			_app.DoubleTapCoordinates(parent.Right - target.Width, parent.Bottom - 3);
@@ -57,6 +69,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // We cannot scroll to reach the target on WASM yet
 		public void When_InScroll()
 		{
 			Run(_xamlTestPage);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DoubleTappedTapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DoubleTappedTapped_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -39,6 +40,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Browser, Platform.iOS)] // Disabled on Android: The test engine is not able to find "Transformed_Target"
 		public void When_Transformed()
 		{
 			Run(_xamlTestPage);
@@ -49,7 +51,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			IAppRect parent, target;
 			if (AppInitializer.TestEnvironment.CurrentPlatform == Platform.Browser)
 			{
-				// Workaournd until https://github.com/unoplatform/Uno.UITest/pull/35 is merged
+				// Workaround until https://github.com/unoplatform/Uno.UITest/pull/35 is merged
 
 				parent = _app.Query(q => q.Marked(parentName)).Single().Rect;
 				target = _app.Query(q => q.Marked(targetName)).Single().Rect;
@@ -60,8 +62,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 				target = _app.Query(q => q.All().Marked(targetName)).Single().Rect;
 			}
 
+			var dpi = target.Width / 50;
+
 			// Double tap the target
-			_app.DoubleTapCoordinates(parent.Right - target.Width, parent.Bottom - 3);
+			// Note: On WASM the parent is not clipped properly, so we must use absolute coordinates from top/left
+			//		 https://github.com/unoplatform/uno/issues/2514
+			_app.DoubleTapCoordinates(parent.X + 100 * dpi, parent.Y + (100 + 25) * dpi);
 
 			var result = GestureResult.Get(_app.Marked("LastDoubleTapped"));
 			result.Element.Should().Be(targetName);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/TappedTapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/TappedTapped_Tests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
+using Uno.UITest;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 using Uno.UITests.Helpers;
@@ -39,7 +40,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.iOS)]  // Disabled on Android: The test engine is not able to find "Transformed_Target"
+		[ActivePlatforms(Platform.Browser, Platform.iOS)] // Disabled on Android: The test engine is not able to find "Transformed_Target"
 		public void When_Transformed()
 		{
 			Run(_xamlTestPage);
@@ -47,11 +48,26 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			const string parentName = "Transformed_Parent";
 			const string targetName = "Transformed_Target";
 
-			var parent = _app.WaitForElement(parentName).Single().Rect;
-			var target = _app.WaitForElement(targetName).Single().Rect;
+			IAppRect parent, target;
+			if (AppInitializer.TestEnvironment.CurrentPlatform == Platform.Browser)
+			{
+				// Workaround until https://github.com/unoplatform/Uno.UITest/pull/35 is merged
+
+				parent = _app.Query(q => q.Marked(parentName)).Single().Rect;
+				target = _app.Query(q => q.Marked(targetName)).Single().Rect;
+			}
+			else
+			{
+				parent = _app.Query(q => q.All().Marked(parentName)).Single().Rect;
+				target = _app.Query(q => q.All().Marked(targetName)).Single().Rect;
+			}
+
+			var dpi = target.Width / 50;
 
 			// Tap the target
-			_app.TapCoordinates(parent.Right - target.Width, parent.Bottom - 3);
+			// Note: On WASM the parent is not clipped properly, so we must use absolute coordinates from top/left
+			//		 https://github.com/unoplatform/uno/issues/2514
+			_app.TapCoordinates(parent.X + 100 * dpi, parent.Y + (100 + 25) * dpi);
 
 			var result = GestureResult.Get(_app.Marked("LastTapped"));
 			result.Element.Should().Be(targetName);

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.iOS.cs
@@ -26,12 +26,11 @@ namespace Windows.UI.Xaml.Input
 			CanBubbleNatively = true; // Required for native gesture recognition (i.e. ScrollViewer), and integration of native components in the visual tree
 		}
 
-		internal PointerRoutedEventArgs(UITouch nativeTouch, UIEvent nativeEvent, UIElement receiver) : this()
+		internal PointerRoutedEventArgs(uint pointerId, UITouch nativeTouch, UIEvent nativeEvent, UIElement receiver) : this()
 		{
 			_nativeTouch = nativeTouch;
 			_nativeEvent = nativeEvent;
 
-			var pointerId = (uint)_nativeTouch.Handle;
 			var type = _nativeTouch.Type == UITouchType.Stylus
 				? PointerDeviceType.Pen
 				: PointerDeviceType.Touch;

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -138,7 +138,7 @@ namespace Windows.UI.Xaml
 				}
 				if (args.wheelDeltaY != 0)
 				{
-					// Note: Vertical scrolling is inverted between web browser and WinUI!
+					// Note: Web browser vertical scrolling is the opposite compared to WinUI!
 					handled |= target.OnNativePointerWheel(ToPointerArgs(target, args, wheel: (false, -args.wheelDeltaY), isInContact: null /* maybe */));
 				}
 				return handled;


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/2813

## Bugfix
The `UIElement.DoubleTapped` event is not fired

## What is the current behavior?
On iOS, each time a pointer is pressed down, it has a new ID. The issue is that ID is needed to track and detect double tap.

## What is the new behavior?
We now generates a managed pointer ID which is reset only once all pointers are release. So a pointer will always have the same ID for single touch, and we don't have conflicting pointer ID (like we used to have before using the `UITouch.Handle`)

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
