### PR TITLE
fix: Geolocator methods invoked on Dispatcher when necessary

### DIFF
--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.iOSmacOS.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.iOSmacOS.cs
@@ -5,9 +5,12 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using CoreLocation;
+using Uno.Extensions;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Foundation.Metadata;
+using Windows.UI.Core;
+
 namespace Windows.Devices.Geolocation
 {
 	public sealed partial class Geolocator
@@ -38,24 +41,34 @@ namespace Windows.Devices.Geolocation
 		}
 
 #if __IOS__
-		public async Task<Geoposition> GetGeopositionAsync() //will be removed with #2240
+		public Task<Geoposition> GetGeopositionAsync() => GetGeopositionInternalAsync(); //will be removed with #2240
 #else
-		public IAsyncOperation<Geoposition> GetGeopositionAsync()
+		public IAsyncOperation<Geoposition> GetGeopositionAsync() => GetGeopositionInternalAsync().AsAsyncOperation();
 #endif
-		{
-			BroadcastStatus(PositionStatus.Initializing);
-			var location = _locationManager.Location;
-			if (location == null)
-			{
-				throw new InvalidOperationException("Could not obtain the location. Please make sure that NSLocationWhenInUseUsageDescription and NSLocationUsageDescription are set in info.plist.");
-			}
 
-			BroadcastStatus(PositionStatus.Ready);
-#if __IOS__
-			return ToGeoposition(location);
-#else
-			return Task.FromResult(ToGeoposition(location)).AsAsyncOperation();
-#endif
+		public Task<Geoposition> GetGeopositionInternalAsync()
+
+		{
+			if (CoreDispatcher.Main.HasThreadAccess)
+			{
+				BroadcastStatus(PositionStatus.Initializing);
+				var location = _locationManager.Location;
+				if (location == null)
+				{
+					throw new InvalidOperationException("Could not obtain the location. Please make sure that NSLocationWhenInUseUsageDescription and NSLocationUsageDescription are set in info.plist.");
+				}
+
+				BroadcastStatus(PositionStatus.Ready);
+
+				return Task.FromResult(ToGeoposition(location));
+			}
+			else
+			{
+				return CoreDispatcher.Main.RunWithResultAsync<Geoposition>(
+					priority: CoreDispatcherPriority.Normal,
+					task: () => GetGeopositionInternalAsync()
+				);
+			}
 		}
 
 		private static Geoposition ToGeoposition(CLLocation location)
@@ -91,62 +104,71 @@ namespace Windows.Devices.Geolocation
 		private static List<CLLocationManager> _requestManagers = new List<CLLocationManager>();
 
 #if __IOS__
-		public static async Task<GeolocationAccessStatus> RequestAccessAsync() //will be removed with #2240
+		public static Task<GeolocationAccessStatus> RequestAccessAsync() => RequestAccessInternalAsync(); //will be removed with #2240
 #else
-		public static IAsyncOperation<GeolocationAccessStatus> RequestAccessAsync() =>
-			RequestAccessInternalAsync().AsAsyncOperation();
-
+		public static IAsyncOperation<GeolocationAccessStatus> RequestAccessAsync() => RequestAccessInternalAsync().AsAsyncOperation();
+#endif
 		private static async Task<GeolocationAccessStatus> RequestAccessInternalAsync()
-#endif
+
 		{
-			var mgr = new CLLocationManager();
-
-			lock (_requestManagers)
+			if (CoreDispatcher.Main.HasThreadAccess)
 			{
-				_requestManagers.Add(mgr);
-			}
+				var mgr = new CLLocationManager();
 
-			try
-			{
-				GeolocationAccessStatus accessStatus;
-				var cts = new TaskCompletionSource<CLAuthorizationStatus>();
-
-				mgr.AuthorizationChanged += (s, e) =>
-				{
-
-					if (e.Status != CLAuthorizationStatus.NotDetermined)
-					{
-						cts.TrySetResult(e.Status);
-					}
-				};
-
-#if __IOS__ //required only for iOS
-				mgr.RequestWhenInUseAuthorization();
-#endif
-
-				if (CLLocationManager.Status != CLAuthorizationStatus.NotDetermined)
-				{
-					accessStatus = TranslateStatus(CLLocationManager.Status);
-				}
-
-				var cLAuthorizationStatus = await cts.Task;
-
-				accessStatus = TranslateStatus(cLAuthorizationStatus);
-				
-				//if geolocation is not well accessible, default geoposition should be recommended
-				if (accessStatus != GeolocationAccessStatus.Allowed)
-				{
-					IsDefaultGeopositionRecommended = true;
-				}
-
-				return accessStatus;
-			}
-			finally
-			{
 				lock (_requestManagers)
 				{
-					_requestManagers.Remove(mgr);
+					_requestManagers.Add(mgr);
 				}
+
+				try
+				{
+					GeolocationAccessStatus accessStatus;
+					var cts = new TaskCompletionSource<CLAuthorizationStatus>();
+
+					mgr.AuthorizationChanged += (s, e) =>
+					{
+
+						if (e.Status != CLAuthorizationStatus.NotDetermined)
+						{
+							cts.TrySetResult(e.Status);
+						}
+					};
+
+#if __IOS__ //required only for iOS
+					mgr.RequestWhenInUseAuthorization();
+#endif
+
+					if (CLLocationManager.Status != CLAuthorizationStatus.NotDetermined)
+					{
+						accessStatus = TranslateStatus(CLLocationManager.Status);
+					}
+
+					var cLAuthorizationStatus = await cts.Task;
+
+					accessStatus = TranslateStatus(cLAuthorizationStatus);
+
+					//if geolocation is not well accessible, default geoposition should be recommended
+					if (accessStatus != GeolocationAccessStatus.Allowed)
+					{
+						IsDefaultGeopositionRecommended = true;
+					}
+
+					return accessStatus;
+				}
+				finally
+				{
+					lock (_requestManagers)
+					{
+						_requestManagers.Remove(mgr);
+					}
+				}
+			}
+			else
+			{
+				return await CoreDispatcher.Main.RunWithResultAsync<GeolocationAccessStatus>(
+					priority: CoreDispatcherPriority.Normal,
+					task: () => RequestAccessInternalAsync()
+				);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/4029

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

-->

## What is the current behavior?

On Android: when we call GetGeopositionAsync on a background thread, a native exception is raised.
On iOS: when we call GetGeopositionAsync or RequestAccessAsync on a background thread, a native exception is raised.
These restrictions do not apply in UWP.

## What is the new behavior?

We can call GetGeopositionAsync and RequestAccessAsync  on any thread on iOS or Android, without error.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~Validated PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
