### PR TITLE
Clipboard improvements

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel/DataTransfer/Given_Clipboard.cs
@@ -17,17 +17,6 @@ namespace Uno.UI.RuntimeTests.Tests
 	[TestClass]
 	public class Given_Clipboard
 	{
-
-		[TestInitialize]
-		public void Init()
-		{
-		}
-
-		[TestCleanup]
-		public void Cleanup()
-		{
-		}
-
 		[TestMethod]
 		public async Task When_PutAndGet()
 		{
@@ -42,8 +31,7 @@ namespace Uno.UI.RuntimeTests.Tests
 			var clipView = Windows.ApplicationModel.DataTransfer.Clipboard.GetContent();
 			string stringFromClipboard = await clipView.GetTextAsync();
 
-			Assert.AreEqual(stringFromClipboard, testString, false, "text was changed while putting and reading from Clipboard - error in tested methods");
-
+			Assert.AreEqual(stringFromClipboard, testString, false, "Text has changed after storing and reading from Clipboard");
 		}
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Android.cs
@@ -28,13 +28,15 @@ namespace Windows.ApplicationModel.DataTransfer
 				items.Add(new ClipData.Item(content.Text));
 				mimeTypes.Add("text/plaintext");
 			}
-			else if (content.Uri != null)
+			
+			if (content.Uri != null)
 			{
 				var androidUri = Android.Net.Uri.Parse(content.Uri.ToString());
 				items.Add(new ClipData.Item(androidUri));
 				mimeTypes.Add("text/uri-list");
 			}
-			else if (content.Html != null)
+			
+			if (content.Html != null)
 			{
 				// Matches all tags
 				Regex regex = new Regex("(<.*?>\\s*)+", RegexOptions.Singleline);


### PR DESCRIPTION
GitHub Issue (If applicable):  fixes #3178 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Android Clipboard support works with only one data item.

## What is the new behavior?

Improved Clipboard support on Android by allowing storage of multiple data items.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
