### PR TITLE
fix(xBind): Fix x:Bind parsing when ignorable directive is not present

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
@@ -73,8 +73,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private XmlReader ApplyIgnorables(string file)
 		{
+			var adjusted = File.ReadAllText(file);
+
 			var document = new XmlDocument();
-			document.Load(file);
+			document.LoadXml(adjusted);
 
 			var ignorables = FindIgnorables(document);
 
@@ -95,13 +97,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				// change the namespaces using textreplace, to keep the formatting and have proper
 				// line/position reporting.
-				var adjusted = File
-					.ReadAllText(file, Encoding.UTF8)
-					.Replace(
-						"Ignorable=\"{0}\"".InvariantCultureFormat(originalIgnorables),
-						"Ignorable=\"{0}\"".InvariantCultureFormat(ignorables.Value)
-					)
-					.TrimEnd("\r\n");
+				adjusted = adjusted.Replace(
+					"Ignorable=\"{0}\"".InvariantCultureFormat(originalIgnorables),
+					"Ignorable=\"{0}\"".InvariantCultureFormat(ignorables.Value)
+				)
+				.TrimEnd("\r\n");
 
 				// Replace the ignored namespaces with unique urns so that same urn that are placed in Ignored attribute
 				// are ignored independently.
@@ -129,20 +129,18 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							);
 					}
 				}
-
-				if (adjusted.Contains("{x:Bind"))
-				{
-					// Apply replacements to avoid having issues with the XAML parser which does not
-					// support quotes in positional markup extensions parameters.
-					// Note that the UWP preprocessor does not need to apply those replacements as the
-					// x:Bind expressions are being removed during the first phase and replaced by "connections".
-					adjusted = XBindExpressionParser.RewriteDocumentPaths(adjusted);
-				}
-
-				return XmlReader.Create(new StringReader(adjusted));
 			}
 
-			return XmlReader.Create(file);
+			if (adjusted.Contains("{x:Bind", StringComparison.Ordinal))
+			{
+				// Apply replacements to avoid having issues with the XAML parser which does not
+				// support quotes in positional markup extensions parameters.
+				// Note that the UWP preprocessor does not need to apply those replacements as the
+				// x:Bind expressions are being removed during the first phase and replaced by "connections".
+				adjusted = XBindExpressionParser.RewriteDocumentPaths(adjusted);
+			}
+
+			return XmlReader.Create(new StringReader(adjusted));
 		}
 
 		private XmlNode FindIgnorables(XmlDocument document)

--- a/src/SourceGenerators/XamlGenerationTests/XBindIgnorableLess.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/XBindIgnorableLess.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="XamlGenerationTests.Shared.XBindIgnorableLessUserControl"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<Grid>
+		<TextBlock Text="{x:Bind Test}" />
+	</Grid>
+</UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/XBindIgnorableLess.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/XBindIgnorableLess.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+
+namespace XamlGenerationTests.Shared
+{
+	public partial class XBindIgnorableLessUserControl : UserControl
+	{
+		public XBindIgnorableLessUserControl()
+		{
+		}
+
+		public string Test { get; set; }
+	}
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fix x:Bind parsing when ignorable directive is not present in a XAML file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
