### PR TITLE
Fix INPC equality comparison, add support for INPC(String.Empty)

### DIFF
--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.inpc.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.inpc.cs
@@ -56,7 +56,8 @@ namespace Uno.UI.Tests.BinderTests
 			var SUT = new Binder_INPC_Data();
 			SUT.SetBinding(
 				Binder_INPC_Data.MyValueProperty,
-				new Binding {
+				new Binding
+				{
 					Path = new PropertyPath("Value"),
 					Converter = new Binder_INPC_DummyConverter()
 				});
@@ -72,6 +73,34 @@ namespace Uno.UI.Tests.BinderTests
 			Assert.AreEqual(SUT.MyValue, master.Value);
 			Assert.AreEqual(4, master.ValueGetCount);
 			Assert.AreEqual(0, master.ValueSetCount);
+		}
+
+		[TestMethod]
+		public void When_INPC_Raise_All_Updated()
+		{
+			var SUT = new Binder_INPC_Data();
+			SUT.SetBinding(
+				Binder_INPC_Data.MyValueProperty,
+				new Binding
+				{
+					Path = new PropertyPath("Class1.Value")
+				});
+
+			SUT.SetBinding(
+				Binder_INPC_Data.MyValue2Property,
+				new Binding
+				{
+					Path = new PropertyPath("Value"),
+					Converter = new Binder_INPC_DummyConverter()
+				});
+
+			var master = new Binder_INPC_Base_Class();
+			SUT.DataContext = master;
+
+			master.RaiseAllUpdated();
+
+			Assert.AreEqual(SUT.MyValue, master.Class1.Value);
+			Assert.AreEqual(SUT.MyValue2, master.Value);
 		}
 	}
 
@@ -92,6 +121,15 @@ namespace Uno.UI.Tests.BinderTests
 		{
 			MyValuePropertyValueDuringChange = MyValue;
 		}
+
+		public string MyValue2
+		{
+			get => GetMyValue2Value();
+			set => SetMyValue2Value(value);
+		}
+
+		[GeneratedDependencyProperty(DefaultValue = "")]
+		public static DependencyProperty MyValue2Property { get; } = CreateMyValue2Property();
 	}
 
 	public class Binder_INPC_Base_Class : Binder_INPC_BaseViewModel

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.inpc.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.inpc.cs
@@ -1,0 +1,187 @@
+﻿using CommonServiceLocator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Uno.Logging;
+using Uno.Extensions;
+using Uno.Presentation.Resources;
+using Uno.UI.DataBinding;
+using Windows.UI.Xaml.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using Uno.Disposables;
+using Uno.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+using Uno.Conversion;
+using Microsoft.Extensions.Logging;
+using Windows.UI.Xaml.Controls;
+using System.Threading;
+using Uno.UI.Xaml;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Uno.UI.Tests.BinderTests
+{
+	[TestClass]
+	public partial class Given_Binder_INPC
+	{
+		[TestMethod]
+		public void When_INPC_Update_SameReference()
+		{
+			var SUT = new Binder_INPC_Data();
+			SUT.SetBinding(Binder_INPC_Data.MyValueProperty, new Binding { Path = new PropertyPath("Class1.Value") });
+
+			var master = new Binder_INPC_Base_Class();
+			SUT.DataContext = master;
+
+			Assert.AreEqual(SUT.MyValue, master.Class1.Value);
+			Assert.AreEqual(2, master.Class1.ValueGetCount);
+			Assert.AreEqual(0, master.Class1.ValueSetCount);
+
+			master.Update();
+
+			Assert.AreEqual(SUT.MyValue, master.Class1.Value);
+			Assert.AreEqual(4, master.Class1.ValueGetCount);
+			Assert.AreEqual(1, master.Class1.ValueSetCount);
+		}
+
+		[TestMethod]
+		public void When_INPC_Update_SameReference_Converter()
+		{
+			var SUT = new Binder_INPC_Data();
+			SUT.SetBinding(
+				Binder_INPC_Data.MyValueProperty,
+				new Binding {
+					Path = new PropertyPath("Value"),
+					Converter = new Binder_INPC_DummyConverter()
+				});
+
+			var master = new Binder_INPC_Base_Class();
+			SUT.DataContext = master;
+
+			Assert.AreEqual(2, master.ValueGetCount);
+			Assert.AreEqual(0, master.ValueSetCount);
+
+			master.RaiseUpdated();
+
+			Assert.AreEqual(SUT.MyValue, master.Value);
+			Assert.AreEqual(4, master.ValueGetCount);
+			Assert.AreEqual(0, master.ValueSetCount);
+		}
+	}
+
+	public partial class Binder_INPC_Data : DependencyObject
+	{
+		public string MyValuePropertyValueDuringChange { get; private set; }
+
+		public string MyValue
+		{
+			get => GetMyValueValue();
+			set => SetMyValueValue(value);
+		}
+
+		[GeneratedDependencyProperty(DefaultValue = "")]
+		public static DependencyProperty MyValueProperty { get; } = CreateMyValueProperty();
+
+		private void OnMyValueChanged(string oldValue, string newValue)
+		{
+			MyValuePropertyValueDuringChange = MyValue;
+		}
+	}
+
+	public class Binder_INPC_Base_Class : Binder_INPC_BaseViewModel
+	{
+		private string _value = Guid.NewGuid().ToString();
+		public int ValueGetCount { get; private set; }
+		public int ValueSetCount { get; private set; }
+
+		public Binder_INPC_Class1 Class1 { get; set; } = new Binder_INPC_Class1();
+		public string Value
+		{
+			get
+			{
+				ValueGetCount++;
+				return _value;
+			}
+			set
+			{
+				ValueSetCount++;
+				_value = value;
+			}
+		}
+
+		public void Update()
+		{
+			Class1.Value = (Binder_INPC_Class1.IndexCounter++).ToString(CultureInfo.InvariantCulture);
+			Value = (Binder_INPC_Class1.IndexCounter++).ToString(CultureInfo.InvariantCulture);
+			RaiseUpdated();
+		}
+
+		public void RaiseUpdated()
+		{
+			OnPropertyChanged(nameof(Class1));
+			OnPropertyChanged(nameof(Value));
+		}
+
+		public void RaiseAllUpdated()
+		{
+			Class1.Value = (Binder_INPC_Class1.IndexCounter++).ToString(CultureInfo.InvariantCulture);
+			Value = (Binder_INPC_Class1.IndexCounter++).ToString(CultureInfo.InvariantCulture);
+			OnPropertyChanged(string.Empty);
+		}
+	}
+
+	public class Binder_INPC_Class1
+	{
+		public static int IndexCounter = 0;
+		private string _value = (IndexCounter++).ToString(CultureInfo.InvariantCulture);
+		public int ValueGetCount { get; set; }
+		public int ValueSetCount { get; set; }
+
+		public string Value
+		{
+			get
+			{
+				ValueGetCount++;
+				return _value;
+			}
+			set
+			{
+				ValueSetCount++;
+				_value = value;
+			}
+		}
+	}
+
+	public class Binder_INPC_BaseViewModel : System.ComponentModel.INotifyPropertyChanged
+	{
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
+			=> PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+	}
+
+	public class Binder_INPC_DummyConverter : IValueConverter
+	{
+		public static int ConvertCount { get; set; }
+		public static int ConvertBackCount { get; set; }
+
+
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			ConvertCount++;
+			return value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language)
+		{
+			ConvertBackCount++;
+			return value;
+		}
+	}
+}

