### PR TITLE
[WASM] Fixed path with geometries

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3257,6 +3257,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Path_Geometries.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PolygonPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5099,6 +5103,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Path_ClearData.xaml.cs">
       <DependentUpon>Path_ClearData.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Path_Geometries.xaml.cs">
+      <DependentUpon>Path_Geometries.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PolygonPage.xaml.cs">
       <DependentUpon>PolygonPage.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_BrushColorChanging.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_BrushColorChanging.xaml.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Samples.Content.UITests.TextBlockControl
 {
-	[SampleControlInfo("TextBlockControl")]
+	[Sample("TextBlockControl")]
 	public sealed partial class TextBlock_BrushColorChanging : UserControl
 	{
 		public TextBlock_BrushColorChanging()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_Geometries.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_Geometries.xaml
@@ -1,0 +1,34 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Shapes.Path_Geometries"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Shapes"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+	  <Path Stroke="Black" StrokeThickness="1" >
+		<Path.Data>
+		  <PathGeometry>
+			<PathGeometry.Figures>
+			  <PathFigure StartPoint="10,50">
+				<PathFigure.Segments>
+				  <BezierSegment
+					Point1="100,0"
+					Point2="200,200"
+					Point3="300,100"/>
+				  <LineSegment Point="400,100" />
+				  <ArcSegment
+					Size="50,50" RotationAngle="45"
+					IsLargeArc="True" SweepDirection="Clockwise"
+					Point="200,100"/>
+				</PathFigure.Segments>
+			  </PathFigure>
+			</PathGeometry.Figures>
+		  </PathGeometry>
+		</Path.Data>
+	  </Path>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_Geometries.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_Geometries.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml_Shapes
+{
+	[Sample("Shapes")]
+	public sealed partial class Path_Geometries : Page
+	{
+		public Path_Geometries()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/GridViewHeaderItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/GridViewHeaderItem.cs
@@ -2,18 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if false || false || NET461 || __WASM__ || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class GridViewHeaderItem : global::Windows.UI.Xaml.Controls.ListViewBaseHeaderItem
 	{
-		#if false || false || false || __WASM__ || false
-		[global::Uno.NotImplemented]
-		public GridViewHeaderItem() 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.GridViewHeaderItem", "GridViewHeaderItem.GridViewHeaderItem()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.GridViewHeaderItem.GridViewHeaderItem()
 		// Forced skipping of method Windows.UI.Xaml.Controls.GridViewHeaderItem.GridViewHeaderItem()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ProgressRing.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ProgressRing.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if false || false || NET461 || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ProgressRing 
@@ -39,13 +39,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.ProgressRing), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		#if false || false || NET461 || false || false
-		[global::Uno.NotImplemented]
-		public ProgressRing() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.ProgressRing", "ProgressRing.ProgressRing()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.ProgressRing.ProgressRing()
 		// Forced skipping of method Windows.UI.Xaml.Controls.ProgressRing.ProgressRing()
 		// Forced skipping of method Windows.UI.Xaml.Controls.ProgressRing.IsActive.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.ProgressRing.IsActive.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ScrollViewer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ScrollViewer.cs
@@ -559,20 +559,8 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.ScrollViewer.TopHeader.set
 		// Forced skipping of method Windows.UI.Xaml.Controls.ScrollViewer.ViewChanging.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.ScrollViewer.ViewChanging.remove
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  bool ChangeView( double? horizontalOffset,  double? verticalOffset,  float? zoomFactor)
-		{
-			throw new global::System.NotImplementedException("The member bool ScrollViewer.ChangeView(double? horizontalOffset, double? verticalOffset, float? zoomFactor) is not implemented in Uno.");
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  bool ChangeView( double? horizontalOffset,  double? verticalOffset,  float? zoomFactor,  bool disableAnimation)
-		{
-			throw new global::System.NotImplementedException("The member bool ScrollViewer.ChangeView(double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.ScrollViewer.ChangeView(double?, double?, float?)
+		// Skipping already declared method Windows.UI.Xaml.Controls.ScrollViewer.ChangeView(double?, double?, float?, bool)
 		// Forced skipping of method Windows.UI.Xaml.Controls.ScrollViewer.DirectManipulationStarted.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.ScrollViewer.DirectManipulationStarted.remove
 		// Forced skipping of method Windows.UI.Xaml.Controls.ScrollViewer.DirectManipulationCompleted.add

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBlock.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBlock.cs
@@ -7,118 +7,14 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class TextBlock 
 	{
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.TextWrapping TextWrapping
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.TextWrapping)this.GetValue(TextWrappingProperty);
-			}
-			set
-			{
-				this.SetValue(TextWrappingProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.TextTrimming TextTrimming
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.TextTrimming)this.GetValue(TextTrimmingProperty);
-			}
-			set
-			{
-				this.SetValue(TextTrimmingProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.TextAlignment TextAlignment
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.TextAlignment)this.GetValue(TextAlignmentProperty);
-			}
-			set
-			{
-				this.SetValue(TextAlignmentProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string Text
-		{
-			get
-			{
-				return (string)this.GetValue(TextProperty);
-			}
-			set
-			{
-				this.SetValue(TextProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.Thickness Padding
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.Thickness)this.GetValue(PaddingProperty);
-			}
-			set
-			{
-				this.SetValue(PaddingProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.Media.Brush Foreground
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.Media.Brush)this.GetValue(ForegroundProperty);
-			}
-			set
-			{
-				this.SetValue(ForegroundProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Text.FontWeight FontWeight
-		{
-			get
-			{
-				return (global::Windows.UI.Text.FontWeight)this.GetValue(FontWeightProperty);
-			}
-			set
-			{
-				this.SetValue(FontWeightProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Text.FontStyle FontStyle
-		{
-			get
-			{
-				return (global::Windows.UI.Text.FontStyle)this.GetValue(FontStyleProperty);
-			}
-			set
-			{
-				this.SetValue(FontStyleProperty, value);
-			}
-		}
-		#endif
+		// Skipping already declared property TextWrapping
+		// Skipping already declared property TextTrimming
+		// Skipping already declared property TextAlignment
+		// Skipping already declared property Text
+		// Skipping already declared property Padding
+		// Skipping already declared property Foreground
+		// Skipping already declared property FontWeight
+		// Skipping already declared property FontStyle
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Text.FontStretch FontStretch
@@ -133,76 +29,11 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  double FontSize
-		{
-			get
-			{
-				return (double)this.GetValue(FontSizeProperty);
-			}
-			set
-			{
-				this.SetValue(FontSizeProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.Media.FontFamily FontFamily
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.Media.FontFamily)this.GetValue(FontFamilyProperty);
-			}
-			set
-			{
-				this.SetValue(FontFamilyProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.LineStackingStrategy LineStackingStrategy
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.LineStackingStrategy)this.GetValue(LineStackingStrategyProperty);
-			}
-			set
-			{
-				this.SetValue(LineStackingStrategyProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  double LineHeight
-		{
-			get
-			{
-				return (double)this.GetValue(LineHeightProperty);
-			}
-			set
-			{
-				this.SetValue(LineHeightProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  int CharacterSpacing
-		{
-			get
-			{
-				return (int)this.GetValue(CharacterSpacingProperty);
-			}
-			set
-			{
-				this.SetValue(CharacterSpacingProperty, value);
-			}
-		}
-		#endif
+		// Skipping already declared property FontSize
+		// Skipping already declared property FontFamily
+		// Skipping already declared property LineStackingStrategy
+		// Skipping already declared property LineHeight
+		// Skipping already declared property CharacterSpacing
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  bool IsTextSelectionEnabled
@@ -334,20 +165,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  int MaxLines
-		{
-			get
-			{
-				return (int)this.GetValue(MaxLinesProperty);
-			}
-			set
-			{
-				this.SetValue(MaxLinesProperty, value);
-			}
-		}
-		#endif
+		// Skipping already declared property MaxLines
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  bool IsColorFontEnabled
@@ -412,30 +230,9 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty CharacterSpacingProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(CharacterSpacing), typeof(int), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(int)));
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty FontFamilyProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(FontFamily), typeof(global::Windows.UI.Xaml.Media.FontFamily), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.FontFamily)));
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty FontSizeProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(FontSize), typeof(double), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(double)));
-		#endif
+		// Skipping already declared property CharacterSpacingProperty
+		// Skipping already declared property FontFamilyProperty
+		// Skipping already declared property FontSizeProperty
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty FontStretchProperty { get; } = 
@@ -444,30 +241,9 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStretch)));
 		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty FontStyleProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(FontStyle), typeof(global::Windows.UI.Text.FontStyle), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStyle)));
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty FontWeightProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(FontWeight), typeof(global::Windows.UI.Text.FontWeight), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontWeight)));
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty ForegroundProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(Foreground), typeof(global::Windows.UI.Xaml.Media.Brush), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
-		#endif
+		// Skipping already declared property FontStyleProperty
+		// Skipping already declared property FontWeightProperty
+		// Skipping already declared property ForegroundProperty
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextSelectionEnabledProperty { get; } = 
@@ -476,30 +252,9 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty LineHeightProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(LineHeight), typeof(double), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(double)));
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty LineStackingStrategyProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(LineStackingStrategy), typeof(global::Windows.UI.Xaml.LineStackingStrategy), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.LineStackingStrategy)));
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty PaddingProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(Padding), typeof(global::Windows.UI.Xaml.Thickness), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
-		#endif
+		// Skipping already declared property LineHeightProperty
+		// Skipping already declared property LineStackingStrategyProperty
+		// Skipping already declared property PaddingProperty
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedTextProperty { get; } = 
@@ -508,38 +263,10 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty TextAlignmentProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(TextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty TextProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(Text), typeof(string), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(string)));
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty TextTrimmingProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(TextTrimming), typeof(global::Windows.UI.Xaml.TextTrimming), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextTrimming)));
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty TextWrappingProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(TextWrapping), typeof(global::Windows.UI.Xaml.TextWrapping), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextWrapping)));
-		#endif
+		// Skipping already declared property TextAlignmentProperty
+		// Skipping already declared property TextProperty
+		// Skipping already declared property TextTrimmingProperty
+		// Skipping already declared property TextWrappingProperty
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsColorFontEnabledProperty { get; } = 
@@ -548,14 +275,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty MaxLinesProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(MaxLines), typeof(int), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(int)));
-		#endif
+		// Skipping already declared property MaxLinesProperty
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty OpticalMarginAlignmentProperty { get; } = 

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WebView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WebView.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if false || false || NET461 || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class WebView 
@@ -221,13 +221,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.WebView.WebView(Windows.UI.Xaml.Controls.WebViewExecutionMode)
-		#if false || false || NET461 || false || false
-		[global::Uno.NotImplemented]
-		public WebView() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.WebView", "WebView.WebView()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.WebView.WebView()
 		// Forced skipping of method Windows.UI.Xaml.Controls.WebView.WebView()
 		// Forced skipping of method Windows.UI.Xaml.Controls.WebView.Source.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.WebView.Source.set
