### PR TITLE
fix(pointers): [WASM] Fix the original source of the pointer events on shapes

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Shapes_Tests.cs
@@ -59,8 +59,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			_app.TapCoordinates(target.CenterX + offsetX * dpiScale, target.CenterY + offsetY * dpiScale);
 
 			var result = _app.Marked("LastPressed").GetDependencyPropertyValue<string>("Text");
+			var resultSrc = _app.Marked("LastPressedSrc").GetDependencyPropertyValue<string>("Text");
 
 			result.Should().Be(expected);
+			resultSrc.Should().Be(expected);
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Shapes.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Shapes.xaml
@@ -271,6 +271,13 @@
 			Orientation="Horizontal">
 			<TextBlock Text="Last pressed: " />
 			<TextBlock x:Name="LastPressed" Text="__none__" />
+			<TextBlock Text=" (src: " />
+			<TextBlock x:Name="LastPressedSrc" Text="__none__" />
+			<TextBlock Text=") - Last hovered: " />
+			<TextBlock x:Name="LastHovered" Text="__none__" />
+			<TextBlock Text=" (src: " />
+			<TextBlock x:Name="LastHoveredSrc" Text="__none__" />
+			<TextBlock Text=")" />
 		</StackPanel>
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Shapes.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Shapes.xaml.cs
@@ -20,6 +20,13 @@ namespace UITests.Windows_UI_Input.PointersTests
 				{
 					e.Handled = true;
 					LastPressed.Text = elt.Name;
+					LastPressedSrc.Text = (e.OriginalSource as FrameworkElement)?.Name ?? "-unknown-";
+				};
+				elt.PointerMoved += (snd, e) =>
+				{
+					e.Handled = true;
+					LastHovered.Text = elt.Name;
+					LastHoveredSrc.Text = (e.OriginalSource as FrameworkElement)?.Name ?? "-unknown-";
 				};
 			}
 		}

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -1012,6 +1012,15 @@ var Uno;
                     return "";
                 }
                 let src = evt.target;
+                if (src) {
+                    // The XAML SvgElement are UIElement in Uno (so they have a XamlHandle),
+                    // but as on WinUI they are not part of the visual tree, they should not be used as OriginalElement.
+                    // Instead we should use the actual parent <svg /> which is the XAML Shape.
+                    const shape = src.ownerSVGElement;
+                    if (shape) {
+                        src = shape;
+                    }
+                }
                 let srcHandle = "0";
                 while (src) {
                     let handle = src.getAttribute("XamlHandle");

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -920,6 +920,15 @@ namespace Uno.UI {
 			}
 
 			let src = evt.target as HTMLElement | SVGElement;
+			if (src as SVGElement) {
+				// The XAML SvgElement are UIElement in Uno (so they have a XamlHandle),
+				// but as on WinUI they are not part of the visual tree, they should not be used as OriginalElement.
+				// Instead we should use the actual parent <svg /> which is the XAML Shape.
+				const shape = (src as any).ownerSVGElement;
+				if (shape) {
+					src = shape;
+				}
+			}
 			let srcHandle = "0";
 			while (src) {
 				let handle = src.getAttribute("XamlHandle");


### PR DESCRIPTION
GitHub Issue: _private cf. below_

## Bugfix
On WASM the `PointerRoutedEventArgs.OriginalSource` is a Uno's internal element.

## What is the current behavior?
On WASM, when interacting with a `Shape` the `PointerRoutedEventArgs.OriginalSource` is the internal `SvgElement`.

## What is the new behavior?
We are now navigating up to the `<svg />` elemnt which is the XAML `Shape` 

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
