### PR TITLE
fix: Change default ShadowColor Property on ElevatedView for Android 9+

### DIFF
--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedViewTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedViewTests.xaml
@@ -15,6 +15,14 @@
 			<Button x:Name="lowElevation" Tag="4" Click="SetElevationClick">LOW ELEVATION (4)</Button>
 			<Button x:Name="highElevation" Tag="20" Click="SetElevationClick">HIGH ELEVATION (20)</Button>
 		</StackPanel>
+		<TextBlock>
+			ElevatedView With Default Color
+		</TextBlock>
+		<Grid Padding="16">
+			<toolkit:ElevatedView Background="Orange" Elevation="{Binding Value, ElementName=elevation1}">
+				<Rectangle Fill="Red"  Width="60" Height="60" />
+			</toolkit:ElevatedView>
+		</Grid>
 		<StackPanel Orientation="Horizontal" Spacing="10">
 			<Button x:Name="blackColor" Tag="Black" Click="SetColor" Background="Black" Foreground="White">BLACK SHADOW</Button>
 			<Button x:Name="yellowColor" Tag="Yellow" Click="SetColor" Background="Yellow">YELLOW SHADOW</Button>

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -46,6 +46,12 @@ namespace Uno.UI.Toolkit
 		 *
 		 */
 
+#if __ANDROID__
+		private static readonly Color DefaultShadowColor = Colors.Black;
+#else
+		private static readonly Color DefaultShadowColor = Color.FromArgb(64, 0, 0, 0);
+#endif
+
 		private Border _border;
 		private Grid _shadowHost;
 
@@ -85,7 +91,7 @@ namespace Uno.UI.Toolkit
 		}
 
 		public static DependencyProperty ShadowColorProperty { get ; } = DependencyProperty.Register(
-			"ShadowColor", typeof(Color), typeof(ElevatedView), new PropertyMetadata(Color.FromArgb(64, 0, 0, 0), OnChanged));
+			"ShadowColor", typeof(Color), typeof(ElevatedView), new PropertyMetadata(DefaultShadowColor, OnChanged));
 
 		public Color ShadowColor
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

-->

## What is the current behavior?

The default shadowcolor property of ElevatedView on Android 9+ is too light
![Screenshot_20200731-215913_SamplesApp](https://user-images.githubusercontent.com/17461593/89091672-4c21ab80-d379-11ea-9def-ebb49e5de259.jpg)

## What is the new behavior?

The default shadowcolor property of ElevatedView on Android 9+ is now a bit darker to match on the other platforms and android 8 and lower
![Screenshot_20200731-215358_SamplesApp](https://user-images.githubusercontent.com/17461593/89091676-517ef600-d379-11ea-8526-92a89056819a.jpg)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Associated with an issue (GitHub or internal) and uses the [automatic close keywords]~~(https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.~~

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
