### PR TITLE
fix (macOS): Grid inner control display text

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -14,30 +14,6 @@ namespace Windows.UI.Xaml
 {
 	public partial class FrameworkElement
 	{
-		private bool _inLayoutSubviews;
-		private CGSize? _lastAvailableSize;
-		private CGSize _lastMeasure;
-
-		partial void Initialize();
-
-		internal bool RequiresArrange { get; private set; }
-
-		internal bool RequiresMeasure { get; private set; }
-
-
-		/// <summary>
-		/// Determines if InvalidateMeasure has been called
-		/// </summary>
-		/// <remarks>This property is present to mirror the WinUI souce</remarks>
-		internal bool IsMeasureDirty => RequiresMeasure;
-
-		/// <summary>
-		/// Determines if InvalidateArrange has been called
-		/// </summary>
-		/// <remarks>This property is present to mirror the WinUI souce</remarks>
-		internal bool IsArrangeDirty => RequiresArrange;
-
-
 		public override void SetNeedsLayout()
 		{
 			if (!_inLayoutSubviews)
@@ -49,11 +25,6 @@ namespace Windows.UI.Xaml
 			RequiresArrange = true;
 
 			SetSuperviewNeedsLayout();
-		}
-
-		public FrameworkElement()
-		{
-			Initialize();
 		}
 
 		public override void LayoutSubviews()
@@ -88,47 +59,6 @@ namespace Windows.UI.Xaml
 				this.Log().Error($"Layout failed in {GetType()}", e);
 			}
 		}
