### PR TITLE
[WASM] Support for TextBlock.IsTextSelectionEnabled

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -957,6 +957,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_IsTextSelectionEnabled.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Layout.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3874,6 +3878,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_HorizontalTextAlignment.xaml.cs">
       <DependentUpon>TextBlock_HorizontalTextAlignment.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_IsTextSelectionEnabled.xaml.cs">
+      <DependentUpon>TextBlock_IsTextSelectionEnabled.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Layout.xaml.cs">
       <DependentUpon>TextBlock_Layout.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_IsTextSelectionEnabled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_IsTextSelectionEnabled.xaml
@@ -1,0 +1,25 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_IsTextSelectionEnabled"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="15" Margin="10">
+		<TextBlock FontSize="15">Following TextBlock with IsTextSelectionEnabled=false:</TextBlock>
+		<TextBlock FontSize="22" Foreground="Chocolate" IsTextSelectionEnabled="false">Try to select this.</TextBlock>
+
+		<TextBlock FontSize="15">Following TextBlock with IsTextSelectionEnabled=True:</TextBlock>
+		<TextBlock FontSize="22" Foreground="Chocolate" IsTextSelectionEnabled="true">Try to select this.</TextBlock>
+
+		<TextBlock FontSize="15">Following TextBlock with dynamic: (Default to disabled)</TextBlock>
+		<ToggleButton x:Name="isSelectionEnabled1">IsTextSelectionEnabled</ToggleButton>
+		<TextBlock FontSize="22" Foreground="Chocolate" IsTextSelectionEnabled="{Binding IsChecked, ElementName=isSelectionEnabled1}">Try to select this.</TextBlock>
+
+		<TextBlock FontSize="15">Following TextBlock with dynamic: (Default to enabled)</TextBlock>
+		<ToggleButton x:Name="isSelectionEnabled2" IsChecked="True">IsTextSelectionEnabled</ToggleButton>
+		<TextBlock FontSize="22" Foreground="Chocolate" IsTextSelectionEnabled="{Binding IsChecked, ElementName=isSelectionEnabled2}">Try to select this.</TextBlock>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_IsTextSelectionEnabled.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_IsTextSelectionEnabled.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[Sample]
+	public sealed partial class TextBlock_IsTextSelectionEnabled : Page
+	{
+		public TextBlock_IsTextSelectionEnabled()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
@@ -93,14 +93,17 @@ embed.uno-frameworkelement.uno-unarranged {
   height: 0;
 }
 
-.uno-textblock {
-  text-rendering: optimizeLegibility; /* iOS Safari */
+.uno-textblock:not(.selectionEnabled) {
   -webkit-touch-callout: none; /* Safari */
   -webkit-user-select: none; /* iOSSafari */
   -khtml-user-select: none; /* Konqueror HTML */
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* Internet Explorer/Edge */
   user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
+}
+
+.uno-textblock {
+  text-rendering: optimizeLegibility; /* iOS Safari */
 
   /* Following are required for gradient brush as Foreground on text. Should not affect normal rendering. */
   -ms-background-clip: text !important;

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -294,7 +294,12 @@ declare namespace Uno.UI {
         resetStyleNative(pParams: number): boolean;
         private resetStyleInternal;
         /**
-         * Set CSS classes on an element
+         * Set + Unset CSS classes on an element
+         */
+        setUnsetClasses(elementId: number, cssClassesToSet: string[], cssClassesToUnset: string[]): void;
+        setUnsetClassesNative(pParams: number): boolean;
+        /**
+         * Set CSS classes on an element from a specified list
          */
         setClasses(elementId: number, cssClassesList: string[], classIndex: number): string;
         setClassesNative(pParams: number): boolean;
@@ -795,6 +800,14 @@ declare class WindowManagerSetSvgElementRectParams {
     Height: number;
     HtmlId: number;
     static unmarshal(pData: number): WindowManagerSetSvgElementRectParams;
+}
+declare class WindowManagerSetUnsetClassesParams {
+    HtmlId: number;
+    CssClassesToSet_Length: number;
+    CssClassesToSet: Array<string>;
+    CssClassesToUnset_Length: number;
+    CssClassesToUnset: Array<string>;
+    static unmarshal(pData: number): WindowManagerSetUnsetClassesParams;
 }
 declare class WindowManagerSetXUidParams {
     HtmlId: number;

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -747,7 +747,28 @@ var Uno;
                 }
             }
             /**
-             * Set CSS classes on an element
+             * Set + Unset CSS classes on an element
+             */
+            setUnsetClasses(elementId, cssClassesToSet, cssClassesToUnset) {
+                const element = this.getView(elementId);
+                if (cssClassesToSet) {
+                    cssClassesToSet.forEach(c => {
+                        element.classList.add(c);
+                    });
+                }
+                if (cssClassesToUnset) {
+                    cssClassesToUnset.forEach(c => {
+                        element.classList.remove(c);
+                    });
+                }
+            }
+            setUnsetClassesNative(pParams) {
+                const params = WindowManagerSetUnsetClassesParams.unmarshal(pParams);
+                this.setUnsetClasses(params.HtmlId, params.CssClassesToSet, params.CssClassesToUnset);
+                return true;
+            }
+            /**
+             * Set CSS classes on an element from a specified list
              */
             setClasses(elementId, cssClassesList, classIndex) {
                 const element = this.getView(elementId);
@@ -2646,6 +2667,58 @@ class WindowManagerSetSvgElementRectParams {
         }
         {
             ret.HtmlId = Number(Module.getValue(pData + 32, "*"));
+        }
+        return ret;
+    }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class WindowManagerSetUnsetClassesParams {
+    static unmarshal(pData) {
+        const ret = new WindowManagerSetUnsetClassesParams();
+        {
+            ret.HtmlId = Number(Module.getValue(pData + 0, "*"));
+        }
+        {
+            ret.CssClassesToSet_Length = Number(Module.getValue(pData + 4, "i32"));
+        }
+        {
+            const pArray = Module.getValue(pData + 8, "*");
+            if (pArray !== 0) {
+                ret.CssClassesToSet = new Array();
+                for (var i = 0; i < ret.CssClassesToSet_Length; i++) {
+                    const value = Module.getValue(pArray + i * 4, "*");
+                    if (value !== 0) {
+                        ret.CssClassesToSet.push(String(MonoRuntime.conv_string(value)));
+                    }
+                    else {
+                        ret.CssClassesToSet.push(null);
+                    }
+                }
+            }
+            else {
+                ret.CssClassesToSet = null;
+            }
+        }
+        {
+            ret.CssClassesToUnset_Length = Number(Module.getValue(pData + 12, "i32"));
+        }
+        {
+            const pArray = Module.getValue(pData + 16, "*");
+            if (pArray !== 0) {
+                ret.CssClassesToUnset = new Array();
+                for (var i = 0; i < ret.CssClassesToUnset_Length; i++) {
+                    const value = Module.getValue(pArray + i * 4, "*");
+                    if (value !== 0) {
+                        ret.CssClassesToUnset.push(String(MonoRuntime.conv_string(value)));
+                    }
+                    else {
+                        ret.CssClassesToUnset.push(null);
+                    }
+                }
+            }
+            else {
+                ret.CssClassesToUnset = null;
+            }
         }
         return ret;
     }

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -583,9 +583,33 @@ namespace Uno.UI {
 				element.style.setProperty(name, "");
 			}
 		}
+		/**
+		 * Set + Unset CSS classes on an element
+		 */
+
+		public setUnsetClasses(elementId: number, cssClassesToSet: string[], cssClassesToUnset: string[]) {
+			const element = this.getView(elementId);
+
+			if (cssClassesToSet) {
+				cssClassesToSet.forEach(c => {
+					element.classList.add(c);
+				});
+			}
+			if (cssClassesToUnset) {
+				cssClassesToUnset.forEach(c => {
+					element.classList.remove(c);
+				});
+			}
+		}
+
+		public setUnsetClassesNative(pParams: number): boolean {
+			const params = WindowManagerSetUnsetClassesParams.unmarshal(pParams);
+			this.setUnsetClasses(params.HtmlId, params.CssClassesToSet, params.CssClassesToUnset);
+			return true;
+		}
 
 		/**
-		 * Set CSS classes on an element
+		 * Set CSS classes on an element from a specified list
 		 */
 		public setClasses(elementId: number, cssClassesList: string[], classIndex: number): string {
 			const element = this.getView(elementId);

--- a/src/Uno.UI.Wasm/tsBindings/WindowManagerSetUnsetClassesParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/WindowManagerSetUnsetClassesParams.ts
@@ -1,0 +1,79 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class WindowManagerSetUnsetClassesParams
+{
+	/* Pack=4 */
+	public HtmlId : number;
+	public CssClassesToSet_Length : number;
+	public CssClassesToSet : Array<string>;
+	public CssClassesToUnset_Length : number;
+	public CssClassesToUnset : Array<string>;
+	public static unmarshal(pData:number) : WindowManagerSetUnsetClassesParams
+	{
+		const ret = new WindowManagerSetUnsetClassesParams();
+		
+		{
+			ret.HtmlId = Number(Module.getValue(pData + 0, "*"));
+		}
+		
+		{
+			ret.CssClassesToSet_Length = Number(Module.getValue(pData + 4, "i32"));
+		}
+		
+		{
+			const pArray = Module.getValue(pData + 8, "*");
+			if(pArray !== 0)
+			{
+				ret.CssClassesToSet = new Array<string>();
+				for(var i=0; i<ret.CssClassesToSet_Length; i++)
+				{
+					const value = Module.getValue(pArray + i * 4, "*");
+					if(value !== 0)
+					{
+						ret.CssClassesToSet.push(String(MonoRuntime.conv_string(value)));
+					}
+					else
+					
+					{
+						ret.CssClassesToSet.push(null);
+					}
+				}
+			}
+			else
+			
+			{
+				ret.CssClassesToSet = null;
+			}
+		}
+		
+		{
+			ret.CssClassesToUnset_Length = Number(Module.getValue(pData + 12, "i32"));
+		}
+		
+		{
+			const pArray = Module.getValue(pData + 16, "*");
+			if(pArray !== 0)
+			{
+				ret.CssClassesToUnset = new Array<string>();
+				for(var i=0; i<ret.CssClassesToUnset_Length; i++)
+				{
+					const value = Module.getValue(pArray + i * 4, "*");
+					if(value !== 0)
+					{
+						ret.CssClassesToUnset.push(String(MonoRuntime.conv_string(value)));
+					}
+					else
+					
+					{
+						ret.CssClassesToUnset.push(null);
+					}
+				}
+			}
+			else
+			
+			{
+				ret.CssClassesToUnset = null;
+			}
+		}
+		return ret;
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBlock.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBlock.cs
@@ -28,27 +28,14 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(FontStretchProperty, value);
 			}
 		}
-		#endif
+#endif
 		// Skipping already declared property FontSize
 		// Skipping already declared property FontFamily
 		// Skipping already declared property LineStackingStrategy
 		// Skipping already declared property LineHeight
 		// Skipping already declared property CharacterSpacing
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  bool IsTextSelectionEnabled
-		{
-			get
-			{
-				return (bool)this.GetValue(IsTextSelectionEnabledProperty);
-			}
-			set
-			{
-				this.SetValue(IsTextSelectionEnabledProperty, value);
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		// Skipping already declared property IsTextSelectionEnabled
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  string SelectedText
 		{
@@ -240,22 +227,15 @@ namespace Windows.UI.Xaml.Controls
 			nameof(FontStretch), typeof(global::Windows.UI.Text.FontStretch), 
 			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Text.FontStretch)));
-		#endif
+#endif
 		// Skipping already declared property FontStyleProperty
 		// Skipping already declared property FontWeightProperty
 		// Skipping already declared property ForegroundProperty
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty IsTextSelectionEnabledProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(IsTextSelectionEnabled), typeof(bool), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock), 
-			new FrameworkPropertyMetadata(default(bool)));
-		#endif
+		// Skipping already declared property IsTextSelectionEnabledProperty
 		// Skipping already declared property LineHeightProperty
 		// Skipping already declared property LineStackingStrategyProperty
 		// Skipping already declared property PaddingProperty
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -19,6 +19,7 @@ using Windows.Foundation;
 using Windows.UI.Input;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Automation.Peers;
+using Uno;
 
 #if XAMARIN_IOS
 using UIKit;
@@ -61,7 +62,7 @@ namespace Windows.UI.Xaml.Controls
 			OnTextChanged(string.Empty, Text);
 		}
 
-#region Inlines
+		#region Inlines
 
 		/// <summary>
 		/// Gets an InlineCollection containing the top-level Inline elements that comprise the contents of the TextBlock.
@@ -84,10 +85,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		internal void InvalidateInlines()
-		{
-			OnInlinesChanged();
-		}
+		internal void InvalidateInlines() => OnInlinesChanged();
 
 		private void OnInlinesChanged()
 		{
@@ -100,14 +98,14 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnInlinesChangedPartial();
 
-#endregion
+		#endregion
 
-#region FontStyle Dependency Property
+		#region FontStyle Dependency Property
 
 		public FontStyle FontStyle
 		{
-			get { return (FontStyle)this.GetValue(FontStyleProperty); }
-			set { this.SetValue(FontStyleProperty, value); }
+			get => (FontStyle)GetValue(FontStyleProperty);
+			set => SetValue(FontStyleProperty, value);
 		}
 
 		public static readonly DependencyProperty FontStyleProperty =
@@ -130,14 +128,14 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnFontStyleChangedPartial();
 
-#endregion
+		#endregion
 
-#region TextWrapping Dependency Property
+		#region TextWrapping Dependency Property
 
 		public TextWrapping TextWrapping
 		{
-			get { return (TextWrapping)this.GetValue(TextWrappingProperty); }
-			set { this.SetValue(TextWrappingProperty, value); }
+			get => (TextWrapping)GetValue(TextWrappingProperty);
+			set => SetValue(TextWrappingProperty, value);
 		}
 
 		public static readonly DependencyProperty TextWrappingProperty =
@@ -159,14 +157,14 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextWrappingChangedPartial();
 
-#endregion
+		#endregion
 
-#region FontWeight Dependency Property
+		#region FontWeight Dependency Property
 
 		public FontWeight FontWeight
 		{
-			get { return (FontWeight)this.GetValue(FontWeightProperty); }
-			set { this.SetValue(FontWeightProperty, value); }
+			get => (FontWeight)GetValue(FontWeightProperty);
+			set => SetValue(FontWeightProperty, value);
 		}
 
 		public static readonly DependencyProperty FontWeightProperty =
@@ -189,18 +187,18 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnFontWeightChangedPartial();
 
-#endregion
+		#endregion
 
-#region Text Dependency Property
+		#region Text Dependency Property
 
 		public
 #if XAMARIN_IOS
 			new
 #endif
-		string Text
+			string Text
 		{
-			get { return (string)this.GetValue(TextProperty); }
-			set { this.SetValue(TextProperty, value); }
+			get { return (string)GetValue(TextProperty); }
+			set { SetValue(TextProperty, value); }
 		}
 
 		public static readonly DependencyProperty TextProperty =
@@ -211,16 +209,15 @@ namespace Windows.UI.Xaml.Controls
 				new FrameworkPropertyMetadata(
 					defaultValue: string.Empty,
 					coerceValueCallback: CoerceText,
-					propertyChangedCallback: (s, e) => ((TextBlock)s).OnTextChanged((string)e.OldValue, (string)e.NewValue)
+					propertyChangedCallback: (s, e) =>
+						((TextBlock)s).OnTextChanged((string)e.OldValue, (string)e.NewValue)
 				)
 			);
 
-		internal static object CoerceText(DependencyObject dependencyObject, object baseValue)
-		{
-			return baseValue is string
+		internal static object CoerceText(DependencyObject dependencyObject, object baseValue) =>
+			baseValue is string
 				? baseValue
 				: string.Empty;
-		}
 
 		protected virtual void OnTextChanged(string oldValue, string newValue)
 		{
@@ -232,9 +229,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextChangedPartial();
 
-#endregion
+		#endregion
 
-#region FontFamily Dependency Property
+		#region FontFamily Dependency Property
 
 #if XAMARIN_IOS
 		/// <summary>
@@ -243,8 +240,8 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		public FontFamily FontFamily
 		{
-			get { return (FontFamily)this.GetValue(FontFamilyProperty); }
-			set { this.SetValue(FontFamilyProperty, value); }
+			get => (FontFamily)GetValue(FontFamilyProperty);
+			set => SetValue(FontFamilyProperty, value);
 		}
 
 		public static readonly DependencyProperty FontFamilyProperty =
@@ -267,14 +264,14 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnFontFamilyChangedPartial();
 
-#endregion
+		#endregion
 
-#region FontSize Dependency Property
+		#region FontSize Dependency Property
 
 		public double FontSize
 		{
-			get { return (double)this.GetValue(FontSizeProperty); }
-			set { this.SetValue(FontSizeProperty, value); }
+			get => (double)GetValue(FontSizeProperty);
+			set => SetValue(FontSizeProperty, value);
 		}
 
 		public static readonly DependencyProperty FontSizeProperty =
@@ -297,14 +294,14 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnFontSizeChangedPartial();
 
-#endregion
+		#endregion
 
-#region MaxLines Dependency Property
+		#region MaxLines Dependency Property
 
 		public int MaxLines
 		{
-			get { return (int)this.GetValue(MaxLinesProperty); }
-			set { this.SetValue(MaxLinesProperty, value); }
+			get => (int)GetValue(MaxLinesProperty);
+			set => SetValue(MaxLinesProperty, value);
 		}
 
 		public static readonly DependencyProperty MaxLinesProperty =
@@ -326,14 +323,14 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnMaxLinesChangedPartial();
 
-#endregion
+		#endregion
 
-#region TextTrimming Dependency Property
+		#region TextTrimming Dependency Property
 
 		public TextTrimming TextTrimming
 		{
-			get { return (TextTrimming)this.GetValue(TextTrimmingProperty); }
-			set { this.SetValue(TextTrimmingProperty, value); }
+			get => (TextTrimming)GetValue(TextTrimmingProperty);
+			set => SetValue(TextTrimmingProperty, value);
 		}
 
 		public static readonly DependencyProperty TextTrimmingProperty =
@@ -355,15 +352,15 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextTrimmingChangedPartial();
 
-#endregion
+		#endregion
 
-#region Foreground Dependency Property
+		#region Foreground Dependency Property
 
 		public
 #if __ANDROID_23__
 		new
 #endif
-		Brush Foreground
+			Brush Foreground
 		{
 			get => (Brush)GetValue(ForegroundProperty);
 			set
@@ -378,7 +375,7 @@ namespace Windows.UI.Xaml.Controls
 					throw new NotSupportedException("Only SolidColorBrush or GradientBrush's FallbackColor are supported.");
 				}
 #else
-				this.SetValue(ForegroundProperty, value);
+				SetValue(ForegroundProperty, value);
 #endif
 			}
 		}
