### PR TITLE
fix(codegen): double assignments from implicit content+localization

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1641,13 +1641,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					{
 						if (IsTextBlock(topLevelControl.Type))
 						{
-							var objectUid = GetObjectUid(topLevelControl);
-							var isLocalized = objectUid != null &&
-								BuildLocalizedResourceValue(null, "Text", objectUid) != null;
-
-							if (implicitContentChild.Objects.Count != 0 &&
+							if (IsPropertyLocalized(topLevelControl, "Text"))
+							{
 								// A localized value is available. Ignore this implicit content as localized resources take precedence over XAML.
-								!isLocalized)
+								return true;
+							}
+
+							if (implicitContentChild.Objects.Count != 0)
 							{
 								using (writer.BlockInvariant("{0}Inlines = ", setterPrefix))
 								{
@@ -1666,6 +1666,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						}
 						else if (IsRun(topLevelControl.Type))
 						{
+							if (IsPropertyLocalized(topLevelControl, "Text"))
+							{
+								// A localized value is available. Ignore this implicit content as localized resources take precedence over XAML.
+								return true;
+							}
+
 							if (implicitContentChild.Value != null)
 							{
 								var escapedString = DoubleEscape(implicitContentChild.Value.ToString());
@@ -1674,6 +1680,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						}
 						else if (IsSpan(topLevelControl.Type))
 						{
+							if (IsPropertyLocalized(topLevelControl, "Text"))
+							{
+								// A localized value is available. Ignore this implicit content as localized resources take precedence over XAML.
+								return true;
+							}
+
 							if (implicitContentChild.Objects.Count != 0)
 							{
 								using (writer.BlockInvariant("{0}Inlines = ", setterPrefix))
@@ -3549,6 +3561,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 
 			return null;
+		}
+
+		private bool IsPropertyLocalized(XamlObjectDefinition obj, string propertyName)
+		{
+			var uid = GetObjectUid(obj);
+			var isLocalized = uid != null && BuildLocalizedResourceValue(null, propertyName, uid) != null;
+
+			return isLocalized;
 		}
 
 		private string ParseCacheMode(string memberValue)

--- a/src/SourceGenerators/XamlGenerationTests/InlineElementsTest.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/InlineElementsTest.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl
+    x:Class="XamlGenerationTests.Shared.InlineElementsTest"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:XamlGenerationTests.Shared"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <TextBlock>
+        <Run x:Uid="TestText">312</Run>
+    </TextBlock>
+</UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -44,6 +44,7 @@
 	  <None Remove="ThemeResourcesTest.xaml" />
 	  <None Remove="VSM.SetterComplexValue.xaml" />
 	  <None Remove="xNameResources.xaml" />
+	  <PRIResource Include="Resources.resw" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #3272

## PR Type

- Bugfix

## What is the current behavior?

Invalid code is generated when implicit content are localized.

## What is the new behavior?

Valid code is generated when implicit content are localized.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] ~~Validated PR `Screenshots Compare Test Run` results.~~
- [ ] ~~Contains **NO** breaking changes~~
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.