### PR TITLE
feat(ios): customizable MenuFlyout cancel text

### DIFF
--- a/doc/articles/controls/MenuFlyout.md
+++ b/doc/articles/controls/MenuFlyout.md
@@ -7,3 +7,23 @@ MenuFlyout is implemented to provide support for `ContextMenu` and `MenuBar` fea
 On iOS and Android, the flyout can either be displayed using native popup, or Uno managed popups.
 
 The default behavior of the MenuFlyout is to follow the value `FeatureConfiguration.Style.UseUWPDefaultStyles`, but this can be changed per MenuFlyout using the `FlyoutBase.UseNativePopup` property.
+
+### iOS (native)
+
+#### Destructive action
+> If an alert button results in a destructive action, such as deleting content, set the button’s style to Destructive so that it gets appropriate formatting by the system.
+
+```xml
+xmlns:toolkit="using:Uno.UI.Toolkit"
+
+<MenuFlyoutItem Text="Dangerous Menu Item 1"
+                toolkit:MenuFlyoutItemExtensions.IsDestructive="True" />
+```
+
+#### Cancel button text
+```xml
+xmlns:toolkit="using:Uno.UI.Toolkit"
+
+<MenuFlyout UseNativePopup="True"
+            toolkit:MenuFlyoutExtensions.OverrideIosCancelText="Custom cancel text">
+```

--- a/doc/articles/controls/MenuFlyout.md
+++ b/doc/articles/controls/MenuFlyout.md
@@ -25,5 +25,5 @@ xmlns:toolkit="using:Uno.UI.Toolkit"
 xmlns:toolkit="using:Uno.UI.Toolkit"
 
 <MenuFlyout UseNativePopup="True"
