### PR TITLE
fix(transform): [MacOS] Fix transform not applied

### DIFF
--- a/src/Uno.UI/Media/NativeRenderTransformAdapter.iOSmacOS.cs
+++ b/src/Uno.UI/Media/NativeRenderTransformAdapter.iOSmacOS.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Numerics;
 using System.Text;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media.Animation;
 using CoreAnimation;
 using CoreGraphics;
@@ -11,25 +13,66 @@ namespace Uno.UI.Media
 {
 	partial class NativeRenderTransformAdapter
 	{
+		private CATransform3D _transform = CATransform3D.Identity;
+		private bool _wasAnimating = false;
+
 		partial void Initialized()
 		{
 			// On íOS and MacOS Transform are applied by default on the center on the view
 			// so make sure to reset it when the transform is attached to the view
 			InitializeOrigin();
 
+#if __MACOS__
+			// On MAC OS, if we set the Transform before the NSView has been rendered at least once,
+			// it will be definitively ignored (even if updated).
+			// So here we hide the control (using Layer.Opacity to avoid not alter the Element itself),
+			// and wait for the control to be loaded to set the transform and restore the visibility.
+			if (Owner is FrameworkElement element && !element.IsLoaded)
+			{
+				_isDeferring = true;
+				element.Loaded += DeferredInitialize;
+				element.Layer.Opacity = 0;
+
+				return;
+			}
+#endif
+
 			// Apply the transform as soon as its been declared
 			Update();
 		}
 
-		private CATransform3D _transform = CATransform3D.Identity;
-		private bool _wasAnimating = false;
+#if __MACOS__
+		private bool _isDeferring;
+
+		private static void DeferredInitialize(object sender, RoutedEventArgs e)
+		{
+			var fwElt = (FrameworkElement)sender;
+			var adapter = fwElt._renderTransform;
+
+			fwElt.Loaded -= DeferredInitialize;
+			fwElt.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+			{
+				// Note: Deferring to the loaded is not enough ... we must wait for the next dispatcher loop to set the Transform!
+				adapter._isDeferring = false;
+				adapter.Update(isOriginChanged: true);
+				adapter.Update();
+				fwElt.Layer.Opacity = 1;
+			});
+		}
 
 		partial void Apply(bool isSizeChanged, bool isOriginChanged)
 		{
+			if (_isDeferring)
+			{
+				return;
+			}
+#else
+		partial void Apply(bool isSizeChanged, bool isOriginChanged)
+		{
+#endif
 			if (Transform.IsAnimating)
 			{
 				// While animating the transform, we let the Animator apply the transform by itself, so do not update the Transform
-#if __IOS__ || __MACOS__
 				if (!_wasAnimating)
 				{
 					// At the beginning of the animation make sure we disable all properties of the transform
@@ -40,9 +83,6 @@ namespace Uno.UI.Media
 				}
 
 				return;
-#else
-				throw new InvalidOperationException("Should not be 'IsAnimating' on this platform");
-#endif
 			}
 			else if (_wasAnimating)
 			{


### PR DESCRIPTION
## BugFix
The `RenderTransform` is not applied on macOS views when they are set before rendering the elment.

## What is the current behavior?
When a `RenderTransform` is set on a `NSView` it's synchronously set on the `NSView.Layer.Transform`. But this cause a bug on Mac OS and the transform is never applied to the view.

## What is the new behavior?
We wait for the next dispatcher loop after the control has been loaded to set the `NSView.Layer.Transform`.

Note: We hide the control while deferring in order to avoid flickers.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Internal Issue: https://nventive.visualstudio.com/_workitems/edit/191447
