### PR TITLE
fix: Some controls might be recycled on creation

### DIFF
--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -63,7 +63,8 @@ else
 			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests' or \
 			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Media_Animation' or \
 			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests' or \
-			class = 'SamplesApp.UITests.Windows_UI_Xaml_Shapes.Basics_Shapes_Tests'
+			class = 'SamplesApp.UITests.Windows_UI_Xaml_Shapes.Basics_Shapes_Tests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests'
 		"
 	fi
 fi

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollBarTests/UnoSamples_Tests.ScrollBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollBarTests/UnoSamples_Tests.ScrollBar.cs
@@ -12,7 +12,7 @@ using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
-namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollBarTests
 {
 	[TestFixture]
 	public class UnoSamplesTests_ScrollBar : SampleControlUITestBase

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.Automated.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
+{
+	[TestFixture]
+	public class Hosted_ScrollViewer : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void When_Content_NotTemplateBound()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests.Hosted_ScrollViewer");
+
+			var result = _app.Marked("SUT_1").GetDependencyPropertyValue("Content");
+
+			Assert.AreEqual("OuterContentPresenter Tag", result);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void When_Content_TemplateBound()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests.Hosted_ScrollViewer");
+
+			var result = _app.Marked("SUT_2").GetDependencyPropertyValue("Content");
+
+			Assert.AreEqual("OuterContentPresenter Tag", result);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.xaml
@@ -10,13 +10,53 @@
     d:DesignWidth="400">
 
 	<StackPanel>
-		<TextBlock Text="Should show [OuterContentPresenter Tag]" />
+		<TextBlock Text="Should show [OuterContentPresenter Tag] 2 times" />
+
+		<ContentControl Tag="OuterContentPresenter Tag" Margin="0,20">
+			<ContentControl.Template>
+				<ControlTemplate TargetType="ContentControl">
+					<Border>
+						<ScrollViewer Tag="ScrollViewer Tag">
+							<ScrollViewer.Template>
+								<ControlTemplate TargetType="ScrollViewer">
+									<Border
+										BorderBrush="{TemplateBinding BorderBrush}"
+										BorderThickness="{TemplateBinding BorderThickness}"
+										CornerRadius="{TemplateBinding CornerRadius}"
+										Background="{TemplateBinding Background}">
+										<ScrollContentPresenter
+											x:Name="ScrollContentPresenter"
+											Margin="{TemplateBinding Padding}" />
+									</Border>
+								</ControlTemplate>
+							</ScrollViewer.Template>
+							<ContentPresenter Content="{TemplateBinding Tag}" x:Name="SUT_1" />
+						</ScrollViewer>
+					</Border>
+				</ControlTemplate>
+			</ContentControl.Template>
+		</ContentControl>
+
 		<ContentControl Tag="OuterContentPresenter Tag">
 			<ContentControl.Template>
 				<ControlTemplate TargetType="ContentControl">
 					<Border>
 						<ScrollViewer Tag="ScrollViewer Tag">
-							<ContentPresenter Content="{TemplateBinding Tag}" />
+							<ScrollViewer.Template>
+								<ControlTemplate TargetType="ScrollViewer">
+									<Border
+										BorderBrush="{TemplateBinding BorderBrush}"
+										BorderThickness="{TemplateBinding BorderThickness}"
+										CornerRadius="{TemplateBinding CornerRadius}"
+										Background="{TemplateBinding Background}">
+										<ScrollContentPresenter
+											x:Name="ScrollContentPresenter"
+											Margin="{TemplateBinding Padding}"
+											Content="{TemplateBinding Content}" />
+									</Border>
+								</ControlTemplate>
+							</ScrollViewer.Template>
+							<ContentPresenter Content="{TemplateBinding Tag}" x:Name="SUT_2" />
 						</ScrollViewer>
 					</Border>
 				</ControlTemplate>

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -827,15 +827,6 @@ namespace Windows.UI.Xaml.Controls
 
 		private void ApplyScrollContentPresenterContent()
 		{
-			// Stop the automatic propagation of the templated parent on the Content
-			// This prevents issues when the a ScrollViewer is hosted in a control template
-			// and its content is a ContentControl or ContentPresenter, which has a TemplateBinding
-			// on the Content property. This can make the Content added twice in the visual tree.
-			if (Content is IDependencyObjectStoreProvider provider)
-			{
-				provider.Store.SetValue(provider.Store.TemplatedParentProperty, null, DependencyPropertyValuePrecedences.Local);
-			}
-
 			// Then explicitly propagate the Content to the _presenter
 			_presenter.Content = Content as View;
 


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/3704
fixes https://github.com/unoplatform/private/issues/167

## Bugfix
This commit removes a fix (https://github.com/unoplatform/uno/commit/fe83e99a  - https://github.com/unoplatform/uno/pull/607) that was made to avoid adding the same element twice in the visual tree.
We tried to run the sample that was made to validte this fix, and apprently it is no longer relevant.

## What is the current behavior?
When we set the `Content` of a `ScrollViewer` we make sure to **not** propagate the `TemplatedParent` (so it can have its own `TemplatedParent`). This results to reset the `Parent` property to `null` which causes the view to be recycled under certain circumstances.

But some controls like the `CheckBox` are self-cleaning themselves on recyling (for the `CheckBox` for instance they restore the `IsChecked` property to it default value, i.e. `false`)

The issue is that this property might have been set in the template itself.

## What is the new behavior?
We no longer reset the `TemplatedParent` as it seems to be properly inherited now.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This might be only a quick fix for problem: we should probably have a precedence for the values set in the XAML/template instead of arbitrarily restore the value to `false` on recycle: https://github.com/unoplatform/uno/issues/3739