### PR TITLE
fix(reg): Fix invalid lifetime for generated delegates on x:Bind

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/Given_XBindRewriter.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/Given_XBindRewriter.cs
@@ -14,12 +14,16 @@ namespace Uno.UI.SourceGenerators.Tests
 		// DataTemplates (with context)
 		[DataRow("ctx", "MyProperty.A", "ctx.MyProperty.A")]
 		[DataRow("ctx", "MyProperty", "ctx.MyProperty")]
+		[DataRow("ctx", "MyStaticProperty", "MyStaticProperty")]
+		[DataRow("ctx", "MyStaticMethod()", "MyStaticMethod()")]
 		[DataRow("ctx", "MyProperty.A.ToLower()", "ctx.MyProperty.A.ToLower()")]
 		[DataRow("ctx", "System.String.Format('{0:X8}', a.Value)", "System.String.Format('{0:X8}', ctx.a.Value)")]
 		[DataRow("ctx", "Static.MyFunction(42.0)", "Static.MyFunction(42.0)")]
 		[DataRow("ctx", "Static.MyFunction(true)", "Static.MyFunction(true)")]
 		[DataRow("ctx", "Static.MyFunction(MyProperty)", "Static.MyFunction(ctx.MyProperty)")]
 		[DataRow("ctx", "MyNameSpace.Static2.MyProperty", "MyNameSpace.Static2.MyProperty")]
+		[DataRow("ctx", "MyNameSpace.Static2.MyEnum.EnumMember", "MyNameSpace.Static2.MyEnum.EnumMember")]
+		[DataRow("ctx", "MyNameSpace.Static2.MyProperty.ToArray()", "MyNameSpace.Static2.MyProperty.ToArray()")]
 		[DataRow("ctx", "MyNameSpace.Static2.MyFunction(MyProperty)", "MyNameSpace.Static2.MyFunction(ctx.MyProperty)")]
 		[DataRow("ctx", "MyFunction(MyProperty)", "ctx.MyFunction(ctx.MyProperty)")]
 		[DataRow("ctx", "", "ctx")]
@@ -38,19 +42,17 @@ namespace Uno.UI.SourceGenerators.Tests
 		{
 			bool IsStaticMethod(string name)
 			{
-				switch (name)
+				return name switch
 				{
-					case "Static.MyFunction":
-						return true;
-					case "System.String.Format":
-						return true;
-					case "MyNameSpace.Static2.MyFunction":
-						return true;
-					case "MyNameSpace.Static2.MyProperty":
-						return true;
-				}
-
-				return false;
+					"MyStaticProperty" => true,
+					"MyStaticMethod" => true,
+					"Static.MyFunction" => true,
+					"System.String.Format" => true,
+					"MyNameSpace.Static2.MyFunction" => true,
+					"MyNameSpace.Static2.MyProperty" => true,
+					"MyNameSpace.Static2.MyEnum" => true,
+					_ => false,
+				};
 			}
 
 			var output = XBindExpressionParser.Rewrite(contextName, inputExpression, IsStaticMethod);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Utils/XBindExpressionParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Utils/XBindExpressionParser.cs
@@ -61,9 +61,18 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 			{
 				var e = base.VisitInvocationExpression(node);
 
-				var isValidParent = !Helpers.IsInsideMethod(node).result && !Helpers.IsInsideMemberAccessExpression(node).result;
+				var isParentMemberStatic = node.Expression switch
+				{
+					MemberAccessExpressionSyntax ma => _isStaticMember(ma.Expression.ToFullString()),
+					IdentifierNameSyntax ins => _isStaticMember(ins.ToFullString()),
+					_ => false
+				};
 
-				if (isValidParent && !_isStaticMember(node.Expression.ToFullString()))
+				var isValidParent = !Helpers.IsInsideMethod(node).result
+					&& !Helpers.IsInsideMemberAccessExpression(node).result
+					&& !Helpers.IsInsideMemberAccessExpression(node.Expression).result;
+
+				if (isValidParent && !_isStaticMember(node.Expression.ToFullString()) && !isParentMemberStatic)
 				{
 					if (e is InvocationExpressionSyntax newSyntax)
 					{
@@ -92,8 +101,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 			{
 				var e = base.VisitMemberAccessExpression(node);
 				var isValidParent = !Helpers.IsInsideMethod(node).result && !Helpers.IsInsideMemberAccessExpression(node).result;
+				var isParentMemberStatic = node.Expression is MemberAccessExpressionSyntax m && _isStaticMember(m.ToFullString());
 
-				if (isValidParent)
+				if (isValidParent && !_isStaticMember(node.Expression.ToFullString()) && !isParentMemberStatic)
 				{
 					var expression = e.ToFullString();
 					var contextBuilder = _isStaticMember(expression) ? "" : ContextBuilder;
@@ -112,7 +122,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 			{
 				var isValidParent = !Helpers.IsInsideMethod(node).result && !Helpers.IsInsideMemberAccessExpression(node).result;
 
-				if (isValidParent)
+				if (isValidParent && !_isStaticMember(node.ToFullString()))
 				{
 					var newIdentifier = node.ToFullString();
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
@@ -12,6 +12,7 @@ using Uno.UI.SourceGenerators.XamlGenerator.XamlRedirection;
 using System.Text.RegularExpressions;
 using Windows.Foundation.Metadata;
 using Uno.UI.SourceGenerators.XamlGenerator.Utils;
+using System.Diagnostics;
 
 namespace Uno.UI.SourceGenerators.XamlGenerator
 {

--- a/src/Uno.UI/UI/Xaml/Data/Binding.cs
+++ b/src/Uno.UI/UI/Xaml/Data/Binding.cs
@@ -31,8 +31,6 @@ namespace Windows.UI.Xaml.Data
 		/// the binding is explicitly tied to the object containing the weak references. This means
 		/// that there's weak references will be kept alive properly.
 		/// </summary>
-
-		private WeakReference _xBindSelector, _xBindBack;
 		private ManagedWeakReference _compiledSource;
 #endif
 
@@ -184,21 +182,13 @@ namespace Windows.UI.Xaml.Data
 		/// get the resulting value.
 		/// </summary>
 		internal Func<object, object> XBindSelector
-#if UNO_HAS_UIELEMENT_IMPLICIT_PINNING
-		{ get => (Func<object, object>)_xBindSelector?.Target; private set => _xBindSelector = new WeakReference(value); }
-#else
 		{ get; private set; }
-#endif
 
 		/// <summary>
 		/// Provides the method used to set the value back to the source.
 		/// </summary>
 		internal Action<object, object> XBindBack
-#if UNO_HAS_UIELEMENT_IMPLICIT_PINNING
-		{ get => (Action<object, object>)_xBindBack?.Target; private set => _xBindBack = new WeakReference(value); }
-#else
 		{ get; private set; }
-#endif
 
 		/// <summary>
 		/// List of paths to observe in the context x:Bind expressions


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Delegates generated for `x:Bind` may get collected too early as they are not pinned to a long-lived object. Unit tests fail randomly as a consequence.

## What is the new behavior?

Delegates are now pinned to the `Binding` instance, but the context is now provided as a parameter of the bind and bind-back functions to avoid closing on `this`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
