### PR TITLE
[Wasm] Fixed rendering of Ellipses when the Stroke is used

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3113,6 +3113,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Ellipse_StrokeThickness.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\LinePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5011,6 +5015,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\EllipsePage.xaml.cs">
       <DependentUpon>EllipsePage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Ellipse_StrokeThickness.xaml.cs">
+      <DependentUpon>Ellipse_StrokeThickness.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\LinePage.xaml.cs">
       <DependentUpon>LinePage.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Ellipse_StrokeThickness.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Ellipse_StrokeThickness.xaml
@@ -8,12 +8,16 @@
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<StackPanel Spacing="10">
-		<TextBlock FontSize="22">Those 5 ellipses should be identical:</TextBlock>
+		<TextBlock FontSize="22">Those 6 ellipses should be identical:</TextBlock>
 		<Grid>
 			<StackPanel Orientation="Horizontal" VerticalAlignment="Top" Spacing="5">
 				<Grid>
 					<Ellipse Fill="Red" Height="100" Width="100" />
 					<Ellipse Fill="Yellow" Height="50" Width="50" />
+				</Grid>
+				<Grid>
+					<Ellipse Fill="Red" Height="100" Width="100" StrokeThickness="45" />
+					<Ellipse Fill="Yellow" Height="50" Width="50" StrokeThickness="15"/>
 				</Grid>
 				<Grid>
 					<Ellipse Fill="Yellow" Height="100" Width="100" />
@@ -25,8 +29,8 @@
 					<Ellipse Fill="Yellow" Stroke="Red" StrokeThickness="25" />
 				</Border>
 			</StackPanel>