@@ -403,19 +400,49 @@ namespace Windows.UI.Xaml.Controls
 				InvalidateTextBlock();
 			}
 
-			_foregroundChanged.Disposable = Brush.AssignAndObserveBrush(Foreground, c => refreshForeground(), refreshForeground);
+			_foregroundChanged.Disposable =
+				Brush.AssignAndObserveBrush(Foreground, c => refreshForeground(), refreshForeground);
 		}
 
 		partial void OnForegroundChangedPartial();
 
-#endregion
+		#endregion
 
-#region TextAlignment Dependency Property
+		#region IsTextSelectionEnabled Dependency Property
+
+#if !__WASM__
+		[NotImplemented]
+#endif
+		public bool IsTextSelectionEnabled
+		{
+			get => (bool)GetValue(IsTextSelectionEnabledProperty);
+			set => SetValue(IsTextSelectionEnabledProperty, value);
+		}
+
+#if !__WASM__
+		[NotImplemented]
+#endif
+		public static DependencyProperty IsTextSelectionEnabledProperty { get; } =
+			DependencyProperty.Register(
+				nameof(IsTextSelectionEnabled),
+				typeof(bool),
+				typeof(TextBlock),
+				new FrameworkPropertyMetadata(
+					defaultValue: false,
+					propertyChangedCallback: (s, e) => ((TextBlock)s).OnIsTextSelectionEnabledChangedPartial()
+				)
+			);
+
+		partial void OnIsTextSelectionEnabledChangedPartial();
+
+		#endregion
+
+		#region TextAlignment Dependency Property
 
 		public new TextAlignment TextAlignment
 		{
-			get { return (TextAlignment)this.GetValue(TextAlignmentProperty); }
-			set { this.SetValue(TextAlignmentProperty, value); }
+			get => (TextAlignment)GetValue(TextAlignmentProperty);
+			set => SetValue(TextAlignmentProperty, value);
 		}
 
 		public static readonly DependencyProperty TextAlignmentProperty =
