### PR TITLE
fix(lottie): On Wasm, when a Lottie animation were started (`.Play()`) before being loaded, a concurrency issue was preventing the animation from starting once loaded.

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSource.wasm.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSource.wasm.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 		private Uri _loadedEmbeddedUri;
 
 		private (double fromProgress, double toProgress, bool looped)? _playState;
+		private bool _isUpdating;
 
 		partial void InnerUpdate()
 		{
@@ -68,19 +69,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
 				js = new[]
 				{
-					"Uno.UI.Lottie.setAnimationProperties({", "elementId:",
+					"Uno.UI.Lottie.setAnimationProperties({",
+					"elementId:",
 					player.HtmlId.ToString(),
 					",jsonPath:\"",
-					UriSource?.PathAndQuery ?? "", "\",autoplay:",
-					player.AutoPlay ? "true" : "false", ",stretch:\"",
+					UriSource?.PathAndQuery ?? "",
+					"\",autoplay:",
+					player.AutoPlay ? "true" : "false",
+					",stretch:\"",
 					player.Stretch.ToString(),
 					"\",rate:",
-					player.PlaybackRate.ToString(), "});"
+					player.PlaybackRate.ToStringInvariant(),
+					"});"
 				};
 			}
 
+			_isUpdating = true;
+
 			WebAssemblyRuntime.InvokeJS(string.Concat(js));
 			_isPlaying = player.AutoPlay;
+
+			_isUpdating = false;
 
 			ApplyPlayState();
 		}
@@ -94,10 +103,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 			}
 		}
 
-		private void OnStateChanged(object sender, HtmlCustomEventArgs e)
-		{
-			ParseStateString(e.Detail);
-		}
+		private void OnStateChanged(object sender, HtmlCustomEventArgs e) => ParseStateString(e.Detail);
 
 		private void ParseStateString(string stateString)
 		{
@@ -107,7 +113,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 			var loaded = parts[2].Equals("true", StringComparison.Ordinal);
 			var paused = parts[3].Equals("true", StringComparison.Ordinal);
 
-			if (paused)
+			if (paused && !_isUpdating)
 			{
 				_playState = null;
 			}
@@ -211,7 +217,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 				"Uno.UI.Lottie.setProgress(",
 				_player.HtmlId.ToString(),
 				",",
-				progress.ToString(CultureInfo.InvariantCulture),
+				progress.ToStringInvariant(),
 				");"
 			};
 			WebAssemblyRuntime.InvokeJS(string.Concat(js));

--- a/src/AddIns/Uno.UI.Lottie/WasmScripts/uno-lottie.js
+++ b/src/AddIns/Uno.UI.Lottie/WasmScripts/uno-lottie.js
@@ -144,7 +144,7 @@ var Uno;
                         scaleMode = "xMidYMid slice";
                         break;
                     case "Fill":
-                        scaleMode = "noScale";
+                        scaleMode = "none";
                         break;
                 }
                 const containerElement = Uno.UI.WindowManager.current.getView(properties.elementId);

--- a/src/AddIns/Uno.UI.Lottie/ts/Uno.UI.Lottie.ts
+++ b/src/AddIns/Uno.UI.Lottie/ts/Uno.UI.Lottie.ts
@@ -208,7 +208,7 @@ namespace Uno.UI {
 					scaleMode = "xMidYMid slice";
 					break;
 				case "Fill":
-					scaleMode = "noScale";
+					scaleMode = "none";
 					break;
 			}
 

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/ProgressRing/WinUIProgressRingPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/ProgressRing/WinUIProgressRingPage.xaml
@@ -16,5 +16,7 @@
 		<TextBlock FontSize="15">Interactive ProgressRing:</TextBlock>
 		<winui:ProgressRing IsActive="{Binding IsChecked, ElementName=isActive}" Width="64" />
 		<ToggleButton x:Name="isActive">IsActive</ToggleButton>
+		<ToggleButton Click="LoadUnload">LOAD/UNLOAD</ToggleButton>
+		<Border x:Name="container"></Border>
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/ProgressRing/WinUIProgressRingPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/ProgressRing/WinUIProgressRingPage.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Microsoft_UI_Xaml_Controls.ProgressRing
@@ -10,6 +12,15 @@ namespace UITests.Microsoft_UI_Xaml_Controls.ProgressRing
 		public WinUIProgressRingPage()
 		{
 			this.InitializeComponent();
+		}
+
+		private UIElement _loadUnloadProgressBar = new Microsoft.UI.Xaml.Controls.ProgressRing();
+
+		private void LoadUnload(object sender, RoutedEventArgs e)
+		{
+			var isLoaded = (sender as ToggleButton)?.IsChecked ?? false;
+
+			container.Child = isLoaded ? _loadUnloadProgressBar : null;
 		}
 	}
 }


### PR DESCRIPTION
Fix https://github.com/unoplatform/uno/issues/3212 and https://stackoverflow.com/questions/62018364/progressring-stops-animating-after-a-page-navigation-on-uno-2-4-wasm

# Bugfix

## What is the current behavior?
On Wasm, when a Lottie animation were started (`.Play()`) before being loaded in the _VisualTree_, the animation were staled paused instead of playing.

This was caused by a concurrency issue were the `lottie-js` player were reporting his paused state before the _currently playing state_ could be applied on the player. It has been fixed by creating a flag to preving this case.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
