### PR TITLE
fix: ThicknessHelper crash in UWP runtime tests

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Helper/ThicknessHelper2.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Helper/ThicknessHelper2.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Samples.Helper
+{
+	class ThicknessHelper2
+	{
+		public static Thickness FromLengths(double left, double top, double right, double bottom) =>
+#if NETFX_CORE && !HAS_UNO_WINUI
+			new Thickness(left, top, right, bottom);
+#else
+			ThicknessHelper.FromLengths(left, top, right, bottom)
+#endif
+
+		public static Thickness FromUniformLength(double uniformLength) =>
+#if NETFX_CORE && !HAS_UNO_WINUI
+			new Thickness(uniformLength);
+#else
+			ThicknessHelper.FromUniformLength(uniformLength);
+#endif
+	}
+}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Helper/ThicknessHelper2.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Helper/ThicknessHelper2.cs
@@ -13,7 +13,7 @@ namespace Uno.UI.Samples.Helper
 #if NETFX_CORE && !HAS_UNO_WINUI
 			new Thickness(left, top, right, bottom);
 #else
-			ThicknessHelper.FromLengths(left, top, right, bottom)
+			ThicknessHelper.FromLengths(left, top, right, bottom);
 #endif
 
 		public static Thickness FromUniformLength(double uniformLength) =>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Samples.Helper;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests;
 using Windows.Foundation;
@@ -123,7 +124,7 @@ namespace Uno.UI.Samples.Tests
 				{
 					TextWrapping = TextWrapping.Wrap,
 					FontFamily = new FontFamily("Courier New"),
-					Margin = ThicknessHelper.FromLengths(8, 0, 0, 0),
+					Margin = ThicknessHelper2.FromLengths(8, 0, 0, 0),
 					Foreground = new SolidColorBrush(Colors.LightGray)
 				};
 

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.Shared.projitems
@@ -46,6 +46,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\GridLengthHelper2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\PropertyMetadataHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\SampleHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\ThicknessHelper2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UnitTest\UnitTestsControl.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #3487 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

RuntimeTests crash on UWP.

## What is the new behavior?

RuntimeTests don't crash on UWP.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.