### PR TITLE
fix: Prevent possible collection changed while enumerating in CompositionTarget.Rendering

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Android.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Android.Views;
 
 namespace Windows.UI.Xaml.Media
@@ -40,7 +41,11 @@ namespace Windows.UI.Xaml.Media
 
 		private static void OnFrame()
 		{
-			_handlers.ForEach(h => h(null, null));
+			var handlers = _handlers.ToList();
+			foreach (var handler in handlers)
+			{
+				handler(null, null);
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.iOS.cs
@@ -41,7 +41,12 @@ namespace Windows.UI.Xaml.Media
 
 		private static void OnFrame()
 		{
-			_handlers.ToList().ForEach(h => h(null, null));
+			var handlers = _handlers.ToList();
+			foreach (var handler in handlers)
+			{
+				handler(null, null);
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
## Bugfix
Possible source changed while enumerating exception in the `CompositionTarget.Rendering` event

## What is the current behavior?
If you remove an handler while the  `CompositionTarget.Rendering` event is raised, you will get an exception.

## What is the new behavior?
We clone the list of handler before raising the event

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).~~
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
