### PR TITLE
UserControl fixes

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -21,8 +21,6 @@
     <ResourcesDirectory>..\SamplesApp.Shared\Strings</ResourcesDirectory>
     <!-- AndroidUseAapt2 is disabled until https://github.com/unoplatform/uno/issues/1382 is resolved -->
     <AndroidUseAapt2>false</AndroidUseAapt2>
-    <!-- https://github.com/unoplatform/uno/issues/61 -->
-    <UnoSkipUserControlsInVisualTree>false</UnoSkipUserControlsInVisualTree>
   </PropertyGroup>
   <PropertyGroup>
     <IsUiAutomationMappingEnabled>true</IsUiAutomationMappingEnabled>

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -7,9 +7,6 @@
 		<DefineConstants>$(DefineConstants);__WASM__;HAS_UNO</DefineConstants>
 		<NoWarn>NU1701,CS1998</NoWarn>
 		<LangVersion>7.3</LangVersion>
-		<!-- https://github.com/unoplatform/uno/issues/61 -->
-		<UnoSkipUserControlsInVisualTree>false</UnoSkipUserControlsInVisualTree>
-
 		<IsUiAutomationMappingEnabled>true</IsUiAutomationMappingEnabled>
 	<UseUnoXamlParser>true</UseUnoXamlParser>
 	</PropertyGroup>

--- a/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
+++ b/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
@@ -13,8 +13,6 @@
     </NuGetPackageImportStamp>
     <IsUiAutomationMappingEnabled>true</IsUiAutomationMappingEnabled>
     <ResourcesDirectory>..\SamplesApp.Shared\Strings</ResourcesDirectory>
-    <!-- https://github.com/unoplatform/uno/issues/61 -->
-    <UnoSkipUserControlsInVisualTree>false</UnoSkipUserControlsInVisualTree>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
+++ b/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
@@ -11,7 +11,6 @@
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
-    <UnoSkipUserControlsInVisualTree>false</UnoSkipUserControlsInVisualTree>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_ComplexSetters_Automated.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_ComplexSetters_Automated.xaml
@@ -11,30 +11,30 @@
 		<SolidColorBrush x:Key="myStaticResource" Color="Purple" />
 	</UserControl.Resources>
 
-	<VisualStateManager.VisualStateGroups>
-		<VisualStateGroup x:Name="CommonStates">
-			<VisualState x:Name="DefaultState"/>
-
-			<VisualState x:Name="State01">
-				<VisualState.Setters>
-					<!-- Element name binding -->
-					<Setter Target="border01_bound.Background" Value="{Binding Background, ElementName=border01}"/>
-					
-					<!-- Static resource -->
-					<Setter Target="border02.Background" Value="{StaticResource myStaticResource}"/>
-
-					<Setter Target="border03.Background">
-						<Setter.Value>
-							<SolidColorBrush Color="Orange" />
-						</Setter.Value>
-					</Setter>
-					
-				</VisualState.Setters>
-			</VisualState>
-		</VisualStateGroup>
-	</VisualStateManager.VisualStateGroups>
-
 	<Grid>
+		<VisualStateManager.VisualStateGroups>
+			<VisualStateGroup x:Name="CommonStates">
+				<VisualState x:Name="DefaultState"/>
+
+				<VisualState x:Name="State01">
+					<VisualState.Setters>
+						<!-- Element name binding -->
+						<Setter Target="border01_bound.Background" Value="{Binding Background, ElementName=border01}"/>
+					
+						<!-- Static resource -->
+						<Setter Target="border02.Background" Value="{StaticResource myStaticResource}"/>
+
+						<Setter Target="border03.Background">
+							<Setter.Value>
+								<SolidColorBrush Color="Orange" />
+							</Setter.Value>
+						</Setter>
+					
+					</VisualState.Setters>
+				</VisualState>
+			</VisualStateGroup>
+		</VisualStateManager.VisualStateGroups>
+		
 		<StackPanel>
 			<Button x:Name="changeState" Content="Change State" Click="OnClick" />
 			<Border x:Name="border01" Background="Red" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_UpdatesMode.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_UpdatesMode.xaml
@@ -6,7 +6,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:xamarin="http://platform.uno/xamarin"
-	xmlns:not_xamarin="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     mc:Ignorable="d xamarin"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -52,6 +51,4 @@
 			<TextBlock x:Name="_output" />
 		</ScrollViewer>
     </xamarin:StackPanel>
-
-	<not_xamarin:TextBlock Text="Updates mode is specific to Uno" />
 </Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -41,7 +41,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		// Determines if the source generator will skip the inclusion of UseControls in the
 		// visual tree. See https://github.com/unoplatform/uno/issues/61
