### PR TITLE
feat: [MacOS] Add keyboard events support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,7 +37,7 @@ Please check if your PR fulfills the following requirements:
 - [ ] Validated PR `Screenshots Compare Test Run` results.
 - [ ] Contains **NO** breaking changes
 - [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
-- Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
+- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
 
 <!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
      Please note that breaking changes are likely to be rejected -->

--- a/doc/articles/features/routed-events.md
+++ b/doc/articles/features/routed-events.md
@@ -2,37 +2,34 @@
 
 ## Implemented Routed Events
 
-| Routed Event                  | Android | iOS     | Wasm    |     |
-| ----------------------------- | ------- | ------- | ------- | --- |
-| _tapped events_               
-| `Tapped`                      | Yes (1) | Yes (1) | Yes (1) | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.tapped) |
-| `DoubleTapped`                | Yes (1) | Yes (1) | Yes (1) | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.doubletapped) |
-| _focus events_                
-| `GotFocus`                    | Yes     | Yes (2) | Yes (2) | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.gotfocus) |
-| `LostFocus`                   | Yes     | Yes (2) | Yes (2) | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.lostfocus) |
-| _keyboard events_             
-| `KeyDown`           | Hardware Only (3) | Yes (3) | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.keydown) |
-| `KeyUp`             | Hardware Only (3) | Yes (3) | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.keyup) |
-| _pointer events_              
-| `PointerCanceled`             | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointercanceled) |
-| `PointerCaptureLost`          | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointercapturelost) |
-| `PointerEntered`              | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointerentered) |
-| `PointerExited`               | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointerexited) |
-| `PointerMoved`                | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointermoved) |
-| `PointerPressed`              | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointerpressed) |
-| `PointerReleased`             | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointerreleased) |
-| `PointerWheelChanged`         | No      | No      | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointerwheelchanged) |
-| _manipulation events_         
-| `ManipulationStarting`        | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationstarting) |
-| `ManipulationStarted`         | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationstarted) |
-| `ManipulationDelta`           | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationedelta) |
-| `ManipulationInertiaStarting` | No      | No      | No      | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationinertiastarting) |
-| `ManipulationCompleted`       | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationcompleted) |
-| _gesture events_         
-| `Tapped`                      | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.tapped) |
-| `DoubleTapped`                | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.doubletapped) |
-| `RightTapped`                 | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.righttapped) |
-| `Holding`                     | Yes     | Yes     | Yes     | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.holding) |
+| Routed Event                  | Android | iOS     | Wasm    | Mac |     |
+| ----------------------------- | ------- | ------- | ------- | --- | --- |
+| _focus events_                                                    
+| `GotFocus`                    | Yes     | Yes (2) | Yes (2) | ?   | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.gotfocus) |
+| `LostFocus`                   | Yes     | Yes (2) | Yes (2) | ?   | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.lostfocus) |
+| _keyboard events_                                                 
+| `KeyDown`           | Hardware Only (3) | Yes (3) | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.keydown) |
+| `KeyUp`             | Hardware Only (3) | Yes (3) | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.keyup) |
+| _pointer events_                                                  
+| `PointerCanceled`             | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointercanceled) |
+| `PointerCaptureLost`          | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointercapturelost) |
+| `PointerEntered`              | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointerentered) |
+| `PointerExited`               | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointerexited) |
+| `PointerMoved`                | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointermoved) |
+| `PointerPressed`              | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointerpressed) |
+| `PointerReleased`             | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointerreleased) |
+| `PointerWheelChanged`         | No      | No      | Yes     | No  | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.pointerwheelchanged) |
+| _manipulation events_                                             
+| `ManipulationStarting`        | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationstarting) |
+| `ManipulationStarted`         | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationstarted) |
+| `ManipulationDelta`           | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationedelta) |
+| `ManipulationInertiaStarting` | No      | No      | No      | No  | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationinertiastarting) |
+| `ManipulationCompleted`       | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationcompleted) |
+| _gesture events_ (1)                                               
+| `Tapped`                      | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.tapped) |
+| `DoubleTapped`                | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.doubletapped) |
+| `RightTapped`                 | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.righttapped) |
+| `Holding`                     | Yes     | Yes     | Yes     | Yes | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.holding) |
 
 Notes:
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2285,6 +2285,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Keyboard\Keyboard_Events.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Keyboard\Keyboard_Showing_Dismissal.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4488,6 +4492,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Keyboard\Keyboard_Clickthrough_Modal.xaml.cs">
       <DependentUpon>Keyboard_Clickthrough_Modal.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Keyboard\Keyboard_Events.xaml.cs">