@@ -438,14 +465,14 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextAlignmentChangedPartial();
 
-#endregion
+		#endregion
 
-#region HorizontalTextAlignment Dependency Property
+		#region HorizontalTextAlignment Dependency Property
 
 		public new TextAlignment HorizontalTextAlignment
 		{
-			get { return (TextAlignment)this.GetValue(HorizontalTextAlignmentProperty); }
-			set { this.SetValue(HorizontalTextAlignmentProperty, value); }
+			get => (TextAlignment)GetValue(HorizontalTextAlignmentProperty);
+			set => SetValue(HorizontalTextAlignmentProperty, value);
 		}
 
 		public static DependencyProperty HorizontalTextAlignmentProperty { get; } =
@@ -462,19 +489,16 @@ namespace Windows.UI.Xaml.Controls
 		// This property provides the same functionality as the TextAlignment property.
 		// If both properties are set to conflicting values, the last one set is used.
 		// https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textbox.horizontaltextalignment#remarks
-		private void OnHorizontalTextAlignmentChanged()
-		{
-			TextAlignment = HorizontalTextAlignment;
-		}
+		private void OnHorizontalTextAlignmentChanged() => TextAlignment = HorizontalTextAlignment;
 
-#endregion
+		#endregion
 
-#region LineHeight Dependency Property
+		#region LineHeight Dependency Property
 
 		public double LineHeight
 		{
-			get { return (double)GetValue(LineHeightProperty); }
-			set { SetValue(LineHeightProperty, value); }
+			get => (double)GetValue(LineHeightProperty);
+			set => SetValue(LineHeightProperty, value);
 		}
 
 		public static readonly DependencyProperty LineHeightProperty =
