### PR TITLE
feat(wasm): Added ability to call async javascript `Promise<string>` and await it.

### DIFF
--- a/src/Uno.Foundation/LinkerDefinition.Wasm.xml
+++ b/src/Uno.Foundation/LinkerDefinition.Wasm.xml
@@ -1,0 +1,9 @@
+﻿<linker>
+  <assembly fullname="Uno.Foundation">
+	<type fullname="Uno.Foundation.WebAssemblyRuntime">
+		<method name="DispatchAsyncResult" />
+		<method name="DispatchAsyncError" />
+	</type>
+  </assembly>
+</linker>
+

--- a/src/Uno.Foundation/Runtime.wasm.cs
+++ b/src/Uno.Foundation/Runtime.wasm.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Linq;
 using System.Diagnostics.Contracts;
 using System.Reflection;
@@ -11,6 +13,8 @@ using Uno.Diagnostics.Eventing;
 using Microsoft.Extensions.Logging;
 using Uno.Logging;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WebAssembly
 {
@@ -299,6 +303,67 @@ namespace Uno.Foundation
 			}
 
 			return InvokeJS(command);
+		}
+
+		private static ImmutableDictionary<long, TaskCompletionSource<string>> _asyncWaitingList = ImmutableDictionary<long, TaskCompletionSource<string>>.Empty;
+
+		private static long _nextAsync;
+
+		/// <summary>
+		/// Invoke async javascript code.
+		/// </summary>
+		/// <remarks>
+		/// The javascript code is expected to return a Promise&lt;string&gt;
+		/// </remarks>
+		public static Task<string> InvokeAsync(string promiseCode)
+		{
+			var id = Interlocked.Increment(ref _nextAsync);
+
+			var tcs = new TaskCompletionSource<string>();
+
+			ImmutableInterlocked.TryAdd(ref _asyncWaitingList, id, tcs);
+
+			var js = new[]
+			{
+				"const __f = ()=>",
+				promiseCode,
+				";\nUno.UI.Interop.AsyncInteropHelper.Invoke(",
+				id.ToStringInvariant(),
+				", __f);"
+			};
+
+			try
+			{
+
+				WebAssemblyRuntime.InvokeJS(string.Concat(js));
+			}
+			catch (Exception ex)
+			{
+				return Task.FromException<string>(ex);
+			}
+
+			return tcs.Task;
+		}
+
+		[Preserve]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void DispatchAsyncResult(long handle, string result)
+		{
+			if (ImmutableInterlocked.TryRemove(ref _asyncWaitingList, handle, out var tcs))
+			{
+				tcs.TrySetResult(result);
+			}
+		}
+
+		[Preserve]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void DispatchAsyncError(long handle, string error)
+		{
+			if (ImmutableInterlocked.TryRemove(ref _asyncWaitingList, handle, out var tcs))
+			{
+				var exception = new ApplicationException(error);
+				tcs.TrySetException(exception);
+			}
 		}
 
 		[Pure]

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -40,6 +40,12 @@
 		<PackageReference Include="System.Runtime.InteropServices.WindowsRuntime" Version="4.3.0" />
 	</ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+		<EmbeddedResource Include="LinkerDefinition.Wasm.xml">
