### PR TITLE
feat: AutomationPeer methods

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
@@ -251,15 +251,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
 
 		[TestMethod]
 		[RunsOnUIThread]
-		public void When_AutomationPeer_Default_GetParent()
-		{
-			var automationPeer = new TestAutomationPeer();
-			var result = automationPeer.GetParent();
-			Assert.AreEqual(null, result);
-		}
-
-		[TestMethod]
-		[RunsOnUIThread]
 		public void When_AutomationPeer_Default_GetPeerFromPoint()
 		{
 			var automationPeer = new TestAutomationPeer();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Automation/Given_AutomationPeer.cs
@@ -1,0 +1,412 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml.Automation.Peers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Automation
+{
+	[TestClass]
+	class Given_AutomationPeer
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetHeadingLevel()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetHeadingLevel();
+			Assert.AreEqual(AutomationHeadingLevel.None, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_IsDialog()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.IsDialog();
+			Assert.AreEqual(false, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetPattern()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetPattern(PatternInterface.Drag);
+			Assert.AreEqual(null, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetAcceleratorKey()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetAcceleratorKey();
+			Assert.AreEqual(string.Empty, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetAccessKey()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetAccessKey();
+			Assert.AreEqual(string.Empty, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetAutomationControlType()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetAutomationControlType();
+			Assert.AreEqual(AutomationControlType.Custom, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetAutomationId()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetAutomationId();
+			Assert.AreEqual(string.Empty, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetBoundingRectangle()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetBoundingRectangle();
+			Assert.AreEqual(default, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetChildren()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetChildren();
+			Assert.AreEqual(null, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetClassName()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetClassName();
+			Assert.AreEqual(string.Empty, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetClickablePoint()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetClickablePoint();
+			Assert.AreEqual(default, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetHelpText()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetHelpText();
+			Assert.AreEqual(string.Empty, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetItemStatus()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetItemStatus();
+			Assert.AreEqual(string.Empty, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetItemType()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetItemType();
+			Assert.AreEqual(string.Empty, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetLabeledBy()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetLabeledBy();
+			Assert.AreEqual(null, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetLocalizedControlType()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetLocalizedControlType();
+			Assert.AreEqual("custom", result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetName()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetName();
+			Assert.AreEqual(string.Empty, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetOrientation()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetOrientation();
+			Assert.AreEqual(AutomationOrientation.None, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_HasKeyboardFocus()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.HasKeyboardFocus();
+			Assert.AreEqual(false, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_IsContentElement()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.IsContentElement();
+			Assert.AreEqual(false, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_IsControlElement()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.IsControlElement();
+			Assert.AreEqual(false, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_IsEnabled()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.IsEnabled();
+			Assert.AreEqual(true, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_IsKeyboardFocusable()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.IsKeyboardFocusable();
+			Assert.AreEqual(false, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_IsOffscreen()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.IsOffscreen();
+			Assert.AreEqual(false, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_IsPassword()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.IsPassword();
+			Assert.AreEqual(false, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_IsRequiredForForm()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.IsRequiredForForm();
+			Assert.AreEqual(false, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_SetFocus()
+		{
+			var automationPeer = new TestAutomationPeer();
+			// Should not throw
+			automationPeer.SetFocus();
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetParent()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetParent();
+			Assert.AreEqual(null, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetPeerFromPoint()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetPeerFromPoint(default);
+			Assert.AreEqual(automationPeer, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetLiveSetting()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetLiveSetting();
+			Assert.AreEqual(AutomationLiveSetting.Off, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_Navigate()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.Navigate(default);
+			Assert.AreEqual(null, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetElementFromPoint()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetElementFromPoint(default);
+			Assert.AreEqual(automationPeer, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetFocusedElement()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetFocusedElement();
+			Assert.AreEqual(automationPeer, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_ShowContextMenu()
+		{
+			var automationPeer = new TestAutomationPeer();
+			// Should not throw
+			automationPeer.ShowContextMenu();
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetControlledPeers()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetControlledPeers();
+			Assert.AreEqual(null, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetAnnotations()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetAnnotations();
+			Assert.AreEqual(null, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetPositionInSet()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetPositionInSet();
+			Assert.AreEqual(-1, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetSizeOfSet()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetSizeOfSet();
+			Assert.AreEqual(-1, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetLevel()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetLevel();
+			Assert.AreEqual(-1, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetLandmarkType()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetLandmarkType();
+			Assert.AreEqual(AutomationLandmarkType.None, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetLocalizedLandmarkType()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetLocalizedLandmarkType();
+			Assert.AreEqual(string.Empty, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_IsPeripheral()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.IsPeripheral();
+			Assert.AreEqual(false, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_IsDataValidForForm()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.IsDataValidForForm();
+			Assert.AreEqual(true, result);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_AutomationPeer_Default_GetFullDescription()
+		{
+			var automationPeer = new TestAutomationPeer();
+			var result = automationPeer.GetFullDescription();
+			Assert.AreEqual(string.Empty, result);
+		}
+
+		private class TestAutomationPeer : AutomationPeer
+		{
+			public TestAutomationPeer()
+			{
+			}
+		}
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeer.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeer.AutomationPeer()
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeer.EventsSource.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeer.EventsSource.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  object GetPattern( global::Windows.UI.Xaml.Automation.Peers.PatternInterface patternInterface)
 		{
@@ -46,14 +46,14 @@ namespace Windows.UI.Xaml.Automation.Peers
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.AutomationPeer", "void AutomationPeer.RaisePropertyChangedEvent(AutomationProperty automationProperty, object oldValue, object newValue)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string GetAcceleratorKey()
 		{
 			throw new global::System.NotImplementedException("The member string AutomationPeer.GetAcceleratorKey() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string GetAccessKey()
 		{
@@ -61,21 +61,21 @@ namespace Windows.UI.Xaml.Automation.Peers
 		}
 		#endif
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.GetAutomationControlType()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string GetAutomationId()
 		{
 			throw new global::System.NotImplementedException("The member string AutomationPeer.GetAutomationId() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.Rect GetBoundingRectangle()
 		{
 			throw new global::System.NotImplementedException("The member Rect AutomationPeer.GetBoundingRectangle() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Automation.Peers.AutomationPeer> GetChildren()
 		{
@@ -83,28 +83,28 @@ namespace Windows.UI.Xaml.Automation.Peers
 		}
 		#endif
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.GetClassName()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.Point GetClickablePoint()
 		{
 			throw new global::System.NotImplementedException("The member Point AutomationPeer.GetClickablePoint() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string GetHelpText()
 		{
 			throw new global::System.NotImplementedException("The member string AutomationPeer.GetHelpText() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string GetItemStatus()
 		{
 			throw new global::System.NotImplementedException("The member string AutomationPeer.GetItemStatus() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string GetItemType()
 		{
@@ -114,14 +114,14 @@ namespace Windows.UI.Xaml.Automation.Peers
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.GetLabeledBy()
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.GetLocalizedControlType()
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.GetName()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.Automation.Peers.AutomationOrientation GetOrientation()
 		{
 			throw new global::System.NotImplementedException("The member AutomationOrientation AutomationPeer.GetOrientation() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool HasKeyboardFocus()
 		{
@@ -131,14 +131,14 @@ namespace Windows.UI.Xaml.Automation.Peers
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.IsContentElement()
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.IsControlElement()
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.IsEnabled()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool IsKeyboardFocusable()
 		{
 			throw new global::System.NotImplementedException("The member bool AutomationPeer.IsKeyboardFocusable() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool IsOffscreen()
 		{
@@ -146,7 +146,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 		}
 		#endif
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.IsPassword()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool IsRequiredForForm()
 		{
@@ -162,56 +162,56 @@ namespace Windows.UI.Xaml.Automation.Peers
 		}
 		#endif
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.InvalidatePeer()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.Automation.Peers.AutomationPeer GetPeerFromPoint( global::Windows.Foundation.Point point)
 		{
 			throw new global::System.NotImplementedException("The member AutomationPeer AutomationPeer.GetPeerFromPoint(Point point) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.Automation.Peers.AutomationLiveSetting GetLiveSetting()
 		{
 			throw new global::System.NotImplementedException("The member AutomationLiveSetting AutomationPeer.GetLiveSetting() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  object Navigate( global::Windows.UI.Xaml.Automation.Peers.AutomationNavigationDirection direction)
 		{
 			throw new global::System.NotImplementedException("The member object AutomationPeer.Navigate(AutomationNavigationDirection direction) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  object GetElementFromPoint( global::Windows.Foundation.Point pointInWindowCoordinates)
 		{
 			throw new global::System.NotImplementedException("The member object AutomationPeer.GetElementFromPoint(Point pointInWindowCoordinates) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  object GetFocusedElement()
 		{
 			throw new global::System.NotImplementedException("The member object AutomationPeer.GetFocusedElement() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void ShowContextMenu()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.AutomationPeer", "void AutomationPeer.ShowContextMenu()");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.UI.Xaml.Automation.Peers.AutomationPeer> GetControlledPeers()
 		{
 			throw new global::System.NotImplementedException("The member IReadOnlyList<AutomationPeer> AutomationPeer.GetControlledPeers() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation> GetAnnotations()
 		{
@@ -232,21 +232,21 @@ namespace Windows.UI.Xaml.Automation.Peers
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.AutomationPeer", "void AutomationPeer.RaiseTextEditTextChangedEvent(AutomationTextEditChangeType automationTextEditChangeType, IReadOnlyList<string> changedData)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int GetPositionInSet()
 		{
 			throw new global::System.NotImplementedException("The member int AutomationPeer.GetPositionInSet() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int GetSizeOfSet()
 		{
 			throw new global::System.NotImplementedException("The member int AutomationPeer.GetSizeOfSet() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int GetLevel()
 		{
@@ -260,35 +260,35 @@ namespace Windows.UI.Xaml.Automation.Peers
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.AutomationPeer", "void AutomationPeer.RaiseStructureChangedEvent(AutomationStructureChangeType structureChangeType, AutomationPeer child)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.Automation.Peers.AutomationLandmarkType GetLandmarkType()
 		{
 			throw new global::System.NotImplementedException("The member AutomationLandmarkType AutomationPeer.GetLandmarkType() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string GetLocalizedLandmarkType()
 		{
 			throw new global::System.NotImplementedException("The member string AutomationPeer.GetLocalizedLandmarkType() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool IsPeripheral()
 		{
 			throw new global::System.NotImplementedException("The member bool AutomationPeer.IsPeripheral() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool IsDataValidForForm()
 		{
 			throw new global::System.NotImplementedException("The member bool AutomationPeer.IsDataValidForForm() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string GetFullDescription()
 		{
@@ -309,14 +309,14 @@ namespace Windows.UI.Xaml.Automation.Peers
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.AutomationPeer", "void AutomationPeer.RaiseNotificationEvent(AutomationNotificationKind notificationKind, AutomationNotificationProcessing notificationProcessing, string displayString, string activityId)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.Automation.Peers.AutomationHeadingLevel GetHeadingLevel()
 		{
 			throw new global::System.NotImplementedException("The member AutomationHeadingLevel AutomationPeer.GetHeadingLevel() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool IsDialog()
 		{
@@ -337,21 +337,21 @@ namespace Windows.UI.Xaml.Automation.Peers
 			throw new global::System.NotImplementedException("The member IRawElementProviderSimple AutomationPeer.ProviderFromPeer(AutomationPeer peer) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual object GetPatternCore( global::Windows.UI.Xaml.Automation.Peers.PatternInterface patternInterface)
 		{
 			throw new global::System.NotImplementedException("The member object AutomationPeer.GetPatternCore(PatternInterface patternInterface) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual string GetAcceleratorKeyCore()
 		{
 			throw new global::System.NotImplementedException("The member string AutomationPeer.GetAcceleratorKeyCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual string GetAccessKeyCore()
 		{
@@ -359,21 +359,21 @@ namespace Windows.UI.Xaml.Automation.Peers
 		}
 		#endif
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.GetAutomationControlTypeCore()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual string GetAutomationIdCore()
 		{
 			throw new global::System.NotImplementedException("The member string AutomationPeer.GetAutomationIdCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual global::Windows.Foundation.Rect GetBoundingRectangleCore()
 		{
 			throw new global::System.NotImplementedException("The member Rect AutomationPeer.GetBoundingRectangleCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Automation.Peers.AutomationPeer> GetChildrenCore()
 		{
@@ -381,28 +381,28 @@ namespace Windows.UI.Xaml.Automation.Peers
 		}
 		#endif
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.GetClassNameCore()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual global::Windows.Foundation.Point GetClickablePointCore()
 		{
 			throw new global::System.NotImplementedException("The member Point AutomationPeer.GetClickablePointCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual string GetHelpTextCore()
 		{
 			throw new global::System.NotImplementedException("The member string AutomationPeer.GetHelpTextCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual string GetItemStatusCore()
 		{
 			throw new global::System.NotImplementedException("The member string AutomationPeer.GetItemStatusCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual string GetItemTypeCore()
 		{
@@ -412,14 +412,14 @@ namespace Windows.UI.Xaml.Automation.Peers
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.GetLabeledByCore()
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.GetLocalizedControlTypeCore()
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.GetNameCore()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual global::Windows.UI.Xaml.Automation.Peers.AutomationOrientation GetOrientationCore()
 		{
 			throw new global::System.NotImplementedException("The member AutomationOrientation AutomationPeer.GetOrientationCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual bool HasKeyboardFocusCore()
 		{
@@ -429,14 +429,14 @@ namespace Windows.UI.Xaml.Automation.Peers
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.IsContentElementCore()
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.IsControlElementCore()
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.IsEnabledCore()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual bool IsKeyboardFocusableCore()
 		{
 			throw new global::System.NotImplementedException("The member bool AutomationPeer.IsKeyboardFocusableCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual bool IsOffscreenCore()
 		{
@@ -444,7 +444,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 		}
 		#endif
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.IsPasswordCore()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual bool IsRequiredForFormCore()
 		{
@@ -452,112 +452,112 @@ namespace Windows.UI.Xaml.Automation.Peers
 		}
 		#endif
 		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.SetFocusCore()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual global::Windows.UI.Xaml.Automation.Peers.AutomationPeer GetPeerFromPointCore( global::Windows.Foundation.Point point)
 		{
 			throw new global::System.NotImplementedException("The member AutomationPeer AutomationPeer.GetPeerFromPointCore(Point point) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual global::Windows.UI.Xaml.Automation.Peers.AutomationLiveSetting GetLiveSettingCore()
 		{
 			throw new global::System.NotImplementedException("The member AutomationLiveSetting AutomationPeer.GetLiveSettingCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual void ShowContextMenuCore()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.AutomationPeer", "void AutomationPeer.ShowContextMenuCore()");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual global::System.Collections.Generic.IReadOnlyList<global::Windows.UI.Xaml.Automation.Peers.AutomationPeer> GetControlledPeersCore()
 		{
 			throw new global::System.NotImplementedException("The member IReadOnlyList<AutomationPeer> AutomationPeer.GetControlledPeersCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual object NavigateCore( global::Windows.UI.Xaml.Automation.Peers.AutomationNavigationDirection direction)
 		{
 			throw new global::System.NotImplementedException("The member object AutomationPeer.NavigateCore(AutomationNavigationDirection direction) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual object GetElementFromPointCore( global::Windows.Foundation.Point pointInWindowCoordinates)
 		{
 			throw new global::System.NotImplementedException("The member object AutomationPeer.GetElementFromPointCore(Point pointInWindowCoordinates) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual object GetFocusedElementCore()
 		{
 			throw new global::System.NotImplementedException("The member object AutomationPeer.GetFocusedElementCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation> GetAnnotationsCore()
 		{
 			throw new global::System.NotImplementedException("The member IList<AutomationPeerAnnotation> AutomationPeer.GetAnnotationsCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual int GetPositionInSetCore()
 		{
 			throw new global::System.NotImplementedException("The member int AutomationPeer.GetPositionInSetCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual int GetSizeOfSetCore()
 		{
 			throw new global::System.NotImplementedException("The member int AutomationPeer.GetSizeOfSetCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual int GetLevelCore()
 		{
 			throw new global::System.NotImplementedException("The member int AutomationPeer.GetLevelCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual global::Windows.UI.Xaml.Automation.Peers.AutomationLandmarkType GetLandmarkTypeCore()
 		{
 			throw new global::System.NotImplementedException("The member AutomationLandmarkType AutomationPeer.GetLandmarkTypeCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual string GetLocalizedLandmarkTypeCore()
 		{
 			throw new global::System.NotImplementedException("The member string AutomationPeer.GetLocalizedLandmarkTypeCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual bool IsPeripheralCore()
 		{
 			throw new global::System.NotImplementedException("The member bool AutomationPeer.IsPeripheralCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual bool IsDataValidForFormCore()
 		{
 			throw new global::System.NotImplementedException("The member bool AutomationPeer.IsDataValidForFormCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual string GetFullDescriptionCore()
 		{
@@ -586,14 +586,14 @@ namespace Windows.UI.Xaml.Automation.Peers
 			throw new global::System.NotImplementedException("The member int AutomationPeer.GetCultureCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual global::Windows.UI.Xaml.Automation.Peers.AutomationHeadingLevel GetHeadingLevelCore()
 		{
 			throw new global::System.NotImplementedException("The member AutomationHeadingLevel AutomationPeer.GetHeadingLevelCore() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual bool IsDialogCore()
 		{

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.cs
@@ -8,11 +8,11 @@ namespace Windows.UI.Xaml.Automation.Peers
 	public partial class AutomationPeer : DependencyObject
 	{
 		[Uno.NotImplemented]
-		public static bool ListenerExists(AutomationEvents eventId) => false;
+		public static bool ListenerExists(Windows.UI.Xaml.Automation.Peers.AutomationEvents eventId) => false;
 
 		#region Public
 
-		public object GetPattern(PatternInterface patternInterface) => GetPatternCore(patternInterface);
+		public object GetPattern(Windows.UI.Xaml.Automation.Peers.PatternInterface patternInterface) => GetPatternCore(patternInterface);
 
 		public string GetAcceleratorKey() => GetAcceleratorKeyCore();
 
@@ -46,7 +46,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 
 		public AutomationLiveSetting GetLiveSetting() => GetLiveSettingCore();
 
-		public object Navigate(AutomationNavigationDirection direction) => NavigateCore(direction);
+		public object Navigate(Windows.UI.Xaml.Automation.Peers.AutomationNavigationDirection direction) => NavigateCore(direction);
 
 		public object GetElementFromPoint(Point pointInWindowCoordinates) => GetElementFromPointCore(pointInWindowCoordinates);
 
@@ -102,7 +102,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 
 		#region Overrides
 
-		protected virtual object GetPatternCore(PatternInterface patternInterface) => null;
+		protected virtual object GetPatternCore(Windows.UI.Xaml.Automation.Peers.PatternInterface patternInterface) => null;
 
 		protected virtual string GetAcceleratorKeyCore() => string.Empty;
 
@@ -140,7 +140,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 		{
 		}
 
-		protected virtual object NavigateCore(AutomationNavigationDirection direction) => null;
+		protected virtual object NavigateCore(Windows.UI.Xaml.Automation.Peers.AutomationNavigationDirection direction) => null;
 
 		protected virtual IReadOnlyList<AutomationPeer> GetControlledPeersCore() => null;
 

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.cs
@@ -1,137 +1,207 @@
 using System;
 using System.Collections.Generic;
 using Windows.UI.Xaml.Automation.Provider;
+using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Automation.Peers
 {
 	public partial class AutomationPeer : DependencyObject
 	{
-		[global::Uno.NotImplemented]
-		public static bool ListenerExists(global::Windows.UI.Xaml.Automation.Peers.AutomationEvents eventId)
-		{
-			return false;
-		}
+		[Uno.NotImplemented]
+		public static bool ListenerExists(AutomationEvents eventId) => false;
 
 		#region Public
 
-		public bool IsContentElement()
-		{
-			return IsContentElementCore();
-		}
+		public object GetPattern(PatternInterface patternInterface) => GetPatternCore(patternInterface);
 
-		public bool IsControlElement()
-		{
-			return IsControlElementCore();
-		}
+		public string GetAcceleratorKey() => GetAcceleratorKeyCore();
 
-		public bool IsEnabled()
-		{
-			return IsEnabledCore();
-		}
-		
-		public bool IsPassword()
-		{
-			return IsPasswordCore();
-		}
-		
-		public void SetFocus()
-		{
-			SetFocusCore();
-		}
-				
-		public string GetClassName()
-		{
-			return GetClassNameCore();
-		}
+		public string GetAccessKey() => GetAcceleratorKeyCore();
 
-		public AutomationControlType GetAutomationControlType()
-		{
-			return GetAutomationControlTypeCore();
-		}
+		public string GetAutomationId() => GetAutomationIdCore();
 
-		public string GetLocalizedControlType()
-		{
-			return GetLocalizedControlTypeCore();
-		}
+		public Rect GetBoundingRectangle() => GetBoundingRectangleCore();
 
-		public string GetName()
-		{
-			return GetNameCore();
-		}
-		
-		public AutomationPeer GetLabeledBy()
-		{
-			return GetLabeledByCore();
-		}
-		
+		public IList<AutomationPeer> GetChildren() => GetChildrenCore();
+
+		public Point GetClickablePoint() => GetClickablePointCore();
+
+		public string GetHelpText() => GetHelpTextCore();
+
+		public string GetItemStatus() => GetItemStatusCore();
+
+		public string GetItemType() => GetItemTypeCore();
+
+		public AutomationOrientation GetOrientation() => GetOrientationCore();
+
+		public bool HasKeyboardFocus() => HasKeyboardFocusCore();
+
+		public bool IsKeyboardFocusable() => IsKeyboardFocusableCore();
+
+		public bool IsOffscreen() => IsOffscreenCore();
+
+		public bool IsRequiredForForm() => IsRequiredForFormCore();
+
+		public AutomationPeer GetPeerFromPoint(Point point) => GetPeerFromPointCore(point);
+
+		public AutomationLiveSetting GetLiveSetting() => GetLiveSettingCore();
+
+		public object Navigate(AutomationNavigationDirection direction) => NavigateCore(direction);
+
+		public object GetElementFromPoint(Point pointInWindowCoordinates) => GetElementFromPointCore(pointInWindowCoordinates);
+
+		public object GetFocusedElement() => GetFocusedElementCore();
+
+		public void ShowContextMenu() => ShowContextMenuCore();
+
+		public IReadOnlyList<AutomationPeer> GetControlledPeers() => GetControlledPeersCore();
+
+		public IList<AutomationPeerAnnotation> GetAnnotations() => GetAnnotationsCore();
+
+		public int GetPositionInSet() => GetPositionInSetCore();
+
+		public int GetSizeOfSet() => GetSizeOfSetCore();
+
+		public int GetLevel() => GetLevelCore();
+
+		public AutomationLandmarkType GetLandmarkType() => GetLandmarkTypeCore();
+
+		public string GetLocalizedLandmarkType() => GetLocalizedLandmarkTypeCore();
+
+		public bool IsPeripheral() => IsPeripheralCore();
+
+		public bool IsDataValidForForm() => IsDataValidForFormCore();
+
+		public string GetFullDescription() => GetFullDescriptionCore();
+
+		public AutomationHeadingLevel GetHeadingLevel() => GetHeadingLevelCore();
+
+		public bool IsDialog() => IsDialogCore();
+
+		public bool IsContentElement() => IsContentElementCore();
+
+		public bool IsControlElement() => IsControlElementCore();
+
+		public bool IsEnabled() => IsEnabledCore();
+
+		public bool IsPassword() => IsPasswordCore();
+
+		public void SetFocus() => SetFocusCore();
+
+		public string GetClassName() => GetClassNameCore();
+
+		public AutomationControlType GetAutomationControlType() => GetAutomationControlTypeCore();
+
+		public string GetLocalizedControlType() => GetLocalizedControlTypeCore();
+
+		public string GetName() => GetNameCore();
+
+		public AutomationPeer GetLabeledBy() => GetLabeledByCore();
+
 		#endregion
 
 		#region Overrides
 
-		protected virtual bool IsContentElementCore()
+		protected virtual object GetPatternCore(PatternInterface patternInterface) => null;
+
+		protected virtual string GetAcceleratorKeyCore() => string.Empty;
+
+		protected virtual string GetAccessKeyCore() => string.Empty;
+
+		protected virtual string GetAutomationIdCore() => string.Empty;
+
+		protected virtual Rect GetBoundingRectangleCore() => default;
+
+		protected virtual IList<AutomationPeer> GetChildrenCore() => null;
+
+		protected virtual Point GetClickablePointCore() => default;
+
+		protected virtual string GetHelpTextCore() => string.Empty;
+
+		protected virtual string GetItemStatusCore() => string.Empty;
+
+		protected virtual string GetItemTypeCore() => string.Empty;
+
+		protected virtual AutomationOrientation GetOrientationCore() => AutomationOrientation.None;
+
+		protected virtual bool HasKeyboardFocusCore() => false;
+
+		protected virtual bool IsKeyboardFocusableCore() => false;
+
+		protected virtual bool IsOffscreenCore() => false;
+
+		protected virtual bool IsRequiredForFormCore() => false;
+
+		protected virtual AutomationPeer GetPeerFromPointCore(Point point) => this;
+
+		protected virtual AutomationLiveSetting GetLiveSettingCore() => AutomationLiveSetting.Off;
+
+		protected virtual void ShowContextMenuCore()
 		{
-			return false;
 		}
 
-		protected virtual bool IsControlElementCore()
-		{
-			return false;
-		}
+		protected virtual object NavigateCore(AutomationNavigationDirection direction) => null;
 
-		protected virtual bool IsEnabledCore()
-		{
-			return true;
-		}
+		protected virtual IReadOnlyList<AutomationPeer> GetControlledPeersCore() => null;
 
-		protected virtual string GetClassNameCore()
-		{
-			return "";
-		}
+		protected virtual object GetElementFromPointCore(Point pointInWindowCoordinates) => this;
 
-		protected virtual string GetNameCore()
-		{
-			return "";
-		}
+		protected virtual object GetFocusedElementCore() => this;
 
-		protected virtual string GetLocalizedControlTypeCore()
-		{
-			return LocalizeControlType(GetAutomationControlType());
-		}
+		protected virtual IList<AutomationPeerAnnotation> GetAnnotationsCore() => null;
 
-		protected virtual AutomationControlType GetAutomationControlTypeCore()
-		{
-			return AutomationControlType.Custom;
-		}
-		
-		protected virtual bool IsPasswordCore()
-		{
-			return false;
-		}
-		
+		protected virtual int GetPositionInSetCore() => -1;
+
+		protected virtual int GetSizeOfSetCore() => -1;
+
+		protected virtual int GetLevelCore() => -1;
+
+		protected virtual AutomationLandmarkType GetLandmarkTypeCore() => AutomationLandmarkType.None;
+
+		protected virtual string GetLocalizedLandmarkTypeCore() => string.Empty;
+
+		protected virtual bool IsPeripheralCore() => false;
+
+		protected virtual bool IsDataValidForFormCore() => true;
+
+		protected virtual string GetFullDescriptionCore() => string.Empty;
+
+		protected virtual AutomationHeadingLevel GetHeadingLevelCore() => AutomationHeadingLevel.None;
+
+		protected virtual bool IsDialogCore() => false;
+
+		protected virtual bool IsContentElementCore() => false;
+
+		protected virtual bool IsControlElementCore() => false;
+
+		protected virtual bool IsEnabledCore() => true;
+
+		protected virtual string GetClassNameCore() => "";
+
+		protected virtual string GetNameCore() => "";
+
+		protected virtual string GetLocalizedControlTypeCore() => LocalizeControlType(GetAutomationControlType());
+
+		protected virtual AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Custom;
+
+		protected virtual bool IsPasswordCore() => false;
+
 		protected virtual void SetFocusCore()
 		{
 		}
 
-		protected virtual AutomationPeer GetLabeledByCore()
-		{
-			return null;
-		}
-		
-		protected virtual IEnumerable<AutomationPeer> GetDescribedByCore()
-		{
-			return null;
-		}
+		protected virtual AutomationPeer GetLabeledByCore() => null;
+
+		protected virtual IEnumerable<AutomationPeer> GetDescribedByCore() => null;
 
 		#endregion
 
 		#region Private
 
-		private static string LocalizeControlType(AutomationControlType controlType)
-		{
+		private static string LocalizeControlType(AutomationControlType controlType) =>
 			// TODO: Humanize ("AppBarButton" -> "app bar button")
 			// TODO: Localize
-			return Enum.GetName(typeof(AutomationControlType), controlType);
-		}
+			Enum.GetName(typeof(AutomationControlType), controlType).ToLowerInvariant();
 
 		internal bool InvokeAutomationPeer()
 		{
@@ -150,10 +220,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 			return false;
 		}
 
-		internal static void RaiseEventIfListener(DependencyObject target, AutomationEvents eventId)
-		{
-			Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.AutomationPeer", "RaiseEventIfListener");
-		}
+		internal static void RaiseEventIfListener(DependencyObject target, AutomationEvents eventId) => Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.AutomationPeer", "RaiseEventIfListener");
 
 		#endregion
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3931

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Many overridable methods in `AutomationPeer` throw.

## What is the new behavior?

Added default return values for many `AutomationPeer` methods.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.