### PR TITLE
fix(scrollBar): Disable Animation on WASM

### DIFF
--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -7998,8 +7998,36 @@
                                         <Setter Target="VerticalThumb.Opacity" Value="1" />
                                     </VisualState.Setters>
                                 </VisualState>
-                                <VisualState x:Name="NoIndicator">
-
+                                <wasm:VisualState x:Name="NoIndicator">
+									<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 --> 
+									<VisualState.Setters>
+										<Setter Target="HorizontalThumb.Background.Color" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
+										<Setter Target="VerticalThumb.Background.Color)" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
+										<Setter Target="VerticalThumbTransform.ScaleX" Value="{ThemeResource SmallScrollThumbScale}" />
+										<Setter Target="VerticalThumbTransform.TranslateX" Value="{ThemeResource SmallScrollThumbOffset}" />
+										<Setter Target="HorizontalThumbTransform.ScaleY" Value="{ThemeResource SmallScrollThumbScale}" />
+										<Setter Target="HorizontalThumbTransform.TranslateY" Value="{ThemeResource SmallScrollThumbOffset}" />
+										<Setter Target="VerticalSmallIncrease.Opacity" Value="0" />
+										<Setter Target="VerticalLargeIncrease.Opacity" Value="0" />
+										<Setter Target="VerticalLargeDecrease.Opacity" Value="0" />
+										<Setter Target="VerticalThumb.Opacity" Value="0" />
+										<Setter Target="VerticalSmallDecrease.Opacity" Value="0" />
+										<Setter Target="VerticalTrackRect.Opacity" Value="0" />
+										<Setter Target="HorizontalSmallIncrease.Opacity" Value="0" />
+										<Setter Target="HorizontalLargeIncrease.Opacity" Value="0" />
+										<Setter Target="HorizontalLargeDecrease.Opacity" Value="0" />
+										<Setter Target="HorizontalThumb.Opacity" Value="0" />
+										<Setter Target="HorizontalSmallDecrease.Opacity" Value="0" />
+										<Setter Target="HorizontalTrackRect.Opacity" Value="0" />
+										<Setter Target="HorizontalRoot.Visibility" Value="Collapsed" />
+										<Setter Target="VerticalRoot.Visibility" Value="Collapsed" />
+										<Setter Target="HorizontalPanningRoot.Opacity" Value="0" />
+										<Setter Target="VerticalPanningRoot.Opacity" Value="0" />
+										<Setter Target="HorizontalPanningRoot.Visibility" Value="Collapsed" />
+										<Setter Target="VerticalPanningRoot.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</wasm:VisualState>
+                                <not_wasm:VisualState x:Name="NoIndicator">
                                     <Storyboard>
                                         <ColorAnimation Duration="{ThemeResource ScrollBarContractDuration}" Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
                                         <ColorAnimation Duration="{ThemeResource ScrollBarContractDuration}" Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
@@ -8050,14 +8078,15 @@
                                             </DiscreteObjectKeyFrame>
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
-                                </VisualState>
+                                </not_wasm:VisualState>
 
                             </VisualStateGroup>
 
                             <VisualStateGroup x:Name="ConsciousStates">
 
-                                <VisualStateGroup.Transitions>
-                                    <VisualTransition From="Expanded" To="Collapsed">
+                                <not_wasm:VisualStateGroup.Transitions>
+									<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+									<VisualTransition From="Expanded" To="Collapsed">
 
                                         <Storyboard>
                                             <ColorAnimation Duration="{ThemeResource ScrollBarContractDuration}" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" To="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
@@ -8078,10 +8107,38 @@
                                             <DoubleAnimation Duration="{ThemeResource ScrollBarContractDuration}" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="HorizontalTrackRect" Storyboard.TargetProperty="Opacity" To="0" />
                                         </Storyboard>
                                     </VisualTransition>
-                                </VisualStateGroup.Transitions>
+                                </not_wasm:VisualStateGroup.Transitions>
                                 <VisualState x:Name="Collapsed" />
 
                                 <VisualState x:Name="Expanded">
