### PR TITLE
feat: Sensors return null on unsupported platforms

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1113,6 +1113,24 @@
 			<Member 
 				fullName="System.Int32 Windows.UI.Text.FontWeight.get_Weight()"
 				reason="Changed from int to ushort to replicate uwp definition"/>
+			<Member
+				fullName="System.Void Windows.Devices.Sensors.HingeAngleSensor..ctor()"
+				reason="Constructor not part of UWP API" />
+			<Member
+				fullName="System.Void Windows.Devices.Sensors.Pedometer..ctor()"
+				reason="Constructor not part of UWP API" />
+			<Member
+				fullName="System.Void Windows.Devices.Sensors.Accelerometer..ctor()"
+				reason="Constructor not part of UWP API" />
+			<Member
+				fullName="System.Void Windows.Devices.Sensors.Barometer..ctor()"
+				reason="Constructor not part of UWP API" />
+			<Member
+				fullName="System.Void Windows.Devices.Sensors.Gyrometer..ctor()"
+				reason="Constructor not part of UWP API" />
+			<Member
+				fullName="System.Void Windows.Devices.Sensors.Magnetometer..ctor()"
+				reason="Constructor not part of UWP API" />															
 		</Methods>
 
 		<Properties>

--- a/src/Uno.UWP/Devices/Sensors/Accelerometer.unsupported.cs
+++ b/src/Uno.UWP/Devices/Sensors/Accelerometer.unsupported.cs
@@ -1,0 +1,17 @@
+﻿#if __MACOS__ || NET461
+namespace Windows.Devices.Sensors
+{
+	public partial class Accelerometer
+	{
+		private Accelerometer()
+		{
+		}
+
+		/// <summary>
+		/// API not supported, always returns null.
+		/// </summary>
+		/// <returns>Null.</returns>
+		public static Accelerometer GetDefault() => null;
+	}
+}
+#endif

