### PR TITLE
fix: [Wasm] Adjust for newer bootstrapper update to include app base path

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -149,13 +149,13 @@
 	</Target>
 
 	<Target Name="GenerateDoc" DependsOnTargets="BuildSyncGenerator">
-		<Exec Command="..\src\Uno.UWPSyncGenerator\Bin\Release\net461\Uno.UWPSyncGenerator.exe &quot;doc&quot;" />
+		<Exec Command="..\src\Uno.UWPSyncGenerator\Bin\Release\Uno.UWPSyncGenerator.exe &quot;doc&quot;" />
 		<Exec Command="$(Pkgdocfx_console)\tools\docfx.exe ..\doc\docfx.json -o $(OutputDir)\doc" />
 	</Target>
 
 	<Target Name="RunAPISyncTool" DependsOnTargets="BuildSyncGenerator">
 	
-		<Exec Command="..\src\Uno.UWPSyncGenerator\Bin\Release\net461\Uno.UWPSyncGenerator.exe &quot;sync&quot;" />
+		<Exec Command="..\src\Uno.UWPSyncGenerator\Bin\Release\Uno.UWPSyncGenerator.exe &quot;sync&quot;" />
 	</Target>
 
 	<Target Name="PublishVisx" Condition="'$(UNO_UWP_BUILD)'=='true'">

--- a/src/AddIns/Uno.UI.Lottie/WasmScripts/uno-lottie.d.ts
+++ b/src/AddIns/Uno.UI.Lottie/WasmScripts/uno-lottie.d.ts
@@ -1,4 +1,5 @@
 declare const require: any;
