### PR TITLE
feat: Window.Activated, Window.VisibilityChanged, Application.Entered/LeavingBackground

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3656,6 +3656,15 @@
 			<Member
 				fullName="System.Void Windows.UI.Xaml.Controls.SwipeItems.set_IsReadOnly(System.Boolean value)"
 				reason="Not part of the UWP API" />
+			<Member
+				fullName="System.Void Windows.UI.Core.WindowSizeChangedEventArgs..ctor(Windows.Foundation.Size newSize)"
+				reason="Not part of the UWP API" />
+			<Member
+				fullName="System.Void Windows.ApplicationModel.EnteredBackgroundEventArgs..ctor()"
+				reason="Not part of the UWP API" />
+			<Member
+				fullName="System.Void Windows.ApplicationModel.LeavingBackgroundEventArgs..ctor()"
+				reason="Not part of the UWP API" />
 		</Methods>
 		<Fields>
 		</Fields>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3662,25 +3662,6 @@
 		<Properties>
 		</Properties>
 	</IgnoreSet>
-	<IgnoreSet baseVersion="3.7.3">
-		<Types>
-		</Types>
-		<Methods>
-			<Member
-				fullName="System.Void Windows.UI.Core.WindowSizeChangedEventArgs..ctor(Windows.Foundation.Size newSize)"
-				reason="Not part of the UWP API" />
-			<Member
-				fullName="System.Void Windows.ApplicationModel.EnteredBackgroundEventArgs..ctor()"
-				reason="Not part of the UWP API" />
-			<Member
-				fullName="System.Void Windows.ApplicationModel.LeavingBackgroundEventArgs..ctor()"
-				reason="Not part of the UWP API" />
-		</Methods>
-		<Fields>
-		</Fields>
-		<Properties>
-		</Properties>
-	</IgnoreSet>
 	<IgnoreSet baseVersion="3.7.4">
 		<Types>
 			<Member
@@ -3691,6 +3672,15 @@
 			<Member
 				fullName="System.Void Windows.UI.Xaml.FrameworkElement.Dispose()"
 				reason="Not part of the UWP API + false positive, it's not something changed in the source" />
+			<Member
+				fullName="System.Void Windows.UI.Core.WindowSizeChangedEventArgs..ctor(Windows.Foundation.Size newSize)"
+				reason="Not part of the UWP API" />
+			<Member
+				fullName="System.Void Windows.ApplicationModel.EnteredBackgroundEventArgs..ctor()"
+				reason="Not part of the UWP API" />
+			<Member
+				fullName="System.Void Windows.ApplicationModel.LeavingBackgroundEventArgs..ctor()"
+				reason="Not part of the UWP API" />
 		</Methods>
 		<Fields>
 		</Fields>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3656,6 +3656,16 @@
 			<Member
 				fullName="System.Void Windows.UI.Xaml.Controls.SwipeItems.set_IsReadOnly(System.Boolean value)"
 				reason="Not part of the UWP API" />
+		</Methods>
+		<Fields>
+		</Fields>
+		<Properties>
+		</Properties>
+	</IgnoreSet>
+	<IgnoreSet baseVersion="3.7.3">
+		<Types>
+		</Types>
+		<Methods>
 			<Member
 				fullName="System.Void Windows.UI.Core.WindowSizeChangedEventArgs..ctor(Windows.Foundation.Size newSize)"
 				reason="Not part of the UWP API" />

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -497,6 +497,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Core\WindowActivationTests.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\CaptureTests\OverlappedControls.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4473,6 +4477,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Core\CloseRequestedTests.xaml.cs">
       <DependentUpon>CloseRequestedTests.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Core\WindowActivationTests.xaml.cs">
+      <DependentUpon>WindowActivationTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\DoubleTappedTests.xaml.cs">
       <DependentUpon>DoubleTappedTests.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml
@@ -8,12 +8,22 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d">
 
-    <StackPanel Padding="12" Spacing="8">
-        <TextBlock Text="CoreWindow activation state" />
-        <TextBlock FontSize="30" Text="{x:Bind Model.CoreWindowActivationState, Mode=OneWay}" />
-        <TextBlock Text="CoreWindow activation mode" />
-        <TextBlock FontSize="30" Text="{x:Bind Model.CoreWindowActivationMode, Mode=OneWay}" />
-        <TextBlock Text="Last change" />
-        <TextBlock Text="{x:Bind Model.ChangeTime, Mode=OneWay}" />
-    </StackPanel>
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<StackPanel Padding="12" Spacing="8">
+			<TextBlock Text="CoreWindow activation state" />
+			<TextBlock FontSize="30" Text="{x:Bind Model.CoreWindowActivationState, Mode=OneWay}" />
+			<TextBlock Text="CoreWindow activation mode" />
+			<TextBlock FontSize="30" Text="{x:Bind Model.CoreWindowActivationMode, Mode=OneWay}" />
+			<TextBlock Text="Window Visibility" />
+			<TextBlock Text="{x:Bind Model.WindowVisibility, Mode=OneWay}" />
+			<TextBlock Text="Last change" />
+			<TextBlock Text="{x:Bind Model.ChangeTime, Mode=OneWay}" />
+			<Button Command="{x:Bind Model.ClearHistoryCommand}"  Content="Clear event history" />
+		</StackPanel>
+		<ListView Grid.Row="1" ItemsSource="{x:Bind Model.History, Mode=OneWay}" />
+	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml
@@ -1,0 +1,19 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Core.WindowActivationTests"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:UITests.Windows_UI_Core"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <StackPanel Padding="12" Spacing="8">
+        <TextBlock Text="CoreWindow activation state" />
+        <TextBlock FontSize="30" Text="{x:Bind Model.CoreWindowActivationState, Mode=OneWay}" />
+        <TextBlock Text="CoreWindow activation mode" />
+        <TextBlock FontSize="30" Text="{x:Bind Model.CoreWindowActivationMode, Mode=OneWay}" />
+        <TextBlock Text="Last change" />
+        <TextBlock Text="{x:Bind Model.ChangeTime, Mode=OneWay}" />
+    </StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
@@ -109,14 +109,20 @@ namespace UITests.Windows_UI_Core
 			}
 		}
 
-		private void CoreWindowActivated(CoreWindow sender, WindowActivatedEventArgs args)
+		private void CoreWindowActivated(CoreWindow sender, Windows.UI.Core.WindowActivatedEventArgs args)
 		{
 			CoreWindowActivationState = args.WindowActivationState;
 			CoreWindowActivationMode = sender.ActivationMode;
 			AddHistory("CoreWindow.Activated");
 		}
 
