### PR TITLE
fix(Selector): Fix SelectionChanged / SelectedItem ordering to align with UWP

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
@@ -206,6 +206,42 @@ namespace Uno.UI.Tests.ListViewBaseTests
 		}
 
 		[TestMethod]
+		public void When_SelectionChanged_Changes_Order()
+		{
+			var list = new ListView()
+			{
+				Style = null,
+				ItemContainerStyle = BuildBasicContainerStyle(),
+			};
+			list.ItemsSource = Enumerable.Range(0, 20);
+			var callbackCount = 0;
+
+			list.SelectionChanged += OnSelectionChanged;
+			list.SelectedItem = 7;
+
+			using (new AssertionScope())
+			{
+				list.SelectedItem.Should().Be(7);
+				list.SelectedIndex.Should().Be(7);
+				list.SelectedValue.Should().Be(7);
+				callbackCount.Should().Be(1); //Unlike eg TextBox.TextChanged there is no guard on reentrant modification
+			}
+
+			void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+			{
+				callbackCount++;
+
+				using (new AssertionScope())
+				{
+					list.SelectedItem.Should().Be(7);
+					list.SelectedIndex.Should().Be(7);
+					list.SelectedValue.Should().Be(7);
+					callbackCount.Should().Be(1);
+				}
+			}
+		}
+
+		[TestMethod]
 		public void When_ViewModelSource_SelectionChanged_Changes_Selection()
 		{
 			var SUT = new ListView()

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -113,10 +113,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				SelectedIndex = newIndex;
 			}
 
-			InvokeSelectionChanged(wasSelectionUnset ? new object[] { } : new[] { oldSelectedItem },
-				isSelectionUnset ? new object[] { } : new[] { selectedItem }
-			);
-
 			OnSelectedItemChangedPartial(oldSelectedItem, selectedItem);
 
 			UpdateSelectedValue();
@@ -126,6 +122,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				TryUpdateSelectorItemIsSelected(oldSelectedItem, false);
 				TryUpdateSelectorItemIsSelected(selectedItem, true);
 			}
+
+			InvokeSelectionChanged(wasSelectionUnset ? new object[] { } : new[] { oldSelectedItem },
+				isSelectionUnset ? new object[] { } : new[] { selectedItem }
+			);
 		}
 
 		internal void TryUpdateSelectorItemIsSelected(object item, bool isSelected)


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #534

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

BREAKING CHANGE: The `Selector.SelectionChanged` event is now raised after the `SelectedValue`, `SelectedItem` and `SelectedIndex` properties are updated. The original behavior was incorrect.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
