### PR TITLE
fix(wasm): lineheight is applied to textblock

### DIFF
--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -22,12 +22,13 @@ body {
   outline: none;
   pointer-events: auto;
   /*
-    Those are required for measure/arrange to behave well:
+    Padding & margin are required for measure/arrange to behave well:
     margin & padding are calculated through Xaml elements.
   */
   margin: 0 !important;
   padding: 0;
-  line-height: normal !important;
+
+  line-height: normal;
   -webkit-box-sizing: border-box !important;
   -moz-box-sizing: border-box !important;
   box-sizing: border-box !important;


### PR DESCRIPTION
GitHub Issue (If applicable): Fix #3784 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Line height on wasm is not applied to the text.


## What is the new behavior?
Line height is now applied

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.