### PR TITLE
fix: Remove explicit DependentUpon from BlankPage.vstemplate

### DIFF
--- a/src/UnoItemTemplate/BlankPage/BlankPage.vstemplate
+++ b/src/UnoItemTemplate/BlankPage/BlankPage.vstemplate
@@ -14,6 +14,6 @@
   </TemplateData>
   <TemplateContent>
     <ProjectItem OpenInEditor="true" ReplaceParameters="true" ItemType="Page" SubType="Designer" CustomTool="MSBuild:Compile" TargetFileName="$fileinputname$.xaml">BlankPage.xaml</ProjectItem>
-    <ProjectItem ReplaceParameters="true" TargetFileName="$fileinputname$.xaml.cs" DependentUpon="$fileinputname$.xaml">BlankPage.xaml.cs</ProjectItem>
+    <ProjectItem ReplaceParameters="true" TargetFileName="$fileinputname$.xaml.cs">BlankPage.xaml.cs</ProjectItem>
   </TemplateContent>
 </VSTemplate>


### PR DESCRIPTION
GitHub Issue (If applicable): #3075 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Explicit `DependentUpon` attribute generates invalid `<DependentUpon>` declaration.


## What is the new behavior?

Removed `DependentUpon` attribute, now matches the UWP `BlankPage.xaml` template.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.