### PR TITLE
[macOS] FolderPicker

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -181,6 +181,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_Storage\FolderPickerTests.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_System\Display\DisplayRequest.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3369,6 +3373,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_Storage\FilePickerTests.xaml">
+	  <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_ViewManagement\ApplicationViewSizing.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3501,6 +3509,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Storage\StorageFolderTests\Persistence.xaml.cs">
       <DependentUpon>Persistence.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_Storage\FolderPickerTests.xaml.cs">
+      <DependentUpon>FolderPickerTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_System\Display\DisplayRequest.xaml.cs">
       <DependentUpon>DisplayRequest.xaml</DependentUpon>
@@ -5935,6 +5946,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Xaml_CodeGen\BindableMetadataGlobalizationTest.xaml.cs">
       <DependentUpon>BindableMetadataGlobalizationTest.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_Storage\FilePickerTests.xaml.cs">
+      <DependentUpon>FilePickerTests.xaml</DependentUpon>
+	</Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_ViewManagement\ApplicationViewSizing.xaml.cs">
       <DependentUpon>ApplicationViewSizing.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/FilePickerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/FilePickerTests.xaml
@@ -7,10 +7,14 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<StackPanel Padding="20">
-        <TextBlock Text="Open picker" Style="{ThemeResource TitleTextBlockStyle}" />
+	<StackPanel Padding="20" Spacing="8">
+		<TextBlock Text="Open picker" Style="{ThemeResource TitleTextBlockStyle}" />
 		<Button Click="PickOpenSingle_Click" Content="Pick single" />
-        <Button Click="PickOpenMultiple_Click" Content="Pick multiple" />
-		<TextBlock x:Name="PickOpenResult" TextWrapping="Wrap" />
+		<Button Click="PickOpenMultiple_Click" Content="Pick multiple" />
+		<TextBlock FontSize="15" x:Name="PickOpenResult" TextWrapping="Wrap" />
+
+		<TextBlock Text="Save picker" Style="{ThemeResource TitleTextBlockStyle}" />
+		<Button Click="PickSaveSingle_Click" Content="Pick single" />
+		<TextBlock FontSize="15" x:Name="PickSaveResult" TextWrapping="Wrap" />
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/FilePickerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/FilePickerTests.xaml
@@ -1,0 +1,16 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_Storage.FilePickerTests"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Padding="20">
+        <TextBlock Text="Open picker" Style="{ThemeResource TitleTextBlockStyle}" />
+		<Button Click="PickOpenSingle_Click" Content="Pick single" />
+        <Button Click="PickOpenMultiple_Click" Content="Pick multiple" />
+		<TextBlock x:Name="PickOpenResult" TextWrapping="Wrap" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/FilePickerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/FilePickerTests.xaml.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Windows.Storage;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Input;
 using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml;
 using Windows.Storage.Pickers;
+using System.Text;
+using System.Collections.Generic;
 
 namespace UITests.Shared.Windows_Storage
 {
@@ -19,16 +16,56 @@ namespace UITests.Shared.Windows_Storage
 			this.InitializeComponent();
 		}
 
