### PR TITLE
Path - close on Android/iOS/macOS, react to changes on WASM

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.ClosedFigurePage.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.ClosedFigurePage.cs
@@ -1,0 +1,31 @@
+﻿using System.Drawing;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
+{
+	[TestFixture]
+	public partial class GeometryTests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void ClosedPath()
+		{
+			// Navigate to this x:Class control name
+			Run("SamplesApp.Windows_UI_Xaml_Media.Geometry.ClosedFigurePage");
+
+			// Define elements that will be interacted with at the start of the test
+			var path = _app.Marked("Path");
+
+			// Specify what user interface element to wait on before starting test execution
+			_app.WaitForElement(path);
+
+			// if closed path, there should be black color on left hand side
+
+			var screenshot = TakeScreenshot("Closed state");
+
+			ImageAssert.HasColorAt(screenshot, 50, 300, Color.Black);
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.LineSegmentPage.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.LineSegmentPage.cs
@@ -14,7 +14,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 	{
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Browser)]
 		public void LineSegment()
 		{
 			// Navigate to this x:Class control name
@@ -28,6 +27,26 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 
 			// Take an initial screenshot
 			TakeScreenshot("Initial State");
+		}
+
+		[Test]
+		[AutoRetry]
+		public void PointMovement()
+		{
+			Run("SamplesApp.Windows_UI_Xaml_Media.Geometry.LineSegmentPage");
+
+			var path = _app.Marked("Path");
+			var button = _app.Marked("MovePointButton");
+
+			_app.WaitForElement(path);
+
+			var before = TakeScreenshot("Before point movement");
+
+			button.Tap();
+
+			var after = TakeScreenshot("After point movement");
+
+			ImageAssert.AreNotEqual(before, after);
 		}
 	}
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2733,6 +2733,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Geometry\ClosedFigurePage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\GradientBrushTests\GradientsPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4761,6 +4765,9 @@
       <DependentUpon>Brushes_ImplicitConvert.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\ColorPresenter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Geometry\ClosedFigurePage.xaml.cs">
+      <DependentUpon>ClosedFigurePage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\GradientBrushTests\GradientsPage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrush_WriteableBitmap.xaml.cs">
       <DependentUpon>ImageBrush_WriteableBitmap.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Geometry/ClosedFigurePage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Geometry/ClosedFigurePage.xaml
