### PR TITLE
TimePicker and DatePickerFlyout fixes

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -157,5 +157,35 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 
 			_app.WaitForNoElement(datePickerFlyout);
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)] // iOS Specific selection
+		public void DatePickerFlyout_Date_Binding()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePickerFlyout_Date_Binding", skipInitialScreenshot: true);
+
+			var TestDatePickerFlyoutButton = _app.Marked("TestDatePickerFlyoutButton");
+			var datePickerFlyout = _app.CreateQuery(q => q.WithClass("Windows_UI_Xaml_Controls_DatePickerSelector"));
+
+			_app.WaitForElement(TestDatePickerFlyoutButton);
+			TestDatePickerFlyoutButton.FastTap();
+
+			_app.WaitForElement(datePickerFlyout);
+
+			_app.Query(x => x.Class("UIPickerView").Invoke("selectRow", "2020", "inComponent", 2, "animated", true));
+			_app.Tap(x => x.Class("UIPickerView").Descendant().Marked("2020"));
+
+			// Dismiss the flyout
+			_app.Tap(x => x.Marked("AcceptButton"));
+
+			var theDatePicker = _app.Marked("Result");
+			_app.WaitForText(theDatePicker, "5/4/2020 +00:00");
+
+			// Load another sample to dismiss the popup
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePicker_SampleContent", waitForSampleControl: false);
+
+			_app.WaitForNoElement(datePickerFlyout);
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
@@ -190,5 +190,27 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 			// Dismiss the flyout
 			_app.TapCoordinates(10, 10);
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)]
+		public void TimePicker_Flyout_Reloaded()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TimePicker.TimePicker_Flyout_Automated_Reload", skipInitialScreenshot: true);
+
+			var picker = _app.Marked("TestTimePicker");
+
+			_app.WaitForElement(picker);
+
+			picker.FastTap();
+
+			// Wait for the picker to appear
+			_app.WaitForElement(x => x.Class("UIPickerView"));
+
+			TakeScreenshot("TimePicker - Flyout", ignoreInSnapshotCompare: true);
+
+			// Dismiss the flyout
+			_app.Tap(x => x.Marked("AcceptButton"));
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1109,6 +1109,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\TimePicker_Flyout_Automated_Reload.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\TimePicker_TimePickerFlyoutStyle.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3386,7 +3390,7 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_Storage\FilePickerTests.xaml">
-	  <SubType>Designer</SubType>
+      <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_ViewManagement\ApplicationViewSizing.xaml">
@@ -4089,6 +4093,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ThumbTests\Thumb_DragEvents.xaml.cs">
       <DependentUpon>Thumb_DragEvents.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\TimePicker_Flyout_Automated_Reload.xaml.cs">
+      <DependentUpon>TimePicker_Flyout_Automated_Reload.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\TimePicker_TimePickerFlyoutStyle.xaml.cs">
       <DependentUpon>TimePicker_TimePickerFlyoutStyle.xaml</DependentUpon>
@@ -5969,7 +5976,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Storage\FilePickerTests.xaml.cs">
       <DependentUpon>FilePickerTests.xaml</DependentUpon>
-	</Compile>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_ViewManagement\ApplicationViewSizing.xaml.cs">
       <DependentUpon>ApplicationViewSizing.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -761,6 +761,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_Date_Binding.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_MinYear.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3849,6 +3853,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ControlTests\Control_IsEnabled_Inheritance.xaml.cs">
       <DependentUpon>Control_IsEnabled_Inheritance.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_Date_Binding.xaml.cs">
+      <DependentUpon>DatePickerFlyout_Date_Binding.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DropDownButton\DropDownButtonPage.xaml.cs">
       <DependentUpon>DropDownButtonPage.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Date_Binding.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Date_Binding.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.DatePicker.DatePickerFlyout_Date_Binding"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.DatePicker"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel x:Name="root" Spacing="8">
