### PR TITLE
fix: FlyoutPresenter not centering properly

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/MainActivity.cs
+++ b/src/SamplesApp/SamplesApp.Droid/MainActivity.cs
@@ -49,13 +49,16 @@ namespace SamplesApp.Droid
 				activity.Window.ClearFlags(WindowManagerFlags.Fullscreen);
 			}
 		}
+
+		[Export("GetVisibleBounds")]
+		public string GetVisibleBounds() => App.GetVisibleBounds();
+
 		protected override void OnActivityResult(int requestCode, Result resultCode, Android.Content.Intent data)
 		{
 			base.OnActivityResult(requestCode, resultCode, data);
 			AuthenticationContinuationHelper.SetAuthenticationContinuationEventArgs(requestCode, resultCode, data);
 		}
 	}
-
 
 	[Activity]
 	[IntentFilter(
@@ -70,6 +73,5 @@ namespace SamplesApp.Droid
 	public class MsalActivity : BrowserTabActivity
 	{
 	}
-
 }
 

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -28,6 +28,8 @@ using Uno.Logging;
 using Windows.Graphics.Display;
 using System.Globalization;
 using Windows.UI.ViewManagement;
+using Uno.UI;
+
 #if HAS_UNO_WINUI
 using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
 #else
@@ -453,7 +455,23 @@ namespace SamplesApp
 
 		[Foundation.Export("getDisplayScreenScaling:")] // notice the colon at the end of the method name
 		public Foundation.NSString GetDisplayScreenScalingBackdoor(Foundation.NSString value) => new Foundation.NSString(GetDisplayScreenScaling(value).ToString());
+
+		[Foundation.Export("getVisibleBounds:")]
+		public Foundation.NSString GetVisibleBoundsBackdoor() => new Foundation.NSString(GetVisibleBounds());
 #endif
+
+		public static string GetVisibleBounds()
+		{
+			var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
+
+#if !__IOS__
+			var result = bounds.LogicalToPhysicalPixels();
+#else
+			var result = bounds;
+#endif
+
+			return string.Join(",", result.Left, result.Top, result.Width, result.Height);
+		}
 
 		public static bool IsTestDone(string testId) => int.TryParse(testId, out var id) ? _doneTests.Contains(id) : false;
 	}

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -345,5 +345,31 @@ namespace SamplesApp.UITests
 			var currentPlatform = AppInitializer.GetLocalPlatform();
 			return currentPlatform == Platform.Android || currentPlatform == Platform.iOS;
 		}
+
+		internal Rectangle GetVisibleBounds()
+		{
+			switch (AppInitializer.GetLocalPlatform())
+			{
+				case Platform.Browser: throw new NotImplementedException(nameof(GetVisibleBounds));
+			}
+
+			string result = null;
+			try
+			{
+				result = _app.InvokeGeneric(nameof(GetVisibleBounds), default)?.ToString();
+				var ltwh = result.Split(',');
+
+				return new Rectangle(
+					(int)double.Parse(ltwh[0]),
+					(int)double.Parse(ltwh[1]),
+					(int)double.Parse(ltwh[2]),
+					(int)double.Parse(ltwh[3])
+				);
+			}
+			catch (Exception e)
+			{
+				throw new FormatException($"Invalid value returned by {nameof(GetVisibleBounds)}: " + (result ?? throw e), e);
+			}
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml
@@ -117,8 +117,8 @@
 							Content="Show Flyout Full Overlay*"
 							Style="{StaticResource SimpleFlyoutButtonStyle}">
 						<Button.Flyout>
-							<Flyout Placement="Full" FlyoutPresenterStyle="{StaticResource SampleFlyoutPresenterStyle}">
-								<Border Background="#80000000">
+							<Flyout x:Name="FullOverlayFlyout" Placement="Full" FlyoutPresenterStyle="{StaticResource SampleFlyoutPresenterStyle}">
+								<Border x:Name="FullOverlayFlyoutContent" Background="#80000000">
 									<Border VerticalAlignment="Center"
 											HorizontalAlignment="Center"
 											Style="{StaticResource SmallSkyBlueBorderStyle}" />

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
@@ -162,13 +162,13 @@ namespace Windows.UI.Xaml.Controls
 					case FlyoutBase.MajorPlacementMode.Full:
 						desiredSize = visibleBounds.Size.AtMost(maxSize);
 						finalPosition = new Point(
-							x: (visibleBounds.Width - desiredSize.Width) / 2.0,
-							y: (visibleBounds.Height - desiredSize.Height) / 2.0);
+							x: visibleBounds.Left + (visibleBounds.Width - desiredSize.Width) / 2.0,
+							y: visibleBounds.Top + (visibleBounds.Height - desiredSize.Height) / 2.0);
 						break;
 					default: // Other unsupported placements
 						finalPosition = new Point(
-							x: (visibleBounds.Width - desiredSize.Width) / 2.0,
-							y: (visibleBounds.Height - desiredSize.Height) / 2.0);
+							x: visibleBounds.Left + (visibleBounds.Width - desiredSize.Width) / 2.0,
+							y: visibleBounds.Top + (visibleBounds.Height - desiredSize.Height) / 2.0);
 						break;
 				}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #3043

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Full flyout is not properly centered when there are visible padding presents (notch devices).

## What is the new behavior?
Full flyout is now centered even when there are visible padding presents (notch devices).

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.