### PR TITLE
TextBlock: Added support for HorizontalTextAlignment

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -961,6 +961,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_HorizontalTextAlignment.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextWrapping_PR1954_EdgeCase.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3855,6 +3859,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Foreground_While_Collapsed.xaml.cs">
       <DependentUpon>TextBlock_Foreground_While_Collapsed.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_HorizontalTextAlignment.xaml.cs">
+      <DependentUpon>TextBlock_HorizontalTextAlignment.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Layout.xaml.cs">
       <DependentUpon>TextBlock_Layout.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_HorizontalTextAlignment.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_HorizontalTextAlignment.xaml
@@ -1,0 +1,69 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_HorizontalTextAlignment"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBlockControl"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+  <StackPanel Spacing="10" HorizontalAlignment="Left" Width="86">
+	<StackPanel.Resources>
+	  <Style x:Key="rightAlign" TargetType="TextBlock">
+		<Setter Property="HorizontalAlignment" Value="Right" />
+	  </Style>
+	</StackPanel.Resources>
+
+	<TextBlock TextWrapping="Wrap">All text should be centered...</TextBlock>
+	<Border BorderBrush="Red" BorderThickness="3">
+	  <TextBlock Text="1234"
+				 Width="80"
+				 HorizontalTextAlignment="Center"
+				 HorizontalAlignment="Center" />
+	</Border>
+	<Border BorderBrush="Red" BorderThickness="3">
+	  <TextBlock Text="1234"
+				 Width="80"
+				 HorizontalTextAlignment="Right"
+				 TextAlignment="Center" />
+	</Border>
+	<Border BorderBrush="Red" BorderThickness="3">
+	  <TextBlock Text="1234"
+				 Width="80"
+				 TextAlignment="Right"
+				 HorizontalTextAlignment="Center" />
+	</Border>
+	<Border BorderBrush="Red" BorderThickness="3">
+	  <TextBlock Text="1234"
+				 Width="80"
+				 Style="{StaticResource rightAlign}"
+				 HorizontalTextAlignment="Center" />
+	</Border>
+	<Border BorderBrush="Red" BorderThickness="3">
+	  <TextBlock Text="1234"
+				 Width="80"
+				 HorizontalTextAlignment="Center"
+				 Style="{StaticResource rightAlign}" />
+	</Border>
+	<Border BorderBrush="Red" BorderThickness="3">
+	  <TextBlock Text="1234"
+				 Width="80"
+				 HorizontalTextAlignment="Center" />
+	</Border>
+	<Border BorderBrush="Red" BorderThickness="3">
+	  <TextBlock Text="1234"
+				 Width="80"
+				 HorizontalTextAlignment="Center" />
+	</Border>
+	<Border BorderBrush="Red" BorderThickness="3" Width="86">
+	  <TextBlock Text="1234"
+				 HorizontalAlignment="Center" />
+	</Border>
+	<Border BorderBrush="Red" BorderThickness="3" Width="86">
+	  <TextBlock Text="1234"
+				 HorizontalTextAlignment="Right"
+				 HorizontalAlignment="Center" />
+	</Border>
+  </StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_HorizontalTextAlignment.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_HorizontalTextAlignment.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[Sample("TextBlockControl")]
+	public sealed partial class TextBlock_HorizontalTextAlignment : Page
+	{
+		public TextBlock_HorizontalTextAlignment()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBlock.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBlock.cs
@@ -377,20 +377,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 		#endif
 		// Skipping already declared property TextDecorations
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.TextAlignment HorizontalTextAlignment
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.TextAlignment)this.GetValue(HorizontalTextAlignmentProperty);
-			}
-			set
-			{
-				this.SetValue(HorizontalTextAlignmentProperty, value);
-			}
-		}
-		#endif
+		// Skipping already declared property HorizontalTextAlignment
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  bool IsTextTrimmed
@@ -610,14 +597,7 @@ namespace Windows.UI.Xaml.Controls
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
 		// Skipping already declared property TextDecorationsProperty
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty HorizontalTextAlignmentProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(HorizontalTextAlignment), typeof(global::Windows.UI.Xaml.TextAlignment), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.TextAlignment)));
-		#endif
+		// Skipping already declared property HorizontalTextAlignmentProperty
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsTextTrimmedProperty { get; } = 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -431,11 +431,41 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnTextAlignmentChanged()
 		{
+			HorizontalTextAlignment = TextAlignment;
 			OnTextAlignmentChangedPartial();
 			InvalidateTextBlock();
 		}
 
 		partial void OnTextAlignmentChangedPartial();
+
+#endregion
+
+#region HorizontalTextAlignment Dependency Property
+
+		public new TextAlignment HorizontalTextAlignment
+		{
+			get { return (TextAlignment)this.GetValue(HorizontalTextAlignmentProperty); }
+			set { this.SetValue(HorizontalTextAlignmentProperty, value); }
+		}
+
+		public static readonly DependencyProperty HorizontalTextAlignmentProperty =
+			DependencyProperty.Register(
+				"HorizontalTextAlignment",
+				typeof(TextAlignment),
+				typeof(TextBlock),
+				new PropertyMetadata(
+					defaultValue: TextAlignment.Left,
+					propertyChangedCallback: (s, e) => ((TextBlock)s).OnHorizontalTextAlignmentChanged()
+				)
+			);
+
+		// This property provides the same functionality as the TextAlignment property.
+		// If both properties are set to conflicting values, the last one set is used.
+		// https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textbox.horizontaltextalignment#remarks
+		private void OnHorizontalTextAlignmentChanged()
+		{
+			TextAlignment = HorizontalTextAlignment;
+		}
 
 #endregion
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -448,7 +448,7 @@ namespace Windows.UI.Xaml.Controls
 			set { this.SetValue(HorizontalTextAlignmentProperty, value); }
 		}
 
-		public static readonly DependencyProperty HorizontalTextAlignmentProperty =
+		public static DependencyProperty HorizontalTextAlignmentProperty { get; } =
 			DependencyProperty.Register(
 				"HorizontalTextAlignment",
 				typeof(TextAlignment),


### PR DESCRIPTION
Fix https://github.com/unoplatform/uno/issues/3471

# Bugfix

`HorizontalTextAlignment` were not supported by Uno, only `TextAlignment`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- ~~[ ] Validated PR `Screenshots Compare Test Run` results.~~
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
