### PR TITLE
Documentation: sub navigation position in main.scss amended

### DIFF
--- a/doc/templates/uno/styles/scss/main.scss
+++ b/doc/templates/uno/styles/scss/main.scss
@@ -178,7 +178,7 @@ h3 {
 
 .subnav {
     position: fixed;
-    top: 75px;
+    top: 57px;
     width: 100%;
     z-index: 999;
 }


### PR DESCRIPTION
In the previous version of the documentation there was a position typo causing the sub navigation bar to be too low, so the scrolling content peeked above through the navigation header.

In this commit, I corrected that typo (`75px`) by the correct value (`57px`).

## PR Type

### What kind of change does this PR introduce?

- Documentation style bug fix

## What is the current behavior?
The sub navigation bar is positioned too low, so the scrolling content peeks through above the sub navigation bar:

![Documentation styling error](https://user-images.githubusercontent.com/9283914/89565988-a7431a80-d81f-11ea-9eab-09e82249ae1a.gif)

## What is the new behavior?

I fixed the typo, so the sub navigation bar position matches the top navigation bar height:

![Documentation styling fix](https://user-images.githubusercontent.com/9283914/89566381-6697d100-d820-11ea-8812-0eeec90fadd5.gif)