### PR TITLE
fix(pointers): [WASM] Fix negative pointer id on safari for iOS prevents pointers events

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml
 			}
 
 			args = new NativePointerEventArgs { 
-				pointerId = uint.Parse(parts[0], CultureInfo.InvariantCulture),
+				pointerId = double.Parse(parts[0], CultureInfo.InvariantCulture), // On Safari for iOS, the ID might be negative!
 				x = double.Parse(parts[1], CultureInfo.InvariantCulture),
 				y = double.Parse(parts[2], CultureInfo.InvariantCulture),
 				ctrl = parts[3] == "1",
@@ -183,6 +183,7 @@ namespace Windows.UI.Xaml
 			(bool isHorizontalWheel, double delta) wheel = default,
 			bool canBubble = true)
 		{
+			var pointerId = (uint)args.pointerId;
 			var src = GetElementFromHandle(args.srcHandle) ?? (UIElement)snd;
 			var position = new Point(args.x, args.y);
 			var pointerType = ConvertPointerTypeString(args.typeStr);
@@ -192,10 +193,10 @@ namespace Windows.UI.Xaml
 
 			return new PointerRoutedEventArgs(
 				args.timestamp,
-				args.pointerId,
+				pointerId,
 				pointerType,
 				position,
-				isInContact ?? ((UIElement)snd).IsPressed(args.pointerId),
+				isInContact ?? ((UIElement)snd).IsPressed(pointerId),
 				(WindowManagerInterop.HtmlPointerButtonsState)args.buttons,
 				(WindowManagerInterop.HtmlPointerButtonUpdate)args.buttonUpdate,
 				keyModifiers,
@@ -374,7 +375,7 @@ namespace Windows.UI.Xaml
 		// TODO: This should be marshaled instead of being parsed! https://github.com/unoplatform/uno/issues/2116
 		private struct NativePointerEventArgs
 		{
-			public uint pointerId;
+			public double pointerId; // Warning: This is a Number in JS, and it might be negative on safari for iOS
 			public double x;
 			public double y;
 			public bool ctrl;


### PR DESCRIPTION
Twitter Issue https://twitter.com/geolite_livejp/status/1264765429810991105?s=20
Fixes https://github.com/unoplatform/uno/issues/3233

## Bug fix
Pointer events might not work on safari for iOS (WASM)

## What is the current behavior?
Pointer ID is parsed as `uint`, but the on iOS for Safari in some cases it might be negative.

## What is the new behavior?
It's marshaled as double (as the `Number` for JS is a double precision value), and then cats as `uint` to match the WinUI contract.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ _browser specific that not testable on CI yet_
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
