### PR TITLE
feat: Add support for TextBlock.Foreground update on SolidColorBrushColor changes

### DIFF
--- a/doc/articles/Uno-UI-Performance.md
+++ b/doc/articles/Uno-UI-Performance.md
@@ -37,6 +37,14 @@ Here's what to look for:
 	- It is also supported as `xamarin:Phase` on controls that do not have bindings. This feature is not supported by UWP.
 	- It is only supported for elements under the `DataTemplate` of a `ListViewItem`. The 
 	attribute is ignored for templates of `ContentControl` instances, or any other control.
+    - When binding to Brushes with a solid color, prefer binding to the `Color` property like this if the brush type does not change:
+    ```xaml
+    <TextBlock Text="My Text">
+        <TextBlock.Foreground>
+            <SolidColorBrush Color="{x:Bind Color, Mode=OneWay, FallbackValue=Red}" />
+        </TextBlock.Foreground>
+    </TextBlock>
+    ```
 
 
 ## Performance Tracing

--- a/src/SamplesApp/SamplesApp.Droid/MainActivity.cs
+++ b/src/SamplesApp/SamplesApp.Droid/MainActivity.cs
@@ -31,6 +31,9 @@ namespace SamplesApp.Droid
 		[Export("IsTestDone")]
 		public bool IsTestDone(string testId) => App.IsTestDone(testId);
 
