### PR TITLE
fix: Make FrameworkElement.OnLoaded/OnUnloaded private

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1140,6 +1140,83 @@
 			<Member
 				fullName="System.Void Windows.UI.Xaml.Controls.MediaTransportControls.set_FastPlayFallbackBehaviour(System.Boolean value)"
 				reason="Changed from boolean to Windows.UI.Xaml.Media.FastPlayFallbackBehaviour to replicate uwp definition" />				
+
+			<!-- Begin OnLoaded/OnUnloaded removal -->
+			<Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Image.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Image.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ProgressRing.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ProgressRing.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollContentPresenter.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollContentPresenter.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.NativeListViewBase.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.NativeListViewBase.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.NativePagedView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.NativePagedView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.TextBoxView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.TextBoxView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.GridView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.GridView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.HorizontalGridView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.HorizontalGridView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.HorizontalListView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.HorizontalListView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.ListView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.ListView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Image.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Image.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ProgressRing.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ProgressRing.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollContentPresenter.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollContentPresenter.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.NativeListViewBase.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.NativeListViewBase.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.NativePagedView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.NativePagedView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.TextBoxView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.TextBoxView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.GridView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.GridView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.HorizontalGridView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.HorizontalGridView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.HorizontalListView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.HorizontalListView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.ListView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.ListView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Image.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Image.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ProgressRing.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ProgressRing.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollContentPresenter.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollContentPresenter.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.NativeListViewBase.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.NativeListViewBase.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Picker.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Picker.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.MultilineTextBoxView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.MultilineTextBoxView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.SinglelineTextBoxView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.SinglelineTextBoxView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.ListViewBase.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Uno.UI.Controls.Legacy.ListViewBase.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Image.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Image.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollContentPresenter.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollContentPresenter.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.SecureTextBoxView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.SecureTextBoxView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.TextBoxView.OnLoaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.TextBoxView.OnUnloaded()" reason="Removed OnLoaded/OnUnloaded"/>
+			<!-- End OnLoaded/OnUnloaded removal -->
 		</Methods>
 
 		<Properties>

--- a/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml.cs
@@ -20,7 +20,7 @@ namespace UITests.Shared.Wasm
 		}
 
 #if __WASM__
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			var genericId = genericEvent.HtmlId;
 			var stringId = customEventString.HtmlId;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml.cs
@@ -58,7 +58,7 @@ namespace Uno.UI.Samples.Content.UITests.TextBoxControl
 		}
 
 
-        protected override void OnUnloaded()
+        private protected override void OnUnloaded()
         {
             base.OnUnloaded();
 

--- a/src/Uno.UI.Maps/MapPresenter.Android.cs
+++ b/src/Uno.UI.Maps/MapPresenter.Android.cs
@@ -45,6 +45,8 @@ namespace Windows.UI.Xaml.Controls.Maps.Presenter
 
 			_internalMapView.OnCreate(null); // This otherwise the map does not appear
 
+			Loaded += (s, e) => OnControlLoaded();
+			Unloaded += (s, e) => OnControlUnloaded();
 		}
 
 		protected override void OnApplyTemplate()
@@ -96,18 +98,16 @@ namespace Windows.UI.Xaml.Controls.Maps.Presenter
 			_map.AnimateCamera(cameraUpdate);
 		}
 
-		protected override void OnLoaded()
+		private void OnControlLoaded()
 		{
 			_internalMapView.OnResume(); // This otherwise the map stay empty
 
 			HandleActivityLifeCycle();
 
 			_internalMapView.TouchOccurred += MapTouchOccurred;
-
-			base.OnLoaded();
 		}
 
-		protected override void OnUnloaded()
+		private void OnControlUnloaded()
 		{
 			// These line is required for the control to 
 			// stop actively monitoring the user's location.
@@ -119,8 +119,6 @@ namespace Windows.UI.Xaml.Controls.Maps.Presenter
 			{
 				_internalMapView.TouchOccurred -= MapTouchOccurred;
 			}
-
-			base.OnUnloaded();
 		}
 
 		private void MapTouchOccurred(object sender, MotionEvent e)

--- a/src/Uno.UI/Controls/NativeCommandBarPresenter.Android.cs
+++ b/src/Uno.UI/Controls/NativeCommandBarPresenter.Android.cs
@@ -15,7 +15,7 @@ namespace Uno.UI.Controls
 {
 	public partial class NativeCommandBarPresenter : ContentPresenter
 	{
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 			

--- a/src/Uno.UI/Controls/NativeCommandBarPresenter.iOS.cs
+++ b/src/Uno.UI/Controls/NativeCommandBarPresenter.iOS.cs
@@ -20,7 +20,7 @@ namespace Uno.UI.Controls
 		private readonly SerialDisposable _statusBarSubscription = new SerialDisposable();
 		private readonly SerialDisposable _orientationSubscription = new SerialDisposable();
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -51,7 +51,7 @@ namespace Uno.UI.Controls
 			}
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/AnimatedVisualPlayer/AnimatedVisualPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AnimatedVisualPlayer/AnimatedVisualPlayer.cs
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public void Stop() => Source?.Stop();
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			Source?.Update(this);
 			Source?.Load();
@@ -111,7 +111,7 @@ namespace Windows.UI.Xaml.Controls
 			base.OnLoaded();
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			Source?.Unload();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.wasm.cs
@@ -36,7 +36,7 @@ namespace Windows.UI.Xaml.Controls
 			SetBorder(BorderThickness, BorderBrush, CornerRadius);
 		}
 			
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 			UpdateBorder();

