### PR TITLE
Split iOS Automated tests

### DIFF
--- a/build/ci/.azure-devops-ios-tests-run.yml
+++ b/build/ci/.azure-devops-ios-tests-run.yml
@@ -53,6 +53,7 @@ jobs:
       BUILD_ARTIFACTSTAGINGDIRECTORY: "$(build.artifactstagingdirectory)"
       UITEST_SNAPSHOTS_ONLY: "${{ parameters.UITEST_SNAPSHOTS_ONLY }}"
       UITEST_SNAPSHOTS_GROUP: "${{ parameters.UITEST_SNAPSHOTS_GROUP }}"
+      UITEST_AUTOMATED_GROUP: "${{ parameters.UITEST_AUTOMATED_GROUP }}"
       UNO_UITEST_IOSBUNDLE_PATH: "$(build.sourcesdirectory)/build/ios-uitest-build/SamplesApp.app"
 
   - task: PublishTestResults@2

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -57,11 +57,36 @@ jobs:
 - template: .azure-devops-ios-tests-run.yml
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
-    JobName: 'iOS_Automated_Tests'
-    JobDisplayName: 'iOS Automated Tests'
-    JobTimeoutInMinutes: 100
+    JobName: 'iOS_Automated_Tests_Group_01'
+    JobDisplayName: 'iOS Automated Tests Group 01'
+    JobTimeoutInMinutes: 30
     vmImage: ${{ parameters.vmImage }}
     UITEST_SNAPSHOTS_ONLY: false
+    UITEST_AUTOMATED_GROUP: 1
+    xCodeRoot: ${{ parameters.xCodeRoot }}
+    XamarinSDKVersion: ${{ parameters.XamarinSDKVersion }}
+
+- template: .azure-devops-ios-tests-run.yml
+  parameters:
+    nugetPackages: $(NUGET_PACKAGES)
+    JobName: 'iOS_Automated_Tests_Group_02'
+    JobDisplayName: 'iOS Automated Tests Group 02'
+    JobTimeoutInMinutes: 30
+    vmImage: ${{ parameters.vmImage }}
+    UITEST_SNAPSHOTS_ONLY: false
+    UITEST_AUTOMATED_GROUP: 2
+    xCodeRoot: ${{ parameters.xCodeRoot }}
+    XamarinSDKVersion: ${{ parameters.XamarinSDKVersion }}
+
+- template: .azure-devops-ios-tests-run.yml
+  parameters:
+    nugetPackages: $(NUGET_PACKAGES)
+    JobName: 'iOS_Automated_Tests_Group_03'
+    JobDisplayName: 'iOS Automated Tests Group 03'
+    JobTimeoutInMinutes: 30
+    vmImage: ${{ parameters.vmImage }}
+    UITEST_SNAPSHOTS_ONLY: false
+    UITEST_AUTOMATED_GROUP: 3
     xCodeRoot: ${{ parameters.xCodeRoot }}
     XamarinSDKVersion: ${{ parameters.XamarinSDKVersion }}
 

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -59,7 +59,7 @@ jobs:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Group_01'
     JobDisplayName: 'iOS Automated Tests Group 01'
-    JobTimeoutInMinutes: 30
+    JobTimeoutInMinutes: 40
     vmImage: ${{ parameters.vmImage }}
     UITEST_SNAPSHOTS_ONLY: false
     UITEST_AUTOMATED_GROUP: 1
@@ -71,7 +71,7 @@ jobs:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Group_02'
     JobDisplayName: 'iOS Automated Tests Group 02'
-    JobTimeoutInMinutes: 30
+    JobTimeoutInMinutes: 40
     vmImage: ${{ parameters.vmImage }}
     UITEST_SNAPSHOTS_ONLY: false
     UITEST_AUTOMATED_GROUP: 2
@@ -83,7 +83,7 @@ jobs:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Group_03'
     JobDisplayName: 'iOS Automated Tests Group 03'
-    JobTimeoutInMinutes: 30
+    JobTimeoutInMinutes: 40
     vmImage: ${{ parameters.vmImage }}
     UITEST_SNAPSHOTS_ONLY: false
     UITEST_AUTOMATED_GROUP: 3

--- a/build/ci/.azure-devops-screenshot-compare.yml
+++ b/build/ci/.azure-devops-screenshot-compare.yml
@@ -9,7 +9,9 @@ jobs:
     - Wasm_UITests_Automated
     - Android_Tests
     - Skia_UI_Tests
-    - iOS_Automated_Tests
+    - iOS_Automated_Tests_Group_01
+    - iOS_Automated_Tests_Group_02
+    - iOS_Automated_Tests_Group_03
     - iOS_Snaphot_Tests_Group_01
     - iOS_Snaphot_Tests_Group_02
     - iOS_Snaphot_Tests_Group_03

--- a/build/ci/templates/optimize-roslyn-mono.yml
+++ b/build/ci/templates/optimize-roslyn-mono.yml
@@ -7,4 +7,5 @@ steps:
       # clear local files that may have been created by nuget with invalid permissions
       sudo mono $(build.sourcesdirectory)/build/nuget/NuGet.exe locals all -clear
 
+    condition: eq(variables['enable_optimize_roslyn'], 'true')
     displayName: Optimize Roslyn Binaries

--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -29,27 +29,43 @@ then
 	"
 else
 	export SCREENSHOTS_FOLDERNAME=ios
-	export TEST_FILTERS=" \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests' or \
-		namespace = 'SamplesApp.UITests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Input.VisualState_Tests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media.Animation_Tests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ControlTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml.FocusManagerDirectionTests' or \
-		namespace = 'SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.PivotTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media_Animation' or \
-		namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests' or \
-		class = 'SamplesApp.UITests.Windows_UI_Xaml_Shapes.Basics_Shapes_Tests'
-	"
+
+	# Note for test authors, add tests in the last group, notify devops
+	# notify devops when the group gets too big.
+	# See https://github.com/unoplatform/uno/issues/1955 for additional details
+
+	if [ "$UITEST_AUTOMATED_GROUP" == '1' ];
+	then
+		export TEST_FILTERS=" \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests' or \
+			namespace = 'SamplesApp.UITests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Input.VisualState_Tests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests'
+		"
+	elif [ "$UITEST_AUTOMATED_GROUP" == '2' ];
+	then
+		export TEST_FILTERS=" \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media.Animation_Tests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ControlTests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml.FocusManagerDirectionTests' or \
+			namespace = 'SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests'
+		"
+	elif [ "$UITEST_AUTOMATED_GROUP" == '3' ];
+	then
+		export TEST_FILTERS=" \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.PivotTests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media_Animation' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests' or \
+			class = 'SamplesApp.UITests.Windows_UI_Xaml_Shapes.Basics_Shapes_Tests'
+		"
+	fi
 fi
 
 export UNO_UITEST_PLATFORM=iOS

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
@@ -382,6 +382,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 		[Test]
 		[AutoRetry]
+		[Timeout(3*60*1000)] // On iOS, this test is slow
 		public void ListView_SelectedItems()
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Controls.ListView.ListViewSelectedItems");


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Splits the iOS UI Tests in three groups to lower the execution time in case of UI test automation failure.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
