### PR TITLE
fix: Adjust UWP sample head

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/StarStackPanel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/StarStackPanel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Uno.UI.Samples.Helper;
 
 #if !NETFX_CORE && !__ANDROID__ && !__IOS__ && !__WASM__ && !__MACOS__
 using System.Windows;
@@ -106,15 +107,15 @@ namespace Uno.UI.Samples.Controls
 		{
 			var sizeHint = GetChildSizeHint(child);
 
-			if (GridLengthHelper.GetIsStar(sizeHint))
+			if (GridLengthHelper2.GetIsStar(sizeHint))
 			{
 				starTotal += sizeHint.Value;
 			}
-			else if (GridLengthHelper.GetIsAuto(sizeHint))
+			else if (GridLengthHelper2.GetIsAuto(sizeHint))
 			{
 				MesureChildAuto(child, orientation, availableSize, ref totalSize);
 			}
-			else if (GridLengthHelper.GetIsAbsolute(sizeHint))
+			else if (GridLengthHelper2.GetIsAbsolute(sizeHint))
 			{
 				MesureChildAbsolute(child, orientation, availableSize, sizeHint, ref totalSize);
 			}
@@ -178,7 +179,7 @@ namespace Uno.UI.Samples.Controls
 				foreach (UIElement child in children)
 				{
 					var sizeHint = GetChildSizeHint(child);
-					if (GridLengthHelper.GetIsStar(sizeHint))
+					if (GridLengthHelper2.GetIsStar(sizeHint))
 					{
 						MesureChildStar(child, orientation, availableSize, sizeHint, starTotal, ref totalSize);
 					}
@@ -298,15 +299,15 @@ namespace Uno.UI.Samples.Controls
 			var sizeHint = GetChildSizeHint(child);
 			var size = new Size();
 
-			if (GridLengthHelper.GetIsStar(sizeHint))
+			if (GridLengthHelper2.GetIsStar(sizeHint))
 			{
 				starTotal += sizeHint.Value;
 			}
-			else if (GridLengthHelper.GetIsAuto(sizeHint))
+			else if (GridLengthHelper2.GetIsAuto(sizeHint))
 			{
 				ComputeChildAutoSize(child, orientation, ref finalSize, ref totalLength, ref size);
 			}
-			else if (GridLengthHelper.GetIsAbsolute(sizeHint))
+			else if (GridLengthHelper2.GetIsAbsolute(sizeHint))
 			{
 				ComputeChildAbsoluteSize(orientation, ref finalSize, ref totalLength, ref sizeHint, ref size);
 			}
@@ -409,7 +410,7 @@ namespace Uno.UI.Samples.Controls
 		{
 			var size = record.Size;
 
-			if (GridLengthHelper.GetIsStar(record.SizeHint))
+			if (GridLengthHelper2.GetIsStar(record.SizeHint))
 			{
 				var portion = record.SizeHint.Value * starRatio;
 
@@ -550,7 +551,7 @@ namespace Uno.UI.Samples.Controls
 			{
 				if (string.IsNullOrEmpty(part))
 				{
-					result.Add(GridLengthHelper.FromValueAndType(0, GridUnitType.Auto));
+					result.Add(GridLengthHelper2.FromValueAndType(0, GridUnitType.Auto));
 					continue;
 				}
 
@@ -563,7 +564,7 @@ namespace Uno.UI.Samples.Controls
 				var autoGroup = match.Groups["auto"];
 				if (autoGroup.Success)
 				{
-					result.Add(GridLengthHelper.FromValueAndType(0, GridUnitType.Auto));
+					result.Add(GridLengthHelper2.FromValueAndType(0, GridUnitType.Auto));
 					continue;
 				}
 
@@ -574,14 +575,14 @@ namespace Uno.UI.Samples.Controls
 						!string.IsNullOrWhiteSpace(starsGroup.Value)
 							? double.Parse(starsGroup.Value, CultureInfo.InvariantCulture)
 							: 1;
-					result.Add(GridLengthHelper.FromValueAndType(value, GridUnitType.Star));
+					result.Add(GridLengthHelper2.FromValueAndType(value, GridUnitType.Star));
 					continue;
 				}
 
 				var starGroup = match.Groups["star"];
 				if (starGroup.Success)
 				{
-					result.Add(GridLengthHelper.FromValueAndType(1, GridUnitType.Star));
+					result.Add(GridLengthHelper2.FromValueAndType(1, GridUnitType.Star));
 					continue;
 				}
 
@@ -589,7 +590,7 @@ namespace Uno.UI.Samples.Controls
 				if (absGroup.Success)
 				{
 					var value = double.Parse(absGroup.Value, CultureInfo.InvariantCulture);
-					result.Add(GridLengthHelper.FromValueAndType(value, GridUnitType.Pixel));
+					result.Add(GridLengthHelper2.FromValueAndType(value, GridUnitType.Pixel));
 					continue;
 				}
 
@@ -631,7 +632,7 @@ namespace Uno.UI.Samples.Controls
 			"Size",
 			typeof(GridLength),
 			typeof(StarStackPanel),
-			new PropertyMetadata(GridLengthHelper.Auto, HandleSizePropertyChanged)
+			new PropertyMetadata(GridLengthHelper2.Auto, HandleSizePropertyChanged)
 		);
 
 		private static void HandleSizePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Helper/GridLengthHelper2.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Helper/GridLengthHelper2.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Samples.Helper
+{
+	class GridLengthHelper2
+	{
+		public static GridLength Auto =>
+#if NETFX_CORE && !HAS_UNO_WINUI
+			GridLength.Auto;
+#else
+			GridLengthHelper.Auto;
+#endif
+
+		internal static GridLength FromValueAndType(double value, GridUnitType pixel) =>
+#if NETFX_CORE && !HAS_UNO_WINUI
+			new GridLength(value, pixel);
+#else
+			GridLengthHelper.FromValueAndType(value, pixel);
+#endif
+
+		internal static bool GetIsStar(GridLength sizeHint) =>
+#if NETFX_CORE && !HAS_UNO_WINUI
+			sizeHint.IsStar;
+#else
+			GridLengthHelper.GetIsStar(sizeHint);
+#endif
+
+		internal static bool GetIsAbsolute(GridLength sizeHint) =>
+#if NETFX_CORE && !HAS_UNO_WINUI
+			sizeHint.IsAbsolute;
+#else
+			GridLengthHelper.GetIsAbsolute(sizeHint);
+#endif
+
+		internal static bool GetIsAuto(GridLength sizeHint) =>
+#if NETFX_CORE && !HAS_UNO_WINUI
+			sizeHint.IsAuto;
+#else
+			GridLengthHelper.GetIsAuto(sizeHint);
+#endif
+	}
+}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.Shared.projitems
@@ -42,6 +42,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\ContentNavigationBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\DelegateCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\DelegateCommand.T.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\GridLengthHelper2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\PropertyMetadataHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\SampleHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UnitTest\UnitTestsControl.cs" />


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #3217 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

In UWP (non-WinUI) GridLengthHelper.Auto fails with MethodAccessException, this is a UWP-only workaround. This update uses a helper to adjust for the appropriate calls, only for the sample app.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
