### PR TITLE
fix: Race condition in CoreDispatcher.RunAsync

### DIFF
--- a/src/Uno.UWP/UI/Core/CoreDispatcher.cs
+++ b/src/Uno.UWP/UI/Core/CoreDispatcher.cs
@@ -1,4 +1,6 @@
-﻿using Uno.Diagnostics.Eventing;
+﻿#nullable enable
+
+using Uno.Diagnostics.Eventing;
 using Uno.Extensions;
 using System;
 using System.Collections.Generic;
@@ -80,9 +82,9 @@ namespace Windows.UI.Core
 		/// <summary>
 		/// Backs the CompositionTarget.Rendering event for WebAssembly.
 		/// </summary>
-		internal event EventHandler<object> Rendering;
+		internal event EventHandler<object>? Rendering;
 		internal int RenderEventThrottle;
-		internal Func<TimeSpan, object> RenderingEventArgsGenerator { get; set; }
+		internal Func<TimeSpan, object>? RenderingEventArgsGenerator { get; set; }
 
 		private readonly DateTimeOffset _startTime;
 
@@ -144,7 +146,8 @@ namespace Windows.UI.Core
 		/// <returns>An async operation for the scheduled handler.</returns>
 		public UIAsyncOperation RunAsync(CoreDispatcherPriority priority, DispatchedHandler handler)
 		{
-			return EnqueueOperation(priority, handler);
+			EnqueueOperation(priority, handler, out var operation);
+			return operation;
 		}
 
 		/// <summary>
@@ -158,11 +161,26 @@ namespace Windows.UI.Core
 		{
 			CoreDispatcher.CheckThreadAccess();
 
-			UIAsyncOperation operation = null;
+			UIAsyncOperation? operation = null;
 
-			DispatchedHandler nonCancellableHandler = () => handler(operation.Token);
+			void nonCancellableHandler()
+			{
+				if (operation != null)
+				{
+					handler(operation.Token);
+				}
+				else
+				{
+					if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+					{
+						this.Log().Error("Invalid operation");
+					}
+				}
+			}
 
-			return operation = EnqueueOperation(priority, nonCancellableHandler);
+			EnqueueOperation(priority, nonCancellableHandler, out operation);
+
+			return operation;
 		}
 
 		/// <summary>
@@ -172,15 +190,18 @@ namespace Windows.UI.Core
 		/// <returns>An async operation for the scheduled handler.</returns>
 		public UIAsyncOperation RunIdleAsync(IdleDispatchedHandler handler)
 		{
-			return EnqueueOperation(
+			EnqueueOperation(
 				CoreDispatcherPriority.Idle,
-				() => handler(_idleDispatchedHandlerArgs)
+				() => handler(_idleDispatchedHandlerArgs),
+				out var operation
 			);
+
+			return operation;
 		}
 
-		private UIAsyncOperation EnqueueOperation(CoreDispatcherPriority priority, DispatchedHandler handler)
+		private void EnqueueOperation(CoreDispatcherPriority priority, DispatchedHandler handler, out UIAsyncOperation operation)
 		{
-			EventActivity scheduleActivity = null;
+			EventActivity? scheduleActivity = null;
 			if (_trace.IsEnabled)
 			{
 				scheduleActivity = _trace.WriteEventActivity(
@@ -193,7 +214,7 @@ namespace Windows.UI.Core
 				);
 			}
 
-			var operation = new UIAsyncOperation(handler, scheduleActivity);
+			operation = new UIAsyncOperation(handler, scheduleActivity);
 
 			if (priority < CoreDispatcherPriority.Idle || priority > CoreDispatcherPriority.High)
 			{
@@ -214,8 +235,6 @@ namespace Windows.UI.Core
 			{
 				EnqueueNative();
 			}
-
-			return operation;
 		}
 
 		private Queue<UIAsyncOperation> GetQueue(CoreDispatcherPriority priority)
@@ -240,9 +259,12 @@ namespace Windows.UI.Core
 
 		private void DispatchItems()
 		{
-			UIAsyncOperation operation = null;
+			UIAsyncOperation? operation = null;
 
-			Rendering?.Invoke(null, RenderingEventArgsGenerator(DateTimeOffset.UtcNow - _startTime));
+			if (Rendering != null && RenderingEventArgsGenerator != null)
+			{
+				Rendering.Invoke(null, RenderingEventArgsGenerator.Invoke(DateTimeOffset.UtcNow - _startTime));
+			}
 
 			var didEnqueue = false;
 			for (var i = 3; i >= 0; i--)
@@ -270,7 +292,7 @@ namespace Windows.UI.Core
 			{
 				if (!operation.IsCancelled)
 				{
-					IDisposable runActivity = null;
+					IDisposable? runActivity = null;
 
 					try
 					{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

`RunAsync` with cancellation token may fail because of a null reference.

## What is the new behavior?

The race condition has been addressed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
