### PR TITLE
docs: Add Skia to the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -21,11 +21,15 @@ If the matter is security related, please disclose it privately via https://gith
 
 <!-- Please provide a **MINIMAL REPRO PROJECT** and the **STEPS TO REPRODUCE**-->
 
+## Workaround
+
+<!-- Please provide steps to workaround this problem if possible -->
+
 ## Environment
 
 <!-- For bug reports Check one or more of the following options with "x" -->
 
-Nuget Package:
+Nuget Package: <!-- For example Uno.UI, Uno.UI.RemoteControl, Uno.Material, ... -->
 
 Package Version(s):
 
@@ -43,11 +47,14 @@ Affected platform(s):
 - [ ] Build tasks
 - [ ] Solution Templates
 
-Visual Studio:
+IDE:
 
 - [ ] 2017 (version: )
 - [ ] 2019 (version: )
 - [ ] for Mac (version: )
+- [ ] Rider Windows (version: )
+- [ ] Rider macOS (version: )
+- [ ] Visual Studio Code (version: )
 
 Relevant plugins:
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -49,9 +49,9 @@ Affected platform(s):
 
 IDE:
 
-- [ ] 2017 (version: )
-- [ ] 2019 (version: )
-- [ ] for Mac (version: )
+- [ ] Visual Studio 2017 (version: )
+- [ ] Visual Studio 2019 (version: )
+- [ ] Visual Studio for Mac (version: )
 - [ ] Rider Windows (version: )
 - [ ] Rider macOS (version: )
 - [ ] Visual Studio Code (version: )

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -36,6 +36,7 @@ Affected platform(s):
 - [ ] WebAssembly
 - [ ] WebAssembly renderers for Xamarin.Forms
 - [ ] macOS
+- [ ] Skia
 - [ ] Windows
 - [ ] Build tasks
 - [ ] Solution Templates

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -37,6 +37,8 @@ Affected platform(s):
 - [ ] WebAssembly renderers for Xamarin.Forms
 - [ ] macOS
 - [ ] Skia
+  - [ ] WPF
+  - [ ] GTK (Linux)
 - [ ] Windows
 - [ ] Build tasks
 - [ ] Solution Templates

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -26,6 +26,8 @@ labels: kind/consumer-experience, kind/documentation, triage/untriaged
 - [ ] WebAssembly
 - [ ] macOS
 - [ ] Skia
+  - [ ] WPF
+  - [ ] GTK (Linux)
 - [ ] Windows
 
 ## Anything else we need to know?

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -25,6 +25,7 @@ labels: kind/consumer-experience, kind/documentation, triage/untriaged
 - [ ] Android
 - [ ] WebAssembly
 - [ ] macOS
+- [ ] Skia
 - [ ] Windows
 
 ## Anything else we need to know?

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -18,6 +18,8 @@ labels: kind/enhancement, triage/untriaged
 - [ ] WebAssembly renderers for Xamarin.Forms
 - [ ] macOS
 - [ ] Skia
+  - [ ] WPF
+  - [ ] GTK (Linux)
 - [ ] Windows
 - [ ] Build tasks
 - [ ] Solution Templates

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -17,6 +17,7 @@ labels: kind/enhancement, triage/untriaged
 - [ ] WebAssembly
 - [ ] WebAssembly renderers for Xamarin.Forms
 - [ ] macOS
+- [ ] Skia
 - [ ] Windows
 - [ ] Build tasks
 - [ ] Solution Templates

--- a/.github/ISSUE_TEMPLATE/samples-request.md
+++ b/.github/ISSUE_TEMPLATE/samples-request.md
@@ -17,6 +17,7 @@ labels: kind/contributor-experience, kind/documentation, triage/untriaged
 - [ ] WebAssembly
 - [ ] WebAssembly renderers for Xamarin.Forms
 - [ ] macOS
+- [ ] Skia
 - [ ] Windows
 
 

--- a/.github/ISSUE_TEMPLATE/samples-request.md
+++ b/.github/ISSUE_TEMPLATE/samples-request.md
@@ -18,6 +18,8 @@ labels: kind/contributor-experience, kind/documentation, triage/untriaged
 - [ ] WebAssembly renderers for Xamarin.Forms
 - [ ] macOS
 - [ ] Skia
+  - [ ] WPF
+  - [ ] GTK (Linux)
 - [ ] Windows
 
 


### PR DESCRIPTION
## Docs
Add Skia to the issue templates

## What is the current behavior?


## What is the new behavior?

## PR Checklist
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
