### PR TITLE
Remove extra 'LinkerDefinition.Wasm (2).xml' file

### DIFF
--- a/src/Uno.UI.RemoteControl/LinkerDefinition.Wasm (2).xml
+++ b/src/Uno.UI.RemoteControl/LinkerDefinition.Wasm (2).xml
@@ -1,4 +1,0 @@
-<linker>
-  <assembly fullname="Uno.Wasm.WebSockets" />
-  <assembly fullname="Uno.UI.RemoteControl" />
-</linker>


### PR DESCRIPTION
GitHub Issue (If applicable): #

N/A

## PR Type

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

There is an extra `LinkerDefinition.Wasm (2).xaml` file in Uno.UI.RemoteControl. It is the exact same file as `LinkerDefinition.Wasm.xaml` but has the worryingly-named '(2)' suffix. This file isn't referenced anywhere in the code.

![image](https://user-images.githubusercontent.com/17993847/91858935-d76fb480-ec37-11ea-95f9-b2e1cac6e5c8.png)

## What is the new behavior?

The unnecessary file is removed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
