### PR TITLE
feat: Add Uno.UI package to UWP in templates

### DIFF
--- a/src/SolutionTemplate/UnoLibraryTemplate/CrossTargetedLibrary.csproj
+++ b/src/SolutionTemplate/UnoLibraryTemplate/CrossTargetedLibrary.csproj
@@ -11,10 +11,8 @@
 		<DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='MonoAndroid90' or '$(TargetFramework)'=='monoandroid10.0' or '$(TargetFramework)'=='netstandard2.0'">
-		<PackageReference Include="Uno.UI" Version="2.2.0" />
-	</ItemGroup>
-
+	<PackageReference Include="Uno.UI" Version="2.2.0" />
+	
 	<ItemGroup>
 	  <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 		<Compile Update="**\*.xaml.cs">

--- a/src/SolutionTemplate/UnoSolutionTemplate/UWP/UnoQuickStart.Uwp.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UWP/UnoQuickStart.Uwp.csproj
@@ -10,9 +10,10 @@
 			-->
 			<Version>6.2.2</Version>
 		</PackageReference>
+		<PackageReference Include="Uno.Core" Version="2.0.0" />
+		<PackageReference Include="Uno.UI" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-    <PackageReference Include="Uno.Core" Version="2.0.0" />
 	</ItemGroup>
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #2822

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

The UWP project head does not reference Uno.UI in the solution template. However, Uno.UI for UWP target contains only the Uno.UI.Toolkit reference, which is very useful to get `VisibleBoundsPadding` and other extensions, which are very commonly used and should be accessible out of the box.

From my own experience, I thought Uno.UI.Toolkit was referenced by Uno.Core, which is why I reported #2822 a while back. Referencing Uno.UI manually is a bit counterintuitive if it is not done by the template in the first place.

## What is the new behavior?

UWP project head and library template reference Uno.UI NuGet package.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.