+                                    <wasm:VisualState.Setters>
+                                        <Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundPointerOver}" />
+                                        <Setter Target="Root.BorderBrush" Value="{ThemeResource ScrollBarBorderBrushPointerOver}" />
+                                        <Setter Target="HorizontalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
+                                        <Setter Target="VerticalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
+                                        <Setter Target="HorizontalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
+                                        <Setter Target="VerticalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
+
+										<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+										<Setter Target="HorizontalThumb.Background.Color" Value="{ThemeResource ScrollBarThumbBackgroundColor}" />
+										<Setter Target="VerticalThumb.Background.Color" Value="{ThemeResource ScrollBarThumbBackgroundColor}" />
+										<Setter Target="VerticalThumbTransform.ScaleX" Value="1.0" />
+										<Setter Target="VerticalThumbTransform.TranslateX" Value="0" />
+										<Setter Target="HorizontalThumbTransform.ScaleY" Value="1.0" />
+										<Setter Target="HorizontalThumbTransform.TranslateY" Value="0" />
+										<Setter Target="VerticalSmallIncrease.Opacity" Value="1" />
+										<Setter Target="VerticalLargeIncrease.Opacity" Value="1" />
+										<Setter Target="VerticalLargeDecrease.Opacity" Value="1" />
+										<Setter Target="VerticalSmallDecrease.Opacity" Value="1" />
+										<Setter Target="VerticalTrackRect.Opacity" Value="1" />
+										<Setter Target="HorizontalSmallIncrease.Opacity" Value="1" />
+										<Setter Target="HorizontalLargeIncrease.Opacity" Value="1" />
+										<Setter Target="HorizontalLargeDecrease.Opacity" Value="1" />
+										<Setter Target="HorizontalSmallDecrease.Opacity" Value="1" />
+										<Setter Target="HorizontalTrackRect.Opacity" Value="1" />
+									</wasm:VisualState.Setters>
+                                </VisualState>
+                                <not_wasm:VisualState x:Name="Expanded">
                                     <VisualState.Setters>
                                         <Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundPointerOver}" />
                                         <Setter Target="Root.BorderBrush" Value="{ThemeResource ScrollBarBorderBrushPointerOver}" />
@@ -8109,8 +8166,37 @@
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalSmallDecrease" Storyboard.TargetProperty="Opacity" To="1" />
                                         <DoubleAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalTrackRect" Storyboard.TargetProperty="Opacity" To="1" />
                                     </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="ExpandedWithoutAnimation">
+                                </not_wasm:VisualState>
+                                <wasm:VisualState x:Name="ExpandedWithoutAnimation">
+                                    <VisualState.Setters>
+                                        <Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundPointerOver}" />
+                                        <Setter Target="Root.BorderBrush" Value="{ThemeResource ScrollBarBorderBrushPointerOver}" />
+                                        <Setter Target="HorizontalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
+                                        <Setter Target="VerticalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
+                                        <Setter Target="HorizontalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
+                                        <Setter Target="VerticalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
+
+										<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+										<Setter Target="HorizontalThumb.Background.Color" Value="{ThemeResource ScrollBarThumbBackgroundColor}" />
+										<Setter Target="VerticalThumb.Background.Color" Value="{ThemeResource ScrollBarThumbBackgroundColor}" />
+										<Setter Target="VerticalThumbTransform.ScaleX" Value="1.0" />
+										<Setter Target="VerticalThumbTransform.TranslateX" Value="0" />
+										<Setter Target="HorizontalThumbTransform.ScaleY" Value="1.0" />
+										<Setter Target="HorizontalThumbTransform.TranslateY" Value="0" />
+										<Setter Target="VerticalSmallIncrease.Opacity" Value="1" />
+										<Setter Target="VerticalLargeIncrease.Opacity" Value="1" />
+										<Setter Target="VerticalLargeDecrease.Opacity" Value="1" />
+										<Setter Target="VerticalSmallDecrease.Opacity" Value="1" />
+										<Setter Target="VerticalTrackRect.Opacity" Value="1" />
+										<Setter Target="HorizontalSmallIncrease.Opacity" Value="1" />
+										<Setter Target="HorizontalLargeIncrease.Opacity" Value="1" />
+										<Setter Target="HorizontalLargeDecrease.Opacity" Value="1" />
+										<Setter Target="HorizontalSmallDecrease.Opacity" Value="1" />
+										<Setter Target="HorizontalTrackRect.Opacity" Value="1" />
+
+									</VisualState.Setters>
+                                </wasm:VisualState>
+                                <not_wasm:VisualState x:Name="ExpandedWithoutAnimation">
                                     <VisualState.Setters>
                                         <Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundPointerOver}" />
                                         <Setter Target="Root.BorderBrush" Value="{ThemeResource ScrollBarBorderBrushPointerOver}" />