-		/// <summary>
-		/// Called before Arrange is called, this method will be deprecated
-		/// once OnMeasure/OnArrange will be implemented completely
-		/// </summary>
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		protected virtual void OnBeforeArrange()
-		{
-
-		}
-
-		/// <summary>
-		/// Called after Arrange is called, this method will be deprecated
-		/// once OnMeasure/OnArrange will be implemented completely
-		/// </summary>
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		protected virtual void OnAfterArrange()
-		{
-
-		}
-
-		private CGSize? XamlMeasure(CGSize availableSize)
-		{
-			// If set layout has not been called, we can 
-			// return a previously cached result for the same available size.
-			if (
-				!RequiresMeasure
-				&& _lastAvailableSize.HasValue
-				&& availableSize == _lastAvailableSize
-			)
-			{
-				return _lastMeasure;
-			}
-
-			_lastAvailableSize = availableSize;
-			RequiresMeasure = false;
-
-			var result = _layouter.Measure(SizeFromUISize(availableSize));
-
-			// Result here exclude the margins on the element
-			return _lastMeasure = result.LogicalToPhysicalPixels();
-		}
 
 		public override CGSize SizeThatFits(CGSize size)
 		{
@@ -151,28 +81,6 @@ namespace Windows.UI.Xaml
 			{
 				_inLayoutSubviews = false;
 			}
-		}
-
-		protected Size SizeFromUISize(CGSize size)
-		{
-			var width = nfloat.IsNaN(size.Width) ? float.PositiveInfinity : size.Width;
-			var height = nfloat.IsNaN(size.Height) ? float.PositiveInfinity : size.Height;
-
-			return new Size(width, height).PhysicalToLogicalPixels();
-		}
-
-		private bool IsTopLevelXamlView()
-		{
-			UIView parent = this;
-			while (parent != null)
-			{
-				parent = parent.Superview;
-				if (parent is IFrameworkElement)
-				{
-					return false;
-				}
-			}
-			return true;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOSmacOS.cs
@@ -1,0 +1,111 @@
+﻿using CoreGraphics;
+using Uno.Extensions;
+using Uno.UI.Controls;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.ComponentModel;
+using Windows.Foundation;
+using Uno.Logging;
+using Uno.UI;
+
+#if __IOS__
+using _View = UIKit.UIView;
+#elif __MACOS__
+using _View = AppKit.NSView;
+#endif
+
+namespace Windows.UI.Xaml
+{
+	public partial class FrameworkElement
+	{
+		private bool _inLayoutSubviews;
+		private CGSize? _lastAvailableSize;
+		private CGSize _lastMeasure;
+
+		partial void Initialize();
+
+		internal bool RequiresArrange { get; private set; }
+
+		internal bool RequiresMeasure { get; private set; }
+
+		/// <summary>
+		/// Determines if InvalidateMeasure has been called
+		/// </summary>
+		internal bool IsMeasureDirty => RequiresMeasure;
+
+		/// <summary>
+		/// Determines if InvalidateArrange has been called
+		/// </summary>
+		internal bool IsArrangeDirty => RequiresArrange;
+
+		public FrameworkElement()
+		{
+			Initialize();
+		}
+
+		internal CGSize? XamlMeasure(CGSize availableSize)
+		{
+			// If set layout has not been called, we can 
+			// return a previously cached result for the same available size.
+			if (
+				!RequiresMeasure
+				&& _lastAvailableSize.HasValue
+				&& availableSize == _lastAvailableSize
+			)
+			{
+				return _lastMeasure;
+			}
+
+			_lastAvailableSize = availableSize;
+			RequiresMeasure = false;
+
+			var result = _layouter.Measure(SizeFromUISize(availableSize));
+
+			// Result here exclude the margins on the element
+			return _lastMeasure = result.LogicalToPhysicalPixels();
+		}
+
+		/// <summary>
+		/// Called before Arrange is called, this method will be deprecated
+		/// once OnMeasure/OnArrange will be implemented completely
+		/// </summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		protected virtual void OnBeforeArrange()
+		{
+
+		}
+
+		/// <summary>
+		/// Called after Arrange is called, this method will be deprecated
+		/// once OnMeasure/OnArrange will be implemented completely
+		/// </summary>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		protected virtual void OnAfterArrange()
+		{
+
+		}
+
+		protected Size SizeFromUISize(CGSize size)
+		{
+			var width = nfloat.IsNaN(size.Width) ? float.PositiveInfinity : size.Width;
+			var height = nfloat.IsNaN(size.Height) ? float.PositiveInfinity : size.Height;
+
+			return new Size(width, height).PhysicalToLogicalPixels();
+		}
+
+		private bool IsTopLevelXamlView()
+		{
+			_View parent = this;
+			while (parent != null)
+			{
+				parent = parent.Superview;
+				if (parent is IFrameworkElement)
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.macOS.cs
@@ -14,25 +14,11 @@ namespace Windows.UI.Xaml
 {
 	public partial class FrameworkElement
 	{
-		private bool _inLayoutSubviews;
-		private CGSize? _lastAvailableSize;
-		private CGSize _lastMeasure;
-
-		partial void Initialize();
-
-		internal bool RequiresArrange { get; private set; }
-
-		internal bool RequiresMeasure { get; private set; }
-
 		/// <summary>
-		/// Determines if InvalidateMeasure has been called
+		/// When set, measure and invalidate requests will not be propagated further up the visual tree, ie they won't trigger a relayout.
+		/// Used where repeated unnecessary measure/arrange passes would be unacceptable for performance (eg scrolling in a list).
 		/// </summary>
-		internal bool IsMeasureDirty => RequiresMeasure;
-
-		/// <summary>
-		/// Determines if InvalidateArrange has been called
-		/// </summary>
-		internal bool IsArrangeDirty => RequiresArrange;
+		internal bool ShouldInterceptInvalidate { get; set; }
 
 		public override bool NeedsLayout
 		{
@@ -78,17 +64,6 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		/// <summary>
-		/// When set, measure and invalidate requests will not be propagated further up the visual tree, ie they won't trigger a relayout.
-		/// Used where repeated unnecessary measure/arrange passes would be unacceptable for performance (eg scrolling in a list).
-		/// </summary>
-		internal bool ShouldInterceptInvalidate { get; set; }
-
-		public FrameworkElement()
-		{
-			Initialize();
-		}
-
 		public override void Layout()
 		{
 			try
@@ -120,47 +95,6 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		/// <summary>
-		/// Called before Arrange is called, this method will be deprecated
-		/// once OnMeasure/OnArrange will be implemented completely
-		/// </summary>
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		protected virtual void OnBeforeArrange()
-		{
-
-		}
-
-		/// <summary>
-		/// Called after Arrange is called, this method will be deprecated
-		/// once OnMeasure/OnArrange will be implemented completely
-		/// </summary>
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		protected virtual void OnAfterArrange()
-		{
-
-		}
-
-		internal CGSize? XamlMeasure(CGSize availableSize)
-		{
-			// If set layout has not been called, we can 
-			// return a previously cached result for the same available size.
-			if (
-				!RequiresMeasure
-				&& _lastAvailableSize.HasValue
-				&& availableSize == _lastAvailableSize
-			)
-			{
-				return _lastMeasure;
-			}
-
-			_lastAvailableSize = availableSize;
-			RequiresMeasure = false;
-
-			var result = _layouter.Measure(SizeFromUISize(availableSize));
-
-			return _lastMeasure = result.LogicalToPhysicalPixels();
-		}
-
 		public CGSize SizeThatFits(CGSize size)
 		{
 			try
@@ -182,28 +116,6 @@ namespace Windows.UI.Xaml
 			{
 				_inLayoutSubviews = false;
 			}
-		}
-
-		protected Size SizeFromUISize(CGSize size)
-		{
-			var width = nfloat.IsNaN(size.Width) ? float.PositiveInfinity : size.Width;
-			var height = nfloat.IsNaN(size.Height) ? float.PositiveInfinity : size.Height;
-
-			return new Size(width, height).PhysicalToLogicalPixels();
-		}
-
-		private bool IsTopLevelXamlView()
-		{
-			NSView parent = this;
-			while (parent != null)
-			{
-				parent = parent.Superview;
-				if (parent is IFrameworkElement)
-				{
-					return false;
-				}
-			}
-			return true;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.macOS.cs
@@ -158,11 +158,7 @@ namespace Windows.UI.Xaml
 
 			var result = _layouter.Measure(SizeFromUISize(availableSize));
 
-			result = IFrameworkElementHelper
-				.SizeThatFits(this, result)
-				.ToFoundationSize();
-
-			return result.LogicalToPhysicalPixels();
+			return _lastMeasure = result.LogicalToPhysicalPixels();
 		}
 
 		public CGSize SizeThatFits(CGSize size)


### PR DESCRIPTION
GitHub Issue (If applicable): #
fix closes #3198 

## PR Type

- Bugfix

## What is the current behaviour?
When having a `Grid` with a MinWidth assigned to at least one of **ColumnDefinition** the internal UI controls whose **FontSize** is small (less than 12) and have an **HorizontalAlignment** other than Stretch are not displayed.

## What is the new behaviour?
UIControls will display inside a `Grid` even when such Grid has any ColumnDefinition set with MinWidth Value.
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
