### PR TITLE
fix: Exclude ResourceDictionary to improve linkability of `XamlControlsResources`

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -31,7 +31,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 		private INamedTypeSymbol _javaObjectSymbol;
 		private INamedTypeSymbol _nsObjectSymbol;
 		private INamedTypeSymbol _nonBindableSymbol;
-
+		private INamedTypeSymbol _resourceDictionarySymbol;
 		private IModuleSymbol _currentModule;
 
 		public string[] AnalyzerSuppressions { get; set; }
@@ -58,7 +58,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 						_nsObjectSymbol = context.Compilation.GetTypeByMetadataName("Foundation.NSObject");
 						_stringSymbol = context.Compilation.GetTypeByMetadataName("System.String");
 						_nonBindableSymbol = context.Compilation.GetTypeByMetadataName("Windows.UI.Xaml.Data.NonBindableAttribute");
-
+						_resourceDictionarySymbol = context.Compilation.GetTypeByMetadataName("Windows.UI.Xaml.ResourceDictionary");
 						_currentModule = context.Compilation.SourceModule;
 
 						AnalyzerSuppressions = new string[0];
@@ -142,7 +142,12 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 			return writer.ToString();
 		}
 
-		private bool IsValidProvider(INamedTypeSymbol type) => type.IsLocallyPublic(_currentModule);
+		private bool IsValidProvider(INamedTypeSymbol type)
+			=> type.IsLocallyPublic(_currentModule)
+
+			// Exclude resource dictionaries for linking constraints (XamlControlsResources in particular)
+			// Those are not databound, so there's no need to generate providers for them.
+			&& !type.Is(_resourceDictionarySymbol);
 
 		private void GenerateProviderTable(IEnumerable<INamedTypeSymbol> q, IndentedStringBuilder writer)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The `XamlControlsResources` is referenced by the Metadata generation tool, because the type inherits from `DependencyObject`.

## What is the new behavior?

All `ResourceDictionary` inheriting types are removed from the Metadata Generation pass; those are databound.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
