### PR TITLE
fix(lottie): On Wasm, using the PlaybackRate on a system using a comma instead of a dot (mostly european languages) could lead to non-working Lottie animation.

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSource.wasm.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSource.wasm.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 					",stretch:\"",
 					player.Stretch.ToString(),
 					"\",rate:",
-					player.PlaybackRate.ToString(),
+					player.PlaybackRate.ToStringInvariant(),
 					"},",
 					jsonString,
 					");"


### PR DESCRIPTION
Fix #3249 as reported on https://stackoverflow.com/questions/62030326/uncaught-type-javascript-error-in-uno-lottie-webassembly by @berkbb

# Bugfix
`PlaybackRate` for Lottie on Wasm were not serialized using a culture-invariant context, causing parsing problem on javascript.

There was already a unit test/sample for this, but the test wasn't crashing on the server because they are deployed using english language.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
