### PR TITLE
feat: IOS TimePicker flyout styling

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1049,6 +1049,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\TimePicker_TimePickerFlyoutStyle.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\ToggleSwitch_TemplateReuse.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3963,6 +3967,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ThumbTests\Thumb_DragEvents.xaml.cs">
       <DependentUpon>Thumb_DragEvents.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\TimePicker_TimePickerFlyoutStyle.xaml.cs">
+      <DependentUpon>TimePicker_TimePickerFlyoutStyle.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\ToggleSwitch_TemplateReuse.xaml.cs">
       <DependentUpon>ToggleSwitch_TemplateReuse.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/TimePicker_TimePickerFlyoutStyle.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/TimePicker_TimePickerFlyoutStyle.xaml
@@ -1,0 +1,105 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.TimePicker.TimePicker_TimePickerFlyoutStyle"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TimePicker"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:ios="http://uno.ui/ios"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d ios"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<Style x:Key="IOSTimePickerStyle"
+			   TargetType="TimePickerFlyoutPresenter">
+			<!-- System Color that properly changes for iOS, from white/black in light/dark theme -->
+			<Setter Property="Background"
+					Value="{ThemeResource TimePickerFlyoutPresenterBackground}" />
+			<Setter Property="VerticalAlignment"
+					Value="Stretch" />
+			<Setter Property="HorizontalAlignment"
+					Value="Stretch" />
+			<Setter Property="HorizontalContentAlignment"
+					Value="Stretch" />
+			<Setter Property="VerticalContentAlignment"
+					Value="Bottom" />
+			<Setter Property="BorderThickness"
+					Value="0" />
+			<Setter Property="IsTabStop"
+					Value="False" />
+			<Setter Property="AutomationProperties.AutomationId"
+					Value="TimePickerFlyoutPresenter" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="TimePickerFlyoutPresenter">
+						<Grid>
+							<Border x:Name="FlyoutScrim"
+									Opacity="0.30"
+									Background="Black" />
+
+							<Grid x:Name="ContentPanel"
+								  Background="{TemplateBinding Background}"
+								  BorderBrush="{TemplateBinding BorderBrush}"
+								  BorderThickness="{TemplateBinding BorderThickness}"
+								  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								  VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+								</Grid.RowDefinitions>
+
+								<Grid Background="{StaticResource IOSTimePickerHeaderBackgroundBrush}">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="*" />
+										<ColumnDefinition Width="Auto" />
+									</Grid.ColumnDefinitions>
+
+									<Button x:Name="DismissButton"
+											x:Uid="TimePickerDismissButton"
+											Style="{StaticResource IOSTimePickerDoneCancelButtonStyle}"
+											Foreground="Red"
+											Grid.Column="0"
+											Padding="15"
+											Content="Cancel"
+											FontSize="19"
+											HorizontalAlignment="Left" />
+
+									<Border x:Name="HeaderUntapableZone"
+											Background="Transparent"
+											Grid.Column="1"
+											BorderThickness="0" />
+
+									<Button x:Name="AcceptButton"
+											x:Uid="TimePickerAcceptButton"
+											Style="{StaticResource IOSTimePickerDoneCancelButtonStyle}"
+											Foreground="Purple"
+											Grid.Column="2"
+											FontWeight="Bold"
+											Padding="15"
+											Content="Done"
+											FontSize="19"
+											HorizontalAlignment="Right" />
+								</Grid>
+
+								<ContentPresenter Grid.Row="1"
+												  Content="{TemplateBinding Content}"
+												  Foreground="{TemplateBinding Foreground}"
+												  HorizontalContentAlignment="Stretch"
+												  VerticalContentAlignment="Stretch"
+												  HorizontalAlignment="Stretch"
+												  VerticalAlignment="Stretch" />
+							</Grid>
+						</Grid>
+
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<Grid>
+		<TimePicker ios:FlyoutPresenterStyle="{StaticResource IOSTimePickerStyle}" />
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/TimePicker_TimePickerFlyoutStyle.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/TimePicker_TimePickerFlyoutStyle.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.TimePicker
+{
+	[SampleControlInfo("Time Picker", nameof(TimePicker_TimePickerFlyoutStyle))]
+	public sealed partial class TimePicker_TimePickerFlyoutStyle : UserControl
+	{
+		public TimePicker_TimePickerFlyoutStyle()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
@@ -115,6 +115,24 @@ namespace Windows.UI.Xaml.Controls
 
 		#endregion
 
+		#region FlyoutPresenterStyle DependencyProperty
+		// FlyoutPresenterStyle is an Uno-only property to allow the styling of the TimePicker's FlyoutPresenter.
+		public Style FlyoutPresenterStyle
+		{
+			get { return (Style)this.GetValue(FlyoutPresenterStyleProperty); }
+			set { this.SetValue(FlyoutPresenterStyleProperty, value); }
+		}
+
+		public static DependencyProperty FlyoutPresenterStyleProperty { get; } =
+			DependencyProperty.Register(
+				"FlyoutPresenterStyle",
+				typeof(Style),
+				typeof(TimePicker),
+				new FrameworkPropertyMetadata(
+					default(Style),
+					FrameworkPropertyMetadataOptions.ValueDoesNotInheritDataContext));
+
+		#endregion
 
 		public LightDismissOverlayMode LightDismissOverlayMode
 		{
@@ -196,6 +214,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 #if __IOS__
 					Placement = FlyoutPlacement,
+					TimePickerFlyoutPresenterStyle = this.FlyoutPresenterStyle,
 #endif
 					Time = this.Time,
 					MinuteIncrement = this.MinuteIncrement,

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
@@ -23,6 +23,26 @@ namespace Windows.UI.Xaml.Controls
 		{
 		}
 
+		#region TimePickerFlyoutPresenterStyle DependencyProperty
+
+		public Style TimePickerFlyoutPresenterStyle
+		{
+			get { return (Style)this.GetValue(TimePickerFlyoutPresenterStyleProperty); }
+			set { this.SetValue(TimePickerFlyoutPresenterStyleProperty, value); }
+		}
+
+		public static DependencyProperty TimePickerFlyoutPresenterStyleProperty { get; } =
+			DependencyProperty.Register(
+				"TimePickerFlyoutPresenterStyle",
+				typeof(Style),
+				typeof(TimePickerFlyout),
+				new FrameworkPropertyMetadata(
+					default(Style),
+					FrameworkPropertyMetadataOptions.ValueDoesNotInheritDataContext
+					));
+
+		#endregion
+
 		protected override void InitializePopupPanel()
 		{
 			_popup.PopupPanel = new PickerFlyoutPopupPanel(this)
@@ -102,7 +122,11 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override Control CreatePresenter()
 		{
-			_timePickerPresenter = new TimePickerFlyoutPresenter() { Content = Content };
+			_timePickerPresenter = new TimePickerFlyoutPresenter()
+			{
+				Content = Content,
+				Style = TimePickerFlyoutPresenterStyle
+			};
 
 			void onLoad(object sender, RoutedEventArgs e)
 			{

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -2140,9 +2140,8 @@
 	</ios:Style>
 
 	<ios:Style TargetType="TimePickerFlyoutPresenter">
-		<!-- System Color that properly changes for iOS, from white/black in light/dark theme -->
 		<Setter Property="Background"
-				Value="{ThemeResource TimePickerForegroundThemeBrush}" />
+				Value="{ThemeResource TimePickerFlyoutPresenterBackground}" />
 		<Setter Property="VerticalAlignment"
 				Value="Stretch" />
 		<Setter Property="HorizontalAlignment"


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #3606

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the current behavior?
- To update the TimePickerFlyoutPresenter Style in IOS it is necessary to change the default style affecting all TimePicker in app
- Fix-Light mode ios timepicker's background is black
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
- TimePickerFlyoutPresenter Style can now be set in IOS, allowing for customization of a specific TimePicker's flyout
- Fix-Light mode ios timepicker's background is appropriate to app theme

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
