### PR TITLE
Prism template update

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Droid/BlankApp.Droid.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Droid/BlankApp.Droid.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -17,7 +17,7 @@
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\BlankApp.Shared\Strings</ResourcesDirectory>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Droid/BlankApp.Droid.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Droid/BlankApp.Droid.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -66,13 +66,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
 
-		<!--#if (Container == "Unity") -->
-		<PackageReference Include="Prism.Unity.Uno" Version="8.0.0.1717-ci" />
-		<!--#endif -->
-		<!--#if (Container == "DryIoc") -->
-		<PackageReference Include="Prism.DryIoc.Uno" Version="8.0.0.1717-ci" />
-		<!--#endif -->
-	</ItemGroup>
+    <!--#if (Container == "Unity") -->
+    <PackageReference Include="Prism.Unity.Uno" Version="8.0.0.1740-pre" />
+    <!--#endif -->
+    <!--#if (Container == "DryIoc") -->
+    <PackageReference Include="Prism.DryIoc.Uno" Version="8.0.0.1740-pre" />
+    <!--#endif -->
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Droid/Properties/AndroidManifest.xml
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="BlankApp" android:versionCode="1" android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="26" />
+  <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="29" />
   <application android:label="BlankApp"></application>
 </manifest>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Shared/App.xaml
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Shared/App.xaml
@@ -8,7 +8,6 @@
 
 </prismIoc:PrismApplication>
 <!--#endif -->
-
 <!--#if (Container == "DryIoc") -->
 <prismIoc:PrismApplication
     x:Class="BlankApp.App"

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.UWP/BlankApp.Uwp.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.UWP/BlankApp.Uwp.csproj
@@ -3,24 +3,24 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <!-- 
-			If, in the same solution, you are referencing a project that uses https://github.com/onovotny/MSBuildSdkExtras,
-			you need to make sure that the version provided here matches https://github.com/onovotny/MSBuildSdkExtras/blob/master/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets#L11.
-			This is not an issue when libraries are referenced through nuget packages. See https://github.com/unoplatform/uno/issues/446 for more details.
-			-->
+      <!--
+      If, in the same solution, you are referencing a project that uses https://github.com/onovotny/MSBuildSdkExtras,
+      you need to make sure that the version provided here matches https://github.com/onovotny/MSBuildSdkExtras/blob/master/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets#L11.
+      This is not an issue when libraries are referenced through nuget packages. See https://github.com/unoplatform/uno/issues/446 for more details.
+      -->
       <Version>6.2.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-		<PackageReference Include="Uno.Core" Version="2.0.0" />
+    <PackageReference Include="Uno.Core" Version="2.0.0" />
 
-		<!--#if (Container == "Unity") -->
-		<PackageReference Include="Prism.Unity.Uno" Version="8.0.0.1717-ci" />
-		<!--#endif -->
-		<!--#if (Container == "DryIoc") -->
-		<PackageReference Include="Prism.DryIoc.Uno" Version="8.0.0.1717-ci" />
-		<!--#endif -->
-	</ItemGroup>
+    <!--#if (Container == "Unity") -->
+    <PackageReference Include="Prism.Unity.Uno" Version="8.0.0.1740-pre" />
+    <!--#endif -->
+    <!--#if (Container == "DryIoc") -->
+    <PackageReference Include="Prism.DryIoc.Uno" Version="8.0.0.1740-pre" />
+    <!--#endif -->
+  </ItemGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -157,7 +157,7 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Wasm/BlankApp.Wasm.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Wasm/BlankApp.Wasm.csproj
@@ -40,13 +40,13 @@
     <PackageReference Include="Uno.UI.RemoteControl" Version="2.2.0" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.3.0" />
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.3.0" />
-    <PackageReference Include="Prism.Core" Version="8.0.0.1717-ci" />
+    <PackageReference Include="Prism.Core" Version="8.0.0.1740-pre" />
 
 		<!--#if (Container == "Unity") -->
-    <PackageReference Include="Prism.Unity.Uno" Version="8.0.0.1717-ci" />
+    <PackageReference Include="Prism.Unity.Uno" Version="8.0.0.1740-pre" />
 		<!--#endif -->
 		<!--#if (Container == "DryIoc") -->
-		<PackageReference Include="Prism.DryIoc.Uno" Version="8.0.0.1717-ci" />
+		<PackageReference Include="Prism.DryIoc.Uno" Version="8.0.0.1740-pre" />
 		<!--#endif -->
 	</ItemGroup>
   <Import Project="..\BlankApp.Shared\BlankApp.Shared.projitems" Label="Shared" Condition="Exists('..\BlankApp.Shared\BlankApp.Shared.projitems')" />

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.iOS/BlankApp.iOS.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.iOS/BlankApp.iOS.csproj
@@ -120,13 +120,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
 