@@ -490,19 +514,20 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnLineHeightChangedPartial();
 
-#endregion
+		#endregion
 
-#region LineStackingStrategy Dependency Property
+		#region LineStackingStrategy Dependency Property
 
 		public LineStackingStrategy LineStackingStrategy
 		{
-			get { return (LineStackingStrategy)GetValue(LineStackingStrategyProperty); }
-			set { SetValue(LineStackingStrategyProperty, value); }
+			get => (LineStackingStrategy)GetValue(LineStackingStrategyProperty);
+			set => SetValue(LineStackingStrategyProperty, value);
 		}
 
 		public static readonly DependencyProperty LineStackingStrategyProperty =
-			DependencyProperty.Register("LineStackingStrategy", typeof(LineStackingStrategy), typeof(TextBlock), new PropertyMetadata(LineStackingStrategy.MaxHeight,
-				propertyChangedCallback: (s, e) => ((TextBlock)s).OnLineStackingStrategyChanged())
+			DependencyProperty.Register("LineStackingStrategy", typeof(LineStackingStrategy), typeof(TextBlock),
+				new PropertyMetadata(LineStackingStrategy.MaxHeight,
+					propertyChangedCallback: (s, e) => ((TextBlock)s).OnLineStackingStrategyChanged())
 			);
 
 		private void OnLineStackingStrategyChanged()
@@ -513,14 +538,14 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnLineStackingStrategyChangedPartial();
 
-#endregion
+		#endregion
 
-#region Padding Dependency Property
+		#region Padding Dependency Property
 
 		public Thickness Padding
 		{
-			get { return (Thickness)this.GetValue(PaddingProperty); }
-			set { this.SetValue(PaddingProperty, value); }
+			get => (Thickness)GetValue(PaddingProperty);
+			set => SetValue(PaddingProperty, value);
 		}
 
 		public static DependencyProperty PaddingProperty =
@@ -528,7 +553,8 @@ namespace Windows.UI.Xaml.Controls
 				"Padding",
 				typeof(Thickness),
 				typeof(TextBlock),
-				new PropertyMetadata((Thickness)Thickness.Empty, propertyChangedCallback: (s, e) => ((TextBlock)s).OnPaddingChanged())
+				new PropertyMetadata((Thickness)Thickness.Empty,
+					propertyChangedCallback: (s, e) => ((TextBlock)s).OnPaddingChanged())
 			);
 
 		private void OnPaddingChanged()
