### PR TITLE
fix: Correctly initialize value of GeoCoordinate.Point on Android

### DIFF
--- a/src/Uno.UWP/Devices/Geolocation/Geopoint.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geopoint.cs
@@ -15,7 +15,7 @@ namespace Windows.Devices.Geolocation
 
 		public GeoshapeType GeoshapeType => GeoshapeType.Geopoint;
 
-#if __WASM__
+#if __WASM__ || __ANDROID__
 		public Geopoint(BasicGeoposition position, AltitudeReferenceSystem altitudeReferenceSystem) : this(position)
 		{
 			AltitudeReferenceSystem = altitudeReferenceSystem;

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Geolocation/Geopoint.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Geolocation/Geopoint.cs
@@ -8,7 +8,7 @@ namespace Windows.Devices.Geolocation
 	public  partial class Geopoint : global::Windows.Devices.Geolocation.IGeoshape
 	{
 		// Skipping already declared property Position
-		#if __ANDROID__ || __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Devices.Geolocation.AltitudeReferenceSystem AltitudeReferenceSystem
 		{
@@ -19,7 +19,7 @@ namespace Windows.Devices.Geolocation
 		}
 		#endif
 		// Skipping already declared property GeoshapeType
-		#if __ANDROID__ || __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  uint SpatialReferenceId
 		{
@@ -31,7 +31,7 @@ namespace Windows.Devices.Geolocation
 		#endif
 		// Skipping already declared method Windows.Devices.Geolocation.Geopoint.Geopoint(Windows.Devices.Geolocation.BasicGeoposition)
 		// Forced skipping of method Windows.Devices.Geolocation.Geopoint.Geopoint(Windows.Devices.Geolocation.BasicGeoposition)
-		#if __ANDROID__ || __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public Geopoint( global::Windows.Devices.Geolocation.BasicGeoposition position,  global::Windows.Devices.Geolocation.AltitudeReferenceSystem altitudeReferenceSystem) 
 		{
@@ -39,7 +39,7 @@ namespace Windows.Devices.Geolocation
 		}
 		#endif
 		// Forced skipping of method Windows.Devices.Geolocation.Geopoint.Geopoint(Windows.Devices.Geolocation.BasicGeoposition, Windows.Devices.Geolocation.AltitudeReferenceSystem)
-		#if __ANDROID__ || __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public Geopoint( global::Windows.Devices.Geolocation.BasicGeoposition position,  global::Windows.Devices.Geolocation.AltitudeReferenceSystem altitudeReferenceSystem,  uint spatialReferenceId) 
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

-->

## What is the current behavior?

When using Geolocator to obtain a Geocoordinate position, Geocoordinate.Latitude and Geocoordinate.Longitude are correct but Geocoordinate.Point.Latitude and Geocoordinate.Point.Longitude (which are the correct way to obtain those values according to MSDN doc) are all set to 0, because we use a ctor which is not implemented.


## What is the new behavior?

Geocoordinate.Point is correctly set.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ (I have tested that the values are set correctly)
- [ ] ~~Validated PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [ ] ~~Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).~~
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
