### PR TITLE
fix(xbind): [iOS/macOS] Fix memory leak when using x:Bind

### DIFF
--- a/build/uno.winui.targets
+++ b/build/uno.winui.targets
@@ -26,6 +26,7 @@
 			<UnoDefineConstants Condition="'$(MSBuildThisFile)'=='uno.winui.targets'">$(UnoDefineConstants);HAS_UNO_WINUI</UnoDefineConstants>
 			<UnoDefineConstants>$(UnoDefineConstants);UNO_HAS_FRAMEWORKELEMENT_MEASUREOVERRIDE</UnoDefineConstants>
 			<UnoDefineConstants>$(UnoDefineConstants);UNO_HAS_NO_IDEPENDENCYOBJECT</UnoDefineConstants>
+			<UnoDefineConstants Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='xamarinmac20'">$(UnoDefineConstants);UNO_HAS_UIELEMENT_IMPLICIT_PINNING</UnoDefineConstants>
 		</PropertyGroup>
 
 		<PropertyGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETStandard' or '$(TargetFrameworkIdentifier)'=='.NETCoreApp'">

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -731,17 +731,23 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				writer.AppendLineInvariant($"[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]");
 				using (writer.BlockInvariant($"private class {bindingsClassName} : {bindingsInterfaceName}"))
 				{
-					writer.AppendLineInvariant($"private readonly {className} _owner;");
+					writer.AppendLineInvariant("#if UNO_HAS_UIELEMENT_IMPLICIT_PINNING");
+					writer.AppendLineInvariant("{0}", $"private global::System.WeakReference _ownerReference;");
+					writer.AppendLineInvariant("{0}", $"private {className} Owner {{ get => ({className})_ownerReference?.Target; set => _ownerReference = new global::System.WeakReference(value); }}");
+					writer.AppendLineInvariant("#else");
+					writer.AppendLineInvariant("{0}", $"private {className} Owner {{ get; set; }}");
+					writer.AppendLineInvariant("#endif");
+
 
 					using (writer.BlockInvariant($"public {bindingsClassName}({className} owner)"))
 					{
-						writer.AppendLineInvariant($"_owner = owner;");
+						writer.AppendLineInvariant($"Owner = owner;");
 					}
 
 					using (writer.BlockInvariant($"void {bindingsInterfaceName}.Initialize()")) { }
 					using (writer.BlockInvariant($"void {bindingsInterfaceName}.Update()"))
 					{
-						writer.AppendLineInvariant($"_owner.ApplyCompiledBindings();");
+						writer.AppendLineInvariant($"Owner.ApplyCompiledBindings();");
 					}
 					using (writer.BlockInvariant($"void {bindingsInterfaceName}.StopTracking()")) { }
 				}

--- a/src/Uno.CrossTargetting.props
+++ b/src/Uno.CrossTargetting.props
@@ -41,6 +41,20 @@
 	</CreateProperty>
   </Target>
 
+  <!--
+  List of known constants:
+  - __SKIA__: Used when building for the Skia backend
+  - __WASM__: Used when building for the WebAssembly backend
+  - UNO_REFERENCE_API: Used when the netstandard 2.0 Reference API is used.
+  - HAS_EXPENSIVE_TRYFINALLY: Used on WebAssembly until exceptions are supported by the WebAssembly specification
+  - __NETSTD_REFERENCE__: Used when building the reference assemblies for the netstandard 2.0 target
+  - UNO_HAS_UIELEMENT_IMPLICIT_PINNING: Used to mark targets that have specific constraints on
+										UIElements. On iOS, this means additional weak references
+										backed fields to handle opaque native reference pinning and avoid
+										memory leaks.
+  - Constants for Xamarin backends and SDK versions: https://docs.microsoft.com/en-us/xamarin/cross-platform/app-fundamentals/building-cross-platform-applications/platform-divergence-abstraction-divergent-implementation#conditional-compilation
+  -->
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' and '$(UnoRuntimeIdentifier)'=='WebAssembly'">
 	<DefineConstants>$(DefineConstants);__WASM__;UNO_REFERENCE_API;HAS_EXPENSIVE_TRYFINALLY</DefineConstants>
   </PropertyGroup>
