### PR TITLE
fix(shapes): [WASM] StrokeDashArray is not published to native element

### DIFF
--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.wasm.cs
@@ -140,7 +140,7 @@ namespace Windows.UI.Xaml.Shapes
 		{
 			var svgElement = GetMainSvgElement();
 
-			if (Stroke == null)
+			if (StrokeThickness == default)
 			{
 				svgElement.ResetStyle("stroke-width");
 			}
@@ -154,7 +154,7 @@ namespace Windows.UI.Xaml.Shapes
 		{
 			var svgElement = GetMainSvgElement();
 
-			if (Stroke == null)
+			if (StrokeDashArray == null)
 			{
 				svgElement.ResetStyle("stroke-dasharray");
 			}


### PR DESCRIPTION
GitHub Issue: _private_

## Bugfix
The `StrokeDashArray` is not applied on WASM

## What is the current behavior?
The DP callback is validating the `Stroke` instead of the `StrokeDashArray`, so if set later (e.g. with a `StaticRessource`), the value won't be pushed to the native element.

## What is the new behavior?
🙃

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features)~~ **=> test will be added in the "Shapes" refactor PR https://github.com/unoplatform/uno/pull/2997
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).~~ _private_
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