--- a/src/Uno.UI/UI/Xaml/Controls/Button/Button.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/Button.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Controls
 			);
 		#endregion
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Button/RadioButton.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/RadioButton.cs
@@ -121,14 +121,14 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
 			RegisterInGroup(this, GroupName).DisposeWith(_groupMembership);
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -138,7 +138,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 #endif
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -153,7 +153,7 @@ namespace Windows.UI.Xaml.Controls
 			Xaml.Window.Current.SizeChanged += OnWindowSizeChanged;
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -294,7 +294,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -717,7 +717,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -284,7 +284,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			SetUpdateControlTemplate();
 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -246,7 +246,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnApplyTemplatePartial();
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -16,7 +16,7 @@ namespace Windows.UI.Xaml.Controls
 		private NSDate _initialValue;
 		private NSDate _newValue;
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Controls
 			UpdatMinMaxYears();
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 			_picker.ValueChanged -= OnPickerValueChanged;

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Controls
 			Children.CollectionChanged += Children_CollectionChanged;
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -77,7 +77,7 @@ namespace Windows.UI.Xaml.Controls
 			CreateAllChildrenPropertiesSubscription();
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -838,7 +838,7 @@ namespace Windows.UI.Xaml.Controls
 			UpdateItemsPanelRoot();
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerElement.cs
@@ -292,7 +292,7 @@ namespace Windows.UI.Xaml.Controls
 			DefaultStyleKey = typeof(MediaPlayerElement);
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.cs
@@ -90,7 +90,7 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		internal bool IsTogglingFullscreen { get; set; }
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			// The control will get unloaded when going to full screen mode.
 			// Similar to UWP, the video should keep playing while changing mode.

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutItem.cs
@@ -502,7 +502,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -527,7 +527,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.cs
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml.Controls
 		private void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 			=> OnChildrenChanged();
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -52,7 +52,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnLoadedPartial();
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
@@ -24,7 +24,7 @@ namespace Windows.UI.Xaml.Controls
 
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 			RegisterSetPasswordScope();
@@ -72,7 +72,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void EndRevealPartial();
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 			_revealButtonSubscription.Disposable = null;

--- a/src/Uno.UI/UI/Xaml/Controls/Pivot/NativePivotPresenter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Pivot/NativePivotPresenter.iOS.cs
@@ -38,7 +38,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Controls
 			_tabBar.ItemSelected += OnItemSelected;
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popover/Popover.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popover/Popover.iOS.cs
@@ -140,7 +140,7 @@ namespace Windows.UI.Xaml.Controls
 			});
         }
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/NativePopup.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/NativePopup.Android.cs
@@ -23,13 +23,13 @@ namespace Windows.UI.Xaml.Controls
 			_popupWindow.Touchable = true;
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 			_popupWindow.DismissEvent += OnDismissEvent;
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 			_popupWindow.DismissEvent -= OnDismissEvent;

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
@@ -59,7 +59,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -79,7 +79,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.macOS.cs
@@ -59,7 +59,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -79,7 +79,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -36,7 +36,7 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		internal IDynamicPopupLayouter CustomLayouter { get; set; }
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			IsOpen = false;
 			base.OnUnloaded();

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.Android.cs
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			Tapped += (snd, evt) => { };
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -33,7 +33,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			OnCanExecuteChanged();
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 			_isEnabledSubscription.Disposable = null;

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.iOS.cs
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 	{
 		private readonly SerialDisposable _clickSubscription = new SerialDisposable();
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			OnCanExecuteChanged();
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.net.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.net.cs
@@ -20,12 +20,12 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		private readonly SerialDisposable _touchSubscription = new SerialDisposable();
 		private readonly SerialDisposable _isEnabledSubscription = new SerialDisposable();
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 			_isEnabledSubscription.Disposable = null;

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.wasm.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			Tapped += (snd, evt) => { };
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			KeyDown += OnKeyDown;
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -229,7 +229,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			return state;
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 #if __ANDROID__

--- a/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.wasm.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 			// The initial call to OnIsActiveChanged fires before ProgressRing is Loaded, so we also need to set a proper VisualState here

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -196,13 +196,13 @@ namespace Windows.UI.Xaml.Controls
 			return finalSize;
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 			RegisterEventHandler("scroll", (EventHandler)OnScroll);
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 			UnregisterEventHandler("scroll", (EventHandler)OnScroll);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.iOS.cs
@@ -36,7 +36,7 @@ namespace Windows.UI.Xaml.Controls
 			SetScrollableContainer();
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			SetScrollableContainer();
 			base.OnLoaded();

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.macOS.cs
@@ -29,7 +29,7 @@ namespace Windows.UI.Xaml.Controls
 			SetScrollableContainer();
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			SetScrollableContainer();
 			base.OnLoaded();

--- a/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
@@ -86,7 +86,7 @@ namespace Windows.UI.Xaml.Controls
 			UpdateCommonState(useTransitions: false);
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -110,7 +110,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private bool HasXamlTemplate => _horizontalThumb != null || _verticalThumb != null;
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/SplitView/SplitView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SplitView/SplitView.cs
@@ -300,7 +300,7 @@ namespace Windows.UI.Xaml.Controls
 			SynchronizeContentTemplatedParent();
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -313,7 +313,7 @@ namespace Windows.UI.Xaml.Controls
 			SynchronizeContentTemplatedParent();
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -64,7 +64,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(TextBox),
 			new FrameworkPropertyMetadata(false));
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 			SetupTextBoxView();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Controls
 
 		internal bool IsMultiline { get; }
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 			
@@ -72,7 +72,7 @@ namespace Windows.UI.Xaml.Controls
 			SetTextNative(_textBox.Text);
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 			

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
@@ -171,7 +171,7 @@ namespace Windows.UI.Xaml.Controls
 			SetupFlyoutButton();
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.Android.cs
@@ -15,7 +15,7 @@ namespace Windows.UI.Xaml.Controls
 		private Android.Widget.TimePicker _picker;
 		private TimeSpan _initialTime;
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Controls
 		private NSDate _initialTime;
 		private NSDate _newDate;
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -137,7 +137,7 @@ namespace Windows.UI.Xaml.Controls
 			return new NSLocale(localeID);
 		}
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			_picker.ValueChanged -= OnValueChanged;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch.cs
@@ -36,7 +36,7 @@ namespace Windows.UI.Xaml.Controls
 			DefaultStyleKey = typeof(ToggleSwitch);
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
@@ -52,7 +52,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnLoadedPartial();
 
