### PR TITLE
feat: Throw appropriate exception when obtaining location without permission

### DIFF
--- a/src/SamplesApp/SamplesApp.iOS/Info.plist
+++ b/src/SamplesApp/SamplesApp.iOS/Info.plist
@@ -64,5 +64,9 @@
 	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>TODO NSLocationWhenInUseUsageDescription</string>
+	<key>NSLocationUsageDescription</key>
+	<string>TODO NSLocationUsageDescription</string>
 </dict>
 </plist>

--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.iOSmacOS.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.iOSmacOS.cs
@@ -49,6 +49,11 @@ namespace Windows.Devices.Geolocation
 		{
 			BroadcastStatus(PositionStatus.Initializing);
 			var location = _locationManager.Location;
+			if (location == null)
+			{
+				throw new InvalidOperationException("Could not obtain the location. Please make sure that NSLocationWhenInUseUsageDescription and NSLocationUsageDescription are set in info.plist.");
+			}
+
 			BroadcastStatus(PositionStatus.Ready);
 #if __IOS__
 			return ToGeoposition(location);


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

-->

## What is the current behavior?

When the permission is denied and GetGeopositionAsync is called, then a NullReferenceException is thrown.


## What is the new behavior?

When the permission is denied and GetGeopositionAsync is called, then the method throws a helpful exception, as in UWP and Android.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~Validated PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [ ] ~~Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).~~
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
