### PR TITLE
[Wasm] Fix AOT StorageFolder incorrect initialization

### DIFF
--- a/src/Uno.UWP/Storage/StorageFolder.wasm.cs
+++ b/src/Uno.UWP/Storage/StorageFolder.wasm.cs
@@ -54,7 +54,7 @@ namespace Windows.Storage
 			public string[] Paths;
 		}
 
-		internal void DispatchStorageInitialized()
+		internal static void DispatchStorageInitialized()
 		{
 			if (typeof(StorageFolder).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #3521

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The initialization may fail using AOT, which validates against native interop invocations of static methods, which the interpreter does not do.

Related mono issue https://github.com/mono/mono/issues/20104

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
