### PR TITLE
ci: Add explicit timeout for all UI tests

### DIFF
--- a/build/android-uitest-run.sh
+++ b/build/android-uitest-run.sh
@@ -70,7 +70,8 @@ export UNO_UITEST_ANDROIDAPK_PATH=$BUILD_SOURCESDIRECTORY/build/uitests-android-
 
 cd $BUILD_SOURCESDIRECTORY/build
 
-mono nuget/NuGet.exe install NUnit.ConsoleRunner -Version 3.10.0
+export NUNIT_VERSION=3.11.1
+mono nuget/NuGet.exe install NUnit.ConsoleRunner -Version $NUNIT_VERSION
 
 mkdir -p $UNO_UITEST_SCREENSHOT_PATH
 
@@ -78,11 +79,14 @@ mkdir -p $UNO_UITEST_SCREENSHOT_PATH
 # required by Xamarin.UITest
 cd $UNO_UITEST_SCREENSHOT_PATH
 
-mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe \
+mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
+	--trace=Verbose \
+	--framework=mono \
 	--inprocess \
 	--agents=1 \
 	--workers=1 \
 	--result=$BUILD_SOURCESDIRECTORY/build/TestResult.xml \
+	--timeout=120000 \
 	--where "$TEST_FILTERS" \
 	$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/$BUILDCONFIGURATION/net47/SamplesApp.UITests.dll \
 	|| true

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -89,3 +89,27 @@ jobs:
     xCodeRoot: ${{ parameters.xCodeRoot }}
     XamarinSDKVersion: ${{ parameters.XamarinSDKVersion }}
 
+- template: .azure-devops-ios-tests-run.yml
+  parameters:
+    nugetPackages: $(NUGET_PACKAGES)
+    JobName: 'iOS_Snaphot_Tests_Group_03'
+    JobDisplayName: 'iOS Snaphot Tests Group 03'
+    JobTimeoutInMinutes: 45
+    vmImage: ${{ parameters.vmImage }}
+    UITEST_SNAPSHOTS_ONLY: true
+    UITEST_SNAPSHOTS_GROUP: 02
+    xCodeRoot: ${{ parameters.xCodeRoot }}
+    XamarinSDKVersion: ${{ parameters.XamarinSDKVersion }}
+
+- template: .azure-devops-ios-tests-run.yml
+  parameters:
+    nugetPackages: $(NUGET_PACKAGES)
+    JobName: 'iOS_Snaphot_Tests_Group_04'
+    JobDisplayName: 'iOS Snaphot Tests Group 04'
+    JobTimeoutInMinutes: 45
+    vmImage: ${{ parameters.vmImage }}
+    UITEST_SNAPSHOTS_ONLY: true
+    UITEST_SNAPSHOTS_GROUP: 03
+    xCodeRoot: ${{ parameters.xCodeRoot }}
+    XamarinSDKVersion: ${{ parameters.XamarinSDKVersion }}
+

--- a/build/ci/templates/nuget-cache.yml
+++ b/build/ci/templates/nuget-cache.yml
@@ -9,8 +9,8 @@ steps:
 
     condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
 
-  - task: CacheBeta@0
-    condition: eq(variables['enable_package_cache'], 'true')
+  - task: Cache@2
+    # condition: eq(variables['enable_package_cache'], 'true')
     inputs:
       key: nuget | $(Agent.OS) | $(Agent.JobName) | $(build.sourcesdirectory)/**/*.csproj | $(build.sourcesdirectory)/**/Directory.Build.targets | $(build.sourcesdirectory)/**/Directory.Build.props
       path: ${{ parameters.nugetPackages }}

--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -13,7 +13,8 @@ msbuild /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/Sampl
 
 cd $BUILD_SOURCESDIRECTORY/build
 
-mono nuget/nuget.exe install NUnit.ConsoleRunner -Version 3.10.0
+export NUNIT_VERSION=3.11.1
+mono nuget/nuget.exe install NUnit.ConsoleRunner -Version $NUNIT_VERSION
 
 if [ "$UITEST_SNAPSHOTS_ONLY" == 'true' ];
 then
@@ -63,11 +64,9 @@ chmod -R +x $UNO_UITEST_IOSBUNDLE_PATH
 # required by Xamarin.UITest
 cd $UNO_UITEST_SCREENSHOT_PATH
 
-mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.3.10.0/tools/nunit3-console.exe \
-	--inprocess \
-	--agents=1 \
-	--workers=1 \
+mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
 	--result=$BUILD_SOURCESDIRECTORY/build/TestResult.xml \
+	--timeout=120000 \
 	--where "$TEST_FILTERS" \
 	$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/net47/SamplesApp.UITests.dll \
 	|| true

--- a/src/SamplesApp/SamplesApp.UITests.Generator/SnapShotTestGenerator.cs
+++ b/src/SamplesApp/SamplesApp.UITests.Generator/SnapShotTestGenerator.cs
@@ -15,6 +15,8 @@ namespace Uno.Samples.UITest.Generator
 {
 	public class SnapShotTestGenerator : SourceGenerator
 	{
+		private const int GroupCount = 4;
+
 		private INamedTypeSymbol _sampleControlInfoSymbol;
 		private INamedTypeSymbol _sampleSymbol;
 
@@ -147,7 +149,7 @@ namespace Uno.Samples.UITest.Generator
 						foreach (var test in group.Symbols)
 						{
 							builder.AppendLineInvariant("[global::NUnit.Framework.Test]");
-							builder.AppendLineInvariant($"[global::NUnit.Framework.Description(\"runGroup:{group.Index % 2:00}, automated:{test.symbol.ToDisplayString()}\")]");
+							builder.AppendLineInvariant($"[global::NUnit.Framework.Description(\"runGroup:{group.Index % GroupCount:00}, automated:{test.symbol.ToDisplayString()}\")]");
 
 							if (test.ignoreInSnapshotTests)
 							{
@@ -155,9 +157,13 @@ namespace Uno.Samples.UITest.Generator
 							}
 
 							builder.AppendLineInvariant("[global::SamplesApp.UITests.TestFramework.AutoRetry]");
-							using (builder.BlockInvariant($"public void {Sanitize(test.categories.First())}_{Sanitize(test.name)}()"))
+							builder.AppendLineInvariant("[global::NUnit.Framework.Timeout(15000)]");
+							var testName = $"{Sanitize(test.categories.First())}_{Sanitize(test.name)}";
+							using (builder.BlockInvariant($"public void {testName}()"))
 							{
+								builder.AppendLineInvariant($"Console.WriteLine(\"Running test [{testName}]\");");
 								builder.AppendLineInvariant($"Run(\"{test.symbol}\", waitForSampleControl: false);");
+								builder.AppendLineInvariant($"Console.WriteLine(\"Ran test [{testName}]\");");
 							}
 						}
 					}

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" /> 
-		<PackageReference Include="Xamarin.UITest" Version="3.0.7-dev2" />
+		<PackageReference Include="Xamarin.UITest" Version="3.0.8-dev1" />
 		<PackageReference Include="Uno.UITest" />
 		<PackageReference Include="Uno.UITest.Selenium" />
 		<PackageReference Include="Uno.UITest.Xamarin" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Adds an explicit timeout for the test runner on iOS and Android.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