+      <DependentUpon>Keyboard_Events.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Keyboard\Keyboard_Showing_Dismissal.xaml.cs">
       <DependentUpon>Keyboard_Showing_Dismissal.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_Events.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_Events.xaml
@@ -1,0 +1,22 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Input.Keyboard.Keyboard_Events"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Input.Keyboard"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	
+	<Grid BorderBrush="DeepPink" BorderThickness="4" x:Name="_root">
+		<StackPanel>
+			<Button x:Name="_btt1" Content="This is a focusable control to test event routing" />
+			<Button x:Name="_btt2" Content="This is a second focusable control ... to change focus!" />
+
+			<TextBlock Text="Received key events:" Margin="0,10,0,0" />
+			<ScrollViewer>
+				<TextBlock x:Name="_output" />
+			</ScrollViewer>
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_Events.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_Events.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Input.Keyboard
+{
+	[Sample("Keyboard")]
+	public sealed partial class Keyboard_Events : Page
+	{
+		public Keyboard_Events()
+		{
+			this.InitializeComponent();
+
+			SetupEvent(_root);
+			SetupEvent(_btt1);
+			SetupEvent(_btt2);
+		}
+
+		private void SetupEvent(FrameworkElement elt)
+		{
+			elt.KeyDown += (snd, e) =>
+			{
+				Console.WriteLine($"{elt.Name} - [KEYDOWN] {e.Key}");
+				global::System.Diagnostics.Debug.WriteLine($"{elt.Name} - [KEYDOWN] {e.Key}");
+				_output.Text += $"{elt.Name} - [KEYDOWN] {e.Key}\r\n";
+			};
+			elt.KeyUp += (snd, e) =>
+			{
+				Console.WriteLine($"{elt.Name} - [KEYUP] {e.Key}");
+				global::System.Diagnostics.Debug.WriteLine($"{elt.Name} - [KEYUP] {e.Key}");
+				_output.Text += $"{elt.Name} - [KEYUP] {e.Key}\r\n";
+			};
+		}
+	}
+}

--- a/src/Uno.UI/Controls/BindableNSView.macOS.cs
+++ b/src/Uno.UI/Controls/BindableNSView.macOS.cs
@@ -112,5 +112,12 @@ namespace Uno.UI.Controls
 		}
 
 		public IEnumerator GetEnumerator() => Subviews.GetEnumerator();
+
+		// We change the name of the key event methods so it won't conflict with the actual KeyDown / KeyUp events
+		public sealed override void KeyDown(NSEvent evt) => OnNativeKeyDown(evt);
+		private protected virtual void OnNativeKeyDown(NSEvent evt) { }
+
+		public sealed override void KeyUp(NSEvent evt) => OnNativeKeyUp(evt);
+		private protected virtual void OnNativeKeyUp(NSEvent evt) { }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
@@ -12,6 +12,7 @@ using System.Text;
 using Uno.Logging;
 using Uno;
 using Windows.Devices.Input;
+using Windows.UI.Xaml.Controls;
 using Microsoft.Extensions.Logging;
 using Windows.UI.Xaml.Media;
 using Uno.UI.Extensions;

