### PR TITLE
[Wasm] ContentControl Clipping were not incorrect

### DIFF
--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevationView_Clipping.xaml
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevationView_Clipping.xaml
@@ -1,0 +1,72 @@
+﻿<Page
+	x:Class="UITests.Toolkit.ElevationView_Clipping"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Toolkit"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:toolkit="using:Uno.UI.Toolkit"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<Style x:Key="style1" TargetType="ContentControl">
+			<Setter Property="Background" Value="Transparent" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ContentControl">
+						<toolkit:ElevatedView Background="{TemplateBinding Background}"
+					                      ShadowColor="Chartreuse"
+					                      Elevation="15">
+							<ContentPresenter Content="{TemplateBinding Content}"
+						                  ContentTemplate="{TemplateBinding ContentTemplate}"
+						                  VerticalAlignment="{TemplateBinding VerticalAlignment}"
+						                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+						                  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+						                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" />
+						</toolkit:ElevatedView>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</Page.Resources>
+
+	<StackPanel Spacing="10">
+		<TextBlock>The following rectangles should have the same drop shadow...</TextBlock>
+
+		<StackPanel Orientation="Horizontal" Spacing="15">
+			<toolkit:ElevatedView Elevation="15" ShadowColor="Chartreuse" Background="Blue">
+				<Border Background="Red" Width="40" Height="40" />
+			</toolkit:ElevatedView>
+
+			<ContentControl>
+				<toolkit:ElevatedView Elevation="15" ShadowColor="Chartreuse">
+					<Border Background="Red" Width="40" Height="40" />
+				</toolkit:ElevatedView>
+			</ContentControl>
+
+			<Border>
+				<toolkit:ElevatedView Elevation="15" ShadowColor="Chartreuse">
+					<Border Background="Red" Width="40" Height="40" />
+				</toolkit:ElevatedView>
+			</Border>
+
+			<ContentControl Style="{StaticResource style1}">
+				<Border Background="Red" Width="40" Height="40" />
+			</ContentControl>
+
+			<ContentControl Background="Red" Width="40" Height="40" Style="{StaticResource style1}">
+				<Border />
+			</ContentControl>
+
+			<ContentControl Width="40" Height="40" Background="Red" Style="{StaticResource style1}">
+				<Border Background="Red" Width="40" Height="40" />
+			</ContentControl>
+
+			<ContentControl Style="{StaticResource style1}">
+				<Border Background="Red" Width="40" Height="40" />
+			</ContentControl>
+		</StackPanel>
+
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevationView_Clipping.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevationView_Clipping.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Toolkit
+{
+	[Sample("Toolkit")]
+	public sealed partial class ElevationView_Clipping : Page
+	{
+		public ElevationView_Clipping()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -61,6 +61,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Toolkit\ElevationView_Clipping.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Utilities\ControlStateViewer.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3354,6 +3358,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\Elevation.xaml.cs">
       <DependentUpon>Elevation.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevationView_Clipping.xaml.cs">
+      <DependentUpon>ElevationView_Clipping.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ControlStateViewer.xaml.cs">
       <DependentUpon>ControlStateViewer.xaml</DependentUpon>

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -56,6 +56,9 @@ namespace Uno.UI.Toolkit
 
 #if !NETFX_CORE
 			Loaded += (snd, evt) => SynchronizeContentTemplatedParent();
+
+			// Patch to deactivate the clipping by ContentControl
+			RenderTransform = new CompositeTransform();
 #endif
 		}
 

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -60,6 +60,7 @@ namespace Uno.UI.Toolkit
 			// Patch to deactivate the clipping by ContentControl
 			RenderTransform = new CompositeTransform();
 #endif
+			SizeChanged += (snd, evt) => UpdateElevation();
 		}
 
 		protected override void OnApplyTemplate()

--- a/src/Uno.UI.Toolkit/UIElementExtensions.cs
+++ b/src/Uno.UI.Toolkit/UIElementExtensions.cs
@@ -137,7 +137,7 @@ namespace Uno.UI.Toolkit
 					newSize = new Vector2((float)contentFE.ActualWidth, (float)contentFE.ActualHeight);
 				}
 
-				if (!(host is UIElement uiHost))
+				if (!(host is UIElement uiHost) || newSize == default)
 				{
 					return;
 				}

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Wasm.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Wasm.csproj
@@ -60,7 +60,7 @@
 
 		<PropertyGroup>
 			<_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
-			<_TargetNugetFolder>$(USERPROFILE)\.nuget\packages\Uno.UI\$(UnoNugetOverrideVersion)\uno-runtime\$(_OverrideTargetFramework)</_TargetNugetFolder>
+			<_TargetNugetFolder>$(USERPROFILE)\.nuget\packages\Uno.UI\$(UnoNugetOverrideVersion)\uno-runtime\webassembly</_TargetNugetFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<_OutputFiles Include="$(TargetDir)**" />

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.Layout.cs
@@ -88,9 +88,14 @@ namespace Windows.UI.Xaml.Controls
 
 					return false;
 				}
+				if (TemplatedRoot is UIElement tr && tr.RenderTransform != null)
+				{
+					// Same for TemplatedRoot
 
-				// Same for TemplatedRoot
-				return TemplatedRoot?.RenderTransform == null;
+					return false;
+				}
+
+				return true; // Clipping allowed
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.Layout.cs
@@ -1,5 +1,4 @@
-﻿#if XAMARIN
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -25,7 +24,7 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class ContentControl : ICustomClippingElement
 	{
-
+#if XAMARIN
 		protected override Size MeasureOverride(Size availableSize)
 		{
 			if(!IsContentPresenterBypassEnabled)
@@ -76,8 +75,25 @@ namespace Windows.UI.Xaml.Controls
 
 			return finalSize;
 		}
-		bool ICustomClippingElement.AllowClippingToLayoutSlot => !(Content is UIElement ue) || ue.RenderTransform == null;
+#endif
+
+		bool ICustomClippingElement.AllowClippingToLayoutSlot
+		{
+			get
+			{
+				if (Content is UIElement ue && ue.RenderTransform != null)
+				{
+					// If the Content is a UIElement and defines a RenderTransform,
+					// no clipping should apply.
+
+					return false;
+				}
+
+				// Same for TemplatedRoot
+				return TemplatedRoot?.RenderTransform == null;
+			}
+		}
+
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => false;
 	}
 }
-#endif


### PR DESCRIPTION
Fix https://github.com/unoplatform/uno/issues/3563 (wasm part)

# Bugfix
The multi-targetted code to handle the clipping in the `ContentControl` were not properly compiled on all platforms.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
