### PR TITLE
fix(ComboBox): Correctly update CommonStates on apply template to fix disabled ComboBox visual state not appearing (for all platforms)

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
@@ -172,5 +172,47 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			TakeScreenshot("Closed");
 		}
+
+		[Test]
+		[AutoRetry]
+		public void ComboBoxTests_Disabled()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Disabled");
+
+			_app.WaitForElement(_app.Marked("DisabledComboBox"));
+			var disabledComboBox = _app.Marked("DisabledComboBox");
+
+			Assert.IsFalse(disabledComboBox.GetDependencyPropertyValue<bool>("IsEnabled"));
+
+			_app.WaitForElement(_app.Marked("HeaderContentPresenter"));
+			var headerContentPresenter = _app.Marked("HeaderContentPresenter");
+
+			Assert.AreEqual("Test Disabled ComboBox", headerContentPresenter.GetDependencyPropertyValue("Content"));
+		}
+
+		[Test]
+		[AutoRetry]
+		public void ComboBoxTests_ToggleDisabled()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ComboBox.ComboBox_ToggleDisabled");
+
+			_app.WaitForElement(_app.Marked("DisablingComboBox"));
+			var disablingComboBox = _app.Marked("DisablingComboBox");
+
+			TakeScreenshot("ComboBox Enabled");
+
+			_app.FastTap("ToggleDisabledButton");
+
+			_app.WaitForText("IsEnabledComboBox", "False");
+
+			Assert.IsFalse(disablingComboBox.GetDependencyPropertyValue<bool>("IsEnabled"));
+
+			_app.WaitForElement(_app.Marked("HeaderContentPresenter"));
+			var headerContentPresenter = _app.Marked("HeaderContentPresenter");
+
+			Assert.AreEqual("Test Toggle Disabled ComboBox", headerContentPresenter.GetDependencyPropertyValue("Content"));
+
+			TakeScreenshot("ComboBox Disabled");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -569,6 +569,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Disabled.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_DropDownPlacement.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -582,6 +586,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Stretch.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ToggleDisabled.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -3556,6 +3564,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_CornerRadius.xaml.cs">
       <DependentUpon>ComboBox_CornerRadius.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Disabled.xaml.cs">
+      <DependentUpon>ComboBox_Disabled.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_DropDownPlacement.xaml.cs">
       <DependentUpon>ComboBox_DropDownPlacement.xaml</DependentUpon>
     </Compile>
@@ -3564,6 +3575,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Stretch.xaml.cs">
       <DependentUpon>ComboBox_Stretch.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ToggleDisabled.xaml.cs">
+      <DependentUpon>ComboBox_ToggleDisabled.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_VisibleBounds.xaml.cs">
       <DependentUpon>ComboBox_VisibleBounds.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Disabled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Disabled.xaml
