### PR TITLE
fix(doc): updating font doc is easier to read

### DIFF
--- a/doc/articles/uno-fluent-assets.md
+++ b/doc/articles/uno-fluent-assets.md
@@ -1,30 +1,45 @@
----
-title: Uno Fluent UI assets
-author: alextrepa
-description: adding new multiplateform font
----
-
 # Uno Fluent UI assets
-Uno has a new multiplateform font. The new font must be added to app build before the change.
-
-> [!IMPORTANT] \
+> **IMPORTANT** \
 This is a breaking change on most platform the font needs to be changed or most control will display incorrectly.
 
+Uno has a new multiplatform font. The new font must be added manually to each platform to access the new symbols.
+
 ## Font files
-The font is in this repository https://github.com/unoplatform/uno.fonts
+The font is in this repository https://github.com/unoplatform/uno.fonts. The necessary files can be downloaded here: https://github.com/unoplatform/uno.fonts/tree/master/webfonts
 
 ## Changes
 
-| Device family | Description   |
-| -- | -- |
-| iOS & macOS | Once Uno has been updated, it will start looking for a font named symbols (Not necessarily the name of the file). For this font to be available it needs to be in the resource folder.  ![image](Assets/font-ios.png) ![image](Assets/font-macos.png)  The `info.plist` should also be updated for both platforms, replacing winjs-symbols.ttf by uno-fluentui-assets.ttf|
-| Android | Once Uno has been updated, it will start looking for a font file named uno-fluentui-assets.ttf in its assets folder:  ![image](Assets/font-android.png) |
-| WebAssembly | A wasm build won't break after the update but to access the new symbols the file Font.css should be chnaged. The font is passed as a base64 file. ![image](Assets/font-wasm.png) |
+### iOS & macOS 
+---
+The `info.plist` file should be updated for both platforms, replacing the string `winjs-symbols.ttf` with `uno-fluentui-assets.ttf` in the file.
 
-## Limitations
-On iOS and macOS the indeterminate state for a check box is not the right color.
+On iOS and macOS, Uno looks for a font named 'Symbols' (A font's name is not necessarily the name of the file). For this font to be available, the font file needs to be placed in the `Resources/Fonts` folder. The old `winjs-symbols.ttf` file can safely be deleted.  \  \
+\
+![image](Assets/font-ios.png) \
+\
+![image](Assets/font-macos.png)  
+\
+Open the `.csproj` file (`YourApp.iOS.csproj` or `YourApp.macOS.csproj`). Replace the string `winjs-symbols.ttf` with `uno-fluentui-assets.ttf`.
+
+### Android 
+---
+Once Uno has been updated, it will start looking for a font file named uno-fluentui-assets.ttf in the assets folder: \
+\
+![image](Assets/font-droid.png)
+\
+Open the `.csproj` (`YourApp.Droid.csproj`). Replace the string `winjs-symbols.ttf` with `uno-fluentui-assets.ttf`.
+### WebAssembly 
+---
+WASM won't break after the update, but to access the new symbols the file Font.css should be changed. The font is passed as a base64 string: \ \
+\
+![image](Assets/font-wasm.png) 
+\
+Simply replace the contents of Font.css in your app with those of the `Font.css` linked to above.
+
+## Known issues
+On iOS and macOS the indeterminate state for a CheckBox is not the right color.
 
 
 ## Related Topics
-- [#3011](https://github.com/unoplatform/uno/issues/3011)
+- [3011](https://github.com/unoplatform/uno/issues/3011)
 - [967](https://github.com/unoplatform/uno/issues/967)


### PR DESCRIPTION
GitHub Issue (If applicable): Fix #3863

## PR Type

What kind of change does this PR introduce?
- Documentation content changes

## What is the current behavior?
Documentation to update the fonts was hard to read. Platforms were separated in a table and android image was missing.

## What is the new behavior?
Documentation is cleaner. The image link is fix.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.