-            toolkit:MenuFlyoutExtensions.OverrideIosCancelText="Custom cancel text">
+            toolkit:MenuFlyoutExtensions.CancelTextIosOverride="Custom cancel text">
 ```

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -861,6 +861,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyout_IosNative.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\UIElement_ContextFlyout.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3723,6 +3727,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyoutItem_Click.xaml.cs">
       <DependentUpon>MenuFlyoutItem_Click.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyout_IosNative.xaml.cs">
+      <DependentUpon>MenuFlyout_IosNative.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\UIElement_ContextFlyout.xaml.cs">
       <DependentUpon>UIElement_ContextFlyout.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_IosNative.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_IosNative.xaml
@@ -1,0 +1,48 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MenuFlyoutTests.MenuFlyout_IosNative"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:toolkit="using:Uno.UI.Toolkit"
+			 xmlns:ios="http://uno.ui/ios"
+			 mc:Ignorable="d ios"
+			 Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+		<TextBlock Text="Native MenuFlyout" Margin="0,16,0,0" />
+		<Button Content="Show native MenuFlyout">
+			<Button.Flyout>
+				<MenuFlyout ios:UseNativePopup="True">
+					<MenuFlyoutItem Text="Menu Item 1" />
+					<MenuFlyoutItem Text="Menu Item 2" />
+					<MenuFlyoutItem Text="Menu Item 3" />
+				</MenuFlyout>
+			</Button.Flyout>
+		</Button>
+
+		<TextBlock Text="Native MenuFlyout with destructive menu item" Margin="0,16,0,0" />
+		<Button Content="Show native MenuFlyout">
+			<Button.Flyout>
+				<MenuFlyout ios:UseNativePopup="True">
+					<MenuFlyoutItem Text="Dangerous Menu Item 1"
+									toolkit:MenuFlyoutItemExtensions.IsDestructive="True" />
+					<MenuFlyoutItem Text="Menu Item 2" />
+					<MenuFlyoutItem Text="Menu Item 3" />
+				</MenuFlyout>
+			</Button.Flyout>
+		</Button>
+
+		<TextBlock Text="Native MenuFlyout with custom cancel button text" Margin="0,16,0,0" />
+		<Button Content="Show native MenuFlyout">
+			<Button.Flyout>
+				<MenuFlyout ios:UseNativePopup="True"
+							toolkit:MenuFlyoutExtensions.OverrideIosCancelText="Custom cancel text">
+					<MenuFlyoutItem Text="Menu Item 1" />
+					<MenuFlyoutItem Text="Menu Item 2" />
+					<MenuFlyoutItem Text="Menu Item 3" />
+				</MenuFlyout>
+			</Button.Flyout>
+		</Button>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_IosNative.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_IosNative.xaml
@@ -37,7 +37,7 @@
 		<Button Content="Show native MenuFlyout">
 			<Button.Flyout>
 				<MenuFlyout ios:UseNativePopup="True"
-							toolkit:MenuFlyoutExtensions.OverrideIosCancelText="Custom cancel text">
+							toolkit:MenuFlyoutExtensions.CancelTextIosOverride="Custom cancel text">
 					<MenuFlyoutItem Text="Menu Item 1" />
 					<MenuFlyoutItem Text="Menu Item 2" />
 					<MenuFlyoutItem Text="Menu Item 3" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_IosNative.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_IosNative.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.MenuFlyoutTests
+{
+	[Uno.UI.Samples.Controls.SampleControlInfo("MenuFlyout", nameof(MenuFlyout_IosNative), description: "ios native MenuFlyout")]
+	public sealed partial class MenuFlyout_IosNative : UserControl
+	{
+		public MenuFlyout_IosNative()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Toolkit/MenuFlyoutExtensions.cs
+++ b/src/Uno.UI.Toolkit/MenuFlyoutExtensions.cs
@@ -13,16 +13,17 @@ namespace Uno.UI.Toolkit
 #endif
 	public class MenuFlyoutExtensions
 	{
-		#region Property: OverrideIosCancelText
-		public static DependencyProperty OverrideIosCancelTextProperty { get; } = DependencyProperty.RegisterAttached(
-			"OverrideIosCancelText",
+		#region Property: CancelTextIosOverride
+
+		public static DependencyProperty CancelTextIosOverrideProperty { get; } = DependencyProperty.RegisterAttached(
+			"CancelTextIosOverride",
 			typeof(string),
 			typeof(MenuFlyoutExtensions),
 			new PropertyMetadata(default(string)));
 
-		public static string GetOverrideIosCancelText(MenuFlyout obj) => (string)obj.GetValue(OverrideIosCancelTextProperty);
+		public static string GetCancelTextIosOverride(MenuFlyout obj) => (string)obj.GetValue(CancelTextIosOverrideProperty);
 
-		public static void SetOverrideIosCancelText(MenuFlyout obj, string value) => obj.SetValue(OverrideIosCancelTextProperty, value);
+		public static void SetCancelTextIosOverride(MenuFlyout obj, string value) => obj.SetValue(CancelTextIosOverrideProperty, value);
 		#endregion
 	}
 }

--- a/src/Uno.UI.Toolkit/MenuFlyoutExtensions.cs
+++ b/src/Uno.UI.Toolkit/MenuFlyoutExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Toolkit
+{
+#if __IOS__
+	[global::Foundation.PreserveAttribute(AllMembers = true)]
+#elif __ANDROID__
+	[Android.Runtime.PreserveAttribute(AllMembers = true)]
+#endif
+	public class MenuFlyoutExtensions
+	{
+		#region Property: OverrideIosCancelText
+		public static DependencyProperty OverrideIosCancelTextProperty { get; } = DependencyProperty.RegisterAttached(
+			"OverrideIosCancelText",
+			typeof(string),
+			typeof(MenuFlyoutExtensions),
+			new PropertyMetadata(default(string)));
+
+		public static string GetOverrideIosCancelText(MenuFlyout obj) => (string)obj.GetValue(OverrideIosCancelTextProperty);
+
+		public static void SetOverrideIosCancelText(MenuFlyout obj, string value) => obj.SetValue(OverrideIosCancelTextProperty, value);
+		#endregion
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS.cs
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class MenuFlyout
 	{
-		private static DependencyProperty OverrideIosCancelTextProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.MenuFlyoutExtensions", "OverrideIosCancelText");
+		private static DependencyProperty CancelTextIosOverrideProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.MenuFlyoutExtensions", "CancelTextIosOverride");
 
 #pragma warning disable CS0618 // Type or member is obsolete
 		private string LocalizedCancelString => NSBundle.FromIdentifier("com.apple.UIKit").LocalizedString("Cancel", null);

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS.cs
@@ -11,11 +11,13 @@ using Uno.UI.Services;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using UIKit;
+using Uno.UI;
 
 namespace Windows.UI.Xaml.Controls
 {
 	public partial class MenuFlyout
 	{
+		private static DependencyProperty OverrideIosCancelTextProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.MenuFlyoutExtensions", "OverrideIosCancelText");
 
 #pragma warning disable CS0618 // Type or member is obsolete
 		private string LocalizedCancelString => NSBundle.FromIdentifier("com.apple.UIKit").LocalizedString("Cancel", null);

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS7.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS7.iOS.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Controls
 			_actionSheet = new UIActionSheet(
 				title: null,
 				del: null,
-				cancelTitle: GetValue(OverrideIosCancelTextProperty) as string ?? LocalizedCancelString,
+				cancelTitle: GetValue(CancelTextIosOverrideProperty) as string ?? LocalizedCancelString,
 				destroy: null,
 				other: availableItems.OfType<MenuFlyoutItem>().Select(item => item.Text).ToArray()
 			);

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS7.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS7.iOS.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Controls
 			_actionSheet = new UIActionSheet(
 				title: null,
 				del: null,
-				cancelTitle: LocalizedCancelString,
+				cancelTitle: GetValue(OverrideIosCancelTextProperty) as string ?? LocalizedCancelString,
 				destroy: null,
 				other: availableItems.OfType<MenuFlyoutItem>().Select(item => item.Text).ToArray()
 			);

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS8.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS8.iOS.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Controls
 					}
 				))
 				.Concat(UIAlertAction.Create(
-					GetValue(OverrideIosCancelTextProperty) as string ?? LocalizedCancelString,
+					GetValue(CancelTextIosOverrideProperty) as string ?? LocalizedCancelString,
 					UIAlertActionStyle.Cancel,
 					_ => this.Hide()
 				))

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS8.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS8.iOS.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Controls
 					}
 				))
 				.Concat(UIAlertAction.Create(
-					LocalizedCancelString,
+					GetValue(OverrideIosCancelTextProperty) as string ?? LocalizedCancelString,
 					UIAlertActionStyle.Cancel,
 					_ => this.Hide()
 				))


### PR DESCRIPTION
GitHub Issue (If applicable): #3270

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the new behavior?

Cancel button text can be customized with:
```xml
xmlns:toolkit="using:Uno.UI.Toolkit"

<MenuFlyout UseNativePopup="True"
            toolkit:MenuFlyoutExtensions.OverrideIosCancelText="Custom cancel text">
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.