@@ -8140,8 +8226,33 @@
                                         <DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalSmallDecrease" Storyboard.TargetProperty="Opacity" To="1" />
                                         <DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalTrackRect" Storyboard.TargetProperty="Opacity" To="1" />
                                     </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="CollapsedWithoutAnimation">
+                                </not_wasm:VisualState>
+                                <wasm:VisualState x:Name="CollapsedWithoutAnimation">
+									<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+									
+									<!-- The storyboard below cannot be moved to a transition since transitions
+                                             will not be run by the framework when animations are disabled in the system -->
+
+									<VisualState.Setters>
+										<Setter Target="HorizontalThumb.Background.Color" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
+										<Setter Target="VerticalThumb.Background.Color" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
+										<Setter Target="VerticalThumbTransform.ScaleX" Value="{ThemeResource SmallScrollThumbScale}" />
+										<Setter Target="VerticalThumbTransform.TranslateX" Value="{ThemeResource SmallScrollThumbOffset}" />
+										<Setter Target="HorizontalThumbTransform.ScaleY" Value="{ThemeResource SmallScrollThumbScale}" />
+										<Setter Target="HorizontalThumbTransform.TranslateY" Value="{ThemeResource SmallScrollThumbOffset}" />
+										<Setter Target="VerticalSmallIncrease.Opacity" Value="0" />
+										<Setter Target="VerticalLargeIncrease.Opacity" Value="0" />
+										<Setter Target="VerticalLargeDecrease.Opacity" Value="0" />
+										<Setter Target="VerticalSmallDecrease.Opacity" Value="0" />
+										<Setter Target="VerticalTrackRect.Opacity" Value="0" />
+										<Setter Target="HorizontalSmallIncrease.Opacity" Value="0" />
+										<Setter Target="HorizontalLargeIncrease.Opacity" Value="0" />
+										<Setter Target="HorizontalLargeDecrease.Opacity" Value="0" />
+										<Setter Target="HorizontalSmallDecrease.Opacity" Value="0" />
+										<Setter Target="HorizontalTrackRect.Opacity" Value="0" />
+									</VisualState.Setters>
+								</wasm:VisualState>
+                                <not_wasm:VisualState x:Name="CollapsedWithoutAnimation">
                                     <!-- The storyboard below cannot be moved to a transition since transitions
                                              will not be run by the framework when animations are disabled in the system -->
 
@@ -8163,8 +8274,8 @@
                                         <DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="HorizontalSmallDecrease" Storyboard.TargetProperty="Opacity" To="0" />
                                         <DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarContractBeginTime}" Storyboard.TargetName="HorizontalTrackRect" Storyboard.TargetProperty="Opacity" To="0" />
                                     </Storyboard>
-                                </VisualState>
-
+                                </not_wasm:VisualState>
+								
                             </VisualStateGroup>
 
                         </VisualStateManager.VisualStateGroups>


### PR DESCRIPTION
## Work around
`ScrollBar` might not show properly

## What is the current behavior?
A bug in animations on WASM might cause the `ScrollBar` to be unusable in some cases, especially the WCT's `DataGrid`.

## What is the new behavior?
All animations are disable on WASM in the default `ScrollBar` template.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ _non UI testable_
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Linked issue https://github.com/unoplatform/uno/issues/3378