### PR TITLE
fix(combobox): PlaceholderText not displaying

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
@@ -214,5 +214,67 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			TakeScreenshot("ComboBox Disabled");
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android)]
+		public void ComboBoxTests_PlaceholderText() => ComboBoxTests_PlaceholderText_Impl("TestBox", 4, combo =>
+		{
+			var implicitTextBlock = combo.Descendant().Marked("ContentPresenter").Child;
+			var text = implicitTextBlock.GetDependencyPropertyValue<string>("Text");
+
+			Assert.AreEqual("5", text, "item #4 (text: 5) should be now selected");
+		});
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android)]
+		public void ComboBoxTests_PlaceholderText_With_ItemTemplate() => ComboBoxTests_PlaceholderText_Impl("TestBox2", 4, combo =>
+		{
+			var descendants = combo.Descendant().Marked("ContentPresenter").Descendant();
+			//<StackPanel Orientation="Horizontal"><!-- templateRoot -->
+			//	<Rectangle ... />
+			//	<TextBlock Text="Item:" />
+			//	<TextBlock Text="{Binding}" />
+			//</StackPanel>
+			var offset = 2; // skipping the ContentPresenter#0 and the StackPanel#1
+			var text1 = descendants.AtIndex(offset + 1).GetDependencyPropertyValue<string>("Text");
+			var text2 = descendants.AtIndex(offset + 2).GetDependencyPropertyValue<string>("Text");
+
+			Assert.AreEqual("Item:", text1, "item #4 should be now selected with ItemTemplate");
+			Assert.AreEqual("5", text2, "item #4 (value: 5) should be now selected with ItemTemplate");
+		});
+
+		public void ComboBoxTests_PlaceholderText_Impl(string targetName, int selectionIndex, Action<QueryEx> selectionValidation)
+		{
+			Run("SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_PlaceholderText");
+			_app.WaitForElement("sampleControl");
+
+			var testComboBox = _app.Marked(targetName);
+			var resetButton = _app.Marked("ResetButton");
+
+			// check initial value
+			var placeholderTextBlock = testComboBox.Descendant().Marked("PlaceholderTextBlock");
+			var expectedPlaceholderText = testComboBox.GetDependencyPropertyValue<string>("PlaceholderText");
+			var actualPlaceholderText = placeholderTextBlock.GetDependencyPropertyValue<string>("Text");
+			Assert.AreEqual(expectedPlaceholderText, actualPlaceholderText, "PlaceholderText should be shown prior to selection");
+
+			// open combobox flyout
+			testComboBox.FastTap();
+			var popupBorder = _app.Marked("PopupBorder");
+			_app.WaitForElement(popupBorder);
+
+			// select item at {selectionIndex}
+			var item5 = popupBorder.Descendant().WithClass("ComboBoxItem").AtIndex(selectionIndex);
+			item5.FastTap();
+			_app.WaitForDependencyPropertyValue<int>(testComboBox, "SelectedIndex", selectionIndex);
+			selectionValidation(testComboBox);
+
+			// clear selection
+			resetButton.FastTap();
+			_app.WaitForDependencyPropertyValue<int>(testComboBox, "SelectedIndex", -1);
+			actualPlaceholderText = placeholderTextBlock.GetDependencyPropertyValue<string>("Text");
+			Assert.AreEqual(expectedPlaceholderText, actualPlaceholderText, "PlaceholderText should be shown again when the selection is cleared");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_PlaceholderText.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_PlaceholderText.xaml
@@ -10,14 +10,29 @@
 			 d:DesignHeight="300"
 			 d:DesignWidth="400">
 
-	<controls:SampleControl SampleDescription="ComboBox with PlaceholderText">
-		<controls:SampleControl.SampleContent>
-			<DataTemplate>
+	<StackPanel>
+		<ComboBox x:Name="TestBox"
+				  PlaceholderText="PlaceholderText"
+				  ItemsSource="{Binding [SampleItems]}" />
+		<ComboBox x:Name="TestBox2"
+				  PlaceholderText="PlaceholderText + ItemTemplate"
+				  ItemsSource="{Binding [SampleItems]}">
+			<ComboBox.ItemTemplate>
+				<DataTemplate>
+					<StackPanel Orientation="Horizontal">
+						<Rectangle Height="12"
+								   Width="12"
+								   Fill="Pink" />
+						<TextBlock Text="Item:" />
+						<TextBlock Text="{Binding}" />
+					</StackPanel>
+				</DataTemplate>
+			</ComboBox.ItemTemplate>
+		</ComboBox>
 
-				<ComboBox PlaceholderText="PlaceholderText"
-						  ItemsSource="{Binding [SampleItems]}" />
+		<Button x:Name="ResetButton"
+				Content="Reset Selection"
+				Click="ResetSelection" />
+	</StackPanel>
 
-			</DataTemplate>
-		</controls:SampleControl.SampleContent>
-	</controls:SampleControl>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_PlaceholderText.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_PlaceholderText.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Windows.UI.Xaml.Controls;
 using SamplesApp.Windows_UI_Xaml_Controls.Models;
 using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
@@ -10,6 +11,12 @@ namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 		public ComboBox_PlaceholderText()
 		{
 			this.InitializeComponent();
+		}
+
+		void ResetSelection(object sender, RoutedEventArgs e)
+		{
+			TestBox.SelectedItem = null;
+			TestBox2.SelectedItem = null;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -43,9 +43,12 @@ namespace Windows.UI.Xaml.Controls
 		public event EventHandler<object> DropDownClosed;
 		public event EventHandler<object> DropDownOpened;
 
+		private bool _areItemTemplatesForwarded = false;
+
 		private IPopup _popup;
 		private Border _popupBorder;
 		private ContentPresenter _contentPresenter;
+		private TextBlock _placeholderTextBlock;
 		private ContentPresenter _headerContentPresenter;
 
 		/// <summary>
@@ -79,6 +82,7 @@ namespace Windows.UI.Xaml.Controls
 			_popup = this.GetTemplateChild("Popup") as IPopup;
 			_popupBorder = this.GetTemplateChild("PopupBorder") as Border;
 			_contentPresenter = this.GetTemplateChild("ContentPresenter") as ContentPresenter;
+			_placeholderTextBlock = this.GetTemplateChild("PlaceholderTextBlock") as TextBlock;
 
 			if (_popup is PopupBase popup)
 			{
@@ -93,18 +97,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (_contentPresenter != null)
 			{
-				_contentPresenter.SetBinding(
-					ContentPresenter.ContentTemplateProperty,
-					new Binding(new PropertyPath("ItemTemplate"), null)
-					{
-						RelativeSource = RelativeSource.TemplatedParent
-					});
-				_contentPresenter.SetBinding(
-					ContentPresenter.ContentTemplateSelectorProperty,
-					new Binding(new PropertyPath("ItemTemplateSelector"), null)
-					{
-						RelativeSource = RelativeSource.TemplatedParent
-					});
+				_contentPresenter.SynchronizeContentWithOuterTemplatedParent = false;
 
 				_contentPresenter.DataContextChanged += (snd, evt) =>
 				{
@@ -248,10 +241,11 @@ namespace Windows.UI.Xaml.Controls
 
 		private void UpdateContentPresenter()
 		{
-			if (_contentPresenter != null)
+			if (_contentPresenter == null) return;
+
+			if (SelectedItem != null)
 			{
 				var item = GetSelectionContent();
-
 				var itemView = item as _View;
 
 				if (itemView != null)
@@ -273,12 +267,34 @@ namespace Windows.UI.Xaml.Controls
 				}
 
 				_contentPresenter.Content = item;
-
 				if (itemView != null && itemView.GetVisualTreeParent() != _contentPresenter)
 				{
 					// Item may have been put back in list, reattach it to _contentPresenter
 					_contentPresenter.AddChild(itemView);
 				}
+				if (!_areItemTemplatesForwarded)
+				{
+					SetContentPresenterBinding(ContentPresenter.ContentTemplateProperty, nameof(ItemTemplate));
+					SetContentPresenterBinding(ContentPresenter.ContentTemplateSelectorProperty, nameof(ItemTemplateSelector));
+
+					_areItemTemplatesForwarded = true;
+				}
+			}
+			else
+			{
+				_contentPresenter.Content = _placeholderTextBlock;
+				if (_areItemTemplatesForwarded)
+				{
+					_contentPresenter.ClearValue(ContentPresenter.ContentTemplateProperty);
+					_contentPresenter.ClearValue(ContentPresenter.ContentTemplateSelectorProperty);
+
+					_areItemTemplatesForwarded = false;
+				}
+			}
+
+			void SetContentPresenterBinding(DependencyProperty targetProperty, string sourcePropertyPath)
+			{
+				_contentPresenter.SetBinding(targetProperty, new Binding(sourcePropertyPath) { RelativeSource = RelativeSource.TemplatedParent });
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #3358

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
ComboBox.PlaceholderText is now displaying correctly.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Internal Issue (If applicable):
https://dev.azure.com/nventive/Uno%20Gallery/_queries/edit/191190
