### PR TITLE
[Wasm] Fixed ElevatedView with constrained size

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.ElevatedView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.ElevatedView.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Toolkit
+{
+	[TestFixture]
+	partial class UnoSamples_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]
+		public void ElevatedView_Dimensions_Validation()
+		{
+			Run("UITests.Toolkit.ElevatedView_Dimensions");
+
+			_app.WaitForElement("elevatedViewText");
+
+			var elevatedView = _app.Marked("elevatedView");
+
+			using (new AssertionScope())
+			{
+				elevatedView.FirstResult().Rect.X.Should().Be(42f);
+				elevatedView.FirstResult().Rect.Y.Should().Be(98f);
+				elevatedView.FirstResult().Rect.Width.Should().Be(200f);
+				elevatedView.FirstResult().Rect.Height.Should().Be(160f);
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_Dimensions.xaml
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_Dimensions.xaml
@@ -1,0 +1,29 @@
+﻿<Page
+    x:Class="UITests.Toolkit.ElevatedView_Dimensions"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:toolkit="using:Uno.UI.Toolkit"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	      Padding="32,38">
+
+		<toolkit:ElevatedView Background="Gray"
+		                      ShadowColor="Black"
+		                      Height="160"
+		                      Width="200"
+		                      Elevation="8"
+		                      HorizontalAlignment="Left"
+		                      VerticalAlignment="Top"
+		                      x:Name="elevatedView">
+
+			<TextBlock Text="Hello, world!"
+			           Margin="20"
+					   x:Name="elevatedViewText"
+			           FontSize="30" />
+		</toolkit:ElevatedView>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_Dimensions.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_Dimensions.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Toolkit
+{
+	[Sample]
+	public sealed partial class ElevatedView_Dimensions : Page
+	{
+		public ElevatedView_Dimensions()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -57,6 +57,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_Dimensions.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Toolkit\Elevation.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3395,6 +3399,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedViewTests.xaml.cs">
       <DependentUpon>ElevatedViewTests.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_Dimensions.xaml.cs">
+      <DependentUpon>ElevatedView_Dimensions.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\Elevation.xaml.cs">
       <DependentUpon>Elevation.xaml</DependentUpon>

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -178,7 +178,7 @@ namespace Uno.UI.Toolkit
 
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => false;
 
-		protected override Size ArrangeOverride(Size finalSize)
+		protected override Windows.Foundation.Size ArrangeOverride(Windows.Foundation.Size finalSize)
 		{
 			return base.ArrangeOverride(this.ApplySizeConstraints(finalSize));
 		}

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -177,6 +177,11 @@ namespace Uno.UI.Toolkit
 		bool ICustomClippingElement.AllowClippingToLayoutSlot => false; // Never clip, since it will remove the shadow
 
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => false;
+
+		protected override Size ArrangeOverride(Size finalSize)
+		{
+			return base.ArrangeOverride(this.ApplySizeConstraints(finalSize));
+		}
 #endif
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/3564

# Bugfix

## What is the current behavior?
`<ElevatedView>` constrained size were not applied properly.

## What is the new behavior?
Size constains is not applied on the `.Arrange()` phage.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
