### PR TITLE
fix: macOS ApplicationTheme observing

### DIFF
--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -15,6 +15,8 @@ using Uno.Logging;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Selector = ObjCRuntime.Selector;
+using Windows.System.Profile;
+using Uno.Helpers;
 #if HAS_UNO_WINUI
 using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
 #else
@@ -114,7 +116,7 @@ namespace Windows.UI.Xaml
 		/// <returns>System theme</returns>
 		private ApplicationTheme GetDefaultSystemTheme()
 		{
-			var version = GetSystemVersion();
+			var version = DeviceHelper.OperatingSystemVersion;
 			if (version >= new Version(10, 14))
 			{
 				var app = NSAppearance.CurrentAppearance?.FindBestMatch(new string[]
@@ -129,29 +131,6 @@ namespace Windows.UI.Xaml
 				}
 			}
 			return ApplicationTheme.Light;
-		}
-
-		private Version GetSystemVersion()
-		{
-			if (_systemVersion == null)
-			{
-				using var info = new NSProcessInfo();
-				var version = info.OperatingSystemVersion.ToString();
-				if (Version.TryParse(version, out var number))
-				{
-					_systemVersion = number;
-				}
-				else if (int.TryParse(version, out var major))
-				{
-					_systemVersion = new Version(major, 0);
-				}
-				else
-				{
-					_systemVersion = new Version(0, 0);
-				}
-			}
-
-			return _systemVersion;
 		}
 
 		private void SetCurrentLanguage()

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -28,7 +28,6 @@ namespace Windows.UI.Xaml
 	[Register("UnoAppDelegate")]
 	public partial class Application : NSApplicationDelegate
 	{
-		private Version _systemVersion = null;
 		private readonly NSString _themeChangedNotification = new NSString("AppleInterfaceThemeChangedNotification");
 		private readonly Selector _modeSelector = new Selector("themeChanged:");
 

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -14,7 +14,7 @@ using Uno.Extensions;
 using Uno.Logging;
 using System.Linq;
 using Microsoft.Extensions.Logging;
-
+using Selector = ObjCRuntime.Selector;
 #if HAS_UNO_WINUI
 using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
 #else
@@ -27,6 +27,9 @@ namespace Windows.UI.Xaml
 	public partial class Application : NSApplicationDelegate
 	{
 		private Version _systemVersion = null;
+		private readonly NSString _themeChangedNotification = new NSString("AppleInterfaceThemeChangedNotification");
+		private readonly Selector _modeSelector = new Selector("themeChanged:");
+
 		private NSUrl[] _launchUrls = null;
 
 		public Application()
@@ -168,11 +171,15 @@ namespace Windows.UI.Xaml
 		}
 
 		partial void ObserveSystemThemeChanges()
-		{			
-			NSUserDefaults.StandardUserDefaults.AddObserver(
-				"AppleInterfaceStyle",
-				NSKeyValueObservingOptions.New,
-				_ => Application.Current.OnSystemThemeChanged());
+		{
+			NSDistributedNotificationCenter.GetDefaultCenter().AddObserver(
+				this,
+				_modeSelector,
+				_themeChangedNotification,
+				null);
 		}
+
+		[Export("themeChanged:")]
+		public void ThemeChanged(NSObject change) => OnSystemThemeChanged();
 	}
 }

--- a/src/Uno.UWP/Helpers/DeviceHelper.macOS.cs
+++ b/src/Uno.UWP/Helpers/DeviceHelper.macOS.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Foundation;
+
+namespace Uno.Helpers
+{
+	internal static class DeviceHelper
+	{
+		private static Version _version = null;
+
+		public static Version OperatingSystemVersion => _version ??= GetOperatingSystemVersion();
+
+		private static Version GetOperatingSystemVersion()
+		{
+			using var info = new NSProcessInfo();
+			var version = info.OperatingSystemVersion.ToString();
+			if (Version.TryParse(version, out var systemVersion))
+			{
+				return systemVersion;
+			}
+			else if (int.TryParse(version, out var major))
+			{
+				return new Version(major, 0);
+			}
+			return new Version(0, 0);
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #3619

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Theme changes at runtime crash macOS app.

## What is the new behavior?

Theme observing works.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.