### PR TITLE
fix(NavigationView): unable to select first menuitem after selecting

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_Tests.cs
@@ -32,5 +32,37 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.NavigationViewTests
 			_app.TapCoordinates(itemSaveRect.X + 5, itemSaveRect.Y + 5);
 			_app.WaitForDependencyPropertyValue(selectedItemText, "Text", "Save");
 		}
+
+
+		[Test]
+		[AutoRetry()]
+		public void NavigateBackAndForthBetweenMenuItemsAndSettings()
+		{
+			Run("SamplesApp.Samples.Windows_UI_Xaml_Controls.NavigationViewTests.NavigationView_BasicNavigation");
+
+			_app.WaitForElement(_app.Marked("BasicNavigation"));
+
+			var secondMenuItem = _app.Marked("SecondItem");
+			secondMenuItem.FastTap();
+
+			_app.WaitForElement("Page2NavViewContent");
+
+
+			var togglePaneButton = _app.Marked("TogglePaneButton");
+			togglePaneButton.FastTap();
+
+			var settingsItem = _app.Marked("SettingsNavPaneItem");
+			settingsItem.FastTap();
+
+			_app.WaitForElement("SettingsNavViewContent");
+
+			togglePaneButton.FastTap();
+
+			var firstMenuItem = _app.Marked("FirstItem");
+			firstMenuItem.FastTap();
+
+			_app.WaitForElement("Page1NavViewContent");
+
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -873,6 +873,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_BasicNavigation.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_Pane_Automated.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3744,6 +3748,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\RotatedListViewViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_LargeContent.xaml.cs">
       <DependentUpon>Flyout_LargeContent.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_BasicNavigation.xaml.cs">
+      <DependentUpon>NavigationView_BasicNavigation.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_Pane_Automated.xaml.cs">
       <DependentUpon>NavigationView_Pane_Automated.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/Item1Page.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/Item1Page.xaml
@@ -11,7 +11,7 @@
     <Grid>
 		<StackPanel Margin="20" VerticalAlignment="Top" Orientation="Horizontal">
 			<SymbolIcon Symbol="Play" Margin="20" />
-			<TextBlock Text="Page 1" FontSize="30" VerticalAlignment="Center" />
+			<TextBlock x:Name="Page1NavViewContent" Text="Page 1" FontSize="30" VerticalAlignment="Center" />
 		</StackPanel>
     </Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/Item2Page.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/Item2Page.xaml
@@ -11,7 +11,7 @@
     <Grid>
 		<StackPanel Margin="20" VerticalAlignment="Top" Orientation="Horizontal">
 			<SymbolIcon Symbol="Save" Margin="20" />
-			<TextBlock Text="Page 2" FontSize="30" VerticalAlignment="Center" />
+			<TextBlock x:Name="Page2NavViewContent" Text="Page 2" FontSize="30" VerticalAlignment="Center" />
 		</StackPanel>
     </Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_BasicNavigation.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_BasicNavigation.xaml
@@ -1,0 +1,41 @@
+﻿<Page
+    x:Class="SamplesApp.Samples.Windows_UI_Xaml_Controls.NavigationViewTests.NavigationView_BasicNavigation"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.NavigationViewTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="http://uno.ui/xamarin"
+    mc:Ignorable="d xamarin"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<NavigationView 
+						Margin="0,12,0,0"
+						ItemInvoked="BasicNavigation_ItemInvoked"
+						x:Name="BasicNavigation"
+						IsSettingsVisible="true"
+						IsTabStop="False"
+						IsBackButtonVisible="Visible"
+						IsBackEnabled="True"
+						xamarin:BackRequested="BasicNavigation_BackRequested"
+						Header="This is header text.">
+			<NavigationView.MenuItems>
+				<NavigationViewItem x:Name="FirstItem" Content="First item" Tag="First"/>
+				<NavigationViewItem x:Name="SecondItem" Content="Second item" Tag="Second" />
+			</NavigationView.MenuItems>
+
+			<Frame x:Name="contentFrame">
+				<Frame.ContentTransitions>
+					<TransitionCollection>
+						<NavigationThemeTransition>
+							<NavigationThemeTransition.DefaultNavigationTransitionInfo>
+								<EntranceNavigationTransitionInfo />
+							</NavigationThemeTransition.DefaultNavigationTransitionInfo>
+						</NavigationThemeTransition>
+					</TransitionCollection>
+				</Frame.ContentTransitions>
+			</Frame>
+		</NavigationView>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_BasicNavigation.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_BasicNavigation.xaml.cs
@@ -1,0 +1,45 @@
+﻿using SamplesApp.Samples.NavigationViewSample;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace SamplesApp.Samples.Windows_UI_Xaml_Controls.NavigationViewTests
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo("NavigationView", "NavigationView_BasicNavigation")]
+	public sealed partial class NavigationView_BasicNavigation : Page
+    {
+        public NavigationView_BasicNavigation()
+        {
+            this.InitializeComponent();
+        }
+
+		private void BasicNavigation_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
+		{
+			if (args.IsSettingsInvoked)
+			{
+				contentFrame.Navigate(typeof(SettingsPage));
+			}
+			else if (args.InvokedItemContainer is NavigationViewItem item)
+			{
+				switch (item.Tag)
+				{
+					case "First":
+						contentFrame.Navigate(typeof(Item1Page));
+						break;
+					case "Second":
+						contentFrame.Navigate(typeof(Item2Page));
+						break;
+				}
+			}
+		}
+
+		private void BasicNavigation_BackRequested(NavigationView sender, NavigationViewBackRequestedEventArgs args)
+		{
+			contentFrame.GoBack();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/SettingsPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/SettingsPage.xaml
@@ -11,7 +11,7 @@
     <Grid>
 		<StackPanel Margin="20" VerticalAlignment="Top" Orientation="Horizontal">
 			<SymbolIcon Symbol="Setting" Margin="20" />
-			<TextBlock Text="Settings" FontSize="30" VerticalAlignment="Center" />
+			<TextBlock x:Name="SettingsNavViewContent" Text="Settings" FontSize="30" VerticalAlignment="Center" />
 		</StackPanel>
 	</Grid>
 </Page>

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1132,7 +1132,7 @@ namespace Windows.UI.Xaml.Controls
 		public DependencyObject ContainerFromItem(object item)
 		{
 			var index = IndexFromItem(item);
-			return MaterializedContainers.FirstOrDefault(container => Equals(container.GetValue(IndexForItemContainerProperty), index));
+			return index == -1 ? null : MaterializedContainers.FirstOrDefault(container => Equals(IndexFromContainer(container), index));
 		}
 
 		public int IndexFromContainer(DependencyObject container)


### PR DESCRIPTION
GitHub Issue (If applicable): #3148

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When selecting the navigationview settings item and then selecting the top menu item nothing happens and the ItemInvoked is not fired on Android. If first selecting the settings item and then the second menu item everything works as expected.

## What is the new behavior?

When selecting the navigationview settings item and then any menu item ItemInvoked is fired on Android.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X ] Contains **NO** breaking changes
- [X ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
