### PR TITLE
docs: Fixed link to migrating apps

### DIFF
--- a/doc/articles/howto-migrate-existing-code.md
+++ b/doc/articles/howto-migrate-existing-code.md
@@ -4,7 +4,7 @@ There are two separate paths for using an existing UWP codebase on top of uno:
 - An existing UWP application
 - An existing UWP library
 
-For migrating UWP application, see [this article](dummies1.md).
+For migrating UWP application, see [this article](migrating-apps.md).
 
 ## Migrate an existing library
 


### PR DESCRIPTION
## PR Type

- Documentation content changes

## What is the current behavior?

The link was pointing to a dummy file.

## What is the new behavior?

The link is pointing to the migrating apps article.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