@@ -1,0 +1,316 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Disabled"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ComboBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns:not_wasm="http://uno.ui/not_wasm"
+			 mc:Ignorable="d not_wasm">
+	
+	<UserControl.Resources>
+		<Style x:Key="DisabledTestComboBoxStyle"
+			   TargetType="ComboBox">
+			<Setter Property="Padding"
+					Value="12,5,0,7" />
+			<Setter Property="MinWidth"
+					Value="{ThemeResource ComboBoxThemeMinWidth}" />
+			<Setter Property="Foreground"
+					Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+			<Setter Property="Background"
+					Value="{ThemeResource SystemControlBackgroundAltMediumLowBrush}" />
+			<Setter Property="BorderBrush"
+					Value="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
+			<Setter Property="BorderThickness"
+					Value="{ThemeResource ComboBoxBorderThemeThickness}" />
+			<Setter Property="TabNavigation"
+					Value="Once" />
+			<Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+					Value="Disabled" />
+			<Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+					Value="Auto" />
+			<Setter Property="ScrollViewer.HorizontalScrollMode"
+					Value="Disabled" />
+			<Setter Property="ScrollViewer.VerticalScrollMode"
+					Value="Auto" />
+			<Setter Property="ScrollViewer.IsVerticalRailEnabled"
+					Value="True" />
+			<Setter Property="ScrollViewer.IsDeferredScrollingEnabled"
+					Value="False" />
+			<Setter Property="ScrollViewer.BringIntoViewOnFocusChange"
+					Value="True" />
+			<Setter Property="HorizontalContentAlignment"
+					Value="Stretch" />
+			<Setter Property="HorizontalAlignment"
+					Value="Left" />
+			<Setter Property="VerticalAlignment"
+					Value="Top" />
+			<Setter Property="FontFamily"
+					Value="{ThemeResource ContentControlThemeFontFamily}" />
+			<Setter Property="FontSize"
+					Value="{ThemeResource ControlContentThemeFontSize}" />
+			<Setter Property="MinWidth"
+					Value="150" />
+			<Setter Property="ItemsPanel">
+				<Setter.Value>
+					<ItemsPanelTemplate>
+						<CarouselPanel />
+					</ItemsPanelTemplate>
+				</Setter.Value>
+			</Setter>
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ComboBox">
+						<Grid>
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlPageBackgroundAltMediumBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="BorderBrush">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightBaseMediumBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Pressed">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlBackgroundListMediumBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="BorderBrush">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Disabled">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter"
+																		   Storyboard.TargetProperty="Content">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Test Disabled ComboBox" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="BorderBrush">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<not_wasm:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+																					Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+											</not_wasm:ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+								<VisualStateGroup x:Name="FocusStates">
+									<VisualState x:Name="Focused">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HighlightBackground"
+																		   Storyboard.TargetProperty="BorderBrush">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<DoubleAnimation Storyboard.TargetName="HighlightBackground"
+															 Storyboard.TargetProperty="Opacity"
+															 To="1"
+															 Duration="0" />
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<not_wasm:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+																					Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+											</not_wasm:ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="FocusedPressed">
+										<Storyboard>
+											<DoubleAnimation Storyboard.TargetName="HighlightBackground"
+															 Storyboard.TargetProperty="Opacity"
+															 To="1"
+															 Duration="0" />
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<not_wasm:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+																					Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+											</not_wasm:ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Unfocused" />
+									<VisualState x:Name="PointerFocused" />
+									<VisualState x:Name="FocusedDropDown">
+										<Storyboard>
+											<not_wasm:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PopupBorder"
+																					Storyboard.TargetProperty="Visibility"
+																					Duration="0">
+												<DiscreteObjectKeyFrame KeyTime="0">
+													<DiscreteObjectKeyFrame.Value>
+														<Visibility>Visible</Visibility>
+													</DiscreteObjectKeyFrame.Value>
+												</DiscreteObjectKeyFrame>
+											</not_wasm:ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+								<VisualStateGroup x:Name="DropDownStates">
+									<VisualState x:Name="Opened">
+										<Storyboard>
+											<win:SplitOpenThemeAnimation OpenedTargetName="PopupBorder"
+																		 ClosedTargetName="ContentPresenter"
+																		 OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+																		 OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Closed">
+										<Storyboard>
+											<win:SplitCloseThemeAnimation OpenedTargetName="PopupBorder"
+																		  ClosedTargetName="ContentPresenter"
+																		  OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+																		  OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+							<ContentPresenter x:Name="HeaderContentPresenter"
+											  x:DeferLoadStrategy="Lazy"
+											  Margin="{ThemeResource ComboBoxHeaderThemeMargin}"
+											  FlowDirection="{TemplateBinding FlowDirection}"
+											  FontWeight="{ThemeResource ComboBoxHeaderThemeFontWeight}"
+											  Visibility="Collapsed"
+											  Content="{TemplateBinding Header}"
+											  ContentTemplate="{TemplateBinding HeaderTemplate}" />
+							<Border x:Name="Background"
+									Grid.Row="1"
+									Grid.ColumnSpan="2"
+									Background="{TemplateBinding Background}"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									CornerRadius="{TemplateBinding CornerRadius}" />
+							<Border x:Name="HighlightBackground"
+									Grid.Row="1"
+									Grid.ColumnSpan="2"
+									Background="{ThemeResource SystemControlHighlightListAccentLowBrush}"
+									BorderBrush="{ThemeResource SystemControlHighlightBaseMediumLowBrush}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									CornerRadius="{TemplateBinding CornerRadius}"
+									Opacity="0" />
+							<ContentPresenter x:Name="ContentPresenter"
+											  Grid.Row="1"
+											  Margin="{TemplateBinding Padding}"
+											  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+								<TextBlock x:Name="PlaceholderTextBlock"
+										   Text="{TemplateBinding PlaceholderText}"
+										   Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}" />
+							</ContentPresenter>
+							<TextBlock x:Name="DropDownGlyph"
+									   Grid.Row="1"
+									   Grid.Column="1"
+									   IsHitTestVisible="False"
+									   Margin="0,10,10,10"
+									   Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+									   FontFamily="{ThemeResource SymbolThemeFontFamily}"
+									   FontSize="12"
+									   Text="&#xE0E5;"
+									   HorizontalAlignment="Right"
+									   VerticalAlignment="Center"
+									   AutomationProperties.AccessibilityView="Raw" />
+							<Popup x:Name="Popup">
+								<Border x:Name="PopupBorder"
+										Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+										BorderBrush="{ThemeResource SystemControlForegroundChromeHighBrush}"
+										BorderThickness="{ThemeResource ComboBoxDropdownBorderThickness}"
+										Margin="0,-1,0,-1"
+										HorizontalAlignment="Stretch">
+									<ScrollViewer x:Name="ScrollViewer"
+												  Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+												  win:MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownContentMinWidth}"
+												  VerticalSnapPointsType="OptionalSingle"
+												  VerticalSnapPointsAlignment="Near"
+												  HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+												  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+												  VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+												  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+												  IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+												  IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+												  IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+												  BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+												  ZoomMode="Disabled"
+												  AutomationProperties.AccessibilityView="Raw">
+										<ItemsPresenter Margin="{ThemeResource ComboBoxDropdownContentMargin}" />
+									</ScrollViewer>
+								</Border>
+							</Popup>
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<Grid>
+		<!-- Disabled by default -->
+		<ComboBox x:Name="DisabledComboBox"
+				  IsEnabled="False"
+				  Header="Disabled ComboBox"
+				  Style="{StaticResource DisabledTestComboBoxStyle}" />
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Disabled.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Disabled.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using SamplesApp.Windows_UI_Xaml_Controls.Models;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_Disabled", typeof(ListViewViewModel), description: "ComboBox should be disabled by default.")]
+	public sealed partial class ComboBox_Disabled : UserControl
+	{
+		public ComboBox_Disabled()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ToggleDisabled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ToggleDisabled.xaml
@@ -1,0 +1,323 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.ComboBox.ComboBox_ToggleDisabled"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ComboBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns:not_wasm="http://uno.ui/not_wasm"
+			 mc:Ignorable="d not_wasm">
+
+	<UserControl.Resources>
+		<Style x:Key="ToggleDisabledTestComboBoxStyle"
+			   TargetType="ComboBox">
+			<Setter Property="Padding"
+					Value="12,5,0,7" />
+			<Setter Property="MinWidth"
+					Value="{ThemeResource ComboBoxThemeMinWidth}" />
+			<Setter Property="Foreground"
+					Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+			<Setter Property="Background"
+					Value="{ThemeResource SystemControlBackgroundAltMediumLowBrush}" />
+			<Setter Property="BorderBrush"
+					Value="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
+			<Setter Property="BorderThickness"
+					Value="{ThemeResource ComboBoxBorderThemeThickness}" />
+			<Setter Property="TabNavigation"
+					Value="Once" />
+			<Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+					Value="Disabled" />
+			<Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+					Value="Auto" />
+			<Setter Property="ScrollViewer.HorizontalScrollMode"
+					Value="Disabled" />
+			<Setter Property="ScrollViewer.VerticalScrollMode"
+					Value="Auto" />
+			<Setter Property="ScrollViewer.IsVerticalRailEnabled"
+					Value="True" />
+			<Setter Property="ScrollViewer.IsDeferredScrollingEnabled"
+					Value="False" />
+			<Setter Property="ScrollViewer.BringIntoViewOnFocusChange"
+					Value="True" />
+			<Setter Property="HorizontalContentAlignment"
+					Value="Stretch" />
+			<Setter Property="HorizontalAlignment"
+					Value="Left" />
+			<Setter Property="VerticalAlignment"
+					Value="Top" />
+			<Setter Property="FontFamily"
+					Value="{ThemeResource ContentControlThemeFontFamily}" />
+			<Setter Property="FontSize"
+					Value="{ThemeResource ControlContentThemeFontSize}" />
+			<Setter Property="MinWidth"
+					Value="150" />
+			<Setter Property="ItemsPanel">
+				<Setter.Value>
+					<ItemsPanelTemplate>
+						<CarouselPanel />
+					</ItemsPanelTemplate>
+				</Setter.Value>
+			</Setter>
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ComboBox">
+						<Grid>
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlPageBackgroundAltMediumBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="BorderBrush">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightBaseMediumBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Pressed">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlBackgroundListMediumBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="BorderBrush">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Disabled">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter"
+																		   Storyboard.TargetProperty="Content">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Test Toggle Disabled ComboBox" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+																		   Storyboard.TargetProperty="BorderBrush">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<not_wasm:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+																					Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+											</not_wasm:ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+								<VisualStateGroup x:Name="FocusStates">
+									<VisualState x:Name="Focused">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HighlightBackground"
+																		   Storyboard.TargetProperty="BorderBrush">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<DoubleAnimation Storyboard.TargetName="HighlightBackground"
+															 Storyboard.TargetProperty="Opacity"
+															 To="1"
+															 Duration="0" />
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<not_wasm:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+																					Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+											</not_wasm:ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="FocusedPressed">
+										<Storyboard>
+											<DoubleAnimation Storyboard.TargetName="HighlightBackground"
+															 Storyboard.TargetProperty="Opacity"
+															 To="1"
+															 Duration="0" />
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<not_wasm:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+																					Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+											</not_wasm:ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Unfocused" />
+									<VisualState x:Name="PointerFocused" />
+									<VisualState x:Name="FocusedDropDown">
+										<Storyboard>
+											<not_wasm:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PopupBorder"
+																					Storyboard.TargetProperty="Visibility"
+																					Duration="0">
+												<DiscreteObjectKeyFrame KeyTime="0">
+													<DiscreteObjectKeyFrame.Value>
+														<Visibility>Visible</Visibility>
+													</DiscreteObjectKeyFrame.Value>
+												</DiscreteObjectKeyFrame>
+											</not_wasm:ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+								<VisualStateGroup x:Name="DropDownStates">
+									<VisualState x:Name="Opened">
+										<Storyboard>
+											<win:SplitOpenThemeAnimation OpenedTargetName="PopupBorder"
+																		 ClosedTargetName="ContentPresenter"
+																		 OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+																		 OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Closed">
+										<Storyboard>
+											<win:SplitCloseThemeAnimation OpenedTargetName="PopupBorder"
+																		  ClosedTargetName="ContentPresenter"
+																		  OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+																		  OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+							<ContentPresenter x:Name="HeaderContentPresenter"
+											  x:DeferLoadStrategy="Lazy"
+											  Margin="{ThemeResource ComboBoxHeaderThemeMargin}"
+											  FlowDirection="{TemplateBinding FlowDirection}"
+											  FontWeight="{ThemeResource ComboBoxHeaderThemeFontWeight}"
+											  Visibility="Collapsed"
+											  Content="{TemplateBinding Header}"
+											  ContentTemplate="{TemplateBinding HeaderTemplate}" />
+							<Border x:Name="Background"
+									Grid.Row="1"
+									Grid.ColumnSpan="2"
+									Background="{TemplateBinding Background}"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									CornerRadius="{TemplateBinding CornerRadius}" />
+							<Border x:Name="HighlightBackground"
+									Grid.Row="1"
+									Grid.ColumnSpan="2"
+									Background="{ThemeResource SystemControlHighlightListAccentLowBrush}"
+									BorderBrush="{ThemeResource SystemControlHighlightBaseMediumLowBrush}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									CornerRadius="{TemplateBinding CornerRadius}"
+									Opacity="0" />
+							<ContentPresenter x:Name="ContentPresenter"
+											  Grid.Row="1"
+											  Margin="{TemplateBinding Padding}"
+											  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+								<TextBlock x:Name="PlaceholderTextBlock"
+										   Text="{TemplateBinding PlaceholderText}"
+										   Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}" />
+							</ContentPresenter>
+							<TextBlock x:Name="DropDownGlyph"
+									   Grid.Row="1"
+									   Grid.Column="1"
+									   IsHitTestVisible="False"
+									   Margin="0,10,10,10"
+									   Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+									   FontFamily="{ThemeResource SymbolThemeFontFamily}"
+									   FontSize="12"
+									   Text="&#xE0E5;"
+									   HorizontalAlignment="Right"
+									   VerticalAlignment="Center"
+									   AutomationProperties.AccessibilityView="Raw" />
+							<Popup x:Name="Popup">
+								<Border x:Name="PopupBorder"
+										Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+										BorderBrush="{ThemeResource SystemControlForegroundChromeHighBrush}"
+										BorderThickness="{ThemeResource ComboBoxDropdownBorderThickness}"
+										Margin="0,-1,0,-1"
+										HorizontalAlignment="Stretch">
+									<ScrollViewer x:Name="ScrollViewer"
+												  Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+												  win:MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownContentMinWidth}"
+												  VerticalSnapPointsType="OptionalSingle"
+												  VerticalSnapPointsAlignment="Near"
+												  HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+												  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+												  VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+												  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+												  IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+												  IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+												  IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+												  BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+												  ZoomMode="Disabled"
+												  AutomationProperties.AccessibilityView="Raw">
+										<ItemsPresenter Margin="{ThemeResource ComboBoxDropdownContentMargin}" />
+									</ScrollViewer>
+								</Border>
+							</Popup>
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<StackPanel>
+		<Button x:Name="ToggleDisabledButton"
+				Content="Toggle disabled"
+				Click="ToggleDisabled" />
+
+		<TextBlock x:Name="IsEnabledComboBox"
+				   Text="{Binding ElementName=DisablingComboBox, Path=IsEnabled}" />
+
+		<!-- Should be disabled with the ToggleDisabledButton -->
+		<ComboBox x:Name="DisablingComboBox"
+				  IsEnabled="True"
+				  Header="Disabling ComboBox"
+				  Style="{StaticResource ToggleDisabledTestComboBoxStyle}" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ToggleDisabled.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ToggleDisabled.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using SamplesApp.Windows_UI_Xaml_Controls.Models;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_ToggleDisabled", typeof(ListViewViewModel), description: "Toggling button to disable the ComboBox should disable it.")]
+	public sealed partial class ComboBox_ToggleDisabled : UserControl
+	{
+		public ComboBox_ToggleDisabled()
+		{
+			this.InitializeComponent();
+		}
+
+
+		private void ToggleDisabled(object sender, RoutedEventArgs args)
+		{
+			var currentlyDisabled = DisablingComboBox.IsEnabled;
+			DisablingComboBox.IsEnabled = !currentlyDisabled;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -125,6 +125,8 @@ namespace Windows.UI.Xaml.Controls
 						_contentPresenter.DataContext = null; // Remove problematic inherited DataContext
 					}
 				};
+
+				UpdateCommonStates();
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue: 
Closes unoplatform/Uno.Material#51

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When IsEnabled="False", the ComboBox is correctly disabled but the disabled visual state doesn't appear for iOS, Android and WASM.

## What is the new behavior?

When IsEnabled="False", the ComboBox is correctly disabled and the disabled visual state is visible on all platforms.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
