### PR TITLE
StorageFolder.CreateFileAsync(...) fixes

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1060,6 +1060,9 @@
 			<Member
 				fullName="System.Void Windows.UI.Xaml.Shapes.Shape.RefreshShape(System.Boolean forceRefresh)"
 				reason="Not part of the WinUI API." />
+			<Member
+					fullName="Windows.Foundation.IAsyncOperation`1&lt;Windows.Storage.StorageFile&gt; Windows.Storage.StorageFolder.CreateFileAsync(System.String path, Windows.Storage.CreationCollisionOption option)"
+					reason="UWP alignment" />
 			<!-- Styles overhaul -->
 			<Member
 				fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnStyleChanged(Windows.UI.Xaml.Style oldStyle, Windows.UI.Xaml.Style newStyle)"

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFolder.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFolder.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Storage;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
+{
+	[TestClass]
+	public class Given_StorageFolder
+	{
+		[TestMethod]
+		public async Task When_CreateFile_FailIfExists()
+		{
+			var folder = ApplicationData.Current.LocalFolder;
+
+			var filename = $"{Guid.NewGuid()}.txt";
+
+			await folder.CreateFileAsync(filename);
+
+			await Assert.ThrowsExceptionAsync<Exception>(() => folder.CreateFileAsync(filename).AsTask());
+		}
+
+		[TestMethod]
+		public async Task When_CreateFile_ReplaceExisting()
+		{
+			var folder = ApplicationData.Current.LocalFolder;
+
+			var filename = $"{Guid.NewGuid()}.txt";
+
+			var file = await folder.CreateFileAsync(filename);
+
+			using (var sw = new StreamWriter(await file.OpenStreamForWriteAsync()))
+			{
+				sw.Write("Failed !");
+			}
+
+			file = await folder.CreateFileAsync(filename, CreationCollisionOption.ReplaceExisting);
+
+			using (var sw = new StreamWriter(await file.OpenStreamForWriteAsync()))
+			{
+				sw.Write("OK !");
+			}
+
+			using (var sr = new StreamReader(await file.OpenStreamForReadAsync()))
+			{
+				Assert.AreEqual("OK !", sr.ReadToEnd());
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/StorageFolder.cs
+++ b/src/Uno.UWP/Storage/StorageFolder.cs
@@ -186,8 +186,10 @@ namespace Windows.Storage
 						case CreationCollisionOption.FailIfExists:
 							throw new Exception("Cannot create a file when that file already exists.");
                         case CreationCollisionOption.OpenIfExists:
+							break;
                         case CreationCollisionOption.ReplaceExisting:
-                            break;
+							File.Create(global::System.IO.Path.Combine(Path, path)).Close();
+							break;
                         case CreationCollisionOption.GenerateUniqueName:
 
                             var pathExtension = global::System.IO.Path.GetExtension(path);
@@ -200,17 +202,15 @@ namespace Windows.Storage
                                 path = path + "_" + Guid.NewGuid();
                             }
 
-                            var stream = File.Create(global::System.IO.Path.Combine(Path, path));
-                            stream.Close();
+                            File.Create(global::System.IO.Path.Combine(Path, path)).Close();
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException("option");
+                            throw new ArgumentOutOfRangeException(nameof(option));
                     }
                 }
                 else
                 {
-                    var stream = File.Create(global::System.IO.Path.Combine(Path, path));
-                    stream.Close();
+                    File.Create(global::System.IO.Path.Combine(Path, path)).Close();
                 }
 
                 return await StorageFile.GetFileFromPathAsync(global::System.IO.Path.Combine(Path, path));

--- a/src/Uno.UWP/Storage/StorageFolder.cs
+++ b/src/Uno.UWP/Storage/StorageFolder.cs
@@ -176,44 +176,44 @@ namespace Windows.Storage
 
 		public IAsyncOperation<StorageFile> CreateFileAsync(string desiredName) => CreateFileAsync(desiredName, CreationCollisionOption.FailIfExists);
 
-        public IAsyncOperation<StorageFile> CreateFileAsync(string path, CreationCollisionOption option) =>
+        public IAsyncOperation<StorageFile> CreateFileAsync(string desiredName, CreationCollisionOption options) =>
             AsyncOperation.FromTask(async ct =>
             {
-                if (File.Exists(global::System.IO.Path.Combine(Path, path)))
+                if (File.Exists(global::System.IO.Path.Combine(Path, desiredName)))
                 {
-                    switch (option)
+                    switch (options)
                     {
 						case CreationCollisionOption.FailIfExists:
 							throw new Exception("Cannot create a file when that file already exists.");
                         case CreationCollisionOption.OpenIfExists:
 							break;
                         case CreationCollisionOption.ReplaceExisting:
-							File.Create(global::System.IO.Path.Combine(Path, path)).Close();
+							File.Create(global::System.IO.Path.Combine(Path, desiredName)).Close();
 							break;
                         case CreationCollisionOption.GenerateUniqueName:
 
-                            var pathExtension = global::System.IO.Path.GetExtension(path);
+                            var pathExtension = global::System.IO.Path.GetExtension(desiredName);
                             if (!string.IsNullOrEmpty(pathExtension))
                             {
-                                path = path.Replace(pathExtension, "_" + Guid.NewGuid().ToStringInvariant().Replace("-", "") + pathExtension);
+                                desiredName = desiredName.Replace(pathExtension, "_" + Guid.NewGuid().ToStringInvariant().Replace("-", "") + pathExtension);
                             }
                             else
                             {
-                                path = path + "_" + Guid.NewGuid();
+                                desiredName = desiredName + "_" + Guid.NewGuid();
                             }
 
-                            File.Create(global::System.IO.Path.Combine(Path, path)).Close();
+                            File.Create(global::System.IO.Path.Combine(Path, desiredName)).Close();
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException(nameof(option));
+                            throw new ArgumentOutOfRangeException(nameof(options));
                     }
                 }
                 else
                 {
-                    File.Create(global::System.IO.Path.Combine(Path, path)).Close();
+                    File.Create(global::System.IO.Path.Combine(Path, desiredName)).Close();
                 }
 
-                return await StorageFile.GetFileFromPathAsync(global::System.IO.Path.Combine(Path, path));
+                return await StorageFile.GetFileFromPathAsync(global::System.IO.Path.Combine(Path, desiredName));
             });
 
         public IAsyncAction DeleteAsync() =>

--- a/src/Uno.UWP/Storage/StorageFolder.cs
+++ b/src/Uno.UWP/Storage/StorageFolder.cs
@@ -183,6 +183,8 @@ namespace Windows.Storage
                 {
                     switch (option)
                     {
+						case CreationCollisionOption.FailIfExists:
+							throw new Exception("Cannot create a file when that file already exists.");
                         case CreationCollisionOption.OpenIfExists:
                         case CreationCollisionOption.ReplaceExisting:
                             break;


### PR DESCRIPTION
Fixes #1067, Fixes #3123

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

- StorageFolder.CreateFileAsync(String) throws ArgumentOutOfRangeException if file already exists.
- StorageFolder.CreateFileAsync(String, CreationCollisionOption.ReplaceExisting) behaves like OpenIfExists

## What is the new behavior?

- StorageFolder.CreateFileAsync(String) throws Exception if file already exists. (As per UWP)
- StorageFolder.CreateFileAsync(String, CreationCollisionOption.ReplaceExisting) behaves correctly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