+declare const config: any;
 declare namespace Uno.UI {
     import AnimationData = Lottie.AnimationData;
     interface LottieAnimationProperties {

--- a/src/AddIns/Uno.UI.Lottie/WasmScripts/uno-lottie.js
+++ b/src/AddIns/Uno.UI.Lottie/WasmScripts/uno-lottie.js
@@ -174,7 +174,7 @@ var Uno;
                     action(Lottie._player);
                 }
                 else {
-                    require(["lottie"], (p) => {
+                    require([`${config.uno_app_base}/lottie`], (p) => {
                         if (!Lottie._player) {
                             Lottie._player = p;
                         }

--- a/src/AddIns/Uno.UI.Lottie/ts/Uno.UI.Lottie.ts
+++ b/src/AddIns/Uno.UI.Lottie/ts/Uno.UI.Lottie.ts
@@ -1,4 +1,5 @@
 ﻿declare const require: any;
+declare const config: any;
 
 namespace Uno.UI {
 	import AnimationData = Lottie.AnimationData;
@@ -242,7 +243,7 @@ namespace Uno.UI {
 			if (Lottie._player) {
 				action(Lottie._player);
 			} else {
-				require(["lottie"], (p: LottiePlayer) => {
+				require([`${config.uno_app_base}/lottie`], (p: LottiePlayer) => {
 					if (!Lottie._player) {
 						Lottie._player = p;
 					}

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -16,8 +16,8 @@
     <PackageReference Update="Uno.SourceGeneration" Version="2.0.6" />
     <PackageReference Update="Uno.Core" Version="2.0.0" />
     <PackageReference Update="Uno.Core.Build" Version="2.0.0" />
-    <PackageReference Update="Uno.Wasm.Bootstrap" Version="1.2.0" />
-    <PackageReference Update="Uno.Wasm.Bootstrap.DevServer" Version="1.2.0" />
+    <PackageReference Update="Uno.Wasm.Bootstrap" Version="1.3.0-dev.42" />
+    <PackageReference Update="Uno.Wasm.Bootstrap.DevServer" Version="1.3.0-dev.42" />
     <PackageReference Update="xamarin.build.download" Version="0.4.11" />
     <PackageReference Update="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Update="MSTest.TestFramework" Version="2.1.1" />

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile2.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile2.cs
@@ -45,9 +45,9 @@ namespace Uno.UI.RuntimeTests.Tests
 				testFile = await folderForTestFile.CreateFileAsync(_filename, Windows.Storage.CreationCollisionOption.FailIfExists);
 				Assert.IsNotNull(testFile, "cannot create file - error outside tested method");
 			}
-			catch
+			catch (Exception e)
 			{
-				Assert.Fail("CreateFile exception - error outside tested method");
+				Assert.Fail($"CreateFile exception - error outside tested method ({e})");
 			}
 
 			DateTimeOffset dateAfterCreating = DateTimeOffset.Now;
@@ -61,9 +61,9 @@ namespace Uno.UI.RuntimeTests.Tests
 			{
 				dateOnCreating = testFile.DateCreated;
 			}
-			catch
+			catch (Exception e)
 			{
-				Assert.Fail("DateCreated exception - error in tested method");
+				Assert.Fail($"DateCreated exception - error in tested method ({e})");
 			}
 
 			// while testing date, we should remember about filesystem date resolution.
@@ -123,9 +123,9 @@ namespace Uno.UI.RuntimeTests.Tests
 			{
 				dateModified = (await testFile.GetBasicPropertiesAsync()).DateModified;
 			}
-			catch
+			catch (Exception e)
 			{
-				Assert.Fail("DateModified exception - error in tested method");
+				Assert.Fail($"DateModified exception - error in tested method ({e})");
 			}
 
 			// first, date should not be year 1601 or something like that...

--- a/src/Uno.UI.Wasm.Tests/WasmScripts/UnitTests.js
+++ b/src/Uno.UI.Wasm.Tests/WasmScripts/UnitTests.js
@@ -1,4 +1,4 @@
-require(["Uno.UI"], () => {
+require([`${config.uno_app_base}/Uno.UI`], () => {
     MonoSupport.jsCallDispatcher.registerScope("TSBindingsUnitTests", new TSBindingsTests());
 });
 class TSBindingsTests {

--- a/src/Uno.UI.Wasm.Tests/ts/TSBindingsTests.ts
+++ b/src/Uno.UI.Wasm.Tests/ts/TSBindingsTests.ts
@@ -1,4 +1,4 @@
-﻿require(["Uno.UI"], () => {
+﻿require([`${config.uno_app_base}/Uno.UI`], () => {
 
 	MonoSupport.jsCallDispatcher.registerScope("TSBindingsUnitTests", new TSBindingsTests());
 

--- a/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
@@ -182,7 +182,7 @@ embed.uno-frameworkelement.uno-unarranged {
     overflow-y: scroll;
   }
 
-.uno-splash {
+.uno-splash .logo {
   position: fixed;
   top: 50%;
   left: 50%;

--- a/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
@@ -182,7 +182,7 @@ embed.uno-frameworkelement.uno-unarranged {
     overflow-y: scroll;
   }
 
-.uno-splash .logo {
+.uno-splash {
   position: fixed;
   top: 50%;
   left: 50%;
@@ -192,6 +192,19 @@ embed.uno-frameworkelement.uno-unarranged {
   background-repeat: no-repeat;
   background-position: center;
   background-size: 620px 300px;
+}
+
+/* Bootstrapper logo override */
+.uno-loader .logo {
+  position: fixed !important;
+  top: 50% !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%) !important;
+  width: 620px !important;
+  height: 300px !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  background-size: 620px 300px !important;
 }
 
 textarea {

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -114,6 +114,7 @@ declare namespace MonoSupport {
         private static getMethodMapId;
     }
 }
+declare const config: any;
 declare namespace Uno.UI {
     class WindowManager {
         private containerElementId;

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -1734,7 +1734,7 @@ var Uno;
         WindowManager.MAX_HEIGHT = `${Number.MAX_SAFE_INTEGER}vh`;
         UI.WindowManager = WindowManager;
         if (typeof define === "function") {
-            define(["AppManifest"], () => {
+            define([`${config.uno_app_base}/AppManifest`], () => {
             });
         }
         else {

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -1,4 +1,5 @@
-﻿
+﻿declare const config: any;
+
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Uno.UI {
 
@@ -1829,7 +1830,7 @@ namespace Uno.UI {
 
 	if (typeof define === "function") {
 		define(
-			["AppManifest"],
+			[`${config.uno_app_base}/AppManifest`],
 			() => {
 			}
 		);

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
@@ -24,6 +24,7 @@ namespace Windows.UI.Xaml.Controls
 	partial class Image : FrameworkElement, ICustomClippingElement
 	{
 		private readonly SerialDisposable _sourceDisposable = new SerialDisposable();
+		private static readonly string UNO_BOOTSTRAP_APP_BASE = global::System.Environment.GetEnvironmentVariable(nameof(UNO_BOOTSTRAP_APP_BASE));
 
 		private readonly HtmlImage _htmlImage;
 		private Size _lastMeasuredSize;
@@ -201,7 +202,20 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else
 			{
-				_htmlImage.SetAttribute("src", url);
+				if (UNO_BOOTSTRAP_APP_BASE != null)
+				{
+					var adjustedUrl = url switch
+					{
+						string u when u.StartsWith("http:/", StringComparison.OrdinalIgnoreCase) || u.StartsWith("https:/", StringComparison.OrdinalIgnoreCase) => url,
+						_ => UNO_BOOTSTRAP_APP_BASE + "/" + url
+					};
+
+					_htmlImage.SetAttribute("src", adjustedUrl);
+				}
+				else
+				{
+					_htmlImage.SetAttribute("src", url);
+				}
 			}
 		}
 

--- a/src/Uno.UWPSyncGenerator/DocGenerator.cs
+++ b/src/Uno.UWPSyncGenerator/DocGenerator.cs
@@ -15,7 +15,7 @@ namespace Uno.UWPSyncGenerator
 	/// </summary>
 	class DocGenerator : Generator
 	{
-		private const string DocPath = @"..\..\..\..\..\doc\articles";
+		private const string DocPath = @"..\..\..\..\doc\articles";
 		private const string ImplementedViewsFileName = "implemented-views.md";
 		private const string ImplementedPath = @"./implemented/";
 

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -56,7 +56,7 @@ namespace Uno.UWPSyncGenerator
 
 			Console.WriteLine($"Generating for {baseName} {sourceAssembly}");
 
-			_referenceCompilation = LoadProject(@"..\..\..\..\Uno.UWPSyncGenerator.Reference\Uno.UWPSyncGenerator.Reference.csproj");
+			_referenceCompilation = LoadProject(@"..\..\..\Uno.UWPSyncGenerator.Reference\Uno.UWPSyncGenerator.Reference.csproj");
 			_iOSCompilation = LoadProject($@"{basePath}\{baseName}.csproj", "xamarinios10");
 			_androidCompilation = LoadProject($@"{basePath}\{baseName}.csproj", "MonoAndroid10.0");
 			_net461Compilation = LoadProject($@"{basePath}\{baseName}.csproj", "net461");
@@ -162,7 +162,7 @@ namespace Uno.UWPSyncGenerator
 		{
 			if (type.ContainingAssembly.Name == "Windows.Foundation.FoundationContract")
 			{
-				return @"..\..\..\..\Uno.Foundation\Generated\2.0.0.0";
+				return @"..\..\..\Uno.Foundation\Generated\2.0.0.0";
 			}
 			else if (!(
 				type.ContainingNamespace.ToString().StartsWith("Windows.UI.Xaml")
@@ -173,11 +173,11 @@ namespace Uno.UWPSyncGenerator
 #endif
 			))
 			{
-				return @"..\..\..\..\Uno.UWP\Generated\3.0.0.0";
+				return @"..\..\..\Uno.UWP\Generated\3.0.0.0";
 			}
 			else
 			{
-				return @"..\..\..\..\Uno.UI\Generated\3.0.0.0";
+				return @"..\..\..\Uno.UI\Generated\3.0.0.0";
 			}
 		}
 
@@ -304,14 +304,22 @@ namespace Uno.UWPSyncGenerator
 		}
 
 		private PlatformSymbols<ISymbol> GetAllGetNonGeneratedMembers(PlatformSymbols<INamedTypeSymbol> types, string name, Func<IEnumerable<ISymbol>, ISymbol> filter, ISymbol uapSymbol = null)
-			=> new PlatformSymbols<ISymbol>(
-				filter(GetNonGeneratedMembers(types.AndroidSymbol, name)),
-				filter(GetNonGeneratedMembers(types.IOSSymbol, name)),
-				filter(GetNonGeneratedMembers(types.MacOSSymbol, name)),
-				filter(GetNonGeneratedMembers(types.net461ymbol, name)),
-				filter(GetNonGeneratedMembers(types.WasmSymbol, name)),
+		{
+			var android = GetNonGeneratedMembers(types.AndroidSymbol, name);
+			var ios = GetNonGeneratedMembers(types.IOSSymbol, name);
+			var macOS = GetNonGeneratedMembers(types.MacOSSymbol, name);
+			var net461 = GetNonGeneratedMembers(types.net461ymbol, name);
+			var wasm = GetNonGeneratedMembers(types.WasmSymbol, name);
+
+			return new PlatformSymbols<ISymbol>(
+				filter(android),
+				filter(ios),
+				filter(macOS),
+				filter(net461),
+				filter(wasm),
 				uapType: uapSymbol
 			);
+		}
 
 		protected PlatformSymbols<IMethodSymbol> GetAllMatchingMethods(PlatformSymbols<INamedTypeSymbol> types, IMethodSymbol method)
 			=> new PlatformSymbols<IMethodSymbol>(
@@ -1484,6 +1492,7 @@ namespace Uno.UWPSyncGenerator
 								//{ "BuildingInsideVisualStudio", "true" },
 								{ "SkipUnoResourceGeneration", "true" }, // Required to avoid loading a non-existent task
 								{ "DocsGeneration", "true" }, // Detect that source generation is running
+								{ "LangVersion", "8.0" },
 								//{ "DesignTimeBuild", "true" },
 								//{ "UseHostCompilerIfAvailable", "false" },
 								//{ "UseSharedCompilation", "false" },

--- a/src/Uno.UWPSyncGenerator/Helpers/ProjectLoader.cs
+++ b/src/Uno.UWPSyncGenerator/Helpers/ProjectLoader.cs
@@ -65,6 +65,7 @@ namespace Uno.SourceGeneration.Host
 			properties["Configuration"] = configuration;
 			properties["UseHostCompilerIfAvailable"] = "true";
 			properties["UseSharedCompilation"] = "true";
+			properties["LangVersion"] = "8.0";
 
 			// Platform is intentionally kept as not defined, to avoid having 
 			// dependent projects being loaded with a platform they don't support.

--- a/src/Uno.UWPSyncGenerator/Program.cs
+++ b/src/Uno.UWPSyncGenerator/Program.cs
@@ -27,26 +27,26 @@ namespace Uno.UWPSyncGenerator
 
 			if (mode == SyncMode || mode == AllMode)
 			{
-				new SyncGenerator().Build(@"..\..\..\..\Uno.Foundation", "Uno.Foundation", "Windows.Foundation.FoundationContract");
-				new SyncGenerator().Build(@"..\..\..\..\Uno.UWP", "Uno", "Windows.Foundation.UniversalApiContract");
-				new SyncGenerator().Build(@"..\..\..\..\Uno.UWP", "Uno", "Windows.Phone.PhoneContract");
-				new SyncGenerator().Build(@"..\..\..\..\Uno.UWP", "Uno", "Windows.Networking.Connectivity.WwanContract");
-				new SyncGenerator().Build(@"..\..\..\..\Uno.UWP", "Uno", "Windows.ApplicationModel.Calls.CallsPhoneContract");
+				new SyncGenerator().Build(@"..\..\..\Uno.Foundation", "Uno.Foundation", "Windows.Foundation.FoundationContract");
+				new SyncGenerator().Build(@"..\..\..\Uno.UWP", "Uno", "Windows.Foundation.UniversalApiContract");
+				new SyncGenerator().Build(@"..\..\..\Uno.UWP", "Uno", "Windows.Phone.PhoneContract");
+				new SyncGenerator().Build(@"..\..\..\Uno.UWP", "Uno", "Windows.Networking.Connectivity.WwanContract");
+				new SyncGenerator().Build(@"..\..\..\Uno.UWP", "Uno", "Windows.ApplicationModel.Calls.CallsPhoneContract");
 
 #if HAS_UNO_WINUI
-				new SyncGenerator().Build(@"..\..\..\..\Uno.UI", "Uno.UI", "Microsoft.UI");
-				new SyncGenerator().Build(@"..\..\..\..\Uno.UI", "Uno.UI", "Microsoft.System");
+				new SyncGenerator().Build(@"..\..\..\Uno.UI", "Uno.UI", "Microsoft.UI");
+				new SyncGenerator().Build(@"..\..\..\Uno.UI", "Uno.UI", "Microsoft.System");
 #else
-				new SyncGenerator().Build(@"..\..\..\..\Uno.UI", "Uno.UI", "Windows.Foundation.UniversalApiContract");
+				new SyncGenerator().Build(@"..\..\..\Uno.UI", "Uno.UI", "Windows.Foundation.UniversalApiContract");
 #endif
 			}
 
 			if (mode == DocMode || mode == AllMode)
 			{
 #if HAS_UNO_WINUI
-				new DocGenerator().Build(@"..\..\..\..\Uno.UI", "Uno.UI", "Microsoft.UI");
+				new DocGenerator().Build(@"..\..\..\Uno.UI", "Uno.UI", "Microsoft.UI");
 #else
-				new DocGenerator().Build(@"..\..\..\..\Uno.UI", "Uno.UI", "Windows.Foundation.UniversalApiContract");
+				new DocGenerator().Build(@"..\..\..\Uno.UI", "Uno.UI", "Windows.Foundation.UniversalApiContract");
 #endif
 			}
 		}

--- a/src/Uno.UWPSyncGenerator/Uno.UWPSyncGenerator.csproj
+++ b/src/Uno.UWPSyncGenerator/Uno.UWPSyncGenerator.csproj
@@ -2,7 +2,8 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net461</TargetFramework>
+		<TargetFramework>net472</TargetFramework>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
@@ -29,27 +30,27 @@
 			<Version>15.8.166</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis">
-			<Version>2.9.0</Version>
+			<Version>3.6.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.Common">
-			<Version>2.9.0</Version>
+			<Version>3.6.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-			<Version>2.9.0</Version>
+			<Version>3.6.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-			<Version>2.9.0</Version>
+			<Version>3.6.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic">
-			<Version>2.9.0</Version>
+			<Version>3.6.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
-			<Version>2.9.0</Version>
+			<Version>3.6.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
-			<Version>2.9.0</Version>
+			<Version>3.6.0</Version>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.6.0" />
 		<PackageReference Include="Microsoft.Tpl.Dataflow">
 			<Version>4.5.24</Version>
 		</PackageReference>


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This update deals with the bootstrapper 1.3 changes to move all app content files to a versioned subfolder to avoid caching issues when deployed from a CDN. This change mainly impacts the images and splash screen resources.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
