### PR TITLE
fix(navView): Back button visiblity not updated properly

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -2795,7 +2795,18 @@ namespace Windows.UI.Xaml.Controls
 					}
 				}
 			}
+
 			SetPaneToggleButtonAutomationName();
+
+			// ***************************** Uno only - begin
+			// When the OnSplitViewClosedCompactChanged callback is invoked (registered on SplitView.IsPaneOpen),
+			// the two-way binding between SplitView.IsOpen and NavView.IsPaneOpen has not been updated yet,
+			// the the local NavView.IsPaneOpen is still == true. (cf. https://github.com/unoplatform/uno/issues/3774)
+			// (Yeah ... there is 2 code path to track the IsPaneOpen of the SplitView: callback and 2-way binding :/)
+			// So we make sure to request an update of the back button visibility also when the local IsPaneOpen is being updated.
+			UpdateBackButtonVisibility();
+			// ***************************** Uno only - end
+
 			UpdatePaneTabFocusNavigation();
 			UpdateSettingsItemToolTip();
 		}


### PR DESCRIPTION
GitHub Issue https://github.com/unoplatform/uno/issues/3774

## Workaround
The back button of the `NavigationView` stays hidden when the menu is light dismissed

## What is the current behavior?
Using the `NavigationView`, when you navigate to a page the back button appears.
If you open the menu, then **light dismiss** it (clicking the burger menu button again does not reproduce the issue), then the back button stays hidden.

![ch9-navback](https://user-images.githubusercontent.com/8635919/89812121-a1925100-db0d-11ea-8e78-e440340be3fd.gif)

This is because when the OnSplitViewClosedCompactChanged callback is invoked (registered on SplitView.IsPaneOpen), the two-way binding between SplitView.IsOpen and NavView.IsPaneOpen has not been updated yet, the the local NavView.IsPaneOpen is still == true.

## What is the new behavior?
The button is re-updated when the local `IsPaneOpen` is updated by the 2-way binding.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This is only a workaround to hide the real bug https://github.com/unoplatform/uno/issues/3774