### PR TITLE
[WIP] fix: Change default values for Horizontal and Vertical content alignment

### DIFF
--- a/src/Uno.UI/Mixins/DependencyPropertyMixins.tt
+++ b/src/Uno.UI/Mixins/DependencyPropertyMixins.tt
@@ -6,8 +6,8 @@
 		.Namespace("Windows.UI.Xaml.Controls")
 
 			.Class("Control")
-				.Property("HorizontalContentAlignment", "HorizontalAlignment", "(Uno.UI.FeatureConfiguration.Control.UseLegacyContentAlignment ? HorizontalAlignment.Left : HorizontalAlignment.Center)")
-				.Property("VerticalContentAlignment", "VerticalAlignment", "(Uno.UI.FeatureConfiguration.Control.UseLegacyContentAlignment ? VerticalAlignment.Top : VerticalAlignment.Center)")				
+				.Property("HorizontalContentAlignment", "HorizontalAlignment", "HorizontalAlignment.Left")
+				.Property("VerticalContentAlignment", "VerticalAlignment", "VerticalAlignment.Top")
 			.Class("PopupBase")
 				.Property("IsOpen", "bool", "false")
 				.Property("Child", "UIElement", "null", frameworkPropertyOption: "ValueInheritsDataContext")


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #4038

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Default alignment is `Center`.


## What is the new behavior?

Default alignment matches UWP.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

Quite likely a breaking change, but aligns with UWP and existing apps probably had to use workaround (explicitly aligning).