### PR TITLE
fix: Compositor NullReferenceException

### DIFF
--- a/src/Uno.UWP/UI/Composition/Visual.cs
+++ b/src/Uno.UWP/UI/Composition/Visual.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Composition
 			get => transformMatrix; set
 			{
 				transformMatrix = value;
-				Compositor.InvalidateRender();
+				Compositor?.InvalidateRender();
 			}
 		}
 		public Vector3 Offset
@@ -36,7 +36,7 @@ namespace Windows.UI.Composition
 			{
 				_offset = value;
 				OnOffsetChanged(value);
-				Compositor.InvalidateRender();
+				Compositor?.InvalidateRender();
 			}
 		}
 
@@ -47,7 +47,7 @@ namespace Windows.UI.Composition
 			get => isVisible; set
 			{
 				isVisible = value;
-				Compositor.InvalidateRender();
+				Compositor?.InvalidateRender();
 			}
 		}
 
@@ -59,7 +59,7 @@ namespace Windows.UI.Composition
 			set
 			{
 				_centerPoint = value; OnCenterPointChanged(value);
-				Compositor.InvalidateRender();
+				Compositor?.InvalidateRender();
 			}
 		}
 
@@ -71,7 +71,7 @@ namespace Windows.UI.Composition
 			set
 			{
 				_scale = value; OnScaleChanged(value);
-				Compositor.InvalidateRender();
+				Compositor?.InvalidateRender();
 			}
 		}
 
@@ -83,7 +83,7 @@ namespace Windows.UI.Composition
 			set
 			{
 				_rotationAngleInDegrees = value; OnRotationAngleInDegreesChanged(value);
-				Compositor.InvalidateRender();
+				Compositor?.InvalidateRender();
 			}
 		}
 
@@ -95,7 +95,7 @@ namespace Windows.UI.Composition
 			set
 			{
 				_size = value; OnSizeChanged(value);
-				Compositor.InvalidateRender();
+				Compositor?.InvalidateRender();
 			}
 		}
 
@@ -106,7 +106,7 @@ namespace Windows.UI.Composition
 			get => opacity; set
 			{
 				opacity = value;
-				Compositor.InvalidateRender();
+				Compositor?.InvalidateRender();
 			}
 		}
 		public Vector3 RotationAxis
@@ -115,7 +115,7 @@ namespace Windows.UI.Composition
 			set
 			{
 				_rotationAxis = value; OnRotationAxisChanged(value);
-				Compositor.InvalidateRender();
+				Compositor?.InvalidateRender();
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #3676

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

App crashes with exception when Visual property is set.

## What is the new behavior?

No crash.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.