### PR TITLE
Update `dotnet new` templates to use CI versions for uno references

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -79,30 +79,33 @@
 		<ItemGroup>
 			<_PackageToUpdate Include="Uno.UI" />
 			<_PackageToUpdate Include="Uno.UI.RemoteControl" />
+
+			<_legacyProject Include="..\src\SolutionTemplate\**\*.Droid.csproj"/>
+			<_legacyProject Include="..\src\SolutionTemplate\**\*.iOS.csproj"/>
+			<_legacyProject Include="..\src\SolutionTemplate\**\*.macOS.csproj"/>
+
+			<_sdkProject Include="..\src\SolutionTemplate\**\*.Wasm.csproj"/>
+			<_sdkProject Include="..\src\SolutionTemplate\UnoLibraryTemplate\CrossTargetedLibrary.csproj"/>
 		</ItemGroup>
 
-		<XmlUpdate XmlFileName="..\src\SolutionTemplate\UnoSolutionTemplate\Droid\UnoQuickStart.Droid.csproj"
-							 XPath="//x:PackageReference[@Include='%(_PackageToUpdate.Identity)']/@Version" Value="$(GitVersion_FullSemVer)"
+		<XmlUpdate XmlFileName="%(_legacyProject.Identity)"
+							 XPath="//x:PackageReference[@Include='Uno.UI.RemoteControl']/@Version"
+							 Value="$(GitVersion_FullSemVer)"
+							 Namespace="http://schemas.microsoft.com/developer/msbuild/2003"
+							 Prefix="x" />
+		
+		<XmlUpdate XmlFileName="%(_legacyProject.Identity)"
+							 XPath="//x:PackageReference[@Include='Uno.UI']/@Version"
+							 Value="$(GitVersion_FullSemVer)"
 							 Namespace="http://schemas.microsoft.com/developer/msbuild/2003"
 							 Prefix="x" />
 
-		<XmlUpdate XmlFileName="..\src\SolutionTemplate\UnoSolutionTemplate\iOS\UnoQuickStart.iOS.csproj"
-							 XPath="//x:PackageReference[@Include='%(_PackageToUpdate.Identity)']/@Version" Value="$(GitVersion_FullSemVer)"
-							 Namespace="http://schemas.microsoft.com/developer/msbuild/2003"
-							 Prefix="x" />
-
-		<XmlUpdate XmlFileName="..\src\SolutionTemplate\UnoSolutionTemplate\Wasm\UnoQuickStart.Wasm.csproj"
-							 XPath="//PackageReference[@Include='%(_PackageToUpdate.Identity)']/@Version"
+		<XmlUpdate XmlFileName="%(_sdkProject.Identity)"
+							 XPath="//PackageReference[@Include='Uno.UI']/@Version"
 							 Value="$(GitVersion_FullSemVer)" />
-
-		<XmlUpdate XmlFileName="..\src\SolutionTemplate\UnoSolutionTemplate\macOS\UnoQuickStart.macOS.csproj"
-							 XPath="//PackageReference[@Include='%(_PackageToUpdate.Identity)']/@Version"
+		<XmlUpdate XmlFileName="%(_sdkProject.Identity)"
+							 XPath="//PackageReference[@Include='Uno.UI.RemoteControl']/@Version"
 							 Value="$(GitVersion_FullSemVer)" />
-
-		<XmlUpdate XmlFileName="..\src\SolutionTemplate\UnoLibraryTemplate\CrossTargetedLibrary.csproj"
-							 XPath="//PackageReference[@Include='%(_PackageToUpdate.Identity)']/@Version"
-							 Value="$(GitVersion_FullSemVer)" />
-
 	</Target>
 
 	<Target Name="UpdateTasksSHA">

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.UWP/Package.appxmanifest
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.UWP/Package.appxmanifest
@@ -8,7 +8,7 @@
 
   <Identity
     Name="a99917c8-9110-4177-a5b0-b12f1ae4bbfe"
-    Publisher="MyCompany"
+    Publisher="$XmlEscapedPublisherDistinguishedName$"
     Version="1.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="d92515f1-7d7f-4ac3-8d24-a663e04517d6" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

- The Uno.UI package reference is no updated during CI.
- The publisher name is incorrect in the Prism template

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
