### PR TITLE
Improve DepencencyProperty R/W performance

### DIFF
--- a/src/SamplesApp/Benchmarks.Shared/Benchmarks.Shared.projitems
+++ b/src/SamplesApp/Benchmarks.Shared/Benchmarks.Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Suite\SpanBench\SimpleSpanBenchmark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\BenchmarkDotNetControl.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\BenchmarkDotNetTestsPage.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Suite\Windows_UI_Xaml_Controls\DependencyPropertyBench\SimpleDPBenchmark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Suite\Windows_UI_Xaml_Controls\UIElementPerf\UIElementCreationBenchmark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Suite\Windows_UI_Xaml_Controls\GridBench\SimpleGridBenchmark.cs" />
   </ItemGroup>

--- a/src/SamplesApp/Benchmarks.Shared/Suite/Windows_UI_Xaml_Controls/DependencyPropertyBench/SimpleDPBenchmark.cs
+++ b/src/SamplesApp/Benchmarks.Shared/Suite/Windows_UI_Xaml_Controls/DependencyPropertyBench/SimpleDPBenchmark.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Windows.Foundation;
+using Windows.UI.Xaml.Controls;
+
+namespace SamplesApp.Benchmarks.Suite.Windows_UI_Xaml_Controls.GridBench
+{
+	public class SimpleDPBenchmark
+	{
+		private Grid SUT;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			SUT = new Grid();
+		}
+
+		[Benchmark()]
+		public void DP_Write()
+		{
+			for (int i = 0; i < 100; i++)
+			{
+				SUT.Width = i;
+			}
+		}
+
+		[Benchmark()]
+		public void DP_Read()
+		{
+			for (int i = 0; i < 100; i++)
+			{
+				var r = SUT.Width;
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -401,6 +401,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Performance\Performance_Dopes.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Properties\DataContextProperty.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3482,6 +3486,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\MarkupExtensionTests\Entity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\MarkupExtensionTests\InverseBool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\MarkupExtensionTests\MarkupExtensionBehaviors.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Performance\Performance_Dopes.xaml.cs">
+      <DependentUpon>Performance_Dopes.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\StyleTests\Style_Inline.xaml.cs">
       <DependentUpon>Style_Inline.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Performance/Performance_Dopes.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Performance/Performance_Dopes.xaml
@@ -1,0 +1,79 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml.Performance.Performance_Dopes"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.Performance"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Background="Black">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="55" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+
+		<Canvas x:Name="absolute" Grid.Row="0" Grid.RowSpan="2" Grid.Column="0">
+
+		</Canvas>
+
+		<Grid x:Name="grid" Grid.Row="0" Grid.RowSpan="2" Grid.Column="0">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+		</Grid>
+
+		<TextBlock x:Name="dopes" 
+				   Grid.Row="0" 
+				   Grid.Column="0" 
+				   Margin="0,20,0,0" 
+				   Padding="7,7,7,7" 
+				   Foreground="White"
+				   VerticalAlignment="Top"
+				   HorizontalAlignment="Center"
+				   Text="Warming up.." 
+				   Visibility="Collapsed"/>
+
+		<StackPanel x:Name="buttons" 
+					Orientation="Horizontal"
+					Grid.Row="1"
+					Grid.Column="0" 
+					VerticalAlignment="Bottom"
+                    HorizontalAlignment="Center" 
+					Margin="5,0,0,25" >
+
+			<Button x:Name="stop"
+				Content="@ Stop"
+					Background="Red" 
+					HorizontalAlignment="Center"
+					Visibility="Collapsed"
+					Click="Stop_Clicked"/>
+
+			<Button x:Name="startST"
+				Content="@ Build"
+				Background="Blue"
+				Click="startST_Clicked"/>
+			<Button x:Name="startGridST"
+				Content="@ Grid" 
+					Background="Blue"
+				Click="startGridST_Clicked"/>
+			<Button x:Name="startChangeST"
+				Content="@ Change"
+					Background="Blue"
+				Click="startChangeST_Clicked"/>
+			<Button x:Name="startReuseST"
+				Content="@ Reuse"
+					Background="Blue"
+				Click="startChangeReuse_Clicked"/>
+
+		</StackPanel>
+
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Performance/Performance_Dopes.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Performance/Performance_Dopes.xaml.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml.Performance
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo("Performance", "MarkupExtension")]
+	public sealed partial class Performance_Dopes : Page
+	{
+		volatile bool breakTest = false;
+		const int max = 600;
+
+		public Performance_Dopes()
+		{
+			this.InitializeComponent();
+		}
+
+		private void StartTestST()
+		{
+			var rand = new Random(0);
+
+			breakTest = false;
+
+			var width = absolute.ActualWidth;
+			var height = absolute.ActualHeight;
+
+			const int step = 20;
+			var labels = new TextBlock[step * 2];
+
+			var processed = 0;
+
+			long prevTicks = 0;
+			long prevMs = 0;
+			int prevProcessed = 0;
+			double avgSum = 0;
+			int avgN = 0;
+			var sw = new Stopwatch();
+
+			Action loop = null;
+
+			loop = () =>
+			{
+				var now = sw.ElapsedMilliseconds;
+
+				if (breakTest)
+				{
+					var avg = avgSum / avgN;
+					dopes.Text = string.Format("{0:0.00} Dopes/s (AVG)", avg).PadLeft(21);
+					return;
+				}
+
+				//60hz, 16ms to build the frame
+				while (sw.ElapsedMilliseconds - now < 16)
+				{
+					var label = new TextBlock()
+					{
+						Text = "Dope",
+						Foreground = new SolidColorBrush(Color.FromArgb(0xFF, (byte)(rand.NextDouble() * 255), (byte)(rand.NextDouble() * 255), (byte)(rand.NextDouble() * 255)))
+					};
+
+					label.RenderTransform = new RotateTransform() { Angle = rand.NextDouble() * 360 };
+
+					Canvas.SetLeft(label, rand.NextDouble() * width);
+					Canvas.SetTop(label, rand.NextDouble() * height);
+
+					if (processed > max)
+					{
+						absolute.Children.RemoveAt(0);
+					}
+
+					absolute.Children.Add(label);
+
+					processed++;
+
+					if (sw.ElapsedMilliseconds - prevMs > 500)
+					{
+
+						var r = (double)(processed - prevProcessed) / ((double)(sw.ElapsedTicks - prevTicks) / Stopwatch.Frequency);
+						prevTicks = sw.ElapsedTicks;
+						prevProcessed = processed;
+
+						if (processed > max)
+						{
+							dopes.Text = string.Format("{0:0.00} Dopes/s", r).PadLeft(15);
+							avgSum += r;
+							avgN++;
+						}
+
+						prevMs = sw.ElapsedMilliseconds;
+					}
+				}
+
+				_ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Low, () => loop());
+			};
+
+			sw.Start();
+
+			_ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => loop());
+		}
+
+		private void StartTestReuseST()
+		{
+			var rand = new Random(0);
+
+			breakTest = false;
+
+			var width = absolute.ActualWidth;
+			var height = absolute.ActualHeight;
+
+			const int step = 20;
+			var labels = new TextBlock[step * 2];
+
+			var processed = 0;
+
+			long prevTicks = 0;
+			long prevMs = 0;
+			int prevProcessed = 0;
+			double avgSum = 0;
+			int avgN = 0;
+			var sw = new Stopwatch();
+
+			Action loop = null;
+
+			System.Collections.Concurrent.ConcurrentBag<TextBlock> _cache = new System.Collections.Concurrent.ConcurrentBag<TextBlock>();
+
+			loop = () =>
+			{
+				var now = sw.ElapsedMilliseconds;
+
+				if (breakTest)
+				{
+					var avg = avgSum / avgN;
+					dopes.Text = string.Format("{0:0.00} Dopes/s (AVG)", avg).PadLeft(21);
+					return;
+				}
+
+				//60hz, 16ms to build the frame
+				while (sw.ElapsedMilliseconds - now < 16)
+				{
+					if (!_cache.TryTake(out var label))
+					{
+						label = new TextBlock();
+					}
+
+					label.Text = "Dope";
+					label.Foreground = new SolidColorBrush(Color.FromArgb(0xFF, (byte)(rand.NextDouble() * 255), (byte)(rand.NextDouble() * 255), (byte)(rand.NextDouble() * 255)));
+
+					label.RenderTransform = new RotateTransform() { Angle = rand.NextDouble() * 360 };
+
+					Canvas.SetLeft(label, rand.NextDouble() * width);
+					Canvas.SetTop(label, rand.NextDouble() * height);
+
+					if (processed > max)
+					{
+						_cache.Add(absolute.Children[0] as TextBlock);
+						absolute.Children.RemoveAt(0);
+					}
+
+					absolute.Children.Add(label);
+
+					processed++;
+
+					if (sw.ElapsedMilliseconds - prevMs > 500)
+					{
+
+						var r = (double)(processed - prevProcessed) / ((double)(sw.ElapsedTicks - prevTicks) / Stopwatch.Frequency);
+						prevTicks = sw.ElapsedTicks;
+						prevProcessed = processed;
+
+						if (processed > max)
+						{
+							dopes.Text = string.Format("{0:0.00} Dopes/s", r).PadLeft(15);
+							avgSum += r;
+							avgN++;
+						}
+
+						prevMs = sw.ElapsedMilliseconds;
+					}
+				}
+
+				_ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Low, () => loop());
+			};
+
+			sw.Start();
+
+			_ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Low, () => loop());
+		}
+
+		private void SetControlsAtStart()
+		{
+			startChangeST.Visibility = startST.Visibility = startGridST.Visibility = Visibility.Collapsed;
+			stop.Visibility = dopes.Visibility = Visibility.Visible;
+			absolute.Children.Clear();
+			grid.Children.Clear();
+			dopes.Text = "Warming up..";
+		}
+
+		private void startMT_Clicked(System.Object sender, object e)
+		{
+			SetControlsAtStart();
+			//StartTestMT2();
+		}
+
+		private void startST_Clicked(System.Object sender, object e)
+		{
+			SetControlsAtStart();
+			StartTestST();
+		}
+
+		private void startGridST_Clicked(System.Object sender, object e)
+		{
+			SetControlsAtStart();
+			//StartTestGridST();
+		}
+
+		private void startChangeST_Clicked(System.Object sender, object e)
+		{
+			SetControlsAtStart();
+			//StartTestChangeST();
+		}
+
+		private void startChangeReuse_Clicked(System.Object sender, object e)
+		{
+			SetControlsAtStart();
+			StartTestReuseST();
+		}
+
+		private void Stop_Clicked(System.Object sender, object e)
+		{
+			breakTest = true;
+			stop.Visibility = Visibility.Collapsed;
+			startChangeST.Visibility = startST.Visibility = startGridST.Visibility = Visibility.Visible;
+		}
+
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.wasm.cs
@@ -73,5 +73,7 @@ namespace Windows.UI.Xaml.Controls
 
 		bool ICustomClippingElement.AllowClippingToLayoutSlot => !(Child is UIElement ue) || ue.RenderTransform == null;
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => CornerRadius != CornerRadius.None;
+
+		private protected override Thickness GetBorderThickness() => BorderThickness;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.wasm.cs
@@ -51,5 +51,7 @@ namespace Windows.UI.Xaml.Controls
 		bool ICustomClippingElement.AllowClippingToLayoutSlot => true;
 
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => CornerRadius != CornerRadius.None;
+
+		private protected override Thickness GetBorderThickness() => BorderThickness;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
@@ -949,13 +949,28 @@ namespace Windows.UI.Xaml.Controls
 			var res = new Memory<ViewPosition>(new ViewPosition[positions.Length]);
 			int count = 0;
 
