### PR TITLE
fix: Remove arbitrary 5 seconds delay workaround for iOS

### DIFF
--- a/src/Uno.UI.Wasm/ts/CoreDispatcher.ts
+++ b/src/Uno.UI.Wasm/ts/CoreDispatcher.ts
@@ -4,8 +4,6 @@
 	 * */
 	export class CoreDispatcher {
 		static _coreDispatcherCallback: any;
-		static _isIOS: boolean;
-		static _isSafari: boolean;
 		static _isFirstCall: boolean = true;
 		static _isReady: Promise<boolean>;
 		static _isWaitingReady: boolean;
@@ -14,9 +12,6 @@
 			MonoSupport.jsCallDispatcher.registerScope("CoreDispatcher", Windows.UI.Core.CoreDispatcher);
 			CoreDispatcher.initMethods();
 			CoreDispatcher._isReady = isReady;
-
-			CoreDispatcher._isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(<any>window).MSStream;
-			CoreDispatcher._isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 		}
 
 		/**
@@ -46,27 +41,15 @@
 		}
 
 		private static InnerWakeUp() {
-
-			if ((CoreDispatcher._isIOS || CoreDispatcher._isSafari) && CoreDispatcher._isFirstCall) {
-				//
-				// This is a workaround for the available call stack during the first 5 (?) seconds
-				// of the startup of an application. See https://github.com/mono/mono/issues/12357 for
-				// more details.
-				//
-				CoreDispatcher._isFirstCall = false;
-				console.warn("Detected iOS, delaying first CoreDispatcher dispatch for 5 seconds (see https://github.com/mono/mono/issues/12357)");
-				window.setTimeout(() => this.WakeUp(), 5000);
-			} else {
-				(<any>window).setImmediate(() => {
-					try {
-						CoreDispatcher._coreDispatcherCallback();
-					}
-					catch (e) {
-						console.error(`Unhandled dispatcher exception: ${e} (${e.stack})`);
-						throw e;
-					}
-				});
-			}
+			(<any>window).setImmediate(() => {
+				try {
+					CoreDispatcher._coreDispatcherCallback();
+				}
+				catch (e) {
+					console.error(`Unhandled dispatcher exception: ${e} (${e.stack})`);
+					throw e;
+				}
+			});
 		}
 
 		private static initMethods() {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This workaround was introduced for https://github.com/mono/mono/issues/12357, and got fixed in recent Safari builds.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
