### PR TITLE
[iOS] ProgressRing were still visible on Visibility=Collapsed

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -905,6 +905,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ProgressRing\WindowsProgressRing_GH1220.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\RadioButtonTests\RadioButton2450.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3810,6 +3814,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Overlay_On.xaml.cs">
       <DependentUpon>Popup_Overlay_On.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ProgressRing\WindowsProgressRing_GH1220.xaml.cs">
+      <DependentUpon>WindowsProgressRing_GH1220.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\RadioButtonTests\RadioButton2450.xaml.cs">
       <DependentUpon>RadioButton2450.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ProgressRing/WindowsProgressRing_GH1220.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ProgressRing/WindowsProgressRing_GH1220.xaml
@@ -1,0 +1,20 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.ProgressRing.WindowsProgressRing_GH1220"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="10" Margin="15">
+		<TextBlock FontSize="15">This is an illustration of GH bug #1220 - ProgressRing doesn't collapse on iOS.</TextBlock>
+		<TextBlock FontSize="15">The following ProgressRing should NOT be visible. If you see a ProgressRing, there's a problem.</TextBlock>
+
+		<ProgressRing Width="200" Height="200" Foreground="Red" IsActive="True" Visibility="Collapsed"/>
+
+		<TextBlock FontSize="15">Another ProgressRing, but visibility is dynamic:</TextBlock>
+		<ToggleButton x:Name="isVisible">IS VISIBLE</ToggleButton>
+		<ProgressRing Width="200" Height="200" Foreground="Red" IsActive="True" Visibility="{Binding IsChecked, ElementName=isVisible}"/>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ProgressRing/WindowsProgressRing_GH1220.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ProgressRing/WindowsProgressRing_GH1220.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.ProgressRing
+{
+	[Sample("Progress", "GH Bugs")]
+	public sealed partial class WindowsProgressRing_GH1220 : Page
+	{
+		public WindowsProgressRing_GH1220()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOS.cs
@@ -57,21 +57,18 @@ namespace Windows.UI.Xaml.Controls
 
 		private static void OnIsActiveChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
-			(dependencyObject as ProgressRing)?.SetIsActive(args.NewValue as bool?);
+			(dependencyObject as ProgressRing)?.SetIsActive((bool)args.NewValue);
 		}
 
-		private void SetIsActive(bool? isActive)
+		private void SetIsActive(bool isActive)
 		{
-			if (isActive is { } b)
+			if (isActive)
 			{
-				if(b)
-				{
-					StartAnimating();
-				}
-				else
-				{
-					StopAnimating();
-				}
+				StartAnimating();
+			}
+			else
+			{
+				StopAnimating();
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOS.cs
@@ -50,22 +50,29 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-        private static void OnIsActiveChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
-        {
-            var progressRing = dependencyObject as ProgressRing;
-            var isActive = args.NewValue as bool?;
+		partial void OnVisibilityChangedPartial(Visibility oldValue, Visibility newValue)
+		{
+			SetIsActive(newValue == Visibility.Visible && IsActive);
+		}
 
-            if (progressRing != null && isActive != null)
-            {
-                if (isActive.Value)
-                {
-                    progressRing.StartAnimating();
-                }
-                else
-                {
-                    progressRing.StopAnimating();                    
-                }
-            }
-        }
-    }
+		private static void OnIsActiveChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			(dependencyObject as ProgressRing)?.SetIsActive(args.NewValue as bool?);
+		}
+
+		private void SetIsActive(bool? isActive)
+		{
+			if (isActive is { } b)
+			{
+				if(b)
+				{
+					StartAnimating();
+				}
+				else
+				{
+					StopAnimating();
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fix https://github.com/unoplatform/uno/issues/1220

# Bugfix

When setting `Visibility=Collapsed` directly on a `<ProgressRing>` control in Xaml, it was still visible.

This was caused by the fact the `Visibility` property callback were not implemented properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
