### PR TITLE
docs: Ensure gif files are included in docfx output

### DIFF
--- a/doc/docfx.json
+++ b/doc/docfx.json
@@ -42,7 +42,8 @@
         "files": [
           "images/**",
           "articles/**.png",
-          "articles/**.jpg"
+          "articles/**.jpg",
+          "articles/**.gif"
         ]
       }
     ],


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Other: Website documentation related content

## What is the current behavior?

Gif files are not used for the site generation


## What is the new behavior?

Gif files are included in docfx output


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

