### PR TITLE
[WASM & Skia] Fixed clipping issues

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -127,7 +127,7 @@ namespace SamplesApp.UITests
 			}
 		}
 
-		public FileInfo TakeScreenshot(string stepName, bool? ignoreInSnapshotCompare = null)
+		public ScreenshotInfo TakeScreenshot(string stepName, bool? ignoreInSnapshotCompare = null)
 			=> TakeScreenshot(
 				stepName,
 				ignoreInSnapshotCompare != null
@@ -135,7 +135,7 @@ namespace SamplesApp.UITests
 					: null
 			);
 
-		public FileInfo TakeScreenshot(string stepName, ScreenshotOptions options)
+		public ScreenshotInfo TakeScreenshot(string stepName, ScreenshotOptions? options)
 		{
 			if(_app == null)
 			{
@@ -177,7 +177,7 @@ namespace SamplesApp.UITests
 				SetOptions(fileInfo, options);
 			}
 
-			return fileInfo;
+			return new ScreenshotInfo(fileInfo, stepName) ;
 		}
 
 		public void SetOptions(FileInfo screenshot, ScreenshotOptions options)
@@ -282,10 +282,10 @@ namespace SamplesApp.UITests
 
 		internal double GetDisplayScreenScaling()
 		{
-			var scalingRaw = _app.InvokeGeneric("browser:SampleRunner|GetDisplayScreenScaling", "0");
-
 			if (_scaling == null)
 			{
+				var scalingRaw = _app.InvokeGeneric("browser:SampleRunner|GetDisplayScreenScaling", "0");
+
 				if (double.TryParse(scalingRaw?.ToString(), out var scaling))
 				{
 					Console.WriteLine($"Display Scaling: {scaling}");

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net47</TargetFramework>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup> 

--- a/src/SamplesApp/SamplesApp.UITests/ScreenshotInfo.cs
+++ b/src/SamplesApp/SamplesApp.UITests/ScreenshotInfo.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+
+namespace SamplesApp.UITests
+{
+	public class ScreenshotInfo
+	{
+		public FileInfo File { get; }
+
+		public string StepName { get; }
+
+		public ScreenshotInfo(FileInfo file, string stepName)
+		{
+			File = file;
+			StepName = stepName;
+		}
+
+		public static implicit operator FileInfo(ScreenshotInfo si) => si.File;
+
+		public static implicit operator ScreenshotInfo(FileInfo fi) => new ScreenshotInfo(fi, fi.Name);
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
@@ -18,75 +18,75 @@ namespace SamplesApp.UITests.TestFramework
 		public static Rectangle FirstQuadrant { get; } = new Rectangle(0, 0, int.MaxValue, int.MaxValue);
 
 		#region Are[Almost]Equal
-		public static void AreEqual(FileInfo expected, FileInfo actual, IAppRect rect, [CallerLineNumber] int line = 0)
+		public static void AreEqual(ScreenshotInfo expected, ScreenshotInfo actual, IAppRect rect, [CallerLineNumber] int line = 0)
 			=> AreEqualImpl(expected, rect.ToRectangle(), actual, rect.ToRectangle(), 1, PixelTolerance.None, line);
 
-		public static void AreEqual(FileInfo expected, FileInfo actual, Rectangle? rect = null, [CallerLineNumber] int line = 0)
+		public static void AreEqual(ScreenshotInfo expected, ScreenshotInfo actual, Rectangle? rect = null, [CallerLineNumber] int line = 0)
 			=> AreEqualImpl(expected, rect ?? FirstQuadrant, actual, rect ?? FirstQuadrant, 1, PixelTolerance.None, line);
 
-		public static void AreEqual(FileInfo expected, IAppRect expectedRect, FileInfo actual, IAppRect actualRect, [CallerLineNumber] int line = 0)
+		public static void AreEqual(ScreenshotInfo expected, IAppRect expectedRect, ScreenshotInfo actual, IAppRect actualRect, [CallerLineNumber] int line = 0)
 			=> AreEqualImpl(expected, expectedRect.ToRectangle(), actual, actualRect.ToRectangle(), 1, PixelTolerance.None, line);
 
-		public static void AreEqual(FileInfo expected, Rectangle expectedRect, FileInfo actual, Rectangle actualRect, [CallerLineNumber] int line = 0)
+		public static void AreEqual(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, [CallerLineNumber] int line = 0)
 			=> AreEqualImpl(expected, expectedRect, actual, actualRect, 1, PixelTolerance.None, line);
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
 		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
-		public static void AreAlmostEqual(FileInfo expected, FileInfo actual, IAppRect rect, int permittedPixelError, [CallerLineNumber] int line = 0)
+		public static void AreAlmostEqual(ScreenshotInfo expected, ScreenshotInfo actual, IAppRect rect, int permittedPixelError, [CallerLineNumber] int line = 0)
 			=> AreEqualImpl(expected, rect.ToRectangle(), actual, rect.ToRectangle(), 1, PixelTolerance.Cummulative(permittedPixelError), line);
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
 		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
-		public static void AreAlmostEqual(FileInfo expected, FileInfo actual, Rectangle? rect = null, int permittedPixelError = 5, [CallerLineNumber] int line = 0)
+		public static void AreAlmostEqual(ScreenshotInfo expected, ScreenshotInfo actual, Rectangle? rect = null, int permittedPixelError = 5, [CallerLineNumber] int line = 0)
 			=> AreEqualImpl(expected, rect ?? FirstQuadrant, actual, rect ?? FirstQuadrant, 1, PixelTolerance.Cummulative(permittedPixelError), line);
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
 		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
-		public static void AreAlmostEqual(FileInfo expected, IAppRect expectedRect, FileInfo actual, IAppRect actualRect, int permittedPixelError, [CallerLineNumber] int line = 0)
+		public static void AreAlmostEqual(ScreenshotInfo expected, IAppRect expectedRect, ScreenshotInfo actual, IAppRect actualRect, int permittedPixelError, [CallerLineNumber] int line = 0)
 			=> AreEqualImpl(expected, expectedRect.ToRectangle(), actual, actualRect.ToRectangle(), 1, PixelTolerance.Cummulative(permittedPixelError), line);
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
 		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
-		public static void AreAlmostEqual(FileInfo expected, Rectangle expectedRect, FileInfo actual, Rectangle actualRect, int permittedPixelError, [CallerLineNumber] int line = 0)
+		public static void AreAlmostEqual(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, int permittedPixelError, [CallerLineNumber] int line = 0)
 			=> AreEqualImpl(expected, expectedRect, actual, actualRect, 1, PixelTolerance.Cummulative(permittedPixelError), line);
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
 		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
-		public static void AreAlmostEqual(FileInfo expected, Rectangle expectedRect, FileInfo actual, Rectangle actualRect, double expectedToActualScale, PixelTolerance tolerance, [CallerLineNumber] int line = 0)
+		public static void AreAlmostEqual(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, double expectedToActualScale, PixelTolerance tolerance, [CallerLineNumber] int line = 0)
 			=> AreEqualImpl(expected, expectedRect, actual, actualRect, expectedToActualScale, tolerance, line);
 
-		public static void AreAlmostEqual(FileInfo expected, Rectangle expectedRect, Bitmap actual, Rectangle actualRect, double expectedToActualScale, PixelTolerance tolerance, [CallerLineNumber] int line = 0)
+		public static void AreAlmostEqual(ScreenshotInfo expected, Rectangle expectedRect, Bitmap actual, Rectangle actualRect, double expectedToActualScale, PixelTolerance tolerance, [CallerLineNumber] int line = 0)
 			=> AreEqualImpl(expected, expectedRect, null, actual, actualRect, expectedToActualScale, tolerance, line);
 
 		private static void AreEqualImpl(
-			FileInfo expected,
+			ScreenshotInfo expected,
 			Rectangle expectedRect,
-			FileInfo actual,
+			ScreenshotInfo actual,
 			Rectangle actualRect,
 			double expectedToActualScale,
 			PixelTolerance tolerance,
 			int line)
 		{
-			using (var actualBitmap = new Bitmap(actual.FullName))
+			using (var actualBitmap = new Bitmap(actual.File.FullName))
 			{
 				AreEqualImpl(expected, expectedRect, actual, actualBitmap, actualRect, expectedToActualScale, tolerance, line);
 			}
 		}
 
 		private static void AreEqualImpl(
-			FileInfo expected,
+			ScreenshotInfo expected,
 			Rectangle expectedRect,
-			FileInfo actual,
+			ScreenshotInfo actual,
 			Bitmap actualBitmap,
 			Rectangle actualRect,
 			double expectedToActualScale,
@@ -98,7 +98,7 @@ namespace SamplesApp.UITests.TestFramework
 				Assert.AreEqual(expectedRect.Size, actualRect.Size, WithContext("Compare rects don't have the same size"));
 			}
 
-			using (var expectedBitmap = new Bitmap(expected.FullName))
+			using (var expectedBitmap = new Bitmap(expected.File.FullName))
 			{
 				if (expectedRect == FirstQuadrant && actualRect == FirstQuadrant)
 				{
@@ -114,7 +114,7 @@ namespace SamplesApp.UITests.TestFramework
 				var expectedPixels = ExpectedPixels
 					.At(actualRect.Location)
 					.Pixels(expectedBitmap, expectedRect)
-					.Named(expected.Name)
+					.Named(expected.StepName)
 					.WithTolerance(tolerance);
 
 				var report = GetContext();
@@ -132,8 +132,8 @@ namespace SamplesApp.UITests.TestFramework
 				=> new StringBuilder()
 					.AppendLine($"ImageAssert.AreEqual @ line {line}")
 					.AppendLine("pixelTolerance: " + tolerance)
-					.AppendLine("expected: " + expected?.Name + (expectedRect == FirstQuadrant ? null : $" in {expectedRect}"))
-					.AppendLine("actual  : " + (actual?.Name ?? "--unknown--") + (actualRect == FirstQuadrant ? null : $" in {actualRect}"))
+					.AppendLine($"expected: {expected?.StepName} ({expected?.File.Name}){(expectedRect == FirstQuadrant ? null : $" in {expectedRect}")}")
+					.AppendLine($"actual  : {actual?.StepName ?? "--unknown--"} ({actual?.File.Name}){(actualRect == FirstQuadrant ? null : $" in {actualRect}")}")
 					.AppendLine("====================");
 
 			string WithContext(string message)
@@ -144,24 +144,24 @@ namespace SamplesApp.UITests.TestFramework
 		#endregion
 
 		#region AreNotEqual
-		public static void AreNotEqual(FileInfo expected, FileInfo actual, IAppRect rect, [CallerLineNumber] int line = 0)
+		public static void AreNotEqual(ScreenshotInfo expected, ScreenshotInfo actual, IAppRect rect, [CallerLineNumber] int line = 0)
 			=> AreNotEqualImpl(expected, rect.ToRectangle(), actual, rect.ToRectangle(), line);
 
-		public static void AreNotEqual(FileInfo expected, FileInfo actual, Rectangle? rect = null, [CallerLineNumber] int line = 0)
+		public static void AreNotEqual(ScreenshotInfo expected, ScreenshotInfo actual, Rectangle? rect = null, [CallerLineNumber] int line = 0)
 			=> AreNotEqualImpl(expected, rect ?? FirstQuadrant, actual, rect ?? FirstQuadrant, line);
 
-		public static void AreNotEqual(FileInfo expected, IAppRect expectedRect, FileInfo actual, IAppRect actualRect, [CallerLineNumber] int line = 0)
+		public static void AreNotEqual(ScreenshotInfo expected, IAppRect expectedRect, ScreenshotInfo actual, IAppRect actualRect, [CallerLineNumber] int line = 0)
 			=> AreNotEqualImpl(expected, expectedRect.ToRectangle(), actual, actualRect.ToRectangle(), line);
 
-		public static void AreNotEqual(FileInfo expected, Rectangle expectedRect, FileInfo actual, Rectangle actualRect, [CallerLineNumber] int line = 0)
+		public static void AreNotEqual(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, [CallerLineNumber] int line = 0)
 			=> AreNotEqualImpl(expected, expectedRect, actual, actualRect, line);
 
-		private static void AreNotEqualImpl(FileInfo expected, Rectangle expectedRect, FileInfo actual, Rectangle actualRect, int line)
+		private static void AreNotEqualImpl(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, int line)
 		{
 			Assert.AreEqual(expectedRect.Size, actualRect.Size, WithContext("Compare rects don't have the same size"));
 
-			using (var expectedBitmap = new Bitmap(expected.FullName))
-			using (var actualBitmap = new Bitmap(actual.FullName))
+			using (var expectedBitmap = new Bitmap(expected.File.FullName))
+			using (var actualBitmap = new Bitmap(actual.File.FullName))
 			{
 				Assert.AreEqual(expectedBitmap.Size, actualBitmap.Size, WithContext("Screenshots don't have the same size"));
 
@@ -193,8 +193,8 @@ namespace SamplesApp.UITests.TestFramework
 			{
 				return new StringBuilder()
 					.AppendLine($"ImageAssert.AreNotEqual @ line {line}")
-					.AppendLine("expected: " + expected?.Name + (expectedRect == FirstQuadrant ? null : $"in {expectedRect}"))
-					.AppendLine("actual  : " + actual?.Name + (actualRect == FirstQuadrant ? null : $"in {actualRect}"))
+					.AppendLine($"expected: {expected?.StepName} ({expected?.File.Name}){(expectedRect == FirstQuadrant ? null : $" in {expectedRect}")}")
+					.AppendLine($"actual  : {actual?.StepName ?? "--unknown--"} ({actual?.File.Name}){(actualRect == FirstQuadrant ? null : $" in {actualRect}")}")
 					.AppendLine("====================")
 					.ApplyIf(message != null, x => x.AppendLine(message))
 					.ApplyIf(builder != null, builder)
@@ -204,15 +204,22 @@ namespace SamplesApp.UITests.TestFramework
 		#endregion
 
 		#region HasColorAt
-		public static void HasColorAt(FileInfo screenshot, float x, float y, string expectedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
+		public static void HasColorAt(ScreenshotInfo screenshot, float x, float y, string expectedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
 			=> HasColorAtImpl(screenshot, (int)x, (int)y, ColorCodeParser.Parse(expectedColorCode), tolerance, line);
 
-		public static void HasColorAt(FileInfo screenshot, float x, float y, Color expectedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
+		public static void HasColorAt(ScreenshotInfo screenshot, float x, float y, Color expectedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
 			=> HasColorAtImpl(screenshot, (int)x, (int)y, expectedColor, tolerance, line);
 
-		private static void HasColorAtImpl(FileInfo screenshot, int x, int y, Color expectedColor, byte tolerance, int line)
+		private static void HasColorAtImpl(ScreenshotInfo screenshot, int x, int y, Color expectedColor, byte tolerance, int line)
 		{
-			using (var bitmap = new Bitmap(screenshot.FullName))
+			var file = screenshot?.File;
+			if (file == null)
+			{
+				Assert.Fail("No file");
+				return;
+			}
+
+			using (var bitmap = new Bitmap(file.FullName))
 			{
 				if (bitmap.Width <= x || bitmap.Height <= y)
 				{
@@ -236,7 +243,7 @@ namespace SamplesApp.UITests.TestFramework
 			{
 				return new StringBuilder()
 					.AppendLine($"ImageAssert.HasColorAt @ line {line}")
-					.AppendLine("screenshot: " + screenshot?.Name)
+					.AppendLine($"screenshot: {screenshot.StepName} ({file.Name})")
 					.AppendLine("====================")
 					.ApplyIf(message != null, sb => sb.AppendLine(message))
 					.ApplyIf(builder != null, builder)
@@ -246,15 +253,16 @@ namespace SamplesApp.UITests.TestFramework
 		#endregion
 
 		#region DoesNotHaveColorAt
-		public static void DoesNotHaveColorAt(FileInfo screenshot, float x, float y, string excludedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
+		public static void DoesNotHaveColorAt(ScreenshotInfo screenshot, float x, float y, string excludedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
 			=> DoesNotHaveColorAtImpl(screenshot, (int)x, (int)y, ColorCodeParser.Parse(excludedColorCode), tolerance, line);
 
-		public static void DoesNotHaveColorAt(FileInfo screenshot, float x, float y, Color excludedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
+		public static void DoesNotHaveColorAt(ScreenshotInfo screenshot, float x, float y, Color excludedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
 			=> DoesNotHaveColorAtImpl(screenshot, (int)x, (int)y, excludedColor, tolerance, line);
 
-		private static void DoesNotHaveColorAtImpl(FileInfo screenshot, int x, int y, Color excludedColor, byte tolerance, int line)
+		private static void DoesNotHaveColorAtImpl(ScreenshotInfo screenshot, int x, int y, Color excludedColor, byte tolerance, int line)
 		{
-			using (var bitmap = new Bitmap(screenshot.FullName))
+			var file = screenshot.File;
+			using (var bitmap = new Bitmap(file.FullName))
 			{
 				if (bitmap.Width <= x || bitmap.Height <= y)
 				{
@@ -277,7 +285,7 @@ namespace SamplesApp.UITests.TestFramework
 			{
 				return new StringBuilder()
 					.AppendLine($"ImageAssert.DoesNotHaveColorAt @ line {line}")
-					.AppendLine("screenshot: " + screenshot?.Name)
+					.AppendLine($"screenshot: {screenshot.StepName} ({file.Name})")
 					.AppendLine("====================")
 					.ApplyIf(message != null, sb => sb.AppendLine(message))
 					.ApplyIf(builder != null, builder)
@@ -287,12 +295,12 @@ namespace SamplesApp.UITests.TestFramework
 		#endregion
 
 		#region HasPixels
-		public static void HasPixels(FileInfo actual, params ExpectedPixels[] expectations)
+		public static void HasPixels(ScreenshotInfo actual, params ExpectedPixels[] expectations)
 		{
 			var isSuccess = true;
 			var result = new StringBuilder();
 
-			using (var bitmap = new Bitmap(actual.FullName))
+			using (var bitmap = new Bitmap(actual.File.FullName))
 			{
 				foreach (var expectation in expectations)
 				{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
@@ -1,0 +1,36 @@
+﻿using System.Drawing;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml.ClippingTests
+{
+	[TestFixture]
+	public class ClippingTests_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void When_Clip_Is_Set_On_Container_Element()
+		{
+			Run("UITests.Windows_UI_Xaml.Clipping.Clipping652");
+
+			var grid1 = _app.Marked("ClippingGrid1");
+			var grid2 = _app.Marked("ClippingGrid2");
+
+			_app.WaitForElement(grid1);
+			_app.WaitForElement(grid2);
+
+			var rect1 = grid1.FirstResult().Rect;
+			var rect2 = grid2.FirstResult().Rect;
+
+			var screenshot = TakeScreenshot("Clipping");
+
+			ImageAssert.HasColorAt(screenshot, rect1.Right + 8, rect1.Y + 75, Color.Blue);
+			ImageAssert.HasColorAt(screenshot, rect1.X + 75, rect1.Bottom + 8, Color.Blue);
+
+			ImageAssert.HasColorAt(screenshot, rect2.Right + 8, rect2.Y + 75, Color.Blue);
+			ImageAssert.HasColorAt(screenshot, rect2.X + 75, rect2.Bottom + 8, Color.Blue);
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
@@ -15,7 +15,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 	[TestFixture]
 	public partial class ContentDialog_Tests : SampleControlUITestBase
 	{
-		private System.IO.FileInfo CurrentTestTakeScreenShot(string name) =>
+		private ScreenshotInfo CurrentTestTakeScreenShot(string name) =>
 			// Screenshot taking for this fixture is disabled on Android because of the
 			// presence of the status bar when native popups are opened, adding the clock
 			// (that is always changing :)).

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SplitViewTests/SplitViewTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SplitViewTests/SplitViewTests.cs
@@ -24,19 +24,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.SplitViewTests
 
 			var targetGridRectangle = _app.GetRect("TargetRect");
 
-			var compactScreenshot = _app.Screenshot("Compact");
+			var compactScreenshot = TakeScreenshot("Compact");
 			// Compact pane is 48 pixels wide
 			ImageAssert.HasColorAt(compactScreenshot, targetGridRectangle.Right - 4, targetGridRectangle.CenterY, Color.Blue);
 
 			var toggleButton = _app.Marked("PaneToggle");
 			toggleButton.Tap();
 
-			var expandedScreenshot = _app.Screenshot("Expanded");
+			var expandedScreenshot = TakeScreenshot("Expanded");
 			ImageAssert.HasColorAt(expandedScreenshot, targetGridRectangle.Right - 4, targetGridRectangle.CenterY, Color.Red);
 
 			toggleButton.Tap();
 
-			var compactAgainScreenshot = _app.Screenshot("Compact again");
+			var compactAgainScreenshot = TakeScreenshot("Compact again");
 			ImageAssert.HasColorAt(compactAgainScreenshot, targetGridRectangle.Right - 4, targetGridRectangle.CenterY, Color.Blue);
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/Transform_Tests/Basics_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/Transform_Tests/Basics_Automated.cs
@@ -16,7 +16,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.Transform_Tests
 	public partial class Basics_Automated : SampleControlUITestBase
 	{
 		private IAppRect _sut;
-		private FileInfo _result;
+		private ScreenshotInfo _result;
 
 		[Test]
 		[AutoRetry]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/ColorAnimation_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/ColorAnimation_Tests.cs
@@ -38,7 +38,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 
 			var indepRect = _app.GetRect("IndependentBorder");
 
-			var bmp = _app.Screenshot("Completed");
+			var bmp = TakeScreenshot("Completed");
 
 			ImageAssert.HasColorAt(bmp, targetRect.CenterX, targetRect.CenterY, Color.Red);
 
@@ -60,7 +60,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 
 			var targetRect = _app.GetRect("TargetRectangle");
 
-			var bmp = _app.Screenshot("Completed");
+			var bmp = TakeScreenshot("Completed");
 
 			ImageAssert.HasColorAt(bmp, targetRect.CenterX, targetRect.CenterY, Color.Brown);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.TransformGroup.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.TransformGroup.cs
@@ -501,7 +501,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 			);
 		}
 
-		private (Rectangle host, float scale, FileInfo half, FileInfo final) BeginTransformGroupTest(string elementName)
+		private (Rectangle host, float scale, ScreenshotInfo half, ScreenshotInfo final) BeginTransformGroupTest(string elementName)
 		{
 			Run(_transformGroupTestControl, skipInitialScreenshot: true);
 			TakeScreenshot("Initial", ignoreInSnapshotCompare: true);

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -325,7 +325,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\ButtonClipping652.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\Clipping652.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -3618,14 +3618,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_ViewManagement\TitleBarColorTests.xaml.cs">
       <DependentUpon>TitleBarColorTests.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\ButtonClipping652.xaml.cs">
-      <DependentUpon>ButtonClipping652.xaml</DependentUpon>
-    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\ButtonClippingTestsControl.xaml.cs">
       <DependentUpon>ButtonClippingTestsControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\ButtonWithClippingAndOffset.xaml.cs">
       <DependentUpon>ButtonWithClippingAndOffset.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\Clipping652.xaml.cs">
+      <DependentUpon>Clipping652.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\ClippingRoundedCorners.xaml.cs">
       <DependentUpon>ClippingRoundedCorners.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ButtonClipping652.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ButtonClipping652.xaml
@@ -12,7 +12,7 @@
 			This is an illustration of Github bug
 			<Hyperlink NavigateUri="https://github.com/unoplatform/uno/issues/652">#652</Hyperlink>
 		</TextBlock>
-		<Grid Width="100" Height="100" BorderBrush="Red" BorderThickness="1">
+		<Grid Width="100" Height="100" BorderBrush="Red" BorderThickness="1" x:Name="Grid1">
 			<Grid.Clip>
 				<RectangleGeometry Rect="0,0,110,110" />
 			</Grid.Clip>
@@ -21,7 +21,8 @@
 				Height="100"
 				Content="Hello world"
 				VerticalAlignment="Top"
-				HorizontalAlignment="Left">
+				HorizontalAlignment="Left"
+				x:Name="Button1">
 				<ToggleButton.RenderTransform>
 					<TranslateTransform X="50" Y="50"/>
 				</ToggleButton.RenderTransform>
@@ -31,7 +32,7 @@
 			It should be identical to this:
 			<LineBreak />(the button should be 100x100, but cut at 60x60)
 		</TextBlock>
-		<Grid HorizontalAlignment="Center">
+		<Grid HorizontalAlignment="Center" x:Name="Grid2">
 			<Border Width="100" Height="100" BorderBrush="Red" BorderThickness="1" VerticalAlignment="Top" HorizontalAlignment="Left" />
 			<Border Width="60" Height="60" VerticalAlignment="Top" HorizontalAlignment="Left">
 				<Border.RenderTransform>
@@ -41,7 +42,8 @@
 					Height="100"
 					Width="100"
 					VerticalAlignment="Top"
-					Content="Hello world" />
+					Content="Hello world"
+					x:Name="Button2"/>
 			</Border>
 		</Grid>
 	</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ButtonClipping652.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ButtonClipping652.xaml.cs
@@ -1,5 +1,9 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using System;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
+
+using Uno.UI;
 
 namespace UITests.Windows_UI_Xaml.Clipping
 {
@@ -9,6 +13,17 @@ namespace UITests.Windows_UI_Xaml.Clipping
 		public ButtonClipping652()
 		{
 			this.InitializeComponent();
+
+			DumpTree();
+		}
+
+		private async void DumpTree()
+		{
+#if NETSTANDARD
+			await Task.Delay(1200);
+			var tree = this.ShowLocalVisualTree();
+			System.Diagnostics.Debug.WriteLine(tree);
+#endif
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ButtonClippingTestsControl.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ButtonClippingTestsControl.xaml
@@ -1,4 +1,4 @@
-<UserControl
+<Page
 	x:Class="SamplesApp.Windows_UI_Xaml.Clipping.ButtonClippingTestsControl" 
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -133,4 +133,4 @@
 			</StackPanel>
 		</StackPanel>
 	</ScrollViewer>
-</UserControl>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ButtonClippingTestsControl.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ButtonClippingTestsControl.xaml.cs
@@ -5,7 +5,7 @@ using Windows.UI.Xaml.Controls;
 namespace SamplesApp.Windows_UI_Xaml.Clipping
 {
 	[SampleControlInfo("Clipping", viewModelType: typeof(ButtonTestsViewModel))]
-	public sealed partial class ButtonClippingTestsControl : UserControl
+	public sealed partial class ButtonClippingTestsControl : Page
 	{
 		public ButtonClippingTestsControl()
 		{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Clipping652.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Clipping652.xaml
@@ -1,5 +1,5 @@
 ﻿<Page
-	x:Class="UITests.Windows_UI_Xaml.Clipping.ButtonClipping652"
+	x:Class="UITests.Windows_UI_Xaml.Clipping.Clipping652"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -12,37 +12,36 @@
 			This is an illustration of Github bug
 			<Hyperlink NavigateUri="https://github.com/unoplatform/uno/issues/652">#652</Hyperlink>
 		</TextBlock>
-		<Grid Width="100" Height="100" BorderBrush="Red" BorderThickness="1" x:Name="Grid1">
+		<Grid Width="100" Height="100" BorderBrush="Red" BorderThickness="4" x:Name="ClippingGrid1">
 			<Grid.Clip>
 				<RectangleGeometry Rect="0,0,110,110" />
 			</Grid.Clip>
-			<ToggleButton
+			<Rectangle
 				Width="100"
 				Height="100"
-				Content="Hello world"
+				Fill="Blue"
 				VerticalAlignment="Top"
-				HorizontalAlignment="Left"
-				x:Name="Button1">
-				<ToggleButton.RenderTransform>
+				HorizontalAlignment="Left">
+				<Rectangle.RenderTransform>
 					<TranslateTransform X="50" Y="50"/>
-				</ToggleButton.RenderTransform>
-			</ToggleButton>
+				</Rectangle.RenderTransform>
+			</Rectangle>
 		</Grid>
 		<TextBlock FontSize="15">
 			It should be identical to this:
 			<LineBreak />(the button should be 100x100, but cut at 60x60)
 		</TextBlock>
-		<Grid HorizontalAlignment="Center" x:Name="Grid2">
-			<Border Width="100" Height="100" BorderBrush="Red" BorderThickness="1" VerticalAlignment="Top" HorizontalAlignment="Left" />
+		<Grid HorizontalAlignment="Center" x:Name="ClippingGrid2">
+			<Border Width="100" Height="100" BorderBrush="Red" BorderThickness="4" VerticalAlignment="Top" HorizontalAlignment="Left" />
 			<Border Width="60" Height="60" VerticalAlignment="Top" HorizontalAlignment="Left">
 				<Border.RenderTransform>
 					<TranslateTransform X="50" Y="50"/>
 				</Border.RenderTransform>
-				<ToggleButton
+				<Rectangle
 					Height="100"
 					Width="100"
 					VerticalAlignment="Top"
-					Content="Hello world"
+					Fill="Blue"
 					x:Name="Button2"/>
 			</Border>
 		</Grid>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Clipping652.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Clipping652.xaml.cs
@@ -8,9 +8,9 @@ using Uno.UI;
 namespace UITests.Windows_UI_Xaml.Clipping
 {
 	[Sample("Clipping", "GH Bugs")]
-	public sealed partial class ButtonClipping652 : Page
+	public sealed partial class Clipping652 : Page
 	{
-		public ButtonClipping652()
+		public Clipping652()
 		{
 			this.InitializeComponent();
 

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -92,6 +93,11 @@ namespace Windows.Foundation
 
 		public static implicit operator Rect(string text)
 		{
+			if (text == null)
+			{
+				return default;
+			}
+
 			var parts = text
 				.Split(new[] { ',' })
 				.SelectToArray(s => double.Parse(s, NumberFormatInfo.InvariantInfo));

--- a/src/Uno.UI.Runtime.Skia.Wpf/WPF/WpfUIElementPointersSupport.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WPF/WpfUIElementPointersSupport.cs
@@ -279,7 +279,7 @@ namespace Uno.UI.Skia.Platform
 						IsHorizontalMouseWheel = msg == WM_MOUSEHWHEEL,
 						IsPrimary = true,
 						IsInRange = true,
-						MouseWheelDelta = -((int)wparam >> 16) / 20
+						MouseWheelDelta = -((int)wparam >> 16) / 40
 					};
 					var modifiers = VirtualKeyModifiers.None;
 					if (keys.HasFlag(MouseModifierKeys.MK_SHIFT))

--- a/src/Uno.UI/Extensions/ViewExtensions.netstd.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.netstd.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+#if !__NETSTD_REFERENCE__
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -122,3 +123,4 @@ namespace Uno.UI
 		}
 	}
 }
+#endif

--- a/src/Uno.UI/Extensions/ViewExtensions.netstd.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.netstd.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Linq;
@@ -91,6 +93,7 @@ namespace Uno.UI
 					.Append(fe != null && fe.TryGetBorderThickness(out var b) && b != default ? $" Border={b}" : "")
 					.Append(fe != null && fe.TryGetPadding(out var p) && p != default ? $" Padding={p}" : "")
 					.Append(uiElement != null ? $" DesiredSize={uiElement.DesiredSize}" : "")
+					.Append(uiElement?.Clip != null ? $" Clip={uiElement.Clip.Rect}" : "")
 					.Append(uiElement?.NeedsClipToSlot ?? false ? " CLIPPED_TO_SLOT" : "")
 					.Append(innerView is TextBlock textBlock ? $" Text=\"{textBlock.Text}\"" : "")
 					.AppendLine();

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
@@ -170,7 +170,7 @@ namespace Windows.UI.Xaml.Controls
 			// Calculate the position of the image to follow stretch and alignment requirements
 			var finalPosition = this.ArrangeSource(finalSize, containerSize);
 
-			_htmlImage.ArrangeVisual(finalPosition, false, clipRect: null);
+			_htmlImage.ArrangeVisual(finalPosition, clipRect: null);
 
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.netstd.cs
@@ -1,4 +1,5 @@
 #if !__NETSTD_REFERENCE__
+#nullable enable
 using System;
 using System.Globalization;
 using System.Linq;
@@ -165,12 +166,12 @@ namespace Windows.UI.Xaml
 			{
 				if (IsLessThanAndNotCloseTo(arrangeSize.Width, _unclippedDesiredSize.Width))
 				{
-					_logDebug?.Debug($"{DepthIndentation}{FormatDebugName()}: (arrangeSize.Width) {arrangeSize.Width} < {_unclippedDesiredSize.Width}: NEEDS CLIPPING.");
+					_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}: (arrangeSize.Width) {arrangeSize.Width} < {_unclippedDesiredSize.Width}: NEEDS CLIPPING.");
 					needsClipToSlot = true;
 				}
 				else if (IsLessThanAndNotCloseTo(arrangeSize.Height, _unclippedDesiredSize.Height))
 				{
-					_logDebug?.Debug($"{DepthIndentation}{FormatDebugName()}: (arrangeSize.Height) {arrangeSize.Height} < {_unclippedDesiredSize.Height}: NEEDS CLIPPING.");
+					_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}: (arrangeSize.Height) {arrangeSize.Height} < {_unclippedDesiredSize.Height}: NEEDS CLIPPING.");
 					needsClipToSlot = true;
 				}
 			}
@@ -196,13 +197,13 @@ namespace Windows.UI.Xaml
 			{
 				if (IsLessThanAndNotCloseTo(effectiveMaxSize.Width, arrangeSize.Width))
 				{
-					_logDebug?.Debug($"{DepthIndentation}{FormatDebugName()}: (effectiveMaxSize.Width) {effectiveMaxSize.Width} < {arrangeSize.Width}: NEEDS CLIPPING.");
+					_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}: (effectiveMaxSize.Width) {effectiveMaxSize.Width} < {arrangeSize.Width}: NEEDS CLIPPING.");
 					needsClipToSlot = true;
 					arrangeSize.Width = effectiveMaxSize.Width;
 				}
 				if (IsLessThanAndNotCloseTo(effectiveMaxSize.Height, arrangeSize.Height))
 				{
-					_logDebug?.Debug($"{DepthIndentation}{FormatDebugName()}: (effectiveMaxSize.Height) {effectiveMaxSize.Height} < {arrangeSize.Height}: NEEDS CLIPPING.");
+					_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}: (effectiveMaxSize.Height) {effectiveMaxSize.Height} < {arrangeSize.Height}: NEEDS CLIPPING.");
 					needsClipToSlot = true;
 					arrangeSize.Height = effectiveMaxSize.Height;
 				}
@@ -240,12 +241,12 @@ namespace Windows.UI.Xaml
 			_logDebug?.Debug(
 				$"{DepthIndentation}[{FormatDebugName()}] ArrangeChild(offset={offset}, margin={margin}) [oldRenderSize={oldRenderSize}] [RenderSize={RenderSize}] [clippedInkSize={clippedInkSize}] [RequiresClipping={needsClipToSlot}]");
 
-			RequiresClipping = needsClipToSlot;
+			NeedsClipToSlot = needsClipToSlot;
 
 #if __WASM__
 			if (FeatureConfiguration.UIElement.AssignDOMXamlProperties)
 			{
-				UpdateDOMXamlProperty(nameof(RequiresClipping), RequiresClipping);
+				UpdateDOMXamlProperty(nameof(NeedsClipToSlot), NeedsClipToSlot);
 			}
 #endif
 
@@ -266,11 +267,11 @@ namespace Windows.UI.Xaml
 					clippedFrameWithParentOrigin.Width,
 					clippedFrameWithParentOrigin.Height);
 
-				ArrangeNative(offset, clippedFrame);
+				ArrangeNative(offset, true, clippedFrame);
 			}
 			else
 			{
-				ArrangeNative(offset);
+				ArrangeNative(offset, false);
 			}
 
 			OnLayoutUpdated();
@@ -280,8 +281,9 @@ namespace Windows.UI.Xaml
 		/// Calculates and applies native arrange properties.
 		/// </summary>
 		/// <param name="offset">Offset of the view from its parent</param>
+		/// <param name="needsClipToSlot">If the control should be clip to its bounds</param>
 		/// <param name="clippedFrame">Zone to clip, if clipping is required</param>
-		private void ArrangeNative(Point offset, Rect clippedFrame = default)
+		private void ArrangeNative(Point offset, bool needsClipToSlot, Rect clippedFrame = default)
 		{
 			_visualOffset = offset;
 
@@ -301,25 +303,21 @@ namespace Windows.UI.Xaml
 
 			Rect? getClip()
 			{
-				// Clip transform not supported yet on Wasm
+				// Clip transform not supported yet on Wasm/Skia
 
-				if (RequiresClipping) // if control should be clipped by layout constrains
+				var clip = Clip;
+				if (clip == null)
 				{
-					if (Clip != null)
-					{
-						return clippedFrame.IntersectWith(Clip.Rect);
-					}
-					return clippedFrame;
+					return !needsClipToSlot ? (Rect?) null : clippedFrame;
 				}
-
-				return Clip?.Rect;
+				return clip.Rect;
 			}
 
 			var clipRect = getClip();
 
-			_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}.ArrangeElementNative({newRect}, clip={clipRect} (RequiresClipping={RequiresClipping})");
+			_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}.ArrangeElementNative({newRect}, clip={clipRect} (NeedsClipToSlot={NeedsClipToSlot})");
 
-			ArrangeVisual(newRect, RequiresClipping, clipRect);
+			ArrangeVisual(newRect, clipRect);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Globalization;
-using System.Text;
 using Windows.Foundation;
 #if XAMARIN_IOS
 using UIKit;
@@ -18,8 +14,8 @@ namespace Windows.UI.Xaml.Media
 
 		public Rect Rect
 		{
-			get { return (Rect)this.GetValue(RectProperty); }
-			set { this.SetValue(RectProperty, value); }
+			get => (Rect)this.GetValue(RectProperty);
+			set => this.SetValue(RectProperty, value);
 		}
 
 		public static DependencyProperty RectProperty { get ; } =

--- a/src/Uno.UI/UI/Xaml/UIElement.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Skia.cs
@@ -286,9 +286,24 @@ namespace Windows.UI.Xaml
 			Visual.Size = new Vector2((float)roundedRect.Width, (float)roundedRect.Height);
 			Visual.CenterPoint = new Vector3((float)RenderTransformOrigin.X, (float)RenderTransformOrigin.Y, 0);
 
-			if (clip is Rect rectClip)
+			ApplyNativeClip(clip ?? Rect.Empty);
+
+		}
+
+		partial void ApplyNativeClip(Rect clip)
+		{
+			if (ClippingIsSetByCornerRadius)
 			{
-				var roundedRectClip = LayoutRound(rectClip);
+				return; // already applied
+			}
+
+			if (clip.IsEmpty)
+			{
+				Visual.Clip = null;
+			}
+			else
+			{
+				var roundedRectClip = LayoutRound(clip);
 
 				Visual.Clip = Visual.Compositor.CreateInsetClip(
 					topInset: (float)roundedRectClip.Top,
@@ -296,10 +311,6 @@ namespace Windows.UI.Xaml
 					bottomInset: (float)roundedRectClip.Bottom,
 					rightInset: (float)roundedRectClip.Right
 				);
-			}
-			else if (!ClippingIsSetByCornerRadius)
-			{
-				Visual.Clip = null;
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/UIElement.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Skia.cs
@@ -234,7 +234,7 @@ namespace Windows.UI.Xaml
 		{
 		}
 
-		internal void ArrangeVisual(Rect finalRect, bool clipToBounds, Rect? clippedFrame = default)
+		internal void ArrangeVisual(Rect finalRect, Rect? clippedFrame = default)
 		{
 			LayoutSlotWithMarginsAndAlignments =
 				VisualTreeHelper.GetParent(this) is UIElement parent
@@ -260,27 +260,17 @@ namespace Windows.UI.Xaml
 					throw new InvalidOperationException($"{this}: Invalid frame size {newRect}. No dimension should be NaN or negative value.");
 				}
 
-				Rect? getClip()
+				Rect? clip;
+				if (this is Controls.ScrollViewer)
 				{
-					if (this is Controls.ScrollViewer)
-					{
-						return null;
-					}
-					else if (ClippingIsSetByCornerRadius)
-					{
-						// The clip geometry is set by the corner radius
-						// of Border, Grid, StackPanel, etc...
-						return null;
-					}
-					else if (Clip != null)
-					{
-						return Clip.Rect;
-					}
-
-					return new Rect(0, 0, newRect.Width, newRect.Height);
+					clip = (Rect?)null;
+				}
+				else
+				{
+					clip = clippedFrame;
 				}
 
-				OnArrangeVisual(newRect, getClip());
+				OnArrangeVisual(newRect, clip);
 			}
 			else
 			{
@@ -307,7 +297,7 @@ namespace Windows.UI.Xaml
 					rightInset: (float)roundedRectClip.Right
 				);
 			}
-			else
+			else if (!ClippingIsSetByCornerRadius)
 			{
 				Visual.Clip = null;
 			}

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -304,6 +304,15 @@ namespace Windows.UI.Xaml
 			if (Clip == null)
 			{
 				rect = Rect.Empty;
+
+				if (NeedsClipToSlot)
+				{
+#if NETSTANDARD
+					rect = new Rect(0, 0, RenderSize.Width, RenderSize.Height);
+#else
+					rect = ClippedFrame ?? Rect.Empty;
+#endif
+				}
 			}
 			else
 			{
@@ -313,23 +322,6 @@ namespace Windows.UI.Xaml
 				if (Clip.Transform != null)
 				{
 					rect = Clip.Transform.TransformBounds(rect);
-				}
-			}
-
-			if (NeedsClipToSlot)
-			{
-#if NETSTANDARD
-				var boundsClipping = new Rect(0, 0, RenderSize.Width, RenderSize.Height);
-#else
-				var boundsClipping = ClippedFrame ?? Rect.Empty;
-#endif
-				if (rect.IsEmpty)
-				{
-					rect = boundsClipping;
-				}
-				else
-				{
-					rect.Intersect(boundsClipping);
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -58,8 +58,6 @@ namespace Windows.UI.Xaml
 
 		partial void OnUidChangedPartial();
 
-		private protected bool RequiresClipping { get; set; } = true;
-
 		#region Clip DependencyProperty
 
 		public RectangleGeometry Clip

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -331,6 +331,28 @@ namespace Windows.UI.Xaml
 			Uno.UI.Xaml.WindowManagerInterop.SetContentHtml(HtmlId, html);
 		}
 
+		partial void ApplyNativeClip(Rect rect)
+		{
+			if (rect.IsEmpty)
+			{
+				ResetStyle("clip");
+				return;
+			}
+
+			var width = double.IsInfinity(rect.Width) ? 100000.0f : rect.Width;
+			var height = double.IsInfinity(rect.Height) ? 100000.0f : rect.Height;
+
+			SetStyle(
+				"clip",
+				"rect("
+				+ Math.Floor(rect.Y) + "px,"
+				+ Math.Ceiling(rect.X + width) + "px,"
+				+ Math.Ceiling(rect.Y + height) + "px,"
+				+ Math.Floor(rect.X) + "px"
+				+ ")"
+			);
+		}
+
 		internal static UIElement GetElementFromHandle(int handle)
 		{
 			var gcHandle = GCHandle.FromIntPtr((IntPtr)handle);
@@ -634,7 +656,7 @@ namespace Windows.UI.Xaml
 		internal virtual void ManagedOnLoading()
 		{
 			IsLoading = true;
-			
+
 			for (var i = 0; i < _children.Count; i++)
 			{
 				var child = _children[i];

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -248,9 +248,8 @@ namespace Windows.UI.Xaml
 		/// Natively arranges and clips an element.
 		/// </summary>
 		/// <param name="rect">The dimensions to apply to the element</param>
-		/// <param name="clipToBounds">Whether the element should be clipped to its bounds</param>
 		/// <param name="clipRect">The Clip rect to set, if any</param>
-		protected internal void ArrangeVisual(Rect rect, bool clipToBounds, Rect? clipRect)
+		protected internal void ArrangeVisual(Rect rect, Rect? clipRect)
 		{
 			LayoutSlotWithMarginsAndAlignments =
 				VisualTreeHelper.GetParent(this) is UIElement parent
@@ -262,7 +261,7 @@ namespace Windows.UI.Xaml
 				UpdateDOMXamlProperty(nameof(LayoutSlotWithMarginsAndAlignments), LayoutSlotWithMarginsAndAlignments);
 			}
 
-			Uno.UI.Xaml.WindowManagerInterop.ArrangeElement(HtmlId, rect, clipToBounds, clipRect);
+			Uno.UI.Xaml.WindowManagerInterop.ArrangeElement(HtmlId, rect, clipRect);
 
 #if DEBUG
 			var count = ++_arrangeCount;
@@ -273,7 +272,7 @@ namespace Windows.UI.Xaml
 
 		protected internal void SetNativeTransform(Matrix3x2 matrix)
 		{
-			Uno.UI.Xaml.WindowManagerInterop.SetElementTransform(HtmlId, matrix, requiresClipping: RequiresClipping);
+			Uno.UI.Xaml.WindowManagerInterop.SetElementTransform(HtmlId, matrix);
 		}
 
 		protected internal void ResetStyle(params string[] names)
@@ -330,29 +329,6 @@ namespace Windows.UI.Xaml
 		protected internal void SetHtmlContent(string html)
 		{
 			Uno.UI.Xaml.WindowManagerInterop.SetContentHtml(HtmlId, html);
-		}
-
-		partial void ApplyNativeClip(Rect rect)
-		{
-
-			if (rect.IsEmpty)
-			{
-				SetStyle("clip", "");
-				return;
-			}
-
-			var width = double.IsInfinity(rect.Width) ? 100000.0f : rect.Width;
-			var height = double.IsInfinity(rect.Height) ? 100000.0f : rect.Height;
-
-			SetStyle(
-				"clip",
-				"rect("
-				+ Math.Floor(rect.Y) + "px,"
-				+ Math.Ceiling(rect.X + width) + "px,"
-				+ Math.Ceiling(rect.Y + height) + "px,"
-				+ Math.Floor(rect.X) + "px"
-				+ ")"
-			);
 		}
 
 		internal static UIElement GetElementFromHandle(int handle)

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -162,7 +162,7 @@ namespace Uno.UI.Xaml
 
 		#region SetElementTransform
 
-		internal static void SetElementTransform(IntPtr htmlId, Matrix3x2 matrix, bool requiresClipping)
+		internal static void SetElementTransform(IntPtr htmlId, Matrix3x2 matrix)
 		{
 			if (UseJavascriptEval)
 			{
@@ -173,7 +173,7 @@ namespace Uno.UI.Xaml
 					new[] { ("transform", native.ToStringInvariant()) }
 				);
 
-				SetArrangeProperties(htmlId, requiresClipping);
+				SetArrangeProperties(htmlId);
 			}
 			else
 			{
@@ -186,7 +186,6 @@ namespace Uno.UI.Xaml
 					M22 = matrix.M22,
 					M31 = matrix.M31,
 					M32 = matrix.M32,
-					ClipToBounds = requiresClipping
 				};
 
 				TSInteropMarshaller.InvokeJS<WindowManagerSetElementTransformParams, bool>("Uno:setElementTransformNative", parms);
@@ -205,8 +204,6 @@ namespace Uno.UI.Xaml
 			public double M22;
 			public double M31;
 			public double M32;
-
-			public bool ClipToBounds;
 		}
 
 		#endregion
@@ -440,14 +437,14 @@ namespace Uno.UI.Xaml
 
 		#endregion
 
-		private static void SetArrangeProperties(IntPtr htmlId, bool requiresClipping)
+		private static void SetArrangeProperties(IntPtr htmlId)
 		{
 			if (!UseJavascriptEval)
 			{
 				throw new InvalidOperationException("This should only be called when UseJavascriptEval flag is set");
 			}
 
-			var command = "Uno.UI.WindowManager.current.setArrangeProperties(\"" + htmlId + "\", " + (requiresClipping ? "true" : "false") + "); ";
+			var command = "Uno.UI.WindowManager.current.setArrangeProperties(\"" + htmlId + "\"); ";
 
 			WebAssemblyRuntime.InvokeJS(command);
 		}
@@ -1073,7 +1070,7 @@ namespace Uno.UI.Xaml
 
 		#region ArrangeElement
 
-		internal static void ArrangeElement(IntPtr htmlId, Rect rect, bool clipToBounds, Rect? clipRect)
+		internal static void ArrangeElement(IntPtr htmlId, Rect rect, Rect? clipRect)
 		{
 			if (UseJavascriptEval)
 			{
@@ -1100,7 +1097,7 @@ namespace Uno.UI.Xaml
 					}
 				);
 
-				SetArrangeProperties(htmlId, clipToBounds);
+				SetArrangeProperties(htmlId);
 			}
 			else
 			{
@@ -1111,7 +1108,6 @@ namespace Uno.UI.Xaml
 					Left = rect.Left,
 					Width = rect.Width,
 					Height = rect.Height,
-					ClipToBounds = clipToBounds
 				};
 
 				if (clipRect != null)
@@ -1143,7 +1139,6 @@ namespace Uno.UI.Xaml
 
 			public IntPtr HtmlId;
 			public bool Clip;
-			public bool ClipToBounds;
 		}
 
 

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -50,15 +50,6 @@ svg.uno-uielement {
   stroke-width: 1px; /* default value of Shape.StrokeThickness */
 }
 
-.uno-frameworkelement.uno-clippedToBounds {
-  /*
-    This CSS class is applied when a control is a _clipping mode_:
-    it's happening during the "arrange" phase when the availableSize is less than desiredSize.
-    All FrameworkElements are following this behavior, except <Canvas>.
-  */
-  overflow: hidden;
-}
-
 .uno-frameworkelement.uno-unarranged {
   -ms-opacity: 0;
   opacity: 0;

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -135,7 +135,6 @@ declare namespace Uno.UI {
         static readonly isLoadEventsEnabled: boolean;
         private static readonly unoRootClassName;
         private static readonly unoUnarrangedClassName;
-        private static readonly unoClippedToBoundsClassName;
         private static _cctor;
         /**
             * Initialize the WindowManager
@@ -283,7 +282,7 @@ declare namespace Uno.UI {
         *
         */
         setStyleDoubleNative(pParams: number): boolean;
-        setArrangeProperties(elementId: number, clipToBounds: boolean): string;
+        setArrangeProperties(elementId: number): string;
         /**
             * Remove the CSS style of a html element.
             */
@@ -312,7 +311,6 @@ declare namespace Uno.UI {
         arrangeElementNative(pParams: number): boolean;
         private setAsArranged;
         private setAsUnarranged;
-        private setClipToBounds;
         /**
         * Sets the transform matrix of an element
         *
@@ -632,7 +630,6 @@ declare class WindowManagerArrangeElementParams {
     ClipRight: number;
     HtmlId: number;
     Clip: boolean;
-    ClipToBounds: boolean;
     static unmarshal(pData: number): WindowManagerArrangeElementParams;
 }
 declare class WindowManagerCreateContentParams {
@@ -765,7 +762,6 @@ declare class WindowManagerSetElementTransformParams {
     M22: number;
     M31: number;
     M32: number;
-    ClipToBounds: boolean;
     static unmarshal(pData: number): WindowManagerSetElementTransformParams;
 }
 declare class WindowManagerSetNameParams {

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -719,10 +719,9 @@ var Uno;
                 element.style.setProperty(params.Name, this.handleToString(params.Value));
                 return true;
             }
-            setArrangeProperties(elementId, clipToBounds) {
+            setArrangeProperties(elementId) {
                 const element = this.getView(elementId);
                 this.setAsArranged(element);
-                this.setClipToBounds(element, clipToBounds);
                 return "ok";
             }
             /**
@@ -813,7 +812,6 @@ var Uno;
                     style.clip = "";
                 }
                 this.setAsArranged(element);
-                this.setClipToBounds(element, params.ClipToBounds);
                 return true;
             }
             setAsArranged(element) {
@@ -821,14 +819,6 @@ var Uno;
             }
             setAsUnarranged(element) {
                 element.classList.add(WindowManager.unoUnarrangedClassName);
-            }
-            setClipToBounds(element, clipToBounds) {
-                if (clipToBounds) {
-                    element.classList.add(WindowManager.unoClippedToBoundsClassName);
-                }
-                else {
-                    element.classList.remove(WindowManager.unoClippedToBoundsClassName);
-                }
             }
             /**
             * Sets the transform matrix of an element
@@ -841,7 +831,6 @@ var Uno;
                 const matrix = `matrix(${params.M11},${params.M12},${params.M21},${params.M22},${params.M31},${params.M32})`;
                 style.transform = matrix;
                 this.setAsArranged(element);
-                this.setClipToBounds(element, params.ClipToBounds);
                 return true;
             }
             setPointerEvents(htmlId, enabled) {
@@ -1776,7 +1765,6 @@ var Uno;
         WindowManager._isLoadEventsEnabled = false;
         WindowManager.unoRootClassName = "uno-root-element";
         WindowManager.unoUnarrangedClassName = "uno-unarranged";
-        WindowManager.unoClippedToBoundsClassName = "uno-clippedToBounds";
         WindowManager._cctor = (() => {
             WindowManager.initMethods();
             UI.HtmlDom.initPolyfills();
@@ -2114,9 +2102,6 @@ class WindowManagerArrangeElementParams {
         }
         {
             ret.Clip = Boolean(Module.getValue(pData + 68, "i32"));
-        }
-        {
-            ret.ClipToBounds = Boolean(Module.getValue(pData + 72, "i32"));
         }
         return ret;
     }
@@ -2541,9 +2526,6 @@ class WindowManagerSetElementTransformParams {
         }
         {
             ret.M32 = Number(Module.getValue(pData + 48, "double"));
-        }
-        {
-            ret.ClipToBounds = Boolean(Module.getValue(pData + 56, "i32"));
         }
         return ret;
     }

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -28,7 +28,6 @@ namespace Uno.UI {
 
 		private static readonly unoRootClassName = "uno-root-element";
 		private static readonly unoUnarrangedClassName = "uno-unarranged";
-		private static readonly unoClippedToBoundsClassName = "uno-clippedToBounds";
 
 		private static _cctor = (() => {
 			WindowManager.initMethods();
@@ -550,11 +549,10 @@ namespace Uno.UI {
 			return true;
 		}
 
-		public setArrangeProperties(elementId: number, clipToBounds: boolean): string {
+		public setArrangeProperties(elementId: number): string {
 			const element = this.getView(elementId);
 
 			this.setAsArranged(element);
-			this.setClipToBounds(element, clipToBounds);
 
 			return "ok";
 		}
@@ -662,7 +660,6 @@ namespace Uno.UI {
 			}
 
 			this.setAsArranged(element);
-			this.setClipToBounds(element, params.ClipToBounds);
 
 			return true;
 		}
@@ -674,14 +671,6 @@ namespace Uno.UI {
 
 		private setAsUnarranged(element: HTMLElement | SVGElement) {
 			element.classList.add(WindowManager.unoUnarrangedClassName);
-		}
-
-		private setClipToBounds(element: HTMLElement | SVGElement, clipToBounds: boolean) {
-			if (clipToBounds) {
-				element.classList.add(WindowManager.unoClippedToBoundsClassName);
-			} else {
-				element.classList.remove(WindowManager.unoClippedToBoundsClassName);
-			}
 		}
 
 		/**
@@ -699,7 +688,6 @@ namespace Uno.UI {
 			style.transform = matrix;
 
 			this.setAsArranged(element);
-			this.setClipToBounds(element, params.ClipToBounds);
 
 			return true;
 		}

--- a/src/Uno.UI/tsBindings/WindowManagerArrangeElementParams.ts
+++ b/src/Uno.UI/tsBindings/WindowManagerArrangeElementParams.ts
@@ -12,7 +12,6 @@ class WindowManagerArrangeElementParams
 	public ClipRight : number;
 	public HtmlId : number;
 	public Clip : boolean;
-	public ClipToBounds : boolean;
 	public static unmarshal(pData:number) : WindowManagerArrangeElementParams
 	{
 		const ret = new WindowManagerArrangeElementParams();
@@ -55,10 +54,6 @@ class WindowManagerArrangeElementParams
 		
 		{
 			ret.Clip = Boolean(Module.getValue(pData + 68, "i32"));
-		}
-		
-		{
-			ret.ClipToBounds = Boolean(Module.getValue(pData + 72, "i32"));
 		}
 		return ret;
 	}

--- a/src/Uno.UI/tsBindings/WindowManagerSetElementTransformParams.ts
+++ b/src/Uno.UI/tsBindings/WindowManagerSetElementTransformParams.ts
@@ -9,7 +9,6 @@ class WindowManagerSetElementTransformParams
 	public M22 : number;
 	public M31 : number;
 	public M32 : number;
-	public ClipToBounds : boolean;
 	public static unmarshal(pData:number) : WindowManagerSetElementTransformParams
 	{
 		const ret = new WindowManagerSetElementTransformParams();
@@ -40,10 +39,6 @@ class WindowManagerSetElementTransformParams
 		
 		{
 			ret.M32 = Number(Module.getValue(pData + 48, "double"));
-		}
-		
-		{
-			ret.ClipToBounds = Boolean(Module.getValue(pData + 56, "i32"));
 		}
 		return ret;
 	}


### PR DESCRIPTION
Fixes #652

# Bugfix
Clipping were wrongly applied on both Skia & Wasm. On Wasm, the CSS `overflow: hidden` were not only useless but were also creating problems. The native "clipping" feature is now uses in all cases.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
