### PR TITLE
fix(splitView): SplitViewStyle

### DIFF
--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -2418,6 +2418,9 @@
 									</Storyboard>
 								</VisualState>
 								<VisualState x:Name="ClosedCompactLeft">
+									<VisualState.Setters>
+										<Setter Target="PaneTransform.TranslateX" Value="0" />
+									</VisualState.Setters>
 									<Storyboard>
 										<xamarin:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
 																			   Storyboard.TargetName="PaneRoot">
@@ -2542,7 +2545,15 @@
 									</Storyboard>
 								</VisualState>
 								<VisualState x:Name="OpenInlineLeft">
+									<VisualState.Setters>
+										<Setter Target="PaneTransform.TranslateX" Value="0" />
+									</VisualState.Setters>
 									<Storyboard>
+										<xamarin:ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Clip"
+																			   Storyboard.TargetName="PaneRoot">
+											<DiscreteObjectKeyFrame KeyTime="0:0:0"
+																	Value="{x:Null}" />
+										</xamarin:ObjectAnimationUsingKeyFrames>
 										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot"
 																	   Storyboard.TargetProperty="(Grid.Column)">
 											<DiscreteObjectKeyFrame KeyTime="0:0:0"


### PR DESCRIPTION
## Bugfix
The default style of the `SplitView` result in invalid states when switching between Compact and Normal mode 

## What is the current behavior?
If you 
1. Launch app with `NavigationView`
1. Resize window to minimum width
1. Close the `NavigationView`
1. Maximize the window
1. Open the `NavigationView`
1. Notice that the `NavigationView` is blank

OR
1. Launch app
1. Close the `NavigationView`
1. Resize window to minimum width
1. Maximize the window
1. Notice that the compact `NavigationView` is blank

## What is the new behavior?
It works ... at least when displayed on left.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This is only a temporary fix. The real fix is to fully support the WinUI `SPlitView` style: https://github.com/unoplatform/uno/issues/3747

Internal Issue: https://nventive.visualstudio.com/_workitems/edit/190689
