### PR TITLE
Fix invalid templated parent for wrapped internal native views

### DIFF
--- a/src/SamplesApp/SamplesApp.Skia.Gtk/Properties/launchSettings.json
+++ b/src/SamplesApp/SamplesApp.Skia.Gtk/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SamplesApp.Skia.Gtk": {
       "commandName": "Project",
-      "commandLineArgs": "--_auto-screenshots=C:\\temp\\screenshots",
+      "commandLineArgs": "--auto-screenshots=C:\\temp\\screenshots",
       "nativeDebugging": false
     }
   }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Native_View.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Native_View.cs
@@ -61,5 +61,21 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			page.flyoutHostButton.Flyout.Hide();
 			TestServices.WindowHelper.WindowContent = null;
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Inner_IFrameworkElement()
+		{
+			var page = new NativeView_Page();
+
+			TestServices.WindowHelper.WindowContent = page;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Validates that the templated parent of the native child is the immediate parent's one, not the one from
+			// the outer parent.
+			var nativeViewIFrameworkElement01 = page.innerFrameworkElement.FindFirstChild<NativeViewIFrameworkElement>();
+			Assert.IsNotNull(nativeViewIFrameworkElement01);
+			Assert.AreEqual(page.innerFrameworkElement.Tag, nativeViewIFrameworkElement01.MyValue);
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeViewIFrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeViewIFrameworkElement.cs
@@ -1,0 +1,129 @@
+﻿#pragma warning disable 108,114
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.Foundation;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Animation;
+#if __IOS__
+using _NativeBase = UIKit.UISwitch;
+#elif __ANDROID__
+using _NativeBase = AndroidX.AppCompat.Widget.AppCompatCheckBox;
+#elif __MACOS__
+using _NativeBase = AppKit.NSSwitch;
+#else
+using _NativeBase = Windows.UI.Xaml.Controls.CheckBox; // No native views on other platforms
+#endif
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	public partial class NativeViewIFrameworkElement : _NativeBase
+#if __IOS__ || __ANDROID__ || __MACOS__
+		, DependencyObject, IFrameworkElement
+#endif
+	{
+#if __ANDROID__
+		public NativeViewIFrameworkElement() : base(ContextHelper.Current)
+		{
+
+		}
+#endif
+
+		public object MyValue
+		{
+			get { return (object)GetValue(MyValueProperty); }
+			set { SetValue(MyValueProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for MyValue.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyValueProperty =
+			DependencyProperty.Register("MyValue", typeof(object), typeof(NativeViewIFrameworkElement), new PropertyMetadata(0));
+
+
+#if __IOS__ || __ANDROID__ || __MACOS__
+
+		private void OnUnloaded() { }
+		private void OnLoading() { }
+		private void OnLoaded() { }
+
+		public VerticalAlignment VerticalAlignment
+		{
+			get { return (VerticalAlignment)GetValue(VerticalAlignmentProperty); }
+			set { SetValue(VerticalAlignmentProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for VerticalAlignment.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty VerticalAlignmentProperty =
+			DependencyProperty.Register("VerticalAlignment", typeof(VerticalAlignment), typeof(NativeViewIFrameworkElement), new PropertyMetadata(VerticalAlignment.Top));
+
+
+
+		public HorizontalAlignment HorizontalAlignment
+		{
+			get { return (HorizontalAlignment)GetValue(HorizontalAlignmentProperty); }
+			set { SetValue(HorizontalAlignmentProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for HorizontalAlignment.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty HorizontalAlignmentProperty =
+			DependencyProperty.Register("HorizontalAlignment", typeof(HorizontalAlignment), typeof(NativeViewIFrameworkElement), new PropertyMetadata(HorizontalAlignment.Left));
+
+
+
+		public DependencyObject Parent => this.GetParent() as DependencyObject;
+
+		public string Name { get; set; }
+		public bool IsEnabled { get; set; }
+		public Visibility Visibility { get; set; }
+		public Thickness Margin { get; set; }
+		public double Width { get; set; }
+		public double Height { get; set; }
+		public double MinWidth { get; set; }
+		public double MinHeight { get; set; }
+		public double MaxWidth { get; set; }
+		public double MaxHeight { get; set; }
+
+		public double ActualWidth => 0;
+
+		public double ActualHeight => 0;
+
+		public double Opacity { get; set; }
+		public Style Style { get; set; }
+		public Brush Background { get; set; }
+		public Transform RenderTransform { get; set; }
+		public Point RenderTransformOrigin { get; set; }
+		public TransitionCollection Transitions { get; set; }
+
+		public Uri BaseUri => new Uri("ms-appx://local");
+
+		public int? RenderPhase { get; set; }
+
+		public Rect AppliedFrame => default;
+
+		public bool IsParsing { get; set; }
+
+		public event RoutedEventHandler Loaded;
+		public event RoutedEventHandler Unloaded;
+		public event EventHandler<object> LayoutUpdated;
+		public event SizeChangedEventHandler SizeChanged;
+
+		public Size AdjustArrange(Size finalSize) => finalSize;
+
+		public void ApplyBindingPhase(int phase) { }
+
+		public void CreationComplete() { }
+
+		public object FindName(string name) => null;
+
+		public string GetAccessibilityInnerText() => null;
+
+		public AutomationPeer GetAutomationPeer() => null;
+
+		public void SetSubviewsNeedLayout() { }
+#endif
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeView_Page.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeView_Page.xaml
@@ -42,5 +42,20 @@
 				</Flyout>
 			</Button.Flyout>
 		</Button>
+		<ContentControl
+			x:Name="innerFrameworkElement"
+			   x:FieldModifier="public"
+				Tag="42">
+			<ContentControl.Template>
+				<ControlTemplate TargetType="ContentControl">
+					<Border>
+						<local:NativeViewIFrameworkElement
+							x:FieldModifier="public"
+							x:Name="nativeViewIFrameworkElement01"
+							MyValue="{TemplateBinding Tag}" />
+					</Border>
+				</ControlTemplate>
+			</ContentControl.Template>
+		</ContentControl>
 	</StackPanel>
 </Page>

--- a/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
@@ -174,6 +174,7 @@ namespace Windows.UI.Xaml.Media
 
 			return new ContentPresenter
 			{
+				IsNativeHost = true,
 				Content = nativeView
 			};
 		}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Internal Native elements hosted in `ContentPresenter` do not get the templated parent propagated properly.

## What is the new behavior?

Native elements are now managed in a specific way in `ContentPresenter` for templated parent propagation

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): fixes https://github.com/unoplatform/private/issues/160