### PR TITLE
fix: Adjust gitpod serve script

### DIFF
--- a/build/gitpod/serve-sampleapp-wasm.sh
+++ b/build/gitpod/serve-sampleapp-wasm.sh
@@ -2,6 +2,6 @@
 
 pushd /workspace/uno/src/SamplesApp/SamplesApp.Wasm
 
-dotnet unowasm serve --urls=http://*:8000 --pathbase /workspace/uno/src/SamplesApp/SamplesApp.Wasm/bin/Debug/netstandard2.0/dist
+dotnet $NUGET_PACKAGES/uno.wasm.bootstrap.devserver/*/tools/server/dotnet-unowasm.dll serve --urls=http://*:8000 --pathbase /workspace/uno/src/SamplesApp/SamplesApp.Wasm/bin/Debug/netstandard2.0/dist
 
 popd


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Launching `build/gitpod/serve-sampleapp-wasm.sh` now serves the application properly in GitPod.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
