### PR TITLE
Adjust UI Tests timeout handling

### DIFF
--- a/build/ci/.azure-devops-screenshot-compare.yml
+++ b/build/ci/.azure-devops-screenshot-compare.yml
@@ -11,6 +11,8 @@ jobs:
     - iOS_Automated_Tests
     - iOS_Snaphot_Tests_Group_01
     - iOS_Snaphot_Tests_Group_02
+    - iOS_Snaphot_Tests_Group_03
+    - iOS_Snaphot_Tests_Group_04
   condition: succeededOrFailed()
 
   pool:

--- a/src/SamplesApp/SamplesApp.UITests.Generator/SnapShotTestGenerator.cs
+++ b/src/SamplesApp/SamplesApp.UITests.Generator/SnapShotTestGenerator.cs
@@ -157,7 +157,8 @@ namespace Uno.Samples.UITest.Generator
 							}
 
 							builder.AppendLineInvariant("[global::SamplesApp.UITests.TestFramework.AutoRetry]");
-							builder.AppendLineInvariant("[global::NUnit.Framework.Timeout(15000)]");
+							// Set to 60 seconds to cover possible restart of the device
+							builder.AppendLineInvariant("[global::NUnit.Framework.Timeout(60000)]");
 							var testName = $"{Sanitize(test.categories.First())}_{Sanitize(test.name)}";
 							using (builder.BlockInvariant($"public void {testName}()"))
 							{

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -137,6 +137,12 @@ namespace SamplesApp.UITests
 
 		public FileInfo TakeScreenshot(string stepName, ScreenshotOptions options)
 		{
+			if(_app == null)
+			{
+				Console.WriteLine($"Skipping TakeScreenshot _app is not available");
+				return null;
+			}
+
 			var title = $"{TestContext.CurrentContext.Test.Name}_{stepName}"
 				.Replace(" ", "_")
 				.Replace(".", "_");

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -245,7 +245,11 @@ namespace SamplesApp.UITests
 		{
 			if (waitForSampleControl)
 			{
-				_app.WaitForElement("sampleControl", timeout: TimeSpan.FromSeconds(sampleLoadTimeout));
+				var sampleControlQuery = AppInitializer.GetLocalPlatform() == Platform.Browser
+					? new QueryEx(q => q.Marked("sampleControl"))
+					: new QueryEx(q => q.All().Marked("sampleControl"));
+
+				_app.WaitForElement(sampleControlQuery, timeout: TimeSpan.FromSeconds(sampleLoadTimeout));
 			}
 
 			var testRunId = _app.InvokeGeneric("browser:SampleRunner|RunTest", metadataName);

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/AutoRetry.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/AutoRetry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -11,91 +12,15 @@ namespace SamplesApp.UITests.TestFramework
 	/// maximum number of times.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-	public class AutoRetryAttribute : NUnitAttribute, IWrapSetUpTearDown
+	public class AutoRetryAttribute : RetryAttribute
 	{
-		private readonly int _tryCount;
 
 		/// <summary>
 		/// Construct a <see cref="RetryAttribute" />
 		/// </summary>
 		/// <param name="tryCount">The maximum number of times the test should be run if it fails</param>
-		public AutoRetryAttribute(int tryCount = 2)
+		public AutoRetryAttribute(int tryCount = 3) : base(tryCount)
 		{
-			_tryCount = tryCount;
 		}
-
-		#region IRepeatTest Members
-
-		/// <summary>
-		/// Wrap a command and return the result.
-		/// </summary>
-		/// <param name="command">The command to be wrapped</param>
-		/// <returns>The wrapped command</returns>
-		public TestCommand Wrap(TestCommand command)
-		{
-			return new RetryCommand(command, _tryCount);
-		}
-
-		#endregion
-
-		#region Nested RetryCommand Class
-
-		/// <summary>
-		/// The test command for the <see cref="RetryAttribute"/>
-		/// </summary>
-		public class RetryCommand : DelegatingTestCommand
-		{
-			private readonly int _tryCount;
-
-			/// <summary>
-			/// Initializes a new instance of the <see cref="RetryCommand"/> class.
-			/// </summary>
-			/// <param name="innerCommand">The inner command.</param>
-			/// <param name="tryCount">The maximum number of repetitions</param>
-			public RetryCommand(TestCommand innerCommand, int tryCount)
-				: base(innerCommand)
-			{
-				_tryCount = tryCount;
-			}
-
-			/// <summary>
-			/// Runs the test, saving a TestResult in the supplied TestExecutionContext.
-			/// </summary>
-			/// <param name="context">The context in which the test should run.</param>
-			/// <returns>A TestResult</returns>
-			public override TestResult Execute(TestExecutionContext context)
-			{
-				int count = _tryCount;
-
-				while (count-- > 0)
-				{
-					try
-					{
-						context.CurrentResult = innerCommand.Execute(context);
-					}
-					// Commands are supposed to catch exceptions, but some don't
-					// and we want to look at restructuring the API in the future.
-					catch (Exception ex)
-					{
-						if (context.CurrentResult == null) context.CurrentResult = context.CurrentTest.MakeTestResult();
-						context.CurrentResult.RecordException(ex);
-					}
-
-					if (context.CurrentResult.ResultState != ResultState.Failure && context.CurrentResult.ResultState.Status != ResultState.Failure.Status)
-						break;
-
-					// Clear result for retry
-					if (count > 0)
-					{
-						context.CurrentResult = context.CurrentTest.MakeTestResult();
-						context.CurrentRepeatCount++; // increment Retry count for next iteration. will only happen if we are guaranteed another iteration
-					}
-				}
-
-				return context.CurrentResult;
-			}
-		}
-
-		#endregion
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutTests.cs
@@ -139,7 +139,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 
 			TakeScreenshot("Initial");
 
-			_app.FastTap(_app.Marked("fileMenu"));
+			var fileMenu = _app.Marked("fileMenu");
+			_app.FastTap(fileMenu);
 
 			TakeScreenshot("fileMenu");
 
@@ -152,6 +153,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			_app.WaitForElement("disabledItem");
 
 			TakeScreenshot("AfterSuccess");
+
+			_app.Tap(fileMenu);
 		}
 
 		[Test]
@@ -160,16 +163,20 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.MenuBarTests.SimpleMenuBar");
 
+			var fileMenu = _app.Marked("fileMenu");
 			_app.WaitForElement(_app.Marked("fileMenu"));
 			var result = _app.Marked("result");
 
 			TakeScreenshot("Initial");
 
-			_app.FastTap(_app.Marked("fileMenu"));
+			_app.Tap(fileMenu);
 
 			TakeScreenshot("fileMenu");
 
-			var exitItemResult = _app.Query(_app.Marked("exitMenu")).First();
+			var exitMenu = _app.Marked("exitMenu");
+			_app.WaitForElement(exitMenu);
+
+			var exitItemResult = _app.Query(exitMenu).First();
 
 			_app.TapCoordinates(0, exitItemResult.Rect.Bottom + 20);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -17,11 +17,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 	{
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Android)] // Disabled for Browser because of missing top level .All() support
 		public void When_Visibility_Changed_During_Arrange()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_Visibility_Arrange");
 
-			var textBlock = _app.Marked("SubjectTextBlock");
+			QueryEx textBlock = new QueryEx(q => q.All().Marked("SubjectTextBlock"));
 
 			_app.WaitForElement(textBlock);
 

--- a/src/Uno.UI.TestComparer/Program.cs
+++ b/src/Uno.UI.TestComparer/Program.cs
@@ -188,14 +188,14 @@ namespace Umbrella.UI.TestComparer
 			{
 				var summaryQuery =
 					from result in results
-					from test in result.Tests
 					let lastChangedTests = result.Tests.Where(t => t.ResultRun.LastOrDefault()?.HasChanged ?? false).ToList()
 					select $"`{result.Platform}`: **{lastChangedTests.Count}**";
 
 				var summary = string.Join(", ", summaryQuery);
 
+				comment.AppendLine($"The [build {currentBuild}](https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId={currentBuild}) found UI Test snapshots differences: {summary}\r\n");
 				comment.AppendLine("<details>");
-				comment.AppendLine($"<summary>The build {currentBuild} found UI Test snapshots differences: {summary}</summary>\r\n");
+				comment.AppendLine($"<summary>Details</summary>\r\n");
 				comment.AppendLine("");
 
 				foreach (var result in results)

--- a/src/Uno.UI.TestComparer/Program.cs
+++ b/src/Uno.UI.TestComparer/Program.cs
@@ -186,7 +186,17 @@ namespace Umbrella.UI.TestComparer
 
 			if (hasErrors)
 			{
-				comment.AppendLine($"The build {currentBuild} found UI Test snapshots differences.\r\n");
+				var summaryQuery =
+					from result in results
+					from test in result.Tests
+					let lastChangedTests = result.Tests.Where(t => t.ResultRun.LastOrDefault()?.HasChanged ?? false).ToList()
+					select $"`{result.Platform}`: **{lastChangedTests.Count}**";
+
+				var summary = string.Join(", ", summaryQuery);
+
+				comment.AppendLine("<details>");
+				comment.AppendLine($"<summary>The build {currentBuild} found UI Test snapshots differences: {summary}</summary>\r\n");
+				comment.AppendLine("");
 
 				foreach (var result in results)
 				{
@@ -210,6 +220,8 @@ namespace Umbrella.UI.TestComparer
 						comment.AppendLine("");
 					}
 				}
+
+				comment.AppendLine("</details>");
 			}
 			else
 			{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

UI Tests failing on timeout are properly restarted using the provided timeout for each retry.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
