### PR TITLE
fix(wasm): splash screen now respects aspect ratio

### DIFF
--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -185,8 +185,9 @@ embed.uno-frameworkelement.uno-unarranged {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 620px;
-  height: 300px;
+  max-width: 620px;
+  width: calc(100vw - 10px);
+  height: auto;
   background-repeat: no-repeat;
   background-position: center;
   background-size: 620px 300px;
@@ -198,8 +199,9 @@ embed.uno-frameworkelement.uno-unarranged {
   top: 50% !important;
   left: 50% !important;
   transform: translate(-50%, -50%) !important;
-  width: 620px !important;
-  height: 300px !important;
+  max-width: 620px !important;
+  width: calc(100vw - 10px) !important;
+  height: auto !important;
   background-repeat: no-repeat !important;
   background-position: center !important;
   background-size: 620px 300px !important;


### PR DESCRIPTION
GitHub Issue (If applicable): Fix #3756

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Splashscreen does not keep its aspect ratio

## What is the new behavior?
Aspect ratio is now kept

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.