@@ -1,0 +1,31 @@
+﻿<Page
+    x:Class="SamplesApp.Windows_UI_Xaml_Media.Geometry.ClosedFigurePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:SamplesApp.Windows_UI_Xaml_Media.Geometry"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+	  <Path x:Name="Path" Stroke="Black" StrokeThickness="100">
+		<Path.Data>
+		  <PathGeometry>
+			<PathGeometry.Figures>
+			  <PathFigureCollection>
+				<PathFigure IsClosed="True" StartPoint="0,0">
+				  <PathFigure.Segments>
+					<PathSegmentCollection>
+					  <LineSegment Point="600,600" />
+					  <LineSegment Point="0,600" />
+					</PathSegmentCollection>
+				  </PathFigure.Segments>
+				</PathFigure>
+			  </PathFigureCollection>
+			</PathGeometry.Figures>
+		  </PathGeometry>
+		</Path.Data>
+	  </Path>
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Geometry/ClosedFigurePage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Geometry/ClosedFigurePage.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace SamplesApp.Windows_UI_Xaml_Media.Geometry
+{
+	[SampleControlInfo("Geometry", "ClosedFigure")]
+	public sealed partial class ClosedFigurePage : Page
+    {
+        public ClosedFigurePage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Geometry/LineSegmentPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Geometry/LineSegmentPage.xaml
@@ -8,31 +8,34 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <StackPanel>
-		<Path x:Name="Path" Stroke="Black" StrokeThickness="1">
-			<Path.Data>
-				<PathGeometry>
-					<PathGeometry.Figures>
-						<PathFigureCollection>
-							<PathFigure IsClosed="True" StartPoint="10,100">
-								<PathFigure.Segments>
-									<PathSegmentCollection>
-										<LineSegment Point="100,100" />
-										<LineSegment Point="100,50" />
-									</PathSegmentCollection>
-								</PathFigure.Segments>
-							</PathFigure>
-							<PathFigure IsClosed="True" StartPoint="10,10">
-								<PathFigure.Segments>
-									<PathSegmentCollection>
-										<LineSegment Point="100,10" />
-										<LineSegment Point="100,40" />
-									</PathSegmentCollection>
-								</PathFigure.Segments>
-							</PathFigure>
-						</PathFigureCollection>
-					</PathGeometry.Figures>
-				</PathGeometry>
-			</Path.Data>
-		</Path>
+		<Button x:Name="MovePointButton" Click="MovePointClick" Content="Move point" />
+		<Canvas x:Name="CanvasWrapper" Width="100" Height="100">
+		  <Path x:Name="Path" Stroke="Black" StrokeThickness="4">
+			  <Path.Data>
+				  <PathGeometry>
+					  <PathGeometry.Figures>
+						  <PathFigureCollection>
+							  <PathFigure IsClosed="True" StartPoint="10,100">
+								  <PathFigure.Segments>
+									  <PathSegmentCollection>
+										  <LineSegment x:Name="LineToChange" Point="100,100" />
+										  <LineSegment Point="100,50" />
+									  </PathSegmentCollection>
+								  </PathFigure.Segments>
+							  </PathFigure>
+							  <PathFigure IsClosed="True" StartPoint="10,10">
+								  <PathFigure.Segments>
+									  <PathSegmentCollection>
+										  <LineSegment Point="100,10" />
+										  <LineSegment Point="100,40" />
+									  </PathSegmentCollection>
+								  </PathFigure.Segments>
+							  </PathFigure>
+						  </PathFigureCollection>
+					  </PathGeometry.Figures>
+				  </PathGeometry>
+			  </Path.Data>
+		  </Path>
+	    </Canvas>
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Geometry/LineSegmentPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Geometry/LineSegmentPage.xaml.cs
@@ -23,5 +23,10 @@ namespace SamplesApp.Windows_UI_Xaml_Media.Geometry
 		{
 			this.InitializeComponent();
 		}
+
+		public void MovePointClick(object sender, RoutedEventArgs args)
+		{
+			LineToChange.Point = new Point(LineToChange.Point.X - 20, LineToChange.Point.Y - 20);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/GeometryHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GeometryHelper.cs
@@ -65,6 +65,7 @@ namespace Windows.UI.Xaml.Media
 		{
 			ctx.BeginFigure(pathFigure.StartPoint, pathFigure.IsFilled, pathFigure.IsClosed);
 			pathFigure.Segments.ForEach(ctx.Write);
+			ctx.SetClosedState(pathFigure.IsClosed);
 		}
 
 		public static void Write(this StreamGeometryContext ctx, PathSegment pathSegment)

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.wasm.cs
@@ -21,6 +21,8 @@ namespace Windows.UI.Xaml.Shapes
 
 		private Size GetActualSize() => Size.Empty;
 
+		protected virtual void InvalidateShape() { }
+
 		protected override Size MeasureOverride(Size availableSize)
 		{
 			// We make sure to invoke native methods while not in the visual tree
@@ -29,6 +31,8 @@ namespace Windows.UI.Xaml.Shapes
 			{
 				return new Size();
 			}
+
+			InvalidateShape();
 
 			var measurements = GetMeasurements(availableSize);
 			var desiredSize = measurements.desiredSize;

--- a/src/Uno.UI/UI/Xaml/Shapes/Path.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Path.wasm.cs
@@ -26,7 +26,9 @@ namespace Windows.UI.Xaml.Shapes
 			return _path;
 		}
 
-		partial void OnDataChanged()
+		partial void OnDataChanged() => InvalidateMeasure();
+
+		protected override void InvalidateShape()
 		{
 			switch (Data)
 			{
@@ -43,6 +45,7 @@ namespace Windows.UI.Xaml.Shapes
 					break;
 			}
 		}
+
 		/// <summary>
 		/// Transform the figures collection into a SVG Path according to :
 		/// https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d


### PR DESCRIPTION
GitHub Issue (If applicable): partially #3561

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

- `PathFigure.IsClosed` is not respected on Android, iOS and macOS
- Runtime changes to `PathSegment` on WASM are not applied


## What is the new behavior?

- `PathFigure.IsClosed` is respected on Android, iOS and macOS
- Runtime changes to `PathSegment` on WASM are applied


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.