### PR TITLE
fix(AutoSuggestBox): handle keyboard input for chosing suggestions. i…

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/BasicAutoSuggestBox.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/BasicAutoSuggestBox.xaml
@@ -14,9 +14,26 @@
 							HorizontalAlignment="Left"
 							TextChanged="AutoSuggestBox_TextChanged"
 							SuggestionChosen="AutoSuggestBox_SuggestionChosen"
+							QuerySubmitted="AutoSuggestBox_QuerySubmitted"
 							Width="300"
+							
 							AutomationProperties.Name="Basic AutoSuggestBox" />
-			<TextBlock x:Name="result" />
+			<TextBlock x:Name="IWantToSeeStuffUnderTheSuggestions" xml:space="preserve">
+				
+				
+				
+				
+				
+				
+				
+				
+				
+				
+				
+			</TextBlock>
+			<TextBlock x:Name="suggest" />
+			<TextBlock x:Name="query" />
+			<TextBlock x:Name="textChanged" />
 			<CheckBox x:Name="ShouldClearTextBox"
 					  Content="Should clear"
 					  IsChecked="True" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/BasicAutoSuggestBox.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/BasicAutoSuggestBox.xaml.cs
@@ -23,6 +23,12 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.AutoSuggestBoxTests
 	public sealed partial class BasicAutoSuggestBox : UserControl
 	{
 		private ObservableCollection<string> _suggestions = new ObservableCollection<string>();
+		int suggests = 0;
+		int querys = 0;
+		int textChangeds = 0;
+		int userInput = 0;
+		int programmatic = 0;
+		int suggestionChosen = 0;
 
 		public BasicAutoSuggestBox()
 		{
@@ -33,22 +39,43 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.AutoSuggestBoxTests
 
 		private void AutoSuggestBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
 		{
-			if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
-			{
-				if (ShouldClear || _suggestions.Count > 10)
-				{
-					_suggestions.Clear();
-				}
+			textChangeds += 1;
 
-				_suggestions.Add(sender.Text + "1");
-				_suggestions.Add(sender.Text + "2");
+			switch (args.Reason)
+			{
+				case AutoSuggestionBoxTextChangeReason.UserInput:
+					userInput += 1;
+
+					if (ShouldClear || _suggestions.Count > 10)
+					{
+						_suggestions.Clear();
+					}
+
+					_suggestions.Add(sender.Text + "1");
+					_suggestions.Add(sender.Text + "2");
+					box1.ItemsSource = _suggestions;
+					break;
+				case AutoSuggestionBoxTextChangeReason.ProgrammaticChange:
+					programmatic += 1;
+					break;
+				case AutoSuggestionBoxTextChangeReason.SuggestionChosen:
+					suggestionChosen += 1;
+					break;
 			}
-			box1.ItemsSource = _suggestions;
+
+			textChanged.Text = $"{textChangeds}:\n\tUserInputs: {userInput}\n\tProgrammatic Changes: {programmatic}\n\tSuggestions Chosen: {suggestionChosen}";
 		}
 
 		private void AutoSuggestBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
 		{
-			result.Text = args.SelectedItem.ToString();
+			suggests += 1;
+			suggest.Text = "SuggestionChosen: " + suggests + " " + args.SelectedItem.ToString();
+		}
+
+		private void AutoSuggestBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+		{
+			querys += 1;
+			query.Text = "QuerySubmitted: " + querys + " " + args.QueryText;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -633,10 +633,15 @@ namespace Windows.UI.Xaml.Controls
 			//		 AND ** only KeyDown ** is handled (not KeyUp)
 			switch (args.Key)
 			{
-				case VirtualKey.Left:
-				case VirtualKey.Right:
 				case VirtualKey.Up:
 				case VirtualKey.Down:
+					if (AcceptsReturn)
+					{
+						args.Handled = true;
+					}
+					break;
+				case VirtualKey.Left:
+				case VirtualKey.Right:
 				case VirtualKey.Home:
 				case VirtualKey.End:
 					args.Handled = true;


### PR DESCRIPTION
…nvoke proper events as per uwp.


<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
fixes #364

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
#364


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Keyboard input is handled to replicate uwp design. QuerySubmitted is raised on suggestion click, whereas on suggestion selection (via keyboard input), SuggestionChosen is raised.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.