@@ -539,14 +565,14 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnPaddingChangedPartial();
 
-#endregion
+		#endregion
 
-#region CharacterSpacing Dependency Property
+		#region CharacterSpacing Dependency Property
 
 		public int CharacterSpacing
 		{
-			get { return (int)this.GetValue(CharacterSpacingProperty); }
-			set { this.SetValue(CharacterSpacingProperty, value); }
+			get => (int)GetValue(CharacterSpacingProperty);
+			set => SetValue(CharacterSpacingProperty, value);
 		}
 
 		public static DependencyProperty CharacterSpacingProperty =
@@ -575,8 +601,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public TextDecorations TextDecorations
 		{
-			get { return (TextDecorations)this.GetValue(TextDecorationsProperty); }
-			set { this.SetValue(TextDecorationsProperty, value); }
+			get => (TextDecorations)GetValue(TextDecorationsProperty);
+			set => SetValue(TextDecorationsProperty, value);
 		}
 
 		public static DependencyProperty TextDecorationsProperty =
@@ -639,7 +665,7 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			if (this.ReadLocalValue(TextProperty) is UnsetValue)
+			if (ReadLocalValue(TextProperty) is UnsetValue)
 			{
 				Inlines.Clear();
 				ClearTextPartial();
@@ -656,6 +682,7 @@ namespace Windows.UI.Xaml.Controls
 		partial void ClearTextPartial();
 
 		#region Hyperlinks
+
 #if __WASM__
 		// As on wasm the TextElements are UIElement, when the hosting TextBlock will capture the pointer on Pressed,
 		// the original source of the Release event will be this TextBlock (and we won't receive 'pointerup' nor 'click'
@@ -773,7 +800,8 @@ namespace Windows.UI.Xaml.Controls
 			return aborted;
 		}
 
