### PR TITLE
Fix x:Bind invalid type cast, static properties in DataTemplates

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/Given_XBindRewriter.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/Given_XBindRewriter.cs
@@ -19,6 +19,7 @@ namespace Uno.UI.SourceGenerators.Tests
 		[DataRow("ctx", "Static.MyFunction(42.0)", "Static.MyFunction(42.0)")]
 		[DataRow("ctx", "Static.MyFunction(true)", "Static.MyFunction(true)")]
 		[DataRow("ctx", "Static.MyFunction(MyProperty)", "Static.MyFunction(ctx.MyProperty)")]
+		[DataRow("ctx", "MyNameSpace.Static2.MyProperty", "MyNameSpace.Static2.MyProperty")]
 		[DataRow("ctx", "MyNameSpace.Static2.MyFunction(MyProperty)", "MyNameSpace.Static2.MyFunction(ctx.MyProperty)")]
 		[DataRow("ctx", "MyFunction(MyProperty)", "ctx.MyFunction(ctx.MyProperty)")]
 		[DataRow("ctx", "", "ctx")]
@@ -44,6 +45,8 @@ namespace Uno.UI.SourceGenerators.Tests
 					case "System.String.Format":
 						return true;
 					case "MyNameSpace.Static2.MyFunction":
+						return true;
+					case "MyNameSpace.Static2.MyProperty":
 						return true;
 				}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Utils/XBindExpressionParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Utils/XBindExpressionParser.cs
