### PR TITLE
[Android] Broadcast status after requesting access

### DIFF
--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -48,14 +48,26 @@ namespace Windows.Devices.Geolocation
 
 		public static async Task<GeolocationAccessStatus> RequestAccessAsync()
 		{
-			if(!await PermissionsHelper.CheckFineLocationPermission(CancellationToken.None))
+			var status = GeolocationAccessStatus.Allowed;
+
+			if (!await PermissionsHelper.CheckFineLocationPermission(CancellationToken.None))
 			{
-				return await PermissionsHelper.TryGetFineLocationPermission(CancellationToken.None)
+				status = await PermissionsHelper.TryGetFineLocationPermission(CancellationToken.None)
 					? GeolocationAccessStatus.Allowed
 					: GeolocationAccessStatus.Denied;
+
+				BroadcastStatus(PositionStatus.Initializing);
+				if (status == GeolocationAccessStatus.Allowed)
+				{
+					BroadcastStatus(PositionStatus.Ready);
+				}
+				else
+				{
+					BroadcastStatus(PositionStatus.Disabled);
+				}
 			}
 
-			return GeolocationAccessStatus.Allowed;
+			return status;
 		}
 
 		private LocationManager InitializeLocationProvider(double desiredAccuracy)


### PR DESCRIPTION
GitHub Issue (If applicable): #

https://github.com/unoplatform/uno/issues/3970

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

-->

## What is the current behavior?

When we call Geolocator.RequestAccessAsync and the call is successful, StatusChanged is still not raised. That event is only raised when we call GetGeopositionAsync.


## What is the new behavior?

When we call Geolocator.RequestAccessAsync, StatusChanged is raised - the same as UWP and iOS.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~Validated PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
