### PR TITLE
fix(tooltip): Place tooltip relative to mouse pointer

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToolTipTests/ToolTip_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToolTipTests/ToolTip_Tests.cs
@@ -50,5 +50,50 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ToolTipTests
 
 			TakeScreenshot("opened-textonly-tooltip");
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // Only WASM supports mouse-based tests for now
+		public void ToolTip_Large_Text()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_Long_Text");
+
+			const string ButtonWithTooltip = "ButtonWithTooltip";
+			const string BorderInsideToolTip = "BorderInsideToolTip";
+
+			_app.WaitForElement(ButtonWithTooltip);
+			var buttonRect = _app.GetRect(ButtonWithTooltip);
+
+			var upperRect = _app.GetRect("UpperLocator");
+			var lowerRect = _app.GetRect("LowerLocator");
+
+			var before = TakeScreenshot("Before");
+
+			var lowerHoverY = buttonRect.Bottom - buttonRect.Height / 10;
+			_app.TapCoordinates(buttonRect.CenterX, lowerHoverY);
+
+			_app.WaitForElement(BorderInsideToolTip);
+
+			var lowerToolTip = TakeScreenshot("Lower ToolTip");
+
+			ImageAssert.AreEqual(before, lowerToolTip, lowerRect);
+			ImageAssert.AreEqual(before, lowerToolTip, upperRect); // ToolTip should be just above mouse, shouldn't extend above Button bounds
+			ImageAssert.AreNotEqual(before, lowerToolTip, buttonRect);
+
+			_app.FastTap("DummyButton");
+
+			_app.WaitForNoElement(BorderInsideToolTip);
+
+			var upperHoverY = buttonRect.Y + buttonRect.Height / 10;
+			_app.TapCoordinates(buttonRect.CenterX, upperHoverY);
+
+			_app.WaitForElement(BorderInsideToolTip);
+
+			var upperToolTip = TakeScreenshot("Upper ToolTip");
+
+			ImageAssert.AreEqual(before, upperToolTip, lowerRect);
+			ImageAssert.AreNotEqual(before, upperToolTip, upperRect); // Mouse is close to top of button, ToolTip should extend above Button bounds
+			ImageAssert.AreNotEqual(before, upperToolTip, buttonRect);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -957,6 +957,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Long_Text.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\UIElementCollectionTests\UIElementCollection_Insert.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3724,6 +3728,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\TimePicker_Flyout_Automated.xaml.cs">
       <DependentUpon>TimePicker_Flyout_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Long_Text.xaml.cs">
+      <DependentUpon>ToolTip_Long_Text.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\UIElementCollectionTests\UIElementCollection_Insert.xaml.cs">
       <DependentUpon>UIElementCollection_Insert.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Long_Text.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Long_Text.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_Long_Text"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ToolTip"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<StackPanel Margin="0,100,0,0"
