### PR TITLE
feat: TimeTrigger (struct)

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Background/IBackgroundTrigger.cs
+++ b/src/Uno.UWP/ApplicationModel/Background/IBackgroundTrigger.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Windows.ApplicationModel.Background
+{
+	public partial interface IBackgroundTrigger
+	{
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/Background/TimeTrigger.cs
+++ b/src/Uno.UWP/ApplicationModel/Background/TimeTrigger.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Windows.ApplicationModel.Background
+{
+	public partial class TimeTrigger : IBackgroundTrigger
+	{
+		public uint FreshnessTime { get; }
+		public bool OneShot { get; }
+
+		public TimeTrigger(uint freshnessTime, bool oneShot)
+		{
+			if (freshnessTime < 15)
+			{
+				throw new ArgumentOutOfRangeException("TimeTrigger.FreshnessTime should be > 15 minutes");
+			}
+			FreshnessTime = freshnessTime;
+			OneShot = oneShot;
+		}
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/IBackgroundTrigger.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/IBackgroundTrigger.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel.Background
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IBackgroundTrigger 

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/TimeTrigger.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/TimeTrigger.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel.Background
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TimeTrigger : global::Windows.ApplicationModel.Background.IBackgroundTrigger
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  uint FreshnessTime
 		{
@@ -17,7 +17,7 @@ namespace Windows.ApplicationModel.Background
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool OneShot
 		{
@@ -27,7 +27,7 @@ namespace Windows.ApplicationModel.Background
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public TimeTrigger( uint freshnessTime,  bool oneShot) 
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #

Encouraged by davidjohnoliver's answer to question in #2079, and quick merge of resulting #3906... Part of #2655 - seems like TimeTrigger should not be platform dependent (in 2655, it was only for Android).

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
TimeTrigger is not implemented.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Implemented.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