+			<LogicalName>$(AssemblyName).xml</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>
+
 	<Import Project="..\Uno.CrossTargetting.props" />
 
 </Project>

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_Foundation/Given_WebAssemblyRuntime.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_Foundation/Given_WebAssemblyRuntime.cs
@@ -1,0 +1,79 @@
+﻿#if __WASM__
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Foundation;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_Foundation
+{
+	[TestClass]
+	public class Given_WebAssemblyRuntime
+	{
+		[TestMethod]
+		public async Task WhenPromiseReturnSynchronously()
+		{
+			var js = @"
+				(function(){
+				  return new Promise((ok, err)=> ok(""success""));
+				})();";
+
+			var result = await WebAssemblyRuntime.InvokeAsync(js);
+
+			result.Should().Be("success");
+		}
+
+		[TestMethod]
+		public async Task WhenPromiseReturnAsynchronously()
+		{
+			var js = @"
+				(function(){
+				  return new Promise((ok, err)=> setTimeout(()=>ok(""success"")));
+				})();";
+
+			var result = await WebAssemblyRuntime.InvokeAsync(js);
+
+			result.Should().Be("success");
+		}
+
+		[TestMethod]
+		public async Task WhenPromiseReturnErrorSynchronously()
+		{
+			var js = @"
+				(function(){
+				  return new Promise((ok, err)=> err(""error""));
+				})();";
+
+			Func<Task> Do = ()=> WebAssemblyRuntime.InvokeAsync(js);
+
+			await Do.Should().ThrowAsync<Exception>().WithMessage("error");
+		}
+
+		[TestMethod]
+		public async Task WhenPromiseReturnErrorAsynchronously()
+		{
+			var js = @"
+				(function(){
+				  return new Promise((ok, err)=> setTimeout(()=>err(""error"")));
+				})();";
+
+			Func<Task> Do = () => WebAssemblyRuntime.InvokeAsync(js);
+
+			await Do.Should().ThrowAsync<Exception>().WithMessage("error");
+		}
+
+		[TestMethod]
+		public async Task WhenPromiseThrowsExceptionDuringSetup()
+		{
+			var js = @"
+				(function(){
+				  throw ""error"";
+				})();";
+
+			Func<Task> Do = () => WebAssemblyRuntime.InvokeAsync(js);
+
+			await Do.Should().ThrowAsync<Exception>().WithMessage("error");
+		}
+	}
+}
+#endif

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -662,13 +662,14 @@ declare class WindowManagerSetContentHtmlParams {
     static unmarshal(pData: number): WindowManagerSetContentHtmlParams;
 }
 declare class WindowManagerSetElementTransformParams {
+    HtmlId: number;
     M11: number;
     M12: number;
     M21: number;
     M22: number;
     M31: number;
     M32: number;
-    HtmlId: number;
+    ClipToBounds: boolean;
     static unmarshal(pData: number): WindowManagerSetElementTransformParams;
 }
 declare class WindowManagerSetNameParams {
@@ -715,6 +716,14 @@ declare class WindowManagerSetXUidParams {
 interface PointerEvent {
     isOver(this: PointerEvent, element: HTMLElement | SVGElement): boolean;
     isOverDeep(this: PointerEvent, element: HTMLElement | SVGElement): boolean;
+}
+declare namespace Uno.UI.Interop {
+    class AsyncInteropHelper {
+        private static dispatchResultMethod;
+        private static dispatchErrorMethod;
+        private static init;
+        static Invoke(h: number, m: () => Promise<string>): void;
+    }
 }
 declare module Uno.UI {
     interface IAppManifest {
@@ -928,5 +937,26 @@ declare namespace Windows.Phone.Devices.Notification {
     class VibrationDevice {
         static initialize(): boolean;
         static vibrate(duration: number): boolean;
+    }
+}
+declare namespace Windows.UI.Xaml.Media.Animation {
+    class RenderingLoopFloatAnimator {
+        private managedHandle;
+        private static activeInstances;
+        static createInstance(managedHandle: string, jsHandle: number): void;
+        static getInstance(jsHandle: number): RenderingLoopFloatAnimator;
+        static destroyInstance(jsHandle: number): void;
+        private constructor();
+        SetStartFrameDelay(delay: number): void;
+        SetAnimationFramesInterval(): void;
+        EnableFrameReporting(): void;
+        DisableFrameReporting(): void;
+        private onFrame;
+        private unscheduleFrame;
+        private scheduleDelayedFrame;
+        private scheduleAnimationFrame;
+        private _delayRequestId?;
+        private _frameRequestId?;
+        private _isEnabled;
     }
 }

--- a/src/Uno.UI.Wasm/ts/Interop/AsyncInteropHelper.ts
+++ b/src/Uno.UI.Wasm/ts/Interop/AsyncInteropHelper.ts
@@ -1,0 +1,38 @@
+﻿namespace Uno.UI.Interop {
+	export class AsyncInteropHelper {
+
+		private static dispatchResultMethod: (handle: number, result: string) => string;
+		private static dispatchErrorMethod: (handle: number, error: string) => string;
+
+		private static init() {
+			if (AsyncInteropHelper.dispatchErrorMethod) {
+				return; // already initialized
+			}
+			const w = window as any;
+			AsyncInteropHelper.dispatchResultMethod =
+				w.Module.mono_bind_static_method("[Uno.Foundation] Uno.Foundation.WebAssemblyRuntime:DispatchAsyncResult");
+			AsyncInteropHelper.dispatchErrorMethod =
+				w.Module.mono_bind_static_method("[Uno.Foundation] Uno.Foundation.WebAssemblyRuntime:DispatchAsyncError");
+		}
+
+		public static Invoke(handle: number, promiseFunction: () => Promise<string>): void {
+			AsyncInteropHelper.init();
+
+			try {
+				promiseFunction()
+					.then(str => {
+						if (typeof str == "string") {
+							AsyncInteropHelper.dispatchResultMethod(handle, str);
+						} else {
+							AsyncInteropHelper.dispatchResultMethod(handle, null);
+						}
+					})
+					.catch(err => {
+						AsyncInteropHelper.dispatchErrorMethod(handle, err);
+					});
+			} catch (err) {
+				AsyncInteropHelper.dispatchErrorMethod(handle, err);
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Feature
Implements #3084

## What is the new behavior?
It is now possible to await javascript/TypeScript execution when it's returning a `Promise<string>`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- ~~[ ] Validated PR `Screenshots Compare Test Run` results.~~
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
