### PR TITLE
fix(pointers): Fix possible null ref on FF when defering leave

### DIFF
--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -356,6 +356,7 @@ declare namespace Uno.UI {
         registerEventOnViewNative(pParams: number): boolean;
         registerPointerEventsOnView(pParams: number): void;
         static onPointerEventReceived(evt: PointerEvent): void;
+        static dispatchPointerEvent(element: HTMLElement | SVGElement, evt: PointerEvent): void;
         static onPointerEnterReceived(evt: PointerEvent): void;
         static onPointerLeaveReceived(evt: PointerEvent): void;
         private processPendingLeaveEvent;


### PR DESCRIPTION
## Bugfix
Possible null ref when dispatching **deferred** pointer leave on FF

## What is the current behavior?
We defer the dispatch of the pointer leave on FF under certain circumstances, but we relly on the `evt.currentTarget` which is available only while in the pointer handler.

## What is the new behavior?
We manually keep a reference on the `currentTarget` and make sure to dispatch to it.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

