### PR TITLE
fix(reg): Restore Flyout TemplatedParent propagation

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -190,5 +190,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 				return (rect2.CenterX, (rect1.Bottom + rect2.Y) / 2);
 			}
 		}
+
+		[Test]
+		[AutoRetry]
+		public void Flyout_TemplatedParent()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.Flyout.Flyout_TemplatedParent");
+
+			var button01 = _app.Marked("button01");
+			var innerTextBlock = _app.Marked("innerTextBlock");
+
+			_app.FastTap(button01);
+			_app.WaitForElement(innerTextBlock);
+
+			_app.WaitForDependencyPropertyValue(innerTextBlock, "Text", "Hello !");
+
+			_app.TapCoordinates(10, 100);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -697,6 +697,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_TemplatedParent.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Unloaded.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3595,6 +3599,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\FlyoutButtonViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_Unloaded.xaml.cs">
       <DependentUpon>DatePickerFlyout_Unloaded.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_TemplatedParent.xaml.cs">
+      <DependentUpon>Flyout_TemplatedParent.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Unloaded.xaml.cs">
       <DependentUpon>Flyout_Unloaded.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_TemplatedParent.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_TemplatedParent.xaml
@@ -1,0 +1,31 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.Flyout.Flyout_TemplatedParent"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.Flyout"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+
+    <Grid>
+		<ContentControl Tag="Hello !">
+			<ContentControl.Template>
+				<ControlTemplate TargetType="ContentControl">
+					<Button x:Name="button01" Content="Tap Me!">
+						<Button.Flyout>
+							<Flyout>
+								<StackPanel>
+									<TextBlock Text="Should show &quot;Hello !&quot; below:"/>
+									<TextBlock x:Name="innerTextBlock" Text="{Binding Tag, RelativeSource={RelativeSource TemplatedParent}}"/>
+								</StackPanel>
+							</Flyout>
+						</Button.Flyout>
+					</Button>
+				</ControlTemplate>
+			</ContentControl.Template>
+		</ContentControl>
+    </Grid>
+
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_TemplatedParent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_TemplatedParent.xaml.cs
@@ -1,0 +1,19 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.Flyout
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo("Flyout")]
+	public sealed partial class Flyout_TemplatedParent : Page
+	{
+		public Flyout_TemplatedParent()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -53,6 +53,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 					IsLightDismissEnabled = _isLightDismissEnabled,
 				};
 
+				SynchronizeTemplatedParent();
+
 				_popup.Opened += OnPopupOpened;
 				_popup.Closed += OnPopupClosed;
 
@@ -289,6 +291,9 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			_popup?.SetValue(Popup.DataContextProperty, this.DataContext, precedence: DependencyPropertyValuePrecedences.Local);
 
 		partial void OnTemplatedParentChangedPartial(DependencyPropertyChangedEventArgs e)
+			=> SynchronizeTemplatedParent();
+
+		private void SynchronizeTemplatedParent()
 		{
 			_popup?.SetValue(Popup.TemplatedParentProperty, TemplatedParent, precedence: DependencyPropertyValuePrecedences.Local);
 		}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The `TemplatedParent` propagation in `Flyout` instances is restored.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
