### PR TITLE
chore(doc): Update doc since Rider 2020.2 is no more EAP and is published now

### DIFF
--- a/doc/articles/get-started.md
+++ b/doc/articles/get-started.md
@@ -175,7 +175,7 @@ Building for WebAssembly takes a few more steps than iOS and Android:
 ## JetBrains Rider
 
 ### Prerequisites
-* [**Rider Version 2020.2 Early Access**](https://www.jetbrains.com/rider/nextversion/)
+* [**Rider Version "2020.2+"**](https://www.jetbrains.com/rider/)
 * [**Rider Xamarin Android Support Plugin**](https://plugins.jetbrains.com/plugin/12056-rider-xamarin-android-support/)
 
 ### Creating a new Uno project


### PR DESCRIPTION
## PR Type 

What kind of change does this PR introduce?

- Documentation content changes

## What is the new behavior?

Update doc since Rider 2020.2 is no more EAP and is published now.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.