### PR TITLE
fix(android-geolocator): Request and validate permissions

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/Properties/AndroidManifest.xml
+++ b/src/SamplesApp/SamplesApp.Droid/Properties/AndroidManifest.xml
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="uno.platform.unosampleapp" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
-	<uses-permission android:name="android.permission.VIBRATE" />
-	<uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+	<!-- NOTE: Add permissions in AssemblyInfo.cs -->
 	<application android:label="SamplesApp"></application>
 	<meta-data android:name="com.google.android.geo.API_KEY" android:value="YOUR API KEY" />
 </manifest>

--- a/src/SamplesApp/SamplesApp.Droid/Properties/AssemblyInfo.cs
+++ b/src/SamplesApp/SamplesApp.Droid/Properties/AssemblyInfo.cs
@@ -28,3 +28,8 @@ using Android.App;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: UsesPermission("android.permission.ACCESS_COARSE_LOCATION")]
+[assembly: UsesPermission("android.permission.ACCESS_FINE_LOCATION")]
+[assembly: UsesPermission("android.permission.VIBRATE")]
+[assembly: UsesPermission("android.permission.ACTIVITY_RECOGNITION")]


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

GeoLocator on android does not request permissions for location.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
