### PR TITLE
fix(pointers): [WASM] Fix the OriginalSource of pointer events for Image

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Image_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_Image_Tests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Input
+{
+	[TestFixture]
+	public partial class HitTest_Image_Tests : SampleControlUITestBase
+	{
+		private const string _sample = "UITests.Windows_UI_Input.PointersTests.HitTest_Image";
+
+		[Test] [AutoRetry] public void When_Image()
+		{
+			var element = "TheImage";
+
+			Run(_sample);
+
+			var target = _app.WaitForElement(element).Single().Rect;
+
+			_app.TapCoordinates(target.CenterX, target.CenterY);
+
+			var result = _app.Marked("LastPressed").GetDependencyPropertyValue<string>("Text");
+			var resultSrc = _app.Marked("LastPressedSrc").GetDependencyPropertyValue<string>("Text");
+
+			result.Should().Be(element);
+			resultSrc.Should().Be(element);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -237,6 +237,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_Image.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_Shapes.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3461,6 +3465,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Capture.xaml.cs">
       <DependentUpon>Capture.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_Image.xaml.cs">
+      <DependentUpon>HitTest_Image.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_Shapes.xaml.cs">
       <DependentUpon>HitTest_Shapes.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Image.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Image.xaml
@@ -1,0 +1,40 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Input.PointersTests.HitTest_Image"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Input.PointersTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid x:Name="Root" Background="Transparent">
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<Border
+			HorizontalAlignment="Center"
+			VerticalAlignment="Center">
+			<Image
+				x:Name="TheImage"
+				Stretch="None"
+				Source="ms-appx:///Assets/test_image_150_100.png" />
+		</Border>
+
+		<StackPanel
+			Grid.Row="1"
+			Orientation="Horizontal">
+			<TextBlock Text="Last pressed: " />
+			<TextBlock x:Name="LastPressed" Text="__none__" />
+			<TextBlock Text=" (src: " />
+			<TextBlock x:Name="LastPressedSrc" Text="__none__" />
+			<TextBlock Text=") - Last hovered: " />
+			<TextBlock x:Name="LastHovered" Text="__none__" />
+			<TextBlock Text=" (src: " />
+			<TextBlock x:Name="LastHoveredSrc" Text="__none__" />
+			<TextBlock Text=")" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Image.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_Image.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Input.PointersTests
+{
+	[Sample("Pointers", "Image")]
+	public sealed partial class HitTest_Image : Page
+	{
+		public HitTest_Image()
+		{
+			this.InitializeComponent();
+
+			Root.PointerPressed += (snd, e) =>
+			{
+				e.Handled = true;
+				LastPressed.Text = Root.Name;
+				LastPressedSrc.Text = (e.OriginalSource as FrameworkElement)?.Name ?? "-unknown-";
+			};
+			Root.PointerMoved += (snd, e) =>
+			{
+				e.Handled = true;
+				LastHovered.Text = Root.Name;
+				LastHoveredSrc.Text = (e.OriginalSource as FrameworkElement)?.Name ?? "-unknown-";
+			};
+			TheImage.PointerPressed += (snd, e) =>
+			{
+				e.Handled = true;
+				LastPressed.Text = TheImage.Name;
+				LastPressedSrc.Text = (e.OriginalSource as FrameworkElement)?.Name ?? "-unknown-";
+			};
+			TheImage.PointerMoved += (snd, e) =>
+			{
+				e.Handled = true;
+				LastHovered.Text = TheImage.Name;
+				LastHoveredSrc.Text = (e.OriginalSource as FrameworkElement)?.Name ?? "-unknown-";
+			};
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -1033,7 +1033,7 @@ var Uno;
                     return "";
                 }
                 let src = evt.target;
-                if (src) {
+                if (src instanceof SVGElement) {
                     // The XAML SvgElement are UIElement in Uno (so they have a XamlHandle),
                     // but as on WinUI they are not part of the visual tree, they should not be used as OriginalElement.
                     // Instead we should use the actual parent <svg /> which is the XAML Shape.
@@ -1041,6 +1041,10 @@ var Uno;
                     if (shape) {
                         src = shape;
                     }
+                }
+                else if (src instanceof HTMLImageElement) {
+                    // Same as above for images (<img /> == HtmlImage, we use the parent <div /> which is the XAML Image).
+                    src = src.parentElement;
                 }
                 let srcHandle = "0";
                 while (src) {

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -944,7 +944,7 @@ namespace Uno.UI {
 			}
 
 			let src = evt.target as HTMLElement | SVGElement;
-			if (src as SVGElement) {
+			if (src instanceof SVGElement) {
 				// The XAML SvgElement are UIElement in Uno (so they have a XamlHandle),
 				// but as on WinUI they are not part of the visual tree, they should not be used as OriginalElement.
 				// Instead we should use the actual parent <svg /> which is the XAML Shape.
@@ -952,7 +952,11 @@ namespace Uno.UI {
 				if (shape) {
 					src = shape;
 				}
+			} else if (src instanceof HTMLImageElement) {
+				// Same as above for images (<img /> == HtmlImage, we use the parent <div /> which is the XAML Image).
+				src = src.parentElement;
 			}
+
 			let srcHandle = "0";
 			while (src) {
 				let handle = src.getAttribute("XamlHandle");


### PR DESCRIPTION
GitHub Issue: _private, cf. below_

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## BugFix
The `PointerRoutedEventArgs.OriginalSource` is an internal element while over an `Image`

## What is the current behavior?
The `PointerRoutedEventArgs.OriginalSource` is the internal `HtmlImage` instead of the `Image`

## What is the new behavior?
The `PointerRoutedEventArgs.OriginalSource` is now the `Image` as WinUI

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
