### PR TITLE
fix(reg): missing auto-convert in Canvas properties

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/CanvasTests/Given_Canvas.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/CanvasTests/Given_Canvas.cs
@@ -62,5 +62,26 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.CanvasTests
 
 			Assert.AreEqual(2, CAV.GetChildren().Count());
 		}
+
+		[TestMethod]
+		public void When_CanvasPropertyConvert()
+		{
+			var SUT = new Canvas();
+
+			SUT.SetValue(Canvas.LeftProperty, "42");
+			Assert.AreEqual(42d, SUT.GetValue(Canvas.LeftProperty));
+
+			SUT.SetValue(Canvas.LeftProperty, 43);
+			Assert.AreEqual(43d, SUT.GetValue(Canvas.LeftProperty));
+
+			SUT.SetValue(Canvas.LeftProperty, 44f);
+			Assert.AreEqual(44d, SUT.GetValue(Canvas.LeftProperty));
+
+			SUT.SetValue(Canvas.TopProperty, "42");
+			Assert.AreEqual(42d, SUT.GetValue(Canvas.TopProperty));
+
+			SUT.SetValue(Canvas.ZIndexProperty, "42");
+			Assert.AreEqual(42d, SUT.GetValue(Canvas.ZIndexProperty));
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.cs
@@ -29,7 +29,7 @@ namespace Windows.UI.Xaml.Controls
 			=> SetLeftValue(obj, value);
 
 
-		[GeneratedDependencyProperty(DefaultValue = 0.0d, AttachedBackingFieldOwner = typeof(UIElement), Attached = true)]
+		[GeneratedDependencyProperty(DefaultValue = 0.0d, AttachedBackingFieldOwner = typeof(UIElement), Attached = true, Options = FrameworkPropertyMetadataOptions.AutoConvert)]
 		public static DependencyProperty LeftProperty { get ; } = CreateLeftProperty();
 
 		private static void OnLeftChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
@@ -54,7 +54,7 @@ namespace Windows.UI.Xaml.Controls
 		public static void SetTop(DependencyObject obj, double value)
 			=> SetTopValue(obj, value);
 
-		[GeneratedDependencyProperty(DefaultValue = 0.0d, AttachedBackingFieldOwner = typeof(UIElement), Attached = true)]
+		[GeneratedDependencyProperty(DefaultValue = 0.0d, AttachedBackingFieldOwner = typeof(UIElement), Attached = true, Options = FrameworkPropertyMetadataOptions.AutoConvert)]
 		public static DependencyProperty TopProperty { get ; } = CreateTopProperty();
 
 		private static void OnTopChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
@@ -79,7 +79,7 @@ namespace Windows.UI.Xaml.Controls
 		public static void SetZIndex(DependencyObject obj, double value)
 			=> SetZIndexValue(obj, value);
 
-		[GeneratedDependencyProperty(DefaultValue = 0.0d, AttachedBackingFieldOwner = typeof(UIElement), Attached = true)]
+		[GeneratedDependencyProperty(DefaultValue = 0.0d, AttachedBackingFieldOwner = typeof(UIElement), Attached = true, Options = FrameworkPropertyMetadataOptions.AutoConvert)]
 		public static DependencyProperty ZIndexProperty { get ; } = CreateZIndexProperty();
 
 		private static void OnZIndexChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes https://github.com/unoplatform/uno/issues/3622

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`Canvas.[Top|Left|ZIndex]` property auto convert incoming values to the `double`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
