### PR TITLE
docs(progressring): Improve the documentation of ProgressRing (WinUI)

### DIFF
--- a/doc/articles/features/progressring.md
+++ b/doc/articles/features/progressring.md
@@ -1,0 +1,23 @@
+# ProgressRing
+
+There is 2 progress rings available in Uno:
+
+* `Windows.UI.Xaml.Controls.ProgressRing` - the default "legacy" one, support for both native & UWP styling.
+* `Microsoft.UI.Xaml.Controls.ProgressRing` - the new version, which is powered by Lottie.
+
+## Using the legacy `Windows.UI.Xaml.Controls.ProgressRing`
+
+This should work on all platforms and will use the native progress ring control by default. Except on Wasm where there's no such thing as a native progress ring control.
+
+## Using the new `Microsoft.UI.Xaml.Controls.ProgressRing`
+
+This version come with [WinUI 2.4](https://docs.microsoft.com/en-us/windows/apps/winui/winui2/release-notes/winui-2.4#progressring) and is using an `<AnimatedVisualPlayer />` in its Control Template. It's also designed to be a replacement for the legacy version, so your custom template should work unchanged with this version.
+
+**IMPORTANT**: To use the refreshed visual style, you **MUST** add a reference to `Uno.UI.Lottie` package to your projects or the ring won't show at all.
+
+
+
+
+
+
+

--- a/doc/articles/features/progressring.md
+++ b/doc/articles/features/progressring.md
@@ -1,19 +1,19 @@
 # ProgressRing
 
-There is 2 progress rings available in Uno:
+There are 2 progress rings available in Uno:
 
-* `Windows.UI.Xaml.Controls.ProgressRing` - the default "legacy" one, support for both native & UWP styling.
+* `Windows.UI.Xaml.Controls.ProgressRing` - the UWP one, support for both native & UWP styling.
 * `Microsoft.UI.Xaml.Controls.ProgressRing` - the new version, which is powered by Lottie.
 
 ## Using the legacy `Windows.UI.Xaml.Controls.ProgressRing`
 
-This should work on all platforms and will use the native progress ring control by default. Except on Wasm where there's no such thing as a native progress ring control.
+This control works on all platforms and uses the native progress ring control by default, with the exception of Wasm where there is no native progress ring control.
 
 ## Using the new `Microsoft.UI.Xaml.Controls.ProgressRing`
 
-This version come with [WinUI 2.4](https://docs.microsoft.com/en-us/windows/apps/winui/winui2/release-notes/winui-2.4#progressring) and is using an `<AnimatedVisualPlayer />` in its Control Template. It's also designed to be a replacement for the legacy version, so your custom template should work unchanged with this version.
+This version comes with [WinUI 2.4](https://docs.microsoft.com/en-us/windows/apps/winui/winui2/release-notes/winui-2.4#progressring) and is using an `<AnimatedVisualPlayer />` in its Control Template. It is also designed to be a replacement for the legacy version, where a custom template should work unchanged with this control.
 
-**IMPORTANT**: To use the refreshed visual style, you **MUST** add a reference to `Uno.UI.Lottie` package to your projects or the ring won't show at all.
+**IMPORTANT**: To use the refreshed visual style, you must add a reference to `Uno.UI.Lottie` package to your projects or the ring will not be displayed.
 
 
 

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -72,6 +72,8 @@
     href: features/SpeechRecognition.md
   - name: PowerManager
     href: features/windows-system-power.md
+  - name: ProgressRing
+    href: features/progressring.md
   - name: Windows.System.Profile
     href: features/windows-system-profile.md
   - name: PasswordVault
@@ -123,14 +125,12 @@
   topicHref: implemented-views.md
 - name: Using Uno - advanced topics
   items:
+    - name: Azure Authentication using MSAL
+      href: interop/MSAL.md
     - name: (Wasm) Handling custom HTML events
       href: wasm-custom-events.md
     - name: Using Uno Platform Controls in Xamarin.Forms
       href: howto-use-uno-in-xamarin-forms.md
-- name: Advanced Interoperability
-  item:
-    - name: Azure Authentication using MSAL
-      href: introp/msal.md
 - name: Contributing to Uno
   items:
     - name: Guidelines for creating tests

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/ProgressRing/ProgressRing.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/ProgressRing/ProgressRing.cs
@@ -12,12 +12,13 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class ProgressRing : Control
 	{
-		private ILottieVisualSourceProvider _lottieProvider;
+		private readonly ILottieVisualSourceProvider _lottieProvider;
 
 		public static readonly DependencyProperty IsActiveProperty = DependencyProperty.Register(
 			"IsActive", typeof(bool), typeof(ProgressRing), new PropertyMetadata(true, OnIsActivePropertyChanged));
 
 		private AnimatedVisualPlayer _player;
+		private Panel _layoutRoot;
 
 		public bool IsActive
 		{
@@ -45,6 +46,7 @@ namespace Microsoft.UI.Xaml.Controls
 		protected override void OnApplyTemplate()
 		{
 			_player = GetTemplateChild("IndeterminateAnimatedVisualPlayer") as Windows.UI.Xaml.Controls.AnimatedVisualPlayer;
+			_layoutRoot = GetTemplateChild("LayoutRoot") as Panel;
 
 			SetAnimatedVisualPlayerSource();
 
@@ -79,6 +81,20 @@ namespace Microsoft.UI.Xaml.Controls
 				var animatedVisualSource = _lottieProvider.CreateFromLottieAsset(FeatureConfiguration.ProgressRing.ProgressRingAsset);
 				_player.Source = animatedVisualSource;
 				ChangeVisualState();
+			}
+			else if (_player != null && _layoutRoot != null)
+			{
+				// If we have a _player, it means we're having a ControlTemplate relying
+				// on it.  In this case, the Uno.UI.Lottie reference is required for the
+				// rendering of the ProgressRing.
+
+				var txt = new TextBlock
+				{
+					Text = "⚠️ Uno.UI.Lottie missing ⚠️",
+					Foreground = SolidColorBrushHelper.Red
+				};
+
+				_layoutRoot.Children.Add(txt);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #3196 

# Documentation
Documentation of ProgressRing.

Also added a visual notification when `Uno.UI.Lottie` is not present.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- ~~[ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- ~~[ ] Validated PR `Screenshots Compare Test Run` results.~~
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