-		<!--#if (Container == "Unity") -->
-		<PackageReference Include="Prism.Unity.Uno" Version="8.0.0.1717-ci" />
-		<!--#endif -->
-		<!--#if (Container == "DryIoc") -->
-		<PackageReference Include="Prism.DryIoc.Uno" Version="8.0.0.1717-ci" />
-		<!--#endif -->
-	</ItemGroup>
+    <!--#if (Container == "Unity") -->
+    <PackageReference Include="Prism.Unity.Uno" Version="8.0.0.1740-pre" />
+    <!--#endif -->
+    <!--#if (Container == "DryIoc") -->
+    <PackageReference Include="Prism.DryIoc.Uno" Version="8.0.0.1740-pre" />
+    <!--#endif -->
+  </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Media.xcassets\AppIcons.appiconset\Contents.json">
       <Visible>false</Visible>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.macOS/BlankApp.macOS.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.macOS/BlankApp.macOS.csproj
@@ -68,20 +68,20 @@
     <Reference Include="System.Memory" />
   </ItemGroup>
   <ItemGroup>
-		<PackageReference Include="Uno.UI" Version="2.2.0" />
-		<PackageReference Include="Uno.UI.RemoteControl" Version="2.2.0" Condition="'$(Configuration)'=='Debug'" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
+    <PackageReference Include="Uno.UI" Version="2.2.0" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="2.2.0" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
 
-		<!--#if (Container == "Unity") -->
-		<PackageReference Include="Prism.Unity.Uno" Version="8.0.0.1717-ci" />
-		<!--#endif -->
-		<!--#if (Container == "DryIoc") -->
-		<PackageReference Include="Prism.DryIoc.Uno" Version="8.0.0.1717-ci" />
-		<!--#endif -->
-	</ItemGroup>
-	<Import Project="..\BlankApp.Shared\BlankApp.Shared.projitems" Label="Shared" Condition="Exists('..\BlankApp.Shared\BlankApp.Shared.projitems')" />
-	<ItemGroup>
+    <!--#if (Container == "Unity") -->
+    <PackageReference Include="Prism.Unity.Uno" Version="8.0.0.1740-pre" />
+    <!--#endif -->
+    <!--#if (Container == "DryIoc") -->
+    <PackageReference Include="Prism.DryIoc.Uno" Version="8.0.0.1740-pre" />
+    <!--#endif -->
+  </ItemGroup>
+  <Import Project="..\BlankApp.Shared\BlankApp.Shared.projitems" Label="Shared" Condition="Exists('..\BlankApp.Shared\BlankApp.Shared.projitems')" />
+  <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-128.png" />
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-128%402x.png" />
@@ -116,25 +116,25 @@
     </BundleResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
-	
-		<Target Name="VS16Mac_RemoveSystemMemory" BeforeTargets="ResolveAssemblyReferences">
-		<!--
-				VS4Mac seems to process System.Memory differently, and removes
-				the System.Memory local reference if the package is transitively referenced.
-				We remove the Reference added by the nuget targets so that ResolveAssemblyReferences
-				is properly adding the local System.Memory to the Reference item group.
-		-->
-		<ItemGroup>
-			<_ReferenceToRemove Include="@(Reference)" Condition="'%(Reference.Identity)'=='System.Memory'" />
-			<Reference Remove="@(_ReferenceToRemove)" />
-			<Reference Include="System.Memory" />
-		</ItemGroup>
-	</Target>
 
-	<Target Name="VS16_RemoveSystemMemory" BeforeTargets="FindReferenceAssembliesForReferences">
-		<ItemGroup>
-			<_ReferencePathToRemove Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)'=='System.Memory'" />
-			<ReferencePath Remove="@(_ReferencePathToRemove)" />
-		</ItemGroup>
-	</Target>
+    <Target Name="VS16Mac_RemoveSystemMemory" BeforeTargets="ResolveAssemblyReferences">
+    <!--
+        VS4Mac seems to process System.Memory differently, and removes
+        the System.Memory local reference if the package is transitively referenced.
+        We remove the Reference added by the nuget targets so that ResolveAssemblyReferences
+        is properly adding the local System.Memory to the Reference item group.
+    -->
+    <ItemGroup>
+      <_ReferenceToRemove Include="@(Reference)" Condition="'%(Reference.Identity)'=='System.Memory'" />
+      <Reference Remove="@(_ReferenceToRemove)" />
+      <Reference Include="System.Memory" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="VS16_RemoveSystemMemory" BeforeTargets="FindReferenceAssembliesForReferences">
+    <ItemGroup>
+      <_ReferencePathToRemove Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)'=='System.Memory'" />
+      <ReferencePath Remove="@(_ReferencePathToRemove)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): #

this is just a fix to the templates for Prism

## PR Type

What kind of change does this PR introduce?
Updates Prism Templates

## What is the current behavior?

- Android project csproj and manifest target different API versions
- Android project for Prism template is still targeting Android 9, where the standard template targets Android 10
- Prism template still targeting old CI package. 

## What is the new behavior?

- Android project csproj and manifest target the same API versions
- Android project for the Prism template now targets Android 10 like the standard template
- Prism Package References updated to use the latest preview on NuGet.org

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

n/a

Internal Issue (If applicable):

n/a