+			// Use local function to avoid the use of Enumerable.Any. foreach on List<T> uses allocation less
+			bool hasStarChildren(View key)
+			{
+				foreach (var child in autoSizeChildren)
+				{
+					if (child.Key == key)
+					{
+						return true;
+					}
+				}
+
+				return false;
+			}
+
+
 			for (int i = 0; i < positions.Length; i++)
 			{
 				var item = positions[i];
 
 				if (
 					!pixelSizeChildren.Span.Any(c => c.Key == item.Key)
-					&& !autoSizeChildren.Any(c => c.Key == item.Key)
+					&& !hasStarChildren(item.Key)
 				)
 				{
 					res.Span[count++] = item;

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.wasm.cs
@@ -87,5 +87,7 @@ namespace Windows.UI.Xaml.Controls
 
 		bool ICustomClippingElement.AllowClippingToLayoutSlot => true;
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => CornerRadius != CornerRadius.None;
+
+		private protected override Thickness GetBorderThickness() => BorderThickness;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -39,8 +39,8 @@ namespace Windows.UI.Xaml
 		private bool _isApplyingTemplateBindings;
 		private bool _isApplyingDataContextBindings;
 		private bool _bindingsSuspended;
-		private DependencyProperty _dataContextProperty = UIElement.DataContextProperty;
-		private DependencyProperty _templatedParentProperty = UIElement.TemplatedParentProperty;
+		private readonly DependencyProperty _dataContextProperty;
+		private readonly DependencyProperty _templatedParentProperty;
 
 		/// <summary>
 		/// Sets the templated parent, with the ability to control the propagation of the templated parent.
@@ -162,12 +162,6 @@ namespace Windows.UI.Xaml
 
 		private string GetOwnerDebugString()
 			=> ActualInstance?.GetType().ToString() ?? "[collected]";
-
-		private void InitializeBinder(DependencyProperty dataContextProperty, DependencyProperty templatedParentProperty)
-		{
-			_dataContextProperty = dataContextProperty;
-			_templatedParentProperty = templatedParentProperty;
-		}
 
 		static void InitializeStaticBinder()
 		{

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -169,7 +169,8 @@ namespace Windows.UI.Xaml
 			_dataContextPropertyDetails = _properties.DataContextPropertyDetails;
 			_templatedParentPropertyDetails = _properties.TemplatedParentPropertyDetails;
 
-			InitializeBinder(dataContextProperty, templatedParentProperty);
+			_dataContextProperty = dataContextProperty;
+			_templatedParentProperty = templatedParentProperty;
 
 			if (_trace.IsEnabled)
 			{

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Uno.UI.DataBinding;
 using System.Collections.Generic;
@@ -36,7 +38,7 @@ namespace Windows.UI.Xaml
 	/// <param name="instance">The DependencyObject instance being updated</param>
 	/// <param name="key">An optional key passed as a parameter to <see cref="DependencyObject.RegisterParentChangedCallback(object, ParentChangedCallback)"/>.</param>
 	/// <param name="args">The arguments of the change</param>
-	internal delegate void ParentChangedCallback(object instance, object key, DependencyObjectParentChangedEventArgs args);
+	internal delegate void ParentChangedCallback(object instance, object? key, DependencyObjectParentChangedEventArgs args);
 
 	/// <summary>
 	/// Defines a Dependency Object
@@ -68,10 +70,10 @@ namespace Windows.UI.Xaml
 		private readonly DependencyPropertyDetailsCollection _properties;
 		private readonly DependencyPropertyDetails _dataContextPropertyDetails;
 		private readonly DependencyPropertyDetails _templatedParentPropertyDetails;
-		private Dictionary<DependencyProperty, ResourceBinding> _resourceBindings;
+		private Dictionary<DependencyProperty, ResourceBinding>? _resourceBindings;
 
-		private DependencyProperty _parentTemplatedParentProperty;
-		private DependencyProperty _parentDataContextProperty;
+		private DependencyProperty _parentTemplatedParentProperty = UIElement.TemplatedParentProperty;
+		private DependencyProperty _parentDataContextProperty = UIElement.DataContextProperty;
 
 		private ImmutableList<ExplicitPropertyChangedCallback> _genericCallbacks = ImmutableList<ExplicitPropertyChangedCallback>.Empty;
 		private ImmutableList<DependencyObjectStore> _childrenStores = ImmutableList<DependencyObjectStore>.Empty;
@@ -90,7 +92,7 @@ namespace Windows.UI.Xaml
 		private readonly Type _originalObjectType;
 		private SerialDisposable _inheritedProperties = new SerialDisposable();
 		private SerialDisposable _compiledBindings = new SerialDisposable();
-		private ManagedWeakReference _parentRef;
+		private ManagedWeakReference? _parentRef;
 		private Dictionary<DependencyProperty, ManagedWeakReference> _inheritedForwardedProperties = new Dictionary<DependencyProperty, ManagedWeakReference>(DependencyPropertyComparer.Default);
 		private DependencyPropertyValuePrecedences? _precedenceOverride;
 
@@ -109,7 +111,7 @@ namespace Windows.UI.Xaml
 		/// This property is an <see cref="object"/> as the parent of a <see cref="DependencyObject"/> may
 		/// not always be another <see cref="DependencyObject"/>, particularly in the case of the root element.
 		/// </remarks>
-		public object Parent
+		public object? Parent
 		{
 			get => _parentRef?.Target;
 			set
@@ -252,13 +254,13 @@ namespace Windows.UI.Xaml
 			return GetValue(property, null, precedence, isPrecedenceSpecific);
 		}
 
-		internal object GetValue(DependencyProperty property, DependencyPropertyDetails propertyDetails, DependencyPropertyValuePrecedences? precedence = null, bool isPrecedenceSpecific = false)
+		internal object GetValue(DependencyProperty property, DependencyPropertyDetails? propertyDetails, DependencyPropertyValuePrecedences? precedence = null, bool isPrecedenceSpecific = false)
 		{
 			WritePropertyEventTrace(TraceProvider.GetValue, property, precedence);
 
 			ValidatePropertyOwner(property);
 
-			propertyDetails = propertyDetails ?? _properties.GetPropertyDetails(property);
+			propertyDetails ??= _properties.GetPropertyDetails(property);
 
 			return GetValue(propertyDetails, precedence, isPrecedenceSpecific);
 		}
@@ -315,7 +317,7 @@ namespace Windows.UI.Xaml
 		/// <param name="instance">The instance to override</param>
 		/// <param name="precedence">The precedence to set</param>
 		/// <returns>A disposable to dispose to cancel the override.</returns>
-		internal IDisposable OverrideLocalPrecedence(DependencyPropertyValuePrecedences precedence)
+		internal IDisposable? OverrideLocalPrecedence(DependencyPropertyValuePrecedences precedence)
 		{
 			if (_precedenceOverride != null)
 			{
@@ -351,7 +353,7 @@ namespace Windows.UI.Xaml
 		private static Dictionary<DependencyPropertyPath, object> _propagationBypassed =
 			new Dictionary<DependencyPropertyPath, object>(DependencyPropertyPath.Comparer.Default);
 
-		internal static IDisposable BypassPropagation(DependencyObject instance, DependencyProperty property)
+		internal static IDisposable? BypassPropagation(DependencyObject instance, DependencyProperty property)
 		{
 			var obj = instance;
 
@@ -407,7 +409,7 @@ namespace Windows.UI.Xaml
 			SetValue(property, DependencyProperty.UnsetValue, precedence);
 		}
 
-		internal void SetValue(DependencyProperty property, object value, DependencyPropertyValuePrecedences precedence, DependencyPropertyDetails propertyDetails = null)
+		internal void SetValue(DependencyProperty property, object? value, DependencyPropertyValuePrecedences precedence, DependencyPropertyDetails? propertyDetails = null)
 		{
 			if (_trace.IsEnabled)
 			{
@@ -423,7 +425,7 @@ namespace Windows.UI.Xaml
 
 		}
 
-		private void InnerSetValue(DependencyProperty property, object value, DependencyPropertyValuePrecedences precedence, DependencyPropertyDetails propertyDetails)
+		private void InnerSetValue(DependencyProperty property, object? value, DependencyPropertyValuePrecedences precedence, DependencyPropertyDetails? propertyDetails)
 		{
 			if (precedence == DependencyPropertyValuePrecedences.Coercion)
 			{
@@ -503,7 +505,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private void ApplyCoercion(DependencyObject actualInstanceAlias, DependencyPropertyDetails propertyDetails, object previousValue, object baseValue)
+		private void ApplyCoercion(DependencyObject actualInstanceAlias, DependencyPropertyDetails propertyDetails, object? previousValue, object? baseValue)
 		{
 			if (baseValue is UnsetValue)
 			{
@@ -565,7 +567,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private IDisposable WritePropertyEventTrace(int startEventId, int stopEventId, DependencyProperty property, DependencyPropertyValuePrecedences precedence)
+		private IDisposable? WritePropertyEventTrace(int startEventId, int stopEventId, DependencyProperty property, DependencyPropertyValuePrecedences precedence)
 		{
 			if (_trace.IsEnabled)
 			{
@@ -664,7 +666,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		internal IDisposable RegisterPropertyChangedCallback(DependencyProperty property, PropertyChangedCallback callback, DependencyPropertyDetails propertyDetails = null)
+		internal IDisposable RegisterPropertyChangedCallback(DependencyProperty property, PropertyChangedCallback callback, DependencyPropertyDetails? propertyDetails = null)
 		{
 			var weakDelegate = CreateWeakDelegate(callback);
 
@@ -692,7 +694,7 @@ namespace Windows.UI.Xaml
 
 						// Force a closure on the callback, to make its lifetime as long
 						// as the subscription being held by the callee.
-						callback = null;
+						callback = null!;
 					}
 				});
 		}
@@ -729,7 +731,7 @@ namespace Windows.UI.Xaml
 
 					// Force a closure on the callback, to make its lifetime as long
 					// as the subscription being held by the callee.
-					handler = null;
+					handler = null!;
 				}
 			);
 		}
@@ -812,7 +814,7 @@ namespace Windows.UI.Xaml
 
 					// Force a closure on the callback, to make its lifetime as long
 					// as the subscription being held by the callee.
-					handler = null;
+					handler = null!;
 				}
 			);
 		}
@@ -860,7 +862,7 @@ namespace Windows.UI.Xaml
 
 				// Force a closure on the callback, to make its lifetime as long
 				// as the subscription being held by the callee.
-				callback = null;
+				callback = null!;
 			}
 
 			return new DispatcherConditionalDisposable(
@@ -914,7 +916,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private void TryRegisterInheritedProperties(IDependencyObjectStoreProvider parentProvider = null, bool force = false)
+		private void TryRegisterInheritedProperties(IDependencyObjectStoreProvider? parentProvider = null, bool force = false)
 		{
 			if (
 				!_registeringInheritedProperties
@@ -1019,8 +1021,8 @@ namespace Windows.UI.Xaml
 						SetValue(dp, DependencyProperty.UnsetValue, DependencyPropertyValuePrecedences.Inheritance);
 					}
 
-					SetValue(_dataContextProperty, DependencyProperty.UnsetValue, DependencyPropertyValuePrecedences.Inheritance);
-					SetValue(_templatedParentProperty, DependencyProperty.UnsetValue, DependencyPropertyValuePrecedences.Inheritance);
+					SetValue(_dataContextProperty!, DependencyProperty.UnsetValue, DependencyPropertyValuePrecedences.Inheritance);
+					SetValue(_templatedParentProperty!, DependencyProperty.UnsetValue, DependencyPropertyValuePrecedences.Inheritance);
 				}
 			}
 #if !HAS_EXPENSIVE_TRYFINALLY
@@ -1032,7 +1034,7 @@ namespace Windows.UI.Xaml
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private (DependencyProperty localProperty, DependencyPropertyDetails propertyDetails) GetLocalPropertyDetails(DependencyProperty property)
+		private (DependencyProperty? localProperty, DependencyPropertyDetails? propertyDetails) GetLocalPropertyDetails(DependencyProperty property)
 		{
 			if (_parentDataContextProperty.UniqueId == property.UniqueId)
 			{
@@ -1152,7 +1154,7 @@ namespace Windows.UI.Xaml
 		/// <summary>
 		/// Retrieve the implicit Style for <see cref="ActualInstance"/> by walking the visual tree.
 		/// </summary>
-		internal Style GetImplicitStyle()
+		internal Style? GetImplicitStyle()
 		{
 			foreach (var dict in GetResourceDictionaries(includeAppResources: true))
 			{
@@ -1168,7 +1170,7 @@ namespace Windows.UI.Xaml
 		/// <summary>
 		/// Propagate the current inheritable properties to the registered children.
 		/// </summary>
-		internal void PropagateInheritedProperties(DependencyObjectStore childStore = null)
+		internal void PropagateInheritedProperties(DependencyObjectStore? childStore = null)
 		{
 			// Raise the property change for the current values
 			var props = DependencyProperty.GetFrameworkPropertiesForType(_originalObjectType, FrameworkPropertyMetadataOptions.Inherits);
@@ -1208,7 +1210,7 @@ namespace Windows.UI.Xaml
 			PropagateInheritedNonLocalProperties(childStore);
 		}
 
-		private void PropagateInheritedNonLocalProperties(DependencyObjectStore childStore)
+		private void PropagateInheritedNonLocalProperties(DependencyObjectStore? childStore)
 		{
 			// Propagate the properties that have been inherited from an other
 			// parent, but that are not defined in the current instance.
@@ -1264,11 +1266,14 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private static bool IsAncestor(DependencyObject instance, Dictionary<object, bool> map, object ancestor)
+		private static bool IsAncestor(DependencyObject? instance, Dictionary<object, bool> map, object ancestor)
 		{
 #if DEBUG
 			var hashSet = new HashSet<DependencyObject>(Uno.ReferenceEqualityComparer<DependencyObject>.Default);
-			hashSet.Add(instance);
+			if (instance != null)
+			{
+				hashSet.Add(instance);
+			}
 #endif
 
 			bool isAncestor = false;
@@ -1283,14 +1288,17 @@ namespace Windows.UI.Xaml
 					instance = DependencyObjectExtensions.GetParent(instance) as DependencyObject;
 
 #if DEBUG
-					if (!hashSet.Contains(instance))
+					if (instance != null)
 					{
-						// Console.WriteLine($"Added other {(instance as FrameworkElement)?.Name}");
-						hashSet.Add(instance);
-					}
-					else
-					{
-						throw new Exception($"Cycle detected: [{prevInstance}/{(prevInstance as FrameworkElement)?.Name}] has already added [{instance}/{(instance as FrameworkElement).Name}] as parent/");
+						if (!hashSet.Contains(instance!))
+						{
+							// Console.WriteLine($"Added other {(instance as FrameworkElement)?.Name}");
+							hashSet.Add(instance);
+						}
+						else
+						{
+							throw new Exception($"Cycle detected: [{prevInstance}/{(prevInstance as FrameworkElement)?.Name}] has already added [{instance}/{(instance as FrameworkElement)?.Name}] as parent/");
+						}
 					}
 #endif
 
@@ -1320,32 +1328,8 @@ namespace Windows.UI.Xaml
 			return false;
 		}
 
-		public DependencyObject ActualInstance
+		public DependencyObject? ActualInstance
 			=> _originalObjectRef.Target as DependencyObject;
-
-		/// <summary>
-		/// Finds the first dependency object that matches the specified <paramref name="ownerType"/>, self included.
-		/// </summary>
-		/// <param name="instance">The instance used to walk up the tree</param>
-		/// <param name="ownerType">The owner type to find</param>
-		/// <returns>A known parent instance, otherwise null.</returns>
-		private Tuple<DependencyObject, DependencyProperty> FindFirstInheritanceParent(DependencyObject instance, string name)
-		{
-			do
-			{
-				var property = DependencyProperty.GetProperty(instance.GetType(), name);
-
-				if (property != null)
-				{
-					return Tuple.Create(instance, property);
-				}
-
-				instance = DependencyObjectExtensions.GetParent(instance) as DependencyObject;
-			}
-			while (instance != null);
-
-			return null;
-		}
 
 		/// <summary>
 		/// Creates a weak delegate for the specified PropertyChangedCallback callback.
@@ -1432,25 +1416,25 @@ namespace Windows.UI.Xaml
 
 			if (AreDifferent(newValue, previousValue))
 			{
-				var bypassesPropagation = hasPropagationBypass && _propagationBypass.Contains(propertyPath);
+				var bypassesPropagation = hasPropagationBypass && _propagationBypass.Contains(propertyPath!);
 
 				if (bypassesPropagation)
 				{
-					_propagationBypassed[propertyPath] = previousValue;
+					_propagationBypassed[propertyPath!] = previousValue;
 				}
 
 				InvokeCallbacks(actualInstanceAlias, propertyDetails.Property, propertyDetails, previousValue, previousPrecedence, newValue, newPrecedence, bypassesPropagation);
 			}
 			else if (
 				hasPropagationBypass
-				&& _propagationBypassed.ContainsKey(propertyPath)
+				&& _propagationBypassed.ContainsKey(propertyPath!)
 				&& !_propagationBypass.Contains(propertyPath, DependencyPropertyPath.Comparer.Default)
 			)
 			{
 				// If unchanged, but previous value was set with propagation bypass enabled (and we are currently being set without bypass enabled),
 				// then we should invoke callbacks so that the value can be propagated. This arises in animation scenarios.
-				var unpropagatedPrevious = _propagationBypassed[propertyPath];
-				_propagationBypassed.Remove(propertyPath);
+				var unpropagatedPrevious = _propagationBypassed[propertyPath!];
+				_propagationBypassed.Remove(propertyPath!);
 
 				InvokeCallbacks(actualInstanceAlias, propertyDetails.Property, propertyDetails, unpropagatedPrevious, previousPrecedence, newValue, newPrecedence);
 			}
@@ -1567,7 +1551,7 @@ namespace Windows.UI.Xaml
 		/// <param name="value">The value to set</param>
 		/// <param name="precedence">The value precedence to assign</param>
 		private void SetValueInternal(
-			object value,
+			object? value,
 			DependencyPropertyValuePrecedences precedence,
 			DependencyPropertyDetails propertyDetails
 		)
@@ -1595,7 +1579,7 @@ namespace Windows.UI.Xaml
 		/// <param name="newValue">The new value</param>
 		/// <returns>True if different, otherwise false</returns>
 		/// <remarks>This comparison uses value for value types, references for reference types.</remarks>
-		public static bool AreDifferent(object previousValue, object newValue)
+		public static bool AreDifferent(object? previousValue, object? newValue)
 		{
 			if (newValue is ValueType || newValue is string)
 			{
@@ -1607,23 +1591,26 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private void OnParentChanged(object previousParent, object value)
+		private void OnParentChanged(object? previousParent, object? value)
 		{
 			if (_parentChangedCallbacks.Data.Length != 0)
 			{
 				var actualInstanceAlias = ActualInstance;
 
-				var args = new DependencyObjectParentChangedEventArgs(previousParent, value);
-
-				for (var parentCallbackIndex = 0; parentCallbackIndex < _parentChangedCallbacks.Data.Length; parentCallbackIndex++)
+				if (actualInstanceAlias != null)
 				{
-					var handler = _parentChangedCallbacks.Data[parentCallbackIndex];
-					handler.Invoke(actualInstanceAlias, null, args);
+					var args = new DependencyObjectParentChangedEventArgs(previousParent, value);
+
+					for (var parentCallbackIndex = 0; parentCallbackIndex < _parentChangedCallbacks.Data.Length; parentCallbackIndex++)
+					{
+						var handler = _parentChangedCallbacks.Data[parentCallbackIndex];
+						handler.Invoke(actualInstanceAlias, null, args);
+					}
 				}
 			}
 		}
 
-		private class DependencyPropertyPath : IEquatable<DependencyPropertyPath>
+		private class DependencyPropertyPath : IEquatable<DependencyPropertyPath?>
 		{
 			public DependencyPropertyPath(DependencyObject instance, DependencyProperty property)
 			{
@@ -1642,12 +1629,12 @@ namespace Windows.UI.Xaml
 			public override bool Equals(object obj)
 				=> Equals(obj as DependencyPropertyPath);
 
-			public bool Equals(DependencyPropertyPath other)
+			public bool Equals(DependencyPropertyPath? other)
 				=> other != null &&
 					ReferenceEquals(this.Instance, other.Instance) &&
 					this.Property.UniqueId == other.Property.UniqueId;
 
-			public class Comparer : IEqualityComparer<DependencyPropertyPath>
+			public class Comparer : IEqualityComparer<DependencyPropertyPath?>
 			{
 				public static Comparer Default { get; } = new Comparer();
 
@@ -1655,11 +1642,11 @@ namespace Windows.UI.Xaml
 				{
 				}
 
-				public bool Equals(DependencyPropertyPath x, DependencyPropertyPath y)
-					=> x.Equals(y);
+				public bool Equals(DependencyPropertyPath? x, DependencyPropertyPath? y)
+					=> x?.Equals(y) ?? false;
 
-				public int GetHashCode(DependencyPropertyPath obj)
-					=> obj.GetHashCode();
+				public int GetHashCode(DependencyPropertyPath? obj)
+					=> obj?.GetHashCode() ?? 0;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.wasm.cs
@@ -270,23 +270,7 @@ namespace Windows.UI.Xaml
 			OnLayoutUpdated();
 		}
 
-		internal Thickness GetThicknessAdjust()
-		{
-			switch (this)
-			{
-				case Controls.Border b:
-					return b.BorderThickness;
-
-				case Controls.Panel g:
-					return g.BorderThickness;
-
-				case Controls.ContentPresenter p:
-					return p.BorderThickness;
-
-				default:
-					return Thickness.Empty;
-			}
-		}
+		private protected virtual Thickness GetBorderThickness() => Thickness.Empty;
 
 		/// <summary>
 		/// Calculates and applies native arrange properties.

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -239,7 +239,7 @@ namespace Windows.UI.Xaml
 		protected void ArrangeElement(View view, Rect finalRect)
 		{
 #if __WASM__
-			var adjust = GetThicknessAdjust();
+			var adjust = GetBorderThickness();
 
 			// HTML moves the origin along with the border thickness.
 			// Adjust the child based on this element's border thickness.


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
-- Refactoring (no functional changes, no api changes)

## What is the new behavior?

- Move DependencyObjectStore to C# 8.0 nullable
- Change `DependencyPropertyDetailsCollection` to use an O(1) lookup
- Other minor performance updates

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
