### PR TITLE
ci: Disable strict merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,7 +30,10 @@ pull_request_rules:
         method: merge
         # https://doc.mergify.io/strict-workflow.html
         # https://doc.mergify.io/actions.html#label
-        strict: smart
+        
+        # Disable strict mode, as it's less costly to validate builds that may fail because
+        # it happens less often than rebuilding because of up-to-date checks.
+        strict: false 
 
   - name: automatic merge for allcontributors pull requests
     conditions:


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Disable strict mode for mergify, as it's quite rare that build issues happen as a result of a non-conflicting merge. 

`Ready to merge` PRs will be merged as soon as checks are passed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
