### PR TITLE
fix: [macOS] Allow setting title before window becomes key

### DIFF
--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -41,7 +41,7 @@ namespace Uno.UI.Controls
 		public Window(CGRect contentRect, NSWindowStyle aStyle, NSBackingStore bufferingType, bool deferCreation)
 			: base(contentRect, aStyle, bufferingType, deferCreation)
 		{
-			Delegate = new WindowDelegate();
+			Delegate = new WindowDelegate(this);
 			_inputPane = InputPane.GetForCurrentView();
 			_inputPane.Window = this;
 		}
@@ -68,7 +68,7 @@ namespace Uno.UI.Controls
 				|| view is NSTextField
 				|| GetNeedsKeyboard(view);
 		}
-		
+
 		public BringIntoViewMode? FocusedViewBringIntoViewOnKeyboardOpensMode { get; set; }
 
 
@@ -105,7 +105,7 @@ namespace Uno.UI.Controls
 			}
 
 			var viewRectInScrollView = CGRect.Empty;
-			
+
 			if (!(view is TextBox))
 			{
 				// We want to scroll to the textbox and not the inner textview.
@@ -119,8 +119,16 @@ namespace Uno.UI.Controls
 
 		private class WindowDelegate : NSWindowDelegate
 		{
+			private readonly NSWindow _window;
+
+			public WindowDelegate(NSWindow window)
+			{
+				_window = window;
+			}
+
 			public override async void DidBecomeMain(NSNotification notification)
 			{
+				ApplicationView.GetForCurrentView().SyncTitleWithWindow(_window);
 				// Ensure custom cursor is reset after window activation.
 				// Artificial delay is necessary due to the fact that setting cursor
 				// immediately after window becoming main does not have any effect.

--- a/src/Uno.UI/UI/Xaml/Window.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.macOS.cs
@@ -42,8 +42,6 @@ namespace Windows.UI.Xaml
 
 			_mainController = ViewControllerGenerator?.Invoke() ?? new RootViewController();
 
-			_window.TitleVisibility = NSWindowTitleVisibility.Hidden;
-
 			ObserveOrientationAndSize();
 
 			Dispatcher = CoreDispatcher.Main;

--- a/src/Uno.UWP/UI/ViewManagement/ApplicationView.macOS.cs
+++ b/src/Uno.UWP/UI/ViewManagement/ApplicationView.macOS.cs
@@ -12,7 +12,9 @@ using CoreGraphics;
 namespace Windows.UI.ViewManagement
 {
     partial class ApplicationView
-	{
+    {
+	    private string _title = string.Empty;
+
 		internal void SetCoreBounds(NSWindow keyWindow, Foundation.Rect windowBounds)
 		{
             VisibleBounds = windowBounds;
@@ -27,15 +29,15 @@ namespace Windows.UI.ViewManagement
 
 		public string Title
 		{
-			get
-			{
-				VerifyKeyWindowInitialized();
-				return NSApplication.SharedApplication.KeyWindow.Title;
-			}
+			get => IsKeyWindowInitialized() ? NSApplication.SharedApplication.KeyWindow.Title : _title;
 			set
 			{
-				VerifyKeyWindowInitialized();
-				NSApplication.SharedApplication.KeyWindow.Title = value;
+				if (IsKeyWindowInitialized())
+				{
+					NSApplication.SharedApplication.KeyWindow.Title = value;
+				}
+
+				_title = value;
 			}
 		}
 
@@ -86,13 +88,23 @@ namespace Windows.UI.ViewManagement
 			window.MinSize = new CGSize(minSize.Width, minSize.Height);
 		}
 
+		internal void SyncTitleWithWindow(NSWindow window)
+		{
+			if (!string.IsNullOrWhiteSpace(_title))
+			{
+				window.Title = _title;
+			}
+		}
+
 		private void VerifyKeyWindowInitialized([CallerMemberName]string propertyName = null)
 		{
-			if (NSApplication.SharedApplication.KeyWindow == null)
+			if (!IsKeyWindowInitialized())
 			{
 				throw new InvalidOperationException($"{propertyName} API must be used after KeyWindow is set");
 			}
 		}
-	}
+
+		private bool IsKeyWindowInitialized() => NSApplication.SharedApplication.KeyWindow != null;
+    }
 }
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When application view title is set before it becomes key, null reference exception is thrown.

## What is the new behavior?

Title is retrospectively when window is ready.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
