### PR TITLE
fix(winui3): Removed Microsoft.System namespace for non-WinUI3 output.

### DIFF
--- a/src/Uno.UI/System/DispatcherQueue.cs
+++ b/src/Uno.UI/System/DispatcherQueue.cs
@@ -1,3 +1,4 @@
+#if HAS_UNO_WINUI
 using System;
 using Windows.UI.Core;
 
@@ -34,3 +35,4 @@ namespace Microsoft.System
 		}
 	}
 }
+#endif

--- a/src/Uno.UI/System/DispatcherQueueTimer.Android.cs
+++ b/src/Uno.UI/System/DispatcherQueueTimer.Android.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if HAS_UNO_WINUI
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Android.OS;
@@ -65,3 +66,4 @@ namespace Microsoft.System
 		}
 	}
 }
+#endif

--- a/src/Uno.UI/System/DispatcherQueueTimer.cs
+++ b/src/Uno.UI/System/DispatcherQueueTimer.cs
@@ -1,3 +1,4 @@
+#if HAS_UNO_WINUI
 using System;
 using System.Threading;
 using Microsoft.Extensions.Logging;
@@ -145,3 +146,4 @@ namespace Microsoft.System
 		}
 	}
 }
+#endif

--- a/src/Uno.UI/System/DispatcherQueueTimer.iOSmacOS.cs
+++ b/src/Uno.UI/System/DispatcherQueueTimer.iOSmacOS.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if HAS_UNO_WINUI
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
@@ -53,3 +54,4 @@ namespace Microsoft.System
 		}
 	}
 }
+#endif

--- a/src/Uno.UI/System/DispatcherQueueTimer.net.cs
+++ b/src/Uno.UI/System/DispatcherQueueTimer.net.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if HAS_UNO_WINUI
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -25,3 +26,4 @@ namespace Microsoft.System
 		}
 	}
 }
+#endif

--- a/src/Uno.UI/System/DispatcherQueueTimer.wasm.cs
+++ b/src/Uno.UI/System/DispatcherQueueTimer.wasm.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if HAS_UNO_WINUI
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -38,3 +39,4 @@ namespace Microsoft.System
 		}
 	}
 }
+#endif


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/3199

# Bugfix
Removed `Microsoft.System` namespace.

## What is the new behavior?
Fix #3199

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
