### PR TITLE
StartStopEventWrapper

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_StartStopEventWrapper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_StartStopEventWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if HAS_UNO
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Helpers;
 using Windows.Devices.Sensors;
@@ -220,3 +221,4 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 		}
 	}
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_StartStopEventWrapper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_StartStopEventWrapper.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Helpers;
+using Windows.Devices.Sensors;
+using Windows.Foundation;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
+{
+	[TestClass]
+	public class Given_StartStopEventWrapper
+	{
+		[TestMethod]
+		public void When_Default_Event_Null()
+		{
+			var wrapper = new StartStopEventWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
+			Assert.IsNull(wrapper.Event);
+		}
+
+		[TestMethod]
+		public void When_Add_Handler_Event_Not_Null()
+		{
+			var wrapper = new StartStopEventWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
+			wrapper.AddHandler((s, e) => { });
+			Assert.IsNotNull(wrapper.Event);
+		}
+
+		[TestMethod]
+		public void When_Add_Remove_Event_Null()
+		{
+			void Handler(Accelerometer a, AccelerometerReadingChangedEventArgs e)
+			{
+			}
+			var wrapper = new StartStopEventWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
+			wrapper.AddHandler(Handler);
+			wrapper.RemoveHandler(Handler);
+			Assert.IsNull(wrapper.Event);
+		}
+
+		[TestMethod]
+		public void When_Remove_On_Empty()
+		{
+			var wrapper = new StartStopEventWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
+			wrapper.RemoveHandler((s, e) => { });
+			Assert.IsNull(wrapper.Event);
+		}
+
+
+		[TestMethod]
+		public void When_Remove_Nonexistent()
+		{
+			var wrapper = new StartStopEventWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
+			wrapper.AddHandler((s, e) => { });
+			wrapper.RemoveHandler((s, e) => { });
+			Assert.IsNotNull(wrapper.Event);
+		}
+
+		[TestMethod]
+		public void When_Single_Invoked()
+		{
+			var invoked = false;
+			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => { });
+			wrapper.AddHandler((s, e) => invoked = true);
+			Assert.IsFalse(invoked);
+			wrapper.Event?.Invoke(null, EventArgs.Empty);
+			Assert.IsTrue(invoked);
+		}
+
+		[TestMethod]
+		public void When_Multiple_Invoked()
+		{
+			var firstInvoked = false;
+			var secondInvoked = false;
+			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => { });
+			wrapper.AddHandler((s, e) => firstInvoked = true);
+			wrapper.AddHandler((s, e) => secondInvoked = true);
+			Assert.IsFalse(firstInvoked);
+			Assert.IsFalse(secondInvoked);
+			wrapper.Event?.Invoke(null, EventArgs.Empty);
+			Assert.IsTrue(firstInvoked);
+			Assert.IsTrue(secondInvoked);
+		}
+
+		[TestMethod]
+		public void When_Multiple_First_Removed_Invoked()
+		{
+			var firstInvoked = false;
+			void FirstHandler(object sender, EventArgs args)
+			{
+				firstInvoked = true;
+			}
+			var secondInvoked = false;
+			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => { });
+			wrapper.AddHandler(FirstHandler);
+			wrapper.AddHandler((s, e) => secondInvoked = true);
+			Assert.IsFalse(firstInvoked);
+			Assert.IsFalse(secondInvoked);
+			wrapper.RemoveHandler(FirstHandler);
+			wrapper.Event?.Invoke(null, EventArgs.Empty);
+			Assert.IsFalse(firstInvoked);
+			Assert.IsTrue(secondInvoked);
+		}
+
+		[TestMethod]
+		public void When_First_Subscriber_OnFirst_Invoked()
+		{
+			var onFirst = false;
+			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => onFirst = true, () => { });
+			Assert.IsFalse(onFirst);
+			wrapper.AddHandler((s, e) => { });
+			Assert.IsTrue(onFirst);
+		}
+
+		[TestMethod]
+		public void When_Multiple_Subscribers_OnFirst_Once()
+		{
+			var onFirstCounter = 0;
+			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => onFirstCounter++, () => { });
+			Assert.AreEqual(0, onFirstCounter);
+			wrapper.AddHandler((s, e) => { });
+			wrapper.AddHandler((s, e) => { });
+			Assert.AreEqual(1, onFirstCounter);
+		}
+
+		[TestMethod]
+		public void When_Multiple_Subscribers_Sequence_OnFirst()
+		{
+			void FirstSubscriber(object sender, EventArgs e)
+			{
+			}
+
+			void SecondSubscriber(object sender, EventArgs e)
+			{
+			}
+
+			var onFirstCounter = 0;
+			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => onFirstCounter++, () => { });
+			Assert.AreEqual(0, onFirstCounter);
+			wrapper.AddHandler(FirstSubscriber);
+			wrapper.AddHandler(SecondSubscriber);
+			Assert.AreEqual(1, onFirstCounter);
+			wrapper.RemoveHandler(FirstSubscriber);
+			wrapper.RemoveHandler(SecondSubscriber);
+			Assert.AreEqual(1, onFirstCounter);
+			wrapper.AddHandler(FirstSubscriber);
+			Assert.AreEqual(2, onFirstCounter);
+		}
+
+		[TestMethod]
+		public void When_First_Subscriber_OnLast_Invoked()
+		{
+			void FirstSubscriber(object sender, EventArgs e)
+			{
+			}
+			var onLast = false;
+			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => onLast = true);
+			wrapper.AddHandler(FirstSubscriber);
+			Assert.IsFalse(onLast);
+			wrapper.RemoveHandler(FirstSubscriber);
+			Assert.IsTrue(onLast);
+		}
+
+		[TestMethod]
+		public void When_Multiple_Subscribers_OnLast_Once()
+		{
+			void FirstSubscriber(object sender, EventArgs e)
+			{
+			}
+
+			void SecondSubscriber(object sender, EventArgs e)
+			{
+			}
+			var onLastCounter = 0;
+			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => onLastCounter++);
+			wrapper.AddHandler(FirstSubscriber);
+			wrapper.AddHandler(SecondSubscriber);
+			Assert.AreEqual(0, onLastCounter);
+			wrapper.RemoveHandler(FirstSubscriber);
+			wrapper.RemoveHandler(SecondSubscriber);
+			Assert.AreEqual(1, onLastCounter);
+		}
+
+		[TestMethod]
+		public void When_Fake_Unsubscribe_OnLast_Once()
+		{
+			void FirstSubscriber(object sender, EventArgs e)
+			{
+			}
+
+			var onLastCounter = 0;
+			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => onLastCounter++);
+			wrapper.AddHandler(FirstSubscriber);
+			Assert.AreEqual(0, onLastCounter);
+			wrapper.RemoveHandler(FirstSubscriber);
+			wrapper.RemoveHandler(FirstSubscriber);
+			Assert.AreEqual(1, onLastCounter);
+		}
+
+		[TestMethod]
+		public void When_Multiple_Subscribers_Sequence_OnLast()
+		{
+			void FirstSubscriber(object sender, EventArgs e)
+			{
+			}
+
+			void SecondSubscriber(object sender, EventArgs e)
+			{
+			}
+
+			var onLastCounter = 0;
+			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => onLastCounter++);
+			wrapper.AddHandler(FirstSubscriber);
+			wrapper.AddHandler(SecondSubscriber);
+			Assert.AreEqual(0, onLastCounter);
+			wrapper.RemoveHandler(FirstSubscriber);
+			wrapper.RemoveHandler(SecondSubscriber);
+			Assert.AreEqual(1, onLastCounter);
+			wrapper.AddHandler(FirstSubscriber);
+			wrapper.RemoveHandler(FirstSubscriber);
+			Assert.AreEqual(2, onLastCounter);
+		}
+	}
+}

