### PR TITLE
fix(style): Fix property set not applied within callback from style application

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
@@ -1389,6 +1389,23 @@ namespace Uno.UI.Tests.BinderTests
 			changes.Count.Should().Be(4);
 			changes.Last().NewValue.Should().Be(42);
 		}
+
+		[TestMethod]
+		public void When_Set_Within_Style_Application()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			var button = new Button();
+			button.RegisterPropertyChangedCallback(Button.PaddingProperty, (o, e) =>
+			{
+				button.Content = "Frogurt";
+			});
+
+			app.HostView.Children.Add(button); // Causes default style to be applied
+
+			var localContent = button.ReadLocalValue(Button.ContentProperty);
+			Assert.AreEqual("Frogurt", localContent);
+		}
 	}
 
 	#region DependencyObjects


### PR DESCRIPTION
Setting a DP within the property changed callback of another DP that was set by a Style, was causing the first DP to also be set with style-level precedence. Fix so that nested DP changes are applied with the usual precedence, per UWP.

GitHub Issue (If applicable): fixes #3398 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
