### PR TITLE
fix(FontWeight): changed UI.Text.FontWeight to better reflect uwp definition

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1078,6 +1078,13 @@
 				  fullName="System.Object Windows.UI.Xaml.ResourceDictionary.Lookup(System.Object key)"
 				  reason="Not a public WinUI method (in the .NET projection)"/>
 			<!-- ^^ Styles overhaul -->
+
+		<Member 
+			fullName="System.Void Windows.UI.Text.FontWeight..ctor(System.Int32 weight)"
+			reason="Changed from int to ushort to replicate uwp definition"/>
+		<Member 
+			fullName="System.Int32 Windows.UI.Text.FontWeight.get_Weight()"
+			reason="Changed from int to ushort to replicate uwp definition"/>
 	  </Methods>
 	  <Properties>
 
@@ -1092,7 +1099,10 @@
 				  fullName="Windows.UI.Xaml.Style Windows.UI.Xaml.Controls.NativePage::Style()"
 				  reason="Removed unused non-standard property"/>
 			<!-- ^^ Styles overhaul -->
-	  
+
+		<Member 
+			fullName="System.Int32 Windows.UI.Text.FontWeight::Weight()"
+			reason="Changed from int to ushort to replicate uwp definition"/>	  
 	  </Properties>
 	  <Fields>
 	  

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -112,5 +112,27 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			ImageAssert.AreEqual(before, restored);
 		}
+
+		[Test]
+		[AutoRetry]
+		public void When_FontWeight_Changed()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_FontWeight_Dynamic");
+
+			var testBlock = _app.Marked("testBlock");
+
+			testBlock.SetDependencyPropertyValue("FontWeight", "Thin");
+			var rectBefore = _app.GetRect("testBlock");
+			var widthBefore = rectBefore.Width;
+			var heightBefore = rectBefore.Height;
+
+			testBlock.SetDependencyPropertyValue("FontWeight", "Heavy");
+			var rectAfter = _app.GetRect("testBlock");
+			var widthAfter = rectAfter.Width;
+			var heightAfter = rectAfter.Height;
+
+			Assert.IsTrue(widthBefore < widthAfter);
+			Assert.IsTrue(heightBefore == heightAfter);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -917,6 +917,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FontWeight_Dynamic.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Foreground_While_Collapsed.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3775,6 +3779,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Decorations.xaml.cs">
       <DependentUpon>TextBlock_Decorations.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FontWeight_Dynamic.xaml.cs">
+      <DependentUpon>TextBlock_FontWeight_Dynamic.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Foreground_While_Collapsed.xaml.cs">
       <DependentUpon>TextBlock_Foreground_While_Collapsed.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontWeight_Dynamic.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontWeight_Dynamic.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_FontWeight_Dynamic"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+    <StackPanel>
+		<TextBlock x:Name="testBlock" HorizontalAlignment="Left" Text="My font weight will change!" FontWeight="Thin" />
+        <Button Content="Click me to change font weight!" Click="OnClick" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontWeight_Dynamic.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontWeight_Dynamic.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using FluentAssertions.Types;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Text;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[Sample("TextBlockControl")]
+	public sealed partial class TextBlock_FontWeight_Dynamic : UserControl
+	{
+		int CurrentIndex;
+		List<FontWeight> Weights;
+
+        public TextBlock_FontWeight_Dynamic()
+        {
+            this.InitializeComponent();
+			this.InitWeights();
+        }
+
+		private void InitWeights()
+		{
+			CurrentIndex = 0;
+			Weights = new List<FontWeight>();
+			Weights.Add(FontWeights.Thin);
+			Weights.Add(FontWeights.Light);
+			Weights.Add(FontWeights.Normal);
+			Weights.Add(FontWeights.Bold);
+			Weights.Add(FontWeights.Black);
+		}
+
+        private void OnClick(object sender, object args)
+        {
+			ChangeFontWeight();
+		}
+
+		private void ChangeFontWeight()
+		{
+			int nextIndex = (CurrentIndex + 1) % Weights.Count;
+			FontWeight nextWeight = Weights[nextIndex];
+			testBlock.FontWeight = nextWeight;
+			testBlock.Text = $"Font weight changed to {nextWeight.Weight}";
+			CurrentIndex = nextIndex;
+		}
+
+	}
+}

--- a/src/Uno.UWP/UI/Text/FontWeight.cs
+++ b/src/Uno.UWP/UI/Text/FontWeight.cs
@@ -6,12 +6,12 @@ namespace Windows.UI.Text
 {
 	public partial struct FontWeight
 	{
-		public FontWeight(int weight)
+		public FontWeight(ushort weight)
 		{
 			Weight = weight;
 		}
 
-		public int Weight { get; }
+		public ushort Weight { get; set; }
 
 		public override int GetHashCode() => Weight.GetHashCode();
 


### PR DESCRIPTION
fixes #3273

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
#3273

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
`FontWeight.Weight` is now read/write as well as a ushort instead of an int.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


