### PR TITLE
[Prism-dotnetnew] Use template SourceName instead of old template parameters

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Shared/Strings/en/Resources.resw
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Shared/Strings/en/Resources.resw
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApplicationName" xml:space="preserve">
-    <value>$ext_safeprojectname$</value>
+    <value>BlankApp</value>
   </data>
 </root>


### PR DESCRIPTION
GitHub Issue: closes #3478 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Creating a new app through `dotnet new unoapp-prism -n MyApp` will leave a $ext_safeprojectname$ in the Resource.resw file


## What is the new behavior?

Creating a new app through `dotnet new unoapp-prism -n MyApp` will properly set the ApplicationName resource to MyApp.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.