### PR TITLE
fix(transforms): [MacOS] Fix support of RenderTransformOrigin

### DIFF
--- a/src/Uno.UI/Media/NativeRenderTransformAdapter.iOSmacOS.cs
+++ b/src/Uno.UI/Media/NativeRenderTransformAdapter.iOSmacOS.cs
@@ -7,6 +7,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media.Animation;
 using CoreAnimation;
 using CoreGraphics;
+using Uno.Disposables;
 using Uno.UI.Extensions;
 
 namespace Uno.UI.Media
@@ -16,13 +17,17 @@ namespace Uno.UI.Media
 		private CATransform3D _transform = CATransform3D.Identity;
 		private bool _wasAnimating = false;
 
+#if __MACOS__
+		private bool _isDisposed;
+		private bool _isDeferring;
+		private IDisposable _deferredInitialization;
+#endif
+
 		partial void Initialized()
 		{
-			// On íOS and MacOS Transform are applied by default on the center on the view
-			// so make sure to reset it when the transform is attached to the view
-			InitializeOrigin();
-
 #if __MACOS__
+			Owner.WantsLayer = true;
+
 			// On MAC OS, if we set the Transform before the NSView has been rendered at least once,
 			// it will be definitively ignored (even if updated).
 			// So here we hide the control (using Layer.Opacity to avoid not alter the Element itself),
@@ -30,45 +35,64 @@ namespace Uno.UI.Media
 			if (Owner is FrameworkElement element && !element.IsLoaded)
 			{
 				_isDeferring = true;
-				element.Loaded += DeferredInitialize;
 				element.Layer.Opacity = 0;
+				element.Loaded += DeferredInitialize;
+
+				_deferredInitialization = Disposable.Create(CompleteInitialization);
 
 				return;
+
+				void DeferredInitialize(object sender, RoutedEventArgs e)
+				{
+					element.Loaded -= DeferredInitialize;
+
+					// Note: Deferring to the loaded is not enough ... we must wait for the next dispatcher loop to set the Transform!
+					element.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, CompleteInitialization);
+				}
+
+				void CompleteInitialization()
+				{
+					// Note: we unsubscribe from the event a second time in case of this adapter is being disposed before the load (cf. _deferredInitialization)
+					element.Loaded -= DeferredInitialize;
+
+					_isDeferring = false;
+					element.Layer.Opacity = 1;
+
+					if (!_isDisposed)
+					{
+						InitializeOrigin();
+						Update();
+					}
+				}
 			}
-#endif
+#else
+			// On íOS and MacOS Transform are applied by default on the center on the view
+			// so make sure to reset it when the transform is attached to the view
+			InitializeOrigin();
 
 			// Apply the transform as soon as its been declared
 			Update();
+#endif
 		}
 
-#if __MACOS__
-		private bool _isDeferring;
-
-		private static void DeferredInitialize(object sender, RoutedEventArgs e)
+		private void InitializeOrigin()
 		{
-			var fwElt = (FrameworkElement)sender;
-			var adapter = fwElt._renderTransform;
+			var oldFrame = Owner.Layer.Frame;
 
-			fwElt.Loaded -= DeferredInitialize;
-			fwElt.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-			{
-				// Note: Deferring to the loaded is not enough ... we must wait for the next dispatcher loop to set the Transform!
-				adapter._isDeferring = false;
-				adapter.Update(isOriginChanged: true);
-				adapter.Update();
-				fwElt.Layer.Opacity = 1;
-			});
+			Owner.Layer.AnchorPoint = CurrentOrigin;
+
+			// Restore the old frame to correct the offset potentially introduced by changing AnchorPoint. This is safe to do since we know
+			// that the transform is currently identity.
+			Owner.Layer.Frame = oldFrame;
 		}
 
 		partial void Apply(bool isSizeChanged, bool isOriginChanged)
 		{
+#if __MACOS__
 			if (_isDeferring)
 			{
 				return;
 			}
-#else
-		partial void Apply(bool isSizeChanged, bool isOriginChanged)
-		{
 #endif
 			if (Transform.IsAnimating)
 			{
@@ -112,23 +136,12 @@ namespace Uno.UI.Media
 			}
 		}
 
-		private void InitializeOrigin()
-		{
-#if __MACOS__
-			Owner.WantsLayer = true;
-#endif
-
-			var oldFrame = Owner.Layer.Frame;
-
-			Owner.Layer.AnchorPoint = CurrentOrigin;
-
-			// Restore the old frame to correct the offset potentially introduced by changing AnchorPoint. This is safe to do since we know
-			// that the transform is currently identity.
-			Owner.Layer.Frame = oldFrame;
-		}
-
 		partial void Cleanup()
 		{
+#if __MACOS__
+			_isDisposed = true;
+			_deferredInitialization?.Dispose();
+#endif
 			Owner.Layer.Transform = CATransform3D.Identity;
 		}
 	}


### PR DESCRIPTION
## Bugfix
Fix support of `RenderTransformOrigin` on macOS.

## What is the current behavior?
When configuring a `RenderTransformOrigin` different of (0,0) before the load, the element was misaligned.

## What is the new behavior?
The origin is deferred with the transform itself.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
