### PR TITLE
ci: Update to latest Xcode, mono.

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -21,8 +21,8 @@ variables:
   windowsVMImage: 'windows-2019'
   linuxVMImage: 'ubuntu-16.04'
   macOSVMImage: 'macOS-10.15'
-  xCodeRoot: '/Applications/Xcode_11.3.app'
-  XamarinSDKVersion: 6_6_0
+  xCodeRoot: '/Applications/Xcode_11.5.app'
+  XamarinSDKVersion: 6_10_0
 
 jobs:
 - template: build/ci/.azure-devops-windows.yml

--- a/build/ci/templates/nuget-cache.yml
+++ b/build/ci/templates/nuget-cache.yml
@@ -10,7 +10,7 @@ steps:
     condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
 
   - task: Cache@2
-    # condition: eq(variables['enable_package_cache'], 'true')
+    condition: eq(variables['enable_package_cache'], 'true')
     inputs:
       key: nuget | $(Agent.OS) | $(Agent.JobName) | $(build.sourcesdirectory)/**/*.csproj | $(build.sourcesdirectory)/**/Directory.Build.targets | $(build.sourcesdirectory)/**/Directory.Build.props
       path: ${{ parameters.nugetPackages }}

--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -80,12 +80,18 @@ pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool
 dotnet run list-failed $UNO_ORIGINAL_TEST_RESULTS $UNO_TESTS_FAILED_LIST
 popd
 
-# Rerun failed tests
-echo Retrying failed tests
+if [ -n "`cat $UNO_TESTS_FAILED_LIST`" ]; then
 
-mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
-	--result=$UNO_RERUN_TEST_RESULTS \
-	--timeout=120000 \
-	--testlist $UNO_TESTS_FAILED_LIST \
-	$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/net47/SamplesApp.UITests.dll \
-	|| true
+	# Rerun failed tests
+	echo Retrying failed tests
+
+	echo Terminating Simulator instance
+	killall Simulator || echo "Simulator was not running"
+
+	mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
+		--result=$UNO_RERUN_TEST_RESULTS \
+		--timeout=120000 \
+		--testlist $UNO_TESTS_FAILED_LIST \
+		$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/net47/SamplesApp.UITests.dll \
+		|| true
+fi

--- a/src/SamplesApp/SamplesApp.UITests/Constants.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Constants.cs
@@ -12,7 +12,7 @@ namespace SamplesApp.UITests
 		public const string WebAssemblyDefaultUri = "http://localhost:55838/";
 		public const string iOSAppName = "uno.platform.uitestsample";
 		public const string AndroidAppName = "uno.platform.unosampleapp";
-		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (3rd generation)";
+		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";
 
 		// Default active platform when running under Visual Studio test runner
 		public const Platform CurrentPlatform = Platform.Browser;

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" /> 
-		<PackageReference Include="Xamarin.UITest" Version="3.0.8-dev1" />
+		<PackageReference Include="Xamarin.UITest" Version="3.0.7" />
 		<PackageReference Include="Uno.UITest" />
 		<PackageReference Include="Uno.UITest.Selenium" />
 		<PackageReference Include="Uno.UITest.Xamarin" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

- Update to latest Xcode, mono (Xcode 11.5, Mono 6.10)
- Disable package caching (It takes more time than restoring the files using a normal nuget restore)
- Restarting iOS simulator before retrying failed tests (Clean environment for Xamarin.UITest)
- Downgrade Xamarin.,UITest to 3.0.7 to work around a timing issue (3.0.8-dev1 issue)
- Add an iOS dispatcher WatchDog for the SamplesApp (Auto kill for https://github.com/unoplatform/uno/issues/3363)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
