### PR TITLE
[Wasm] Slightly improved ImageBrush image positionning on Wasm.

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_WriteableBitmap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_WriteableBitmap.xaml.cs
@@ -18,7 +18,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Windows_UI_Xaml_Media.ImageBrushTests
 {
-	[Sample(typeof(ImageBrush), typeof(WriteableBitmap), IgnoreInSnapshotTests = true)]
+	[Sample("ImageBrushTests", nameof(WriteableBitmap), IgnoreInSnapshotTests = true)]
 	public sealed partial class ImageBrush_WriteableBitmap : Page
 	{
 		public ImageBrush_WriteableBitmap()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_WriteableBitmap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_WriteableBitmap.xaml.cs
@@ -18,7 +18,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Windows_UI_Xaml_Media.ImageBrushTests
 {
-	[Sample("ImageBrushTests", nameof(WriteableBitmap), IgnoreInSnapshotTests = true)]
+	[Sample("ImageBrushTestControl", "WriteableBitmap", IgnoreInSnapshotTests = true)]
 	public sealed partial class ImageBrush_WriteableBitmap : Page
 	{
 		public ImageBrush_WriteableBitmap()

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
@@ -136,15 +136,19 @@ namespace Windows.UI.Xaml
 					{
 						case ImageDataKind.Empty:
 						case ImageDataKind.Error:
-							ResetStyle("background-color");
-							ResetStyle("background-image");
+							ResetStyle("background-color", "background-image", "background-size");
 							break;
 
 						case ImageDataKind.Base64:
 						case ImageDataKind.Url:
 						default:
-							ResetStyle("background-color");
-							SetStyle("background-image", "url(" + img.Value + ")");
+							SetStyle(
+								("background-color", ""),
+								("background-origin", "content-box"),
+								("background-position", imgBrush.ToCssPosition()),
+								("background-size", imgBrush.ToCssBackgroundSize()),
+								("background-image", "url(" + img.Value + ")")
+							);
 							break;
 					}
 				});
@@ -171,8 +175,7 @@ namespace Windows.UI.Xaml
 					RecalculateBrushOnSizeChanged(true);
 					break;
 				default:
-					ResetStyle("background-color");
-					ResetStyle("background-image");
+					ResetStyle("background-color", "background-image", "background-size");
 					RecalculateBrushOnSizeChanged(false);
 					break;
 			}

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.wasm.cs
@@ -1,0 +1,39 @@
+﻿using Windows.Foundation;
+
+namespace Windows.UI.Xaml.Media
+{
+	partial class ImageBrush
+	{
+		internal string ToCssPosition()
+		{
+			var x = AlignmentX switch
+			{
+				AlignmentX.Left => "left",
+				AlignmentX.Center => "center",
+				AlignmentX.Right => "right",
+				_ => ""
+			};
+
+			var y = AlignmentY switch
+			{
+				AlignmentY.Top=> "top",
+				AlignmentY.Center => "center",
+				AlignmentY.Bottom => "bottom",
+				_ => ""
+			};
+
+			return $"{x} {y}";
+		}
+		internal string ToCssBackgroundSize()
+		{
+			return Stretch switch
+			{
+				Stretch.Fill => "100% 100%",
+				Stretch.None => "auto",
+				Stretch.Uniform => "auto", // patch for now
+				Stretch.UniformToFill => "auto", // patch for now
+				_ => "auto"
+			};
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
@@ -24,11 +24,11 @@ namespace Windows.UI.Xaml.Media
 	[TypeConverter(typeof(ImageSourceConverter))]
 	public partial class ImageSource : DependencyObject, IDisposable
 	{
-		private readonly static IEventProvider _trace = Tracing.Get(TraceProvider.Id);
+		private static readonly IEventProvider _trace = Tracing.Get(TraceProvider.Id);
 
 		public static class TraceProvider
 		{
-			public readonly static Guid Id = Guid.Parse("{FC4E2720-2DCF-418C-B360-93314AB3B813}");
+			public static readonly Guid Id = Guid.Parse("{FC4E2720-2DCF-418C-B360-93314AB3B813}");
 
 			public const int ImageSource_SetImageDecodeStart = 1;
 			public const int ImageSource_SetImageDecodeStop = 2;
@@ -63,14 +63,12 @@ namespace Windows.UI.Xaml.Media
 
 		protected ImageSource(string url) : this()
 		{
-			Uri uri;
-
 			if (url.StartsWith("/"))
 			{
 				url = MsAppXScheme + "://" + url;
 			}
 
-			if (url.HasValueTrimmed() && Uri.TryCreate(url.Trim(), UriKind.RelativeOrAbsolute, out uri))
+			if (url.HasValueTrimmed() && Uri.TryCreate(url.Trim(), UriKind.RelativeOrAbsolute, out var uri))
 			{
 				InitFromUri(uri);
 			}


### PR DESCRIPTION
Fixes https://github.com/unoplatform/private/issues/168

# Feature
Better support for `<ImageBrush />` on Wasm. Not 100% accurate with UWP/WinUI, but the stretch will behave.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
