### PR TITLE
Grid: Fixed "star" arranged size when measured available size was infinite.

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -737,6 +737,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_InfiniteMeasure.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Spacing_Adjustable.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3718,6 +3722,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Unloaded.xaml.cs">
       <DependentUpon>Flyout_Unloaded.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_InfiniteMeasure.xaml.cs">
+      <DependentUpon>Grid_InfiniteMeasure.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Spacing_Adjustable.xaml.cs">
       <DependentUpon>Grid_Spacing_Adjustable.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_InfiniteMeasure.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_InfiniteMeasure.xaml
@@ -1,0 +1,37 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.GridTestsControl.Grid_InfiniteMeasure"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="10">
+		<TextBlock FontSize="15">Following rectangles with text should be identical:</TextBlock>
+		<Border Background="Pink" HorizontalAlignment="Left">
+			<TextBlock FontSize="18" Margin="5">Uno Platform</TextBlock>
+		</Border>
+
+		<StackPanel Orientation="Horizontal">
+			<Grid Background="Pink" HorizontalAlignment="Left">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="*" />
+				</Grid.ColumnDefinitions>
+				<TextBlock FontSize="18" Margin="5">Uno Platform</TextBlock>
+			</Grid>
+		</StackPanel>
+
+		<Canvas>
+			<Grid Background="Pink">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="*" />
+				</Grid.ColumnDefinitions>
+				<TextBlock FontSize="18" Margin="5" Grid.Column="1">Uno Platform</TextBlock>
+			</Grid>
+		</Canvas>
+	</StackPanel>
+
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_InfiniteMeasure.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_InfiniteMeasure.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.GridTestsControl
+{
+	[Sample("GridTestsControl")]
+	public sealed partial class Grid_InfiniteMeasure : Page
+	{
+		public Grid_InfiniteMeasure()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
@@ -43,6 +43,8 @@ namespace Windows.UI.Xaml.Controls
 
 		private Memory<DoubleRange> _calculatedRows;
 		private Memory<DoubleRange> _calculatedColumns;
+		private bool _considerStarColumnsAsAuto;
+		private bool _considerStarRowsAsAuto;
 
 		private Memory<Column> GetColumns(bool considerStarAsAuto)
 		{
@@ -154,11 +156,11 @@ namespace Windows.UI.Xaml.Controls
 			var spacingSize = new Size(ColumnSpacing * (definedColumns.Length - 1), RowSpacing * (definedRows.Length - 1));
 			availableSize = availableSize.Subtract(spacingSize);
 
-			var considerStarColumnsAsAuto = ConsiderStarColumnsAsAuto(availableSize.Width);
-			var considerStarRowsAsAuto = ConsiderStarRowsAsAuto(availableSize.Height);
+			_considerStarColumnsAsAuto = ConsiderStarColumnsAsAuto(availableSize.Width);
+			_considerStarRowsAsAuto = ConsiderStarRowsAsAuto(availableSize.Height);
 
-			var columns = GetColumns(considerStarColumnsAsAuto).Span;
-			var rows = GetRows(considerStarRowsAsAuto).Span;
+			var columns = GetColumns(_considerStarColumnsAsAuto).Span;
+			var rows = GetRows(_considerStarRowsAsAuto).Span;
 
 			Size size;
 			if (!TryMeasureUsingFastPath(availableSize, columns, definedColumns, rows, definedRows, out size))
@@ -216,11 +218,8 @@ namespace Windows.UI.Xaml.Controls
 				.Subtract(borderAndPaddingSize)
 				.Subtract(spacingSize);
 
-			var considerStarColumnsAsAuto = ConsiderStarColumnsAsAuto(availableSize.Width);
-			var considerStarRowsAsAuto = ConsiderStarRowsAsAuto(availableSize.Height);
-
-			var columns = GetColumns(considerStarColumnsAsAuto).Span;
-			var rows = GetRows(considerStarRowsAsAuto).Span;
+			var columns = GetColumns(_considerStarColumnsAsAuto).Span;
+			var rows = GetRows(_considerStarRowsAsAuto).Span;
 
 			var positions = GetPositions(columns.Length, rows.Length);
 

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
@@ -269,6 +269,9 @@ namespace Windows.UI.Xaml.Controls
 			var rowSpacing = RowSpacing;
 			var columnSpacing = ColumnSpacing;
 
+			Span<double> calculatedPixelColumnsMinValue = stackalloc double[calculatedPixelColumns.Length];
+			Span<double> calculatedPixelRowsMinValue = stackalloc double[calculatedPixelRows.Length];
+
 			// Layout the children
 			var offset = GetChildrenOffset();
 			foreach (var child in Children)
@@ -280,10 +283,8 @@ namespace Windows.UI.Xaml.Controls
 				x += columnSpacing * gridPosition.Column;
 				y += rowSpacing * gridPosition.Row;
 
-				Span<double> calculatedPixelColumnsMinValue = stackalloc double[calculatedPixelColumns.Length];
 				calculatedPixelColumns.SelectToSpan(calculatedPixelColumnsMinValue, cs => cs.MinValue);
 
-				Span<double> calculatedPixelRowsMinValue = stackalloc double[calculatedPixelRows.Length];
 				calculatedPixelRows.SelectToSpan(calculatedPixelRowsMinValue, cs => cs.MinValue);
 
 				var width = GetSpanSum(gridPosition.Column, gridPosition.ColumnSpan, calculatedPixelColumnsMinValue);
@@ -377,6 +378,8 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
+			Span<GridSizeEntry> columnSizes = stackalloc GridSizeEntry[columns.Length];
+
 			// Auto size: This type of measure is always required. 
 			// It's the type of size that depends directly on the size of its content.
 			foreach (var autoChild in autoSizeChildrenX)
@@ -395,7 +398,6 @@ namespace Windows.UI.Xaml.Controls
 					GetElementDesiredSize(autoChild.Key);
 				maxHeightMeasured = Math.Max(maxHeightMeasured, childSize.Height);
 
-				Span<GridSizeEntry> columnSizes = stackalloc GridSizeEntry[columns.Length];
 				GetSizes(autoChild.Value.Column, autoChild.Value.ColumnSpan, columns, columnSizes);
 
 				var autoColumns = columnSizes.WhereToMemory(pair => pair.Value.IsAuto);
@@ -698,6 +700,10 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
+			Span<GridSizeEntry> rowSizes = stackalloc GridSizeEntry[rows.Length];
+			Span<GridSizeEntry> autoRowsTemp = stackalloc GridSizeEntry[rowSizes.Length];
+			Span<GridSizeEntry> pixelRowsTemp = stackalloc GridSizeEntry[rowSizes.Length];
+
 			foreach (var autoChild in autoSizeChildrenY)
 			{
 				var gridPosition = autoChild.Value;
@@ -715,13 +721,10 @@ namespace Windows.UI.Xaml.Controls
 					GetElementDesiredSize(autoChild.Key);
 				maxMeasuredWidth = Math.Max(maxMeasuredWidth, childSize.Width);
 
-				Span<GridSizeEntry> rowSizes = stackalloc GridSizeEntry[rows.Length];
 				GetSizes(autoChild.Value.Row, autoChild.Value.RowSpan, rows, rowSizes);
 
-				Span<GridSizeEntry> autoRowsTemp = stackalloc GridSizeEntry[rowSizes.Length];
 				var autoRows = rowSizes.WhereToSpan(autoRowsTemp, pair => pair.Value.IsAuto);
 
-				Span<GridSizeEntry> pixelRowsTemp = stackalloc GridSizeEntry[rowSizes.Length];
 				var pixelRows = rowSizes.WhereToSpan(pixelRowsTemp, pair => pair.Value.IsPixelSize);
 
 				var pixelSize = pixelRows.Sum(pair => pair.Value.PixelSize.GetValueOrDefault());


### PR DESCRIPTION
Fix https://github.com/unoplatform/uno/issues/3483

# Bugfix
fix(grid): Fix bug where "star" sizes where not appropriately calculated during the arrange phase when the available size was infinite during the measure phase. Specially when used in a <Canvas> or a <StackPanel>.

On UWP, when the available size is infinite during the _measure_ phase, the _star_ sizes are calculated as if they were `Auto` and their weight is ignored for both _measure_ and _arrange_ phases.

## What is the current behavior?
On Uno, during the _arrange_ phase, the final size is never _infinite_. That means the mecanism to treat _star_ as _auto_ were never applied during the _arrange_ phase.

## What is the new behavior?
The `_considerStarColumnsAsAuto` and `_considerStarRowsAsAuto` now saves the behavior between the 2 phases to fix that bug.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
