### PR TITLE
fix(ApplicationDataContainer): Update WebAssembly storage to use javascript `localStorage`

### DIFF
--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -533,6 +533,71 @@ declare namespace Uno.UI {
         setCursor(cssCursor: string): string;
     }
 }
+declare class ApplicationDataContainer_ClearParams {
+    Locality: string;
+    static unmarshal(pData: number): ApplicationDataContainer_ClearParams;
+}
+declare class ApplicationDataContainer_ContainsKeyParams {
+    Key: string;
+    Value: string;
+    Locality: string;
+    static unmarshal(pData: number): ApplicationDataContainer_ContainsKeyParams;
+}
+declare class ApplicationDataContainer_ContainsKeyReturn {
+    ContainsKey: boolean;
+    marshal(pData: number): void;
+}
+declare class ApplicationDataContainer_GetCountParams {
+    Locality: string;
+    static unmarshal(pData: number): ApplicationDataContainer_GetCountParams;
+}
+declare class ApplicationDataContainer_GetCountReturn {
+    Count: number;
+    marshal(pData: number): void;
+}
+declare class ApplicationDataContainer_GetKeyByIndexParams {
+    Locality: string;
+    Index: number;
+    static unmarshal(pData: number): ApplicationDataContainer_GetKeyByIndexParams;
+}
+declare class ApplicationDataContainer_GetKeyByIndexReturn {
+    Value: string;
+    marshal(pData: number): void;
+}
+declare class ApplicationDataContainer_GetValueByIndexParams {
+    Locality: string;
+    Index: number;
+    static unmarshal(pData: number): ApplicationDataContainer_GetValueByIndexParams;
+}
+declare class ApplicationDataContainer_GetValueByIndexReturn {
+    Value: string;
+    marshal(pData: number): void;
+}
+declare class ApplicationDataContainer_RemoveParams {
+    Locality: string;
+    Key: string;
+    static unmarshal(pData: number): ApplicationDataContainer_RemoveParams;
+}
+declare class ApplicationDataContainer_RemoveReturn {
+    Removed: boolean;
+    marshal(pData: number): void;
+}
+declare class ApplicationDataContainer_SetValueParams {
+    Key: string;
+    Value: string;
+    Locality: string;
+    static unmarshal(pData: number): ApplicationDataContainer_SetValueParams;
+}
+declare class ApplicationDataContainer_TryGetValueParams {
+    Key: string;
+    Locality: string;
+    static unmarshal(pData: number): ApplicationDataContainer_TryGetValueParams;
+}
+declare class ApplicationDataContainer_TryGetValueReturn {
+    Value: string;
+    HasValue: boolean;
+    marshal(pData: number): void;
+}
 declare class StorageFolderMakePersistentParams {
     Paths_Length: number;
     Paths: Array<string>;
@@ -806,6 +871,44 @@ declare const MonoRuntime: Uno.UI.Interop.IMonoRuntime;
 declare const WebAssemblyApp: Uno.UI.Interop.IWebAssemblyApp;
 declare const UnoAppManifest: Uno.UI.IAppManifest;
 declare const UnoDispatch: Uno.UI.Interop.IUnoDispatch;
+declare namespace Windows.Storage {
+    class ApplicationDataContainer {
+        private static buildStorageKey;
+        private static buildStoragePrefix;
+        /**
+         * Try to get a value from localStorage
+         * */
+        private static tryGetValue;
+        /**
+         * Set a value to localStorage
+         * */
+        private static setValue;
+        /**
+         * Determines if a key is contained in localStorage
+         * */
+        private static containsKey;
+        /**
+         * Gets a key by index in localStorage
+         * */
+        private static getKeyByIndex;
+        /**
+         * Determines the number of items contained in localStorage
+         * */
+        private static getCount;
+        /**
+         * Clears items contained in localStorage
+         * */
+        private static clear;
+        /**
+         * Removes an item contained in localStorage
+         * */
+        private static remove;
+        /**
+         * Gets a key by index in localStorage
+         * */
+        private static getValueByIndex;
+    }
+}
 declare namespace Windows.Storage {
     class StorageFolder {
         private static _isInit;

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -261,6 +261,7 @@ var MonoSupport;
                 if (!jsCallDispatcher._isUnoRegistered) {
                     jsCallDispatcher.registerScope("UnoStatic", Uno.UI.WindowManager);
                     jsCallDispatcher.registerScope("UnoStatic_Windows_Storage_StorageFolder", Windows.Storage.StorageFolder);
+                    jsCallDispatcher.registerScope("UnoStatic_Windows_Storage_ApplicationDataContainer", Windows.Storage.ApplicationDataContainer);
                     jsCallDispatcher._isUnoRegistered = true;
                 }
                 const { ns, methodName } = jsCallDispatcher.parseIdentifier(identifier);
@@ -1755,6 +1756,246 @@ var Uno;
 window.Uno = Uno;
 window.Windows = Windows;
 /* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_ClearParams {
+    static unmarshal(pData) {
+        const ret = new ApplicationDataContainer_ClearParams();
+        {
+            const ptr = Module.getValue(pData + 0, "*");
+            if (ptr !== 0) {
+                ret.Locality = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Locality = null;
+            }
+        }
+        return ret;
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_ContainsKeyParams {
+    static unmarshal(pData) {
+        const ret = new ApplicationDataContainer_ContainsKeyParams();
+        {
+            const ptr = Module.getValue(pData + 0, "*");
+            if (ptr !== 0) {
+                ret.Key = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Key = null;
+            }
+        }
+        {
+            const ptr = Module.getValue(pData + 4, "*");
+            if (ptr !== 0) {
+                ret.Value = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Value = null;
+            }
+        }
+        {
+            const ptr = Module.getValue(pData + 8, "*");
+            if (ptr !== 0) {
+                ret.Locality = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Locality = null;
+            }
+        }
+        return ret;
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_ContainsKeyReturn {
+    marshal(pData) {
+        Module.setValue(pData + 0, this.ContainsKey, "i32");
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetCountParams {
+    static unmarshal(pData) {
+        const ret = new ApplicationDataContainer_GetCountParams();
+        {
+            const ptr = Module.getValue(pData + 0, "*");
+            if (ptr !== 0) {
+                ret.Locality = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Locality = null;
+            }
+        }
+        return ret;
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetCountReturn {
+    marshal(pData) {
+        Module.setValue(pData + 0, this.Count, "i32");
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetKeyByIndexParams {
+    static unmarshal(pData) {
+        const ret = new ApplicationDataContainer_GetKeyByIndexParams();
+        {
+            const ptr = Module.getValue(pData + 0, "*");
+            if (ptr !== 0) {
+                ret.Locality = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Locality = null;
+            }
+        }
+        {
+            ret.Index = Number(Module.getValue(pData + 4, "i32"));
+        }
+        return ret;
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetKeyByIndexReturn {
+    marshal(pData) {
+        {
+            const stringLength = lengthBytesUTF8(this.Value);
+            const pString = Module._malloc(stringLength + 1);
+            stringToUTF8(this.Value, pString, stringLength + 1);
+            Module.setValue(pData + 0, pString, "*");
+        }
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetValueByIndexParams {
+    static unmarshal(pData) {
+        const ret = new ApplicationDataContainer_GetValueByIndexParams();
+        {
+            const ptr = Module.getValue(pData + 0, "*");
+            if (ptr !== 0) {
+                ret.Locality = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Locality = null;
+            }
+        }
+        {
+            ret.Index = Number(Module.getValue(pData + 4, "i32"));
+        }
+        return ret;
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetValueByIndexReturn {
+    marshal(pData) {
+        {
+            const stringLength = lengthBytesUTF8(this.Value);
+            const pString = Module._malloc(stringLength + 1);
+            stringToUTF8(this.Value, pString, stringLength + 1);
+            Module.setValue(pData + 0, pString, "*");
+        }
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_RemoveParams {
+    static unmarshal(pData) {
+        const ret = new ApplicationDataContainer_RemoveParams();
+        {
+            const ptr = Module.getValue(pData + 0, "*");
+            if (ptr !== 0) {
+                ret.Locality = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Locality = null;
+            }
+        }
+        {
+            const ptr = Module.getValue(pData + 4, "*");
+            if (ptr !== 0) {
+                ret.Key = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Key = null;
+            }
+        }
+        return ret;
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_RemoveReturn {
+    marshal(pData) {
+        Module.setValue(pData + 0, this.Removed, "i32");
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_SetValueParams {
+    static unmarshal(pData) {
+        const ret = new ApplicationDataContainer_SetValueParams();
+        {
+            const ptr = Module.getValue(pData + 0, "*");
+            if (ptr !== 0) {
+                ret.Key = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Key = null;
+            }
+        }
+        {
+            const ptr = Module.getValue(pData + 4, "*");
+            if (ptr !== 0) {
+                ret.Value = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Value = null;
+            }
+        }
+        {
+            const ptr = Module.getValue(pData + 8, "*");
+            if (ptr !== 0) {
+                ret.Locality = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Locality = null;
+            }
+        }
+        return ret;
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_TryGetValueParams {
+    static unmarshal(pData) {
+        const ret = new ApplicationDataContainer_TryGetValueParams();
+        {
+            const ptr = Module.getValue(pData + 0, "*");
+            if (ptr !== 0) {
+                ret.Key = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Key = null;
+            }
+        }
+        {
+            const ptr = Module.getValue(pData + 4, "*");
+            if (ptr !== 0) {
+                ret.Locality = String(Module.UTF8ToString(ptr));
+            }
+            else {
+                ret.Locality = null;
+            }
+        }
+        return ret;
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_TryGetValueReturn {
+    marshal(pData) {
+        {
+            const stringLength = lengthBytesUTF8(this.Value);
+            const pString = Module._malloc(stringLength + 1);
+            stringToUTF8(this.Value, pString, stringLength + 1);
+            Module.setValue(pData + 0, pString, "*");
+        }
+        Module.setValue(pData + 4, this.HasValue, "i32");
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
 class StorageFolderMakePersistentParams {
     static unmarshal(pData) {
         const ret = new StorageFolderMakePersistentParams();
@@ -2523,6 +2764,153 @@ var Uno;
     })(UI = Uno.UI || (Uno.UI = {}));
 })(Uno || (Uno = {}));
 // ReSharper disable InconsistentNaming
+// eslint-disable-next-line @typescript-eslint/no-namespace
+var Windows;
+(function (Windows) {
+    var Storage;
+    (function (Storage) {
+        class ApplicationDataContainer {
+            static buildStorageKey(locality, key) {
+                return `UnoApplicationDataContainer_${locality}_${key}`;
+            }
+            static buildStoragePrefix(locality) {
+                return `UnoApplicationDataContainer_${locality}_`;
+            }
+            /**
+             * Try to get a value from localStorage
+             * */
+            static tryGetValue(pParams, pReturn) {
+                const params = ApplicationDataContainer_TryGetValueParams.unmarshal(pParams);
+                const ret = new ApplicationDataContainer_TryGetValueReturn();
+                const storageKey = ApplicationDataContainer.buildStorageKey(params.Locality, params.Key);
+                if (localStorage.hasOwnProperty(storageKey)) {
+                    ret.HasValue = true;
+                    ret.Value = localStorage.getItem(storageKey);
+                }
+                else {
+                    ret.Value = "";
+                    ret.HasValue = false;
+                }
+                ret.marshal(pReturn);
+                return true;
+            }
+            /**
+             * Set a value to localStorage
+             * */
+            static setValue(pParams) {
+                const params = ApplicationDataContainer_SetValueParams.unmarshal(pParams);
+                const storageKey = ApplicationDataContainer.buildStorageKey(params.Locality, params.Key);
+                localStorage.setItem(storageKey, params.Value);
+                return true;
+            }
+            /**
+             * Determines if a key is contained in localStorage
+             * */
+            static containsKey(pParams, pReturn) {
+                const params = ApplicationDataContainer_ContainsKeyParams.unmarshal(pParams);
+                const ret = new ApplicationDataContainer_ContainsKeyReturn();
+                const storageKey = ApplicationDataContainer.buildStorageKey(params.Locality, params.Key);
+                ret.ContainsKey = localStorage.hasOwnProperty(storageKey);
+                ret.marshal(pReturn);
+                return true;
+            }
+            /**
+             * Gets a key by index in localStorage
+             * */
+            static getKeyByIndex(pParams, pReturn) {
+                const params = ApplicationDataContainer_GetKeyByIndexParams.unmarshal(pParams);
+                const ret = new ApplicationDataContainer_GetKeyByIndexReturn();
+                let localityIndex = 0;
+                let returnKey = "";
+                const prefix = ApplicationDataContainer.buildStoragePrefix(params.Locality);
+                for (let i = 0; i < localStorage.length; i++) {
+                    const storageKey = localStorage.key(i);
+                    if (storageKey.startsWith(prefix)) {
+                        if (localityIndex === params.Index) {
+                            returnKey = storageKey.substr(prefix.length);
+                        }
+                        localityIndex++;
+                    }
+                }
+                ret.Value = returnKey;
+                ret.marshal(pReturn);
+                return true;
+            }
+            /**
+             * Determines the number of items contained in localStorage
+             * */
+            static getCount(pParams, pReturn) {
+                const params = ApplicationDataContainer_GetCountParams.unmarshal(pParams);
+                const ret = new ApplicationDataContainer_GetCountReturn();
+                ret.Count = 0;
+                const prefix = ApplicationDataContainer.buildStoragePrefix(params.Locality);
+                for (let i = 0; i < localStorage.length; i++) {
+                    const storageKey = localStorage.key(i);
+                    if (storageKey.startsWith(prefix)) {
+                        ret.Count++;
+                    }
+                }
+                ret.marshal(pReturn);
+                return true;
+            }
+            /**
+             * Clears items contained in localStorage
+             * */
+            static clear(pParams) {
+                const params = ApplicationDataContainer_ClearParams.unmarshal(pParams);
+                const prefix = ApplicationDataContainer.buildStoragePrefix(params.Locality);
+                const itemsToRemove = [];
+                for (let i = 0; i < localStorage.length; i++) {
+                    const storageKey = localStorage.key(i);
+                    if (storageKey.startsWith(prefix)) {
+                        itemsToRemove.push(storageKey);
+                    }
+                }
+                for (const item in itemsToRemove) {
+                    localStorage.removeItem(itemsToRemove[item]);
+                }
+                return true;
+            }
+            /**
+             * Removes an item contained in localStorage
+             * */
+            static remove(pParams, pReturn) {
+                const params = ApplicationDataContainer_RemoveParams.unmarshal(pParams);
+                const ret = new ApplicationDataContainer_RemoveReturn();
+                const storageKey = ApplicationDataContainer.buildStorageKey(params.Locality, params.Key);
+                ret.Removed = localStorage.hasOwnProperty(storageKey);
+                if (ret.Removed) {
+                    localStorage.removeItem(storageKey);
+                }
+                ret.marshal(pReturn);
+                return true;
+            }
+            /**
+             * Gets a key by index in localStorage
+             * */
+            static getValueByIndex(pParams, pReturn) {
+                const params = ApplicationDataContainer_GetValueByIndexParams.unmarshal(pParams);
+                const ret = new ApplicationDataContainer_GetKeyByIndexReturn();
+                let localityIndex = 0;
+                let returnKey = "";
+                const prefix = ApplicationDataContainer.buildStoragePrefix(params.Locality);
+                for (let i = 0; i < localStorage.length; i++) {
+                    const storageKey = localStorage.key(i);
+                    if (storageKey.startsWith(prefix)) {
+                        if (localityIndex === params.Index) {
+                            returnKey = localStorage.getItem(storageKey);
+                        }
+                        localityIndex++;
+                    }
+                }
+                ret.Value = returnKey;
+                ret.marshal(pReturn);
+                return true;
+            }
+        }
+        Storage.ApplicationDataContainer = ApplicationDataContainer;
+    })(Storage = Windows.Storage || (Windows.Storage = {}));
+})(Windows || (Windows = {}));
 var Windows;
 (function (Windows) {
     var Storage;

--- a/src/Uno.UI.Wasm/ts/MonoSupport.ts
+++ b/src/Uno.UI.Wasm/ts/MonoSupport.ts
@@ -30,6 +30,7 @@ namespace MonoSupport {
 				if (!jsCallDispatcher._isUnoRegistered) {
 					jsCallDispatcher.registerScope("UnoStatic", Uno.UI.WindowManager);
 					jsCallDispatcher.registerScope("UnoStatic_Windows_Storage_StorageFolder", Windows.Storage.StorageFolder);
+					jsCallDispatcher.registerScope("UnoStatic_Windows_Storage_ApplicationDataContainer", Windows.Storage.ApplicationDataContainer);
 					jsCallDispatcher._isUnoRegistered = true;
 				}
 

--- a/src/Uno.UI.Wasm/ts/Windows/Storage/ApplicationDataContainer.ts
+++ b/src/Uno.UI.Wasm/ts/Windows/Storage/ApplicationDataContainer.ts
@@ -1,0 +1,195 @@
+﻿// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace Windows.Storage {
+
+	export class ApplicationDataContainer {
+
+		private static buildStorageKey(locality: string, key: string): string {
+			return `UnoApplicationDataContainer_${locality}_${key}`;
+		}
+		private static buildStoragePrefix(locality: string): string {
+			return `UnoApplicationDataContainer_${locality}_`;
+		}
+
+		/**
+		 * Try to get a value from localStorage
+		 * */
+		private static tryGetValue(pParams: number, pReturn: number): boolean {
+			const params = ApplicationDataContainer_TryGetValueParams.unmarshal(pParams);
+			const ret = new ApplicationDataContainer_TryGetValueReturn();
+
+			const storageKey = ApplicationDataContainer.buildStorageKey(params.Locality, params.Key);
+
+			if (localStorage.hasOwnProperty(storageKey)) {
+				ret.HasValue = true;
+				ret.Value = localStorage.getItem(storageKey);
+			} else {
+				ret.Value = "";
+				ret.HasValue = false;
+			}
+
+			ret.marshal(pReturn);
+
+			return true;
+		}
+
+		/**
+		 * Set a value to localStorage
+		 * */
+		private static setValue(pParams: number): boolean {
+			const params = ApplicationDataContainer_SetValueParams.unmarshal(pParams);
+
+			const storageKey = ApplicationDataContainer.buildStorageKey(params.Locality, params.Key);
+
+			localStorage.setItem(storageKey, params.Value);
+
+			return true;
+		}
+
+		/**
+		 * Determines if a key is contained in localStorage
+		 * */
+		private static containsKey(pParams: number, pReturn: number): boolean {
+			const params = ApplicationDataContainer_ContainsKeyParams.unmarshal(pParams);
+			const ret = new ApplicationDataContainer_ContainsKeyReturn();
+
+			const storageKey = ApplicationDataContainer.buildStorageKey(params.Locality, params.Key);
+
+			ret.ContainsKey = localStorage.hasOwnProperty(storageKey);
+
+			ret.marshal(pReturn);
+
+			return true;
+		}
+
+		/**
+		 * Gets a key by index in localStorage
+		 * */
+		private static getKeyByIndex(pParams: number, pReturn: number): boolean {
+			const params = ApplicationDataContainer_GetKeyByIndexParams.unmarshal(pParams);
+			const ret = new ApplicationDataContainer_GetKeyByIndexReturn();
+
+			let localityIndex = 0;
+			let returnKey = "";
+			const prefix = ApplicationDataContainer.buildStoragePrefix(params.Locality);
+
+			for (let i = 0; i < localStorage.length; i++) {
+				const storageKey = localStorage.key(i);
+
+				if (storageKey.startsWith(prefix)) {
+
+					if (localityIndex === params.Index) {
+						returnKey = storageKey.substr(prefix.length);
+					}
+
+					localityIndex++;
+				}
+			}
+
+			ret.Value = returnKey;
+
+			ret.marshal(pReturn);
+
+			return true;
+		}
+
+		/**
+		 * Determines the number of items contained in localStorage
+		 * */
+		private static getCount(pParams: number, pReturn: number): boolean {
+			const params = ApplicationDataContainer_GetCountParams.unmarshal(pParams);
+			const ret = new ApplicationDataContainer_GetCountReturn();
+
+			ret.Count = 0;
+			const prefix = ApplicationDataContainer.buildStoragePrefix(params.Locality);
+
+			for (let i = 0; i < localStorage.length; i++) {
+				const storageKey = localStorage.key(i);
+
+				if (storageKey.startsWith(prefix)) {
+					ret.Count++;
+				}
+			}
+
+			ret.marshal(pReturn);
+
+			return true;
+		}
+
+		/**
+		 * Clears items contained in localStorage
+		 * */
+		private static clear(pParams: number): boolean {
+			const params = ApplicationDataContainer_ClearParams.unmarshal(pParams);
+
+			const prefix = ApplicationDataContainer.buildStoragePrefix(params.Locality);
+
+			const itemsToRemove: string[] = [];
+
+			for (let i = 0; i < localStorage.length; i++) {
+				const storageKey = localStorage.key(i);
+
+				if (storageKey.startsWith(prefix)) {
+					itemsToRemove.push(storageKey);
+				}
+			}
+
+			for (const item in itemsToRemove) {
+				localStorage.removeItem(itemsToRemove[item]);
+			}
+
+			return true;
+		}
+
+		/**
+		 * Removes an item contained in localStorage
+		 * */
+		private static remove(pParams: number, pReturn: number): boolean {
+			const params = ApplicationDataContainer_RemoveParams.unmarshal(pParams);
+			const ret = new ApplicationDataContainer_RemoveReturn();
+
+			const storageKey = ApplicationDataContainer.buildStorageKey(params.Locality, params.Key);
+
+			ret.Removed = localStorage.hasOwnProperty(storageKey);
+
+			if (ret.Removed) {
+				localStorage.removeItem(storageKey);
+			}
+
+			ret.marshal(pReturn);
+
+			return true;
+		}
+
+		/**
+		 * Gets a key by index in localStorage
+		 * */
+		private static getValueByIndex(pParams: number, pReturn: number): boolean {
+			const params = ApplicationDataContainer_GetValueByIndexParams.unmarshal(pParams);
+			const ret = new ApplicationDataContainer_GetKeyByIndexReturn();
+
+			let localityIndex = 0;
+			let returnKey = "";
+			const prefix = ApplicationDataContainer.buildStoragePrefix(params.Locality);
+
+			for (let i = 0; i < localStorage.length; i++) {
+				const storageKey = localStorage.key(i);
+
+				if (storageKey.startsWith(prefix)) {
+
+					if (localityIndex === params.Index) {
+						returnKey = localStorage.getItem(storageKey);
+					}
+
+					localityIndex++;
+				}
+			}
+
+			ret.Value = returnKey;
+
+			ret.marshal(pReturn);
+
+			return true;
+		}
+
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_ClearParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_ClearParams.ts
@@ -1,0 +1,24 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_ClearParams
+{
+	/* Pack=4 */
+	public Locality : string;
+	public static unmarshal(pData:number) : ApplicationDataContainer_ClearParams
+	{
+		const ret = new ApplicationDataContainer_ClearParams();
+		
+		{
+			const ptr = Module.getValue(pData + 0, "*");
+			if(ptr !== 0)
+			{
+				ret.Locality = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Locality = null;
+			}
+		}
+		return ret;
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_ContainsKeyParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_ContainsKeyParams.ts
@@ -1,0 +1,52 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_ContainsKeyParams
+{
+	/* Pack=4 */
+	public Key : string;
+	public Value : string;
+	public Locality : string;
+	public static unmarshal(pData:number) : ApplicationDataContainer_ContainsKeyParams
+	{
+		const ret = new ApplicationDataContainer_ContainsKeyParams();
+		
+		{
+			const ptr = Module.getValue(pData + 0, "*");
+			if(ptr !== 0)
+			{
+				ret.Key = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Key = null;
+			}
+		}
+		
+		{
+			const ptr = Module.getValue(pData + 4, "*");
+			if(ptr !== 0)
+			{
+				ret.Value = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Value = null;
+			}
+		}
+		
+		{
+			const ptr = Module.getValue(pData + 8, "*");
+			if(ptr !== 0)
+			{
+				ret.Locality = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Locality = null;
+			}
+		}
+		return ret;
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_ContainsKeyReturn.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_ContainsKeyReturn.ts
@@ -1,0 +1,10 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_ContainsKeyReturn
+{
+	/* Pack=4 */
+	public ContainsKey : boolean;
+	public marshal(pData:number)
+	{
+		Module.setValue(pData + 0, this.ContainsKey, "i32");
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetCountParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetCountParams.ts
@@ -1,0 +1,24 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetCountParams
+{
+	/* Pack=4 */
+	public Locality : string;
+	public static unmarshal(pData:number) : ApplicationDataContainer_GetCountParams
+	{
+		const ret = new ApplicationDataContainer_GetCountParams();
+		
+		{
+			const ptr = Module.getValue(pData + 0, "*");
+			if(ptr !== 0)
+			{
+				ret.Locality = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Locality = null;
+			}
+		}
+		return ret;
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetCountReturn.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetCountReturn.ts
@@ -1,0 +1,10 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetCountReturn
+{
+	/* Pack=4 */
+	public Count : number;
+	public marshal(pData:number)
+	{
+		Module.setValue(pData + 0, this.Count, "i32");
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetKeyByIndexParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetKeyByIndexParams.ts
@@ -1,0 +1,29 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetKeyByIndexParams
+{
+	/* Pack=4 */
+	public Locality : string;
+	public Index : number;
+	public static unmarshal(pData:number) : ApplicationDataContainer_GetKeyByIndexParams
+	{
+		const ret = new ApplicationDataContainer_GetKeyByIndexParams();
+		
+		{
+			const ptr = Module.getValue(pData + 0, "*");
+			if(ptr !== 0)
+			{
+				ret.Locality = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Locality = null;
+			}
+		}
+		
+		{
+			ret.Index = Number(Module.getValue(pData + 4, "i32"));
+		}
+		return ret;
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetKeyByIndexReturn.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetKeyByIndexReturn.ts
@@ -1,0 +1,16 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetKeyByIndexReturn
+{
+	/* Pack=4 */
+	public Value : string;
+	public marshal(pData:number)
+	{
+		
+		{
+			const stringLength = lengthBytesUTF8(this.Value);
+			const pString = Module._malloc(stringLength + 1);
+			stringToUTF8(this.Value, pString, stringLength + 1);
+			Module.setValue(pData + 0, pString, "*");
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetValueByIndexParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetValueByIndexParams.ts
@@ -1,0 +1,29 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetValueByIndexParams
+{
+	/* Pack=4 */
+	public Locality : string;
+	public Index : number;
+	public static unmarshal(pData:number) : ApplicationDataContainer_GetValueByIndexParams
+	{
+		const ret = new ApplicationDataContainer_GetValueByIndexParams();
+		
+		{
+			const ptr = Module.getValue(pData + 0, "*");
+			if(ptr !== 0)
+			{
+				ret.Locality = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Locality = null;
+			}
+		}
+		
+		{
+			ret.Index = Number(Module.getValue(pData + 4, "i32"));
+		}
+		return ret;
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetValueByIndexReturn.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_GetValueByIndexReturn.ts
@@ -1,0 +1,16 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_GetValueByIndexReturn
+{
+	/* Pack=1 */
+	public Value : string;
+	public marshal(pData:number)
+	{
+		
+		{
+			const stringLength = lengthBytesUTF8(this.Value);
+			const pString = Module._malloc(stringLength + 1);
+			stringToUTF8(this.Value, pString, stringLength + 1);
+			Module.setValue(pData + 0, pString, "*");
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_RemoveParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_RemoveParams.ts
@@ -1,0 +1,38 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_RemoveParams
+{
+	/* Pack=4 */
+	public Locality : string;
+	public Key : string;
+	public static unmarshal(pData:number) : ApplicationDataContainer_RemoveParams
+	{
+		const ret = new ApplicationDataContainer_RemoveParams();
+		
+		{
+			const ptr = Module.getValue(pData + 0, "*");
+			if(ptr !== 0)
+			{
+				ret.Locality = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Locality = null;
+			}
+		}
+		
+		{
+			const ptr = Module.getValue(pData + 4, "*");
+			if(ptr !== 0)
+			{
+				ret.Key = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Key = null;
+			}
+		}
+		return ret;
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_RemoveReturn.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_RemoveReturn.ts
@@ -1,0 +1,10 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_RemoveReturn
+{
+	/* Pack=1 */
+	public Removed : boolean;
+	public marshal(pData:number)
+	{
+		Module.setValue(pData + 0, this.Removed, "i32");
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_SetValueParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_SetValueParams.ts
@@ -1,0 +1,52 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_SetValueParams
+{
+	/* Pack=4 */
+	public Key : string;
+	public Value : string;
+	public Locality : string;
+	public static unmarshal(pData:number) : ApplicationDataContainer_SetValueParams
+	{
+		const ret = new ApplicationDataContainer_SetValueParams();
+		
+		{
+			const ptr = Module.getValue(pData + 0, "*");
+			if(ptr !== 0)
+			{
+				ret.Key = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Key = null;
+			}
+		}
+		
+		{
+			const ptr = Module.getValue(pData + 4, "*");
+			if(ptr !== 0)
+			{
+				ret.Value = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Value = null;
+			}
+		}
+		
+		{
+			const ptr = Module.getValue(pData + 8, "*");
+			if(ptr !== 0)
+			{
+				ret.Locality = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Locality = null;
+			}
+		}
+		return ret;
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_TryGetValueParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_TryGetValueParams.ts
@@ -1,0 +1,38 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_TryGetValueParams
+{
+	/* Pack=4 */
+	public Key : string;
+	public Locality : string;
+	public static unmarshal(pData:number) : ApplicationDataContainer_TryGetValueParams
+	{
+		const ret = new ApplicationDataContainer_TryGetValueParams();
+		
+		{
+			const ptr = Module.getValue(pData + 0, "*");
+			if(ptr !== 0)
+			{
+				ret.Key = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Key = null;
+			}
+		}
+		
+		{
+			const ptr = Module.getValue(pData + 4, "*");
+			if(ptr !== 0)
+			{
+				ret.Locality = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.Locality = null;
+			}
+		}
+		return ret;
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_TryGetValueReturn.ts
+++ b/src/Uno.UI.Wasm/tsBindings/ApplicationDataContainer_TryGetValueReturn.ts
@@ -1,0 +1,18 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class ApplicationDataContainer_TryGetValueReturn
+{
+	/* Pack=4 */
+	public Value : string;
+	public HasValue : boolean;
+	public marshal(pData:number)
+	{
+		
+		{
+			const stringLength = lengthBytesUTF8(this.Value);
+			const pString = Module._malloc(stringLength + 1);
+			stringToUTF8(this.Value, pString, stringLength + 1);
+			Module.setValue(pData + 0, pString, "*");
+		}
+		Module.setValue(pData + 4, this.HasValue, "i32");
+	}
+}

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.wasm.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.wasm.cs
@@ -1,11 +1,15 @@
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
+using Uno.Foundation;
+using Uno.Foundation.Interop;
 using Uno.Logging;
 using Windows.Foundation.Collections;
 
@@ -20,165 +24,88 @@ namespace Windows.Storage
 
 		private class FilePropertySet : IPropertySet
 		{
-			private const string UWPFileName = ".UWPAppSettings";
-			private readonly Dictionary<string, string> _values = new Dictionary<string, string>();
-			private readonly string _folderPath;
-			private readonly string _filePath;
+			private readonly ApplicationDataLocality _locality;
+			private readonly ApplicationData _owner;
 
 			public FilePropertySet(ApplicationData owner, ApplicationDataLocality locality)
 			{
-				StorageFolder folder;
-				switch (locality)
-				{
-					case ApplicationDataLocality.Local:
-						folder = owner.LocalFolder;
-						break;
+				_locality = locality;
+				_owner = owner;
 
-					case ApplicationDataLocality.Roaming:
-						folder = owner.RoamingFolder;
-						break;
-					case ApplicationDataLocality.LocalCache:
-						folder = owner.LocalCacheFolder;
-						break;
-
-					case ApplicationDataLocality.Temporary:
-						folder = owner.TemporaryFolder;
-						break;
-
-					default:
-						throw new ArgumentOutOfRangeException(nameof(locality));
-				}
-
-				_folderPath = folder.Path;
-				_filePath = Path.Combine(folder.Path, UWPFileName);
-
-				ReadFromFile();
+				ReadFromLegacyFile();
 			}
 
-			public object this[string key]
+			public object? this[string key]
 			{
 				get
 				{
-					if(_values.TryGetValue(key, out var value))
+					if (ApplicationDataContainerInterop.TryGetValue(_locality, key, out var value))
 					{
 						return DataTypeSerializer.Deserialize(value);
 					}
-
 					return null;
 				}
 				set
 				{
 					if (value != null)
 					{
-						_values[key] = DataTypeSerializer.Serialize(value);
+						ApplicationDataContainerInterop.SetValue(_locality, key, DataTypeSerializer.Serialize(value));
 					}
 					else
 					{
 						Remove(key);
 					}
-
-					WriteToFile();
-				}
-			}
-
-			private void ReadFromFile()
-			{
-				try
-				{
-
-					if (File.Exists(_filePath))
-					{
-						using (var reader = new BinaryReader(File.OpenRead(_filePath)))
-						{
-							var count = reader.ReadInt32();
-
-							if (this.Log().IsEnabled(LogLevel.Debug))
-							{
-								this.Log().Debug($"Reading {count} settings values");
-							}
-
-							for (int i = 0; i < count; i++)
-							{
-								var key = reader.ReadString();
-								var value = reader.ReadString();
-
-								_values[key] = value;
-							}
-						}
-					}
-					else
-					{
-						if (this.Log().IsEnabled(LogLevel.Debug))
-						{
-							this.Log().Debug($"File {_filePath} does not exist, skipping reading settings");
-						}
-					}
-				}
-				catch (Exception e)
-				{
-					if (this.Log().IsEnabled(LogLevel.Error))
-					{
-						this.Log().Error($"Failed to read settings from {_filePath}", e);
-					}
-				}
-			}
-
-			private void WriteToFile()
-			{
-				try
-				{
-					Directory.CreateDirectory(_folderPath);
-
-					if (this.Log().IsEnabled(LogLevel.Debug))
-					{
-						this.Log().Debug($"Writing {_values.Count} settings to {_filePath}");
-					}
-
-					using (var writer = new BinaryWriter(File.OpenWrite(_filePath)))
-					{
-						writer.Write(_values.Count);
-
-						foreach (var pair in _values)
-						{
-							writer.Write(pair.Key);
-							writer.Write(pair.Value ?? "");
-						}
-					}
-				}
-				catch (Exception e)
-				{
-					if (this.Log().IsEnabled(LogLevel.Error))
-					{
-						this.Log().Error($"Failed to write settings to {_filePath}", e);
-					}
 				}
 			}
 
 			public ICollection<string> Keys
-				=> _values.Keys;
+			{
+				get
+				{
+					var keys = new List<string>();
+
+					for (int i = 0; i < Count; i++)
+					{
+						keys.Add(ApplicationDataContainerInterop.GetKeyByIndex(_locality, i));
+					}
+
+					return keys.AsReadOnly();
+				}
+			}
 
 			public ICollection<object> Values
-				=> _values.Values.Select(DataTypeSerializer.Deserialize).ToList();
+			{
+				get
+				{
+					var values = new List<object>();
+
+					for (int i = 0; i < Count; i++)
+					{
+						var rawValue = ApplicationDataContainerInterop.GetValueByIndex(_locality, i);
+						values.Add(DataTypeSerializer.Deserialize(rawValue));
+					}
+
+					return values.AsReadOnly();
+				}
+			}
 
 			public int Count
-				=> _values.Count;
+				=> ApplicationDataContainerInterop.GetCount(_locality);
 
 			public bool IsReadOnly => false;
 
-#pragma warning disable CS0067
-			public event MapChangedEventHandler<string, object> MapChanged;
-#pragma warning restore CS0067
+			public event MapChangedEventHandler<string, object>? MapChanged;
 
 			public void Add(string key, object value)
 			{
-                if (ContainsKey(key))
-                {
-                    throw new ArgumentException("An item with the same key has already been added.");
-                }
-                if (value != null)
-				{				
-					_values.Add(key, DataTypeSerializer.Serialize(value));
-					WriteToFile();
+				if (ContainsKey(key))
+				{
+					throw new ArgumentException("An item with the same key has already been added.");
+				}
+				if (value != null)
+				{
+					ApplicationDataContainerInterop.SetValue(_locality, key, DataTypeSerializer.Serialize(value));
+					MapChanged?.Invoke(this, null);
 				}
 			}
 
@@ -187,15 +114,14 @@ namespace Windows.Storage
 
 			public void Clear()
 			{
-				_values.Clear();
-				WriteToFile();
+				ApplicationDataContainerInterop.Clear(_locality);
 			}
 
-			public bool Contains(KeyValuePair<string, object> item) 
+			public bool Contains(KeyValuePair<string, object> item)
 				=> throw new NotSupportedException();
 
 			public bool ContainsKey(string key)
-				=> _values.ContainsKey(key);
+				=> ApplicationDataContainerInterop.ContainsKey(_locality, key);
 
 			public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
 				=> throw new NotSupportedException();
@@ -205,18 +131,15 @@ namespace Windows.Storage
 
 			public bool Remove(string key)
 			{
-				var ret = _values.Remove(key);
-
-				WriteToFile();
-
+				var ret = ApplicationDataContainerInterop.Remove(_locality, key);
 				return ret;
 			}
 
 			public bool Remove(KeyValuePair<string, object> item) => Remove(item.Key);
 
-			public bool TryGetValue(string key, out object value)
+			public bool TryGetValue(string key, out object? value)
 			{
-				if (_values.TryGetValue(key, out var innervalue))
+				if (ApplicationDataContainerInterop.TryGetValue(_locality, key, out var innervalue))
 				{
 					value = DataTypeSerializer.Deserialize(innervalue);
 					return true;
@@ -227,6 +150,288 @@ namespace Windows.Storage
 			}
 
 			IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
+
+			private void ReadFromLegacyFile()
+			{
+				const string UWPFileName = ".UWPAppSettings";
+
+				var folder = _locality switch
+				{
+					ApplicationDataLocality.Local => _owner.LocalFolder,
+					ApplicationDataLocality.Roaming => _owner.RoamingFolder,
+					ApplicationDataLocality.LocalCache => _owner.LocalCacheFolder,
+					ApplicationDataLocality.Temporary => _owner.TemporaryFolder,
+					_ => throw new ArgumentOutOfRangeException($"Unsupported locality {_locality}"),
+				};
+
+				var filePath = Path.Combine(folder.Path, UWPFileName);
+
+				try
+				{
+					if (File.Exists(filePath))
+					{
+						using var reader = new BinaryReader(File.OpenRead(filePath));
+
+						var count = reader.ReadInt32();
+
+						if (this.Log().IsEnabled(LogLevel.Debug))
+						{
+							this.Log().Debug($"Reading {count} settings values");
+						}
+
+						for (var i = 0; i < count; i++)
+						{
+							var key = reader.ReadString();
+							var value = reader.ReadString();
+
+							this[key] = value;
+						}
+					}
+					else
+					{
+						if (this.Log().IsEnabled(LogLevel.Debug))
+						{
+							this.Log().Debug($"File {filePath} does not exist, skipping reading legacy settings");
+						}
+					}
+				}
+				catch (Exception e)
+				{
+					if (this.Log().IsEnabled(LogLevel.Error))
+					{
+						this.Log().Error($"Failed to read settings from {filePath}", e);
+					}
+				}
+			}
 		}
+	}
+
+	class ApplicationDataContainerInterop
+	{
+		#region TryGetValue
+		internal static bool TryGetValue(ApplicationDataLocality locality, string key, out string? value)
+		{
+			var parms = new ApplicationDataContainer_TryGetValueParams
+			{
+				Key = key,
+				Locality = locality.ToStringInvariant()
+			};
+
+			var ret = TSInteropMarshaller.InvokeJS<ApplicationDataContainer_TryGetValueParams, ApplicationDataContainer_TryGetValueReturn>("UnoStatic_Windows_Storage_ApplicationDataContainer:tryGetValue", parms);
+
+			value = ret.Value;
+
+			return ret.HasValue;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_TryGetValueParams
+		{
+			public string Key;
+			public string Locality;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_TryGetValueReturn
+		{
+			public string? Value;
+			public bool HasValue;
+		}
+		#endregion
+
+		#region SetValue
+		internal static void SetValue(ApplicationDataLocality locality, string key, string value)
+		{
+			var parms = new ApplicationDataContainer_SetValueParams
+			{
+				Key = key,
+				Value = value,
+				Locality = locality.ToStringInvariant()
+			};
+
+			TSInteropMarshaller.InvokeJS<ApplicationDataContainer_SetValueParams>("UnoStatic_Windows_Storage_ApplicationDataContainer:setValue", parms);
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_SetValueParams
+		{
+			public string Key;
+			public string Value;
+			public string Locality;
+		}
+
+		#endregion
+
+		#region ContainsKey
+		internal static bool ContainsKey(ApplicationDataLocality locality, string key)
+		{
+			var parms = new ApplicationDataContainer_ContainsKeyParams
+			{
+				Key = key,
+				Locality = locality.ToStringInvariant()
+			};
+
+			var ret = TSInteropMarshaller.InvokeJS<ApplicationDataContainer_ContainsKeyParams, ApplicationDataContainer_ContainsKeyReturn>("UnoStatic_Windows_Storage_ApplicationDataContainer:containsKey", parms);
+			return ret.ContainsKey;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_ContainsKeyParams
+		{
+			public string Key;
+			public string Value;
+			public string Locality;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_ContainsKeyReturn
+		{
+			public bool ContainsKey;
+		}
+		#endregion
+
+		#region GetKeyByIndex
+		internal static string GetKeyByIndex(ApplicationDataLocality locality, int index)
+		{
+			var parms = new ApplicationDataContainer_GetKeyByIndexParams
+			{
+				Locality = locality.ToStringInvariant(),
+				Index = index
+			};
+
+			var ret = TSInteropMarshaller.InvokeJS<ApplicationDataContainer_GetKeyByIndexParams, ApplicationDataContainer_GetKeyByIndexReturn>("UnoStatic_Windows_Storage_ApplicationDataContainer:getKeyByIndex", parms);
+			return ret.Value;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_GetKeyByIndexParams
+		{
+			public string Locality;
+			public int Index;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_GetKeyByIndexReturn
+		{
+			public string Value;
+		}
+		#endregion
+
+		#region GetCount
+
+		internal static int GetCount(ApplicationDataLocality locality)
+		{
+			var parms = new ApplicationDataContainer_GetCountParams
+			{
+				Locality = locality.ToStringInvariant()
+			};
+
+			var ret = TSInteropMarshaller.InvokeJS<ApplicationDataContainer_GetCountParams, ApplicationDataContainer_GetCountReturn>("UnoStatic_Windows_Storage_ApplicationDataContainer:getCount", parms);
+			return ret.Count;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_GetCountParams
+		{
+			public string Locality;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_GetCountReturn
+		{
+			public int Count;
+		}
+		#endregion
+
+		#region Clear
+
+		internal static void Clear(ApplicationDataLocality locality)
+		{
+			var parms = new ApplicationDataContainer_ClearParams
+			{
+				Locality = locality.ToStringInvariant()
+			};
+
+			TSInteropMarshaller.InvokeJS("UnoStatic_Windows_Storage_ApplicationDataContainer:clear", parms);
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_ClearParams
+		{
+			public string Locality;
+		}
+
+		#endregion
+
+		#region Remove
+
+		internal static bool Remove(ApplicationDataLocality locality, string key)
+		{
+			var parms = new ApplicationDataContainer_RemoveParams
+			{
+				Locality = locality.ToStringInvariant(),
+				Key = key
+			};
+
+			var ret = TSInteropMarshaller.InvokeJS<ApplicationDataContainer_RemoveParams, ApplicationDataContainer_RemoveReturn>("UnoStatic_Windows_Storage_ApplicationDataContainer:remove", parms);
+			return ret.Removed;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_RemoveParams
+		{
+			public string Locality;
+			public string Key;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct ApplicationDataContainer_RemoveReturn
+		{
+			public bool Removed;
+		}
+
+		#endregion
+
+		#region GetValueByIndex
+
+		internal static string GetValueByIndex(ApplicationDataLocality locality, int index)
+		{
+			var parms = new ApplicationDataContainer_GetValueByIndexParams
+			{
+				Locality = locality.ToStringInvariant(),
+				Index = index
+			};
+
+			var ret = TSInteropMarshaller.InvokeJS<ApplicationDataContainer_GetValueByIndexParams, ApplicationDataContainer_GetValueByIndexReturn>("UnoStatic_Windows_Storage_ApplicationDataContainer:getValueByIndex", parms);
+			return ret.Value;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct ApplicationDataContainer_GetValueByIndexParams
+		{
+			public string Locality;
+			public int Index;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 1)]
+		private struct ApplicationDataContainer_GetValueByIndexReturn
+		{
+			public string Value;
+		}
+		#endregion
 	}
 }


### PR DESCRIPTION
Fixes #2923

GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The change is required to allow for synchronous access to local container values, where the previous implementation was relying on IDBFS. IDBFS is asynchronous and may require the app to be temporarily stalled a startup for the data to be available.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.