-		private readonly List<(int start, int end, Hyperlink hyperlink)> _hyperlinks = new List<(int start, int end, Hyperlink hyperlink)>();
+		private readonly List<(int start, int end, Hyperlink hyperlink)> _hyperlinks =
+			new List<(int start, int end, Hyperlink hyperlink)>();
 
 		private void UpdateHyperlinks()
 		{
@@ -852,25 +880,20 @@ namespace Windows.UI.Xaml.Controls
 			return hyperlink;
 		}
 #endif
+
 		#endregion
 
 		private void InvalidateTextBlock()
 		{
 			InvalidateTextBlockPartial();
-			this.InvalidateMeasure();
+			InvalidateMeasure();
 		}
 
 		partial void InvalidateTextBlockPartial();
 
-		protected override AutomationPeer OnCreateAutomationPeer()
-		{
-			return new TextBlockAutomationPeer(this);
-		}
+		protected override AutomationPeer OnCreateAutomationPeer() => new TextBlockAutomationPeer(this);
 
-		public override string GetAccessibilityInnerText()
-		{
-			return Text;
-		}
+		public override string GetAccessibilityInnerText() => Text;
 
 		// This approximates UWP behavior
 		private protected override double GetActualWidth() => DesiredSize.Width;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -44,6 +44,7 @@ namespace Windows.UI.Xaml.Controls
 			OnLineHeightChangedPartial();
 			OnTextAlignmentChangedPartial();
 			OnTextWrappingChangedPartial();
