### PR TITLE
Style resources now auto-convert Color to SolidColorBrush

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2709,6 +2709,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\Brushes_ImplicitConvert.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\GradientBrushTests\GradientsPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4717,6 +4721,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\RoutedEvents\RoutedEvent_TappedControl.xaml.cs">
       <DependentUpon>RoutedEvent_TappedControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\Brushes_ImplicitConvert.xaml.cs">
+      <DependentUpon>Brushes_ImplicitConvert.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\ColorPresenter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\GradientBrushTests\GradientsPage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrush_WriteableBitmap.xaml.cs">
       <DependentUpon>ImageBrush_WriteableBitmap.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/Brushes_ImplicitConvert.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/Brushes_ImplicitConvert.xaml
@@ -1,0 +1,55 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Media.BrushesTests.Brushes_ImplicitConvert"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:brushesTests="using:UITests.Windows_UI_Xaml_Media.BrushesTests"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="blue">Blue</SolidColorBrush>
+		<Color x:Key="red">Red</Color>
+
+		<Style x:Key="styleRed" TargetType="Rectangle">
+			<Setter Property="Fill" Value="{StaticResource red}" />
+		</Style>
+
+		<Style x:Key="presenterBlue" TargetType="brushesTests:ColorPresenter">
+			<Setter Property="Color" Value="{StaticResource blue}" />
+		</Style>
+		<Style x:Key="presenterRed" TargetType="brushesTests:ColorPresenter">
+			<Setter Property="Color" Value="{StaticResource red}" />
+		</Style>
+	</Page.Resources>
+
+	<StackPanel Spacing="10">
+		<TextBlock>Following 2 rectangles should be both blue. You should not see 3 rectangles.</TextBlock>
+		<StackPanel Orientation="Horizontal" Spacing="15">
+			<Rectangle Width="75" Height="75" x:Name="rectblue" Fill="{StaticResource blue}" Stroke="Black" StrokeThickness="1" />
+			<Rectangle Width="75" Height="75" Stroke="Black" StrokeThickness="1">
+				<Rectangle.Fill>
+					<SolidColorBrush Color="{Binding Fill, ElementName=rectblue}" />
+				</Rectangle.Fill>
+			</Rectangle>
+			<Border BorderBrush="Black" BorderThickness="1">
+				<brushesTests:ColorPresenter Width="75" Height="75" Style="{StaticResource presenterBlue}"/>
+			</Border>
+		</StackPanel>
+
+		<TextBlock>You should see only 1 red rectangle.</TextBlock>
+		<StackPanel Orientation="Horizontal" Spacing="15">
+			<Rectangle Width="75" Height="75" x:Name="rectred" Stroke="Black" StrokeThickness="1">
+				<Rectangle.Fill>
+					<SolidColorBrush Color="{StaticResource red}" />
+				</Rectangle.Fill>
+			</Rectangle>
+			<Border BorderBrush="Black" BorderThickness="1">
+				<brushesTests:ColorPresenter Width="75" Height="75" Style="{StaticResource presenterRed}"/>
+			</Border>
+			<Rectangle Width="75" Height="75" Fill="{Binding Fill.Color, ElementName=rectred}" Stroke="Black" StrokeThickness="1" />
+			<Rectangle Width="75" Height="75" Style="{StaticResource styleRed}" Stroke="Black" StrokeThickness="1" />
+		</StackPanel>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/Brushes_ImplicitConvert.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/Brushes_ImplicitConvert.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml_Media.BrushesTests
+{
+	[Sample]
+	public sealed partial class Brushes_ImplicitConvert : Page
+	{
+		public Brushes_ImplicitConvert()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/ColorPresenter.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/ColorPresenter.cs
@@ -1,0 +1,27 @@
+﻿using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace UITests.Windows_UI_Xaml_Media.BrushesTests
+{
+    public partial class ColorPresenter : Panel
+    {
+	    public static readonly DependencyProperty ColorProperty = DependencyProperty.Register(
+		    "Color", typeof(Color), typeof(ColorPresenter), new PropertyMetadata(default(Color), OnColorChanged));
+
+	    private static void OnColorChanged(DependencyObject dependencyobject, DependencyPropertyChangedEventArgs args)
+	    {
+		    if (dependencyobject is ColorPresenter cp)
+		    {
+				cp.Background = new SolidColorBrush((Windows.UI.Color)args.NewValue);
+		    }
+	    }
+
+	    public Color Color
+	    {
+		    get => (Color)GetValue(ColorProperty);
+		    set => SetValue(ColorProperty, value);
+	    }
+    }
+}

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -89,6 +89,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Page Remove="Themes\Generic.xaml" />
 		<Page Include="Themes\Generic.xaml" />
 	</ItemGroup>
 

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -58,6 +58,7 @@ namespace Uno.UI.DataBinding
 			{
 				Enum _ => FastEnumConvert(outputType, input, ref output),
 				bool boolInput => FastBooleanConvert(outputType, boolInput, ref output),
+				Windows.UI.Color color => FastColorConvert(outputType, color, ref output),
 				SolidColorBrush solidColorBrush => FastSolidColorBrushConvert(outputType, solidColorBrush, ref output),
 				ColorOffset colorOffsetInput => FastColorOffsetConvert(outputType, colorOffsetInput, ref output),
 				_ => false
@@ -91,6 +92,17 @@ namespace Uno.UI.DataBinding
 			if (outputType == typeof(Windows.UI.Color))
 			{
 				output = (Windows.UI.Color)input;
+				return true;
+			}
+
+			return false;
+		}
+
+		private static bool FastColorConvert(Type outputType, Windows.UI.Color color, ref object output)
+		{
+			if (outputType == typeof(SolidColorBrush))
+			{
+				output = new SolidColorBrush(color);
 				return true;
 			}
 


### PR DESCRIPTION
Fix https://github.com/unoplatform/uno/issues/3558

# Feature

## What is the current behavior?
Using a `<Color>` resource in a `<Style>` setter on a `SolidColorBrush` property were not supported on Uno, but works on UWP.

## What is the new behavior?
I works.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
