### PR TITLE
fix: Reduce the use of `Assembly.Load` during startup

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -520,7 +520,15 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				if (asm.MainModule.HasResources && asm.MainModule.Resources.Any(r => r.Name.EndsWith("upri")))
 				{
-					writer.AppendLineInvariant($"global::Windows.ApplicationModel.Resources.ResourceLoader.AddLookupAssembly(global::System.Reflection.Assembly.Load(\"{asm.FullName}\"));");
+					if (asm.FullName == "Uno.UI")
+					{
+						// Avoid the use of assembly lookup as we already know the assembly
+						writer.AppendLineInvariant($"global::Windows.ApplicationModel.Resources.ResourceLoader.AddLookupAssembly(typeof(global::Windows.UI.Xaml.FrameworkElement).Assembly);");
+					}
+					else
+					{
+						writer.AppendLineInvariant($"global::Windows.ApplicationModel.Resources.ResourceLoader.AddLookupAssembly(\"{asm.FullName}\");");
+					}
 				}
 			}
 		}

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
@@ -145,6 +145,30 @@ namespace Windows.ApplicationModel.Resources
 		}
 
 		/// <summary>
+		/// Registers an assembly for resources lookup using its fullname
+		/// </summary>
+		/// <param name="assembly">The assembly containing upri resources</param>
+		public static void AddLookupAssembly(string assemblyName)
+		{
+#if __WASM__
+			// For wasm, Assembly.Load is not well supported when using AOT, because of stack crawling.
+			// If the feature gets restored, remove this conditional.
+
+			if(AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.FullName == assemblyName) is Assembly assembly)
+			{
+				AddLookupAssembly(assembly);
+			}
+			else
+			{
+				throw new InvalidOperationException($"Unable to find {assemblyName} in the loaded assemblies");
+			}
+#else
+			AddLookupAssembly(Assembly.Load(assemblyName));
+#endif
+
+		}
+
+		/// <summary>
 		/// Registers an assembly for resources lookup
 		/// </summary>
 		/// <param name="assembly">The assembly containing upri resources</param>


### PR DESCRIPTION

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

```
g_log_disabled    @    goutput.c:189
mono_arch_unwind_frame    @    exceptions-wasm.c:47
arch_unwind_frame    @    mini-exceptions.c:462
mono_find_jit_info_ext    @    mini-exceptions.c:650
unwinder_unwind_frame    @    mini-exceptions.c:771
mono_walk_stack_full    @    mini-exceptions.c:1331
mono_walk_stack_with_ctx    @    mini-exceptions.c:1192
mono_runtime_walk_stack_with_ctx    @    mini-exceptions.c:1169
mono_stack_walk_no_il    @    loader.c:1719
mono_runtime_get_caller_from_stack_mark    @    icall.c:1802
ves_icall_System_AppDomain_LoadAssembly    @    appdomain.c:2905
ves_icall_System_AppDomain_LoadAssembly_raw    @    icall-def.h:198
aot_wrapper_mscorlib_System_System_dot_AppDomain__LoadAssembly_pinvoke_cls14_Reflection_dAssembly__this_cl6_string_cls1a_Security_dPolicy_dEvidence_boolbcls1c_Threading_dStackCrawlMark_26_cls14_Reflection_dAssembly__cls9_AppDomain_cl6_string_cls1a_Security_dPolicy_dEvidence_boolbcls1c_Threading_dStackCrawlMark_26_    @    corebindings.c:174
mscorlib_System_AppDomain_Load_string_System_Security_Policy_Evidence_bool_System_Threading_StackCrawlMark_    @    corebindings.c:174
mscorlib_System_AppDomain_Load_string
```

## What is the new behavior?

Avoids the use stack crawling for no useful reason (break Wasm AOT)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
