### PR TITLE
[Wasm] Fixed DOM & visual tree synchronization issues

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_StackPanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_StackPanel.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	public class Given_StackPanel
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_InsertingChildren_Then_ResultIsInRightOrder()
+		{
+			// This is an illustration of the bug https://github.com/unoplatform/uno/issues/3543
+
+			var pnl = new StackPanel();
+			pnl.Children.Add(new Button { Content = "abc" });
+			pnl.Children.Insert(0, new TextBlock { Text = "TextBlock" });
+			pnl.Children.Insert(0, new TextBox());
+
+			TestServices.WindowHelper.WindowContent = pnl;
+
+			using var _ = new AssertionScope();
+
+			pnl.Children
+				.Select(c => c.GetType())
+				.Should()
+				.Equal(typeof(TextBox), typeof(TextBlock), typeof(Button));
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+#if __WASM__
+			// Ensure children are synchronized in the DOM
+			var js = $@"
+				(function() {{
+					var stackPanel = document.getElementById(""{pnl.HtmlId}"");
+					var result = """";
+					for(const elem of stackPanel.children) {{
+						result = result + "";"" + elem.id;
+					}}
+					return result;
+				}})();";
+			var expectedIds = ";" + string.Join(";", pnl.Children.Select(c => c.HtmlId));
+
+			var ids = global::Uno.Foundation.WebAssemblyRuntime.InvokeJS(js);
+
+			ids.Should().Be(expectedIds, "Expected from DOM");
+#endif
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -490,7 +490,15 @@ namespace Windows.UI.Xaml
 
 			OnAddingChild(child);
 
-			_children.Add(child);
+			if (index is { } i)
+			{
+				_children.Insert(i, child);
+			}
+			else
+			{
+				_children.Add(child);
+			}
+
 			Uno.UI.Xaml.WindowManagerInterop.AddView(HtmlId, child.HtmlId, index);
 
 			OnChildAdded(child);


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/3543

# Bugfix
Doing a `.Children.Insert()` on a panel on Wasm was correctly updating the DOM, but the synchronized managed visual tree were not correctly updated, so the ordering was desynchronized between the two lists.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
