### PR TITLE
feat(wasm): Added .GetHtmlAttribute() for an Element on Wasm.

### DIFF
--- a/doc/articles/interop/wasm-javascript-1.md
+++ b/doc/articles/interop/wasm-javascript-1.md
@@ -113,12 +113,15 @@ Here is a list of helper methods used to facilitate the integration with the HTM
   ``` csharp
   // Set the "href" attribute of an <a> element
   this.SetHtmlAttribute("href", "#section2");
-
+  
   // Set many attributes at once
   this.SetHtmlAttribute(("target", "_blank"), ("referrerpolicy", "no-referrer"));
-
+  
   // Remove attribute from DOM element
   this.ClearHtmlAttribute("href");
+  
+  // Get the value of an attribute of a DOM element
+  var href = this.GetHtmlAttribute("href");
   ```
 
 * The `element.SetCssClass()` and `element.UnsetCssClass()` extension methods can be used to add or remove CSS classes to the HTML Element:

--- a/src/Uno.UI.Runtime.WebAssembly/Xaml/UIElementWasmExtensions.cs
+++ b/src/Uno.UI.Runtime.WebAssembly/Xaml/UIElementWasmExtensions.cs
@@ -82,6 +82,14 @@ namespace Windows.UI.Xaml
 		}
 
 		/// <summary>
+		/// Get the HTML attribute value of an element
+		/// </summary>
+		public static string GetHtmlAttribute(this UIElement element, string name)
+		{
+			return WindowManagerInterop.GetAttribute(element.HtmlId, name);
+		}
+
+		/// <summary>
 		/// Clear/remove a HTML attribute from an element.
 		/// </summary>
 		public static void ClearHtmlAttribute(this UIElement element, string name)

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -661,7 +661,7 @@ namespace Uno.UI.Xaml
 		#region GetAttribute
 		internal static string GetAttribute(IntPtr htmlId, string name)
 		{
-			var command = "Uno.UI.WindowManager.current.setAttributes(\"" + htmlId + "\", \"" + name + "\");";
+			var command = "Uno.UI.WindowManager.current.getAttribute(\"" + htmlId + "\", \"" + name + "\");";
 
 			return WebAssemblyRuntime.InvokeJS(command);
 		}

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -658,6 +658,15 @@ namespace Uno.UI.Xaml
 
 		#endregion
 
+		#region GetAttribute
+		internal static string GetAttribute(IntPtr htmlId, string name)
+		{
+			var command = "Uno.UI.WindowManager.current.setAttributes(\"" + htmlId + "\", \"" + name + "\");";
+
+			return WebAssemblyRuntime.InvokeJS(command);
+		}
+		#endregion
+
 		#region ClearAttribute
 		internal static void RemoveAttribute(IntPtr htmlId, string name)
 		{


### PR DESCRIPTION
# Feature

Added the ability to do `.GetHtmlAttribute()` on an UIElement on Wasm. This feature has been lost in the recent changes to create new _uno runtimes_.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