--- a/src/Uno.UWP/Devices/Sensors/Barometer.unsupported.cs
+++ b/src/Uno.UWP/Devices/Sensors/Barometer.unsupported.cs
@@ -1,4 +1,4 @@
-﻿#if __MACOS__ || NET461
+﻿#if __MACOS__ || NET461 || __WASM__
 namespace Windows.Devices.Sensors
 {
 	public partial class Barometer

--- a/src/Uno.UWP/Devices/Sensors/Barometer.unsupported.cs
+++ b/src/Uno.UWP/Devices/Sensors/Barometer.unsupported.cs
@@ -1,0 +1,17 @@
+﻿#if __MACOS__ || NET461
+namespace Windows.Devices.Sensors
+{
+	public partial class Barometer
+	{
+		private Barometer()
+		{
+		}
+
+		/// <summary>
+		/// API not supported, always returns null.
+		/// </summary>
+		/// <returns>Null.</returns>
+		public static Barometer GetDefault() => null;
+	}
+}
+#endif

--- a/src/Uno.UWP/Devices/Sensors/Gyrometer.unsupported.cs
+++ b/src/Uno.UWP/Devices/Sensors/Gyrometer.unsupported.cs
@@ -1,0 +1,17 @@
+﻿#if __MACOS__ || NET461
+namespace Windows.Devices.Sensors
+{
+	public partial class Gyrometer
+	{
+		private Gyrometer()
+		{
+		}
+
+		/// <summary>
+		/// API not supported, always returns null.
+		/// </summary>
+		/// <returns>Null.</returns>
+		public static Gyrometer GetDefault() => null;
+	}
+}
+#endif

--- a/src/Uno.UWP/Devices/Sensors/HingeAngleSensor.unsupported.cs
+++ b/src/Uno.UWP/Devices/Sensors/HingeAngleSensor.unsupported.cs
@@ -1,0 +1,21 @@
+﻿#if __IOS__ || __MACOS__ || __WASM__ || NET461
+using System;
+using System.Threading.Tasks;
+using Windows.Foundation;
+
+namespace Windows.Devices.Sensors
+{
+	public partial class HingeAngleSensor
+	{
+		private HingeAngleSensor()
+		{
+		}
+
+		/// <summary>
+		/// API not supported, always returns null.
+		/// </summary>
+		/// <returns>Null.</returns>
+		public static IAsyncOperation<HingeAngleSensor> GetDefaultAsync() => Task.FromResult<HingeAngleSensor>(null).AsAsyncOperation();
+	}
+}
+#endif

--- a/src/Uno.UWP/Devices/Sensors/Magnetometer.unsupported.cs
+++ b/src/Uno.UWP/Devices/Sensors/Magnetometer.unsupported.cs
@@ -1,0 +1,17 @@
+﻿#if __MACOS__ || NET461
+namespace Windows.Devices.Sensors
+{
+	public partial class Magnetometer
+	{
+		private Magnetometer()
+		{
+		}
+
+		/// <summary>
+		/// API not supported, always returns null.
+		/// </summary>
+		/// <returns>Null.</returns>
+		public static Magnetometer GetDefault() => null;
+	}
+}
+#endif

--- a/src/Uno.UWP/Devices/Sensors/Pedometer.unsupported.cs
+++ b/src/Uno.UWP/Devices/Sensors/Pedometer.unsupported.cs
@@ -1,0 +1,21 @@
+﻿#if __MACOS__ || __WASM__ || NET461
+using System;
+using System.Threading.Tasks;
+using Windows.Foundation;
+
+namespace Windows.Devices.Sensors
+{
+	public partial class Pedometer
+	{
+		private Pedometer()
+		{
+		}
+
+		/// <summary>
+		/// API not supported, always returns null.
+		/// </summary>
+		/// <returns>Null.</returns>
+		public static IAsyncOperation<Pedometer> GetDefaultAsync() => Task.FromResult<Pedometer>(null).AsAsyncOperation();
+	}
+}
+#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Accelerometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Accelerometer.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-	#if false || false || NET461 || false || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Accelerometer 
@@ -142,7 +142,7 @@ namespace Windows.Devices.Sensors
 			throw new global::System.NotImplementedException("The member Accelerometer Accelerometer.GetDefault(AccelerometerReadingType readingType) is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || false || __MACOS__
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public static global::Windows.Devices.Sensors.Accelerometer GetDefault()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Barometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Barometer.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-	#if false || false || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Barometer 
@@ -106,7 +106,7 @@ namespace Windows.Devices.Sensors
 			throw new global::System.NotImplementedException("The member string Barometer.GetDeviceSelector() is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || __WASM__ || __MACOS__
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public static global::Windows.Devices.Sensors.Barometer GetDefault()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Gyrometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Gyrometer.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-	#if false || false || NET461 || false || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Gyrometer 
@@ -122,7 +122,7 @@ namespace Windows.Devices.Sensors
 			throw new global::System.NotImplementedException("The member IAsyncOperation<Gyrometer> Gyrometer.FromIdAsync(string deviceId) is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || false || __MACOS__
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public static global::Windows.Devices.Sensors.Gyrometer GetDefault()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/HingeAngleSensor.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/HingeAngleSensor.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-	#if false || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class HingeAngleSensor 
@@ -61,7 +61,7 @@ namespace Windows.Devices.Sensors
 			throw new global::System.NotImplementedException("The member string HingeAngleSensor.GetDeviceSelector() is not implemented in Uno.");
 		}
 		#endif
-		#if false || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Devices.Sensors.HingeAngleSensor> GetDefaultAsync()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Magnetometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Magnetometer.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-	#if false || false || NET461 || false || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Magnetometer 
@@ -122,7 +122,7 @@ namespace Windows.Devices.Sensors
 			throw new global::System.NotImplementedException("The member IAsyncOperation<Magnetometer> Magnetometer.FromIdAsync(string deviceId) is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || false || __MACOS__
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public static global::Windows.Devices.Sensors.Magnetometer GetDefault()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Pedometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Pedometer.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Sensors
 {
-	#if false || false || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Pedometer 
@@ -79,7 +79,7 @@ namespace Windows.Devices.Sensors
 			throw new global::System.NotImplementedException("The member IAsyncOperation<Pedometer> Pedometer.FromIdAsync(string deviceId) is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || __WASM__ || __MACOS__
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Devices.Sensors.Pedometer> GetDefaultAsync()
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3450 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

All sensor methods throw on unsupported platforms.

## What is the new behavior?

`GetDefault` and `GetDefaultAsync` static methods of various sensors now return `null` when the sensor is not supported on target platform (mainly macOS, NET461, but also WASM and iOS in some cases). This way it is easier to write code that uses sensors, as the behaviour matches the case when the device does not have the given sensor available on UWP, and such check must be part of the consuming code anyway.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.