### PR TITLE
[Android] Remove forced software rendering for WebView

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2329,6 +2329,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Video_Bug546.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_WithHeaders.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4594,6 +4598,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Title.xaml.cs">
       <DependentUpon>WebView_Title.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Video_Bug546.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Keyboard\Keyboard_Clickthrough_Modal.xaml.cs">
       <DependentUpon>Keyboard_Clickthrough_Modal.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Video_Bug546.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Video_Bug546.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.WebView
+{
+	[Sample("WebView", "GH Bugs", IgnoreInSnapshotTests = true)]
+	public sealed partial class WebView_Video_Bug546 : Page
+	{
+		public WebView_Video_Bug546()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ButtonBase_OnClick(object sender, RoutedEventArgs e)
+		{
+			webview.Navigate(new Uri(addr.Text));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Video_Bug546.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Video_Bug546.xaml
@@ -1,0 +1,26 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.WebView.WebView_Video_Bug546"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<StackPanel>
+			<TextBlock>This is an illuatration of GH bug #546 where the video were not playing (only sound) in a webview on Android.</TextBlock>
+			<StackPanel Orientation="Horizontal">
+				<Button Click="ButtonBase_OnClick">PLAY</Button>
+				<TextBox x:Name="addr" Text="https://www.youtube.com/watch?v=K8Cp-1n_MQY" />
+			</StackPanel>
+		</StackPanel>
+		<WebView x:Name="webview" Grid.Row="1" />
+	</Grid>
+</Page>
+

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -37,6 +37,20 @@ namespace Uno.UI
 			public static bool UseSimpleAccessibility { get; set; } = false;
 		}
 
+		public static class ComboBox
+		{
+			/// <summary>
+			/// This defines the default value of the <see cref="UI.Xaml.Controls.ComboBox.DropDownPreferredPlacementProperty"/>. (cf. Remarks.)
+			/// </summary>
+			/// <remarks>
+			/// As this value is read only once when initializing the dependency property,
+			/// make sure to define it in the early stages of you application initialization,
+			/// before any UI related initialization (like generic styles init) and even before
+			/// referencing the ** type ** ComboBox in any way.
+			/// </remarks>
+			public static Uno.UI.Xaml.Controls.DropDownPlacement DefaultDropDownPreferredPlacement { get; set; } = Uno.UI.Xaml.Controls.DropDownPlacement.Auto;
+		}
+
 		public static class CompositionTarget
 		{
 			/// <summary>
@@ -148,6 +162,18 @@ namespace Uno.UI
 			public static bool LegacyIosAlignment { get; set; } = false;
 		}
 
+		public static class Interop
+		{
+#if __WASM__
+			/// <summary>
+			/// Used to control the behavior of the C#/Javascript interop. Setting this
+			/// flag to true forces the use of the Javascript eval mode, instead of binary interop.
+			/// This flag has no effect when running in hosted mode.
+			/// </summary>
+			public static bool ForceJavascriptInterop { get; set; } = false;
+#endif
+		}
+
 		public static class Popup
 		{
 #if __ANDROID__
@@ -161,18 +187,6 @@ namespace Uno.UI
 		public static class ProgressRing
 		{
 			public static Uri ProgressRingAsset { get; set; } = new Uri("embedded://Uno.UI/Uno.UI.Microsoft.UI.Xaml.Controls.ProgressRing.ProgressRingIntdeterminate.json");
-		}
-
-		public static class Interop
-		{
-#if __WASM__
-			/// <summary>
-			/// Used to control the behavior of the C#/Javascript interop. Setting this
-			/// flag to true forces the use of the Javascript eval mode, instead of binary interop.
-			/// This flag has no effect when running in hosted mode.
-			/// </summary>
-			public static bool ForceJavascriptInterop { get; set; } = false;
-#endif
 		}
 
 		public static class ListViewBase
@@ -268,6 +282,51 @@ namespace Uno.UI
 			public static bool HideCaret { get; set; } = false;
 		}
 
+		public static class ScrollViewer
+		{
+			/// <summary>
+			/// This defines the default value of the <see cref="Uno.UI.Xaml.Controls.ScrollViewer.UpdatesModeProperty"/>.
+			/// For backward compatibility, you should set it to Synchronous.
+			/// For better compatibility with Windows, you should keep the default value 'AsynchronousIdle'.
+			/// </summary>
+			/// <remarks>
+			/// As this value is read only once when initializing the dependency property,
+			/// make sure to define it in the early stages of you application initialization,
+			/// before any UI related initialization (like generic styles init) and even before
+			/// referencing the ** type ** ScrollViewer in any way.
+			/// </remarks>
+			public static ScrollViewerUpdatesMode DefaultUpdatesMode { get; set; } = ScrollViewerUpdatesMode.AsynchronousIdle;
+
+#if __ANDROID__
+			/// <summary>
+			/// This value defines an optional delay to be set for native ScrollBar thumbs to disapear. The
+			/// platform default is 300ms, which can make the thumbs appear on screenshots, changing this value
+			/// to <see cref="TimeSpan.Zero"/> makes those disapear faster.
+			/// </summary>
+			public static TimeSpan? AndroidScrollbarFadeDelay { get; set; }
+#endif
+		}
+
+		public static class ThemeAnimation
+		{
+			/// <summary>
+			/// Default duration for xxxThemeAnimation
+			/// </summary>
+			public static TimeSpan DefaultThemeAnimationDuration { get; set; } = TimeSpan.FromSeconds(0.75);
+		}
+
+		public static class ToolTip
+		{
+			public static bool UseToolTips { get; set; }
+#if __WASM__
+				= true;
+#endif
+
+			public static int ShowDelay { get; set; } = 1000;
+
+			public static int ShowDuration { get; set; } = 7000;
+		}
+
 		public static class UIElement
 		{
 			/// <summary>
@@ -321,63 +380,18 @@ namespace Uno.UI
 #endif
 		}
 
-		public static class ScrollViewer
+		public static class WebView
 		{
-			/// <summary>
-			/// This defines the default value of the <see cref="Uno.UI.Xaml.Controls.ScrollViewer.UpdatesModeProperty"/>.
-			/// For backward compatibility, you should set it to Synchronous.
-			/// For better compatibility with Windows, you should keep the default value 'AsynchronousIdle'.
-			/// </summary>
-			/// <remarks>
-			/// As this value is read only once when initializing the dependency property,
-			/// make sure to define it in the early stages of you application initialization,
-			/// before any UI related initialization (like generic styles init) and even before
-			/// referencing the ** type ** ScrollViewer in any way.
-			/// </remarks>
-			public static ScrollViewerUpdatesMode DefaultUpdatesMode { get; set; } = ScrollViewerUpdatesMode.AsynchronousIdle;
-
 #if __ANDROID__
 			/// <summary>
-			/// This value defines an optional delay to be set for native ScrollBar thumbs to disapear. The
-			/// platform default is 300ms, which can make the thumbs appear on screenshots, changing this value
-			/// to <see cref="TimeSpan.Zero"/> makes those disapear faster.
-			/// </summary>
-			public static TimeSpan? AndroidScrollbarFadeDelay { get; set; }
-#endif
-		}
-
-		public static class ThemeAnimation
-		{
-			/// <summary>
-			/// Default duration for xxxThemeAnimation
-			/// </summary>
-			public static TimeSpan DefaultThemeAnimationDuration { get; set; } = TimeSpan.FromSeconds(0.75);
-		}
-
-		public static class ComboBox
-		{
-			/// <summary>
-			/// This defines the default value of the <see cref="UI.Xaml.Controls.ComboBox.DropDownPreferredPlacementProperty"/>. (cf. Remarks.)
+			/// Prevent the WebView from using hardware rendering.
+			/// This was the default behavior in Uno from a long time because of keyboard pop-up
 			/// </summary>
 			/// <remarks>
-			/// As this value is read only once when initializing the dependency property,
-			/// make sure to define it in the early stages of you application initialization,
-			/// before any UI related initialization (like generic styles init) and even before
-			/// referencing the ** type ** ComboBox in any way.
+			/// See this for more info: https://github.com/unoplatform/uno/blob/26c5cc5992cae3c8c25adf51eb77ca4b0dd34e93/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs#L251_L255
 			/// </remarks>
-			public static Uno.UI.Xaml.Controls.DropDownPlacement DefaultDropDownPreferredPlacement { get; set; } = Uno.UI.Xaml.Controls.DropDownPlacement.Auto;
-		}
-
-		public static class ToolTip
-		{
-			public static bool UseToolTips { get; set; }
-#if __WASM__
-				= true;
+			public static bool ForceSoftwareRendering { get; set; } = false;
 #endif
-
-			public static int ShowDelay { get; set; } = 1000;
-
-			public static int ShowDuration { get; set; } = 7000;
 		}
 
 		public static class Xaml

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -354,6 +354,20 @@ namespace Uno.UI
 			public static TimeSpan DefaultThemeAnimationDuration { get; set; } = TimeSpan.FromSeconds(0.75);
 		}
 
+		public static class ComboBox
+		{
+			/// <summary>
+			/// This defines the default value of the <see cref="UI.Xaml.Controls.ComboBox.DropDownPreferredPlacementProperty"/>. (cf. Remarks.)
+			/// </summary>
+			/// <remarks>
+			/// As this value is read only once when initializing the dependency property,
+			/// make sure to define it in the early stages of you application initialization,
+			/// before any UI related initialization (like generic styles init) and even before
+			/// referencing the ** type ** ComboBox in any way.
+			/// </remarks>
+			public static Uno.UI.Xaml.Controls.DropDownPlacement DefaultDropDownPreferredPlacement { get; set; } = Uno.UI.Xaml.Controls.DropDownPlacement.Auto;
+		}
+
 		public static class ToolTip
 		{
 			public static bool UseToolTips { get; set; }
@@ -377,20 +391,6 @@ namespace Uno.UI
 			[Obsolete("This flag is no longer used.")]
 			[EditorBrowsable(EditorBrowsableState.Never)]
 			public static int MaxRecursiveResolvingDepth { get; set; } = 12;
-		}
-
-		public static class ComboBox
-		{
-			/// <summary>
-			/// This defines the default value of the <see cref="UI.Xaml.Controls.ComboBox.DropDownPreferredPlacementProperty"/>. (cf. Remarks.)
-			/// </summary>
-			/// <remarks>
-			/// As this value is read only once when initializing the dependency property,
-			/// make sure to define it in the early stages of you application initialization,
-			/// before any UI related initialization (like generic styles init) and even before
-			/// referencing the ** type ** ComboBox in any way.
-			/// </remarks>
-			public static Uno.UI.Xaml.Controls.DropDownPlacement DefaultDropDownPreferredPlacement { get; set; } = Uno.UI.Xaml.Controls.DropDownPlacement.Auto;
 		}
 	}
 }

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -385,7 +385,7 @@ namespace Uno.UI
 #if __ANDROID__
 			/// <summary>
 			/// Prevent the WebView from using hardware rendering.
