### PR TITLE
fix(NavigationView): toggle pane button width when light-dismissed

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_Tests.cs
@@ -32,5 +32,33 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.NavigationViewTests
 			_app.TapCoordinates(itemSaveRect.X + 5, itemSaveRect.Y + 5);
 			_app.WaitForDependencyPropertyValue(selectedItemText, "Text", "Save");
 		}
+
+		[Test]
+		[AutoRetry()]
+		public void NavigationView_OnLightDismiss_TogglePaneButton_IsSizedCorrectly()
+		{
+			Run("SamplesApp.Samples.NavigationViewSample.NavigationViewSample");
+
+			var descendants = _app.Marked("nvSample").Descendant();
+
+			var lightDismissLayer = descendants.Marked("LightDismissLayer").FirstResult();
+			var paneRoot = descendants.Marked("PaneRoot").FirstResult();
+			var togglePaneButton = descendants.Marked("TogglePaneButton").FirstResult();
+
+			Assert.AreEqual(paneRoot.Rect.Width, togglePaneButton.Rect.Width, "when NavigationView is opened, PaneRoot and TogglePaneButton should shared the same width");
+
+			// to light-dismiss the flyout, we need to tap the right side of LightDismissLayer that isnt occupied by PaneRoot
+			var dismissibleArea = new
+			{
+				CenterX = (paneRoot.Rect.GetRight() + lightDismissLayer.Rect.GetRight()) / 2,
+				CenterY = lightDismissLayer.Rect.CenterY,
+			};
+			_app.TapCoordinates(dismissibleArea.CenterX, dismissibleArea.CenterY);
+
+			// refresh because FirstResult snapshots values
+			togglePaneButton = descendants.Marked("TogglePaneButton").FirstResult();
+
+			Assert.Less(togglePaneButton.Rect.Width, paneRoot.Rect.Width, "when NavigationView is closed, TogglePaneButton should not take the width of PaneRoot");
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -3034,12 +3034,15 @@ namespace Windows.UI.Xaml.Controls
 
 					if (!m_isClosedCompact && PaneTitle?.Length > 0)
 					{
-						if (splitView.DisplayMode == SplitViewDisplayMode.Overlay && IsPaneOpen)
+						// if splitView.IsPaneOpen changed directly by SplitView,
+						// the two-way binding haven't sync'd up IsPaneOpen yet.
+						var isPaneOpen = m_isOpenPaneForInteraction ? IsPaneOpen : splitView.IsPaneOpen;
+						if (splitView.DisplayMode == SplitViewDisplayMode.Overlay && isPaneOpen)
 						{
 							width = OpenPaneLength;
 							togglePaneButtonWidth = OpenPaneLength - (ShouldShowBackButton() ? c_backButtonWidth : 0);
 						}
-						else if (!(splitView.DisplayMode == SplitViewDisplayMode.Overlay && !IsPaneOpen))
+						else if (!(splitView.DisplayMode == SplitViewDisplayMode.Overlay && !isPaneOpen))
 						{
 							width = OpenPaneLength;
 							togglePaneButtonWidth = OpenPaneLength;


### PR DESCRIPTION
GitHub Issue (If applicable): #3339

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
The `NavigationView`'s burger menu (`TogglePaneButton`) button width is bugged when light-dismissed.

## What is the new behavior?
It is resized accordingly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