-		private void WindowActivated(object sender, WindowActivatedEventArgs e)
+		private void WindowActivated(object sender,
+#if HAS_
+			Microsoft.UI.Xaml.WindowActivatedEventArgs e
+#else
+			Windows.UI.Core.WindowActivatedEventArgs e
+#endif
+			)
 		{
 			CoreWindowActivationState = e.WindowActivationState;
 			AddHistory("Window.Activated");
@@ -130,12 +136,12 @@ namespace UITests.Windows_UI_Core
 
 
 		private void AppLeavingBackground(object sender, Windows.ApplicationModel.LeavingBackgroundEventArgs e)
-		{			
+		{
 			AddHistory("Application.LeavingBackground");
 		}
 
 		private void AppEnteredBackground(object sender, Windows.ApplicationModel.EnteredBackgroundEventArgs e)
-		{			
+		{
 			AddHistory("Application.EnteredBackground");
 		}
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.Disposables;
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.UITests.Helpers;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Core;
+using Windows.UI.WebUI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Core
+{
+	[SampleControlInfo("Windows.UI.Core", viewModelType: typeof(WindowActivationViewModel))]
+    public sealed partial class WindowActivationTests : Page
+    {
+        public WindowActivationTests()
+        {
+            this.InitializeComponent();
+			this.DataContextChanged += WindowActivationTests_DataContextChanged;
+        }
+
+		public WindowActivationViewModel Model { get; private set; }
+
+		private void WindowActivationTests_DataContextChanged(DependencyObject sender, DataContextChangedEventArgs args)
+		{
+			Model = (WindowActivationViewModel)args.NewValue;
+		}
+	}
+
+	public class WindowActivationViewModel : ViewModelBase
+	{
+		private string _changeTime;
+		private CoreWindowActivationState _coreWindowActivationState;
+		private CoreWindowActivationMode _coreWindowActivationMode;
+
+		public WindowActivationViewModel(CoreDispatcher dispatcher) : base(dispatcher)
+		{			
+			CoreWindow.GetForCurrentThread().Activated += WindowActivationViewModel_Activated;
+			Disposables.Add(() =>
+			{
+				CoreWindow.GetForCurrentThread().Activated -= WindowActivationViewModel_Activated;
+			});
+		}
+
+		private void WindowActivationViewModel_Activated(CoreWindow sender, WindowActivatedEventArgs args)
+		{
+			CoreWindowActivationState = args.WindowActivationState;
+			CoreWindowActivationMode = sender.ActivationMode;
+			ChangeTime = DateTime.Now.ToLongTimeString();
+		}
+
+		public CoreWindowActivationState CoreWindowActivationState
+		{
+			get => _coreWindowActivationState;
+			set
+			{
+				_coreWindowActivationState = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public CoreWindowActivationMode CoreWindowActivationMode
+		{
+			get => _coreWindowActivationMode;
+			set
+			{
+				_coreWindowActivationMode = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public string ChangeTime
+		{
+			get => _changeTime;
+			set
+			{
+				_changeTime = value;
+				RaisePropertyChanged();
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
@@ -52,12 +52,16 @@ namespace UITests.Windows_UI_Core
 			CoreWindow.GetForCurrentThread().Activated += CoreWindowActivated;
 			XamlWindow.Current.Activated += WindowActivated;
 			XamlWindow.Current.VisibilityChanged += WindowVisibilityChanged;
+			Application.Current.EnteredBackground += AppEnteredBackground;
+			Application.Current.LeavingBackground += AppLeavingBackground;
 
 			Disposables.Add(() =>
 			{
 				CoreWindow.GetForCurrentThread().Activated -= CoreWindowActivated;
 				XamlWindow.Current.Activated -= WindowActivated;
 				XamlWindow.Current.VisibilityChanged -= WindowVisibilityChanged;
+				Application.Current.EnteredBackground -= AppEnteredBackground;
+				Application.Current.LeavingBackground -= AppLeavingBackground;
 			});
 		}
 
@@ -109,29 +113,38 @@ namespace UITests.Windows_UI_Core
 		{
 			CoreWindowActivationState = args.WindowActivationState;
 			CoreWindowActivationMode = sender.ActivationMode;
-			ChangeTime = DateTime.Now.ToLongTimeString();
 			AddHistory("CoreWindow.Activated");
 		}
 
 		private void WindowActivated(object sender, WindowActivatedEventArgs e)
 		{
 			CoreWindowActivationState = e.WindowActivationState;
-			ChangeTime = DateTime.Now.ToLongTimeString();
 			AddHistory("Window.Activated");
 		}
 
 		private void WindowVisibilityChanged(object sender, VisibilityChangedEventArgs e)
 		{
 			WindowVisibility = XamlWindow.Current.Visible ? "Visible" : "Hidden";
-			ChangeTime = DateTime.Now.ToLongTimeString();
 			AddHistory("Window.VisibilityChanged");
+		}
+
+
+		private void AppLeavingBackground(object sender, Windows.ApplicationModel.LeavingBackgroundEventArgs e)
+		{			
+			AddHistory("Application.LeavingBackground");
+		}
+
+		private void AppEnteredBackground(object sender, Windows.ApplicationModel.EnteredBackgroundEventArgs e)
+		{			
+			AddHistory("Application.EnteredBackground");
 		}
 
 		private void AddHistory(string eventName)
 		{
+			ChangeTime = DateTime.Now.ToLongTimeString();
 			var historyItem =
-				$"{DateTime.Now.ToShortTimeString()} | {eventName} | State: {CoreWindowActivationState} " +
-				$"| Mode: {CoreWindowActivationMode} | Visibility: {WindowVisibility}";
+				$"{DateTime.Now.ToLongTimeString()} | {eventName} | State: {CoreWindowActivationState} " +
+				$"| Mode: {CoreWindow.GetForCurrentThread().ActivationMode} | Visibility: {XamlWindow.Current.Visible}";
 			History.Insert(0, historyItem);
 		}
 	}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
@@ -117,7 +117,7 @@ namespace UITests.Windows_UI_Core
 		}
 
 		private void WindowActivated(object sender,
-#if HAS_
+#if HAS_UNO_WINUI
 			Microsoft.UI.Xaml.WindowActivatedEventArgs e
 #else
 			Windows.UI.Core.WindowActivatedEventArgs e

--- a/src/Uno.UI.RemoteControl.Host/Startup.cs
+++ b/src/Uno.UI.RemoteControl.Host/Startup.cs
@@ -22,7 +22,7 @@ namespace Uno.UI.RemoteControl.Host
 
 		public IConfiguration Configuration { get; }
 
-		public void Configure(IApplicationBuilder app, IOptionsMonitor<RemoteControlOptions> optionsAccessor, IHostingEnvironment env)
+		public void Configure(IApplicationBuilder app, IOptionsMonitor<RemoteControlOptions> optionsAccessor)
 		{
 			var provider = new ServiceLocatorAdapter(app.ApplicationServices);
 			ServiceLocator.SetLocatorProvider(() => provider);

--- a/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net47;netcoreapp3.1;net5.0-windows</TargetFrameworks>
   </PropertyGroup>
 
 	<Import Project="../netcore-build-windows.props" />

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -108,6 +108,10 @@ namespace Uno.UI.Skia.Platform
 
 			WinUI.Window.InvalidateRender += () => InvalidateVisual();
 
+			WpfApplication.Current.Activated += Current_Activated;
+			WpfApplication.Current.Deactivated += Current_Deactivated;
+			WpfApplication.Current.MainWindow.StateChanged += MainWindow_StateChanged;
+
 			SizeChanged += WpfHost_SizeChanged;
 			Loaded += WpfHost_Loaded;
 		}
@@ -117,6 +121,32 @@ namespace Uno.UI.Skia.Platform
 			base.OnApplyTemplate();
 
 			_nativeOverlayLayer = GetTemplateChild(NativeOverlayLayerPart) as WpfCanvas;
+		}
+
+		private void MainWindow_StateChanged(object? sender, EventArgs e)
+		{
+			var wpfWindow = WpfApplication.Current.MainWindow;
+			var winUIWindow = WinUI.Window.Current;
+			var isVisible = wpfWindow.WindowState != WindowState.Minimized;
+			winUIWindow.OnVisibilityChanged(isVisible);
+		}
+
+		private void Current_Deactivated(object? sender, EventArgs e)
+		{
+			var winUIWindow = WinUI.Window.Current;
+			winUIWindow?.OnActivated(Windows.UI.Core.CoreWindowActivationState.Deactivated);
+
+			var application = WinUI.Application.Current;
+			application?.OnEnteredBackground();
+		}
+
+		private void Current_Activated(object? sender, EventArgs e)
+		{
+			var application = WinUI.Application.Current;
+			application?.OnLeavingBackground();
+
+			var winUIWindow = WinUI.Window.Current;
+			winUIWindow?.OnActivated(Windows.UI.Core.CoreWindowActivationState.CodeActivated);
 		}
 
 		private void WpfHost_Loaded(object sender, RoutedEventArgs e)

--- a/src/Uno.UI/BaseActivity.Android.cs
+++ b/src/Uno.UI/BaseActivity.Android.cs
@@ -217,8 +217,8 @@ namespace Uno.UI
 		{
 			ResignCurrent();
 
-			Windows.UI.Xaml.Application.Current?.OnEnteredBackground();
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
+			Windows.UI.Xaml.Application.Current?.OnEnteredBackground();
 		}
 
 		partial void InnerDestroy() => ResignCurrent();

--- a/src/Uno.UI/BaseActivity.Android.cs
+++ b/src/Uno.UI/BaseActivity.Android.cs
@@ -179,23 +179,47 @@ namespace Uno.UI
 
 		partial void InnerCreateWithPersistedState(Android.OS.Bundle bundle, PersistableBundle persistentState) => SetAsCurrent();
 
-		partial void InnerStart() => SetAsCurrent();
+		partial void InnerStart()
+		{
+			SetAsCurrent();
+
+			Windows.UI.Xaml.Application.Current?.OnLeavingBackground();
+			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
+		}
 
 		partial void InnerRestart() => SetAsCurrent();
 		
 		partial void InnerResume()
 		{
-			SetAsCurrent();
+			SetAsCurrent();			
+
 			Windows.UI.Xaml.Application.Current?.OnResuming();
+			Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.CodeActivated);
+		}
+
+		partial void InnerTopResumedActivityChanged(bool isTopResumedActivity)
+		{
+			Windows.UI.Xaml.Window.Current?.OnActivated(
+				isTopResumedActivity ?
+					CoreWindowActivationState.CodeActivated :
+					CoreWindowActivationState.Deactivated);
 		}
 
 		partial void InnerPause()
 		{
 			ResignCurrent();
+
+			Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.Deactivated);
 			Windows.UI.Xaml.Application.Current?.OnSuspending();
 		}
 
-		partial void InnerStop() => ResignCurrent();
+		partial void InnerStop()
+		{
+			ResignCurrent();
+
+			Windows.UI.Xaml.Application.Current?.OnEnteredBackground();
+			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
+		}
 
 		partial void InnerDestroy() => ResignCurrent();
 

--- a/src/Uno.UI/BaseActivity.Callbacks.Implementation.Android.tt
+++ b/src/Uno.UI/BaseActivity.Callbacks.Implementation.Android.tt
@@ -86,6 +86,7 @@ var overridableMethods = @"
 	protected virtual void OnRestoreInstanceState(Bundle savedInstanceState);
 	public virtual void OnRestoreInstanceState(Bundle savedInstanceState, PersistableBundle persistentState);RestoreInstanceStateWithPersistedState
 	protected virtual void OnResume();
+	public virtual void OnTopResumedActivityChanged(bool isTopResumedActivity);
 	//public virtual Java.Lang.Object OnRetainNonConfigurationInstance();
 	protected virtual void OnSaveInstanceState(Bundle outState);
 	public virtual void OnSaveInstanceState(Bundle outState, PersistableBundle outPersistentState);SaveInstanceStateWithPersistedState

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -604,6 +604,30 @@ namespace Uno.UI.Controls
 				_window = window;
 			}
 
+			public override void DidMiniaturize(NSNotification notification)
+			{
+				Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
+				Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.Deactivated);
+				Windows.UI.Xaml.Application.Current?.OnEnteredBackground();
+			}
+
+			public override void DidDeminiaturize(NSNotification notification)
+			{
+				Windows.UI.Xaml.Application.Current?.OnLeavingBackground();
+				Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
+				Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.CodeActivated);
+			}
+
+			public override void DidBecomeKey(NSNotification notification)
+			{
+				Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.CodeActivated);
+			}
+
+			public override void DidResignKey(NSNotification notification)
+			{
+				Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.Deactivated);
+			}
+
 			public override async void DidBecomeMain(NSNotification notification)
 			{
 				ApplicationView.GetForCurrentView().SyncTitleWithWindow(_window);

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/Application.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/Application.cs
@@ -148,7 +148,7 @@ namespace Windows.UI.Xaml
 		// Skipping already declared event Windows.UI.Xaml.Application.Resuming
 		// Skipping already declared event Windows.UI.Xaml.Application.Suspending
 		// Skipping already declared event Windows.UI.Xaml.Application.UnhandledException
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  event global::Windows.UI.Xaml.EnteredBackgroundEventHandler EnteredBackground
 		{
@@ -164,7 +164,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  event global::Windows.UI.Xaml.LeavingBackgroundEventHandler LeavingBackground
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/EnteredBackgroundEventHandler.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/EnteredBackgroundEventHandler.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	public delegate void EnteredBackgroundEventHandler(object @sender, global::Windows.ApplicationModel.EnteredBackgroundEventArgs @e);
 	#endif
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/LeavingBackgroundEventHandler.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/LeavingBackgroundEventHandler.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	public delegate void LeavingBackgroundEventHandler(object @sender, global::Windows.ApplicationModel.LeavingBackgroundEventArgs @e);
 	#endif
 }

--- a/src/Uno.UI/LinkerDefinition.Wasm.xml
+++ b/src/Uno.UI/LinkerDefinition.Wasm.xml
@@ -15,7 +15,8 @@
 	</type>
 	<type fullname="Windows.UI.Xaml.Application">
 	  <method name="DispatchSuspending" />
-	  <method name="DispatchSystemThemeChange" />
+      <method name="DispatchSystemThemeChange" />
+      <method name="DispatchVisibilityChange" />
 	</type>
   </assembly>
 

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -47,6 +47,7 @@ namespace Windows.UI.Xaml
 		private ApplicationTheme? _requestedTheme;
 		private bool _systemThemeChangesObserved = false;
 		private SpecializedResourceDictionary.ResourceKey _requestedThemeForResources;
+		private bool _isInBackground = false;
 
 		static Application()
 		{
@@ -258,9 +259,23 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		internal void OnEnteredBackground() => EnteredBackground?.Invoke(this, new EnteredBackgroundEventArgs());
+		internal void OnEnteredBackground()
+		{
+			if (!_isInBackground)
+			{
+				_isInBackground = true;
+				EnteredBackground?.Invoke(this, new EnteredBackgroundEventArgs());
+			}
+		}
 
-		internal void OnLeavingBackground() => LeavingBackground?.Invoke(this, new LeavingBackgroundEventArgs());
+		internal void OnLeavingBackground()
+		{
+			if (_isInBackground)
+			{
+				_isInBackground = false;
+				LeavingBackground?.Invoke(this, new LeavingBackgroundEventArgs());
+			}
+		}
 
 		internal void OnResuming()
 		{

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -165,13 +165,33 @@ namespace Windows.UI.Xaml
 		public ResourceDictionary Resources { get; set; } = new ResourceDictionary();
 
 #pragma warning disable CS0067 // The event is never used
+		/// <summary>
+		/// Occurs when the application transitions from Suspended state to Running state.
+		/// </summary>
 		public event EventHandler<object> Resuming;
 #pragma warning restore CS0067 // The event is never used
 
 #pragma warning disable CS0067 // The event is never used
+		/// <summary>
+		/// Occurs when the application transitions to Suspended state from some other state.
+		/// </summary>
 		public event SuspendingEventHandler Suspending;
 #pragma warning restore CS0067 // The event is never used
 
+		/// <summary>
+		/// Occurs when the app moves from the foreground to the background.
+		/// </summary>
+		public event EnteredBackgroundEventHandler EnteredBackground;
+
+		/// <summary>
+		/// Occurs when the app moves from the background to the foreground.
+		/// </summary>
+		public event LeavingBackgroundEventHandler LeavingBackground;
+
+		/// <summary>
+		/// Occurs when an exception can be handled by app code, as forwarded from a native-level Windows Runtime error.
+		/// Apps can mark the occurrence as handled in event data.
+		/// </summary>
 		public event UnhandledExceptionEventHandler UnhandledException;
 
 		public void OnSystemThemeChanged()
@@ -237,6 +257,10 @@ namespace Windows.UI.Xaml
 				return null;
 			}
 		}
+
+		internal void OnEnteredBackground() => EnteredBackground?.Invoke(this, new EnteredBackgroundEventArgs());
+
+		internal void OnLeavingBackground() => LeavingBackground?.Invoke(this, new LeavingBackgroundEventArgs());
 
 		internal void OnResuming()
 		{

--- a/src/Uno.UI/UI/Xaml/EnteredBackgroundEventHandler.cs
+++ b/src/Uno.UI/UI/Xaml/EnteredBackgroundEventHandler.cs
@@ -1,0 +1,11 @@
+using Windows.ApplicationModel;
+
+namespace Windows.UI.Xaml
+{
+	/// <summary>
+	/// Represents the method that will handle the Application.EnteredBackground event.
+	/// </summary>
+	/// <param name="sender">The object where the handler is attached.</param>
+	/// <param name="e">Event data for the event.</param>
+	public delegate void EnteredBackgroundEventHandler(object sender, EnteredBackgroundEventArgs e);
+}

--- a/src/Uno.UI/UI/Xaml/LeavingBackgroundEventHandler.cs
+++ b/src/Uno.UI/UI/Xaml/LeavingBackgroundEventHandler.cs
@@ -1,0 +1,11 @@
+using Windows.ApplicationModel;
+
+namespace Windows.UI.Xaml
+{
+	/// <summary>
+	/// Represents the method that will handle the Application.LeavingBackground event.
+	/// </summary>
+	/// <param name="sender">The object where the handler is attached.</param>
+	/// <param name="e">Event data for the event.</param>
+	public delegate void LeavingBackgroundEventHandler(object sender, LeavingBackgroundEventArgs e);
+}

--- a/src/Uno.UI/UI/Xaml/Window.Desktop.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Desktop.cs
@@ -20,6 +20,8 @@ namespace Windows.UI.Xaml
 
 		public Window()
 		{
+			CoreWindow = new CoreWindow();
+
 			InitializeCommon();
 		}
 

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -18,6 +18,8 @@ namespace Windows.UI.Xaml
 	/// </summary>
 	public sealed partial class Window
 	{
+		private CoreWindowActivationState? _lastActivationState;
+
 		private List<WeakEventHelper.GenericEventHandler> _sizeChangedHandlers = new List<WeakEventHelper.GenericEventHandler>();
 
 #pragma warning disable 67
@@ -132,6 +134,9 @@ namespace Windows.UI.Xaml
 			InternalActivate();
 
 			OnActivated(CoreWindowActivationState.CodeActivated);
+
+			// Initialize visibility on first activation.
+			Visible = true;
 		}
 
 		partial void InternalActivate();
@@ -156,9 +161,13 @@ namespace Windows.UI.Xaml
 
 		internal void OnActivated(CoreWindowActivationState state)
 		{
-			var activatedEventArgs = new WindowActivatedEventArgs(state);
-			CoreWindow.OnActivated(activatedEventArgs);
-			Activated?.Invoke(this, activatedEventArgs);
+			if (_lastActivationState != state)
+			{
+				_lastActivationState = state;
+				var activatedEventArgs = new WindowActivatedEventArgs(state);
+				CoreWindow.OnActivated(activatedEventArgs);
+				Activated?.Invoke(this, activatedEventArgs);
+			}
 		}
 
 		internal void OnVisibilityChanged(bool newVisibility)

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -13,14 +13,32 @@ using Uno.Logging;
 
 namespace Windows.UI.Xaml
 {
+	/// <summary>
+	/// Represents an application window.
+	/// </summary>
 	public sealed partial class Window
 	{
 		private List<WeakEventHelper.GenericEventHandler> _sizeChangedHandlers = new List<WeakEventHelper.GenericEventHandler>();
 
 #pragma warning disable 67
+		/// <summary>
+		/// Occurs when the window has successfully been activated.
+		/// </summary>
 		public event WindowActivatedEventHandler Activated;
+
+		/// <summary>
+		/// Occurs when the window has closed.
+		/// </summary>
 		public event WindowClosedEventHandler Closed;
+
+		/// <summary>
+		/// Occurs when the app window has first rendered or has changed its rendering size.
+		/// </summary>
 		public event WindowSizeChangedEventHandler SizeChanged;
+
+		/// <summary>
+		/// Occurs when the value of the Visible property changes.
+		/// </summary>
 		public event WindowVisibilityChangedEventHandler VisibilityChanged;
 
 		private void InitializeCommon()
@@ -80,20 +98,40 @@ namespace Windows.UI.Xaml
 		/// <remarks>This element is flagged with IsVisualTreeRoot.</remarks>
 		internal UIElement RootElement => InternalGetRootElement();
 
+		/// <summary>
+		/// Gets a Rect value containing the height and width of the application window in units of effective (view) pixels.
+		/// </summary>
 		public Rect Bounds { get; private set; }
 
+		/// <summary>
+		/// Gets an internal core object for the application window.
+		/// </summary>
 		public CoreWindow CoreWindow { get; private set; }
 
+		/// <summary>
+		/// Gets the CoreDispatcher object for the Window, which is generally the CoreDispatcher for the UI thread.
+		/// </summary>
 		public CoreDispatcher Dispatcher { get; private set; }
 
-		public bool Visible { get; private set; }
+		/// <summary>
+		/// Gets a value that reports whether the window is visible.
+		/// </summary>
+		public bool Visible
+		{
+			get => CoreWindow.Visible;
+			set => CoreWindow.Visible = value;
+		}
 
+		/// <summary>
+		/// Gets the window of the current thread.
+		/// </summary>
 		public static Window Current => InternalGetCurrentWindow();
 
 		public void Activate()
 		{
 			InternalActivate();
-			Activated?.Invoke(this, new WindowActivatedEventArgs(CoreWindowActivationState.CodeActivated));
+
+			OnActivated(CoreWindowActivationState.CodeActivated);
 		}
 
 		partial void InternalActivate();
@@ -114,6 +152,22 @@ namespace Windows.UI.Xaml
 				(h, s, e) =>
 					(h as Windows.UI.Xaml.WindowSizeChangedEventHandler)?.Invoke(s, (Windows.UI.Core.WindowSizeChangedEventArgs)e)
 			);
+		}
+
+		internal void OnActivated(CoreWindowActivationState state)
+		{
+			var activatedEventArgs = new WindowActivatedEventArgs(state);
+			CoreWindow.OnActivated(activatedEventArgs);
+			Activated?.Invoke(this, activatedEventArgs);
+		}
+
+		internal void OnVisibilityChanged(bool newVisibility)
+		{
+			Visible = newVisibility;
+
+			var args = new VisibilityChangedEventArgs();
+			CoreWindow.OnVisibilityChanged(args);
+			VisibilityChanged?.Invoke(this, args);
 		}
 
 		private void RootSizeChanged(object sender, SizeChangedEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -163,11 +163,14 @@ namespace Windows.UI.Xaml
 
 		internal void OnVisibilityChanged(bool newVisibility)
 		{
-			Visible = newVisibility;
+			if (Visible != newVisibility)
+			{
+				Visible = newVisibility;
 
-			var args = new VisibilityChangedEventArgs();
-			CoreWindow.OnVisibilityChanged(args);
-			VisibilityChanged?.Invoke(this, args);
+				var args = new VisibilityChangedEventArgs();
+				CoreWindow.OnVisibilityChanged(args);
+				VisibilityChanged?.Invoke(this, args);
+			}
 		}
 
 		private void RootSizeChanged(object sender, SizeChangedEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -165,7 +165,15 @@ namespace Windows.UI.Xaml
 			{
 				_lastActivationState = state;
 				var activatedEventArgs = new WindowActivatedEventArgs(state);
-				CoreWindow.OnActivated(activatedEventArgs);
+#if HAS_UNO_WINUI
+				// There are two "versions" of WindowActivatedEventArgs in Uno currently
+				// when using WinUI, we need to use "legacy" version to work with CoreWindow
+				// (which will eventually be removed as a legacy API as well.
+				var coreWindowActivatedEventArgs = new Windows.UI.Core.WindowActivatedEventArgs(state);
+#else
+				var coreWindowActivatedEventArgs = activatedEventArgs;
+#endif
+				CoreWindow.OnActivated(coreWindowActivatedEventArgs);
 				Activated?.Invoke(this, activatedEventArgs);
 			}
 		}
@@ -198,7 +206,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		#region Drag and Drop
+#region Drag and Drop
 		private DragRoot _dragRoot;
 
 		internal DragDropManager DragDrop { get; private set; }
@@ -243,6 +251,6 @@ namespace Windows.UI.Xaml
 				}
 			}
 		}
-		#endregion
+#endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -10,6 +10,7 @@ using Windows.Foundation.Metadata;
 using Windows.UI.Core;
 using Windows.UI.Xaml.Controls;
 using Uno.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Windows.UI.Xaml
 {
@@ -163,6 +164,11 @@ namespace Windows.UI.Xaml
 		{
 			if (_lastActivationState != state)
 			{
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().LogDebug($"Window activating with {state} state.");
+				}
+
 				_lastActivationState = state;
 				var activatedEventArgs = new WindowActivatedEventArgs(state);
 #if HAS_UNO_WINUI
@@ -182,6 +188,11 @@ namespace Windows.UI.Xaml
 		{
 			if (Visible != newVisibility)
 			{
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().LogDebug($"Window visibility changing to {newVisibility}");
+				}
+
 				Visible = newVisibility;
 
 				var args = new VisibilityChangedEventArgs();

--- a/src/Uno.UI/UI/Xaml/WindowActivatedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/WindowActivatedEventArgs.cs
@@ -6,6 +6,9 @@ using Windows.UI.Core;
 
 namespace Microsoft.UI.Xaml
 {
+	/// <summary>
+	/// Contains the windows activation state information returned by the CoreWindow.Activated event.
+	/// </summary>
 	public sealed partial class WindowActivatedEventArgs
 	{
 		internal WindowActivatedEventArgs(CoreWindowActivationState windowActivationState)
@@ -13,16 +16,15 @@ namespace Microsoft.UI.Xaml
 			WindowActivationState = windowActivationState;
 		}
 
-		public bool Handled
-		{
-			get;
-			set;
-		}
+		/// <summary>
+		/// Specifies the property that gets or sets whether the window activation event was handled.
+		/// </summary>
+		public bool Handled { get; set; }
 
-		public CoreWindowActivationState WindowActivationState
-		{
-			get;
-		}
+		/// <summary>
+		/// Gets the activation state of the window at the time the Activated event was raised.
+		/// </summary>
+		public CoreWindowActivationState WindowActivationState { get; }
 	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/WindowActivatedEventHandler.cs
+++ b/src/Uno.UI/UI/Xaml/WindowActivatedEventHandler.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Runtime.InteropServices;
-using Windows.Foundation;
-using Windows.Foundation.Metadata;
 using Windows.UI.Core;
 
 namespace Windows.UI.Xaml

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -1116,8 +1116,10 @@ declare namespace Windows.UI.ViewManagement {
 declare namespace Windows.UI.Xaml {
     class Application {
         private static dispatchThemeChange;
+        private static dispatchVisibilityChange;
         static getDefaultSystemTheme(): string;
         static observeSystemTheme(): void;
+        static observeVisibility(): void;
     }
 }
 declare namespace Windows.UI.Xaml {

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -4028,8 +4028,8 @@ var Windows;
                     return null;
                 }
                 static observeSystemTheme() {
-                    if (!this.dispatchThemeChange) {
-                        this.dispatchThemeChange = Module.mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchSystemThemeChange");
+                    if (!Application.dispatchThemeChange) {
+                        Application.dispatchThemeChange = Module.mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchSystemThemeChange");
                     }
                     if (window.matchMedia) {
                         window.matchMedia('(prefers-color-scheme: dark)').addEventListener("change", () => {
@@ -4038,12 +4038,24 @@ var Windows;
                     }
                 }
                 static observeVisibility() {
-                    if (!this.dispatchVisibilityChange) {
-                        this.dispatchVisibilityChange = Module.mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchVisibilityChange");
+                    if (!Application.dispatchVisibilityChange) {
+                        Application.dispatchVisibilityChange = Module.mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchVisibilityChange");
                     }
-                    document.addEventListener("visibilitychange", () => {
-                        Application.dispatchVisibilityChange(document.visibilityState == "visible");
-                    });
+                    if (document.onvisibilitychange !== undefined) {
+                        document.addEventListener("visibilitychange", () => {
+                            Application.dispatchVisibilityChange(document.visibilityState == "visible");
+                        });
+                    }
+                    if (window.onpagehide !== undefined) {
+                        window.addEventListener("pagehide", () => {
+                            Application.dispatchVisibilityChange(false);
+                        });
+                    }
+                    if (window.onpageshow !== undefined) {
+                        window.addEventListener("pageshow", () => {
+                            Application.dispatchVisibilityChange(true);
+                        });
+                    }
                 }
             }
             Xaml.Application = Application;

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -4037,6 +4037,14 @@ var Windows;
                         });
                     }
                 }
+                static observeVisibility() {
+                    if (!this.dispatchVisibilityChange) {
+                        this.dispatchVisibilityChange = Module.mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchVisibilityChange");
+                    }
+                    document.addEventListener("visibilitychange", () => {
+                        Application.dispatchVisibilityChange(document.visibilityState == "visible");
+                    });
+                }
             }
             Xaml.Application = Application;
         })(Xaml = UI.Xaml || (UI.Xaml = {}));

--- a/src/Uno.UI/ts/Windows/UI/Xaml/Application.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/Application.ts
@@ -33,9 +33,23 @@
 				Application.dispatchVisibilityChange = (<any>Module).mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchVisibilityChange");
 			}
 
-			document.addEventListener("visibilitychange", () => {
-				Application.dispatchVisibilityChange(document.visibilityState == "visible");
-			});
+			if (document.onvisibilitychange !== undefined) {
+				document.addEventListener("visibilitychange", () => {
+					Application.dispatchVisibilityChange(document.visibilityState == "visible");
+				});
+			}
+
+			if (window.onpagehide !== undefined) {
+				window.addEventListener("pagehide", () => {
+					Application.dispatchVisibilityChange(false);
+				});
+			}
+
+			if (window.onpageshow !== undefined) {
+				window.addEventListener("pageshow", () => {
+					Application.dispatchVisibilityChange(true);
+				});
+			}
 		}
 	}
 }

