### PR TITLE
fix: [iOS] Fix DependencyObjectStore dispose race condition, remove u…

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -29,12 +29,7 @@ namespace Windows.UI.Xaml
 		private delegate void DataContextProviderAction(IDataContextProvider provider);
 		private delegate void ObjectAction(object instance);
 
-		private static readonly object[] EmptyChildren = new object[0];
-
-		// Initialize the field with zero capacity, as it may stay empty more often than it is being used.
-		private readonly CompositeDisposable _subscriptions = new CompositeDisposable(0);
-
-		private readonly SerialDisposable _propertyChangedSubscription = new SerialDisposable();
+		private readonly object _gate = new object();
 
 		private readonly Dictionary<DependencyProperty, int> _childrenBindableMap = new Dictionary<DependencyProperty, int>(0, DependencyPropertyComparer.Default);
 		private readonly List<object> _childrenBindable = new List<object>();
@@ -229,15 +224,18 @@ namespace Windows.UI.Xaml
 
 		private void BinderDispose()
 		{
-			if (_isDisposed)
+			lock (_gate)
 			{
-				return;
+				// Guard the dispose as it may be invoked from both a finalizer and the dispatcher.
+				if (_isDisposed)
+				{
+					return;
+				}
+
+				_isDisposed = true;
 			}
 
-			_subscriptions.Dispose();
-			_propertyChangedSubscription.Dispose();
 			_properties.Dispose();
-			_isDisposed = true;
 		}
 
 		private void OnDataContextChanged(object providedDataContext, object actualDataContext, DependencyPropertyValuePrecedences precedence)

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyCallbackManager.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyCallbackManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using Uno.Buffers;
 
@@ -18,13 +19,27 @@ namespace Windows.UI.Xaml
         private readonly static ArrayPool<PropertyChangedCallback> _pool = ArrayPool<PropertyChangedCallback>.Create(100, 100);
         private PropertyChangedCallback[] _callbacksShadow;
         private int _id;
+		private bool _disposed;
 
         public DependencyPropertyCallbackManager()
         {
         }
 
 		public void Dispose()
-			=> ReturnShadowToPool();
+		{
+			if (_disposed)
+			{
+#if DEBUG
+				// Dispose here may not be invoked multiple times. If this is the case,
+				// this means that the Dispose method from DependencyObjectStore is invoked
+				// multiple times from different threads and is not synchronized properly.
+				Debug.Fail("Dispose may not be invoked multiple times.");
+#endif
+				return;
+			}
+			_disposed = true;
+			ReturnShadowToPool();
+		}
 
 		/// <summary>
 		/// Registers a callback to be called by <see cref="RaisePropertyChanged(DependencyObject, DependencyPropertyChangedEventArgs)"/>


### PR DESCRIPTION
Fixes #3359

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

On iOS, the Dispose of `DependencyObjectStore` may be called multiple times due to the memory management of `BindableUIView`. This change adds a synchronization to avoid the dispose method to be called in both the finalizer and dispatcher threads.

Two unused other members are removed from `DependencyObjectStore`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
