### PR TITLE
fix: SharedAssets.md build action is not supported

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/Shared/UnoQuickStart.Shared.projitems
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Shared/UnoQuickStart.Shared.projitems
@@ -29,7 +29,7 @@
     </Page>
   </ItemGroup>
 	<ItemGroup>
-		<Content Include="$(MSBuildThisFileDirectory)Assets\SharedAssets.md" />
+		<None Include="$(MSBuildThisFileDirectory)Assets\SharedAssets.md" />
 	</ItemGroup>
 	<ItemGroup>
 		<PRIResource Include="$(MSBuildThisFileDirectory)Strings\en\Resources.resw" />


### PR DESCRIPTION
The default template produces a warning on the Droid project: @(Content) build action is not supported ... Shared\Assets\SharedAssets.md

This fixes the issue by changing the build action on SharedAssets.md from Content to None.

GitHub Issue (If applicable): #3095 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The default template sets the build action on SharedAssets.md to Content.


## What is the new behavior?

The default template sets the build action on SharedAssets.md to None.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [n/a] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [n/a] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [n/a] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.