+		[Export("GetDisplayScreenScaling")]
+		public string GetDisplayScreenScaling(string displayId) => App.GetDisplayScreenScaling(displayId);
+
 		[Export("SetFullScreenMode")]
 		public void SetFullScreenMode(bool fullscreen)
 		{

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -24,6 +24,8 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Logging;
+using Windows.Graphics.Display;
+using System.Globalization;
 
 #if HAS_UNO_WINUI
 using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
@@ -283,6 +285,9 @@ namespace SamplesApp
 		public static string GetAllTests()
 			=> SampleControl.Presentation.SampleChooserViewModel.Instance.GetAllSamplesNames();
 
+		public static string GetDisplayScreenScaling(string displayId)
+			=> DisplayInformation.GetForCurrentView().LogicalDpi.ToString(CultureInfo.InvariantCulture);
+
 		public static string RunTest(string metadataName)
 		{
 			try
@@ -359,6 +364,9 @@ namespace SamplesApp
 
 		[Foundation.Export("isTestDone:")] // notice the colon at the end of the method name
 		public Foundation.NSString IsTestDoneBackdoor(Foundation.NSString value) => new Foundation.NSString(IsTestDone(value).ToString());
+
+		[Foundation.Export("getDisplayScreenScaling:")] // notice the colon at the end of the method name
+		public Foundation.NSString GetDisplayScreenScalingBackdoor(Foundation.NSString value) => new Foundation.NSString(GetDisplayScreenScaling(value).ToString());
 #endif
 
 		public static bool IsTestDone(string testId) => int.TryParse(testId, out var id) ? _doneTests.Contains(id) : false;

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -16,6 +16,7 @@ namespace SamplesApp.UITests
 	{
 		protected IApp _app;
 		private static int _totalTestFixtureCount;
+		private double? _scaling;
 
 		public SampleControlUITestBase()
 		{
@@ -267,6 +268,26 @@ namespace SamplesApp.UITests
 			{
 				return _app.GetScreenDimensions();
 			}
+		}
+
+		internal double GetDisplayScreenScaling()
+		{
+			var scalingRaw = _app.InvokeGeneric("browser:SampleRunner|GetDisplayScreenScaling", "0");
+
+			if (_scaling == null)
+			{
+				if (double.TryParse(scalingRaw?.ToString(), out var scaling))
+				{
+					Console.WriteLine($"Display Scaling: {scaling}");
+					_scaling = scaling / 100;
+				}
+				else
+				{
+					_scaling = 1;
+				}
+			}
+
+			return _scaling.Value;
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -102,7 +103,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 			text02.SetDependencyPropertyValue("TextDecorations", "2"); // Strikethrough
 
 			var after = TakeScreenshot("Updated");
-			
+
 			ImageAssert.AreNotEqual(before, after);
 
 			text01.SetDependencyPropertyValue("TextDecorations", "0"); // None
@@ -133,6 +134,26 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			Assert.IsTrue(widthBefore < widthAfter);
 			Assert.IsTrue(heightBefore == heightAfter);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void When_Foreground_Brush_Color_Changed()
+		{
+			Run("Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_BrushColorChanging");
+
+			var textColor = _app.Marked("textColor");
+
+			var rectBefore = _app.GetRect("textResult");
+			var beforeColorChanged = TakeScreenshot("beforeColor");
+
+			textColor.SetDependencyPropertyValue("Text", "Blue");
+
+			var afterColorChanged = TakeScreenshot("afterColor");
+			ImageAssert.AreNotEqual(afterColorChanged, beforeColorChanged);
+
+			var scale = (float)GetDisplayScreenScaling();
+			ImageAssert.HasColorAt(afterColorChanged, (rectBefore.X + 10) * scale, (rectBefore.Y + 10) * scale, Color.Blue);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.Wasm/WasmScripts/TestRunner.js
+++ b/src/SamplesApp/SamplesApp.Wasm/WasmScripts/TestRunner.js
@@ -6,6 +6,7 @@
             this._getAllTests = this.getMethod("[SamplesApp.Wasm] SamplesApp.App:GetAllTests");
             this._runTest = this.getMethod("[SamplesApp.Wasm] SamplesApp.App:RunTest");
             this._isTestDone = this.getMethod("[SamplesApp.Wasm] SamplesApp.App:IsTestDone");
+            this._getDisplayScreenScaling = this.getMethod("[SamplesApp.Wasm] SamplesApp.App:GetDisplayScreenScaling");
         }
     }
 
@@ -32,5 +33,10 @@
     static GetAllTests() {
         SampleRunner.init();
         return this._getAllTests();
+    } 
+
+    static GetDisplayScreenScaling(displayId) {
+        SampleRunner.init();
+        return this._getDisplayScreenScaling(displayId);
     } 
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -937,6 +937,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_BrushColorChanging.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Decorations.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3839,6 +3843,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SplitView\SplitViewClip.xaml.cs">
       <DependentUpon>SplitViewClip.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_BrushColorChanging.xaml.cs">
+      <DependentUpon>TextBlock_BrushColorChanging.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Decorations.xaml.cs">
       <DependentUpon>TextBlock_Decorations.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_BrushColorChanging.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_BrushColorChanging.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_BrushColorChanging"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock x:Name="textColor" Text="Red" />
+		<ContentControl HorizontalContentAlignment="Left" VerticalContentAlignment="Top">
+			<TextBlock x:Name="textResult" Text="█████" FontSize="32" HorizontalAlignment="Left" VerticalAlignment="top">
+				<TextBlock.Foreground>
+					<SolidColorBrush Color="{Binding Text, ElementName=textColor}" />
+				</TextBlock.Foreground>
+			</TextBlock>
+		</ContentControl>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_BrushColorChanging.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_BrushColorChanging.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl")]
+	public sealed partial class TextBlock_BrushColorChanging : UserControl
+	{
+		public TextBlock_BrushColorChanging()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/Mock/Brush.net.cs
+++ b/src/Uno.UI/Mock/Brush.net.cs
@@ -10,7 +10,7 @@ namespace Windows.UI.Xaml.Media
 	//Android partial for Brush
 	public abstract partial class Brush
 	{
-		internal static IDisposable AssignAndObserveBrush(Brush b, Action<Color> colorSetter)
+		internal static IDisposable AssignAndObserveBrush(Brush b, Action<Color> colorSetter, Action imageBrushCallback = null)
 		{
 			return null;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -31,6 +31,8 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private InlineCollection _inlines;
 		private string _inlinesText; // Text derived from the content of Inlines
+		private readonly SerialDisposable _foregroundChanged = new SerialDisposable();
+
 
 #if !__WASM__
 		public TextBlock()
@@ -395,8 +397,13 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnForegroundChanged()
 		{
-			OnForegroundChangedPartial();
-			InvalidateTextBlock();
+			void refreshForeground()
+			{
+				OnForegroundChangedPartial();
+				InvalidateTextBlock();
+			}
+
+			_foregroundChanged.Disposable = Brush.AssignAndObserveBrush(Foreground, c => refreshForeground(), refreshForeground);
 		}
 
 		partial void OnForegroundChangedPartial();

--- a/src/Uno.UI/UI/Xaml/Media/Brush.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.iOSmacOS.cs
@@ -19,7 +19,7 @@ namespace Windows.UI.Xaml.Media
 	// iOS partial for SolidColorBrush
 	public partial class Brush
 	{
-		internal static IDisposable AssignAndObserveBrush(Brush b, Action<CGColor> colorSetter)
+		internal static IDisposable AssignAndObserveBrush(Brush b, Action<CGColor> colorSetter, Action imageBrushCallback = null)
 		{
 
 			if (b is SolidColorBrush colorBrush)

--- a/src/Uno.UI/UI/Xaml/Media/Brush.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.wasm.cs
@@ -8,7 +8,7 @@ namespace Windows.UI.Xaml.Media
 {
 	public abstract partial class Brush
 	{
-		internal static IDisposable AssignAndObserveBrush(Brush b, Action<Windows.UI.Color> colorSetter)
+		internal static IDisposable AssignAndObserveBrush(Brush b, Action<Windows.UI.Color> colorSetter, Action imageBrushCallback = null)
 		{
 			if (b is SolidColorBrush colorBrush)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

- Feature

## What is the new behavior?

The following block now updates the color of the TextBlock properly:

```xaml
    <TextBlock Text="My Text">
        <TextBlock.Foreground>
            <SolidColorBrush Color="{x:Bind Color, Mode=OneWay, FallbackValue=Red}" />
        </TextBlock.Foreground>
    </TextBlock>
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
