### PR TITLE
fix(ios): TimePicker ClockIdentifier getting overwritten

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
@@ -78,7 +78,8 @@ namespace Windows.UI.Xaml.Controls
 				BorderThickness = Thickness.Empty,
 				HorizontalAlignment = HorizontalAlignment.Stretch,
 				HorizontalContentAlignment = HorizontalAlignment.Stretch,
-				Time = Time
+				Time = Time,
+				ClockIdentifier = ClockIdentifier,
 			};
 
 			Content = _timeSelector;


### PR DESCRIPTION
GitHub Issue (If applicable): #3541 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
`TimePicker.ClockIdentifier` is getting overwritten by os default once the flyout is shown.


## What is the new behavior?
`TimePicker.ClockIdentifier` doesnt get overwritten by os default once the flyout is shown.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
`TimePickerSelector.ClockIdentifier`'s default value is getting sync onto `TimePickerFlyout` because of the two-way binding.