### PR TITLE
fix(bindableswithcompat, shapes): [android,wasm] Color brushes added …

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToggleSwitchControl/ToggleSwitch_Default_Style.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToggleSwitchControl/ToggleSwitch_Default_Style.xaml
@@ -1,32 +1,38 @@
-<UserControl
-	x:Class="SamplesApp.Windows_UI_Xaml_Controls.ToggleSwitchControl.ToggleSwitch_Default_Style" 
-	xmlns:controls="using:Uno.UI.Samples.Controls"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:u="using:Uno.UI.Samples.Controls"
-	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
-	xmlns:ios="http://uno.ui/ios"
-	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:android="http://uno.ui/android"
-	xmlns:wasm="http://uno.ui/android"
-	xmlns:xamarin="http://uno.ui/xamarin"
-	mc:Ignorable="d ios android xamarin wasm"
-	d:DesignHeight="2000"
-	d:DesignWidth="400">
+<UserControl x:Class="SamplesApp.Windows_UI_Xaml_Controls.ToggleSwitchControl.ToggleSwitch_Default_Style"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:u="using:Uno.UI.Samples.Controls"
+			 xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+			 xmlns:ios="http://uno.ui/ios"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:android="http://uno.ui/android"
+			 xmlns:wasm="http://uno.ui/android"
+			 xmlns:xamarin="http://uno.ui/xamarin"
+			 mc:Ignorable="d ios android xamarin wasm"
+			 d:DesignHeight="2000"
+			 d:DesignWidth="400">
 
 	<UserControl.Resources>
 		<ResourceDictionary>
+
+			<SolidColorBrush x:Key="LightGreyBrush"
+							 Color="#000000"
+							 Opacity="0.38" />
+
 			<xamarin:Style x:Key="UmbrellaToggleSwitchStyle"
-				TargetType="ToggleSwitch">
+						   TargetType="ToggleSwitch">
 				<Setter Property="Template">
 					<Setter.Value>
 						<ControlTemplate TargetType="ToggleSwitch">
-			  <android:BindableSwitchCompat Checked="{TemplateBinding IsOn, Mode=TwoWay}"
-											Enabled="{TemplateBinding IsEnabled}"/>
+							<android:BindableSwitchCompat Checked="{TemplateBinding IsOn, Mode=TwoWay}"
+														  Enabled="{TemplateBinding IsEnabled}"
+														  ThumbTint="{StaticResource LightGreyBrush}"
+														  TrackTint="{StaticResource LightGreyBrush}" />
 							<ios:BindableUISwitch IsOn="{TemplateBinding IsOn, Mode=TwoWay}"
-											Enabled="{TemplateBinding IsEnabled}"/>
+												  Enabled="{TemplateBinding IsEnabled}" />
 							<wasm:TextBlock Text="Not yet supported" />
 						</ControlTemplate>
 					</Setter.Value>
@@ -43,10 +49,10 @@
 								  xamarin:Style="{StaticResource UmbrellaToggleSwitchStyle}"
 								  IsOn="{Binding [IsOn], Mode=TwoWay}" />
 					<TextBlock Foreground="Blue">
-						<Run Text="(TextBlock) ToggleSwitch IsOn: "/><Run Text="{Binding [IsOn]}"/>
+						<Run Text="(TextBlock) ToggleSwitch IsOn: " /><Run Text="{Binding [IsOn]}" />
 					</TextBlock>
 					<Button Command="{Binding [Flip]}"
-									Content="Flip the Switch"/>
+							Content="Flip the Switch" />
 				</StackPanel>
 			</DataTemplate>
 		</controls:SampleControl.SampleContent>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/EllipsePage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/EllipsePage.xaml
@@ -7,6 +7,16 @@
 	mc:Ignorable="d"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
+	<Page.Resources>
+		<ResourceDictionary>
+
+			<SolidColorBrush x:Key="LightGreyBrush"
+							 Color="#000000"
+							 Opacity="0.38" />
+		</ResourceDictionary>
+	</Page.Resources>
+
+
 	<StackPanel Spacing="5">
 		<TextBlock FontSize="22">This is an ellipse</TextBlock>
 		<Ellipse x:Name="ellipse0" Stroke="Black" Height="125" Width="150" StrokeThickness="5" HorizontalAlignment="Left"/>
@@ -22,22 +32,55 @@
 				<ColumnDefinition Width="20" />
 				<ColumnDefinition Width="*" />
 			</Grid.ColumnDefinitions>
-			<Grid Grid.Column="0" Width="175" Height="125">
-				<Rectangle StrokeDashArray="2.5,1" Stroke="Brown" StrokeThickness="3" />
-				<Ellipse Width="175" Height="125" Fill="DarkSalmon" x:Name="ellipse1" />
+			<Grid Grid.Column="0"
+				  Width="175"
+				  Height="125">
+				<Rectangle StrokeDashArray="2.5,1"
+						   Stroke="Brown"
+						   StrokeThickness="3" />
+				<Ellipse Width="175"
+						 Height="125"
+						 Fill="DarkSalmon"
+						 x:Name="ellipse1" />
 			</Grid>
