### PR TITLE
fix(reg): Restore grid spans reset

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
@@ -1266,6 +1266,7 @@ namespace Uno.UI.Tests.GridTests
 
 			SUT.RowDefinitions.Should().HaveCount(0);
 		}
+
 		[TestMethod]
 		public void When_Zero_Star_Size()
 		{
@@ -1290,6 +1291,47 @@ namespace Uno.UI.Tests.GridTests
 				Grid.SetRow(border, row);
 				SUT.Children.Add(border);
 			}
+		}
+
+		[TestMethod]
+		public void When_RowSpan_Reuse()
+		{
+			// This sample is taken from the ToggleSwitch template
+
+			var SUT = new StackPanel();
+
+			var topLevel = new Grid();
+			SUT.Children.Add(topLevel);
+
+			topLevel.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			topLevel.RowDefinitions.Add(new RowDefinition { Height = GridLengthHelper.FromPixels(10) });
+			topLevel.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			topLevel.RowDefinitions.Add(new RowDefinition { Height = GridLengthHelper.FromPixels(10) });
+
+			topLevel.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+			topLevel.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLengthHelper.FromPixels(12), MaxWidth = 12 });
+			topLevel.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLengthHelper.FromPixels(12) });
+			topLevel.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+			topLevel.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLengthHelper.OneStar });
+
+			var spacer = new Grid() { Margin = new Thickness(0, 5) };
+			topLevel.Children.Add(spacer);
+			Grid.SetRow(spacer, 1);
+			Grid.SetRowSpan(spacer, 3);
+			Grid.SetColumnSpan(spacer, 3);
+
+			var knob = new Grid()
+			{
+				HorizontalAlignment = HorizontalAlignment.Left,
+				Width = 20,
+				Height = 20
+			};
+
+			Grid.SetRow(spacer, 2);
+			topLevel.Children.Add(knob);
+
+			SUT.Measure(new Size(800, 800));
+			Assert.AreEqual(new Size(20, 20), knob.DesiredSize);
 		}
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/TextBlockTests/Given_TextBlock.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/TextBlockTests/Given_TextBlock.cs
@@ -7,6 +7,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Controls;
+using System.Drawing;
+using Windows.UI.Xaml.Media;
 
 namespace Uno.UI.Tests.Windows_UI_XAML_Controls.TextBlockTests
 {
@@ -29,6 +31,20 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.TextBlockTests
 
 			var cp = new ContentPresenter();
 			Assert.AreEqual(DefaultFontSize, cp.FontSize);
+		}
+
+		[TestMethod]
+		public void When_Changing_Foreground_Property()
+		{
+			var tb = new TextBlock();
+			tb.Foreground = SolidColorBrushHelper.Red;
+			Assert.AreEqual(SolidColorBrushHelper.Red.Color, (tb.Foreground as SolidColorBrush)?.Color);
+
+			tb.Foreground = null;
+			Assert.AreEqual(null, tb.Foreground);
+
+			tb.Foreground = SolidColorBrushHelper.AliceBlue;
+			Assert.AreEqual(SolidColorBrushHelper.AliceBlue.Color, (tb.Foreground as SolidColorBrush)?.Color);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
@@ -269,6 +269,7 @@ namespace Windows.UI.Xaml.Controls
 			var rowSpacing = RowSpacing;
 			var columnSpacing = ColumnSpacing;
 
+			bool resetCalculatedPixelSpans = false;
 			Span<double> calculatedPixelColumnsMinValue = stackalloc double[calculatedPixelColumns.Length];
 			Span<double> calculatedPixelRowsMinValue = stackalloc double[calculatedPixelRows.Length];
 
@@ -276,6 +277,17 @@ namespace Windows.UI.Xaml.Controls
 			var offset = GetChildrenOffset();
 			foreach (var child in Children)
 			{
+				if (resetCalculatedPixelSpans)
+				{
+					// Reset the allocated pixel values
+					calculatedPixelColumnsMinValue.Fill(default);
+					calculatedPixelRowsMinValue.Fill(default);
+				}
+				else
+				{
+					resetCalculatedPixelSpans = true;
+				}
+
 				var gridPosition = childrenToPositionsMap[child];
 				var x = offset.X + calculatedPixelColumns.SliceClamped(0, gridPosition.Column).Sum(cs => cs.MinValue);
 				var y = offset.Y + calculatedPixelRows.SliceClamped(0, gridPosition.Row).Sum(cs => cs.MinValue);
@@ -284,7 +296,6 @@ namespace Windows.UI.Xaml.Controls
 				y += rowSpacing * gridPosition.Row;
 
 				calculatedPixelColumns.SelectToSpan(calculatedPixelColumnsMinValue, cs => cs.MinValue);
-
 				calculatedPixelRows.SelectToSpan(calculatedPixelRowsMinValue, cs => cs.MinValue);
 
 				var width = GetSpanSum(gridPosition.Column, gridPosition.ColumnSpan, calculatedPixelColumnsMinValue);
@@ -378,12 +389,22 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
+			bool resetColumnSizes = false;
 			Span<GridSizeEntry> columnSizes = stackalloc GridSizeEntry[columns.Length];
 
 			// Auto size: This type of measure is always required. 
 			// It's the type of size that depends directly on the size of its content.
 			foreach (var autoChild in autoSizeChildrenX)
 			{
+				if (resetColumnSizes)
+				{
+					columnSizes.Fill(default);
+				}
+				else
+				{
+					resetColumnSizes = true;
+				}
+
 				var gridPosition = autoChild.Value;
 
 				var childAvailableWidth = availableWidth - GetAvailableSizeForPosition(calculatedPixelColumns, gridPosition);
@@ -700,12 +721,24 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
+			bool resetSpans = false;
 			Span<GridSizeEntry> rowSizes = stackalloc GridSizeEntry[rows.Length];
 			Span<GridSizeEntry> autoRowsTemp = stackalloc GridSizeEntry[rowSizes.Length];
 			Span<GridSizeEntry> pixelRowsTemp = stackalloc GridSizeEntry[rowSizes.Length];
 
 			foreach (var autoChild in autoSizeChildrenY)
 			{
+				if (resetSpans)
+				{
+					rowSizes.Fill(default);
+					autoRowsTemp.Fill(default);
+					pixelRowsTemp.Fill(default);
+				}
+				else
+				{
+					resetSpans = true;
+				}
+
 				var gridPosition = autoChild.Value;
 				var width = GetSpanSum(gridPosition.Column, gridPosition.ColumnSpan, calculatedColumns.SelectToMemory(cs => cs.MaxValue).Span);
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -366,7 +366,7 @@ namespace Windows.UI.Xaml.Controls
 			set
 			{
 #if !__WASM__
-				if (value is SolidColorBrush || value is GradientBrush)
+				if (value is SolidColorBrush || value is GradientBrush || value is null)
 				{
 					SetValue(ForegroundProperty, value);
 				}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`RowSpan` calculation was incorrect, leading to incorrect layout for `ToggleSwitch` templates.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