-		private async void PickFolder_Click(object sender, RoutedEventArgs args)
+		private async void PickOpenSingle_Click(object sender, RoutedEventArgs args)
 		{
-			var picker = new FolderPicker();
-			var result = await picker.PickSingleFolderAsync();
+			var picker = new FileOpenPicker();
+			picker.SuggestedStartLocation = PickerLocationId.PicturesLibrary;
+			picker.FileTypeFilter.Add(".jpg");
+			var result = await picker.PickSingleFileAsync();
 			if (result == null) {
-				PickResult.Text = "No folder was picked";
+				PickOpenResult.Text = "No file was picked";
 			}
 			else
 			{
-				PickResult.Text = result.Path;
+				PickOpenResult.Text = result.Path;
+			}
+		}
+
+		private async void PickSaveSingle_Click(object sender, RoutedEventArgs args)
+		{
+			var picker = new FileSavePicker();
+			picker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+			picker.FileTypeChoices.Add("Plain Text", new List<string>() { ".txt" });
+			picker.SuggestedFileName = "New Document";
+			var result = await picker.PickSaveFileAsync();
+			if (result == null)
+			{
+				PickOpenResult.Text = "No file was picked";
+			}
+			else
+			{
+				PickOpenResult.Text = result.Path;
+			}
+		}
+
+		private async void PickOpenMultiple_Click(object sender, RoutedEventArgs args)
+		{
+			var picker = new FileOpenPicker();
+			picker.SuggestedStartLocation = PickerLocationId.PicturesLibrary;
+			picker.FileTypeFilter.Add(".jpg");
+			var result = await picker.PickMultipleFilesAsync();
+			if (result.Count == 0)
+			{
+				PickOpenResult.Text = "No file was picked";
+			}
+			else
+			{
+				var builder = new StringBuilder();
+				foreach (var file in result)
+				{
+					builder.AppendLine(file.Path);
+				}
+				PickOpenResult.Text = builder.ToString();
 			}
 		}
 	}

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/FilePickerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/FilePickerTests.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.Storage.Pickers;
+
+namespace UITests.Shared.Windows_Storage
+{
+	[SampleControlInfo("Windows.Storage")]
+	public sealed partial class FilePickerTests : Page
+	{
+		public FilePickerTests()
+		{
+			this.InitializeComponent();
+		}
+
+		private async void PickFolder_Click(object sender, RoutedEventArgs args)
+		{
+			var picker = new FolderPicker();
+			var result = await picker.PickSingleFolderAsync();
+			if (result == null) {
+				PickResult.Text = "No folder was picked";
+			}
+			else
+			{
+				PickResult.Text = result.Path;
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/FolderPickerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/FolderPickerTests.xaml
@@ -7,8 +7,8 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<StackPanel>
+	<StackPanel Padding="20" Spacing="8">
 		<Button Click="PickFolder_Click" Content="Pick folder" />
-		<TextBlock x:Name="PickResult" />
+		<TextBlock x:Name="PickResult" FontSize="15" />
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/FolderPickerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/FolderPickerTests.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_Storage.FolderPickerTests"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+		<Button Click="PickFolder_Click" Content="Pick folder" />
+		<TextBlock x:Name="PickResult" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/FolderPickerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/FolderPickerTests.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.Storage.Pickers;
+
+namespace UITests.Shared.Windows_Storage
+{
+	[SampleControlInfo("Windows.Storage")]
+	public sealed partial class FolderPickerTests : Page
+	{
+		public FolderPickerTests()
+		{
+			this.InitializeComponent();
+		}
+
+		private async void PickFolder_Click(object sender, RoutedEventArgs args)
+		{
+			var picker = new FolderPicker();
+			var result = await picker.PickSingleFolderAsync();
+			if (result == null) {
+				PickResult.Text = "No folder was picked";
+			}
+			else
+			{
+				PickResult.Text = result.Path;
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FolderPicker.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FolderPicker.cs
@@ -2,13 +2,13 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Pickers
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class FolderPicker 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  global::Windows.Storage.Pickers.PickerViewMode ViewMode
 		{
 			get
@@ -93,8 +93,8 @@ namespace Windows.Storage.Pickers
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public FolderPicker() 
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.Pickers.FolderPicker", "FolderPicker.FolderPicker()");
@@ -118,8 +118,8 @@ namespace Windows.Storage.Pickers
 		// Forced skipping of method Windows.Storage.Pickers.FolderPicker.CommitButtonText.get
 		// Forced skipping of method Windows.Storage.Pickers.FolderPicker.CommitButtonText.set
 		// Forced skipping of method Windows.Storage.Pickers.FolderPicker.FileTypeFilter.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFolder> PickSingleFolderAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFolder> FolderPicker.PickSingleFolderAsync() is not implemented in Uno.");

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FolderPicker.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FolderPicker.cs
@@ -7,8 +7,8 @@ namespace Windows.Storage.Pickers
 	#endif
 	public  partial class FolderPicker 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Storage.Pickers.PickerViewMode ViewMode
 		{
 			get

--- a/src/Uno.UWP/Storage/Pickers/FolderPicker.macOS.cs
+++ b/src/Uno.UWP/Storage/Pickers/FolderPicker.macOS.cs
@@ -1,0 +1,38 @@
+﻿#if __MACOS__
+using System;
+using System.Threading.Tasks;
+using AppKit;
+using Windows.Foundation;
+
+namespace Windows.Storage.Pickers
+{
+	public partial class FolderPicker
+	{
+		public FolderPicker()
+		{	
+		}
+
+		public IAsyncOperation<StorageFolder> PickSingleFolderAsync() =>
+			PickSingleFolderImplAsync().AsAsyncOperation();
+
+		private async Task<StorageFolder> PickSingleFolderImplAsync()
+		{
+			var openPanel = new NSOpenPanel();
+			openPanel.AllowedFileTypes = new[] { "none" };
+			openPanel.AllowsOtherFileTypes = false;
+			openPanel.CanChooseDirectories = true;
+			openPanel.CanChooseFiles = false;
+			var response = openPanel.RunModal();
+			if (response == 1 && openPanel.Urls.Length > 0)
+			{
+				var path = openPanel.Urls[0]?.Path;
+				if (path != null)
+				{
+					return new StorageFolder(path);
+				}
+			}
+			return null;
+		}
+	}
+}
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3843

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Not supported.

## What is the new behavior?

Supported.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.