### PR TITLE
Add missing Symbols

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -997,6 +997,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SymbolIconTests\SymbolIcon_Generic.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockButton\Simple_TextBlockButton.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4016,6 +4020,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SplitView\SplitViewClip.xaml.cs">
       <DependentUpon>SplitViewClip.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SymbolIconTests\SymbolIcon_Generic.xaml.cs">
+      <DependentUpon>SymbolIcon_Generic.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockButton\Simple_TextBlockButton.xaml.cs">
       <DependentUpon>Simple_TextBlockButton.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SymbolIconTests/SymbolIcon_Generic.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SymbolIconTests/SymbolIcon_Generic.xaml
@@ -11,10 +11,10 @@
 	<Grid>
 		<ListView ItemsSource="{x:Bind Symbols}">
 			<ListView.ItemTemplate>
-				<DataTemplate>
+				<DataTemplate x:DataType="local:SymbolListItem">
 					<StackPanel Orientation="Horizontal" Spacing="8">
-						<SymbolIcon Symbol="{Binding Symbol}" />
-						<TextBlock Text="{Binding Name}" />
+						<SymbolIcon Symbol="{x:Bind Symbol}" />
+						<TextBlock Text="{x:Bind Name}" />
 					</StackPanel>
 				</DataTemplate>
 			</ListView.ItemTemplate>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SymbolIconTests/SymbolIcon_Generic.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SymbolIconTests/SymbolIcon_Generic.xaml
@@ -1,0 +1,23 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.SymbolIconTests.SymbolIcon_Generic"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.SymbolIconTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<ListView ItemsSource="{x:Bind Symbols}">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<StackPanel Orientation="Horizontal" Spacing="8">
+						<SymbolIcon Symbol="{Binding Symbol}" />
+						<TextBlock Text="{Binding Name}" />
+					</StackPanel>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SymbolIconTests/SymbolIcon_Generic.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SymbolIconTests/SymbolIcon_Generic.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.SymbolIconTests
+{
+	[Sample("SymbolIcon")]
+	public sealed partial class SymbolIcon_Generic : Page
+    {
+        public SymbolIcon_Generic()
+        {
+            this.InitializeComponent();
+        }
+
+		public List<SymbolItem> Symbols { get; } =
+			Enum.GetValues(typeof(Symbol))
+				.Cast<Symbol>()
+				.Select(symbol => new SymbolItem(symbol))
+				.ToList();
+
+		public class SymbolItem
+		{
+			public SymbolItem(Symbol symbol)
+			{
+				Symbol = symbol;
+				Name = Enum.GetName(typeof(Symbol), symbol);
+			}
+
+			public Symbol Symbol { get; }
+
+			public string Name { get; }
+		}
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SymbolIconTests/SymbolIcon_Generic.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SymbolIconTests/SymbolIcon_Generic.xaml.cs
@@ -15,23 +15,23 @@ namespace UITests.Windows_UI_Xaml_Controls.SymbolIconTests
             this.InitializeComponent();
         }
 
-		public List<SymbolItem> Symbols { get; } =
+		public List<SymbolListItem> Symbols { get; } =
 			Enum.GetValues(typeof(Symbol))
 				.Cast<Symbol>()
-				.Select(symbol => new SymbolItem(symbol))
-				.ToList();
-
-		public class SymbolItem
-		{
-			public SymbolItem(Symbol symbol)
-			{
-				Symbol = symbol;
-				Name = Enum.GetName(typeof(Symbol), symbol);
-			}
-
-			public Symbol Symbol { get; }
-
-			public string Name { get; }
-		}
+				.Select(symbol => new SymbolListItem(symbol))
+				.ToList();		
     }
+
+	public class SymbolListItem
+	{
+		public SymbolListItem(Symbol symbol)
+		{
+			Symbol = symbol;
+			Name = Enum.GetName(typeof(Symbol), symbol);
+		}
+
+		public Symbol Symbol { get; }
+
+		public string Name { get; }
+	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Symbol.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/Symbol.cs
@@ -2,10 +2,10 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if false || false || false || false || false || false || false
-	#if false || false || false || false || false || false || false
+#if false || false || false || false || false || false || false
+#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
-	#endif
+#endif
 	public   enum Symbol 
 	{
 		// Skipping already declared field Windows.UI.Xaml.Controls.Symbol.Previous
@@ -201,18 +201,10 @@ namespace Windows.UI.Xaml.Controls
 		// Skipping already declared field Windows.UI.Xaml.Controls.Symbol.FourBars
 		// Skipping already declared field Windows.UI.Xaml.Controls.Symbol.Scan
 		// Skipping already declared field Windows.UI.Xaml.Controls.Symbol.Preview
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		GlobalNavigationButton,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		Share,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		Print,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		XboxOneConsole,
-		#endif
+		// Skipping already declared field Windows.UI.Xaml.Controls.Symbol.GlobalNavigationButton
+		// Skipping already declared field Windows.UI.Xaml.Controls.Symbol.Share
+		// Skipping already declared field Windows.UI.Xaml.Controls.Symbol.Print
+		// Skipping already declared field Windows.UI.Xaml.Controls.Symbol.XboxOneConsole
 	}
-	#endif
+#endif
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Symbol.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Symbol.cs
@@ -1,7 +1,4 @@
-﻿using Windows.Foundation;
-using Windows.Foundation.Metadata;
-
-namespace Windows.UI.Xaml.Controls
+﻿namespace Windows.UI.Xaml.Controls
 {
 	public enum Symbol
 	{
@@ -197,6 +194,10 @@ namespace Windows.UI.Xaml.Controls
 		ThreeBars = 57832,
 		FourBars = 57833,
 		Scan = 58004,
-		Preview = 58005
+		Preview = 58005,
+		GlobalNavigationButton = 59136,
+		Share = 59181,
+		Print = 59209,
+		XboxOneConsole = 59792
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/SymbolIcon/SymbolIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SymbolIcon/SymbolIcon.cs
@@ -30,7 +30,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty SymbolProperty { get; } =
-			DependencyProperty.Register("Symbol", typeof(Symbol), typeof(SymbolIcon), new FrameworkPropertyMetadata(Symbol.Emoji, OnSymbolChanged));
+			DependencyProperty.Register(nameof(Symbol), typeof(Symbol), typeof(SymbolIcon), new FrameworkPropertyMetadata(Symbol.Emoji, OnSymbolChanged));
 
 		private static void OnSymbolChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #3510

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

A few members of the `Symbol` enum were added in UWP, but were not present in Uno.

## What is the new behavior?

Symbols are added. They were already in our icon font.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.