-			<Line Stroke="Black" Y1="25" Y2="25" X1="0" X2="520" VerticalAlignment="Top" StrokeDashArray="5 4" StrokeThickness="1" />
-			<Line Stroke="Black" Y1="75" Y2="75" X1="0" X2="520" VerticalAlignment="Top" StrokeDashArray="5 4" StrokeThickness="1" />
+			<Line Stroke="Black" Y1="25" Y2="25" X1="0" X2="630" VerticalAlignment="Top" StrokeDashArray="5 4" StrokeThickness="1" />
+			<Line Stroke="Black" Y1="75" Y2="75" X1="0" X2="630" VerticalAlignment="Top" StrokeDashArray="5 4" StrokeThickness="1" />
 		</Grid>
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Ellipse_StrokeThickness.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Ellipse_StrokeThickness.xaml
@@ -1,0 +1,32 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Shapes.Ellipse_StrokeThickness"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="10">
+		<TextBlock FontSize="22">Those 5 ellipses should be identical:</TextBlock>
+		<Grid>
+			<StackPanel Orientation="Horizontal" VerticalAlignment="Top" Spacing="5">
+				<Grid>
+					<Ellipse Fill="Red" Height="100" Width="100" />
+					<Ellipse Fill="Yellow" Height="50" Width="50" />
+				</Grid>
+				<Grid>
+					<Ellipse Fill="Yellow" Height="100" Width="100" />
+					<Ellipse Stroke="Red" StrokeThickness="25" Height="100" Width="100" />
+				</Grid>
+				<Ellipse Fill="Yellow" Height="100" Width="100" Stroke="Red" StrokeThickness="25" />
+				<Ellipse Fill="Yellow" Stroke="Red" StrokeThickness="25" Width="100" />
+				<Border Width="100">
+					<Ellipse Fill="Yellow" Stroke="Red" StrokeThickness="25" />
+				</Border>
+			</StackPanel>
+			<Line Stroke="Black" Y1="25" Y2="25" X1="0" X2="520" VerticalAlignment="Top" StrokeDashArray="5 4" StrokeThickness="1" />
+			<Line Stroke="Black" Y1="75" Y2="75" X1="0" X2="520" VerticalAlignment="Top" StrokeDashArray="5 4" StrokeThickness="1" />
+		</Grid>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Ellipse_StrokeThickness.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Ellipse_StrokeThickness.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Shapes
+{
+	[Sample("Shapes")]
+	public sealed partial class Ellipse_StrokeThickness : Page
+	{
+		public Ellipse_StrokeThickness()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.wasm.cs
@@ -17,10 +17,7 @@ namespace Windows.UI.Xaml.Shapes
 		private double _scaleY;
 #pragma warning restore CS0067, CS0649
 
-		private IDisposable BuildDrawableLayer()
-		{
-			return Disposable.Empty;
-		}
+		private IDisposable BuildDrawableLayer() => Disposable.Empty;
 
 		private Size GetActualSize() => Size.Empty;
 

--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.wasm.cs
@@ -2,6 +2,7 @@
 using Windows.UI.Xaml.Wasm;
 using Uno.Extensions;
 using Uno.UI;
+using NotImplementedException = System.NotImplementedException;
 
 namespace Windows.UI.Xaml.Shapes
 {
@@ -14,7 +15,11 @@ namespace Windows.UI.Xaml.Shapes
 			SvgChildren.Add(_ellipse);
 
 			InitCommonShapeProperties();
+
+			RegisterPropertyChangedCallback(StrokeProperty, OnStrokeChanged);
 		}
+
+		private void OnStrokeChanged(DependencyObject sender, DependencyProperty dp) => InvalidateArrange();
 
 		protected override SvgElement GetMainSvgElement()
 		{
@@ -23,22 +28,18 @@ namespace Windows.UI.Xaml.Shapes
 
 		protected override Size ArrangeOverride(Size finalSize)
 		{
-			var minMax = this.GetMinMax();
+			var size = this.ApplySizeConstraints(finalSize);
 
-			var arrangeSize = finalSize
-				.AtLeast(minMax.min)
-				.AtMost(minMax.max);
+			var cx = size.Width / 2;
+			var cy = size.Height / 2;
 
-			var cx = arrangeSize.Width / 2;
-			var cy = arrangeSize.Height / 2;
-
-			var strokeThickness = ActualStrokeThickness;
+			var halfStrokeThickness = ActualStrokeThickness / 2;
 
 			_ellipse.SetAttribute(
 				("cx", cx.ToStringInvariant()),
 				("cy", cy.ToStringInvariant()),
-				("rx", (cx - strokeThickness/2).ToStringInvariant()),
-				("ry", (cy - strokeThickness/2).ToStringInvariant()));
+				("rx", (cx - halfStrokeThickness).ToStringInvariant()),
+				("ry", (cy - halfStrokeThickness).ToStringInvariant()));
 
 			return base.ArrangeOverride(finalSize);
 		}

--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.wasm.cs
@@ -37,8 +37,8 @@ namespace Windows.UI.Xaml.Shapes
 			_ellipse.SetAttribute(
 				("cx", cx.ToStringInvariant()),
 				("cy", cy.ToStringInvariant()),
-				("rx", (cx - strokeThickness).ToStringInvariant()),
-				("ry", (cy - strokeThickness).ToStringInvariant()));
+				("rx", (cx - strokeThickness/2).ToStringInvariant()),
+				("ry", (cy - strokeThickness/2).ToStringInvariant()));
 
 			return base.ArrangeOverride(finalSize);
 		}


### PR DESCRIPTION
# Bug fix
Rendering of `<Ellipse>` on Wasm when a `StrockThickness` were used were producing strange results.

## Observed
As illustrated in the snippet on the Playground: https://playground.platform.uno/#49ff79fb
![image](https://user-images.githubusercontent.com/4174207/87973053-f0f8da80-ca95-11ea-8967-633a11768ac7.png)

## Expected
Same code on XAML Studio (on UWP):
![image](https://user-images.githubusercontent.com/4174207/87973102-04a44100-ca96-11ea-8949-66f33a3e18e5.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
