### PR TITLE
fix(MessageDialog): fixed ShowAsync not handling strings with escaped…

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/MessageDialog.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/MessageDialog.xaml
@@ -13,5 +13,6 @@
 		<Button x:Name="WithOneCommandAndTitle">With a title. A customized command is added to the dialog.</Button>
 		<Button x:Name="WithTwoCommandsAndTitle">With a title. Two customized commands are added to the dialog.</Button>
 		<Button x:Name="WithThreeCommandsAndTitle">With a title. Three customized commands are added to the dialog.</Button>
+		<Button x:Name="WithEscapedCharacters">Without a title. Message has escapable characters.</Button>
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/MessageDialog.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/MessageDialog.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Uno.UI.Samples.Controls;
+using Windows.UI.Core;
 using Windows.UI.Popups;
 using Windows.UI.Xaml.Controls;
 
@@ -19,7 +20,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Popup
 			{
 				var messageDialog = new Windows.UI.Popups.MessageDialog("No internet connection has been found.");
 
-				Task.Run(async () => await messageDialog.ShowAsync());
+				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () => await messageDialog.ShowAsync());
 			};
 
 			WithTitle.Tapped += (snd, evt) =>
@@ -27,7 +28,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Popup
 				var messageDialog = new Windows.UI.Popups.MessageDialog("No internet connection has been found.");
 				messageDialog.Title = "Internet Connectivity";
 
-				Task.Run(async () => await messageDialog.ShowAsync());
+				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () => await messageDialog.ShowAsync());
 			};
 
 
@@ -38,7 +39,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Popup
 				messageDialog.Commands.Add(new UICommand("Acknowledge", new UICommandInvokedHandler(this.CommandInvokedHandler)));
 				messageDialog.Title = "Internet Connectivity";
 
-				Task.Run(async () => await messageDialog.ShowAsync());
+				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () => await messageDialog.ShowAsync());
 			};
 
 			WithTwoCommandsAndTitle.Tapped += (snd, evt) =>
@@ -52,7 +53,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Popup
 				messageDialog.Commands.Add(new UICommand("Cancel",new UICommandInvokedHandler(this.CommandInvokedHandler)));
 				messageDialog.DefaultCommandIndex = 1;
 
-				Task.Run(async () => await messageDialog.ShowAsync());
+				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () => await messageDialog.ShowAsync());
 			};
 
 			WithThreeCommandsAndTitle.Tapped += (snd, evt) =>
@@ -68,9 +69,15 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Popup
 				messageDialog.Commands.Add(new UICommand("Cancel",new UICommandInvokedHandler(this.CommandInvokedHandler)));
 				messageDialog.CancelCommandIndex = 2;
 
-				Task.Run(async () => await messageDialog.ShowAsync());
+				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () => await messageDialog.ShowAsync());
 			};
 
+			WithEscapedCharacters.Tapped += (snd, evt) =>
+			{
+				var messageDialog = new Windows.UI.Popups.MessageDialog("\"Sample \\\"force escape test\\\" \\n \\t \\r continued sample.\"");
+				
+				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () => await messageDialog.ShowAsync());
+			};
 		}
 
 		private void CommandInvokedHandler(IUICommand command)

--- a/src/Uno.UWP/UI/Popups/MessageDialog.wasm.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.wasm.cs
@@ -16,7 +16,7 @@ namespace Windows.UI.Popups
 
 		public IAsyncOperation<IUICommand> ShowAsync()
 		{
-			var command = $"Uno.UI.WindowManager.current.alert(\"{Content}\");";
+			var command = $"Uno.UI.WindowManager.current.alert(\"{Uno.Foundation.WebAssemblyRuntime.EscapeJs(Content)}\");";
 			Uno.Foundation.WebAssemblyRuntime.InvokeJS(command);
 
 			return AsyncOperation.FromTask<IUICommand>(


### PR DESCRIPTION
… characters properly on wasm

fixes #2501

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
#2501 

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Strings with escapable characters are handled.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.