+		<Button x:Name="TestDatePickerFlyoutButton"
+					Content="Open DatePickerFlyout">
+			<Button.Flyout>
+				<DatePickerFlyout x:Name="TestDatePickerFlyout"
+								  Date="{x:Bind Date, Mode=TwoWay}"/>
+			</Button.Flyout>
+		</Button>
+		<TextBlock x:Name="Result" Text="{x:Bind Date, Mode=TwoWay}" />
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Date_Binding.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePickerFlyout_Date_Binding.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.Extensions;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.DatePicker
+{
+	[SampleControlInfo]
+	public sealed partial class DatePickerFlyout_Date_Binding : UserControl
+	{
+		public DatePickerFlyout_Date_Binding()
+		{
+			this.InitializeComponent();
+		}
+
+		public DateTimeOffset Date
+		{
+			get { return (DateTimeOffset)GetValue(DateProperty); }
+			set { SetValue(DateProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for Date.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty DateProperty =
+			DependencyProperty.Register(
+				name: "Date",
+				propertyType: typeof(DateTimeOffset),
+				ownerType: typeof(DatePickerFlyout_Date_Binding),
+				typeMetadata: new PropertyMetadata(new DateTimeOffset(2019, 05, 04, 0, 0, 0, TimeSpan.Zero))
+			);
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/TimePicker_Flyout_Automated_Reload.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/TimePicker_Flyout_Automated_Reload.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TimePicker.TimePicker_Flyout_Automated_Reload"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TimePicker"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid x:Name="root">
+		<TimePicker x:Name="TestTimePicker" />
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/TimePicker_Flyout_Automated_Reload.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/TimePicker_Flyout_Automated_Reload.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TimePicker
+{
+
+	[SampleControlInfo("Time Picker")]
+	public sealed partial class TimePicker_Flyout_Automated_Reload : UserControl
+	{
+		public TimePicker_Flyout_Automated_Reload()
+		{
+			this.InitializeComponent();
+
+			_ = Dispatcher.RunAsync(
+				Windows.UI.Core.CoreDispatcherPriority.Normal,
+				() => {
+					root.Children.Remove(TestTimePicker);
+
+					_ = Dispatcher.RunAsync(
+						Windows.UI.Core.CoreDispatcherPriority.Normal,
+						() =>
+						{
+							root.Children.Add(TestTimePicker);
+
+							this.TestTimePicker.Time = new TimeSpan(3, 12, 0);
+						});
+				}
+			);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.iOS.cs
@@ -161,7 +161,10 @@ namespace Windows.UI.Xaml.Controls
 			_selector.SaveValue();
 			Hide(false);
 
-			DatePicked?.Invoke(this, new DatePickedEventArgs(_selector.Date, Date));
+			var oldDate = Date;
+			Date = _selector.Date;
+
+			DatePicked?.Invoke(this, new DatePickedEventArgs(Date, oldDate));
 		}
 
 		private void Dismiss()

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
@@ -1,4 +1,6 @@
-﻿#if XAMARIN_IOS
+﻿#nullable enable
+
+#if XAMARIN_IOS
 
 using CoreGraphics;
 using UIKit;
@@ -15,8 +17,9 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private readonly SerialDisposable _onLoad = new SerialDisposable();
 		private readonly SerialDisposable _onUnloaded = new SerialDisposable();
-		internal protected TimePickerSelector _timeSelector;
-		internal protected FrameworkElement _headerUntapZone;
+		internal protected TimePickerSelector? _timeSelector;
+		internal protected FrameworkElement? _headerUntapZone;
+		private TimePickerFlyoutPresenter? _timePickerPresenter;
 		private bool _isInitialized;
 
 		public TimePickerFlyout()
@@ -103,13 +106,12 @@ namespace Windows.UI.Xaml.Controls
 				typeof(IFrameworkElement),
 				typeof(TimePickerFlyout),
 				new FrameworkPropertyMetadata(default(IFrameworkElement), FrameworkPropertyMetadataOptions.AffectsMeasure, OnContentChanged));
-		private TimePickerFlyoutPresenter _timePickerPresenter;
 
 		private static void OnContentChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
 			var flyout = dependencyObject as TimePickerFlyout;
 
-			if (flyout._timePickerPresenter != null)
+			if (flyout?._timePickerPresenter != null)
 			{
 				if (args.NewValue is IDependencyObjectStoreProvider binder)
 				{
@@ -133,8 +135,11 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_headerUntapZone = _timePickerPresenter?.FindName("HeaderUntapableZone") as FrameworkElement;
 
-				AttachAcceptCommand(_timePickerPresenter);
-				AttachDismissCommand(_timePickerPresenter);
+				if (_timePickerPresenter != null)
+				{
+					AttachAcceptCommand(_timePickerPresenter);
+					AttachDismissCommand(_timePickerPresenter);
+				}
 
 				_onLoad.Disposable = null;
 			}
@@ -154,7 +159,7 @@ namespace Windows.UI.Xaml.Controls
 				_timePickerPresenter.Unloaded += onUnload;
 			}
 
-			return _timePickerPresenter;
+			return _timePickerPresenter!;
 		}
 
 		private void OnTap(object sender, Input.PointerRoutedEventArgs e) => e.Handled = true;
@@ -163,7 +168,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			InitializeContent();
 
-			_timeSelector.Initialize();
+			_timeSelector?.Initialize();
 
 			//Gobbling pressed tap on the flyout header background so that it doesn't close the flyout popup. 
 			if (_headerUntapZone != null)
@@ -181,7 +186,7 @@ namespace Windows.UI.Xaml.Controls
 				_headerUntapZone.PointerPressed -= OnTap;
 			}
 
-			_timeSelector.Cancel();
+			_timeSelector?.Cancel();
 
 			base.Close();
 		}
@@ -210,7 +215,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void Accept()
 		{
-			_timeSelector.SaveTime();
+			_timeSelector?.SaveTime();
 			Hide(false);
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/3930, fixes https://github.com/unoplatform/uno/issues/3511

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Fixes `DatePickerFlyout.Date` property not updating properly
- Fixes `TimePickerFlyout` unloaded state NRE

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