-			<Grid Grid.Column="2" Width="175" Height="125">
-				<Rectangle StrokeDashArray="2.5,1" Stroke="Brown" StrokeThickness="3" />
-				<Ellipse Fill="DarkSalmon" x:Name="ellipse2" />
+			<Grid Grid.Column="2"
+				  Width="175"
+				  Height="125">
+				<Rectangle StrokeDashArray="2.5,1"
+						   Stroke="Brown"
+						   StrokeThickness="3" />
+				<Ellipse Fill="DarkSalmon"
+						 x:Name="ellipse2" />
 			</Grid>
 			<Grid Grid.Column="4">
-				<Rectangle StrokeDashArray="2.5,1" Stroke="Brown" StrokeThickness="3" />
-				<Ellipse Height="125" Fill="DarkSalmon" x:Name="ellipse3" />
+				<Rectangle StrokeDashArray="2.5,1"
+						   Stroke="Brown"
+						   StrokeThickness="3" />
+				<Ellipse Height="125"
+						 Fill="DarkSalmon"
+						 x:Name="ellipse3" />
 			</Grid>
-			<Grid Grid.Column="6" MaxWidth="175" HorizontalAlignment="Left">
-				<Rectangle StrokeDashArray="2.5,1" Stroke="Brown" StrokeThickness="3" />
-				<Ellipse Height="125" Fill="DarkGreen" x:Name="ellipse4" />
+			<Grid Grid.Column="6"
+				  MaxWidth="175"
+				  HorizontalAlignment="Left">
+				<Rectangle StrokeDashArray="2.5,1"
+						   Stroke="Brown"
+						   StrokeThickness="3" />
+				<Ellipse Height="125"
+						 Fill="DarkGreen"
+						 x:Name="ellipse4" />
 			</Grid>
 		</Grid>
+		
+		<TextBlock FontSize="22">This is an ellipse that has a fill with opacity</TextBlock>
+		<Ellipse x:Name="ellipse5"
+				 Stroke="Black"
+				 Height="125"
+				 Width="150"
+				 StrokeThickness="5"
+				 HorizontalAlignment="Left" />
+
+		<TextBlock FontSize="22">This is an ellipse that has a stroke opacity</TextBlock>
+		<Ellipse x:Name="ellipse6" Stroke="Black" Height="125" Width="150" StrokeThickness="5" HorizontalAlignment="Left"/>
 	</StackPanel>
 </Page>

--- a/src/Uno.UI/Controls/BindableSwitchCompat.Android.cs
+++ b/src/Uno.UI/Controls/BindableSwitchCompat.Android.cs
@@ -76,7 +76,7 @@ namespace Uno.UI.Controls
 		{
 			if (newValue is SolidColorBrush asColorBrush)
 			{
-				ThumbDrawable?.SetColorFilter(asColorBrush.Color, PorterDuff.Mode.SrcIn);
+				ThumbDrawable?.SetColorFilter(asColorBrush.ColorWithOpacity, PorterDuff.Mode.SrcIn);
 			}
 		}
 
@@ -100,7 +100,7 @@ namespace Uno.UI.Controls
 		{
 			if (newValue is SolidColorBrush asColorBrush)
 			{
-				TrackDrawable?.SetColorFilter(asColorBrush.Color, PorterDuff.Mode.SrcIn);
+				TrackDrawable?.SetColorFilter(asColorBrush.ColorWithOpacity, PorterDuff.Mode.SrcIn);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.wasm.cs
@@ -80,7 +80,7 @@ namespace Windows.UI.Xaml.Shapes
 			switch (fill)
 			{
 				case SolidColorBrush scb:
-					svgElement.SetStyle("fill", scb.Color.ToHexString());
+					svgElement.SetStyle("fill", scb.ColorWithOpacity.ToHexString());
 					_fillBrushSubscription.Disposable = null;
 					break;
 				case ImageBrush ib:
@@ -115,7 +115,7 @@ namespace Windows.UI.Xaml.Shapes
 			switch (Stroke)
 			{
 				case SolidColorBrush scb:
-					svgElement.SetStyle("stroke", scb.Color.ToHexString());
+					svgElement.SetStyle("stroke", scb.ColorWithOpacity.ToHexString());
 					_strokeBrushSubscription.Disposable = null;
 					break;
 				case LinearGradientBrush lgb:


### PR DESCRIPTION
SolidColorBrushes added to Thumbtint, TrackTint (BindableSwitchCompat for Android), Fill, and Stroke (Shapes for Wasm) missing opacity

GitHub Issue (If applicable): #3125 #3126

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
SolidColorBrushed that contained Opacity when added 

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

~~- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
~~- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
~~- [ ] Validated PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
