### PR TITLE
fix(dotnet_new): Fix wasm head is not added to the existing solution

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/.template.config/template.json
@@ -16,7 +16,7 @@
   "symbols": {
   },
   "primaryOutputs": [
-    { "path": "UnoQuickStart.Wasm" }
+    { "path": "UnoXFQuickStart.Wasm" }
     // Cannot add the shared project because of path replace issues: https://github.com/dotnet/templating/issues/2068
   ],
   "postActions": [


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #3285 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The generated WebAssemblyhead is properly included in the existing solution.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
