### PR TITLE
fix(reg): Fix invalid component generation for nested resources

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2743,7 +2743,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						}
 					}
 
-					if (!IsMemberInsideResourceDictionary(objectDefinition)
+					if (!IsMemberInsideResourceDictionary(objectDefinition, maxDepth: null)
 						&& (HasXBindMarkupExtension(objectDefinition) || HasMarkupExtensionNeedingComponent(objectDefinition)))
 					{
 						writer.AppendLineInvariant($"this._component_{CurrentScope.ComponentCount} = {closureName};");
@@ -3561,8 +3561,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				.Select(n => IsMemberInside(xamlObject, n))
 				.FirstOrDefault(n => n.isInside);
 
-		private bool IsMemberInsideResourceDictionary(XamlObjectDefinition xamlObject)
-			=> IsMemberInside(xamlObject, "ResourceDictionary", maxDepth: 1).isInside;
+		private bool IsMemberInsideResourceDictionary(XamlObjectDefinition xamlObject, int? maxDepth = 1)
+			=> IsMemberInside(xamlObject, "ResourceDictionary", maxDepth: maxDepth).isInside;
 
 		private static (bool isInside, XamlObjectDefinition xamlObject) IsMemberInside(XamlObjectDefinition xamlObject, string typeName, int? maxDepth = null)
 		{

--- a/src/Uno.UI.Tests/App/Xaml/Subclassed_Dictionary.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Subclassed_Dictionary.xaml
@@ -1,6 +1,7 @@
 <ResourceDictionary x:Class="Uno.UI.Tests.App.Xaml.Subclassed_Dictionary"
 					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:local="using:Uno.UI.Tests.App.Xaml"
 					xmlns:views="using:Uno.UI.Tests.App.Views">
 	<ResourceDictionary.ThemeDictionaries>
 		<ResourceDictionary x:Key="Default">
@@ -13,4 +14,9 @@
 	<DataTemplate x:Key="UproariousTemplate">
 		<CheckBox x:Name="TemplateRoot" />
 	</DataTemplate>
+	<local:MyConverter x:Key="InnerResourceConverter" Value="{StaticResource ProblemFreePhilosophy}">
+		<local:MyConverter.Values>
+			<local:MyConverterItem Value="{StaticResource PerilousColorBrush}" />
+		</local:MyConverter.Values>
+	</local:MyConverter>
 </ResourceDictionary>

--- a/src/Uno.UI.Tests/App/Xaml/Subclassed_Dictionary.xaml.cs
+++ b/src/Uno.UI.Tests/App/Xaml/Subclassed_Dictionary.xaml.cs
@@ -7,6 +7,7 @@ using Uno.UI.Tests.App.Views;
 using Uno.UI.Tests.ViewLibrary;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.Networking.Sockets;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -29,5 +30,19 @@ namespace Uno.UI.Tests.App.Xaml
 		{
 			this.InitializeComponent();
 		}
+	}
+
+	public class MyConverter : IValueConverter
+	{
+		public List<MyConverterItem> Values { get; } = new List<MyConverterItem>();
+		public object Value { get; set; }
+
+		public object Convert(object value, Type targetType, object parameter, string language) => Values[0].Value;
+		public object ConvertBack(object value, Type targetType, object parameter, string language) => Values[0].Value;
+	}
+
+	public class MyConverterItem
+	{
+		public object Value { get; set; }
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
@@ -609,6 +609,21 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		public void When_Nested_StaticResource()
+		{
+			var dict = new Subclassed_Dictionary();
+
+			var converter = dict["InnerResourceConverter"] as MyConverter;
+			var brush = dict["PerilousColorBrush"];
+			var text = dict["ProblemFreePhilosophy"];
+
+			Assert.IsNotNull(converter);
+			Assert.IsNotNull(brush);
+			Assert.AreEqual(brush, converter.Values[0].Value);
+			Assert.AreEqual(text, converter.Value);
+		}
+
+		[TestMethod]
 		public void When_By_Type_With_Template()
 		{
 			var dict = new Subclassed_Dictionary();


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Nested resources use in a resource dictionary.

## What is the new behavior?

The following XAML is now supported.
```xaml
<SolidColorBrush x:Key="PerilousColorBrush"
					Color="WhiteSmoke" />
<DataTemplate x:Key="UproariousTemplate">
	<CheckBox x:Name="TemplateRoot" />
</DataTemplate>
<local:MyConverter x:Key="InnerResourceConverter" Value="{StaticResource ProblemFreePhilosophy}">
	<local:MyConverter.Values>
		<local:MyConverterItem Value="{StaticResource PerilousColorBrush}" />
	</local:MyConverter.Values>
</local:MyConverter>
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): fixes https://github.com/unoplatform/nventive-private/issues/11