### PR TITLE
feat: Update Android project template to SDK 29

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/Droid/Properties/AndroidManifest.xml
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="$ext_safeprojectname$" android:versionCode="1" android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="26" />
+  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="29" />
   <application android:label="$ext_safeprojectname$"></application>
 </manifest>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Droid/UnoQuickStart.Droid.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Droid/UnoQuickStart.Droid.csproj
@@ -18,7 +18,7 @@
 		<AndroidUseAapt2>false</AndroidUseAapt2>
 		<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
 		<AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-		<TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+		<TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
 		<AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
 		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
 		<ResourcesDirectory>..\$ext_safeprojectname$.Shared\Strings</ResourcesDirectory>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3457

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

SDK 26 is referenced in Android project template manifest

## What is the new behavior?

- SDK 29 in manifest
- TargetFrameworkVersion set to 10.0

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.