### PR TITLE
fix: Adjust unbounded relative shapes measure

### DIFF
--- a/build/android-uitest-build.sh
+++ b/build/android-uitest-build.sh
@@ -9,7 +9,7 @@ cd $BUILD_SOURCESDIRECTORY/build
 export IsUiAutomationMappingEnabled=true
 
 # build the sample and tests, while the emulator is starting
-msbuild /r /p:Configuration=$BUILDCONFIGURATION $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+msbuild /m /r /p:Configuration=$BUILDCONFIGURATION $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
 
 mkdir -p $BUILD_ARTIFACTSTAGINGDIRECTORY/android
 cp $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/bin/$BUILDCONFIGURATION/uno.platform.unosampleapp-Signed.apk $BUILD_ARTIFACTSTAGINGDIRECTORY/android

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -59,7 +59,7 @@ jobs:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests'
     JobDisplayName: 'iOS Automated Tests'
-    JobTimeoutInMinutes: 75
+    JobTimeoutInMinutes: 100
     vmImage: ${{ parameters.vmImage }}
     UITEST_SNAPSHOTS_ONLY: false
     xCodeRoot: ${{ parameters.xCodeRoot }}

--- a/build/ci/.azure-devops-screenshot-compare.yml
+++ b/build/ci/.azure-devops-screenshot-compare.yml
@@ -46,7 +46,7 @@ jobs:
       createLogFile: false
 
   - script: |
-      src\Uno.UI.TestComparer\bin\Release\Uno.UI.TestComparer.exe "azdo" --pat="$(UITestsCompare_PAT)" --base-path="$(COMPARE_WORKDIR)" --source-branch="%GIT_SOURCEBRANCH%" --target-branch="%GIT_TARGETBRANCH%" --artifact-name="uitests-results" --artifact-inner-path="uitests-results\screenshots" --definition-name="$(Build.DefinitionName)" --project-name="$(System.TeamProject)" --server-uri="$(System.TeamFoundationCollectionUri)" --current-build="$(Build.BuildId)" --run-limit="3" --github-pat="$(CommentsGitHubPAT)" --source-repository="$(system.pullRequest.sourceRepositoryUri)" --github-pr-id="$(system.pullRequest.pullRequestNumber)"
+      src\Uno.UI.TestComparer\bin\Release\Uno.UI.TestComparer.exe "azdo" --pat="$(UITestsCompare_PAT)" --base-path="$(COMPARE_WORKDIR)" --source-branch="%GIT_SOURCEBRANCH%" --target-branch="%GIT_TARGETBRANCH%" --artifact-name="uitests-results" --artifact-inner-path="uitests-results\screenshots" --definition-name="$(Build.DefinitionName)" --project-name="$(System.TeamProject)" --server-uri="$(System.TeamFoundationCollectionUri)" --current-build="$(Build.BuildId)" --run-limit="2" --github-pat="$(CommentsGitHubPAT)" --source-repository="$(system.pullRequest.sourceRepositoryUri)" --github-pr-id="$(system.pullRequest.pullRequestNumber)"
 
     env:
       GIT_TARGETBRANCH: "$(System.PullRequest.TargetBranch)"

--- a/build/ios-uitest-build.sh
+++ b/build/ios-uitest-build.sh
@@ -4,4 +4,4 @@ IFS=$'\n\t'
 
 cd $BUILD_SOURCESDIRECTORY
 
-msbuild /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
+msbuild /m /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj

--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -48,7 +48,7 @@ else
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media_Animation' or \
 		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Shapes.Basics_Shapes_Tests'
+		class = 'SamplesApp.UITests.Windows_UI_Xaml_Shapes.Basics_Shapes_Tests'
 	"
 fi
 

--- a/doc/articles/uno-development/building-uno-macos.md
+++ b/doc/articles/uno-development/building-uno-macos.md
@@ -19,7 +19,7 @@ Support for building the `Uno.UI` solution is still somewhat unstable, this is a
  * If NuGet restore fails when building from the IDE, or if it gets stuck for some other reason, try building from the command line. Open a terminal session in the `uno/src` folder and use the following command:
 
    ``` shell
-   msbuild /r SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj`
+   msbuild /m /r SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj`
    ```
 
    Then reopen Visual Studio and try to launch the sample again.

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Basics_Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Basics_Shapes_Tests.cs
@@ -52,7 +52,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			// se we increase the pixel offset tolerance to ignore it.
 			var tolerance = new PixelTolerance()
 				.WithColor(132) // We are almost only trying to detect edges
-				.WithOffset(6, 6, LocationToleranceKind.PerPixel) 
+				.WithOffset(10, 10, LocationToleranceKind.PerPixel) 
 				.Discrete(2);
 				
 			ValidateShape("Polygon", tolerance);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Basics_Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Basics_Shapes_Tests.cs