--- a/src/Uno.UI/ts/Windows/UI/Xaml/Application.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/Application.ts
@@ -2,6 +2,7 @@
 
 	export class Application {
 		private static dispatchThemeChange: () => number;
+		private static dispatchVisibilityChange: (isVisible: boolean) => number;
 
 		public static getDefaultSystemTheme(): string {
 			if (window.matchMedia) {
@@ -13,19 +14,28 @@
 				}
 			}
 			return null;
-        }
+		}
 
 		public static observeSystemTheme() {
 			if (!this.dispatchThemeChange) {
 				this.dispatchThemeChange = (<any>Module).mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchSystemThemeChange");
 			}
 
-			if (window.matchMedia)
-			{
+			if (window.matchMedia) {
 				window.matchMedia('(prefers-color-scheme: dark)').addEventListener("change", () => {
 					Application.dispatchThemeChange();
 				});
 			}
 		}
-    }
+
+		public static observeVisibility() {
+			if (!this.dispatchVisibilityChange) {
+				this.dispatchVisibilityChange = (<any>Module).mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchVisibilityChange");
+			}
+
+			document.addEventListener("visibilitychange", () => {
+				Application.dispatchVisibilityChange(document.visibilityState == "visible");
+			});
+		}
+	}
 }

--- a/src/Uno.UI/ts/Windows/UI/Xaml/Application.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/Application.ts
@@ -17,8 +17,8 @@
 		}
 
 		public static observeSystemTheme() {
-			if (!this.dispatchThemeChange) {
-				this.dispatchThemeChange = (<any>Module).mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchSystemThemeChange");
+			if (!Application.dispatchThemeChange) {
+				Application.dispatchThemeChange = (<any>Module).mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchSystemThemeChange");
 			}
 
 			if (window.matchMedia) {
@@ -29,8 +29,8 @@
 		}
 
 		public static observeVisibility() {
-			if (!this.dispatchVisibilityChange) {
-				this.dispatchVisibilityChange = (<any>Module).mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchVisibilityChange");
+			if (!Application.dispatchVisibilityChange) {
+				Application.dispatchVisibilityChange = (<any>Module).mono_bind_static_method("[Uno.UI] Windows.UI.Xaml.Application:DispatchVisibilityChange");
 			}
 
 			document.addEventListener("visibilitychange", () => {

--- a/src/Uno.UWP/ApplicationModel/EnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/EnteredBackgroundEventArgs.cs
@@ -2,5 +2,8 @@ namespace Windows.ApplicationModel
 {
 	public partial class EnteredBackgroundEventArgs : IEnteredBackgroundEventArgs
 	{
+		internal EnteredBackgroundEventArgs()
+		{
+		}
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/EnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/EnteredBackgroundEventArgs.cs
@@ -1,0 +1,6 @@
+namespace Windows.ApplicationModel
+{
+	public partial class EnteredBackgroundEventArgs : IEnteredBackgroundEventArgs
+	{
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/IEnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/IEnteredBackgroundEventArgs.cs
@@ -1,0 +1,6 @@
+namespace Windows.ApplicationModel
+{
+	public partial interface IEnteredBackgroundEventArgs
+	{
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/ILeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/ILeavingBackgroundEventArgs.cs
@@ -1,0 +1,6 @@
+namespace Windows.ApplicationModel
+{
+	public partial interface ILeavingBackgroundEventArgs
+	{
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/LeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/LeavingBackgroundEventArgs.cs
@@ -1,0 +1,6 @@
+namespace Windows.ApplicationModel
+{
+	public partial class LeavingBackgroundEventArgs : ILeavingBackgroundEventArgs
+	{
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/LeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/LeavingBackgroundEventArgs.cs
@@ -2,5 +2,8 @@ namespace Windows.ApplicationModel
 {
 	public partial class LeavingBackgroundEventArgs : ILeavingBackgroundEventArgs
 	{
+		internal LeavingBackgroundEventArgs()
+		{
+		}
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/EnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/EnteredBackgroundEventArgs.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class EnteredBackgroundEventArgs : global::Windows.ApplicationModel.IEnteredBackgroundEventArgs

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/IEnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/IEnteredBackgroundEventArgs.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IEnteredBackgroundEventArgs 

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/ILeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/ILeavingBackgroundEventArgs.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface ILeavingBackgroundEventArgs 

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/LeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/LeavingBackgroundEventArgs.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class LeavingBackgroundEventArgs : global::Windows.ApplicationModel.ILeavingBackgroundEventArgs

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreWindow.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreWindow.cs
@@ -68,7 +68,7 @@ namespace Windows.UI.Core
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool Visible
 		{
@@ -78,7 +78,7 @@ namespace Windows.UI.Core
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Core.CoreWindowActivationMode ActivationMode
 		{
@@ -208,7 +208,7 @@ namespace Windows.UI.Core
 		// Forced skipping of method Windows.UI.Core.CoreWindow.ActivationMode.get
 		// Forced skipping of method Windows.UI.Core.CoreWindow.UIContext.get
 		// Skipping already declared method Windows.UI.Core.CoreWindow.GetForCurrentThread()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Core.CoreWindow, global::Windows.UI.Core.WindowActivatedEventArgs> Activated
 		{
@@ -464,7 +464,7 @@ namespace Windows.UI.Core
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Core.CoreWindow, global::Windows.UI.Core.VisibilityChangedEventArgs> VisibilityChanged
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreWindowActivationMode.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreWindowActivationMode.cs
@@ -2,22 +2,22 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Core
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum CoreWindowActivationMode 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		None,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Deactivated,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		ActivatedNotForeground,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		ActivatedInForeground,
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/ICoreWindow.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/ICoreWindow.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Core
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface ICoreWindow 
@@ -25,7 +25,7 @@ namespace Windows.UI.Core
 			get;
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.UI.Core.CoreDispatcher Dispatcher
 		{
 			get;
@@ -58,7 +58,7 @@ namespace Windows.UI.Core
 			get;
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		bool Visible
 		{
 			get;
@@ -128,7 +128,7 @@ namespace Windows.UI.Core
 		// Forced skipping of method Windows.UI.Core.ICoreWindow.SizeChanged.remove
 		// Forced skipping of method Windows.UI.Core.ICoreWindow.VisibilityChanged.add
 		// Forced skipping of method Windows.UI.Core.ICoreWindow.VisibilityChanged.remove
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		 event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Core.CoreWindow, global::Windows.UI.Core.WindowActivatedEventArgs> Activated;
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
@@ -170,13 +170,13 @@ namespace Windows.UI.Core
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		 event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Core.CoreWindow, global::Windows.UI.Core.PointerEventArgs> PointerWheelChanged;
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		 event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Core.CoreWindow, global::Windows.UI.Core.WindowSizeChangedEventArgs> SizeChanged;
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		 event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Core.CoreWindow, global::Windows.UI.Core.TouchHitTestingEventArgs> TouchHitTesting;
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		 event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Core.CoreWindow, global::Windows.UI.Core.VisibilityChangedEventArgs> VisibilityChanged;
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/ICoreWindowEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/ICoreWindowEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Core
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface ICoreWindowEventArgs 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		bool Handled
 		{
 			get;

--- a/src/Uno.UWP/UI/Core/CoreWindow.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.cs
@@ -1,6 +1,8 @@
 #nullable enable
 
 using System;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
 using Windows.Foundation;
 using Windows.UI.Input;
 
@@ -103,6 +105,12 @@ namespace Windows.UI.Core
 		internal void OnActivated(WindowActivatedEventArgs args)
 		{
 			_lastActivationState = args.WindowActivationState;
+
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug($"CoreWindow activating with {_lastActivationState} state.");
+			}
+
 			UpdateActivationMode();
 
 			Activated?.Invoke(this, args);

--- a/src/Uno.UWP/UI/Core/CoreWindow.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.cs
@@ -1,34 +1,22 @@
 #nullable enable
 
 using System;
-using System.Runtime.InteropServices;
-using Windows.ApplicationModel.Core;
 using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.Foundation.Metadata;
 using Windows.UI.Input;
 
 namespace Windows.UI.Core
 {
+	/// <summary>
+	/// Represents the UWP app with input events and basic user interface behaviors.
+	/// </summary>
 	public partial class CoreWindow
 	{
 		[ThreadStatic]
 		private static CoreWindow? _current;
-
-		public static CoreWindow? GetForCurrentThread()
-			=> _current; // UWP returns 'null' if on a BG thread
-
 		private static Action? _invalidateRender;
 
-		internal static void SetInvalidateRender(Action invalidateRender)
-			=> _invalidateRender = invalidateRender;
-
-		internal static void QueueInvalidateRender()
-			=> _invalidateRender?.Invoke();
-
-		public event TypedEventHandler<CoreWindow, WindowSizeChangedEventArgs>? SizeChanged;
-
 		private Point? _pointerPosition;
+		private CoreWindowActivationState _lastActivationState;
 
 		internal CoreWindow()
 		{
@@ -38,12 +26,31 @@ namespace Windows.UI.Core
 			InitializePartial();
 		}
 
+		/// <summary>
+		/// Occurs when the window size is changed.
+		/// </summary>
+		public event TypedEventHandler<CoreWindow, WindowSizeChangedEventArgs>? SizeChanged;
+
+		/// <summary>
+		/// Is fired when the window completes activation or deactivation.
+		/// </summary>
+		public event TypedEventHandler<CoreWindow, WindowActivatedEventArgs>? Activated;
+
+		/// <summary>
+		/// Is fired when the window visibility is changed.
+		/// </summary>
+		public event TypedEventHandler<CoreWindow, VisibilityChangedEventArgs>? VisibilityChanged;
+
 		internal static CoreWindow? Main { get; private set; }
 
+		/// <summary>
+		/// Gets the event dispatcher for the window.
+		/// </summary>
 		public CoreDispatcher Dispatcher => CoreDispatcher.Main;
 
-		internal IPointerEventArgs? LastPointerEvent { get; set; }
-
+		/// <summary>
+		/// Gets the client coordinates of the pointer.
+		/// </summary>
 		public Point PointerPosition
 		{
 			get => _pointerPosition ?? LastPointerEvent?.GetLocation(null).Position ?? new Point();
@@ -51,9 +58,31 @@ namespace Windows.UI.Core
 		}
 
 #if !__WASM__ && !__MACOS__ && !__SKIA__
+		/// <summary>
+		/// Gets or sets the cursor used by the app.
+		/// </summary>
 		[Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__NETSTD_REFERENCE__")]
 		public CoreCursor PointerCursor { get; set; } = new CoreCursor(CoreCursorType.Arrow, 0);
 #endif
+
+		/// <summary>
+		/// Gets a value that indicates whether the window is visible.
+		/// </summary>
+		public bool Visible { get; internal set; }
+
+		/// <summary>
+		/// Gets a value that indicates the activation state of the window.
+		/// </summary>
+		public CoreWindowActivationMode ActivationMode { get; private set; } = CoreWindowActivationMode.None;
+
+		internal IPointerEventArgs? LastPointerEvent { get; set; }
+
+		/// <summary>
+		/// Gets the CoreWindow instance for the currently active thread.
+		/// </summary>
+		/// <returns>The CoreWindow for the currently active thread.</returns>
+		public static CoreWindow? GetForCurrentThread()
+			=> _current; // UWP returns 'null' if on a BG thread
 
 		[Uno.NotImplemented]
 		public CoreVirtualKeyStates GetAsyncKeyState(System.VirtualKey virtualKey)
@@ -63,7 +92,21 @@ namespace Windows.UI.Core
 		public CoreVirtualKeyStates GetKeyState(System.VirtualKey virtualKey)
 			=> CoreVirtualKeyStates.None;
 
+		internal static void SetInvalidateRender(Action invalidateRender)
+			=> _invalidateRender = invalidateRender;
+
+		internal static void QueueInvalidateRender()
+			=> _invalidateRender?.Invoke();
+
 		partial void InitializePartial();
+
+		internal void OnActivated(WindowActivatedEventArgs args)
+		{
+			_lastActivationState = args.WindowActivationState;
+			UpdateActivationMode();
+
+			Activated?.Invoke(this, args);
+		}
 
 		internal void OnSizeChanged(WindowSizeChangedEventArgs windowSizeChangedEventArgs)
 			=> SizeChanged?.Invoke(this, windowSizeChangedEventArgs);
@@ -71,6 +114,27 @@ namespace Windows.UI.Core
 		internal interface IPointerEventArgs
 		{
 			PointerPoint GetLocation(object? relativeTo);
+		}
+
+		internal void OnVisibilityChanged(VisibilityChangedEventArgs visibilityChangedEventArgs)
+		{
+			UpdateActivationMode();
+
+			VisibilityChanged?.Invoke(this, visibilityChangedEventArgs);
+		}
+
+		private void UpdateActivationMode()
+		{
+			if (_lastActivationState == CoreWindowActivationState.Deactivated)
+			{
+				ActivationMode = CoreWindowActivationMode.Deactivated;
+			}
+			else
+			{
+				ActivationMode = Visible ?
+					CoreWindowActivationMode.ActivatedInForeground :
+					CoreWindowActivationMode.ActivatedNotForeground;
+			}
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Core/CoreWindowActivationMode.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindowActivationMode.cs
@@ -1,0 +1,28 @@
+﻿namespace Windows.UI.Core
+{
+	/// <summary>
+	/// Defines constants that specify the activation state of a window.
+	/// </summary>
+	public enum CoreWindowActivationMode
+	{
+		/// <summary>
+		/// No state is specified.
+		/// </summary>
+		None,
+
+		/// <summary>
+		/// The window is deactivated.
+		/// </summary>
+		Deactivated,
+
+		/// <summary>
+		/// The window is activated, but not in the foreground.
+		/// </summary>
+		ActivatedNotForeground,
+
+		/// <summary>
+		/// The window is activated and in the foreground.
+		/// </summary>
+		ActivatedInForeground,
+	}
+}

--- a/src/Uno.UWP/UI/Core/CoreWindowActivationState.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindowActivationState.cs
@@ -1,12 +1,23 @@
-using System;
-using Windows.Foundation;
-using Windows.Foundation.Metadata;
 namespace Windows.UI.Core
 {
+	/// <summary>
+	/// Specifies the set of reasons that a CoreWindow's Activated event was raised.
+	/// </summary>
 	public enum CoreWindowActivationState
 	{
+		/// <summary>
+		/// The window was activated by a call to Activate.
+		/// </summary>
 		CodeActivated,
+
+		/// <summary>
+		/// The window was deactivated.
+		/// </summary>
 		Deactivated,
+
+		/// <summary>
+		/// The window was activated by pointer interaction.
+		/// </summary>
 		PointerActivated
 	}
 }

--- a/src/Uno.UWP/UI/Core/CoreWindowEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindowEventArgs.cs
@@ -1,14 +1,13 @@
-using System;
-using Windows.Foundation;
-using Windows.Foundation.Metadata;
 namespace Windows.UI.Core
 {
-	public sealed partial class CoreWindowEventArgs
+	/// <summary>
+	/// Contains the set of arguments returned to an app after a window input or behavior event.
+	/// </summary>
+	public sealed partial class CoreWindowEventArgs : ICoreWindowEventArgs
 	{
-		public bool Handled
-		{
-			get;
-			set;
-		}
+		/// <summary>
+		/// Specifies the property that gets or sets whether the event was handled.
+		/// </summary>
+		public bool Handled { get; set; }
 	}
 }

--- a/src/Uno.UWP/UI/Core/ICoreWindow.cs
+++ b/src/Uno.UWP/UI/Core/ICoreWindow.cs
@@ -1,0 +1,37 @@
+﻿#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+using Windows.Foundation;
+
+namespace Windows.UI.Core
+{
+	/// <summary>
+	/// Specifies an interface for a window object and its input events as well as basic user interface behaviors.
+	/// </summary>
+	public partial interface ICoreWindow
+	{
+		/// <summary>
+		/// Specifies a property that gets the event dispatcher for the window.
+		/// </summary>
+		CoreDispatcher Dispatcher { get; }
+
+		/// <summary>
+		/// Specifies the property that gets whether the window is visible or not.
+		/// </summary>
+		bool Visible { get; }
+
+		/// <summary>
+		/// Specifies the event that is fired when the window completes activation or deactivation.
+		/// </summary>
+		event TypedEventHandler<CoreWindow, WindowActivatedEventArgs> Activated;
+
+		/// <summary>
+		/// Specifies the event that raises when the window size is changed.
+		/// </summary>
+		event TypedEventHandler<CoreWindow, WindowSizeChangedEventArgs> SizeChanged;
+
+		/// <summary>
+		/// Specifies the event that occurs when the window visibility is changed.
+		/// </summary>
+		event TypedEventHandler<CoreWindow, VisibilityChangedEventArgs> VisibilityChanged;
+	}
+}

--- a/src/Uno.UWP/UI/Core/ICoreWindowEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/ICoreWindowEventArgs.cs
@@ -1,0 +1,13 @@
+﻿namespace Windows.UI.Core
+{
+	/// <summary>
+	/// Defines the set of arguments returned to an app after a window input or behavior event.
+	/// </summary>
+	public partial interface ICoreWindowEventArgs
+	{
+		/// <summary>
+		/// Specifies the property that gets or sets whether the event was handled.
+		/// </summary>
+		bool Handled { get; set; }
+	}
+}

--- a/src/Uno.UWP/UI/Core/VisibilityChangedEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/VisibilityChangedEventArgs.cs
@@ -1,19 +1,18 @@
-using System;
-using Windows.Foundation;
-using Windows.Foundation.Metadata;
-
 namespace Windows.UI.Core
 {
-	public sealed partial class VisibilityChangedEventArgs
+	/// <summary>
+	/// Contains the arguments returned by the event fired when a CoreWindow instance's visibility changes.
+	/// </summary>
+	public sealed partial class VisibilityChangedEventArgs : ICoreWindowEventArgs
 	{
-		public bool Handled
-		{
-			get;
-			set;
-		}
-		public bool Visible
-		{
-			get;
-		}
+		/// <summary>
+		/// Gets or sets a value indicating whether the VisibilityChanged event was handled.
+		/// </summary>
+		public bool Handled { get; set; }
+
+		/// <summary>
+		/// Gets whether the window is visible or not.
+		/// </summary>
+		public bool Visible { get; }
 	}
 }

--- a/src/Uno.UWP/UI/Core/WindowActivatedEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/WindowActivatedEventArgs.cs
@@ -1,9 +1,8 @@
-using System;
-using Windows.Foundation;
-using Windows.Foundation.Metadata;
-
 namespace Windows.UI.Core
 {
+	/// <summary>
+	/// Contains the windows activation state information returned by the CoreWindow.Activated event.
+	/// </summary>
 	public sealed partial class WindowActivatedEventArgs
 	{
 		internal WindowActivatedEventArgs(CoreWindowActivationState windowActivationState)
@@ -11,15 +10,14 @@ namespace Windows.UI.Core
 			WindowActivationState = windowActivationState;
 		}
 
-		public bool Handled
-		{
-			get;
-			set;
-		}
+		/// <summary>
+		/// Specifies the property that gets or sets whether the window activation event was handled.
+		/// </summary>
+		public bool Handled { get; set; }
 
-		public CoreWindowActivationState WindowActivationState
-		{
-			get;
-		}
+		/// <summary>
+		/// Gets the activation state of the window at the time the Activated event was raised.
+		/// </summary>
+		public CoreWindowActivationState WindowActivationState { get; }
 	}
 }

--- a/src/Uno.UWP/UI/Core/WindowSizeChangedEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/WindowSizeChangedEventArgs.cs
@@ -1,25 +1,25 @@
-using System;
 using Windows.Foundation;
-using Windows.Foundation.Metadata;
 
 namespace Windows.UI.Core
 {
-	public sealed partial class WindowSizeChangedEventArgs
+	/// <summary>
+	/// Contains the argument returned by a window size change event.
+	/// </summary>
+	public sealed partial class WindowSizeChangedEventArgs : ICoreWindowEventArgs
 	{
-		public WindowSizeChangedEventArgs(Size newSize)
+		internal WindowSizeChangedEventArgs(Size newSize)
 		{
 			Size = newSize;
 		}
 
-		public bool Handled
-		{
-			get;
-			set;
-		}
+		/// <summary>
+		/// Gets or sets whether the window size event was handled.
+		/// </summary>
+		public bool Handled { get; set; }
 
-		public Size Size
-		{
-			get;
-		}
+		/// <summary>
+		/// Gets the new size of the window in units of effective (view) pixels.
+		/// </summary>
+		public Size Size { get; }
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3309, closes #5708

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`Window.Activated` and `VisibilityChanged` are not supported.

## What is the new behavior?

Added support for the events.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