@@ -358,13 +352,7 @@ namespace Windows.UI.Xaml.Controls
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.WebView", "void WebView.NavigateWithHttpRequestMessage(HttpRequestMessage requestMessage)");
 		}
 		#endif
-		#if false || false || NET461 || false || false
-		[global::Uno.NotImplemented]
-		public  bool Focus( global::Windows.UI.Xaml.FocusState value)
-		{
-			throw new global::System.NotImplementedException("The member bool WebView.Focus(FocusState value) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.WebView.Focus(Windows.UI.Xaml.FocusState)
 		// Forced skipping of method Windows.UI.Xaml.Controls.WebView.ContainsFullScreenElement.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.WebView.ContainsFullScreenElementChanged.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.WebView.ContainsFullScreenElementChanged.remove

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/CircleEase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/CircleEase.cs
@@ -2,18 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CircleEase : global::Windows.UI.Xaml.Media.Animation.EasingFunctionBase
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public CircleEase() 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Animation.CircleEase", "CircleEase.CircleEase()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.CircleEase.CircleEase()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.CircleEase.CircleEase()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorAnimationUsingKeyFrames.cs
@@ -2,11 +2,15 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ColorAnimationUsingKeyFrames : global::Windows.UI.Xaml.Media.Animation.Timeline
 	{
+		// Skipping already declared property EnableDependentAnimation
+		// Skipping already declared property KeyFrames
+		// Skipping already declared property EnableDependentAnimationProperty
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.ColorAnimationUsingKeyFrames.ColorAnimationUsingKeyFrames()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorAnimationUsingKeyFrames.ColorAnimationUsingKeyFrames()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorAnimationUsingKeyFrames.KeyFrames.get
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorAnimationUsingKeyFrames.EnableDependentAnimation.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorKeyFrame.cs
@@ -2,11 +2,15 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ColorKeyFrame : global::Windows.UI.Xaml.DependencyObject
 	{
+		// Skipping already declared property Value
+		// Skipping already declared property KeyTime
+		// Skipping already declared property KeyTimeProperty
+		// Skipping already declared property ValueProperty
 		// Skipping already declared method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.ColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.ColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.Value.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorKeyFrameCollection.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorKeyFrameCollection.cs
@@ -2,10 +2,33 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
-	#if false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ColorKeyFrameCollection : global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Media.Animation.ColorKeyFrame>,global::System.Collections.Generic.IEnumerable<global::Windows.UI.Xaml.Media.Animation.ColorKeyFrame>
 	{
+		// Skipping already declared property Size
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.ColorKeyFrameCollection()
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.ColorKeyFrameCollection()
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.GetAt(uint)
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.Size.get
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.GetView()
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.IndexOf(Windows.UI.Xaml.Media.Animation.ColorKeyFrame, out uint)
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.SetAt(uint, Windows.UI.Xaml.Media.Animation.ColorKeyFrame)
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.InsertAt(uint, Windows.UI.Xaml.Media.Animation.ColorKeyFrame)
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.RemoveAt(uint)
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.Append(Windows.UI.Xaml.Media.Animation.ColorKeyFrame)
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.RemoveAtEnd()
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.Clear()
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.GetMany(uint, Windows.UI.Xaml.Media.Animation.ColorKeyFrame[])
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.ReplaceAll(Windows.UI.Xaml.Media.Animation.ColorKeyFrame[])
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrameCollection.First()
+		// Processing: System.Collections.Generic.IList<Windows.UI.Xaml.Media.Animation.ColorKeyFrame>
+		// Skipping already implement System.Collections.Generic.IList<Windows.UI.Xaml.Media.Animation.ColorKeyFrame>.this[int]
+		// Processing: System.Collections.Generic.ICollection<Windows.UI.Xaml.Media.Animation.ColorKeyFrame>
+		// Skipping already implement System.Collections.Generic.ICollection<Windows.UI.Xaml.Media.Animation.ColorKeyFrame>.Count
+		// Skipping already implement System.Collections.Generic.ICollection<Windows.UI.Xaml.Media.Animation.ColorKeyFrame>.IsReadOnly
+		// Processing: System.Collections.Generic.IEnumerable<Windows.UI.Xaml.Media.Animation.ColorKeyFrame>
+		// Processing: System.Collections.IEnumerable
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DiscreteColorKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/DiscreteColorKeyFrame.cs
@@ -2,18 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class DiscreteColorKeyFrame : global::Windows.UI.Xaml.Media.Animation.ColorKeyFrame
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public DiscreteColorKeyFrame() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Animation.DiscreteColorKeyFrame", "DiscreteColorKeyFrame.DiscreteColorKeyFrame()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.DiscreteColorKeyFrame.DiscreteColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.DiscreteColorKeyFrame.DiscreteColorKeyFrame()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/EasingColorKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/EasingColorKeyFrame.cs
@@ -2,8 +2,14 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
 	public  partial class EasingColorKeyFrame : global::Windows.UI.Xaml.Media.Animation.ColorKeyFrame
 	{
+		// Skipping already declared property EasingFunction
+		// Skipping already declared property EasingFunctionProperty
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.EasingColorKeyFrame.EasingColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.EasingColorKeyFrame.EasingColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.EasingColorKeyFrame.EasingFunction.get
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.EasingColorKeyFrame.EasingFunction.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/FadeInThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/FadeInThemeAnimation.cs
@@ -1,0 +1,18 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.UI.Xaml.Media.Animation
+{
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class FadeInThemeAnimation 
+	{
+		// Skipping already declared property TargetName
+		// Skipping already declared property TargetNameProperty
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.FadeInThemeAnimation.FadeInThemeAnimation()
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.FadeInThemeAnimation.FadeInThemeAnimation()
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.FadeInThemeAnimation.TargetName.get
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.FadeInThemeAnimation.TargetName.set
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.FadeInThemeAnimation.TargetNameProperty.get
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/FadeOutThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/FadeOutThemeAnimation.cs
@@ -1,0 +1,18 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.UI.Xaml.Media.Animation
+{
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class FadeOutThemeAnimation 
+	{
+		// Skipping already declared property TargetName
+		// Skipping already declared property TargetNameProperty
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.FadeOutThemeAnimation.FadeOutThemeAnimation()
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.FadeOutThemeAnimation.FadeOutThemeAnimation()
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.FadeOutThemeAnimation.TargetName.get
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.FadeOutThemeAnimation.TargetName.set
+		// Forced skipping of method Windows.UI.Xaml.Media.Animation.FadeOutThemeAnimation.TargetNameProperty.get
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/LinearColorKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/LinearColorKeyFrame.cs
@@ -2,11 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
-	#if false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class LinearColorKeyFrame : global::Windows.UI.Xaml.Media.Animation.ColorKeyFrame
 	{
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.LinearColorKeyFrame.LinearColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.LinearColorKeyFrame.LinearColorKeyFrame()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointKeyFrame.cs
@@ -51,7 +51,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point)));
 		#endif
-		#if false || __IOS__ || false || __WASM__ || __MACOS__
+		#if __ANDROID__ || __IOS__ || NET461 || false || __MACOS__
 		[global::Uno.NotImplemented]
 		protected PointKeyFrame() : base()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SplineColorKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/SplineColorKeyFrame.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SplineColorKeyFrame : global::Windows.UI.Xaml.Media.Animation.ColorKeyFrame
@@ -29,13 +29,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			typeof(global::Windows.UI.Xaml.Media.Animation.SplineColorKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Animation.KeySpline)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public SplineColorKeyFrame() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Animation.SplineColorKeyFrame", "SplineColorKeyFrame.SplineColorKeyFrame()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.SplineColorKeyFrame.SplineColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.SplineColorKeyFrame.SplineColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.SplineColorKeyFrame.KeySpline.get
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.SplineColorKeyFrame.KeySpline.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Resources/CustomXamlResourceLoader.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Resources/CustomXamlResourceLoader.cs
@@ -7,35 +7,10 @@ namespace Windows.UI.Xaml.Resources
 	#endif
 	public  partial class CustomXamlResourceLoader 
 	{
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.Resources.CustomXamlResourceLoader Current
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member CustomXamlResourceLoader CustomXamlResourceLoader.Current is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Resources.CustomXamlResourceLoader", "CustomXamlResourceLoader CustomXamlResourceLoader.Current");
-			}
-		}
-#endif
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public CustomXamlResourceLoader() 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Resources.CustomXamlResourceLoader", "CustomXamlResourceLoader.CustomXamlResourceLoader()");
-		}
-#endif
+		// Skipping already declared property Current
+		// Skipping already declared method Windows.UI.Xaml.Resources.CustomXamlResourceLoader.CustomXamlResourceLoader()
 		// Forced skipping of method Windows.UI.Xaml.Resources.CustomXamlResourceLoader.CustomXamlResourceLoader()
-#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected virtual object GetResource( string resourceId,  string objectType,  string propertyName,  string propertyType)
-		{
-			throw new global::System.NotImplementedException("The member object CustomXamlResourceLoader.GetResource(string resourceId, string objectType, string propertyName, string propertyType) is not implemented in Uno.");
-		}
-#endif
+		// Skipping already declared method Windows.UI.Xaml.Resources.CustomXamlResourceLoader.GetResource(string, string, string, string)
 		// Forced skipping of method Windows.UI.Xaml.Resources.CustomXamlResourceLoader.Current.get
 		// Forced skipping of method Windows.UI.Xaml.Resources.CustomXamlResourceLoader.Current.set
 	}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/CircleEase.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/CircleEase.cs
@@ -13,7 +13,6 @@ namespace Windows.UI.Xaml.Media.Animation
 			var b = startValue;
 			var d = duration;
 
-
 			//Depending on the mode we have different functions for the return value.
 			switch (this.EasingMode)
 			{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/CircleEase.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/CircleEase.cs
@@ -1,0 +1,41 @@
+﻿
+using System;
+
+namespace Windows.UI.Xaml.Media.Animation
+{
+	public partial class CircleEase : EasingFunctionBase
+	{
+		public override double Ease(double currentTime, double startValue, double finalValue, double duration)
+		{
+			var c = finalValue - startValue;
+
+			var t = currentTime;
+			var b = startValue;
+			var d = duration;
+
+
+			//Depending on the mode we have different functions for the return value.
+			switch (this.EasingMode)
+			{
+				case EasingMode.EaseIn:
+					// http://gizma.com/easing/#circ1
+					t /= d;
+					return -c * (Math.Sqrt(1 - t * t) - 1) + b;
+				case EasingMode.EaseOut:
+					// http://gizma.com/easing/#circ2
+					t /= d;
+					t--;
+					return c * Math.Sqrt(1 - t * t) + b;
+				case EasingMode.EaseInOut:
+					// http://gizma.com/easing/#circ3
+					t /= d / 2;
+					if (t < 1) return -c / 2 * (Math.Sqrt(1 - t * t) - 1) + b;
+					t -= 2;
+					return c / 2 * (Math.Sqrt(1 - t * t) + 1) + b;
+
+				default:
+					return finalValue * currentTime / duration + startValue;
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/EasingFunctionBase.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/EasingFunctionBase.cs
@@ -18,13 +18,17 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		public EasingMode EasingMode
 		{
-			get { return (EasingMode)this.GetValue(EasingModeProperty); }
-			set { this.SetValue(EasingModeProperty, value); }
+			get => (EasingMode)this.GetValue(EasingModeProperty);
+			set => this.SetValue(EasingModeProperty, value);
 		}
 		
 		public static readonly DependencyProperty EasingModeProperty =
 			DependencyProperty.Register("EasingMode", typeof(EasingMode), typeof(EasingFunctionBase), new PropertyMetadata(EasingMode.EaseOut));
 
-		public virtual double Ease(double currentTime, double startValue, double finalValue, double duration) { throw new NotSupportedException(); }
+		public virtual double Ease(double currentTime, double startValue, double finalValue, double duration) =>
+			// Return linear interpolation instead of an exception for unimplemented easing functions.
+			currentTime == 0 ? startValue : Lerp(startValue, finalValue, currentTime / duration);
+
+		private static double Lerp(double first, double last, double by) => first * (1.0 - @by) + last * @by;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/SineEase.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/SineEase.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Windows.UI.Xaml.Media.Animation
 {
-    public partial class SineEase : EasingFunctionBase
+	public partial class SineEase : EasingFunctionBase
 	{
 		public override double Ease(double currentTime, double startValue, double finalValue, double duration)
 		{

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -348,10 +348,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <UpToDateCheckInput Remove="UI\Xaml\LaunchActivatedEventArgs.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <None Update="BaseActivity.Callbacks.Implementation.Android.tt">
 	    <Generator>TextTemplatingFileGenerator</Generator>
 	    <LastGenOutput>BaseActivity.Callbacks.Implementation.Android.cs</LastGenOutput>

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Input/KeyboardCapabilities.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Input/KeyboardCapabilities.cs
@@ -2,7 +2,14 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Input
 {
+	#if false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
 	public  partial class KeyboardCapabilities 
 	{
+		// Skipping already declared property KeyboardPresent
+		// Skipping already declared method Windows.Devices.Input.KeyboardCapabilities.KeyboardCapabilities()
+		// Forced skipping of method Windows.Devices.Input.KeyboardCapabilities.KeyboardCapabilities()
+		// Forced skipping of method Windows.Devices.Input.KeyboardCapabilities.KeyboardPresent.get
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking/HostNameType.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking/HostNameType.cs
@@ -3,23 +3,15 @@
 namespace Windows.Networking
 {
 	#if false || false || false || false || false
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum HostNameType 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		DomainName,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Ipv4,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Ipv6,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		Bluetooth,
-		#endif
+		// Skipping already declared field Windows.Networking.HostNameType.DomainName
+		// Skipping already declared field Windows.Networking.HostNameType.Ipv4
+		// Skipping already declared field Windows.Networking.HostNameType.Ipv6
+		// Skipping already declared field Windows.Networking.HostNameType.Bluetooth
 	}
 	#endif
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/RightTappedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/RightTappedEventArgs.cs
@@ -9,6 +9,7 @@ namespace Windows.UI.Input
 	{
 		// Skipping already declared property PointerDeviceType
 		// Skipping already declared property Position
+		// Skipping already declared property ContactCount
 		// Forced skipping of method Windows.UI.Input.RightTappedEventArgs.PointerDeviceType.get
 		// Forced skipping of method Windows.UI.Input.RightTappedEventArgs.Position.get
 		// Forced skipping of method Windows.UI.Input.RightTappedEventArgs.ContactCount.get

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/TappedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/TappedEventArgs.cs
@@ -10,6 +10,7 @@ namespace Windows.UI.Input
 		// Skipping already declared property PointerDeviceType
 		// Skipping already declared property Position
 		// Skipping already declared property TapCount
+		// Skipping already declared property ContactCount
 		// Forced skipping of method Windows.UI.Input.TappedEventArgs.PointerDeviceType.get
 		// Forced skipping of method Windows.UI.Input.TappedEventArgs.Position.get
 		// Forced skipping of method Windows.UI.Input.TappedEventArgs.TapCount.get


### PR DESCRIPTION
# Bugfix
When using geometries in a Path on Wasm, they are getting serialized as a _path data_ string by [this code](https://github.com/unoplatform/uno/blob/a97622505cea5180d9943965e73b099ca028264d/src/Uno.UI/UI/Xaml/Shapes/Path.wasm.cs#L51_L97). It was generating code using culture-dependant decimal separator.

The fix was to generate the string using culture-independant serialization.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
