### PR TITLE
feat: DisplayRequest on WASM

### DIFF
--- a/doc/articles/features/windows-system-display.md
+++ b/doc/articles/features/windows-system-display.md
@@ -1,0 +1,7 @@
+﻿# Uno Support for Windows.System.Display APIs
+
+## `DisplayRequest`
+
+The `DisplayRequest` API is supported on all platforms.
+
+In case of WASM, it is implemented using the [Screen Wake Lock API](https://w3c.github.io/screen-wake-lock/) which is not yet supported in many browsers. On unsupported browsers the API calls are ignored. In addition, because the JS API is asynchronous, it is recommended not to request and release the screen lock multiple times in quick succession (as the promise may not be completed yet).

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -74,8 +74,6 @@
     href: features/windows-system-power.md
   - name: ProgressRing
     href: features/progressring.md
-  - name: Windows.System.Profile
-    href: features/windows-system-profile.md
   - name: PasswordVault
     href: features\PasswordVault.md
   - name: URI Protocol activation
@@ -100,6 +98,10 @@
     href: features\windows-devices-geolocation.md
   - name: Windows.System
     href: features\windows-system.md
+  - name: Windows.System.Display
+    href: features\windows-system-display.md
+  - name: Windows.System.Profile
+    href: features/windows-system-profile.md
   - name: Windows.Storage
     href: features\windows-storage.md
   - name: Windows.UI.ViewManagement

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -1016,6 +1016,25 @@ declare namespace Windows.Networking.Connectivity {
         static networkStatusChanged(): void;
     }
 }
+interface Navigator {
+    wakeLock: WakeLock;
+}
+declare enum WakeLockType {
+    screen = "screen"
+}
+interface WakeLock {
+    request(type: WakeLockType): Promise<WakeLockSentinel>;
+}
+interface WakeLockSentinel {
+    release(): Promise<void>;
+}
+declare namespace Windows.System.Display {
+    class DisplayRequest {
+        private static activeScreenLockPromise;
+        static activateScreenLock(): void;
+        static deactivateScreenLock(): void;
+    }
+}
 interface Window {
     opr: any;
     opera: any;

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -3299,6 +3299,36 @@ var Windows;
         })(Connectivity = Networking.Connectivity || (Networking.Connectivity = {}));
     })(Networking = Windows.Networking || (Windows.Networking = {}));
 })(Windows || (Windows = {}));