@@ -49,12 +49,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 		class Rewriter : CSharpSyntaxRewriter
 		{
 			private readonly string _contextName;
-			private readonly Func<string, bool> _isStaticMethod;
+			private readonly Func<string, bool> _isStaticMember;
 
-			public Rewriter(string contextName, Func<string, bool> isStaticMethod)
+			public Rewriter(string contextName, Func<string, bool> isStaticMember)
 			{
 				_contextName = contextName;
-				_isStaticMethod = isStaticMethod;
+				_isStaticMember = isStaticMember;
 			}
 
 			public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
@@ -63,7 +63,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 
 				var isValidParent = !Helpers.IsInsideMethod(node).result && !Helpers.IsInsideMemberAccessExpression(node).result;
 
-				if (isValidParent && !_isStaticMethod(node.Expression.ToFullString()))
+				if (isValidParent && !_isStaticMember(node.Expression.ToFullString()))
 				{
 					if (e is InvocationExpressionSyntax newSyntax)
 					{
@@ -85,7 +85,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 				}
 			}
 
-			private object ContextBuilder
+			private string ContextBuilder
 				=> string.IsNullOrEmpty(_contextName) ? "" : _contextName + ".";
 
 			public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
@@ -95,7 +95,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 
 				if (isValidParent)
 				{
-					var output = ParseCompilationUnit($"class __Temp {{ private Func<object> __prop => {ContextBuilder}{e.ToFullString()}; }}");
+					var expression = e.ToFullString();
+					var contextBuilder = _isStaticMember(expression) ? "" : ContextBuilder;
+					var output = ParseCompilationUnit($"class __Temp {{ private Func<object> __prop => {contextBuilder}{expression}; }}");
 
 					var o2 = output.DescendantNodes().OfType<ArrowExpressionClauseSyntax>().First().Expression;
 					return o2;

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2884,7 +2884,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							if (propertyPaths.properties.Length == 1)
 							{
 								var targetPropertyType = GetXBindPropertyPathType(propertyPaths.properties[0], GetType(dataType));
-								return $"(___ctx, __value) => {{ if(___ctx is {dataType} ___tctx) {{ {contextFunction} = ({targetPropertyType})__value; }} }}";
+								return $"(___ctx, __value) => {{ if(___ctx is {dataType} ___tctx) {{ {contextFunction} = ({targetPropertyType})({propertyType})__value; }} }}";
 							}
 							else
 							{
@@ -2924,7 +2924,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							if (propertyPaths.properties.Length == 1)
 							{
 								var targetPropertyType = GetXBindPropertyPathType(propertyPaths.properties[0]);
-								return $"(___tctx, __value) => {rawFunction} = ({targetPropertyType})__value";
+								return $"(___tctx, __value) => {rawFunction} = ({targetPropertyType})({propertyType})__value";
 							}
 							else
 							{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2839,7 +2839,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			// Populate the property paths only if updateable bindings.
 			var propertyPaths = modeMember != "OneTime"
-				? XBindExpressionParser.ParseProperties(rawFunction, IsStaticMethod)
+				? XBindExpressionParser.ParseProperties(rawFunction, IsStaticMember)
 				: (properties: new string[0], hasFunction: false);
 
 			var formattedPaths = propertyPaths
@@ -2861,7 +2861,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				var dataType = RewriteNamespaces(dataTypeObject.Value?.ToString());
 
-				var contextFunction = XBindExpressionParser.Rewrite("___tctx", rawFunction, IsStaticMethod);
+				var contextFunction = XBindExpressionParser.Rewrite("___tctx", rawFunction, IsStaticMember);
 
 				string buildBindBack()
 				{
@@ -2982,16 +2982,17 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return currentType;
 		}
 
-		bool IsStaticMethod(string fullMethodName)
+		bool IsStaticMember(string fullMemberName)
 		{
-			fullMethodName = fullMethodName.TrimStart("global::");
+			fullMemberName = fullMemberName.TrimStart("global::");
 
-			var lastDotIndex = fullMethodName.LastIndexOf(".");
+			var lastDotIndex = fullMemberName.LastIndexOf(".");
 
-			var className = lastDotIndex != -1 ? fullMethodName.Substring(0, lastDotIndex) : fullMethodName;
-			var methodName = lastDotIndex != -1 ? fullMethodName.Substring(lastDotIndex + 1) : fullMethodName;
+			var className = lastDotIndex != -1 ? fullMemberName.Substring(0, lastDotIndex) : fullMemberName;
+			var memberName = lastDotIndex != -1 ? fullMemberName.Substring(lastDotIndex + 1) : fullMemberName;
 
-			return _medataHelper.FindTypeByFullName(className) is INamedTypeSymbol typeSymbol && typeSymbol.GetMethods().Any(m => m.Name == methodName);
+			return _medataHelper.FindTypeByFullName(className) is INamedTypeSymbol typeSymbol
+				&& (typeSymbol.GetMethods().Any(m => m.IsStatic && m.Name == memberName) || typeSymbol.GetProperties().Any(m => m.IsStatic && m.Name == memberName));
 		}
 
 		private string RewriteNamespaces(string xamlString)

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch.xaml
@@ -1,0 +1,15 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.Binding_TypeMismatch"
+	  xmlns:sys="using:System"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<Slider x:Name="mySlider"
+				x:FieldModifier="public"
+				Value="{x:Bind MyInteger, Mode=TwoWay}"/>
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_TypeMismatch : Page, System.ComponentModel.INotifyPropertyChanged
+	{
+		private int _myProperty;
+
+		public Binding_TypeMismatch()
+		{
+			this.InitializeComponent();
+		}
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		public int MyInteger
+		{
+			get => _myProperty;
+			set
+			{
+				_myProperty = value;
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(MyInteger)));
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch_DataTemplate.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch_DataTemplate.xaml
@@ -1,0 +1,22 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.Binding_TypeMismatch_DataTemplate"
+	  xmlns:sys="using:System"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<ContentControl x:Name="root"
+						x:FieldModifier="public">
+			<ContentControl.ContentTemplate>
+				<DataTemplate x:DataType="local:Binding_TypeMismatch_DataTemplate_Data">
+					<Slider x:Name="mySlider"
+							x:FieldModifier="public"
+							Value="{x:Bind MyInteger, Mode=TwoWay}"/>
+				</DataTemplate>
+			</ContentControl.ContentTemplate>
+		</ContentControl>
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch_DataTemplate.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch_DataTemplate.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_TypeMismatch_DataTemplate : Page
+	{
+
+		public Binding_TypeMismatch_DataTemplate()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public class Binding_TypeMismatch_DataTemplate_Data : System.ComponentModel.INotifyPropertyChanged
+	{
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		private int _myProperty;
+
+		public int MyInteger
+		{
+			get => _myProperty;
+			set
+			{
+				_myProperty = value;
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(MyInteger)));
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/DataTemplate_StaticProperty_Control.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/DataTemplate_StaticProperty_Control.xaml
@@ -1,0 +1,25 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.DataTemplate_StaticProperty_Control"
+	  xmlns:sys="using:System"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MyTemplate"
+					  x:DataType="local:DataTemplate_StaticProperty_Control_Data">
+			<StackPanel>
+				<TextBlock x:Name="_MyProperty"
+						   Text="{x:Bind local:DataTemplate_StaticProperty_Control_Data2.TestString}" />
+			</StackPanel>
+		</DataTemplate>
+	</Page.Resources>
+
+	<Grid>
+		<ContentControl x:Name="root"
+						x:FieldModifier="public"
+						ContentTemplate="{StaticResource MyTemplate}" />
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/DataTemplate_StaticProperty_Control.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/DataTemplate_StaticProperty_Control.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class DataTemplate_StaticProperty_Control : Page
+	{
+		public DataTemplate_StaticProperty_Control()
+		{
+			this.InitializeComponent();
+		}
+	}
+	public class DataTemplate_StaticProperty_Control_Data2
+	{
+		public static string TestString => "Hello";
+	}
+
+	public class DataTemplate_StaticProperty_Control_Data
+	{
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls;
+using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 {
@@ -583,13 +584,54 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 
 			SUT.ForceLoaded();
 
-			var inner = SUT.root.FindName("inner") as Windows.UI.Xaml.Controls.TextBlock;
+			var inner = SUT.root.FindName("inner") as TextBlock;
 
 			Assert.IsNull(inner.Text);
 
 			SUT.root.Content = "hello!";
 
 			Assert.AreEqual("hello!", inner.Text);
+		}
+
+		[TestMethod]
+		public void When_TypeMismatch()
+		{
+			var SUT = new Binding_TypeMismatch();
+
+			SUT.ForceLoaded();
+
+			var inner = SUT.FindName("mySlider") as Slider;
+
+			Assert.AreEqual(0.0, inner.Value);
+			Assert.AreEqual(0, SUT.MyInteger);
+
+			inner.Minimum = 10.0;
+
+			Assert.AreEqual(10.0, inner.Value);
+			Assert.AreEqual(10, SUT.MyInteger);
+		}
+
+		[TestMethod]
+		public void When_TypeMismatch_DataTemplate()
+		{
+			var SUT = new Binding_TypeMismatch_DataTemplate();
+
+			var rootData = new Binding_TypeMismatch_DataTemplate_Data();
+			SUT.root.Content = rootData;
+
+			Assert.AreEqual(0, rootData.MyInteger);
+
+			SUT.ForceLoaded();
+
+			var slider = SUT.FindName("mySlider") as Slider;
+
+			Assert.AreEqual(0.0, slider.Value);
+			Assert.AreEqual(0, rootData.MyInteger);
+
+			slider.Minimum = 10.0;
+
+			Assert.AreEqual(10.0, slider.Value);
+			Assert.AreEqual(10, rootData.MyInteger);
 		}
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_DataTemplate.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_DataTemplate.cs
@@ -146,5 +146,18 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 
 			Assert.IsFalse(data.HasPropertyChangedListeners);
 		}
+
+		[TestMethod]
+		public void When_DataTemplate_StaticProperty()
+		{
+			var SUT = new DataTemplate_StaticProperty_Control();
+			var data = new DataTemplate_StaticProperty_Control_Data();
+			SUT.root.Content = data;
+
+			SUT.ForceLoaded();
+
+			var _MyProperty = SUT.FindName("_MyProperty") as TextBlock;
+			Assert.AreEqual("Hello", _MyProperty.Text);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #3098

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

- x:Bind to a static property in a DataBinding is failing
- TwoWay x:Bind to a mismatched property type results in no update

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
