### PR TITLE
fix: [Wasm] Don't use Assemly.Load in ApiInformation

### DIFF
--- a/src/Uno.Foundation/Metadata/ApiInformation.cs
+++ b/src/Uno.Foundation/Metadata/ApiInformation.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,13 +16,24 @@ namespace Windows.Foundation.Metadata
 		private static Dictionary<(string typeName, string methodName, uint inputParameterCount), bool> _isMethodPresent
 			= new Dictionary<(string typeName, string methodName, uint inputParameterCount), bool>();
 
-		private readonly static Assembly[] _assemblies = new[] {
-			Assembly.Load("Uno.UI"),
-			Assembly.Load("Uno.Foundation"),
-			Assembly.Load("Uno")
+		private readonly static Dictionary<string, Type> _typeCache = new Dictionary<string, Type>();
+		private readonly static List<Assembly> _assemblies = new List<Assembly>(3 /* All three uno assemblies */) {
+			typeof(ApiInformation).Assembly
 		};
 
-		private static bool IsImplementedByUno(MemberInfo member) => (member?.GetCustomAttributes(typeof(Uno.NotImplementedAttribute), false)?.Length ?? -1) == 0;
+		/// <summary>
+		/// Registers an assembly as part of the Is*Present methods
+		/// </summary>
+		/// <param name="assembly"></param>
+		internal static void RegisterAssembly(Assembly assembly)
+		{
+			lock (_assemblies)
+			{
+				_assemblies.Add(assembly);
+			}
+		}
+
+		private static bool IsImplementedByUno(MemberInfo? member) => (member?.GetCustomAttributes(typeof(Uno.NotImplementedAttribute), false)?.Length ?? -1) == 0;
 
 		public static bool IsTypePresent(string typeName)
 		{
@@ -61,7 +74,7 @@ namespace Windows.Foundation.Metadata
 
 			if (IsImplementedByUno(property))
 			{
-				return property.GetMethod != null && property.SetMethod == null;
+				return property?.GetMethod != null && property.SetMethod == null;
 			}
 
 			return false;
@@ -74,7 +87,7 @@ namespace Windows.Foundation.Metadata
 
 			if (IsImplementedByUno(property))
 			{
-				return property.GetMethod != null && property.SetMethod != null;
+				return property?.GetMethod != null && property.SetMethod != null;
 			}
 
 			return false;
@@ -93,15 +106,23 @@ namespace Windows.Foundation.Metadata
 		/// </summary>
 		public static bool AlwaysLogNotImplementedMessages { get; set; }
 
-		private static Type GetValidType(string typeName)
+		private static Type? GetValidType(string typeName)
 		{
-			foreach (var assembly in _assemblies)
+			lock (_assemblies)
 			{
-				var type = assembly.GetType(typeName);
-
-				if (type != null)
+				if (!_typeCache.TryGetValue(typeName, out var type))
 				{
-					return type;
+					foreach (var assembly in _assemblies)
+					{
+						type = assembly.GetType(typeName);
+
+						if (type != null)
+						{
+							_typeCache[typeName] = type;
+
+							return type;
+						}
+					}
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -43,6 +43,12 @@ namespace Windows.UI.Xaml
 		private ApplicationTheme? _requestedTheme;
 		private bool _themeSetExplicitly = false;
 
+		static Application()
+		{
+			ApiInformation.RegisterAssembly(typeof(Application).Assembly);
+			ApiInformation.RegisterAssembly(typeof(Windows.Storage.ApplicationData).Assembly);
+		}
+
 		[Preserve]
 		public static class TraceProvider
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes https://github.com/unoplatform/uno/issues/3801

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change avoids relying on APIs performing stack crawling on Wasm AOT.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