-			/// This was the default behavior in Uno from a long time because of keyboard pop-up
+			/// This was previously the default behavior in Uno to work around a keyboard-related visual glitch in Android 5.0 (http://stackoverflow.com/questions/27172217/android-systemui-glitches-in-lollipop), however it prevents video and 3d content from being rendered.
 			/// </summary>
 			/// <remarks>
 			/// See this for more info: https://github.com/unoplatform/uno/blob/26c5cc5992cae3c8c25adf51eb77ca4b0dd34e93/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs#L251_L255

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
@@ -252,11 +252,15 @@ namespace Windows.UI.Xaml.Controls
 			public InternalClient(WebView webView)
 			{
 				_webView = webView;
-				//SetLayerType disables hardware acceleration for a single view.
-				//This is required to remove glitching issues particularly when having a keyboard pop-up with a webview present.
-				//http://developer.android.com/guide/topics/graphics/hardware-accel.html
-				//http://stackoverflow.com/questions/27172217/android-systemui-glitches-in-lollipop
-				_webView.SetLayerType(LayerType.Software, null);
+
+				if (FeatureConfiguration.WebView.ForceSoftwareRendering)
+				{
+					//SetLayerType disables hardware acceleration for a single view.
+					//This is required to remove glitching issues particularly when having a keyboard pop-up with a webview present.
+					//http://developer.android.com/guide/topics/graphics/hardware-accel.html
+					//http://stackoverflow.com/questions/27172217/android-systemui-glitches-in-lollipop
+					_webView.SetLayerType(LayerType.Software, null);
+				}
 			}
 
 #pragma warning disable CS0672 // Member overrides obsolete member


### PR DESCRIPTION
# Bugfix

## What is the current behavior?
Only the sound were played in a WebView on Android, no image. The cause was the WebView control itself which were forced to render using software:

Faulty code:
``` csharp
  //SetLayerType disables hardware acceleration for a single view.
  //This is required to remove glitching issues particularly when having a keyboard pop-up with a webview present.
  //http://developer.android.com/guide/topics/graphics/hardware-accel.html
  //http://stackoverflow.com/questions/27172217/android-systemui-glitches-in-lollipop
  _webView.SetLayerType(LayerType.Software, null);
```

## What is the new behavior?
The software mode is now opt-in using the following code:

``` csharp
#if __ANDROID__
  // Use the old WebView mode
  FeatureConfiguration.WebView.ForceSoftwareRendering = true;
#endif
```
## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Issues
* Fix https://github.com/unoplatform/uno/issues/546
* Fix https://github.com/unoplatform/uno/issues/851
* Caused by this: https://nventive.visualstudio.com/Umbrella/_workitems/edit/30065 (2017-05-29)