### PR TITLE
ci: Add dotnet templates integration tests

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -29,6 +29,10 @@ jobs:
   parameters:
     vmImage: '$(windowsVMImage)'
 
+- template: build/ci/.azure-devops-project-template-tests.yml
+  parameters:
+    vmImage: $(windowsVMImage)
+
 - template: build/ci/.azure-devops-uap.yml
   parameters:
     vmImage: '$(windowsVMImage)'

--- a/build/ci/.azure-devops-project-template-tests.yml
+++ b/build/ci/.azure-devops-project-template-tests.yml
@@ -1,0 +1,26 @@
+parameters:
+  vmImage: ''
+
+jobs:
+- job: Dotnet_Template_Tests
+
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+
+  dependsOn: VS_Latest
+
+  steps:
+  - task: DownloadBuildArtifacts@0
+    inputs:
+      artifactName: NugetPackages
+
+  - script: copy $(System.ArtifactsDirectory)\NugetPackages\vslatest\*.nupkg $(Build.SourcesDirectory)\src\PackageCache
+    displayName: Copy Artifacts to PackageCache
+
+  - script: dotnet new -i $(System.ArtifactsDirectory)\NugetPackages\vslatest\Uno.ProjectTemplates.Dotnet*.nupkg
+    displayName: Install Project Templates
+
+  - powershell: build\run-template-tests.ps1
+    displayName: Run Project Templates Tests
+    env:
+      NUGET_CI_CONFIG: $(Build.SourcesDirectory)\src\nuget.ci.config

--- a/build/run-template-tests.ps1
+++ b/build/run-template-tests.ps1
@@ -1,0 +1,74 @@
+﻿$ErrorActionPreference = 'Stop'
+
+function Get-TemplateConfiguration(
+    [bool]$uwp = $false,
+    [bool]$android = $false,
+    [bool]$iOS = $false,
+    [bool]$macOS = $false,
+    [bool]$wasm = $false,
+    [bool]$wasmVsCode = $false)
+{
+    $uwpFlag = '-uwp'
+    $androidFlag = '-android'
+    $iOSFlag = '-ios'
+    $macOSFlag = '-macos'
+    $wasmFlag = '-wasm'
+    $wasmVsCodeFlag = '--vscodeWasm'
+
+    $a = If ($uwp)        { $uwpFlag }        Else { $uwpFlag        + '=false' }
+    $b = If ($android)    { $androidFlag }    Else { $androidFlag    + '=false' }
+    $c = If ($iOS)        { $iOSFlag }        Else { $iOSFlag        + '=false' }
+    $d = If ($macOS)      { $macOSFlag }      Else { $macOSFlag      + '=false' }
+    $e = If ($wasm)       { $wasmFlag }       Else { $wasmFlag       + '=false' }
+    $f = If ($wasmVsCode) { $wasmVsCodeFlag } Else { $wasmVsCodeFlag + '=false' }
+
+    @($a, $b, $c, $d, $e, $f)
+}
+
+$msbuild = vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
+
+$default = @('/ds', '/r', "/p:RestoreConfigFile=$env:NUGET_CI_CONFIG", '/p:PackageCertificateKeyFile=')
+
+$debug = $default + '/p:Configuration=Debug'
+
+$release = $default + '/p:AotAssemblies=false' + '/p:Configuration=Release'
+$releaseX64 = $release + '/p:Platform=x64'
+$releaseIPhone = $release + '/p:Platform=iPhone'
+$releaseIPhoneSimulator = $release + '/p:Platform=iPhoneSimulator'
+
+$templateConfigurations =
+@(
+    (Get-TemplateConfiguration -uwp 1),
+    (Get-TemplateConfiguration -android 1),
+    (Get-TemplateConfiguration -iOS 1),
+    (Get-TemplateConfiguration -macOS 1),
+    (Get-TemplateConfiguration -wasm 1)
+)
+
+$configurations =
+@(
+    @($templateConfigurations[0], $releaseX64),
+    @($templateConfigurations[1], $release),
+    @($templateConfigurations[2], $releaseIPhone),
+    @($templateConfigurations[3], $releaseIPhoneSimulator),
+    @($templateConfigurations[4], $release)
+)
+
+# Default
+dotnet new unoapp -n UnoAppAll
+& $msbuild $debug UnoAppAll\UnoAppAll.sln
+
+# Heads - Release
+for($i = 0; $i -lt $configurations.Length; $i++)
+{
+    dotnet new unoapp -n "UnoApp$i" $configurations[$i][0]
+    & $msbuild $configurations[$i][1] "UnoApp$i\UnoApp$i.sln"
+}
+
+# VS Code
+dotnet new unoapp -n UnoAppVsCode (Get-TemplateConfiguration -wasm 1 -wasmVsCode 1)
+dotnet build -p:RestoreConfigFile=$env:NUGET_CI_CONFIG UnoAppVsCode\UnoAppVsCode.sln
+
+# WinUI - Release
+# dotnet new unoapp-winui -n UnoAppWinUI
+# & $msbuild $release UnoAppWinUI\UnoAppWinUI.sln


### PR DESCRIPTION
GitHub Issue (If applicable): #1876

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
N/A

## What is the new behavior?
We now do dotnet templates integration tests as part of the ci

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
