### PR TITLE
Fix typos

### DIFF
--- a/doc/articles/contributing/guidelines/creating-tests.md
+++ b/doc/articles/contributing/guidelines/creating-tests.md
@@ -43,7 +43,7 @@ Although only a subset of the samples in the SamplesApp are covered by automated
 
 ### .NET Framework unit tests (`Uno.UI.Tests`)
 
-These are 'classic' unit tests which are built against a mocked version of the `Uno.UI` assembly targetting .NET Framework.
+These are 'classic' unit tests which are built against a mocked version of the `Uno.UI` assembly targeting .NET Framework.
 
 These tests are ideal for testing platform-agnostic parts of the code, such as the dependency property system, or panel measurement logic. They [have access to](https://github.com/unoplatform/uno/blob/af5365331d87a80ed4dd83b9e4839cc0d4a0ee5b/src/Uno.UI/AssemblyInfo.cs#L3) internal Uno.UI members, and the mocking layer allows values to be read or written which can't be accessed via the 'real' API.
 

--- a/doc/articles/contributing/guidelines/updating-dependencies.md
+++ b/doc/articles/contributing/guidelines/updating-dependencies.md
@@ -33,7 +33,7 @@ Updating these dependencies will require consumers to upgrade their dependencies
 
 ## additional care required
 
-These dependancies require care and human testing:
+These dependencies require care and human testing:
 
 - [Com.Airbnb.Android.Lottie](https://github.com/unoplatform/uno/pull/1201#issuecomment-511499023). This dependency reduces the number of supported SDKs (monoandroid80 is not supported). This dependency will be updated once monoandroid80 support is dropped from Uno.
 - [CommonServiceLocator](https://github.com/unoplatform/uno/pull/1174#issuecomment-507659717). This specific dependency needs to be removed from Uno.

--- a/doc/articles/get-started-next-steps.md
+++ b/doc/articles/get-started-next-steps.md
@@ -24,4 +24,4 @@ Already [completed the tutorial](getting-started-tutorial-1.md)? Ready to build 
 
 * To chat with the Uno Platform team and the Uno community, visit our [Discord Channel #uno-platform](https://discord.gg/eBHZSKG).
 
-* A knowledge of working with GitHub and Forks, Pull and Push requests is desireable. To learn more about Forks please see official GitHub documentation. [GitHub - Forks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks).
+* A knowledge of working with GitHub and Forks, Pull and Push requests is desirable. To learn more about Forks please see official GitHub documentation. [GitHub - Forks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks).

--- a/doc/articles/uno-development/api-extensions.md
+++ b/doc/articles/uno-development/api-extensions.md
@@ -1,6 +1,6 @@
 # API Extensions
 
-Uno provides a simple mecanism which allows for external provides to provide an implementation for some known interfaces. The goal behind this is two fold:
+Uno provides a simple mechanism which allows for external provides to provide an implementation for some known interfaces. The goal behind this is two fold:
 
 - Provide a way to remove some types of dependencies from the main Uno.UI package, reducing the payload size of an app if some features are not required
 - Provide a way for developers to provide a custom implementation of a known WinRT or WinUI api for which the default implementation is not provided

--- a/doc/articles/uno-development/release-procedure.md
+++ b/doc/articles/uno-development/release-procedure.md
@@ -7,7 +7,7 @@ Tagging is the main driver for planning releases.
 ## Branches 
 - On the `master` branch, the main development is happening and is considered unstable. The nuget packages produced end with `-dev.X`, where X is the number of commits since the last initiated release.
 - On the `release/beta` branch, stabilisation occurs to get a stable release. The version is inherited from the branch point from master. The nuget packages produced end with `-beta.X`, where X is the number of commits since the last stable release.
-- On the `release/stable` branch, stable nuget packages are produced for each pushed merge or commit. The **Patch** number is increased by the number of commits since the release tagging occured.
+- On the `release/stable` branch, stable nuget packages are produced for each pushed merge or commit. The **Patch** number is increased by the number of commits since the release tagging occurred.
 - On `dev`, `feature`, and `project` branches, the behavior is to inherit from the base branch it was created from and create a nuget package with an experimental tag. Those branches must not be tagged.
 
 ## Creating a release


### PR DESCRIPTION
Hey,

This PR will fix : 

- 1 typo in `doc/articles/contributing/guidelines/creating-tests.md`
- 1 typo in `doc/articles/contributing/guidelines/updating-dependencies.md`
- 1 typo in `doc/articles/get-started-next-steps.md`
- 1 typo in `doc/articles/uno-development/api-extensions.md`
- 1 typo in `doc/articles/uno-development/release-procedure.md`



Best! :robot: