### PR TITLE
fix(mediaplayer): NRE when the surface is destroyed but the player has already been released.

### DIFF
--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -465,8 +465,8 @@ namespace Windows.Media.Playback
 
 		public void SurfaceCreated(ISurfaceHolder holder)
 		{
-			_player.SetDisplay(holder);
-			_player.SetScreenOnWhilePlaying(true);
+			_player?.SetDisplay(holder);
+			_player?.SetScreenOnWhilePlaying(true);
 			_hasValidHolder = true;
 
 			UpdateVideoStretch(_currentStretch);
@@ -474,7 +474,7 @@ namespace Windows.Media.Playback
 
 		public void SurfaceDestroyed(ISurfaceHolder holder)
 		{
-			_player.SetDisplay(null);
+			_player?.SetDisplay(null);
 			_hasValidHolder = false;
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #3073

## PR Type

- Bugfix

## What is the current behavior?

NRE when the surface is destroyed after the player was released.


## What is the new behavior?

Don't set the display on a null object.


## PR Checklist

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
