### PR TITLE
fix(SplitView): Clipping of right pane

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SplitViewTests/SplitViewTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SplitViewTests/SplitViewTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.SplitViewTests
+{
+	[TestFixture]
+    public class SplitViewTests : SampleControlUITestBase
+    {
+        [Test]
+		[AutoRetry]
+		public void When_RightPanne_Clipped()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.SplitView.SplitViewClip");
+
+			_app.WaitForElement("Split");
+
+			var targetGridRectangle = _app.GetRect("TargetRect");
+
+			var compactScreenshot = _app.Screenshot("Compact");
+			// Compact pane is 48 pixels wide
+			ImageAssert.HasColorAt(compactScreenshot, targetGridRectangle.Right - 4, targetGridRectangle.CenterY, Color.Blue);
+
+			var toggleButton = _app.Marked("PaneToggle");
+			toggleButton.Tap();
+
+			var expandedScreenshot = _app.Screenshot("Expanded");
+			ImageAssert.HasColorAt(expandedScreenshot, targetGridRectangle.Right - 4, targetGridRectangle.CenterY, Color.Red);
+
+			toggleButton.Tap();
+
+			var compactAgainScreenshot = _app.Screenshot("Compact again");
+			ImageAssert.HasColorAt(compactAgainScreenshot, targetGridRectangle.Right - 4, targetGridRectangle.CenterY, Color.Blue);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -873,6 +873,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SplitView\SplitViewClip.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Decorations.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3702,6 +3706,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Padding.xaml.cs">
       <DependentUpon>ScrollViewer_Padding.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SplitView\SplitViewClip.xaml.cs">
+      <DependentUpon>SplitViewClip.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Decorations.xaml.cs">
       <DependentUpon>TextBlock_Decorations.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SplitView/SplitViewClip.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SplitView/SplitViewClip.xaml
@@ -1,0 +1,31 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.SplitView.SplitViewClip"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.SplitView"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <SplitView
+        x:Name="Split"
+        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+        CompactPaneLength="48"
+        DisplayMode="CompactOverlay"
+        IsPaneOpen="False"
+        OpenPaneLength="200"
+        PaneBackground="Red"
+        PanePlacement="Right">
+        <SplitView.Content>
+            <Button Click="Button_Click">Toggle</Button>
+        </SplitView.Content>
+        <SplitView.Pane>
+            <TextBlock
+                Margin="20"
+                FontSize="15"
+                Text="This test is very long and should be clipped!"
+                TextWrapping="Wrap" />
+        </SplitView.Pane>
+    </SplitView>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SplitView/SplitViewClip.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SplitView/SplitViewClip.xaml
@@ -8,24 +8,31 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
-    <SplitView
-        x:Name="Split"
-        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-        CompactPaneLength="48"
-        DisplayMode="CompactOverlay"
-        IsPaneOpen="False"
-        OpenPaneLength="200"
-        PaneBackground="Red"
-        PanePlacement="Right">
-        <SplitView.Content>
-            <Button Click="Button_Click">Toggle</Button>
-        </SplitView.Content>
-        <SplitView.Pane>
-            <TextBlock
-                Margin="20"
-                FontSize="15"
-                Text="This test is very long and should be clipped!"
-                TextWrapping="Wrap" />
-        </SplitView.Pane>
-    </SplitView>
+    <Grid x:Name="WrapperGrid">
+        <Border
+            x:Name="TargetRect"
+            Margin="0,0,48,0"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch" />
+        <SplitView
+            x:Name="Split"
+            Background="Blue"
+            CompactPaneLength="48"
+            DisplayMode="CompactOverlay"
+            IsPaneOpen="False"
+            OpenPaneLength="200"
+            PaneBackground="Red"
+            PanePlacement="Right">
+            <SplitView.Content>
+                <Button x:Name="PaneToggle" Click="Button_Click">Toggle</Button>
+            </SplitView.Content>
+            <SplitView.Pane>
+                <TextBlock
+                    Margin="20"
+                    FontSize="15"
+                    Text="This test is very long and should be clipped!"
+                    TextWrapping="Wrap" />
+            </SplitView.Pane>
+        </SplitView>
+    </Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SplitView/SplitViewClip.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SplitView/SplitViewClip.xaml.cs
@@ -1,0 +1,20 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.SplitView
+{
+	[SampleControlInfo("SplitView")]
+	public sealed partial class SplitViewClip : Page
+    {
+        public SplitViewClip()
+        {
+            this.InitializeComponent();
+        }
+
+		public void Button_Click(object sender, RoutedEventArgs args)
+		{
+			Split.IsPaneOpen = !Split.IsPaneOpen;
+		}
+    }
+}

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -2863,6 +2863,11 @@
 								</VisualState>
 								<VisualState x:Name="ClosedCompactRight">
 									<Storyboard>
+										<xamarin:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
+																			   Storyboard.TargetName="PaneRoot">
+											<DiscreteObjectKeyFrame KeyTime="0:0:0"
+																	Value="{Binding TemplateSettings.RightClip, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+										</xamarin:ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColumnDefinition1"
 																	   Storyboard.TargetProperty="Width">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0"


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #3174


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Right pane in `SplitView` was not properly clipped.


## What is the new behavior?

Right pane in `SplitView` is properly clipped.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
