### PR TITLE
fix(macOS): Templated control not attaching events properly

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.macOS.cs
@@ -83,6 +83,8 @@ namespace Windows.UI.Xaml.Controls
 
 			DocumentView = newView;
 
+			// This is not needed on iOS/Android because the native ScrollViewer
+			// relies on the Children property, not on a `DocumentView` property.
 			newView.SetParent(TemplatedParent);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.macOS.cs
@@ -26,7 +26,8 @@ namespace Windows.UI.Xaml.Controls
 			DrawsBackground = false;
 		}
 
-		public nfloat ZoomScale {
+		public nfloat ZoomScale 
+		{
 			get => Magnification;
 			set => Magnification = value;
 		}
@@ -50,7 +51,6 @@ namespace Windows.UI.Xaml.Controls
 			get => HasHorizontalScroller;
 			set => HasHorizontalScroller = value;
 		}
-
 		public override bool NeedsLayout
 		{
 			get => base.NeedsLayout; set
@@ -76,7 +76,14 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnContentChanged(NSView previousView, NSView newView)
 		{
+			if(previousView != null) 
+			{
+				previousView.SetParent(null);
+			}
+
 			DocumentView = newView;
+
+			newView.SetParent(TemplatedParent);
 		}
 
 		private void OnLiveScroll(object sender, NSNotificationEventArgs e)


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
Creating a Templated Control and adding an event to one of the children, ex: `Click` event on a Button, the event is not attached.
 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
The events added to the Children of a Templated Control will work as expected.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
