### PR TITLE
fix: Corner radius parsing with spaces

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3505,7 +3505,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						return BuildThickness(memberValue);
 
 					case XamlConstants.Types.CornerRadius:
-						return $"new {XamlConstants.Types.CornerRadius}({memberValue})";
+						return BuildCornerRadius(memberValue);
 
 					case XamlConstants.Types.FontFamily:
 						return $@"new {propertyType.ToDisplayString()}(""{memberValue}"")";
@@ -3820,6 +3820,18 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 
 			return "new global::Windows.UI.Xaml.Thickness(" + memberValue + ")";
+		}
+
+		private static string BuildCornerRadius(string memberValue)
+		{
+			// values can be separated by commas or whitespace
+			// ensure commas are used for the constructor
+			if (!memberValue.Contains(","))
+			{
+				memberValue = string.Join(",", memberValue.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries));				
+			}
+
+			return $"new {XamlConstants.Types.CornerRadius}({memberValue})";
 		}
 
 		private static string AppendFloatSuffix(string memberValue)

--- a/src/SourceGenerators/XamlGenerationTests/CornerRadiusParse.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/CornerRadiusParse.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="XamlGenerationTests.Shared.CornerRadiusParse"
+<UserControl x:Class="XamlGenerationTests.Shared.CornerRadiusParse"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -7,11 +7,8 @@
 
 	<Grid>
 		<Border CornerRadius="12" />
-		<Border CornerRadius="12,14" />
-		<Border CornerRadius="12 14" />
 		<Border CornerRadius="12,16,18,20" />
 		<Border CornerRadius="12 16 18 20" />
-		<Border CornerRadius="12      34" />
 		<Border CornerRadius="12      34     6            80" />
 	</Grid>
 </UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/CornerRadiusParse.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/CornerRadiusParse.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="XamlGenerationTests.Shared.CornerRadiusParse"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d">
+
+	<Grid>
+		<Border CornerRadius="12" />
+		<Border CornerRadius="12,14" />
+		<Border CornerRadius="12 14" />
+		<Border CornerRadius="12,16,18,20" />
+		<Border CornerRadius="12 16 18 20" />
+		<Border CornerRadius="12      34" />
+		<Border CornerRadius="12      34     6            80" />
+	</Grid>
+</UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/CornerRadiusParse.xaml.cs.cs
+++ b/src/SourceGenerators/XamlGenerationTests/CornerRadiusParse.xaml.cs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Windows.Foundation.Metadata;
+using Windows.UI.Xaml.Controls;
+
+namespace XamlGenerationTests.Shared
+{
+	public sealed partial class CornerRadiusParse : UserControl
+	{
+		public CornerRadiusParse()
+		{
+			this.InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #3386 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`CornerRadius` property with spaces can't be parsed.

## What is the new behavior?

`CornerRadius` property with spaces can be parsed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
