### PR TITLE
fix(PasswordBox): fixed reveal button being visible when it shouldn't…

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Simple.xaml
@@ -11,18 +11,27 @@
 	mc:Ignorable="d ios android"
 	d:DesignHeight="2000"
 	d:DesignWidth="400">
+  
+	<UserControl.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.MergedDictionaries>
+				<ResourceDictionary Source="PasswordBox_Style.xaml" />
+			</ResourceDictionary.MergedDictionaries>
+		</ResourceDictionary>
+	</UserControl.Resources>
 
-	<controls:SampleControl SampleDescription="A PasswordBox with default everything">
-		<controls:SampleControl.SampleContent>
-			<DataTemplate>
-        <StackPanel VerticalAlignment="Top">
-          <TextBlock Text="Simple PasswordBox with a reveal button"/>
-				  <PasswordBox Width="150"/>
+	<StackPanel VerticalAlignment="Top">
+	  <TextBlock Text="Simple PasswordBox with a reveal button"/>
+	  <PasswordBox Width="150"/>
 
-          <TextBlock Text="PasswordBox without a reveal button"/>
-          <PasswordBox Width="150" Style="{StaticResource PasswordBoxWithoutRevealButtonStyle}"/>
-        </StackPanel>
-			</DataTemplate>
-		</controls:SampleControl.SampleContent>
-	</controls:SampleControl>
+	  <TextBlock Text="Simple PasswordBox with Hidden RevealMode"/>
+	  <PasswordBox Width="150" PasswordRevealMode="Hidden"/>
+
+	  <TextBlock Text="PasswordBox without a reveal button"/>
+	  <PasswordBox Width="150" Style="{StaticResource PasswordBoxWithoutRevealButtonStyle}"/>
+		  
+	  <TextBlock Text="PasswordBox with a button to toggle reveal mode"/>
+	  <PasswordBox x:Name="passBox" Width="150"/>
+	  <Button Click="ChangeRevealMode">Change Reveal Mode</Button>
+	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Simple.xaml.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Reflection;
 using Uno.UI.Samples.Controls;
+using Windows.UI.Text;
 using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Samples.Content.UITests.TextBoxControl
@@ -6,9 +9,15 @@ namespace Uno.UI.Samples.Content.UITests.TextBoxControl
 	[SampleControlInfo("TextBox", "PasswordBox_Simple")]
 	public sealed partial class PasswordBox_Simple : UserControl
 	{
+		int currentMode = 0;
 		public PasswordBox_Simple()
 		{
 			this.InitializeComponent();
+		}
+
+		public void ChangeRevealMode(object sender, object args)
+		{
+			passBox.PasswordRevealMode = (PasswordRevealMode) (++currentMode % 3);
 		}
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
@@ -68,23 +68,10 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(TextReadingOrderProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.UI.Xaml.Controls.PasswordRevealMode PasswordRevealMode
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.Controls.PasswordRevealMode)this.GetValue(PasswordRevealModeProperty);
-			}
-			set
-			{
-				this.SetValue(PasswordRevealModeProperty, value);
-			}
-		}
-		#endif
+#endif
+		// Skipping already declared property PasswordRevealMode
 		// Skipping already declared property InputScope
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase SelectionFlyout
 		{
@@ -151,17 +138,10 @@ namespace Windows.UI.Xaml.Controls
 			nameof(SelectionHighlightColor), typeof(global::Windows.UI.Xaml.Media.SolidColorBrush), 
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.SolidColorBrush)));
-		#endif
+#endif
 		// Skipping already declared property InputScopeProperty
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty PasswordRevealModeProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(PasswordRevealMode), typeof(global::Windows.UI.Xaml.Controls.PasswordRevealMode), 
-			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.PasswordRevealMode)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		// Skipping already declared property PasswordRevealModeProperty
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty TextReadingOrderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordRevealMode.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordRevealMode.cs
@@ -2,21 +2,10 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
-	#endif
 	public   enum PasswordRevealMode 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		Peek,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		Hidden,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		Visible,
-		#endif
 	}
-	#endif
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -43,6 +43,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private ContentPresenter _header;
 		protected private bool _isButtonEnabled = true;
+		protected private bool CanShowButton => Text.HasValue() && FocusState != FocusState.Unfocused && !IsReadOnly && !AcceptsReturn && TextWrapping == TextWrapping.NoWrap;
 
 		public event TextChangedEventHandler TextChanged;
 		public event TypedEventHandler<TextBox, TextBoxTextChangingEventArgs> TextChanging;
@@ -651,19 +652,14 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private void UpdateButtonStates()
+		protected virtual void UpdateButtonStates()
 		{
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{
 				this.Log().LogDebug(nameof(UpdateButtonStates));
 			}
 
-			if (_isButtonEnabled
-				&& Text.HasValue()
-				&& FocusState != FocusState.Unfocused
-				&& !IsReadOnly
-				&& !AcceptsReturn
-				&& TextWrapping == TextWrapping.NoWrap
+			if (CanShowButton && _isButtonEnabled
 			// TODO (https://github.com/unoplatform/uno/issues/683): && ActualWidth >= TDB / Note: We also have to invoke this method on SizeChanged
 			)
 			{


### PR DESCRIPTION
…. added passwordrevealmode

GitHub Issue (If applicable): closes #3562

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix
- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Password reveal button stays even on unfocus. This is not in accordance with UWP standards.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
If there is already text in the password box on focus, the reveal button is no longer available

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->
Actually added the DefaultStyleKey to PasswordBox, which may be considered breaking changes for some users?