### PR TITLE
chore: Update Wasm.Bootstrapper is to 1.2.0-dev.37

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -17,8 +17,8 @@
     <PackageReference Update="Uno.SourceGeneration" Version="2.0.0-dev.16" />
     <PackageReference Update="Uno.Core" Version="2.0.0-dev.5" />
     <PackageReference Update="Uno.Core.Build" Version="2.0.0-dev.5" />
-    <PackageReference Update="Uno.Wasm.Bootstrap" Version="1.2.0-dev.18" />
-	<PackageReference Update="Uno.Wasm.Bootstrap.DevServer" Version="1.2.0-dev.18" />
+    <PackageReference Update="Uno.Wasm.Bootstrap" Version="1.2.0-dev.37" />
+    <PackageReference Update="Uno.Wasm.Bootstrap.DevServer" Version="1.2.0-dev.37" />
     <PackageReference Update="xamarin.build.download" Version="0.4.11" />
     <PackageReference Update="MSTest.TestAdapter" Version="2.1.1"/>
     <PackageReference Update="MSTest.TestFramework" Version="2.1.1"/>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Wasm/BlankApp.Wasm.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Wasm/BlankApp.Wasm.csproj
@@ -40,8 +40,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Uno.UI" Version="2.2.0-dev.494" />
     <PackageReference Include="Uno.UI.RemoteControl" Version="2.2.0-dev.494" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.2.0-dev.18" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.2.0-dev.18" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.2.0-dev.37" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.2.0-dev.37" />
     <PackageReference Include="Prism.Core" Version="8.0.0.1717-ci" />
 
 		<!--#if (Container == "Unity") -->

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoXFQuickStart.Wasm/UnoXFQuickStart.Wasm.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoXFQuickStart.Wasm/UnoXFQuickStart.Wasm.csproj
@@ -45,7 +45,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
 		<PackageReference Include="Uno.Xamarin.Forms.Platform" Version="4.1.0-uno.104" />
-		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.302" />
-		<DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.0-dev.302" />
+		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.2.0-dev.37" />
+		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.2.0-dev.37" />
 	</ItemGroup>
 </Project>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Wasm/UnoQuickStart.Wasm.csproj
@@ -46,8 +46,8 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
 		<PackageReference Include="Uno.UI" Version="2.0.512-dev.4178" />
 		<PackageReference Include="Uno.UI.RemoteControl" Version="2.0.512-dev.4178" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.2.0-dev.18" />
-		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.2.0-dev.18" />
+		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.2.0-dev.37" />
+		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.2.0-dev.37" />
 	</ItemGroup>
 
 	<Import Project="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems" Label="Shared" Condition="Exists('..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems')" />


### PR DESCRIPTION
Fixes #1947

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes the Uno templates for Wasm to run properly on macOS, Linux.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
