### PR TITLE
fix(reg): Use XamlBindingHelper.ConvertValue for TwoWay x:Bind

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2884,7 +2884,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							if (propertyPaths.properties.Length == 1)
 							{
 								var targetPropertyType = GetXBindPropertyPathType(propertyPaths.properties[0], GetType(dataType));
-								return $"(___ctx, __value) => {{ if(___ctx is {dataType} ___tctx) {{ {contextFunction} = ({targetPropertyType})({propertyType})__value; }} }}";
+								return $"(___ctx, __value) => {{ if(___ctx is {dataType} ___tctx) {{ {contextFunction} = ({targetPropertyType})global::Windows.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof({targetPropertyType}), __value); }} }}";
 							}
 							else
 							{
@@ -2924,7 +2924,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							if (propertyPaths.properties.Length == 1)
 							{
 								var targetPropertyType = GetXBindPropertyPathType(propertyPaths.properties[0]);
-								return $"(___tctx, __value) => {rawFunction} = ({targetPropertyType})({propertyType})__value";
+								return $"(___tctx, __value) => {rawFunction} = ({targetPropertyType})global::Windows.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof({targetPropertyType}), __value)";
 							}
 							else
 							{

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch.xaml
@@ -10,6 +10,9 @@
 	<Grid>
 		<Slider x:Name="mySlider"
 				x:FieldModifier="public"
-				Value="{x:Bind MyInteger, Mode=TwoWay}"/>
+				Value="{x:Bind MyInteger, Mode=TwoWay}" />
+		<TextBlock x:Name="myTextBlock"
+				   x:FieldModifier="public"
+				   Text="{x:Bind MyInteger, Mode=TwoWay}" />
 	</Grid>
 </Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch_DataTemplate.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_TypeMismatch_DataTemplate.xaml
@@ -12,9 +12,14 @@
 						x:FieldModifier="public">
 			<ContentControl.ContentTemplate>
 				<DataTemplate x:DataType="local:Binding_TypeMismatch_DataTemplate_Data">
-					<Slider x:Name="mySlider"
-							x:FieldModifier="public"
-							Value="{x:Bind MyInteger, Mode=TwoWay}"/>
+					<StackPanel>
+						<Slider x:Name="mySlider"
+								x:FieldModifier="public"
+								Value="{x:Bind MyInteger, Mode=TwoWay}" />
+						<TextBlock x:Name="myTextBlock"
+								   x:FieldModifier="public"
+								   Text="{x:Bind MyInteger, Mode=TwoWay}" />
+					</StackPanel>
 				</DataTemplate>
 			</ContentControl.ContentTemplate>
 		</ContentControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -600,15 +600,18 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 
 			SUT.ForceLoaded();
 
-			var inner = SUT.FindName("mySlider") as Slider;
+			var slider = SUT.FindName("mySlider") as Slider;
+			var textBlock = SUT.FindName("myTextBlock") as TextBlock;
 
-			Assert.AreEqual(0.0, inner.Value);
+			Assert.AreEqual(0.0, slider.Value);
+			Assert.AreEqual("0", textBlock.Text);
 			Assert.AreEqual(0, SUT.MyInteger);
 
-			inner.Minimum = 10.0;
+			slider.Minimum = 10.0;
 
-			Assert.AreEqual(10.0, inner.Value);
+			Assert.AreEqual(10.0, slider.Value);
 			Assert.AreEqual(10, SUT.MyInteger);
+			Assert.AreEqual("10", textBlock.Text);
 		}
 
 		[TestMethod]
@@ -624,14 +627,17 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 			SUT.ForceLoaded();
 
 			var slider = SUT.FindName("mySlider") as Slider;
+			var textBlock = SUT.FindName("myTextBlock") as TextBlock;
 
 			Assert.AreEqual(0.0, slider.Value);
 			Assert.AreEqual(0, rootData.MyInteger);
+			Assert.AreEqual("0", textBlock.Text);
 
 			slider.Minimum = 10.0;
 
 			Assert.AreEqual(10.0, slider.Value);
 			Assert.AreEqual(10, rootData.MyInteger);
+			Assert.AreEqual("10", textBlock.Text);
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

TwoWay x:Bind does not create invalid C# when converting from int to string. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
