### PR TITLE
fix(mediaplayer): Resets the MediaPlayer and its surface when setting its source to null.

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -813,6 +813,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Sources.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyoutItem_Click.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3632,6 +3636,9 @@
       <DependentUpon>RotatedListView_WithRotatedItems.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\WeirdMeasureSequenceControl.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Sources.xaml.cs">
+      <DependentUpon>MediaPlayerElement_Sources.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyoutItem_Click.xaml.cs">
       <DependentUpon>MenuFlyoutItem_Click.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Sources.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Sources.xaml
@@ -1,0 +1,51 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Sources"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.MediaPlayerElement"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<ScrollViewer>
+		<Grid>
+
+			<Grid.RowDefinitions>
+				<RowDefinition Height="400" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+			</Grid.RowDefinitions>
+
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="Auto" />
+			</Grid.ColumnDefinitions>
+
+			<MediaPlayerElement x:Name="Mpe"
+								AreTransportControlsEnabled="True"
+								AutoPlay="True"
+								Grid.ColumnSpan="2" />
+
+			<TextBlock Text="Change the source of the video player dynamically by entering a different url. An empty url should clear the video."
+					   TextWrapping="Wrap"
+					   Margin="12"
+					   Grid.Row="1"
+					   Grid.ColumnSpan="2" />
+
+			<TextBox x:Name="SourceTextBox"
+					 Text="https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
+					 HorizontalAlignment="Stretch"
+					 Margin="12"
+					 Grid.Row="2" />
+
+			<Button x:Name="UpdateButton"
+					Content="Update source"
+					Width="125"
+					Margin="12"
+					Click="UpdateButton_Click"
+					Grid.Row="2"
+					Grid.Column="1" />
+		</Grid>
+	</ScrollViewer>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Sources.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Sources.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.Media.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement
+{
+	[SampleControlInfo("MediaPlayerElement", "Sources", description: "Test for dynamic sources")]
+	public sealed partial class MediaPlayerElement_Sources : UserControl
+	{
+		public MediaPlayerElement_Sources()
+		{
+			this.InitializeComponent();
+		}
+
+		private void UpdateButton_Click(object sender, RoutedEventArgs e)
+		{
+			var uri = SourceTextBox.Text;
+
+			if (!string.IsNullOrEmpty(uri))
+			{
+				Mpe.Source = MediaSource.CreateFromUri(new Uri(uri));
+			}
+			else
+			{
+				Mpe.Source = null;
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/Media/Playback/Internal/VideoSurface.Android.cs
+++ b/src/Uno.UWP/Media/Playback/Internal/VideoSurface.Android.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using Android.Content;
 using Android.Graphics;
+using Android.Opengl;
 using Android.Runtime;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using Javax.Microedition.Khronos.Egl;
 
 namespace Uno.Media.Playback
 {
@@ -13,6 +15,54 @@ namespace Uno.Media.Playback
 	{
 		public VideoSurface(Context context) : base(context)
 		{
+		}
+
+		/// <summary>
+		/// This method will clear the surface view from its last rendered pixels.
+		/// This is used to avoid seeing the previous video rendering when setting
+		/// a video source to null.
+		/// </summary>
+		internal void Clear()
+		{
+			// The solution is as described here:
+			// https://stackoverflow.com/questions/25660994/clear-video-frame-from-surfaceview-on-video-complete
+			if (Holder?.Surface == null)
+			{
+				return;
+			}
+
+			var egl = Javax.Microedition.Khronos.Egl.EGLContext.EGL.JavaCast<IEGL10>();
+			var display = egl.EglGetDisplay(EGL10.EglDefaultDisplay);
+			egl.EglInitialize(display, null);
+
+			int[] attribList =
+			{
+				EGL10.EglRedSize, 8,
+				EGL10.EglGreenSize, 8,
+				EGL10.EglBlueSize, 8,
+				EGL10.EglAlphaSize, 8,
+				EGL10.EglRenderableType, EGL10.EglWindowBit,
+				EGL10.EglNone, 0, // placeholder for recordable [@-3]
+				EGL10.EglNone
+			};
+
+			var configs = new Javax.Microedition.Khronos.Egl.EGLConfig[1];
+			var numConfigs = new int[1];
+
+			egl.EglChooseConfig(display, attribList, configs, configs.Length, numConfigs);
+			var config = configs[0];
+			var context = egl.EglCreateContext(display, config, EGL10.EglNoContext, new int[] { 12440, 2, EGL10.EglNone });
+
+			var eglSurface = egl.EglCreateWindowSurface(display, config, Holder.Surface, new int[]{ EGL10.EglNone });
+
+			egl.EglMakeCurrent(display, eglSurface, eglSurface, context);
+			GLES20.GlClearColor(0, 0, 0, 1);
+			GLES20.GlClear(GLES20.GlColorBufferBit);
+			egl.EglSwapBuffers(display, eglSurface);
+			egl.EglDestroySurface(display, eglSurface);
+			egl.EglMakeCurrent(display, EGL10.EglNoSurface, EGL10.EglNoSurface, EGL10.EglNoContext);
+			egl.EglDestroyContext(display, context);
+			egl.EglTerminate(display);
 		}
 	}
 }

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -74,6 +74,13 @@ namespace Windows.Media.Playback
 					_isPlayRequested = false;
 					_isPlayerPrepared = false;
 					_player.Release();
+
+					// Clear the surface view so we don't see
+					// the previous video rendering.
+					if (RenderSurface is VideoSurface surfaceView && _hasValidHolder)
+					{
+						surfaceView.Clear();
+					}
 				}
 				finally
 				{
@@ -113,6 +120,9 @@ namespace Windows.Media.Playback
 			PlaybackSession.NaturalDuration = TimeSpan.Zero;
 			PlaybackSession.PositionFromPlayer = TimeSpan.Zero;
 
+			// Reset player
+			TryDisposePlayer();
+
 			if (Source == null)
 			{
 				return;
@@ -120,8 +130,6 @@ namespace Windows.Media.Playback
 
 			try
 			{
-				// Reset player
-				TryDisposePlayer();
 				InitializePlayer();
 
 				PlaybackSession.PlaybackState = MediaPlaybackState.Opening;
@@ -353,7 +361,7 @@ namespace Windows.Media.Playback
 		{
 			get
 			{
-				return TimeSpan.FromMilliseconds(_player.CurrentPosition);
+				return TimeSpan.FromMilliseconds(_player?.CurrentPosition ?? 0);
 			}
 			set
 			{

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
@@ -204,7 +204,10 @@ namespace Windows.Media.Playback
 		{
 			PlaybackSession.NaturalDuration = TimeSpan.Zero;
 			PlaybackSession.PositionFromPlayer = TimeSpan.Zero;
-			
+
+			// Reset player
+			TryDisposePlayer();
+
 			if (Source == null)
 			{
 				return;
@@ -212,8 +215,6 @@ namespace Windows.Media.Playback
 
 			try
 			{
-				// Reset player
-				TryDisposePlayer();
 				InitializePlayer();
 
 				PlaybackSession.PlaybackState = MediaPlaybackState.Opening;


### PR DESCRIPTION
Fixes #3073 

GitHub Issue (If applicable): #3073

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
MediaPlayer is not reset when its source is set to null.

## What is the new behavior?
MediaPlayer is reset when its source is set to null.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