+			OnIsTextSelectionEnabledChangedPartial();
 		}
 
 		private void ConditionalUpdate(ref bool condition, Action action)
@@ -119,6 +120,18 @@ namespace Windows.UI.Xaml.Controls
 		partial void OnFontStyleChangedPartial() => _fontStyleChanged = true;
 
 		partial void OnFontWeightChangedPartial() => _fontWeightChanged = true;
+
+		partial void OnIsTextSelectionEnabledChangedPartial()
+		{
+			if (IsTextSelectionEnabled)
+			{
+				SetCssClasses("selectionEnabled");
+			}
+			else
+			{
+				UnsetCssClasses("selectionEnabled");
+			}
+		}
 
 		partial void OnTextChangedPartial()
 		{

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -151,6 +151,40 @@ namespace Windows.UI.Xaml
 		}
 
 		/// <summary>
+		/// Add/Set CSS classes to the HTML element.
+		/// </summary>
+		/// <remarks>
+		/// No effect for classes already present on the element.
+		/// </remarks>
+		protected internal void SetCssClasses(params string[] classesToSet)
+		{
+			Uno.UI.Xaml.WindowManagerInterop.SetUnsetCssClasses(HtmlId, classesToSet, null);
+		}
+
+		/// <summary>
+		/// Remove/Unset CSS classes to the HTML element.
+		/// </summary>
+		/// <remarks>
+		/// No effect for classes already absent from the element.
+		/// </remarks>
+		protected internal void UnsetCssClasses(params string[] classesToUnset)
+		{
+			Uno.UI.Xaml.WindowManagerInterop.SetUnsetCssClasses(HtmlId, null, classesToUnset);
+
+		}
+
+		/// <summary>
+		/// Set and Unset css classes on a HTML element in a single operation.
+		/// </summary>
+		/// <remarks>
+		/// Identical to calling <see cref="SetCssClasses"/> followed by <see cref="UnsetCssClasses"/>.
+		/// </remarks>
+		protected internal void SetUnsetCssClasses(string[] classesToSet, string[] classesToUnset)
+		{
+			Uno.UI.Xaml.WindowManagerInterop.SetUnsetCssClasses(HtmlId, classesToSet, classesToUnset);
+		}
+
+		/// <summary>
 		/// Set a specified CSS class to an element from a set of possible values.
 		/// All other possible values will be removed from the element.
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -434,6 +434,63 @@ namespace Uno.UI.Xaml
 			WebAssemblyRuntime.InvokeJS(command);
 		}
 