-		private bool _skipUserControlsInVisualTree = true;
+		private bool _skipUserControlsInVisualTree = false;
 
 #pragma warning disable 649 // Unused member
 		private readonly bool _forceGeneration;

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -299,7 +299,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 					using (writer.BlockInvariant("public partial class {0} : {1}", _className.className, controlBaseType.ToDisplayString()))
 					{
-						var isDirectUserControlChild = IsUserControl(topLevelControl.Type, checkInheritance: false);
+						var isDirectUserControlChild = _skipUserControlsInVisualTree && IsUserControl(topLevelControl.Type, checkInheritance: false);
 
 						using (Scope("{0}{1}".InvariantCultureFormat(_className.ns.Replace(".", ""), _className.className)))
 						{
@@ -701,7 +701,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				return "protected override void InitializeComponent()";
 			}
-			else if (IsUserControl(topLevelControl.Type, checkInheritance: false))
+			else if (_skipUserControlsInVisualTree && IsUserControl(topLevelControl.Type, checkInheritance: false))
 			{
 				string contentTypeDisplayString = GetImplicitChildTypeDisplayString(topLevelControl);
 
@@ -1706,7 +1706,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								}
 							}
 						}
-						else if (IsUserControl(topLevelControl.Type))
+						else if (_skipUserControlsInVisualTree && IsUserControl(topLevelControl.Type))
 						{
 							if (implicitContentChild.Objects.Any())
 							{
@@ -1929,7 +1929,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 						return true;
 					}
-					else if (returnsContent && IsUserControl(topLevelControl.Type))
+					else if (returnsContent && _skipUserControlsInVisualTree && IsUserControl(topLevelControl.Type))
 					{
 						writer.AppendFormatInvariant(XamlConstants.Types.IFrameworkElement + " content = null");
 					}

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -27,8 +27,8 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-		<PackageReference Include="MSTest.TestAdapter"/>
-    <PackageReference Include="MSTest.TestFramework"/>
+		<PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="FluentAssertions">
       <Version>5.10.3</Version>
     </PackageReference>
@@ -94,6 +94,7 @@
 	</ItemGroup>
 	<ItemGroup Condition="'$(BuildingInsideUnoSourceGenerator)'!=''">
 		<Page Include="Windows_UI_Xaml_Data\**\*.xaml" />
+		<Page Include="Windows_UI_Xaml_Controls\**\*.xaml" />
 		<Page Include="App\App.xaml" />
 		<Page Include="App\Xaml\Test_CreateFromString.xaml" />
 		<Page Include="App\Xaml\Test_Dictionary.xaml" />

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/Given_UserControl.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/Given_UserControl.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.xLoad
+{
+	[TestClass]
+	public class Given_UserControl
+	{
+		[TestMethod]
+		public void When_UserControl_TopLevel_Binding()
+		{
+			var sut = new UserControl_TopLevelBinding();
+			sut.ForceLoaded();
+
+			var uc01 = sut.FindName("uc01");
+
+			Assert.AreEqual(0, UserControl_TopLevelBinding_AttachedProperty.MyPropertyChangedCount);
+			Assert.AreEqual(0, UserControl_TopLevelBinding_AttachedProperty.GetMyProperty(uc01));
+
+			sut.DataContext = 42;
+
+			Assert.AreEqual(1, UserControl_TopLevelBinding_AttachedProperty.MyPropertyChangedCount);
+			Assert.AreEqual(42, UserControl_TopLevelBinding_AttachedProperty.GetMyProperty(uc01));
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_TopLevelBinding.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_TopLevelBinding.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests.UserControl_TopLevelBinding"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid x:Name="test01">
+		<local:UserControl_TopLevelBinding_UserControl x:Name="uc01" />
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_TopLevelBinding.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_TopLevelBinding.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class UserControl_TopLevelBinding : Page
+	{
+		public UserControl_TopLevelBinding()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_TopLevelBinding_UserControl.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_TopLevelBinding_UserControl.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests.UserControl_TopLevelBinding_UserControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+	local:UserControl_TopLevelBinding_AttachedProperty.MyProperty="{Binding}"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		
+    </Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_TopLevelBinding_UserControl.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_TopLevelBinding_UserControl.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class UserControl_TopLevelBinding_UserControl : UserControl
+	{
+		public UserControl_TopLevelBinding_UserControl()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public static class UserControl_TopLevelBinding_AttachedProperty
+	{
+		public static int GetMyProperty(DependencyObject obj)
+		{
+			return (int)obj.GetValue(MyPropertyProperty);
+		}
+
+		public static void SetMyProperty(DependencyObject obj, int value)
+		{
+			obj.SetValue(MyPropertyProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for MyProperty.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyPropertyProperty =
+			DependencyProperty.RegisterAttached("MyProperty", typeof(int), typeof(UserControl_TopLevelBinding_AttachedProperty), new PropertyMetadata(0, OnMyPropertyChanged));
+
+		public static int MyPropertyChangedCount { get; private set; }
+
+		private static void OnMyPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			MyPropertyChangedCount++;
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #3243, Fixes #61, Fixes #3218, Fixes #153

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the new behavior?

`UserControl` instances are now placed in the visual tree by default.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
