### PR TITLE
fix: Update RemoteControl server to netcoreap 3.1

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,7 +15,7 @@ pr:
 resources:
   containers:
   - container: nv-bionic-wasm
-    image: unoplatform/wasm-build:2.0
+    image: unoplatform/wasm-build:2.1.1
 
 variables:
   windowsVMImage: 'windows-2019'

--- a/build/Uno.WinUI.RemoteControl.nuspec
+++ b/build/Uno.WinUI.RemoteControl.nuspec
@@ -85,7 +85,7 @@
 	<file src="..\src\Uno.UI.RemoteControl\bin\Release\xamarinmac20\Uno.UI.RemoteControl.pdb" target="lib\xamarinmac20" />
 
 	<!-- Remote Control host and integration -->
-    <file src="..\src\Uno.UI.RemoteControl.Host\bin\Release\netcoreapp2.2\*.*" target="tools\rc\host" />
+    <file src="..\src\Uno.UI.RemoteControl.Host\bin\Release\netcoreapp3.1\*.*" target="tools\rc\host" />
     <file src="..\src\Uno.UI.RemoteControl.VS\bin\Release\net461\*.dll" target="tools\rc" />
     <file src="..\src\Uno.UI.RemoteControl.VS\bin\Release\net461\*.pdb" target="tools\rc" />
     <file src="..\src\Uno.UI.RemoteControl.VS\bin\Release\net461\Newtonsoft.Json.dll" target="tools\rc" />

--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 
@@ -15,6 +15,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.App" />
 		<PackageReference Include="Mono.Options" Version="6.6.0.161" />
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 		<PackageReference Include="System.Reactive" Version="4.4.1" />
 		<PackageReference Include="Unity" Version="5.11.7" />
 		<PackageReference Include="Uno.Core" Version="2.0.0" />


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #3469

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Updates the dependency on .NET Core 2.2 to .NET Core 3.1 for the RemoteControl server for Hot Reload support.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