--- a/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
@@ -5,16 +5,27 @@ namespace Uno.Helpers
 	internal class StartStopEventWrapper<TDelegate>
 		where TDelegate : Delegate
 	{
-		private readonly object _syncLock = new object();
+		private readonly object _syncLock;
 		private readonly Action _onFirst;
 		private readonly Action _onLast;
 
+		/// <summary>
+		/// Creates a wrapper around an event, which needs to be synchronized
+		/// and needs to run an action when first subscriber is added and when
+		/// last subscriber is removed.
+		/// </summary>
+		/// <param name="onFirst">Action to run when first subscriber is added.</param>
+		/// <param name="onLast">Action to run when last subscriber is removed.</param>
+		/// <param name="sharedLock">Optional shared object to lock on (when multiple events
+		/// rely on the same native platform operation.</param>
 		public StartStopEventWrapper(
 			Action onFirst,
-			Action onLast)
+			Action onLast,
+			object sharedLock = null)
 		{
 			_onFirst = onFirst;
 			_onLast = onLast;
+			_syncLock = sharedLock ?? new object();
 		}
 
 		public TDelegate Event { get; private set; } = null;

--- a/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace Uno.Helpers
+{
+	internal class StartStopEventWrapper<TDelegate>
+		where TDelegate : Delegate
+	{
+		private readonly object _syncLock = new object();
+		private readonly Action _onFirst;
+		private readonly Action _onLast;
+
+		public StartStopEventWrapper(
+			Action onFirst,
+			Action onLast)
+		{
+			_onFirst = onFirst;
+			_onLast = onLast;
+		}
+
+		public TDelegate Event { get; private set; } = null;
+
+		public void AddHandler(TDelegate handler)
+		{
+			lock (_syncLock)
+			{
+				var firstSubscriber = Event == null;
+				Event = (TDelegate)Delegate.Combine(Event, handler);
+				if (firstSubscriber)
+				{
+					_onFirst();
+				}
+			}
+		}
+
+		public void RemoveHandler(TDelegate handler)
+		{
+			lock (_syncLock)
+			{
+				if (Event != null)
+				{
+					Event = (TDelegate)Delegate.Remove(Event, handler);
+					if (Event == null)
+					{
+						_onLast();
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
@@ -1,7 +1,16 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 
 namespace Uno.Helpers
 {
+	/// <summary>
+	/// Creates a wrapper around an event, which needs to be synchronized
+	/// and needs to run an action when first subscriber is added and when
+	/// last subscriber is removed. The operations executed when first subscriber
+	/// is added and last subscriber is removed will execute within
+	/// a synchronization lock, so please avoid blocking within the actions.
+	/// </summary>
 	internal class StartStopEventWrapper<TDelegate>
 		where TDelegate : Delegate
 	{
@@ -10,25 +19,25 @@ namespace Uno.Helpers
 		private readonly Action _onLast;
 
 		/// <summary>
-		/// Creates a wrapper around an event, which needs to be synchronized
-		/// and needs to run an action when first subscriber is added and when
-		/// last subscriber is removed.
+		/// Creates a new instance of start-stop event wrapper.
 		/// </summary>
-		/// <param name="onFirst">Action to run when first subscriber is added.</param>
-		/// <param name="onLast">Action to run when last subscriber is removed.</param>
+		/// <param name="onFirst">Action to run when first subscriber is added.
+		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
+		/// <param name="onLast">Action to run when last subscriber is removed.
+		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
 		/// <param name="sharedLock">Optional shared object to lock on (when multiple events
 		/// rely on the same native platform operation.</param>
 		public StartStopEventWrapper(
 			Action onFirst,
 			Action onLast,
-			object sharedLock = null)
+			object? sharedLock = null)
 		{
 			_onFirst = onFirst;
 			_onLast = onLast;
 			_syncLock = sharedLock ?? new object();
 		}
 
-		public TDelegate Event { get; private set; } = null;
+		public TDelegate? Event { get; private set; } = null;
 
 		public void AddHandler(TDelegate handler)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3310 

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Code duplication of event handlers which need to start/stop a native platform action on first/last subscriber.

## What is the new behavior?

Avoided code duplication with a custom event wrapper.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.