### PR TITLE
fix(timePicker): [IOS] Timepicker is now visible in dark mode

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.md
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.md
@@ -42,9 +42,9 @@ You can change the flyout button by copying and modifying TimePickerFlyoutButton
 You can change the flyout button by copying and modifying TimePickerFlyoutPresenterStyle.
 
 Some ColorBrushes are specific to IOS and could be changed by copying and redoing the new style so they use your own color brushes  
- IOSTimePickerAcceptButtonForegroundBrush  Color="#324f85"
- IOSTimePickerDismissButtonForegroundBrush  Color="#324f85"
- IOSTimePickerHeaderBackgroundBrush  Color="#f8f8f8" 
+ IOSTimePickerAcceptButtonForegroundBrush  Color="#055bb7"
+ IOSTimePickerDismissButtonForegroundBrush  Color="#055bb7"
+ IOSTimePickerHeaderBackgroundBrush  Color="{ThemeResource SystemListLowColor}" 
 
 If you want to show a dimmed overlay underneath the picker, set the `TimePicker.LightDismissOverlayMode` property to `On`.
 

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -2098,7 +2098,7 @@
 	<SolidColorBrush x:Key="IOSTimePickerDismissButtonForegroundBrush"
 					 Color="#055bb7" />
 	<SolidColorBrush x:Key="IOSTimePickerHeaderBackgroundBrush"
-					 Color="#f8f8f8" />
+					 Color="{ThemeResource SystemListLowColor}" />
 
 	<ios:Style x:Key="IOSTimePickerDoneCancelButtonStyle"
 			   TargetType="Button">
@@ -2137,8 +2137,9 @@
 	</ios:Style>
 
 	<ios:Style TargetType="TimePickerFlyoutPresenter">
+		<!-- System Color that properly changes for iOS, from white/black in light/dark theme -->
 		<Setter Property="Background"
-				Value="White" />
+				Value="{ThemeResource TimePickerForegroundThemeBrush}" />
 		<Setter Property="VerticalAlignment"
 				Value="Stretch" />
 		<Setter Property="HorizontalAlignment"


### PR DESCRIPTION
GitHub Issue (If applicable): #3606

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

-->

## What is the current behavior?

- [IOS] Timepicker is not visible in dark mode
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
- [IOS] Timepicker is now visible in dark mode
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
