### PR TITLE
fix(shapes): [WASM] Fix to properly support null Points in Poly[gon|line]

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/PointCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Media/PointCollection.cs
@@ -22,6 +22,12 @@ namespace Windows.UI.Xaml.Media
 			_points = coordinates.ToList();
 		}
 
+		// For implicit conversion from string, avoids to uselessly clone the points list.
+		private PointCollection(List<Point> points)
+		{
+			_points = points;
+		}
+
 		public int Count => _points.Count;
 
 		public bool IsReadOnly => false;

--- a/src/Uno.UI/UI/Xaml/Media/PointCollection.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/PointCollection.wasm.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Windows.Foundation;
+using Uno.Extensions;
+
+namespace Windows.UI.Xaml.Media
+{
+	public partial class PointCollection : IEnumerable<Point>, IList<Point>
+	{
+		internal string ToCssString()
+		{
+			var sb = new StringBuilder();
+			foreach (var p in _points)
+			{
+				sb.Append(p.X.ToStringInvariant());
+				sb.Append(',');
+				sb.Append(p.Y.ToStringInvariant());
+				sb.Append(' ');
+			}
+			return sb.ToString();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/PointCollection.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/PointCollection.wasm.cs
@@ -19,7 +19,7 @@ namespace Windows.UI.Xaml.Media
 				sb.Append(p.X.ToStringInvariant());
 				sb.Append(',');
 				sb.Append(p.Y.ToStringInvariant());
-				sb.Append(' ');
+				sb.Append(' '); // We will have an extra space at the end ... which is going to be ignored by browsers!
 			}
 			return sb.ToString();
 		}

--- a/src/Uno.UI/UI/Xaml/Shapes/Polygon.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polygon.cs
@@ -32,7 +32,13 @@ namespace Windows.UI.Xaml.Shapes
 				defaultValue: default(PointCollection),
 				options: FrameworkPropertyMetadataOptions.LogicalChild | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange,
 #if LEGACY_SHAPE_MEASURE
-				propertyChangedCallback: (s, e) => ((Polygon)s).OnPointsChanged()
+				propertyChangedCallback: (s, e) =>
+				{
+					var polygon = (Polygon)s;
+					polygon.OnPointsChanged();
+					(e.OldValue as PointCollection)?.UnRegisterChangedListener(polygon.OnPointsChanged);
+					(e.NewValue as PointCollection)?.RegisterChangedListener(polygon.OnPointsChanged);
+				}
 #else
 				propertyChangedCallback: (s, e) =>
 				{

--- a/src/Uno.UI/UI/Xaml/Shapes/Polygon.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polygon.cs
@@ -36,8 +36,10 @@ namespace Windows.UI.Xaml.Shapes
 				{
 					var polygon = (Polygon)s;
 					polygon.OnPointsChanged();
+#if __WASM__
 					(e.OldValue as PointCollection)?.UnRegisterChangedListener(polygon.OnPointsChanged);
 					(e.NewValue as PointCollection)?.RegisterChangedListener(polygon.OnPointsChanged);
+#endif
 				}
 #else
 				propertyChangedCallback: (s, e) =>

--- a/src/Uno.UI/UI/Xaml/Shapes/Polygon.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polygon.wasm.cs
@@ -23,8 +23,15 @@ namespace Windows.UI.Xaml.Shapes
 
 		partial void OnPointsChanged()
 		{
-			var points = string.Join(" ", Points.Select(p => $"{p.X.ToStringInvariant()},{p.Y.ToStringInvariant()}"));
-			_polygon.SetAttribute("points", points);
+			var points = Points;
+			if (points == null)
+			{
+				_polygon.RemoveAttribute("points");
+			}
+			else
+			{
+				_polygon.SetAttribute("points", points.ToCssString());
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Polyline.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polyline.cs
@@ -35,8 +35,10 @@ namespace Windows.UI.Xaml.Shapes
 				{
 					var polyline = (Polyline)s;
 					polyline.OnPointsChanged();
+#if __WASM__
 					(e.OldValue as PointCollection)?.UnRegisterChangedListener(polyline.OnPointsChanged);
 					(e.NewValue as PointCollection)?.RegisterChangedListener(polyline.OnPointsChanged);
+#endif
 				}
 #else
 				propertyChangedCallback: (s, e) =>

--- a/src/Uno.UI/UI/Xaml/Shapes/Polyline.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polyline.cs
@@ -31,7 +31,13 @@ namespace Windows.UI.Xaml.Shapes
 				defaultValue: default(PointCollection),
 			    options: FrameworkPropertyMetadataOptions.LogicalChild | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange,
 #if LEGACY_SHAPE_MEASURE
-				propertyChangedCallback: (s, e) => ((Polyline)s).OnPointsChanged()
+				propertyChangedCallback: (s, e) =>
+				{
+					var polyline = (Polyline)s;
+					polyline.OnPointsChanged();
+					(e.OldValue as PointCollection)?.UnRegisterChangedListener(polyline.OnPointsChanged);
+					(e.NewValue as PointCollection)?.RegisterChangedListener(polyline.OnPointsChanged);
+				}
 #else
 				propertyChangedCallback: (s, e) =>
 				{

--- a/src/Uno.UI/UI/Xaml/Shapes/Polyline.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polyline.wasm.cs
@@ -27,8 +27,15 @@ namespace Windows.UI.Xaml.Shapes
 
 		partial void OnPointsChanged()
 		{
-			var points = string.Join(" ", Points.Select(p => $"{p.X.ToStringInvariant()},{p.Y.ToStringInvariant()}"));
-			_polyline.SetAttribute("points", points);
+			var points = Points;
+			if (points == null)
+			{
+				_polyline.RemoveAttribute("points");
+			}
+			else
+			{
+				_polyline.SetAttribute("points", points.ToCssString());
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue: _private, cf. below_

## Bugfix
Fix support of `null` in the `Poly<gon|line>.Points` property.

## What is the current behavior?
Causes a `NullReferenceException`.

## What is the new behavior?
🙃

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