--- a/src/Uno.UI/DataBinding/BindingPath.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.cs
@@ -355,11 +355,11 @@ namespace Uno.UI.DataBinding
 
 				System.ComponentModel.PropertyChangedEventHandler handler = (s, args) =>
 				{
-					if (args.PropertyName == propertyName)
+					if (args.PropertyName == propertyName || args.PropertyName == string.Empty)
 					{
 						if (typeof(BindingPath).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 						{
-							typeof(BindingPath).Log().Debug("Property changed for {0} on [{1}]".InvariantCultureFormat(propertyName, dataContextReference.Target?.GetType()));
+							typeof(BindingPath).Log().Debug($"Property changed for {propertyName} on [{dataContextReference.Target?.GetType()}]");
 						}
 
 						if (!newValueActionWeak.IsDisposed)
@@ -437,7 +437,7 @@ namespace Uno.UI.DataBinding
 						// detrimental to the use of INPC events processing.
 						// In case of an INPC, the bindings engine must reevaluate the path completely from the raising point, regardless
 						// of the reference being changed.
-						if(FeatureConfiguration.Binding.IgnoreINPCSameReferences && DependencyObjectStore.AreDifferent(DataContext, value))
+						if(FeatureConfiguration.Binding.IgnoreINPCSameReferences && !DependencyObjectStore.AreDifferent(DataContext, value))
 						{
 							return;
 						}

--- a/src/Uno.UI/DataBinding/BindingPath.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.cs
@@ -430,8 +430,18 @@ namespace Uno.UI.DataBinding
 				get => _dataContextWeakStorage?.Target;
 				set
 				{
-					if (!_disposed && DependencyObjectStore.AreDifferent(DataContext, value))
+					if (!_disposed)
 					{
+						// Historically, Uno was processing property changes using INPC. Since the inclusion of DependencyObject
+						// values changes are now filtered by DependencyProperty updates, making equality updates at this location
+						// detrimental to the use of INPC events processing.
+						// In case of an INPC, the bindings engine must reevaluate the path completely from the raising point, regardless
+						// of the reference being changed.
+						if(FeatureConfiguration.Binding.IgnoreINPCSameReferences && DependencyObjectStore.AreDifferent(DataContext, value))
+						{
+							return;
+						}
+
 						var weakDataContext = WeakReferencePool.RentWeakReference(this, value);
 						SetWeakDataContext(weakDataContext);
 					}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -174,6 +174,14 @@ namespace Uno.UI
 #endif
 		}
 
+		public static class Binding
+		{
+			/// <summary>
+			/// Determines if the binding engine should ignore identical references in binding paths.
+			/// </summary>
+			public static bool IgnoreINPCSameReferences { get; set; } = false;
+		}
+
 		public static class Popup
 		{
 #if __ANDROID__


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #3447, Fixes #773

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the new behavior?

- Adds support for INPC update if the notified property has not changed (but some of its children did)
- Adds support for all properties updated through INPC(String.Empty)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