--- a/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
@@ -22,20 +22,6 @@ namespace Windows.UI.Xaml
 {
 	public partial class UIElement : BindableNSView
 	{
-		internal bool IsPointerCaptured { get; set; }
-
-		#region Logs
-		private static readonly ILogger _log = typeof(UIElement).Log();
-		private static readonly Action LogRegisterPointerCanceledNotImplemented = Actions.CreateOnce(() => _log.Error("Unable to RegisterPointerCanceled on UIElement for iOS. Not Implemented."));
-		private static readonly Action LogUnregisterPointerCanceledNotImplemented = Actions.CreateOnce(() => _log.Error("Unable to UnregisterPointerCanceled on UIElement for iOS. Not Implemented."));
-		private static readonly Action LogRegisterPointerExitedNotImplemented = Actions.CreateOnce(() => _log.Error("Unable to RegisterPointerExited on UIElement for iOS. Not Implemented."));
-		private static readonly Action LogUnRegisterPointerExitedNotImplemented = Actions.CreateOnce(() => _log.Error("Unable to UnregisterPointerExited on UIElement for iOS. Not Implemented."));
-		private static readonly Action LogRegisterPointerPressedNotImplemented = Actions.CreateOnce(() => _log.Error("Unable to RegisterPointerPressed on UIElement for iOS. Not Implemented."));
-		private static readonly Action LogUnRegisterPointerPressedNotImplemented = Actions.CreateOnce(() => _log.Error("Unable to UnRegisterPointerPressed on UIElement for iOS. Not Implemented."));
-		private static readonly Action LogRegisterPointerReleasedNotImplemented = Actions.CreateOnce(() => _log.Error("Unable to RegisterPointerReleased on UIElement for iOS. Not Implemented."));
-		private static readonly Action LogUnRegisterPointerReleasedNotImplemented = Actions.CreateOnce(() => _log.Error("Unable to UnregisterPointerReleased on UIElement for iOS. Not Implemented."));
-		#endregion
-
 		public UIElement()
 		{
 			Initialize();
@@ -44,9 +30,7 @@ namespace Windows.UI.Xaml
 		
 		internal bool ClippingIsSetByCornerRadius { get; set; } = false;
 
-
-
-        partial void OnOpacityChanged(DependencyPropertyChangedEventArgs args)
+		partial void OnOpacityChanged(DependencyPropertyChangedEventArgs args)
 		{
 			// Don't update the internal value if the value is being animated.
 			// The value is being animated by the platform itself.
@@ -77,10 +61,7 @@ namespace Windows.UI.Xaml
 
 		public override bool Hidden
 		{
-			get
-			{
-				return base.Hidden;
-			}
+			get => base.Hidden;
 			set
 			{
 				// Only set the Visility property, the Hidden property is updated 
@@ -121,125 +102,36 @@ namespace Windows.UI.Xaml
 #endif
 		}
 
-		private CGRect ToCGRect(Rect rect)
-		{
-			return new CGRect
-			(
-				(nfloat)(rect.X),
-				(nfloat)(rect.Y),
-				(nfloat)(rect.Width),
-				(nfloat)(rect.Height)
-			);
-		}
-
-		/// <summary>
-		/// Gets the origin point of the <paramref name="view"/> in the clippingParent's 
-		/// coordinate system.
-		/// </summary>
-		/// <param name="view">The view to get the point from</param>
-		/// <param name="parentView">The view for which to get the adjusted coordinates from</param>
-		/// <returns></returns>
-		private static CGPoint ConvertOriginPointToView(NSView view, NSView parentView)
-		{
-			var value = CGPoint.Empty;
-			var current = view;
-
-			do
-			{
-				if (current is FrameworkElement fr)
-				{
-					value.X += (nfloat)fr.AppliedFrame.X;
-					value.Y += (nfloat)fr.AppliedFrame.Y;
-				}
-				else
-				{
-					value.X += current.Frame.X;
-					value.Y += current.Frame.Y;
-				}
-
-				current = current.Superview;
-
-			} while (current != null && current != parentView);
-
-			return value;
-		}
-
-#region DoubleTapped event
-		private void RegisterDoubleTapped(DoubleTappedEventHandler handler)
-		{
-			LogRegisterPointerCanceledNotImplemented();
-		}
-
-		private void UnregisterDoubleTapped(DoubleTappedEventHandler handler)
-		{
-			LogRegisterPointerCanceledNotImplemented();
-		}
-#endregion
-
-#region PointerCanceled event
-		private void RegisterPointerCanceled(PointerEventHandler handler)
-		{
-			LogRegisterPointerCanceledNotImplemented();
-		}
-
-		private void UnregisterPointerCanceled(PointerEventHandler handler)
-		{
-			LogUnregisterPointerCanceledNotImplemented();
-		}
-#endregion
-
-#region PointerExited event
-		private void RegisterPointerExited(PointerEventHandler handler)
-		{
-			LogRegisterPointerExitedNotImplemented();
-		}
-
-		private void UnregisterPointerExited(PointerEventHandler handler)
-		{
-			LogUnRegisterPointerExitedNotImplemented();
-		}
-#endregion
-
-#region PointerPressed event
-		private void RegisterPointerPressed(PointerEventHandler handler)
-		{
-			LogRegisterPointerPressedNotImplemented();
-		}
-
-		private void UnregisterPointerPressed(PointerEventHandler handler)
-		{
-			LogUnRegisterPointerPressedNotImplemented();
-		}
-#endregion
-
-#region PointerReleased event
-		private void RegisterPointerReleased(PointerEventHandler handler)
-		{
-			LogRegisterPointerReleasedNotImplemented();
-		}
-
-		private void UnregisterPointerReleased(PointerEventHandler handler)
-		{
-			LogUnRegisterPointerReleasedNotImplemented();
-		}
-#endregion
-
-#region Tapped event
-		private void RegisterTapped(TappedEventHandler handler)
-		{
-			LogRegisterPointerReleasedNotImplemented();
-		}
-
-		private void UnregisterTapped(TappedEventHandler handler)
-		{
-			LogUnRegisterPointerReleasedNotImplemented();
-		}
-#endregion
-
-		internal void RaiseTapped(TappedRoutedEventArgs args) => LogUnRegisterPointerReleasedNotImplemented();
-
 #if DEBUG
 		public string ShowLocalVisualTree(int fromHeight) => AppKit.UIViewExtensions.ShowLocalVisualTree(this, fromHeight);
 #endif
+
+		/// <inheritdoc />
+		public override bool AcceptsFirstResponder() 
+			=> true; // This is required to receive the KeyDown / KeyUp. Note: Key events are then bubble in managed.
+
+		private protected override void OnNativeKeyDown(NSEvent evt)
+		{
+			var args = new KeyRoutedEventArgs(this, System.VirtualKeyHelper.FromKeyCode(evt.KeyCode))
+			{
+				CanBubbleNatively = false // Only the first responder gets the event
+			};
+
+			RaiseEvent(KeyDownEvent, args);
+
+			base.OnNativeKeyDown(evt);
+		}
+
+		private protected override void OnNativeKeyUp(NSEvent evt)
+		{
+			var args = new KeyRoutedEventArgs(this, System.VirtualKeyHelper.FromKeyCode(evt.KeyCode))
+			{
+				CanBubbleNatively = false // Only the first responder gets the event
+			};
+
+			RaiseEvent(KeyUpEvent, args);
+
+			base.OnNativeKeyUp(evt);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
@@ -1,22 +1,10 @@
-using CoreAnimation;
-using CoreGraphics;
-using Foundation;
-using Uno.Extensions;
 using Uno.UI.Controls;
 using Windows.Foundation;
 using Windows.UI.Xaml.Input;
+using Windows.System;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using Uno.Logging;
-using Uno;
-using Windows.Devices.Input;
-using Windows.UI.Xaml.Controls;
-using Microsoft.Extensions.Logging;
-using Windows.UI.Xaml.Media;
 using Uno.UI.Extensions;
-using Uno.UI;
 using AppKit;
 
 namespace Windows.UI.Xaml
@@ -113,7 +101,7 @@ namespace Windows.UI.Xaml
 
 		private protected override void OnNativeKeyDown(NSEvent evt)
 		{
-			var args = new KeyRoutedEventArgs(this, System.VirtualKeyHelper.FromKeyCode(evt.KeyCode))
+			var args = new KeyRoutedEventArgs(this, VirtualKeyHelper.FromKeyCode(evt.KeyCode))
 			{
 				CanBubbleNatively = false // Only the first responder gets the event
 			};
@@ -125,7 +113,7 @@ namespace Windows.UI.Xaml
 
 		private protected override void OnNativeKeyUp(NSEvent evt)
 		{
-			var args = new KeyRoutedEventArgs(this, System.VirtualKeyHelper.FromKeyCode(evt.KeyCode))
+			var args = new KeyRoutedEventArgs(this, VirtualKeyHelper.FromKeyCode(evt.KeyCode))
 			{
 				CanBubbleNatively = false // Only the first responder gets the event
 			};

--- a/src/Uno.UWP/System/VirtualKeyHelper.macOS.cs
+++ b/src/Uno.UWP/System/VirtualKeyHelper.macOS.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.System
+{
+	internal static partial class VirtualKeyHelper
+	{
+		// http://macbiblioblog.blogspot.com/2014/12/key-codes-for-function-and-special-keys.html
+		public static VirtualKey FromKeyCode(ushort keyCode)
+			=> keyCode switch
+			{
+				29	=> VirtualKey.Number0,
+				18	=> VirtualKey.Number1,
+				19	=> VirtualKey.Number2,
+				20	=> VirtualKey.Number3,
+				21	=> VirtualKey.Number4,
+				23	=> VirtualKey.Number5,
+				22	=> VirtualKey.Number6,
+				26	=> VirtualKey.Number7,
+				28	=> VirtualKey.Number8,
+				25	=> VirtualKey.Number9,
+
+				0	=> VirtualKey.A,
+				11	=> VirtualKey.B,
+				8	=> VirtualKey.C,
+				2	=> VirtualKey.D,
+				14	=> VirtualKey.E,
+				3	=> VirtualKey.F,
+				5	=> VirtualKey.G,
+				4	=> VirtualKey.H,
+				34	=> VirtualKey.I,
+				38	=> VirtualKey.J,
+				40	=> VirtualKey.K,
+				37	=> VirtualKey.L,
+				46	=> VirtualKey.M,
+				45	=> VirtualKey.N,
+				31	=> VirtualKey.O,
+				35	=> VirtualKey.P,
+				12	=> VirtualKey.Q,
+				15	=> VirtualKey.R,
+				1	=> VirtualKey.S,
+				17	=> VirtualKey.T,
+				32	=> VirtualKey.U,
+				9	=> VirtualKey.V,
+				13	=> VirtualKey.W,
+				7	=> VirtualKey.X,
+				16	=> VirtualKey.Y,
+				6	=> VirtualKey.Z,
+
+				// Those keys are not mapped in the VirtualKey enum by windows, however the event is still raised
+				// WARNING: Those keys are only "LOCATION on keyboard" codes.
+				//			This means that for instance the 187 is a '=' on a querty keyboard, while it's a '+' on an azerty.
+				10	=> (VirtualKey)191, // § (Value observed on UWP 18362, fr-FR AZERTY US-int keyboard)
+				50	=> (VirtualKey)192, // ` (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+				27	=> (VirtualKey)189, // - (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+				24	=> (VirtualKey)187, // = (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+				33	=> (VirtualKey)219, // [ (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+				30	=> (VirtualKey)221, // ] (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+				41	=> (VirtualKey)186, // ; (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+				39	=> (VirtualKey)222, // ' (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+				43	=> (VirtualKey)188, // , (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+				47	=> (VirtualKey)190, // . (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+				44	=> (VirtualKey)191, // / (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+				42	=> (VirtualKey)220, // \ (Value observed on UWP 18362, fr-FR qwerty US-int keyboard)
+
+				// [Key|Number] Pad
+				82	=> VirtualKey.NumberPad0,
+				83	=> VirtualKey.NumberPad1,
+				84	=> VirtualKey.NumberPad2,
+				85	=> VirtualKey.NumberPad3,
+				86	=> VirtualKey.NumberPad4,
+				87	=> VirtualKey.NumberPad5,
+				88	=> VirtualKey.NumberPad6,
+				89	=> VirtualKey.NumberPad7,
+				91	=> VirtualKey.NumberPad8,
+				92	=> VirtualKey.NumberPad9,
+				65	=> VirtualKey.Decimal,
+				67	=> VirtualKey.Multiply,
+				69	=> VirtualKey.Add,
+				75	=> VirtualKey.Divide,
+				78	=> VirtualKey.Subtract,
+				81	=> VirtualKey.Enter, // =
+				71	=> VirtualKey.Clear,
+				76	=> VirtualKey.Enter,
+
+				49	=> VirtualKey.Space,
+				36	=> VirtualKey.Enter,
+				48	=> VirtualKey.Tab,
+				51	=> VirtualKey.Back,
+				117	=> VirtualKey.Delete,
+				// 52	=> VirtualKey.␊
+
+				// Modifiers
+				53	=> VirtualKey.Escape,
+				55	=> VirtualKey.LeftWindows, // Command
+				56	=> VirtualKey.Shift, // Left Shift
+				57	=> VirtualKey.CapitalLock,
+				58	=> VirtualKey.Menu, // Option, a.k.a. Alt
+				59	=> VirtualKey.Control, // Left control
+				60	=> VirtualKey.RightShift,
+				61	=> VirtualKey.RightMenu, // Right option, a.k.a. Right Alt
+				62	=> VirtualKey.RightControl,
+
+				// Functions
+				// 63	=> VirtualKey.fn
+				122	=> VirtualKey.F1,
+				120	=> VirtualKey.F2,
+				99	=> VirtualKey.F3,
+				118	=> VirtualKey.F4,
+				96	=> VirtualKey.F5,
+				97	=> VirtualKey.F6,
+				98	=> VirtualKey.F7,
+				100	=> VirtualKey.F8,
+				101	=> VirtualKey.F9,
+				109	=> VirtualKey.F10,
+				103	=> VirtualKey.F11,
+				111	=> VirtualKey.F12,
+				105	=> VirtualKey.F13,
+				107	=> VirtualKey.F14,
+				113	=> VirtualKey.F15,
+				106	=> VirtualKey.F16,
+				64	=> VirtualKey.F17,
+				79	=> VirtualKey.F18,
+				80	=> VirtualKey.F19,
+				90	=> VirtualKey.F20,
+
+				// Volume (Those keys does not fire any event on UWP)
+				// 72	=> VirtualKey. // Volume down
+				// 73	=> VirtualKey. // Volume up
+				// 74	=> VirtualKey. // Mute
+
+				// Navigation
+				114	=> VirtualKey.Insert,
+				115	=> VirtualKey.Home,
+				119	=> VirtualKey.End,
+				116	=> VirtualKey.PageUp,
+				121	=> VirtualKey.PageDown,
+				123	=> VirtualKey.Left,
+				124	=> VirtualKey.Right,
+				125	=> VirtualKey.Down,
+				126	=> VirtualKey.Up,
+
+				_	=> VirtualKey.None,
+			};
+	}
+}

--- a/src/Uno.UWP/System/VirtualKeyHelper.wasm.cs
+++ b/src/Uno.UWP/System/VirtualKeyHelper.wasm.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Windows.System
 {
-    internal static class VirtualKeyHelper
+    internal static partial class VirtualKeyHelper
     {
 		public static VirtualKey FromKey(string key)
 		{


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/3167

## Feature
Add keyboard events support

## What is the current behavior?
`UIElement.KeyDown` and `UIElement.KeyUp` are not raised on mac.

## What is the new behavior?
🙃

## PR Checklist
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ _No UI test for mac yet_
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
