### PR TITLE
fix: Fully qualify some symbols

### DIFF
--- a/build/run-template-tests.ps1
+++ b/build/run-template-tests.ps1
@@ -1,5 +1,13 @@
 ﻿$ErrorActionPreference = 'Stop'
 
+function Assert-ExitCodeIsZero()
+{
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "Exit code must be zero."
+	}
+}
+
 function Get-TemplateConfiguration(
     [bool]$uwp = $false,
     [bool]$android = $false,
@@ -57,25 +65,31 @@ $configurations =
 # Default
 dotnet new unoapp -n UnoAppAll
 & $msbuild $debug UnoAppAll\UnoAppAll.sln
+Assert-ExitCodeIsZero
 
 # Heads - Release
 for($i = 0; $i -lt $configurations.Length; $i++)
 {
     dotnet new unoapp -n "UnoApp$i" $configurations[$i][0]
     & $msbuild $configurations[$i][1] "UnoApp$i\UnoApp$i.sln"
+    Assert-ExitCodeIsZero
 }
 
 # VS Code
 dotnet new unoapp -n UnoAppVsCode (Get-TemplateConfiguration -wasm 1 -wasmVsCode 1)
 dotnet build -p:RestoreConfigFile=$env:NUGET_CI_CONFIG UnoAppVsCode\UnoAppVsCode.sln
+Assert-ExitCodeIsZero
 
 # Namespace Tests
 dotnet new unoapp -n MyApp.Uno
 & $msbuild $debug MyApp.Uno\MyApp.Uno.sln
+Assert-ExitCodeIsZero
 
 dotnet new unoapp -n MyApp.Android (Get-TemplateConfiguration -android 1)
 & $msbuild $debug MyApp.Android\MyApp.Android.sln
+Assert-ExitCodeIsZero
 
 # WinUI - Default
 # dotnet new unoapp-winui -n UnoAppWinUI
 # & $msbuild $debug UnoAppWinUI\UnoAppWinUI.sln
+# Assert-ExitCodeIsZero

--- a/src/SolutionTemplate/UnoSolutionTemplate/Droid/MainActivity.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Droid/MainActivity.cs
@@ -8,7 +8,7 @@ namespace $ext_safeprojectname$.Droid
 {
 	[Activity(
 			MainLauncher = true,
-			ConfigurationChanges = Uno.UI.ActivityHelper.AllConfigChanges,
+			ConfigurationChanges = global::Uno.UI.ActivityHelper.AllConfigChanges,
 			WindowSoftInputMode = SoftInput.AdjustPan | SoftInput.StateHidden
 		)]
 	public class MainActivity : Windows.UI.Xaml.ApplicationActivity

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4255,7 +4255,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						writer.Append("() => ");
 						// This case is to support the layout switching for the ListViewBaseLayout, which is not
 						// a FrameworkTemplate. This will need to be removed when this custom list view is removed.
-						var returnType = typeName == "ListViewBaseLayoutTemplate" ? "Uno.UI.Controls.Legacy.ListViewBaseLayout" : "_View";
+						var returnType = typeName == "ListViewBaseLayoutTemplate" ? "global::Uno.UI.Controls.Legacy.ListViewBaseLayout" : "_View";
 
 						BuildChildThroughSubclass(writer, contentOwner, returnType);
 
@@ -4458,7 +4458,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				if (phases.Any())
 				{
 					var phasesValue = phases.OrderBy(i => i).Select(s => s.ToString()).JoinBy(",");
-					return $"Uno.UI.FrameworkElementHelper.SetDataTemplateRenderPhases({ownerVariable}, new []{{{phasesValue}}});";
+					return $"global::Uno.UI.FrameworkElementHelper.SetDataTemplateRenderPhases({ownerVariable}, new []{{{phasesValue}}});";
 				}
 			}
 
@@ -4727,7 +4727,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 					if (hasContextConstructor)
 					{
-						return "(Uno.UI.ContextHelper.Current)";
+						return "(global::Uno.UI.ContextHelper.Current)";
 					}
 				}
 			}


### PR DESCRIPTION
Fix: #1120

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Build or CI related changes

## What is the new behavior?

- DotNet templates integration tests now validate MSBuild exit codes
- UnoSolutionTemplate.Droid fully qualifies Uno.UI.ActivityHelper.AllConfigChanges
- XamlGenerator fully qualifies more symbols

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