+				HorizontalAlignment="Center">
+		<Rectangle x:Name="UpperLocator"
+				   HorizontalAlignment="Stretch"
+				   Height="100"
+				   Fill="Transparent" />
+		<Button x:Name="ButtonWithTooltip" Height="200"
+				Width="250"
+				Content="Button with tooltip">
+			<ToolTipService.ToolTip>
+				<Border x:Name="BorderInsideToolTip" Height="80"
+						CornerRadius="15"
+						Background="Pink">
+					<TextBlock Text="Tooltip content" />
+				</Border>
+			</ToolTipService.ToolTip>
+		</Button>
+		<Rectangle x:Name="LowerLocator"
+				   HorizontalAlignment="Stretch"
+				   Height="100"
+				   Fill="Transparent" />
+		<Button x:Name="DummyButton"
+				Content="Dummy" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Long_Text.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Long_Text.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.ToolTip
+{
+	[Sample]
+	public sealed partial class ToolTip_Long_Text : UserControl
+	{
+		public ToolTip_Long_Text()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
@@ -116,6 +116,18 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnPopupPanelChangedPartial(PopupPanel oldHost, PopupPanel newHost);
 
+		protected override void OnVerticalOffsetChanged(double oldVerticalOffset, double newVerticalOffset)
+		{
+			base.OnVerticalOffsetChanged(oldVerticalOffset, newVerticalOffset);
+			PopupPanel?.InvalidateMeasure();
+		}
+
+		protected override void OnHorizontalOffsetChanged(double oldHorizontalOffset, double newHorizontalOffset)
+		{
+			base.OnHorizontalOffsetChanged(oldHorizontalOffset, newHorizontalOffset);
+			PopupPanel?.InvalidateMeasure();
+		}
+
 		private static readonly PointerEventHandler _handleIfOpened = (snd, e) =>
 		{
 			var popup = ((PopupPanel)snd).Popup;

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
@@ -145,8 +145,6 @@ namespace Windows.UI.Xaml.Controls
 			// It is possible for this function to be called even though the ToolTip is closed.
 			// This can happen if the ToolTip gets closed before it has had a chance to layout and complete its opening sequence.
 			// If this happens, we don't want to continue opening, as that could result in a "closed" ToolTip that is still visible on the screen.
-			var isOpen = IsOpen;
-
 			var spPopup = _popup;
 
 			if (spPopup != null && IsOpen)
@@ -165,8 +163,6 @@ namespace Windows.UI.Xaml.Controls
 
 				// If PerformPlacementWithPopup/PerformPlacementWithWindowedPopup fail to position the Popup, they will set ToolTip.IsOpen=False.
 				// If this happens, we don't want to continue opening the ToolTip.
-				isOpen = IsOpen;
-
 				if (!m_bIsPopupPositioned && IsOpen)
 				{
 					m_bIsPopupPositioned = true;
@@ -362,9 +358,6 @@ namespace Windows.UI.Xaml.Controls
 		private void PerformNonMousePlacementWithPopup(
 			Rect? pTargetRect, Rect pDimentions, PlacementMode placement)
 		{
-
-			var tooltipActualWidth = pDimentions.Width;
-			var tooltipActualHeight = pDimentions.Height;
 			var horizontalOffset = pDimentions.Left;
 			var verticalOffset = pDimentions.Top;
 
@@ -548,7 +541,6 @@ namespace Windows.UI.Xaml.Controls
 				CalculateTooltipClip(clipCalculationsRect, visibleRect.Width - visibleRect.X, visibleRect.Height - visibleRect.Y);
 			}
 
-			Console.WriteLine($"wjkreujk rcResult={rcResult}");
 			// Position tooltip by setting popup's offsets
 			spPopup.VerticalOffset = rcResult.Top - origin.Y;
 			// ToolTipPositioning::QueryRelativePosition is used to position in LTR and RTL. In LTR, the horizontal

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
@@ -8,6 +8,7 @@ using Windows.UI.Core;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Media;
+using _Debug = System.Diagnostics.Debug;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -92,7 +93,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				// Ensure we have a correct size before layouting ToolTip, otherwise it may appear under mouse, steal focus and dismiss itself
 				ApplyTemplate();
-				Measure(Window.Current.Bounds.Size);
+				Measure(Windows.UI.Xaml.Window.Current.Bounds.Size);
 			}
 
 			return DesiredSize;
@@ -234,8 +235,8 @@ namespace Windows.UI.Xaml.Controls
 			var toolTipRect = default(Rect);
 			var intersectionRect = default(Rect);
 
-			screenWidth = Window.Current.Bounds.Width;
-			screenHeight = Window.Current.Bounds.Height;
+			screenWidth = Windows.UI.Xaml.Window.Current.Bounds.Width;
+			screenHeight = Windows.UI.Xaml.Window.Current.Bounds.Height;
 
 			var spTarget = Target;
 
@@ -374,7 +375,7 @@ namespace Windows.UI.Xaml.Controls
 			var szFlyout = default(Size);
 
 			var spTarget = _owner as FrameworkElement;
-			Debug.Assert(spTarget != null, "pTarget expected to be non-null in ToolTip_Partial::PerformPlacement()");
+			_Debug.Assert(spTarget != null, "pTarget expected to be non-null in ToolTip_Partial::PerformPlacement()");
 			if (spTarget != null)
 			{
 				// UNO TODO
@@ -408,10 +409,10 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			var visibleRect = Window.Current.Bounds;
+			var visibleRect = Windows.UI.Xaml.Window.Current.Bounds;
 			var constraint = visibleRect;
 
-			var windowRect = Window.Current.Bounds;
+			var windowRect = Windows.UI.Xaml.Window.Current.Bounds;
 			origin.X = windowRect.X;
 			origin.Y = windowRect.Y;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
@@ -1,21 +1,57 @@
-﻿using Uno.Extensions;
+﻿using System;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
 using Uno.Logging;
+using Windows.Foundation;
+using Windows.UI.Core;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Documents;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
-	partial class ToolTip // That's a ContentControl
+	public partial class ToolTip : ContentControl
 	{
-		private readonly Popup _popup = new Popup {IsLightDismissEnabled = false};
+		private const double TOOLTIP_TOLERANCE = 2.0;    // Used in PlacementMode.Mouse positioning to avoid screen edges.
+		private const double DEFAULT_KEYBOARD_OFFSET = 12;  // Default offset for automatic tooltips opened by keyboard.
+		private const double DEFAULT_MOUSE_OFFSET = 20;   // Default offset for automatic tooltips opened by mouse.
+		private const double DEFAULT_TOUCH_OFFSET = 44;  // Default offset for automatic tooltips opened by touch.
+		private const double CONTEXT_MENU_HINT_VERTICAL_OFFSET = -5;    // The hint is slightly above center in the vertical axis.
+
+		private const int m_mousePlacementVerticalOffset = 11;  // Mouse placement vertical offset
+
+		internal const PlacementMode DefaultPlacementMode = PlacementMode.Top;
+
+		private readonly Popup _popup = new Popup { IsLightDismissEnabled = false };
+
+		private DependencyObject _owner;
 
 		internal Popup Popup => _popup;
+
+#pragma warning disable CS0649
+#pragma warning disable CS0169
+#pragma warning disable CS0414
+		private PlacementMode? m_pToolTipServicePlacementModeOverride;
+		private bool m_bIsPopupPositioned;
+		private bool m_bClosing;
+		private bool m_bIsOpenAsAutomaticToolTip;
+		private bool m_bCallPerformPlacementAtNextPopupOpen;
+		private bool m_isSliderThumbToolTip;
+#pragma warning restore CS0649
+#pragma warning restore CS0169
+#pragma warning restore CS0414
+
+		private FrameworkElement Target => _owner as FrameworkElement;
 
 		public ToolTip()
 		{
 			DefaultStyleKey = typeof(ToolTip);
 
-			_popup.PopupPanel = new ToolTipPopupPanel(this);
+			_popup.PopupPanel = new PopupPanel(_popup);
+			_popup.Opened += OnPopupOpened;
 			_popup.Closed += (sender, e) => IsOpen = false;
+			SizeChanged += OnToolTipSizeChanged;
 		}
 
 		public static DependencyProperty PlacementProperty { get; } =
@@ -73,10 +109,601 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		public void SetAnchor(UIElement element) => _popup.Anchor = element;
+		public void SetAnchor(UIElement element) => _owner = element;
 
 		public event RoutedEventHandler Closed;
 
 		public event RoutedEventHandler Opened;
+
+		// Sets the location of the ToolTip's Popup.
+		//
+		// Slider "Disambiguation UI" ToolTips need special handling since they need to remain centered
+		// over the sliding Thumb, which has not yet rendered in its new position.  Therefore, we pass
+		// the new target rect to handle this case.
+		private void PerformPlacement(Rect? pTargetRect = null)
+		{
+			// It is possible for this function to be called even though the ToolTip is closed.
+			// This can happen if the ToolTip gets closed before it has had a chance to layout and complete its opening sequence.
+			// If this happens, we don't want to continue opening, as that could result in a "closed" ToolTip that is still visible on the screen.
+			var isOpen = IsOpen;
+
+			var spPopup = _popup;
+
+			if (spPopup != null && IsOpen)
+			{
+				// UNO TODO
+				//if (static_cast<CPopup*>(spPopup.Cast<Popup>()->GetHandle())->IsWindowed())
+				//{
+				//	// Sets the location of the ToolTip's Popup out of the Xaml window.
+				//	PerformPlacementWithWindowedPopup(pTargetRect);
+				//}
+				//else
+				{
+					// Sets the location of the ToolTip's Popup within the Xaml window.
+					PerformPlacementWithPopup(pTargetRect);
+				}
+
+				// If PerformPlacementWithPopup/PerformPlacementWithWindowedPopup fail to position the Popup, they will set ToolTip.IsOpen=False.
+				// If this happens, we don't want to continue opening the ToolTip.
+				isOpen = IsOpen;
+
+				if (!m_bIsPopupPositioned && IsOpen)
+				{
+					m_bIsPopupPositioned = true;
+					UpdateVisualState();
+				}
+			}
+
+		}
+
+		//// Sets the location of the ToolTip's Popup within the Xaml window.
+		private void PerformPlacementWithPopup(
+			Rect? pTargetRect)
+		{
+
+			// Make sure we can actually place the ToolTip.  The size should be > 0, and
+			// IsOpen and IsEnabled should be true.
+			if (IsOpen == false ||
+				IsEnabled == false
+				// UNO TODO
+				//||
+				//!DoubleUtil::GreaterThan(tooltipActualWidth, 0) ||
+				//!DoubleUtil::GreaterThan(tooltipActualHeight, 0)
+				)
+			{
+				return;
+			}
+
+			// If the ToolTipService is opening the ToolTip, then its Placement is used,
+			// regardless of what the ToolTip.Placement has been set to.
+			var placement = m_pToolTipServicePlacementModeOverride ?? Placement;
+
+			var dimentions = new Rect(HorizontalOffset, VerticalOffset, ActualWidth, ActualHeight);
+
+			// PlacementMode.Mouse only makes sense for automatic ToolTips opened by touch or mouse.
+			if (placement == PlacementMode.Mouse
+				// UNO TODO
+				// &&
+				//(m_inputMode == AutomaticToolTipInputMode::Touch || m_inputMode == AutomaticToolTipInputMode::Mouse)
+				)
+			{
+				PerformMousePlacementWithPopup(dimentions, placement);
+			}
+			else
+			{
+				PerformNonMousePlacementWithPopup(pTargetRect, dimentions, placement);
+			}
+		}
+
+		// Sets the location of the ToolTip's Popup within the Xaml window.
+		private void PerformMousePlacementWithPopup(
+			Rect pDimentions, PlacementMode placement)
+		{
+			double tooltipActualWidth = pDimentions.Right;
+			double tooltipActualHeight = pDimentions.Bottom;
+			double horizontalOffset = pDimentions.Left;
+			double verticalOffset = pDimentions.Top;
+
+			var screenWidth = 0d;
+			var screenHeight = 0d;
+			var bIsRTL = false;
+
+			double maxX = 0.0;
+			double maxY = 0.0;
+			double left = 0.0;
+			double top = 0.0;
+			var toolTipRect = default(Rect);
+			var intersectionRect = default(Rect);
+
+			screenWidth = Window.Current.Bounds.Width;
+			screenHeight = Window.Current.Bounds.Height;
+
+			var spTarget = Target;
+
+			if (spTarget != null)
+			{
+				// UNO TODO
+				//        xaml::FlowDirection targetFlowDirection = xaml::FlowDirection_LeftToRight;
+				//spTarget->get_FlowDirection(&targetFlowDirection);
+				//bIsRTL = targetFlowDirection == xaml::FlowDirection_RightToLeft;
+				bIsRTL = false;
+
+				// We should not do placement if the target is no longer in the live tree.
+				if (!spTarget.IsLoaded)
+				{
+					return;
+				}
+			}
+
+			var spPopup = _popup;
+
+			var lastPointerEnteredPoint = CoreWindow.GetForCurrentThread().PointerPosition;
+
+			left = lastPointerEnteredPoint.X;
+			top = lastPointerEnteredPoint.Y;
+
+			// If we are in RTL mode, then flip the X coordinate around so that it appears to be in LTR mode. That
+			// means all of the LTR logic will still work.
+			if (bIsRTL)
+			{
+				left = screenWidth - left;
+			}
+
+			MovePointToPointerToolTipShowPosition(ref left, ref top, placement);
+
+			// align ToolTip with the bottom left corner of mouse bounding rectangle
+			top += m_mousePlacementVerticalOffset + verticalOffset;
+			left += horizontalOffset;
+
+			// pessimistic check of top value - can be 0 only if TextBlock().FontSize == 0
+			top = Math.Max(TOOLTIP_TOLERANCE, top);
+
+			// left can be less then TOOLTIP_tolerance if user put mouse pointer on the border of object
+			left = Math.Max(TOOLTIP_TOLERANCE, left);
+
+			maxX = screenWidth;
+			maxY = screenHeight;
+
+			toolTipRect.X = left;
+			toolTipRect.Y = top;
+			toolTipRect.Width = tooltipActualWidth;
+			toolTipRect.Height = tooltipActualHeight;
+
+			intersectionRect.Width = maxX;
+			intersectionRect.Height = maxY;
+
+			intersectionRect.Intersect(toolTipRect);
+			if ((Math.Abs(intersectionRect.Width - toolTipRect.Width) < TOOLTIP_TOLERANCE) &&
+				(Math.Abs(intersectionRect.Height - toolTipRect.Height) < TOOLTIP_TOLERANCE))
+			{
+				// The placement algorithm operates in LTR mode (with transformed data if it
+				// is really in RTL mode), so we also need to transform the X value it returns.
+				if (bIsRTL)
+				{
+					left = screenWidth - left;
+				}
+
+				// ToolTip is completely inside the plug-in
+				spPopup.VerticalOffset = top;
+				spPopup.HorizontalOffset = left;
+			}
+			else
+			{
+				if (top + toolTipRect.Height > maxY)
+				{
+					// If the lower edge of the plug-in obscures the ToolTip,
+					// it repositions itself to align with the upper edge of the bounding box of the mouse.
+					top = maxY - toolTipRect.Height - TOOLTIP_TOLERANCE;
+				}
+
+				if (top < 0)
+				{
+					// If the upper edge of Plug-in obscures the ToolTip,
+					// the control repositions itself to align with the upper edge.
+					// align with the top of the plug-in
+					top = 0;
+				}
+
+				if (left + toolTipRect.Width > maxX)
+				{
+					// If the right edge obscures the ToolTip,
+					// it opens in the opposite direction from the obscuring edge.
+					left = maxX - toolTipRect.Width - TOOLTIP_TOLERANCE;
+				}
+
+				if (left < 0)
+				{
+					// If the left edge obscures the ToolTip,
+					// it then aligns with the obscuring screen edge
+					left = 0;
+				}
+
+				// if right/bottom doesn't fit into the plug-in bounds, clip the ToolTip
+				{
+					var clipCalculationsRect = new Rect(left, top, toolTipRect.Width, toolTipRect.Height);
+					CalculateTooltipClip(clipCalculationsRect, maxX, maxY);
+				}
+
+				// The placement algorithm operates in LTR mode (with transformed data if it
+				// is really in RTL mode), so we also need to transform the X value it returns.
+
+				if (bIsRTL)
+				{
+					left = screenWidth - left;
+				}
+
+				// position the parent Popup
+				spPopup.VerticalOffset = top + verticalOffset;
+				spPopup.HorizontalOffset = left + horizontalOffset;
+			}
+		}
+
+		// Sets the location of the ToolTip's Popup within the Xaml window.
+		private void PerformNonMousePlacementWithPopup(
+			Rect? pTargetRect, Rect pDimentions, PlacementMode placement)
+		{
+
+			var tooltipActualWidth = pDimentions.Width;
+			var tooltipActualHeight = pDimentions.Height;
+			var horizontalOffset = pDimentions.Left;
+			var verticalOffset = pDimentions.Top;
+
+			var bIsRTL = false;
+
+			var origin = default(Point);
+			var rcDockTo = default(Rect);
+			var szFlyout = default(Size);
+
+			var spTarget = _owner as FrameworkElement;
+			Debug.Assert(spTarget != null, "pTarget expected to be non-null in ToolTip_Partial::PerformPlacement()");
+			if (spTarget != null)
+			{
+				// UNO TODO
+				//	        xaml::FlowDirection targetFlowDirection = xaml::FlowDirection_LeftToRight;
+
+				//spTarget->get_FlowDirection(&targetFlowDirection);
+				//bIsRTL = targetFlowDirection == xaml::FlowDirection_RightToLeft;
+
+				// We should not do placement if the target is no longer in the live tree.
+				if (!spTarget.IsLoaded)
+				{
+					return;
+				}
+			}
+
+			var spPopup = _popup;
+			if (spPopup == null)
+			{
+				return;
+			}
+
+			// For ToolTips opened by keyboard focus, PlacementMode_Mouse doesn't make any sense.
+			// Fall back to the default - PlacementMode_Top.
+			if (placement == PlacementMode.Mouse)
+			{
+				placement = PlacementMode.Top;
+			}
+
+			if (spTarget == null)
+			{
+				return;
+			}
+
+			var visibleRect = Window.Current.Bounds;
+			var constraint = visibleRect;
+
+			var windowRect = Window.Current.Bounds;
+			origin.X = windowRect.X;
+			origin.Y = windowRect.Y;
+
+			szFlyout.Width = ActualWidth;
+			szFlyout.Height = ActualHeight;
+
+			var placementRect = GetPlacementRectInWindowCoordinates();
+
+			var getDockToRectFromTargetElement = false;
+
+			if (pTargetRect.HasValue)
+			{
+				// Slider case - position ToolTip over Thumb rect
+				rcDockTo = pTargetRect.Value;
+			}
+			else if (!placementRect.IsEmpty)
+			{
+				rcDockTo = placementRect;
+			}
+			else if (!m_isSliderThumbToolTip
+				// UNOTODO
+				//&&
+				//      (AutomaticToolTipInputMode::Touch == m_inputMode || AutomaticToolTipInputMode::Mouse == m_inputMode)
+				)
+			{
+				var lastPointerEnteredPoint = default(Point);
+
+				// UNO TODO: PointerPoint.GetCurrentPoint(uint pointerId)
+				lastPointerEnteredPoint = CoreWindow.GetForCurrentThread().PointerPosition;
+
+				rcDockTo.X = lastPointerEnteredPoint.X;
+				rcDockTo.Y = lastPointerEnteredPoint.Y;
+
+				// UNO TODO
+				//// For touch, we need to account for the fact that the context menu hint has a vertical offset.
+				//if (AutomaticToolTipInputMode::Touch == m_inputMode)
+				//{
+				//    rcDockTo.Top += CONTEXT_MENU_HINT_VERTICAL_OFFSET;
+				//    rcDockTo.bottom += CONTEXT_MENU_HINT_VERTICAL_OFFSET;
+				//}
+			}
+			else
+			{
+				getDockToRectFromTargetElement = true;
+			}
+
+			if (getDockToRectFromTargetElement)
+			{
+				var targetTopLeft = default(Point);
+				Target.TransformToVisual(null).TransformPoint(targetTopLeft);
+
+				//// UNO TODO
+				//      // targetTopLeft.X should be the left edge of the target, so adjust for RTL by
+				//      // subtracting the width of the target.
+				//      if (bIsRTL)
+				//      {
+				//          targetTopLeft.X -= targetActualWidth;
+				//      }
+
+				rcDockTo.X = targetTopLeft.X;
+				rcDockTo.Y = targetTopLeft.Y;
+				rcDockTo.Width = Target.ActualWidth;
+				rcDockTo.Height = Target.ActualHeight;
+			}
+
+			rcDockTo = rcDockTo.OffsetRect(origin.X, origin.Y);
+
+			// If horizontal & vertical offset are not specified, use the system defaults.
+			var isPropertyLocal = this.IsDependencyPropertySet(HorizontalOffsetProperty);
+			if (!isPropertyLocal)
+			{
+				// UNO TODO
+				//switch (m_inputMode)
+				//{
+				//case AutomaticToolTipInputMode::Keyboard:
+				//    horizontalOffset = DEFAULT_KEYBOARD_OFFSET;
+				//    break;
+				//case AutomaticToolTipInputMode::Mouse:
+				//    horizontalOffset = DEFAULT_MOUSE_OFFSET;
+				//    break;
+				//case AutomaticToolTipInputMode::Touch:
+				//    horizontalOffset = DEFAULT_TOUCH_OFFSET;
+				//    break;
+				//}
+				horizontalOffset = DEFAULT_MOUSE_OFFSET;
+			}
+
+			isPropertyLocal = this.IsDependencyPropertySet(VerticalOffsetProperty);
+			if (!isPropertyLocal)
+			{
+				// UNO TODO
+				//switch (m_inputMode)
+				//{
+				//case AutomaticToolTipInputMode::Keyboard:
+				//    verticalOffset = DEFAULT_KEYBOARD_OFFSET;
+				//    break;
+				//case AutomaticToolTipInputMode::Mouse:
+				//    verticalOffset = DEFAULT_MOUSE_OFFSET;
+				//    break;
+				//case AutomaticToolTipInputMode::Touch:
+				//    verticalOffset = DEFAULT_TOUCH_OFFSET;
+				//    break;
+				//}
+
+				verticalOffset = DEFAULT_MOUSE_OFFSET;
+			}
+
+			// UNO TODO
+			//// Reverse Left/Right palacement for RTL, because the target is flipped.
+			//if (bIsRTL)
+			//{
+			//    if (placement == PlacementMode.Right)
+			//    {
+			//        placement = PlacementMode.Left;
+			//    }
+			//    else if (placement == PlacementMode.Left)
+			//    {
+			//        placement = PlacementMode.Right;
+			//    }
+			//}
+
+			// To honor horizontal/vertical offset, inflate the placement target by these offsets before calling into
+			// the Windows popup positioning logic.
+			rcDockTo.Inflate(horizontalOffset, verticalOffset);
+			(var rcResult, var placementChosen) = ToolTipPositioning.QueryRelativePosition(
+				constraint,
+				szFlyout,
+				rcDockTo,
+				placement);
+
+			// if right/bottom doesn't fit into the plug-in bounds, clip the ToolTip
+			{
+				var clipCalculationsRect = new Rect(0, 0, ActualWidth, ActualHeight);
+				CalculateTooltipClip(clipCalculationsRect, visibleRect.Width - visibleRect.X, visibleRect.Height - visibleRect.Y);
+			}
+
+			Console.WriteLine($"wjkreujk rcResult={rcResult}");
+			// Position tooltip by setting popup's offsets
+			spPopup.VerticalOffset = rcResult.Top - origin.Y;
+			// ToolTipPositioning::QueryRelativePosition is used to position in LTR and RTL. In LTR, the horizontal
+			// offset is  in rcResult.Left. In RTL, the horizontal offset is in rcResult.Right because the
+			// popup is flipped.
+			spPopup.HorizontalOffset = (bIsRTL) ? rcResult.Right - origin.X : rcResult.Left - origin.X;
+
+			// There used to be a setting of FromVerticalOffset and FromHorizontalOffset on the ToolTipTemplateSettings
+			// gotten from get_TemplateSettings here.  However, this is no longer done because the ToolTip animation
+			// is now a FadeIn/FadeOut which doesn't use any FromHorizontalOffset/FromVerticalOffset.  This leaves
+			// ToolTipTemplateSettings and all associated code in a basically non-used and deprecated state - but as of
+			// now, we can't make any breaking changes.  So, to preserve max compatibility, the ToolTipTemplateSettings
+			// is still around as a class/interface/property of the tooltip for now.  It should be removed (or at least
+			// the ToolTip-specific-ness of the Tooltip's template settings should be removed) as soon as it's ok to
+			// make a breaking change.
+		}
+
+
+		private void CalculateTooltipClip(
+			Rect toolTipRect, double maxX, double maxY)
+		{
+			var clipSize = default(Size);
+			var dX = 0.0;
+			var dY = 0.0;
+
+			dX = toolTipRect.Left + toolTipRect.Right - maxX;
+			dY = toolTipRect.Top + toolTipRect.Bottom - maxY;
+
+			if ((dX >= 0) || (dY >= 0))
+			{
+				dX = Math.Max(0, dX);
+				dY = Math.Max(0, dY);
+				clipSize.Width = Math.Max(0, toolTipRect.Right - dX);
+				clipSize.Height = Math.Max(0, toolTipRect.Bottom - dY);
+				PerformClipping(clipSize);
+			}
+		}
+
+		private void MovePointToPointerToolTipShowPosition(
+			ref Point point,
+			PlacementMode placement)
+		{
+			// If the point is inside the placement rect, move it out of the placement rect.
+			var placementRect = GetPlacementRectInWindowCoordinates();
+
+			if (!placementRect.IsEmpty && placementRect.Contains(point))
+			{
+				switch (placement)
+				{
+					case PlacementMode.Left:
+						point.X = placementRect.X;
+						break;
+					case PlacementMode.Right:
+						point.X = placementRect.X + placementRect.Width;
+						break;
+					case PlacementMode.Top:
+					case PlacementMode.Mouse:
+						point.Y = placementRect.Y;
+						break;
+					case PlacementMode.Bottom:
+						point.Y = placementRect.Y + placementRect.Height;
+						break;
+				}
+			}
+		}
+
+		private void MovePointToPointerToolTipShowPosition(
+			ref double left,
+			ref double top,
+			PlacementMode placement)
+		{
+			var point = new Point(left, top);
+
+			MovePointToPointerToolTipShowPosition(ref point, placement);
+
+			left = point.X;
+			top = point.Y;
+		}
+
+		private Rect GetPlacementRectInWindowCoordinates()
+		{
+			var placementRectLocal = Rect.Empty;
+
+			if (PlacementRect is Rect placementRect)
+			{
+				placementRectLocal = placementRect;
+
+				if (Target != null)
+				{
+					var tr = Target.TransformToVisual(null);
+					tr.TransformBounds(placementRectLocal);
+				}
+			}
+
+			return placementRectLocal;
+		}
+
+		// If the owner is a TextElement, we'll get its bounding rect and use that as our placement target rect.
+		// Otherwise, we'll use the default rect derived from the target.
+		private void PerformPlacementInternal()
+		{
+			if (_owner is TextElement textElement)
+			{
+				// UNO TODO
+				//        CCoreServices* pCore = static_cast<CCoreServices*>(DXamlCore::GetCurrent()->GetHandle());
+
+				//XRECTF boundingRect;
+				//pCore->GetTextElementBoundingRect(ownerAsTextElement.Cast<TextElement>()->GetHandle(), &boundingRect);
+
+				//        RECT rectDockTo =
+				//		{
+				//			static_cast<long>(boundingRect.X),
+				//			static_cast<long>(boundingRect.Y),
+				//			static_cast<long>(boundingRect.X + boundingRect.Width),
+				//			static_cast<long>(boundingRect.Y + boundingRect.Height)
+				//		};
+				//PerformPlacement(&rectDockTo);
+			}
+			else
+			{
+				PerformPlacement();
+			}
+		}
+
+		// Handle the SizeChanged event.
+		private void OnToolTipSizeChanged(
+			object pSender,
+			SizeChangedEventArgs pArgs)
+		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug($"{nameof(OnToolTipSizeChanged)} - new Size=({ActualWidth}, {ActualHeight})");
+			}
+			PerformPlacementInternal();
+		}
+
+		private void OnPopupOpened(
+				object pUnused1,
+				object pUnused2)
+		{
+			//OnOpened();
+
+			// UNO TODO
+			//// If we've recently closed and reopened this ToolTip, then don't do anything until we receive the final Popup.Opened
+			//// event. See comment for m_pendingPopupOpenEventCount in header for details.
+			//m_pendingPopupOpenEventCount--;
+			//if (m_pendingPopupOpenEventCount == 0 && m_bCallPerformPlacementAtNextPopupOpen)
+			{
+				m_bCallPerformPlacementAtNextPopupOpen = false;
+				PerformPlacementInternal();
+			}
+		}
+
+		private void PerformClipping(
+			Size size)
+		{
+			// By default a tooltip has only 1 child (border).
+			var childCount = VisualTreeHelper.GetChildrenCount(this);
+			if (childCount > 0)
+			{
+				var spChildAsFE = VisualTreeHelper.GetChild(this, 0) as FrameworkElement;
+				if (spChildAsFE != null)
+				{
+					if (size.Width < spChildAsFE.ActualWidth)
+					{
+						spChildAsFE.Width = size.Width;
+					}
+
+					if (size.Height < spChildAsFE.ActualHeight)
+					{
+						spChildAsFE.Height = size.Height;
+					}
+				}
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTipPositioning.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTipPositioning.cs
@@ -1,0 +1,390 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+using Windows.Foundation;
+using Windows.UI.Xaml.Controls.Primitives;
+
+namespace Windows.UI.Xaml.Controls
+{
+	internal static class ToolTipPositioning
+	{
+		// UNO TODO
+		private static bool IsLefthandedUser() => true;
+
+		private static Size ConstrainSize(
+			Size size,
+			double xMax,
+			double yMax)
+		{
+			// Apply constraint
+			var sizeShrunk = size;
+
+			// Calc horizontal constraint
+			if (size.Width > xMax)
+			{
+				sizeShrunk.Width = xMax;
+			}
+			// Calc vertical constraint
+			if (size.Height > yMax)
+			{
+				sizeShrunk.Height = yMax;
+			}
+			return sizeShrunk;
+		}
+
+		private static Rect HorizontallyCenterRect(
+			Rect container,
+			Rect rcToCenter)
+		{
+			var dx = ((container.Left - rcToCenter.Left) + (container.Right - rcToCenter.Right)) / 2;
+			var rcCentered = rcToCenter.OffsetRect(dx, 0);
+			return rcCentered;
+		}
+
+		private static Rect VerticallyCenterRect(
+				Rect container,
+				Rect rcToCenter)
+		{
+			var dy = ((container.Top - rcToCenter.Top) + (container.Bottom - rcToCenter.Bottom)) / 2;
+			var rcCentered = rcToCenter.OffsetRect(0, dy);
+			return rcCentered;
+		}
+
+		private static Rect MoveNearRect(
+			Rect rcWindow,
+			Rect rcWindowToTract,
+			PlacementMode nSide)
+		{
+			var ptOffset = default(Point);
+			switch (nSide)
+			{
+				case PlacementMode.Left:
+					ptOffset.Y = 0;
+					ptOffset.X = rcWindowToTract.Left - rcWindow.Right;
+					break;
+				case PlacementMode.Right:
+					ptOffset.Y = 0;
+					ptOffset.X = rcWindowToTract.Right - rcWindow.Left;
+					break;
+				case PlacementMode.Top:
+					ptOffset.Y = rcWindowToTract.Top - rcWindow.Bottom;
+					ptOffset.X = 0;
+					break;
+				case PlacementMode.Bottom:
+					ptOffset.Y = rcWindowToTract.Bottom - rcWindow.Top;
+					ptOffset.X = 0;
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+			var rcOffset = rcWindow.OffsetRect(ptOffset);
+			return rcOffset;
+		}
+
+		private static bool IsContainedInRect(
+			Rect container,
+			Rect rc)
+		{
+			bool isContained = true;
+			if (rc.Left > rc.Right || rc.Top > rc.Bottom)
+			{
+				typeof(ToolTipPositioning).Log().LogError("This rect is ill formed.", false);
+				isContained = false;
+			}
+			if (rc.Left < container.Left || rc.Right > container.Right || rc.Top < container.Top || rc.Bottom > container.Bottom)
+			{
+				isContained = false;
+			}
+
+			return isContained;
+		}
+
+		private static Rect MoveRectToPoint(
+			Rect rc,
+			double x,
+			double y)
+		{
+			var rcMoved = rc.OffsetRect(x - rc.Left, y - rc.Top);
+			return rcMoved;
+		}
+
+		private static Rect ShiftRectIntoContainer(
+				Rect container,
+				Rect rcToShift)
+		{
+			Debug.Assert((rcToShift.Width <= container.Width) && (rcToShift.Height <= container.Height),
+				"A rect must be fit in a container in order to be shifted into it");
+
+			var rcShifted = rcToShift;
+			if (rcShifted.Left < container.Left)
+			{
+				rcShifted = MoveRectToPoint(rcShifted, container.Left, rcShifted.Top);
+			}
+			else if (rcShifted.Right > container.Right)
+			{
+				rcShifted = MoveRectToPoint(rcShifted, container.Right - rcShifted.Width, rcShifted.Top);
+			}
+
+			if (rcShifted.Top < container.Top)
+			{
+				rcShifted = MoveRectToPoint(rcShifted, rcShifted.Left, container.Top);
+			}
+			else if (rcShifted.Bottom > container.Bottom)
+			{
+				rcShifted = MoveRectToPoint(rcShifted, rcShifted.Left, container.Bottom - rcShifted.Height);
+			}
+			Debug.Assert(IsContainedInRect(container, rcShifted));
+			return rcShifted;
+		}
+
+		private static bool CanPositionRelativeOnSide(
+					Rect windowToTrack,
+					Rect rcWindow,
+					PlacementMode nSide,
+					Rect constraint)
+		{
+			var nAvailableWidth = 0d;
+			var nAvailableHeight = 0d;
+			switch (nSide)
+			{
+				case PlacementMode.Left:
+					{
+						nAvailableWidth = windowToTrack.Left - constraint.Left;
+						nAvailableHeight = constraint.Height;
+					}
+					break;
+
+				case PlacementMode.Top:
+					{
+						nAvailableWidth = constraint.Width;
+						nAvailableHeight = windowToTrack.Top - constraint.Top;
+					}
+					break;
+
+				case PlacementMode.Right:
+					{
+						nAvailableWidth = constraint.Right - windowToTrack.Right;
+						nAvailableHeight = constraint.Height;
+					}
+					break;
+
+				case PlacementMode.Bottom:
+					{
+						nAvailableWidth = constraint.Width;
+						nAvailableHeight = constraint.Bottom - windowToTrack.Bottom;
+					}
+					break;
+			}
+			return ((nAvailableWidth >= rcWindow.Width) &&
+					(nAvailableHeight >= rcWindow.Height));
+		}
+
+		private static Rect PositionRelativeOnSide(
+			Rect windowToTrack,
+			Rect rcWindow,
+			PlacementMode nSide,
+			Rect constraint)
+		{
+			var rcAdjusted = default(Rect);
+			switch (nSide)
+			{
+				case PlacementMode.Left:
+				case PlacementMode.Right:
+					{
+						rcAdjusted = VerticallyCenterRect(windowToTrack, MoveNearRect(rcWindow, windowToTrack, nSide));
+					}
+					break;
+
+				case PlacementMode.Top:
+				case PlacementMode.Bottom:
+					{
+						rcAdjusted = HorizontallyCenterRect(windowToTrack, MoveNearRect(rcWindow, windowToTrack, nSide));
+					}
+					break;
+			}
+
+			if (!IsContainedInRect(constraint, rcAdjusted))
+			{
+				rcAdjusted = ShiftRectIntoContainer(constraint, rcAdjusted);
+			}
+			return rcAdjusted;
+		}
+
+		// Adjusts a window to use relative positioning.
+		// -  constraint is the rectangle which should fully contain the Flyout, in screen coordinates
+		// -  sizeFlyout is the proposed SIZE of the Flyout, in screen coordinates
+		// -  rcDockTo is the RECT Flyout should not obscure, in screen coordinates
+		// -  sidePreferred is the side the Flyout should appear on
+		//
+		// Returns a RECT which should be used for the Flyout, in screen coordinates
+		internal static (Rect rect, PlacementMode sideChosen) QueryRelativePosition(
+			Rect constraint,
+			Size sizeFlyout,
+			Rect rcDockTo,
+			PlacementMode nSidePreferred
+		)
+		{
+			var typographic = constraint;
+			var nSideChosen = ToolTip.DefaultPlacementMode;
+
+			var sizeUnit = ConstrainSize(sizeFlyout, typographic.Width, typographic.Height);
+
+			var rcFlyout = new Rect(0, 0, sizeUnit.Width, sizeUnit.Height);
+
+			var constraintDockTo = rcDockTo;
+
+			var rcAdjusted = default(Rect);
+			if (CanPositionRelativeOnSide(constraintDockTo, rcFlyout, nSidePreferred, typographic))
+			{
+				rcAdjusted = PositionRelativeOnSide(constraintDockTo, rcFlyout, nSidePreferred, typographic);
+				nSideChosen = nSidePreferred;
+			}
+			else
+			{
+				// fTriedRight isnt needed since if we know the other three are true then it must be that
+				// we didnt try the right side
+				bool fTriedLeft = false;
+				bool fTriedAbove = false;
+				bool fTriedBelow = false;
+
+				var nSideOpposite = PlacementMode.Top;
+				switch (nSidePreferred)
+				{
+					case PlacementMode.Top:
+						nSideOpposite = PlacementMode.Bottom;
+						fTriedAbove = true;
+						fTriedBelow = true;
+						break;
+
+					case PlacementMode.Bottom:
+						nSideOpposite = PlacementMode.Top;
+						fTriedAbove = true;
+						fTriedBelow = true;
+						break;
+
+					case PlacementMode.Left:
+						nSideOpposite = PlacementMode.Right;
+						fTriedLeft = true;
+						break;
+
+					case PlacementMode.Right:
+						nSideOpposite = PlacementMode.Left;
+						fTriedLeft = true;
+						break;
+				}
+
+				if (CanPositionRelativeOnSide(constraintDockTo, rcFlyout, nSideOpposite, typographic))
+				{
+					rcAdjusted = PositionRelativeOnSide(constraintDockTo, rcFlyout, nSideOpposite, typographic);
+					nSideChosen = nSideOpposite;
+				}
+				else
+				{
+					PlacementMode nSideAxialBest;
+					if ((nSidePreferred == PlacementMode.Left) || (nSidePreferred == PlacementMode.Right))
+					{
+						nSideAxialBest = PlacementMode.Top;
+						fTriedAbove = true;
+					}
+					else
+					{
+						if (IsLefthandedUser())
+						{
+							nSideAxialBest = PlacementMode.Right;
+						}
+						else
+						{
+							nSideAxialBest = PlacementMode.Left;
+							fTriedLeft = true;
+						}
+					}
+
+					if (CanPositionRelativeOnSide(constraintDockTo, rcFlyout, nSideAxialBest, typographic))
+					{
+						rcAdjusted = PositionRelativeOnSide(constraintDockTo, rcFlyout, nSideAxialBest, typographic);
+						nSideChosen = nSideAxialBest;
+					}
+					else
+					{
+						PlacementMode nSideRemaining;
+						if (!fTriedAbove)
+						{
+							nSideRemaining = PlacementMode.Top;
+						}
+						else if (!fTriedBelow)
+						{
+							nSideRemaining = PlacementMode.Bottom;
+						}
+						else if (!fTriedLeft)
+						{
+							nSideRemaining = PlacementMode.Left;
+						}
+						else
+						{
+							nSideRemaining = PlacementMode.Right;
+						}
+
+						if (CanPositionRelativeOnSide(constraintDockTo, rcFlyout, nSideRemaining, typographic))
+						{
+							rcAdjusted = PositionRelativeOnSide(constraintDockTo, rcFlyout, nSideRemaining, typographic);
+							nSideChosen = nSideRemaining;
+						}
+						else
+						{
+							switch (nSidePreferred)
+							{
+								case PlacementMode.Left:
+									{
+										var pt = default(Point);
+										pt.X = typographic.Left;
+										pt.Y = rcFlyout.Top;
+										rcAdjusted = MoveRectToPoint(rcFlyout, pt.X, pt.Y);
+										rcAdjusted = VerticallyCenterRect(constraintDockTo, rcAdjusted);
+									}
+									break;
+
+								case PlacementMode.Top:
+									{
+										var pt = default(Point);
+										pt.X = rcFlyout.Left;
+										pt.Y = typographic.Top;
+										rcAdjusted = MoveRectToPoint(rcFlyout, pt.X, pt.Y);
+										rcAdjusted = HorizontallyCenterRect(constraintDockTo, rcAdjusted);
+									}
+									break;
+
+								case PlacementMode.Right:
+									{
+										var pt = default(Point);
+										pt.X = typographic.Right - rcFlyout.Width;
+										pt.Y = rcFlyout.Top;
+										rcAdjusted = MoveRectToPoint(rcFlyout, pt.X, pt.Y);
+										rcAdjusted = VerticallyCenterRect(constraintDockTo, rcAdjusted);
+									}
+									break;
+
+								case PlacementMode.Bottom:
+									{
+										var pt = default(Point);
+										pt.X = rcFlyout.Left;
+										pt.Y = typographic.Bottom - rcFlyout.Height;
+										rcAdjusted = MoveRectToPoint(rcFlyout, pt.X, pt.Y);
+										rcAdjusted = HorizontallyCenterRect(constraintDockTo, rcAdjusted);
+									}
+									break;
+							}
+
+							rcAdjusted = ShiftRectIntoContainer(typographic, rcAdjusted);
+							nSideChosen = nSidePreferred;
+						}
+					}
+				}
+			}
+
+			return (rcAdjusted, nSideChosen);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTipService.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTipService.cs
@@ -38,9 +38,9 @@ namespace Windows.UI.Xaml.Controls
 
 			var toolTip = args.NewValue as ToolTip;
 
-			if (toolTip == null && args.NewValue is string toolTipString)
+			if (toolTip == null && args.NewValue != null)
 			{
-				toolTip = new ToolTip {Content = toolTipString};
+				toolTip = new ToolTip { Content = args.NewValue };
 			}
 
 			if (toolTip != null)

--- a/src/Uno.UWP/Extensions/RectExtensions.cs
+++ b/src/Uno.UWP/Extensions/RectExtensions.cs
@@ -38,5 +38,15 @@ namespace Uno.Extensions
 				return DisplayOrientations.None;
 			}
 		}
+
+		internal static Rect OffsetRect(this Rect rect, double dx, double dy)
+		{
+			rect.X += dx;
+			rect.Y += dy;
+
+			return rect;
+		}
+
+		internal static Rect OffsetRect(this Rect rect, Point offset) => rect.OffsetRect(offset.X, offset.Y);
 	}
 }


### PR DESCRIPTION
Tooltip was previously only being placed relative to the owner view, which could cause the tooltip to immediately flick out of view if it appeared over the mouse (hence causing the owner view to lose focus). This change correctly positions it relative to the mouse pointer location.

GitHub Issue (If applicable): resolves #2980

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