@@ -12,33 +12,40 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 {
 	public class Basics_Shapes_Tests : SampleControlUITestBase
 	{
+		private const int TestTimeout = 7 * 60 * 1000;
+
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.iOS)]
+		[Timeout(TestTimeout)]
 		public void When_Rectangle()
 			=> ValidateShape("Rectangle");
 
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.iOS)]
+		[Timeout(TestTimeout)]
 		public void When_Ellipse()
 			=> ValidateShape("Ellipse");
 
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.iOS)]
+		[Timeout(TestTimeout)]
 		public void When_Line()
 			=> ValidateShape("Line");
 
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.iOS)]
+		[Timeout(TestTimeout)]
 		public void When_Polyline()
 			=> ValidateShape("Polyline");
 
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.iOS)]
+		[Timeout(TestTimeout)]
 		public void When_Polygon()
 		{
 			// For Polygon, the junction between the begin and the end of the path is not as smooth as WinUI (on iOS),
@@ -54,6 +61,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.iOS)]
+		[Timeout(TestTimeout)]
 		public void When_Path()
 		{
 			// For Path, the junction between the begin and the end of the path is not as smooth as WinUI (on iOS),

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Basics_Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Basics_Shapes_Tests.cs
@@ -102,7 +102,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			foreach (var testGroup in testGroups)
 			{
 				ctrl.SetDependencyPropertyValue("RunTest", string.Join(";", testGroup));
-				_app.WaitFor(() => !string.IsNullOrWhiteSpace(ctrl.GetDependencyPropertyValue<string>("TestResult")));
+				_app.WaitFor(() => !string.IsNullOrWhiteSpace(ctrl.GetDependencyPropertyValue<string>("TestResult")), timeout: TimeSpan.FromMinutes(1));
 				var testResultsRaw = ctrl.GetDependencyPropertyValue<string>("TestResult");
 
 				var testResults= testResultsRaw

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Basic_Shapes.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Basic_Shapes.xaml.cs
@@ -369,7 +369,7 @@ namespace UITests.Windows_UI_Xaml_Shapes
 		{
 			var tcs = new TaskCompletionSource<object>();
 
-			using (var timeout = Debugger.IsAttached ? default : new CancellationTokenSource(TimeSpan.FromMilliseconds(1500)))
+			using (var timeout = Debugger.IsAttached ? default : new CancellationTokenSource(TimeSpan.FromMilliseconds(5000)))
 			using (var reg = Debugger.IsAttached ? default : timeout.Token.Register(() => tcs.TrySetCanceled()))
 			{
 				RunningTest = "";

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Rectangle.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/When_Rectangle.cs
@@ -1,0 +1,60 @@
+﻿#if __IOS__ || __MACOS__ || __SKIA__
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Shapes
+{
+	[TestClass]
+	class When_Rectangle
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		[DataRow(Stretch.Fill, double.NaN, double.NaN, 0d, 0d, 50d, 50d, 0d, 0d)]
+		[DataRow(Stretch.Fill, double.NaN, double.NaN, 10d, 20d, 50d, 50d, 10d, 20d)]
+		[DataRow(Stretch.Fill, 30d, double.NaN, 10d, 20d, 50d, 50d, 30d, 20d)]
+		[DataRow(Stretch.Fill, double.NaN, 30d, 10d, 20d, 50d, 50d, 10d, 30d)]
+		[DataRow(Stretch.UniformToFill, double.NaN, double.NaN, 0d, 0d, double.PositiveInfinity, double.PositiveInfinity, 0d, 0d)]
+		[DataRow(Stretch.UniformToFill, double.NaN, double.NaN, 10d, 20d, double.PositiveInfinity, double.PositiveInfinity, 10d, 20d)]
+		public async Task When_RectangleMeasure(
+			Stretch stretch,
+			double width,
+			double height,
+			double minWidth,
+			double minHeight,
+			double availableWidth,
+			double availableHeight,
+			double expectedWidth,
+			double expectedHeight)
+		{
+			try
+			{
+				var SUT = new Rectangle();
+
+				TestServices.WindowHelper.WindowContent = SUT;
+				await TestServices.WindowHelper.WaitForIdle();
+
+				SUT.Width = width;
+				SUT.Height = height;
+				SUT.MinWidth = minWidth;
+				SUT.MinHeight = minHeight;
+				SUT.Stretch = stretch;
+				SUT.Measure(new Windows.Foundation.Size(availableWidth, availableHeight));
+
+				Assert.AreEqual(new Size(expectedWidth, expectedHeight), SUT.DesiredSize);
+			}
+			finally
+			{
+				TestServices.WindowHelper.WindowContent = null;
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/private/issues/163

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Slider, and other controls using shapes without constraints are displayed using their parent's given available size, where it should be zero.

## What is the new behavior?

The new measured size respects the original behavior.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
