### PR TITLE
Fixed bugs in AutoSuggestBox when using TextMemberPath

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/BasicAutoSuggestBox.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/BasicAutoSuggestBox.xaml
@@ -12,12 +12,19 @@
 		<StackPanel>
 			<AutoSuggestBox x:Name="box1"
 							HorizontalAlignment="Left"
+							TextMemberPath="SuggestionText"
 							TextChanged="AutoSuggestBox_TextChanged"
 							SuggestionChosen="AutoSuggestBox_SuggestionChosen"
 							QuerySubmitted="AutoSuggestBox_QuerySubmitted"
 							Width="300"
 							
-							AutomationProperties.Name="Basic AutoSuggestBox" />
+							AutomationProperties.Name="Basic AutoSuggestBox">
+				<AutoSuggestBox.ItemTemplate>
+					<DataTemplate>
+						<TextBlock Text="{Binding SuggestionText}" />
+					</DataTemplate>
+				</AutoSuggestBox.ItemTemplate>
+			</AutoSuggestBox>
 			<TextBlock x:Name="IWantToSeeStuffUnderTheSuggestions" xml:space="preserve">
 				
 				

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/BasicAutoSuggestBox.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/BasicAutoSuggestBox.xaml.cs
@@ -22,7 +22,14 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.AutoSuggestBoxTests
 	[SampleControlInfo("AutoSuggestBox", nameof(BasicAutoSuggestBox))]
 	public sealed partial class BasicAutoSuggestBox : UserControl
 	{
-		private ObservableCollection<string> _suggestions = new ObservableCollection<string>();
+		public class Suggestion
+		{
+			public string SuggestionText { get; }
+
+			public Suggestion(string t) { SuggestionText = t; }
+		}
+
+		private ObservableCollection<Suggestion> _suggestions = new ObservableCollection<Suggestion>();
 		int suggests = 0;
 		int querys = 0;
 		int textChangeds = 0;
@@ -51,8 +58,8 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.AutoSuggestBoxTests
 						_suggestions.Clear();
 					}
 
-					_suggestions.Add(sender.Text + "1");
-					_suggestions.Add(sender.Text + "2");
+					_suggestions.Add(new Suggestion(sender.Text + "1"));
+					_suggestions.Add(new Suggestion(sender.Text + "2"));
 					box1.ItemsSource = _suggestions;
 					break;
 				case AutoSuggestionBoxTextChangeReason.ProgrammaticChange:

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBoxTextChangedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBoxTextChangedEventArgs.cs
@@ -13,13 +13,6 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs.AutoSuggestBoxTextChangedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs.Reason.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs.Reason.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  bool CheckCurrent()
-		{
-			throw new global::System.NotImplementedException("The member bool AutoSuggestBoxTextChangedEventArgs.CheckCurrent() is not implemented in Uno.");
-		}
-		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs.ReasonProperty.get
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxTextChangedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxTextChangedEventArgs.cs
@@ -4,10 +4,13 @@ namespace Windows.UI.Xaml.Controls
 {
 	public  partial class AutoSuggestBoxTextChangedEventArgs : global::Windows.UI.Xaml.DependencyObject
 	{
+		private AutoSuggestBox _owner;
+		private string _originalText;
+
 		public AutoSuggestionBoxTextChangeReason Reason
 		{
 			get => (AutoSuggestionBoxTextChangeReason)this.GetValue(ReasonProperty);
-			set => this.SetValue(ReasonProperty, value);
+			set => SetValue(ReasonProperty, value);
 		}
 
 		public static global::Windows.UI.Xaml.DependencyProperty ReasonProperty { get; } = 
@@ -16,8 +19,20 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs), 
 			new FrameworkPropertyMetadata(default(AutoSuggestionBoxTextChangeReason)));
 
+		internal AutoSuggestBox Owner
+		{
+			get => _owner;
+			set
+			{
+				_owner = value;
+				_originalText = _owner.Text;
+			}
+		}
+
 		public AutoSuggestBoxTextChangedEventArgs() : base()
 		{
 		}
+
+		public bool CheckCurrent() => string.Equals(_originalText, _owner.Text);
 	}
 }


### PR DESCRIPTION
# Bugfix

## What is the current behavior?
* Using `TextMemberPath` were causing internal exceptions in the `<AutoSuggestBox>`
* The `.CheckCurrent()` method on `AutoSuggestBoxTextChangedEventArgs` were not implemented.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
