### PR TITLE
feat(passwordBox): [MacOS] Add support of the reveal button

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
@@ -19,6 +19,8 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private readonly bool _isPassword;
 		private ITextBoxView _textBoxView;
+		private TextBoxView _revealView;
+		private bool _isSecured = true;
 
 		protected TextBox(bool isPassword)
 		{
@@ -77,6 +79,8 @@ namespace Windows.UI.Xaml.Controls
 				if (_isPassword)
 				{
 					_textBoxView = new SecureTextBoxView(this) { UsesSingleLineMode = true };
+					_revealView = new TextBoxView(this) { UsesSingleLineMode = true };
+					_isSecured = true;
 				}
 				else
 				{
@@ -106,10 +110,8 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void UpdateFontPartial()
 		{
-			if (_textBoxView != null)
-			{
-				_textBoxView.UpdateFont();
-			}
+			_textBoxView?.UpdateFont();
+			_revealView?.UpdateFont();
 		}
 
 		partial void OnMaxLengthChangedPartial(DependencyPropertyChangedEventArgs e)
@@ -199,11 +201,37 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_textBoxView.Foreground = newValue;
 			}
+			if (_revealView != null)
+			{
+				_revealView.Foreground = newValue;
+			}
 		}
 
-        protected void SetSecureTextEntry(bool isSecure)
-        {
-        }
+		protected void SetSecureTextEntry(bool isSecure)
+		{
+			if (_textBoxView == null || _revealView == null)
+			{
+				return;
+			}
+
+			if (_isSecured == isSecure)
+			{
+				return;
+			}
+
+			if (isSecure)
+			{
+				_contentElement.Content = _textBoxView;
+			}
+			else
+			{
+				_revealView.SetTextNative(Text);
+				_revealView.Frame = _contentElement.Frame;
+				_contentElement.Content = _revealView;
+			}
+
+			_isSecured = isSecure;
+		}
 
 	}
 }


### PR DESCRIPTION
GitHub Issue: _private, cf. below_

## Feature
Add support of the reveal button for macOS

## What is the current behavior?
Reveal button does nothing

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). (cf. below)
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

