### PR TITLE
feat: Add Support for WebView.InvokeScriptAsync

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WebView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WebView.cs
@@ -299,7 +299,7 @@ namespace Windows.UI.Xaml.Controls
 			throw new global::System.NotImplementedException("The member IAsyncAction WebView.CapturePreviewToStreamAsync(IRandomAccessStream stream) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<string> InvokeScriptAsync( string scriptName,  global::System.Collections.Generic.IEnumerable<string> arguments)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WebView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/WebView.cs
@@ -299,7 +299,7 @@ namespace Windows.UI.Xaml.Controls
 			throw new global::System.NotImplementedException("The member IAsyncAction WebView.CapturePreviewToStreamAsync(IRandomAccessStream stream) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if __ANDROID__ || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<string> InvokeScriptAsync( string scriptName,  global::System.Collections.Generic.IEnumerable<string> arguments)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
@@ -154,7 +154,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments) =>
-			AsyncOperation.FromTask(async ct => InvokeScriptAsync(ct, scriptName, arguments?.ToArray()).AsAsyncOperation();
+			AsyncOperation.FromTask(async ct => InvokeScriptAsync(ct, scriptName, arguments?.ToArray()));
 			
 
 		#region Navigation History

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
@@ -154,7 +154,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments) =>
-			InvokeScriptAsync(CancellationToken.None, scriptName, arguments).AsAsyncOperation();
+			InvokeScriptAsync(CancellationToken.None, scriptName, arguments?.ToArray()).AsAsyncOperation();
 			
 
 		#region Navigation History

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using Uno.UI;
 using Uno.Logging;
 using Uno.Disposables;
+using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -151,6 +152,10 @@ namespace Windows.UI.Xaml.Controls
 
 			return await tcs.Task;
 		}
+
+		public IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments) =>
+			InvokeScriptAsync(CancellationToken.None, scriptName, arguments).AsAsyncOperation();
+			
 
 		#region Navigation History
 

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
@@ -154,7 +154,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments) =>
-			AsyncOperation.FromTask(async ct => InvokeScriptAsync(ct, scriptName, arguments?.ToArray()));
+			AsyncOperation.FromTask(ct => InvokeScriptAsync(ct, scriptName, arguments?.ToArray()));
 			
 
 		#region Navigation History

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.Android.cs
@@ -154,7 +154,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments) =>
-			InvokeScriptAsync(CancellationToken.None, scriptName, arguments?.ToArray()).AsAsyncOperation();
+			AsyncOperation.FromTask(async ct => InvokeScriptAsync(ct, scriptName, arguments?.ToArray()).AsAsyncOperation();
 			
 
 		#region Navigation History

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOSmacOS.cs
@@ -74,7 +74,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments) =>
-			AsyncOperation.FromTask(async ct => InvokeScriptAsync(ct, scriptName, arguments?.ToArray()));
+			AsyncOperation.FromTask(ct => InvokeScriptAsync(ct, scriptName, arguments?.ToArray()));
 
 		partial void NavigateWithHttpRequestMessagePartial(HttpRequestMessage requestMessage)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOSmacOS.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using Windows.UI.Core;
 using Uno.Logging;
+using Windows.Foundation;
 
 #if XAMARIN_IOS_UNIFIED
 using MessageUI;
@@ -71,6 +72,9 @@ namespace Windows.UI.Xaml.Controls
 			var argumentString = ConcatenateJavascriptArguments(arguments);
 			return await _nativeWebView.EvaluateJavascriptAsync(ct, string.Format(CultureInfo.InvariantCulture, "javascript:{0}(\"{1}\")", script, argumentString));
 		}
+
+		public IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments) =>
+			InvokeScriptAsync(CancellationToken.None, scriptName, arguments).AsAsyncOperation();
 
 		partial void NavigateWithHttpRequestMessagePartial(HttpRequestMessage requestMessage)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOSmacOS.cs
@@ -74,7 +74,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments) =>
-			InvokeScriptAsync(CancellationToken.None, scriptName, arguments).AsAsyncOperation();
+			InvokeScriptAsync(CancellationToken.None, scriptName, arguments?.ToArray()).AsAsyncOperation();
 
 		partial void NavigateWithHttpRequestMessagePartial(HttpRequestMessage requestMessage)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOSmacOS.cs
@@ -74,7 +74,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments) =>
-			InvokeScriptAsync(CancellationToken.None, scriptName, arguments?.ToArray()).AsAsyncOperation();
+			AsyncOperation.FromTask(async ct => InvokeScriptAsync(ct, scriptName, arguments?.ToArray()));
 
 		partial void NavigateWithHttpRequestMessagePartial(HttpRequestMessage requestMessage)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
closes #3518 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
One of the signatures for WebView.InvokeScriptAsync is not supported.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
WebView.InvokeScriptAsync is now supported for iOS, macOS and Android

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
There was a method with another signature implemented:

`Task<string> InvokeScriptAsync(CancellationToken ct, string script, string[] arguments);`

And this was definitely an option for the users. Unfortunately, the method that was not implemented was the first one to show on the IntelliSense making the users believe that none of the methods were implemented.

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