@@ -54,7 +68,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(IsXamarinIOS)">
-	<DefineConstants>$(DefineConstants);IOS1_0;XAMARIN;XAMARIN_IOS;XAMARIN_IOS_UNIFIED</DefineConstants>
+	<DefineConstants>$(DefineConstants);IOS1_0;XAMARIN;XAMARIN_IOS;XAMARIN_IOS_UNIFIED;UNO_HAS_UIELEMENT_IMPLICIT_PINNING</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(IsXamarinMac)">
+	<DefineConstants>$(DefineConstants);UNO_HAS_UIELEMENT_IMPLICIT_PINNING</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(IsMonoAndroid)">

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.XamlEvent_Leak_UserControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml.FrameworkElementTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<!-- A named button with an event must not leak -->
+		<Button x:Name="namedButton"
+				Content="Button With Handler"
+				Click="Button_Click" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl.xaml.cs
@@ -15,7 +15,7 @@ using Windows.UI.Xaml.Navigation;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
-namespace UITests.Shared.Windows_UI_Xaml.FrameworkElementTests
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
 {
     public sealed partial class XamlEvent_Leak_UserControl : UserControl
     {
@@ -26,6 +26,7 @@ namespace UITests.Shared.Windows_UI_Xaml.FrameworkElementTests
 
 		private void Button_Click(object sender, RoutedEventArgs e)
 		{
+			Console.WriteLine("Button_Click");
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl_xBind.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl_xBind.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.XamlEvent_Leak_UserControl_xBind"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml.FrameworkElementTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<!-- A named button with an x:Bind must not leak -->
+		<Button x:Name="namedButton"
+				Content="{x:Bind Value}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl_xBind.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl_xBind.xaml.cs
@@ -15,17 +15,15 @@ using Windows.UI.Xaml.Navigation;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
-namespace UITests.Shared.Windows_UI_Xaml.FrameworkElementTests
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
 {
-    public sealed partial class XamlEvent_Leak_UserControl : UserControl
+    public sealed partial class XamlEvent_Leak_UserControl_xBind : UserControl
     {
-        public XamlEvent_Leak_UserControl()
+        public XamlEvent_Leak_UserControl_xBind()
         {
             this.InitializeComponent();
         }
 
-		private void Button_Click(object sender, RoutedEventArgs e)
-		{
-		}
+		public int Value { get; set; }
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl_xBind_Event.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl_xBind_Event.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.XamlEvent_Leak_UserControl_xBind_Event"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml.FrameworkElementTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<!-- A named button with an x:Bind event must not leak -->
+		<Button x:Name="namedButton"
+				Click="{x:Bind MyEvent}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl_xBind_Event.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/XamlEvent_Leak_UserControl_xBind_Event.xaml.cs
@@ -15,17 +15,18 @@ using Windows.UI.Xaml.Navigation;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
-namespace UITests.Shared.Windows_UI_Xaml.FrameworkElementTests
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
 {
-    public sealed partial class XamlEvent_Leak_UserControl : UserControl
+    public sealed partial class XamlEvent_Leak_UserControl_xBind_Event : UserControl
     {
-        public XamlEvent_Leak_UserControl()
+        public XamlEvent_Leak_UserControl_xBind_Event()
         {
             this.InitializeComponent();
         }
 
-		private void Button_Click(object sender, RoutedEventArgs e)
+		public void MyEvent()
 		{
+
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -1,0 +1,96 @@
+﻿#if !WINDOWS_UWP
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_FrameworkElement_And_Leak
+	{
+		private static ConditionalWeakTable<FrameworkElement, Holder> _holders
+			= new ConditionalWeakTable<FrameworkElement, Holder>();
+
+#if !__WASM__ // Deactivated until https://github.com/unoplatform/uno/pull/3728 is merged
+		[TestMethod]
+		[DataRow(typeof(XamlEvent_Leak_UserControl), 15)]
+		[DataRow(typeof(XamlEvent_Leak_UserControl_xBind), 15)]
+		[DataRow(typeof(XamlEvent_Leak_UserControl_xBind_Event), 15)]
+#endif
+		public async Task When_Add_Remove(Type controlType, int count)
+		{
+			var maxCounter = 0;
+			var activeControls = 0;
+			var maxActiveControls = 0;
+
+			var rootContainer = new ContentControl();
+
+			TestServices.WindowHelper.WindowContent = rootContainer;
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			for (int i = 0; i < count; i++)
+			{
+				var item = Activator.CreateInstance(controlType) as FrameworkElement;
+				_holders.Add(item, new Holder(HolderUpdate));
+				rootContainer.Content = item;
+				await TestServices.WindowHelper.WaitForIdle();
+				rootContainer.Content = null;
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				await Task.Yield();
+			}
+
+			void HolderUpdate(int value)
+			{
+				_ = rootContainer.Dispatcher.RunAsync(CoreDispatcherPriority.High,
+					() =>
+					{
+						maxCounter = Math.Max(value, maxCounter);
+						activeControls = value;
+						maxActiveControls = maxCounter;
+					}
+				);
+			}
+
+			var sw = Stopwatch.StartNew();
+
+			while (sw.Elapsed < TimeSpan.FromSeconds(5) && activeControls != 0)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				await Task.Yield();
+			}
+
+			Assert.AreEqual(0, activeControls);
+		}
+
+		private class Holder
+		{
+			private readonly Action<int> _update;
+			private static int _counter;
+
+			public Holder(Action<int> update)
+			{
+				_update = update;
+				_update(++_counter);
+			}
+
+			~Holder()
+			{
+				_update(--_counter);
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/3914

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Using x:Bind on iOS/macOS will not keep UIElement instances alive.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
