### PR TITLE
fix: Perform app initialization only for ApplicationActivity

### DIFF
--- a/src/Uno.UI/UI/Xaml/NativeApplication.cs
+++ b/src/Uno.UI/UI/Xaml/NativeApplication.cs
@@ -45,38 +45,41 @@ namespace Windows.UI.Xaml
 
 		private void OnActivityStarted(Activity activity)
 		{
-			_app.InitializationCompleted();
-
-			var handled = false;
-			if (_lastHandledIntent != activity.Intent)
+			if (activity is ApplicationActivity)
 			{
-				_lastHandledIntent = activity.Intent;
-				if (activity.Intent?.Extras?.ContainsKey(JumpListItem.ArgumentsExtraKey) == true)
-				{
-					_app.OnLaunched(new LaunchActivatedEventArgs(ActivationKind.Launch, activity.Intent.GetStringExtra(JumpListItem.ArgumentsExtraKey)));
-					handled = true;					
-				}
-				else if (activity.Intent.Data != null)
-				{
-					if (Uri.TryCreate(activity.Intent.Data.ToString(), UriKind.Absolute, out var uri))
-					{
-						_app.OnActivated(new ProtocolActivatedEventArgs(uri, _isRunning ? ApplicationExecutionState.Running : ApplicationExecutionState.NotRunning));
-						handled = true;						
-					}
-					else
-					{
-						// log error and fall back to normal launch
-						this.Log().LogError($"Activation URI {activity.Intent.Data} could not be parsed");
-					}
-				}
-			}
+				_app.InitializationCompleted();
 
-			// default to normal launch
-			if (!handled)
-			{
-				_app.OnLaunched(new LaunchActivatedEventArgs());
+				var handled = false;
+				if (_lastHandledIntent != activity.Intent)
+				{
+					_lastHandledIntent = activity.Intent;
+					if (activity.Intent?.Extras?.ContainsKey(JumpListItem.ArgumentsExtraKey) == true)
+					{
+						_app.OnLaunched(new LaunchActivatedEventArgs(ActivationKind.Launch, activity.Intent.GetStringExtra(JumpListItem.ArgumentsExtraKey)));
+						handled = true;
+					}
+					else if (activity.Intent.Data != null)
+					{
+						if (Uri.TryCreate(activity.Intent.Data.ToString(), UriKind.Absolute, out var uri))
+						{
+							_app.OnActivated(new ProtocolActivatedEventArgs(uri, _isRunning ? ApplicationExecutionState.Running : ApplicationExecutionState.NotRunning));
+							handled = true;
+						}
+						else
+						{
+							// log error and fall back to normal launch
+							this.Log().LogError($"Activation URI {activity.Intent.Data} could not be parsed");
+						}
+					}
+				}
+
+				// default to normal launch
+				if (!handled)
+				{
+					_app.OnLaunched(new LaunchActivatedEventArgs());
+				}
+				_isRunning = true;
 			}
-			_isRunning = true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #1309

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Null reference exception occurs when a non-application activity is started (e.g. splash screen activity).

## What is the new behavior?

Exception no longer occurs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.