### PR TITLE
feat: more fields in Geoposition (on Android)

### DIFF
--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -177,17 +177,6 @@ namespace Windows.Devices.Geolocation
 			}
 
 
-			Windows.Devices.Geolocation.Geopoint geopoint = new Windows.Devices.Geolocation.Geopoint(
-				new Windows.Devices.Geolocation.BasicGeoposition
-				{
-					Latitude = location.Latitude;
-					Longitude = location.Longitude;
-					Altitude = location.Altitude;
-				},
-				Windows.Devices.Geolocation.AltitudeReferenceSystem.Ellipsoid,
-				Wgs84SpatialReferenceId
-			);
-
 			double? locVertAccuracy = null;
 			// VerticalAccuracy is since API 26
 			if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.O)
@@ -199,14 +188,24 @@ namespace Windows.Devices.Geolocation
 			}
 
 
-			Windows.Devices.Geolocation.Geoposition geopos = new Windows.Devices.Geolocation.Geoposition(
-				new Windows.Devices.Geolocation.Geocoordinate(
+			return new Windows.Devices.Geolocation.Geoposition(
+				new Geocoordinate(
 					latitude: location.Latitude,
 					longitude: location.Longitude,
 					altitude: location.Altitude,
 					timestamp: DateTimeOffset.FromUnixTimeMilliseconds(location.Time),
 					speed: location.HasSpeed ? location.Speed : 0,
-					point: geopoint,
+					point: new Geopoint(
+							new BasicGeoposition
+							{
+								Latitude = location.Latitude,
+								Longitude = location.Longitude,
+								Altitude = location.Altitude
+							},
+							AltitudeReferenceSystem.Ellipsoid,
+							Wgs84SpatialReferenceId
+						),
+
 					accuracy: location.HasAccuracy ? location.Accuracy : 0,
 					altitudeAccuracy: locVertAccuracy,
 					heading: geoheading,
@@ -214,7 +213,6 @@ namespace Windows.Devices.Geolocation
 				)
 			);
 
-			return geopos;
 		}
 
 

--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -215,12 +215,6 @@ namespace Windows.Devices.Geolocation
 
 		}
 
-
-		private static DateTimeOffset FromUnixTime(long time)
-		{
-			var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-			return epoch.AddMilliseconds(time);
-		}
 	}
 }
 #endif

--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -176,15 +176,17 @@ namespace Windows.Devices.Geolocation
 					break;
 			}
 
-			Windows.Devices.Geolocation.BasicGeoposition basicGeoposition;
-			basicGeoposition.Altitude = location.Altitude;
-			basicGeoposition.Latitude = location.Latitude;
-			basicGeoposition.Longitude = location.Longitude;
 
-			Windows.Devices.Geolocation.Geopoint geopoint = new Windows.Devices.Geolocation.Geopoint(basicGeoposition,
-						Windows.Devices.Geolocation.AltitudeReferenceSystem.Ellipsoid,
-						Wgs84SpatialReferenceId
-					);
+			Windows.Devices.Geolocation.Geopoint geopoint = new Windows.Devices.Geolocation.Geopoint(
+				new Windows.Devices.Geolocation.BasicGeoposition
+				{
+					Latitude = location.Latitude;
+					Longitude = location.Longitude;
+					Altitude = location.Altitude;
+				},
+				Windows.Devices.Geolocation.AltitudeReferenceSystem.Ellipsoid,
+				Wgs84SpatialReferenceId
+			);
 
 			double? locVertAccuracy = null;
 			// VerticalAccuracy is since API 26


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
 Some fields of Windows.Devices.Geolocation.Geoposition is not filled.

## What is the new behavior?
More location data is placed in Geoposition struct:
heading
altitudeAccuracy
accuracy
positionSource


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
 Non-controversial part of #2536
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
