### PR TITLE
feat(macos): [MacOS] Add clipping support

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
@@ -6,6 +6,8 @@ using System;
 using System.Linq;
 using Uno.UI.Extensions;
 using AppKit;
+using CoreAnimation;
+using CoreGraphics;
 
 namespace Windows.UI.Xaml
 {
@@ -121,6 +123,35 @@ namespace Windows.UI.Xaml
 			RaiseEvent(KeyUpEvent, args);
 
 			base.OnNativeKeyUp(evt);
+		}
+
+		partial void ApplyNativeClip(Rect rect)
+		{
+			if (rect.IsEmpty
+				|| double.IsPositiveInfinity(rect.X)
+				|| double.IsPositiveInfinity(rect.Y)
+				|| double.IsPositiveInfinity(rect.Width)
+				|| double.IsPositiveInfinity(rect.Height)
+			)
+			{
+				if (!ClippingIsSetByCornerRadius)
+				{
+					if (Layer != null)
+					{
+						this.Layer.Mask = null;
+					}
+				}
+				return;
+			}
+
+			WantsLayer = true;
+			if (Layer != null)
+			{ 
+				this.Layer.Mask = new CAShapeLayer
+				{
+					Path = CGPath.FromRect(rect.ToCGRect())
+				};
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue: _private, cf. below_

## Feature
Implement clipping for MacOS

## What is the current behavior?
`SplitView` in compact mode does hide the content

## What is the new behavior?
Content is visible!

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). _cf. below_
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
