### PR TITLE
fix(android): Uno template for Android now reacts to all Configuratio…

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/Droid/MainActivity.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Droid/MainActivity.cs
@@ -8,7 +8,7 @@ namespace $ext_safeprojectname$.Droid
 {
 	[Activity(
 			MainLauncher = true,
-			ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize,
+			ConfigurationChanges = Uno.UI.ActivityHelper.AllConfigChanges,
 			WindowSoftInputMode = SoftInput.AdjustPan | SoftInput.StateHidden
 		)]
 	public class MainActivity : Windows.UI.Xaml.ApplicationActivity


### PR DESCRIPTION
Uno template for Android now reacts to all ConfigurationChanges

GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?

- Bugfix


## What is the current behavior?

The template for Android only sets ConfigurationChanges to Orientation and ScreenSize but that means the app will not react to other changes like changing language or going in fullscreen (via the MediaElementPlayer for example


## What is the new behavior?

The template for Android now reacts to all configuration changes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


