### PR TITLE
Support spaces in Thickness and CornerRadius type converters

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3819,7 +3819,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			// This is until we find an appropriate way to convert strings to Thickness.
 			if (!memberValue.Contains(","))
 			{
-				memberValue = memberValue.Replace(" ", ",");
+				memberValue = ReplaceWhitespaceByCommas(memberValue);
 			}
 
 			if (memberValue.Contains("."))
@@ -3827,7 +3827,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				// Append 'f' to every decimal value in the thickness
 				memberValue = AppendFloatSuffix(memberValue);
 			}
-
+			
 			return "new global::Windows.UI.Xaml.Thickness(" + memberValue + ")";
 		}
 
@@ -3837,10 +3837,16 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			// ensure commas are used for the constructor
 			if (!memberValue.Contains(","))
 			{
-				memberValue = string.Join(",", memberValue.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries));				
+				memberValue = ReplaceWhitespaceByCommas(memberValue);
 			}
 
 			return $"new {XamlConstants.Types.CornerRadius}({memberValue})";
+		}
+
+		private static string ReplaceWhitespaceByCommas(string memberValue)
+		{
+			// empty delimiter array = whitespace in string.Split
+			return string.Join(",", memberValue.Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries));
 		}
 
 		private static string AppendFloatSuffix(string memberValue)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_CornerRadiusConverter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_CornerRadiusConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !WINDOWS_UWP
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -45,3 +46,4 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		}
 	}
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_CornerRadiusConverter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_CornerRadiusConverter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_CornerRadiusConverter
+	{
+		[TestMethod]
+		public void When_CornerRadius_With_Single_Value()
+		{
+			var converter = new CornerRadiusConverter();
+			var value = (CornerRadius)converter.ConvertFrom("23");
+			Assert.AreEqual(23, value.TopLeft);
+			Assert.AreEqual(23, value.TopRight);
+			Assert.AreEqual(23, value.BottomRight);
+			Assert.AreEqual(23, value.BottomLeft);
+		}
+
+		[TestMethod]
+		public void When_CornerRadius_With_Four_Values_Comma()
+		{
+			var converter = new CornerRadiusConverter();
+			var value = (CornerRadius)converter.ConvertFrom("23,35,2,65");
+			Assert.AreEqual(23, value.TopLeft);
+			Assert.AreEqual(35, value.TopRight);
+			Assert.AreEqual(2, value.BottomRight);
+			Assert.AreEqual(65, value.BottomLeft);
+		}
+
+		[TestMethod]
+		public void When_CornerRadius_With_Four_Values_Whitespace()
+		{
+			var converter = new CornerRadiusConverter();
+			var value = (CornerRadius)converter.ConvertFrom("		 23   35 2				65  ");
+			Assert.AreEqual(23, value.TopLeft);
+			Assert.AreEqual(35, value.TopRight);
+			Assert.AreEqual(2, value.BottomRight);
+			Assert.AreEqual(65, value.BottomLeft);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThicknessConverter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThicknessConverter.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_ThicknessConverter
+	{
+		[TestMethod]
+		public void When_Thickness_With_Single_Value()
+		{
+			var converter = new ThicknessConverter();
+			var value = (Thickness)converter.ConvertFrom("23");
+			Assert.AreEqual(23, value.Left);
+			Assert.AreEqual(23, value.Right);
+			Assert.AreEqual(23, value.Bottom);
+			Assert.AreEqual(23, value.Top);
+		}
+
+		[TestMethod]
+		public void When_Thickness_With_Two_Values_Comma()
+		{
+			var converter = new ThicknessConverter();
+			var value = (Thickness)converter.ConvertFrom("23,35");
+			Assert.AreEqual(23, value.Left);
+			Assert.AreEqual(35, value.Top);
+			Assert.AreEqual(23, value.Right);
+			Assert.AreEqual(35, value.Bottom);
+		}
+
+		[TestMethod]
+		public void When_Thickness_With_Two_Values_Whitespace()
+		{
+			var converter = new ThicknessConverter();
+			var value = (Thickness)converter.ConvertFrom("   23		   35			 ");
+			Assert.AreEqual(23, value.Left);
+			Assert.AreEqual(35, value.Top);
+			Assert.AreEqual(23, value.Right);
+			Assert.AreEqual(35, value.Bottom);
+		}
+
+		[TestMethod]
+		public void When_Thickness_With_Four_Values_Comma()
+		{
+			var converter = new ThicknessConverter();
+			var value = (Thickness)converter.ConvertFrom("23,35,2,65");
+			Assert.AreEqual(23, value.Left);
+			Assert.AreEqual(35, value.Top);
+			Assert.AreEqual(2, value.Right);
+			Assert.AreEqual(65, value.Bottom);
+		}
+
+		[TestMethod]
+		public void When_Thickness_With_Four_Values_Whitespace()
+		{
+			var converter = new ThicknessConverter();
+			var value = (Thickness)converter.ConvertFrom("		 23   35 2				65  ");
+			Assert.AreEqual(23, value.Left);
+			Assert.AreEqual(35, value.Top);
+			Assert.AreEqual(2, value.Right);
+			Assert.AreEqual(65, value.Bottom);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThicknessConverter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThicknessConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !WINDOWS_UWP
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -65,3 +66,4 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		}
 	}
 }
+#endif

--- a/src/Uno.UI/UI/Xaml/CornerRadiusConverter.cs
+++ b/src/Uno.UI/UI/Xaml/CornerRadiusConverter.cs
@@ -10,6 +10,8 @@ namespace Windows.UI.Xaml
 	/// <summary>Defines the radius of a rectangle's corners. </summary>
 	public class CornerRadiusConverter : TypeConverter
 	{
+		private static readonly char[] _valueSeparator = new char[] { ',', ' ', '\t', '\r', '\n' };
+
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
 			var canConvert =
@@ -31,7 +33,7 @@ namespace Windows.UI.Xaml
 			if (value is string stringValue)
 			{
 				var values = stringValue
-					.Split(new[] { ',' })
+					.Split(_valueSeparator, StringSplitOptions.RemoveEmptyEntries)
 					.Select(s => double.Parse(s, CultureInfo.InvariantCulture))
 					.ToArray();
 

--- a/src/Uno.UI/UI/Xaml/ThicknessConverter.cs
+++ b/src/Uno.UI/UI/Xaml/ThicknessConverter.cs
@@ -7,6 +7,8 @@ namespace Windows.UI.Xaml
 {
 	public class ThicknessConverter : TypeConverter
 	{
+		private static readonly char[] _valueSeparator = new char[] { ',', ' ', '\t', '\r', '\n' };
+
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
 			var canConvert = sourceType == typeof(string)
@@ -27,7 +29,7 @@ namespace Windows.UI.Xaml
 			if (value is string stringValue)
 			{
 				var values = stringValue
-					.Split(new[] { ',' })
+					.Split(_valueSeparator, StringSplitOptions.RemoveEmptyEntries)
 					.Select(s => double.Parse(s, CultureInfo.InvariantCulture))
 					.ToArray();
 
@@ -44,7 +46,7 @@ namespace Windows.UI.Xaml
 					return new Thickness(values[0], values[0], values[0], values[0]);
 				}
 			}
-			else if(value is double doubleValue)
+			else if (value is double doubleValue)
 			{
 				return new Thickness(doubleValue);
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3386 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Spaces are not supported for splitting values in thickness/corner radius type converter.

## What is the new behavior?

- Spaces are supported
- XAML parser uses general whitespace splitting for thickness/corner radius.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.