### PR TITLE
fix(NSUImageExtensions): fixed image monochrome recoloring on ios

### DIFF
--- a/src/Uno.UI/Extensions/UIImageExtensions.iOS.cs
+++ b/src/Uno.UI/Extensions/UIImageExtensions.iOS.cs
@@ -37,33 +37,18 @@ namespace Uno.UI.Extensions
 					{
 						context.DrawImage(imageRect, image.CGImage);
 
-						var foregroundColor = foreground.R | (foreground.R << 8) | (foreground.R << 16) | (0xFF << 24);
-
 						for (int x = 0; x < width; x++)
 						{
 							for (int y = 0; y < height; y++)
 							{
 								var index = x * 4 + y * height * 4;
 
-								var red = rawData[index + 0];
-								var green = rawData[index + 1];
-								var blue = rawData[index + 2];
-								var alpha = rawData[index + 3];
+								var sourceAlpha = rawData[index + 3];
 
-								if (red + green + blue != 0)
-								{
-									outputData[index + 0] = foreground.R;
-									outputData[index + 1] = foreground.G;
-									outputData[index + 2] = foreground.B;
-									outputData[index + 3] = 0xFF;
-								}
-								else
-								{
-									outputData[index + 0] = 0;
-									outputData[index + 1] = 0;
-									outputData[index + 2] = 0;
-									outputData[index + 3] = 0;
-								}
+								outputData[index + 0] = foreground.R;
+								outputData[index + 1] = foreground.G;
+								outputData[index + 2] = foreground.B;
+								outputData[index + 3] = sourceAlpha;
 							}
 						}
 					}

--- a/src/Uno.UI/Extensions/UIImageExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIImageExtensions.iOSmacOS.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using CoreGraphics;
+using Windows.UI;
+
+#if __IOS__
+using _UIImage = UIKit.UIImage;
+#elif __MACOS__
+using _UIImage = AppKit.NSImage;
+using AppKit;
+#endif
+
+namespace Uno.UI.Extensions
+{
+	internal static partial class NSUIImageExtensions
+	{
+		internal static _UIImage AsMonochrome(this _UIImage image, Color foreground)
+		{
+			var width = (int)image.Size.Width;
+			var height = (int)image.Size.Height;
+			var imageRect = new CGRect(0, 0, image.Size.Width, image.Size.Height);
+
+			var rawData = new byte[width * height * 4];
+			var outputData = new byte[width * height * 4];
+			var handle = GCHandle.Alloc(rawData);
+
+			try
+			{
+				using (var colorSpace = CGColorSpace.CreateDeviceRGB())
+				{
+					using (var context = new CGBitmapContext(
+						data: rawData,
+						width: (nint)imageRect.Width,
+						height: (nint)imageRect.Height,
+						bitsPerComponent: 8,
+						bytesPerRow: (nint)imageRect.Width * 4,
+						colorSpace: colorSpace,
+						bitmapInfo: CGImageAlphaInfo.PremultipliedLast
+						)
+					)
+					{
+						context.DrawImage(imageRect, image.CGImage);
+
+						for (int x = 0; x < width; x++)
+						{
+							for (int y = 0; y < height; y++)
+							{
+								var index = x * 4 + y * height * 4;
+
+								var sourceAlpha = rawData[index + 3];
+
+								outputData[index + 0] = foreground.R;
+								outputData[index + 1] = foreground.G;
+								outputData[index + 2] = foreground.B;
+								outputData[index + 3] = sourceAlpha;
+							}
+						}
+					}
+				}
+			}
+			finally
+			{
+				handle.Free();
+			}
+
+			using (var dataProvider = new CGDataProvider(outputData, 0, outputData.Length))
+			{
+				using (var colorSpace = CGColorSpace.CreateDeviceRGB())
+				{
+					var bitsPerComponent = 8;
+					var bytesPerPixel = 4;
+
+					using (var cgImage = new CGImage(
+						width,
+						height,
+						bitsPerComponent,
+						bitsPerComponent * bytesPerPixel,
+						bytesPerPixel * width,
+						colorSpace,
+						CGImageAlphaInfo.Last,
+						dataProvider,
+						null,
+						false,
+						CGColorRenderingIntent.Default
+					))
+					{
+						return FromCGImage(cgImage);
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI/Extensions/UIImageExtensions.macOS.cs
+++ b/src/Uno.UI/Extensions/UIImageExtensions.macOS.cs
@@ -3,16 +3,16 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using CoreGraphics;
-using UIKit;
 using Windows.UI;
+using AppKit;
 
 namespace Uno.UI.Extensions
 {
 	internal static partial class NSUIImageExtensions
 	{
-		internal static UIImage FromCGImage(CGImage cgImage)
+		internal static NSImage FromCGImage(CGImage cgImage)
 		{
-			return UIImage.FromImage(cgImage);
+			return new NSImage(cgImage, new CGSize(cgImage.Width, cgImage.Height));
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOSmacOS.cs
@@ -140,12 +140,10 @@ namespace Windows.UI.Xaml.Controls
 				)
 			)
 			{
-#if __IOS__ // MacOS TODO
 				if (MonochromeColor != null)
 				{
 					image = image.AsMonochrome(MonochromeColor.Value);
 				}
-#endif
 
 				TryCreateNative();
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #3680 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix
- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Black images get whiped on iOS on monochrome recolor, thus also making the Foreground property break bitmapicons.

Images do not get recolored at all on macOS.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
AsMonochrome recolors for images work as intended on ios and macOS.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