+var WakeLockType;
+(function (WakeLockType) {
+    WakeLockType["screen"] = "screen";
+})(WakeLockType || (WakeLockType = {}));
+;
+;
+;
+var Windows;
+(function (Windows) {
+    var System;
+    (function (System) {
+        var Display;
+        (function (Display) {
+            class DisplayRequest {
+                static activateScreenLock() {
+                    if (navigator.wakeLock) {
+                        DisplayRequest.activeScreenLockPromise = navigator.wakeLock.request(WakeLockType.screen);
+                    }
+                }
+                static deactivateScreenLock() {
+                    if (DisplayRequest.activeScreenLockPromise) {
+                        DisplayRequest.activeScreenLockPromise.then(sentinel => sentinel.release());
+                        DisplayRequest.activeScreenLockPromise = null;
+                    }
+                }
+            }
+            Display.DisplayRequest = DisplayRequest;
+        })(Display = System.Display || (System.Display = {}));
+    })(System = Windows.System || (Windows.System = {}));
+})(Windows || (Windows = {}));
 var Windows;
 (function (Windows) {
     var System;

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -3316,6 +3316,7 @@ var Windows;
                 static activateScreenLock() {
                     if (navigator.wakeLock) {
                         DisplayRequest.activeScreenLockPromise = navigator.wakeLock.request(WakeLockType.screen);
+                        DisplayRequest.activeScreenLockPromise.catch(reason => console.log("Could not acquire screen lock (" + reason + ")"));
                     }
                 }
                 static deactivateScreenLock() {

--- a/src/Uno.UI.Wasm/ts/Windows/System/Display/DisplayRequest.ts
+++ b/src/Uno.UI.Wasm/ts/Windows/System/Display/DisplayRequest.ts
@@ -3,7 +3,7 @@
 }
 
 enum WakeLockType {
-	screen = "screen"
+	screen = "screen",
 };
 
 interface WakeLock {
@@ -22,7 +22,10 @@ namespace Windows.System.Display {
 		public static activateScreenLock() {
 			if (navigator.wakeLock) {
 				DisplayRequest.activeScreenLockPromise = navigator.wakeLock.request(WakeLockType.screen);
-				DisplayRequest.activeScreenLockPromise.catch(reason => console.log("Could not acquire screen lock (" + reason + ")"));
+				DisplayRequest.activeScreenLockPromise.catch(
+					reason => console.log("Could not acquire screen lock (" + reason + ")"));
+			} else {
+				console.log("Wake Lock API is not available in this browser.");
 			}
 		}
 

--- a/src/Uno.UI.Wasm/ts/Windows/System/Display/DisplayRequest.ts
+++ b/src/Uno.UI.Wasm/ts/Windows/System/Display/DisplayRequest.ts
@@ -1,0 +1,33 @@
+﻿interface Navigator {
+	wakeLock : WakeLock;
+}
+
+enum WakeLockType { "screen" };
+
+interface WakeLock {
+	request(type: WakeLockType): Promise<WakeLockSentinel>;
+};
+
+interface WakeLockSentinel {    
+	release(): Promise<void>;	
+};
+
+namespace Windows.System.Display {
+
+	export class DisplayRequest {
+		private static activeScreenLockPromise: Promise<WakeLockSentinel>;
+
+		public static activateScreenLock() {
+			if (navigator.wakeLock) {
+				DisplayRequest.activeScreenLockPromise = navigator.wakeLock.request(WakeLockType.screen);
+			}
+		}
+
+		public static deactivateScreenLock() {
+			if (DisplayRequest.activeScreenLockPromise) {
+				DisplayRequest.activeScreenLockPromise.then(sentinel => sentinel.release());
+				DisplayRequest.activeScreenLockPromise = null;
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/ts/Windows/System/Display/DisplayRequest.ts
+++ b/src/Uno.UI.Wasm/ts/Windows/System/Display/DisplayRequest.ts
@@ -22,6 +22,7 @@ namespace Windows.System.Display {
 		public static activateScreenLock() {
 			if (navigator.wakeLock) {
 				DisplayRequest.activeScreenLockPromise = navigator.wakeLock.request(WakeLockType.screen);
+				DisplayRequest.activeScreenLockPromise.catch(reason => console.log("Could not acquire screen lock (" + reason + ")"));
 			}
 		}
 

--- a/src/Uno.UI.Wasm/ts/Windows/System/Display/DisplayRequest.ts
+++ b/src/Uno.UI.Wasm/ts/Windows/System/Display/DisplayRequest.ts
@@ -2,7 +2,9 @@
 	wakeLock : WakeLock;
 }
 
-enum WakeLockType { "screen" };
+enum WakeLockType {
+	screen = "screen"
+};
 
 interface WakeLock {
 	request(type: WakeLockType): Promise<WakeLockSentinel>;

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Display/DisplayRequest.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Display/DisplayRequest.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System.Display
 {
-	#if false || false || NET461 || __WASM__ || false
+	#if false || false || NET461 || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class DisplayRequest 
 	{
-		#if false || false || NET461 || __WASM__ || false
+		#if false || false || NET461 || false || false
 		[global::Uno.NotImplemented]
 		public DisplayRequest() 
 		{
@@ -15,14 +15,14 @@ namespace Windows.System.Display
 		}
 		#endif
 		// Forced skipping of method Windows.System.Display.DisplayRequest.DisplayRequest()
-		#if false || false || NET461 || __WASM__ || false
+		#if false || false || NET461 || false || false
 		[global::Uno.NotImplemented]
 		public  void RequestActive()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.System.Display.DisplayRequest", "void DisplayRequest.RequestActive()");
 		}
 		#endif
-		#if false || false || NET461 || __WASM__ || false
+		#if false || false || NET461 || false || false
 		[global::Uno.NotImplemented]
 		public  void RequestRelease()
 		{

--- a/src/Uno.UWP/System/Display/DisplayRequest.cs
+++ b/src/Uno.UWP/System/Display/DisplayRequest.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__ || __IOS__ || __MACOS__
+﻿#if __ANDROID__ || __IOS__ || __MACOS__ || __WASM__
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Uno.UWP/System/Display/DisplayRequest.wasm.cs
+++ b/src/Uno.UWP/System/Display/DisplayRequest.wasm.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.Foundation;
+
+namespace Windows.System.Display
+{
+    public partial class DisplayRequest
+    {
+		private const string JsType = "Windows.System.Display.DisplayRequest";
+
+		partial void ActivateScreenLock()
+		{
+			var command = $"{JsType}.activateScreenLock()";
+			WebAssemblyRuntime.InvokeJS(command);
+		}
+
+		partial void DeactivateScreenLock()
+		{
+			var command = $"{JsType}.deactivateScreenLock()";
+			WebAssemblyRuntime.InvokeJS(command);
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3452 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`DisplayRequest` not supported on WASM

## What is the new behavior?

`DisplayRequest` supported on WASM.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.