### PR TITLE
Prevents stopping the player when going to fullscreen.

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerElement.cs
@@ -143,29 +143,38 @@ namespace Windows.UI.Xaml.Controls
 
 		private void ToogleFullScreen(bool showFullscreen)
 		{
-			if (showFullscreen)
+			try
 			{
-				ApplicationView.GetForCurrentView().TryEnterFullScreenMode();
+				_mediaPlayerPresenter.IsTogglingFullscreen = true;
+
+				if (showFullscreen)
+				{
+					ApplicationView.GetForCurrentView().TryEnterFullScreenMode();
 
 #if __ANDROID__
-				this.RemoveView(_layoutRoot);
+					this.RemoveView(_layoutRoot);
 #elif __IOS__
-				_layoutRoot.RemoveFromSuperview();
+					_layoutRoot.RemoveFromSuperview();
 #endif
 
-				Windows.UI.Xaml.Window.Current.DisplayFullscreen(_layoutRoot);
+					Windows.UI.Xaml.Window.Current.DisplayFullscreen(_layoutRoot);
+				}
+				else
+				{
+					ApplicationView.GetForCurrentView().ExitFullScreenMode();
+
+					Windows.UI.Xaml.Window.Current.DisplayFullscreen(null);
+
+#if __ANDROID__
+					this.AddView(_layoutRoot);
+#elif __IOS__
+					this.Add(_layoutRoot);
+#endif
+				}
 			}
-			else
+			finally
 			{
-				ApplicationView.GetForCurrentView().ExitFullScreenMode();
-
-				Windows.UI.Xaml.Window.Current.DisplayFullscreen(null);
-
-#if __ANDROID__
-				this.AddView(_layoutRoot);
-#elif __IOS__
-				this.Add(_layoutRoot);
-#endif
+				_mediaPlayerPresenter.IsTogglingFullscreen = false;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.cs
@@ -85,9 +85,20 @@ namespace Windows.UI.Xaml.Controls
 		{
 		}
 
+		/// <summary>
+		/// Indicates whether or not the player is currently toggling the fullscreen mode.
+		/// </summary>
+		internal bool IsTogglingFullscreen { get; set; }
+
 		protected override void OnUnloaded()
 		{
-			MediaPlayer.Stop();
+			// The control will get unloaded when going to full screen mode.
+			// Similar to UWP, the video should keep playing while changing mode.
+			if (!IsTogglingFullscreen)
+			{
+				MediaPlayer.Stop();
+			}
+
 			base.OnUnloaded();
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

Fixes #3066 

## PR Type
- Bugfix

## What is the current behavior?

MediaPlayer's playback is restarted when toggling the fullscreen mode.

## What is the new behavior?

MediaPlayer's playback continues when toggling the fullscreen mode.

## PR Checklist

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.