+		#region SetUnsetCssClasses
+		internal static void SetUnsetCssClasses(IntPtr htmlId, string[] cssClassesToSet, string[] cssClassesToUnset)
+		{
+			if (UseJavascriptEval)
+			{
+				var setClasses =
+					cssClassesToSet == null
+						? "null"
+						: "[" +
+						  string.Join(", ", cssClassesToSet
+							  .Select(WebAssemblyRuntime.EscapeJs)
+							  .Select(s => "\"" + s + "\""))
+						  + "]";
+				var unsetClasses =
+					cssClassesToUnset == null
+						? "null"
+						: "[" +
+						  string.Join(", ", cssClassesToUnset
+							  .Select(WebAssemblyRuntime.EscapeJs)
+							  .Select(s => "\"" + s + "\""))
+						  + "]";
+				var command = "Uno.UI.WindowManager.current.setUnsetClasses(" + htmlId + ", " + setClasses + ", " + unsetClasses + ");";
+				WebAssemblyRuntime.InvokeJS(command);
+			}
+			else
+			{
+				var parms = new WindowManagerSetUnsetClassesParams
+				{
+					HtmlId = htmlId,
+					CssClassesToSet = cssClassesToSet,
+					CssClassesToSet_Length = cssClassesToSet?.Length ?? 0,
+					CssClassesToUnset = cssClassesToUnset,
+					CssClassesToUnset_Length = cssClassesToUnset?.Length ?? 0
+				};
+
+				TSInteropMarshaller.InvokeJS<WindowManagerSetUnsetClassesParams>("Uno:setUnsetClassesNative", parms);
+			}
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct WindowManagerSetUnsetClassesParams
+		{
+			public IntPtr HtmlId;
+
+			public int CssClassesToSet_Length;
+
+			[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)]
+			public string[] CssClassesToSet;
+
+			public int CssClassesToUnset_Length;
+
+			[MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)]
+			public string[] CssClassesToUnset;
+		}
+		#endregion
+
 		#region SetClasses
 
 		internal static void SetClasses(IntPtr htmlId, string[] cssClasses, int index)


### PR DESCRIPTION
Fix https://github.com/unoplatform/uno/issues/3446

# Feature
`IsTextSelectionEnabled` is not working for `<TextBlock />` on WASM.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
