### PR TITLE
ci: Set nuspec min version to 5.0

### DIFF
--- a/build/Uno.WinUI.Lottie.nuspec
+++ b/build/Uno.WinUI.Lottie.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
+  <metadata minClientVersion="5.0">
 	<id>Uno.WinUI.Lottie</id>
 	<version>0.0.1</version>
 	<title>Uno.WinUI.Lottie</title>

--- a/build/Uno.WinUI.RemoteControl.nuspec
+++ b/build/Uno.WinUI.RemoteControl.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
+  <metadata minClientVersion="5.0">
     <id>Uno.UI.RemoteControl</id>
     <version>0.1.0.0</version>
     <title>Uno.UI.RemoteControl</title>

--- a/build/Uno.WinUI.Skia.Gtk.nuspec
+++ b/build/Uno.WinUI.Skia.Gtk.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
+  <metadata minClientVersion="5.0">
 	<id>Uno.WinUI.Skia.Gtk</id>
 	<version>1.0.0.0</version>
 	<title>Uno.UI</title>

--- a/build/Uno.WinUI.Skia.Wpf.nuspec
+++ b/build/Uno.WinUI.Skia.Wpf.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
+  <metadata minClientVersion="5.0">
 	<id>Uno.WinUI.Skia.Wpf</id>
 	<version>1.0.0.0</version>
 	<title>Uno.UI</title>

--- a/build/Uno.WinUI.WebAssembly.nuspec
+++ b/build/Uno.WinUI.WebAssembly.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
+  <metadata minClientVersion="5.0">
 	<id>Uno.UI.WebAssembly</id>
 	<version>1.0.0.0</version>
 	<title>Uno.UI</title>

--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
+  <metadata minClientVersion="5.0">
 	<id>Uno.UI</id>
 	<version>2.7.1000</version>
 	<title>Uno.UI</title>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Builds may fail with dependency object implementation not being found:

```
##[error]InteractionEffectBase.cs(9,59): Error CS0535: 'InteractionEffectBase' does not implement interface member 'DependencyObject.GetValue(DependencyProperty)'
```

## What is the new behavior?

Nuget version 5.0 is now required since the introduction of the `buildTransitive` nuget folder.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
