### PR TITLE
fix(mediaplayer): Arranges the player even if the video ratio is of 0 as this will lead to a real video ratio.

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.cs
@@ -107,14 +107,14 @@ namespace Windows.UI.Xaml.Controls
 			if (args > 0) // The VideoRect may initially be empty, ignore because a 0 ratio will lead to infinite dims being returned on measure, resulting in an exception
 			{
 				_currentRatio = args;
-
-				Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-				{
-					Visibility = Visibility.Visible;
-				});
-
-				InvalidateArrange(); 
 			}
+
+			Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+			{
+				Visibility = Visibility.Visible;
+			});
+
+			InvalidateArrange();
 		}
 
 		private void OnMediaFailed(Windows.Media.Playback.MediaPlayer sender, MediaPlayerFailedEventArgs args)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Media player is not shown because it can't calculate it's video ratio without being arranged first.
This issue was introduced in 3fd116dc

## What is the new behavior?

Media player is arranged without a video ratio then the ratio is calculated. This also fixes the infinity measure exception.


## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