-		protected override void OnUnloaded()
+		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
 

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.cs
@@ -157,7 +157,7 @@ namespace Windows.UI.Xaml.Controls
 		partial void NavigateWithHttpRequestMessagePartial(HttpRequestMessage requestMessage);
 		partial void StopPartial();
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 

--- a/src/Uno.UI/UI/Xaml/ElementStub.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.net.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.net.cs
@@ -41,12 +41,12 @@ namespace Windows.UI.Xaml
 			Loading?.Invoke(this, null);
 		}
 
-		protected virtual void OnLoaded()
+		private protected virtual void OnLoaded()
 		{
 			Loaded?.Invoke(this, new RoutedEventArgs(this));
 		}
 
-		protected virtual void OnUnloaded()
+		private protected virtual void OnUnloaded()
 		{
 			Unloaded?.Invoke(this, new RoutedEventArgs(this));
 		}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
@@ -61,12 +61,12 @@ namespace Windows.UI.Xaml
 			internal set;
 		} = DefaultBaseUri;
 
-		protected virtual void OnLoaded()
+		private protected virtual void OnLoaded()
 		{
 
 		}
 
-		protected virtual void OnUnloaded()
+		private protected virtual void OnUnloaded()
 		{
 
 		}

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -751,7 +751,7 @@ namespace <#= mixin.NamespaceName #>
 		
 		partial void OnLoadingPartial();
 
-		protected virtual void OnLoaded()
+		private protected virtual void OnLoaded()
 		{
 			IsLoaded = true;
 
@@ -764,7 +764,7 @@ namespace <#= mixin.NamespaceName #>
 
 		partial void OnLoadedPartial();
 
-		protected virtual void OnUnloaded()
+		private protected virtual void OnUnloaded()
 		{
 			IsLoaded = false;
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -542,7 +542,7 @@ namespace <#= mixin.NamespaceName #>
 
 		partial void OnLoadingPartial();
 
-		protected virtual void OnLoaded()
+		private protected virtual void OnLoaded()
 		{
 			IsLoaded = true;
 
@@ -554,7 +554,7 @@ namespace <#= mixin.NamespaceName #>
 
 		partial void OnLoadedPartial();
 
-		protected virtual void OnUnloaded()
+		private protected virtual void OnUnloaded()
 		{
 			IsLoaded = false;
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
@@ -542,7 +542,7 @@ namespace <#= mixin.NamespaceName #>
 
 		partial void OnLoadingPartial();
 
-		protected virtual void OnLoaded()
+		private protected virtual void OnLoaded()
 		{
 			IsLoaded = true;
 
@@ -554,7 +554,7 @@ namespace <#= mixin.NamespaceName #>
 
 		partial void OnLoadedPartial();
 
-		protected virtual void OnUnloaded()
+		private protected virtual void OnUnloaded()
 		{
 			IsLoaded = false;
 

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.Android.cs
@@ -30,7 +30,7 @@ namespace Windows.UI.Xaml.Shapes
 			RefreshShape();
 		}
 
-		protected override void OnLoaded()
+		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes https://github.com/unoplatform/uno/issues/2897

## PR Type

What kind of change does this PR introduce?
- Bug fix

## What is the new behavior?

Uno was incorrectly exposing `OnLoaded` and `OnUnloaded` on `FrameworkElement. This breaking change removes these methods.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
