### PR TITLE
chore: Use fallback on Acrylic on non-WASM targets

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/AcrylicBrush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/AcrylicBrush.cs
@@ -114,7 +114,16 @@ namespace Windows.UI.Xaml.Media
 				nameof(AlwaysUseFallback),
 				typeof(bool),
 				typeof(AcrylicBrush),
-				new FrameworkPropertyMetadata(default(bool)));
+				new FrameworkPropertyMetadata(
+					// Due to the fact that additional subviews are added to acrylic owner views
+					// on non-WASM platforms, we default to using fallback where not completely safe
+					// When this is explicitly set to false, Acrylic will be displayed
+#if __WASM__
+					false
+#else
+					true
+#endif
+					));
 
 		/// <summary>
 		/// Returns the tint color mixed with tint opacity value.


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Acrylic is by default applied.


## What is the new behavior?

Acrylic is by default not applied.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
