### PR TITLE
fix(reg): [iOS] Fix possible cyclic visual tree

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -827,6 +827,21 @@ namespace Windows.UI.Xaml.Controls
 
 		private void ApplyScrollContentPresenterContent()
 		{
+			// Stop the automatic propagation of the templated parent on the Content
+			// This prevents issues when the a ScrollViewer is hosted in a control template
+			// and its content is a ContentControl or ContentPresenter, which has a TemplateBinding
+			// on the Content property. This can make the Content added twice in the visual tree.
+			// cf. https://github.com/unoplatform/uno/issues/3762
+			if (Content is IDependencyObjectStoreProvider provider)
+			{
+				var contentTemplatedParent = provider.Store.GetValue(provider.Store.TemplatedParentProperty);
+				if (contentTemplatedParent == null || contentTemplatedParent != TemplatedParent)
+				{
+					// Note: Even if the TemplatedParent is already null, we make sure to set it with the local precedence
+					provider.Store.SetValue(provider.Store.TemplatedParentProperty, null, DependencyPropertyValuePrecedences.Local);
+				}
+			}
+			
 			// Then explicitly propagate the Content to the _presenter
 			_presenter.Content = Content as View;
 


### PR DESCRIPTION
## Bug fix
Fix regression introduced by https://github.com/unoplatform/uno/pull/3738

## What is the current behavior?
When starting the Gallery project at commit 932e368, the app is stuck on the splashscreen on iOS

## What is the new behavior?


## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This is only a temporary fix to unblock project, but we should investigate to properly understand the root cause https://github.com/unoplatform/uno/issues/3762