### PR TITLE
Add support for StorageFile.GetFileFromApplicationUriAsync

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -26,12 +26,12 @@ pr:
 resources:
   containers:
   - container: nv-bionic-wasm
-    image: unoplatform/wasm-build:2.1.1
+    image: unoplatform/wasm-build:3.0
 
 variables:
   windowsHostedVMImage: 'windows-2019'
   windowsScaledPool: 'Windows2019-20200608'
-  linuxVMImage: 'ubuntu-16.04'
+  linuxVMImage: 'ubuntu-latest'
   macOSVMImage: 'macOS-10.15'
   xCodeRoot: '/Applications/Xcode_11.5.app'
   XamarinSDKVersion: 6_10_0

--- a/build/run-automated-uitests.sh
+++ b/build/run-automated-uitests.sh
@@ -4,13 +4,13 @@ IFS=$'\n\t'
 
 cd $BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries
 
-npm i chromedriver@74.0.0
-npm i puppeteer@1.13.0
+npm i chromedriver@84.0.1
+npm i puppeteer@5.1.0
 mono $BUILD_SOURCESDIRECTORY/build/nuget/NuGet.exe install NUnit.ConsoleRunner -Version 3.10.0
 
 export UNO_UITEST_TARGETURI=http://localhost:8000
 export UNO_UITEST_DRIVERPATH_CHROME=$BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/node_modules/chromedriver/lib/chromedriver
-export UNO_UITEST_CHROME_BINARY_PATH=$BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/node_modules/puppeteer/.local-chromium/linux-637110/chrome-linux/chrome
+export UNO_UITEST_CHROME_BINARY_PATH=$BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/node_modules/puppeteer/.local-chromium/linux-768783/chrome-linux/chrome
 export UNO_UITEST_SCREENSHOT_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/wasm-automated
 export UNO_UITEST_PLATFORM=Browser
 

--- a/doc/articles/features/windows-storage.md
+++ b/doc/articles/features/windows-storage.md
@@ -26,3 +26,26 @@ File.WriteAllText(Path.Combine(folder.Path, "MyFile.txt"), DateTime.Now.ToLongDa
 Note that for WebAssembly in particular, the `await localFolder.CreateFolderAsync` is important to ensure that the file system has properly been initialized from the IDBFS persistence. Any asynchronous operation from StorageFolder awaits for the filesystem's initialization before continuing.
 
 Note that you can view the content of the **IndexedDB** in the Application tab of your browser, in the **Storage / IndexedDB** section.
+
+## Support for StorageFile.GetFileFromApplicationUriAsync
+
+Uno supports the ability to get package files using the [`StorageFile.GetFileFromApplicationUriAsync`](https://docs.microsoft.com/en-us/uwp/api/windows.storage.storagefile.getfilefromapplicationuriasync).
+
+Support per platform may vary:
+- On Android, iOS/macOS, the file is available immediately as it is part of the installed package.
+- On WebAssembly, the requested file is part of the remote package and is downloaded on demand to avoid increasing the initial application payload size. The file is then stored in the IndexedDB of the browser.
+
+Here's how to use it:
+
+```csharp
+var file = await Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///MyPackageFile.xml"));
+var content = await FileIO.ReadTextAsync(file);
+```
+Given than in the project there's the following declaration:
+```xml
+<ItemGroup>
+    <Content Include="MyPackageFile.xml" />
+</ItemGroup>
+```
+
+

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ThumbTests/UnoSamples_Tests.Thumb.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ThumbTests/UnoSamples_Tests.Thumb.cs
@@ -21,6 +21,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ThumbTests
 
 		[Test]
 		[AutoRetry]
+		[Ignore("Test fails with Chrome 84")] // https://github.com/unoplatform/uno/issues/4097
 		public void When_DragAndDrop()
 		{
 			Run(_sample);

--- a/src/SamplesApp/UITests.Shared/Asset_GetFileFromApplicationUriAsync.xml
+++ b/src/SamplesApp/UITests.Shared/Asset_GetFileFromApplicationUriAsync.xml
@@ -1,0 +1,1 @@
+﻿<SomeContent/>

--- a/src/SamplesApp/UITests.Shared/Assets/Asset_GetFileFromApplicationUriAsync_Nested.xml
+++ b/src/SamplesApp/UITests.Shared/Assets/Asset_GetFileFromApplicationUriAsync_Nested.xml
@@ -1,0 +1,1 @@
+﻿<SomeContent/>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -6035,6 +6035,7 @@
     <Content Include="$(MSBuildThisFileDirectory)Assets\AcrylicBrush.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\Animations.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\AppIcon.png" />
+    <Content Include="$(MSBuildThisFileDirectory)Assets\Asset_GetFileFromApplicationUriAsync_Nested.xml" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\AutoSave.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\AutoSuggestBox.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\Button.png" />

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -6073,6 +6073,7 @@
     <Content Include="$(MSBuildThisFileDirectory)Assets\MenuFlyout.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\theme-dark\ThemeTestImage.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\theme-light\ThemeTestImage.png" />
+    <Content Include="$(MSBuildThisFileDirectory)Asset_GetFileFromApplicationUriAsync.xml" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)EmbeddedResources\LockScreen.png" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)EmbeddedResources\Wallpaper.png" />
     <Content Include="$(MSBuildThisFileDirectory)Lottie\LightBulb.json" />

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -19,7 +19,7 @@
   to inject Uno properly. Failing to add this task early enough makes X.A and X.I miss the generated resource files.
   -->
   <Target Name="UnoResourcesGeneration"
-				  BeforeTargets="_GetLibraryImports"
+				  BeforeTargets="_GetLibraryImports;PrepareForBuild;_CheckForContent"
                   DependsOnTargets="ResolveProjectReferences"
 				  Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildingInsideUnoSourceGenerator)' == ''">
 
@@ -49,7 +49,7 @@
   </Target>
 
   <Target Name="UnoAssetsGeneration"
-				  BeforeTargets="_GetLibraryImports"
+				  BeforeTargets="_GetLibraryImports;PrepareForBuild;_CheckForContent"
                   DependsOnTargets="ResolveProjectReferences"
 				  Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildingInsideUnoSourceGenerator)' == '' and ('$(XamarinProjectType)'!='' or '$(UnoForceProcessPRIResource)'!='')">
     <!-- Assets -->

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -19,7 +19,7 @@
   to inject Uno properly. Failing to add this task early enough makes X.A and X.I miss the generated resource files.
   -->
   <Target Name="UnoResourcesGeneration"
-				  BeforeTargets="PrepareForBuild;_CheckForContent"
+				  BeforeTargets="_GetLibraryImports"
                   DependsOnTargets="ResolveProjectReferences"
 				  Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildingInsideUnoSourceGenerator)' == ''">
 
@@ -49,7 +49,7 @@
   </Target>
 
   <Target Name="UnoAssetsGeneration"
-				  BeforeTargets="PrepareForBuild;_CheckForContent"
+				  BeforeTargets="_GetLibraryImports"
                   DependsOnTargets="ResolveProjectReferences"
 				  Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildingInsideUnoSourceGenerator)' == '' and ('$(XamarinProjectType)'!='' or '$(UnoForceProcessPRIResource)'!='')">
     <!-- Assets -->
@@ -68,9 +68,15 @@
     </RetargetAssets_v0>
     <ItemGroup>
       <Content Remove="@(Assets)" />
-      <BundleResource Condition="'$(XamarinProjectType)'=='ios'" Include="@(RetargetedAssets)" />
-      <AndroidResource Condition="'$(XamarinProjectType)'=='android'" Include="@(RetargetedAssets)" />
     </ItemGroup>
+	<ItemGroup Condition="'$(XamarinProjectType)'=='ios'">
+	  <BundleResource Condition="'%(RetargetedAssets.AssetType)' == 'image'" Include="@(RetargetedAssets)" />
+	  <BundleResource Condition="'%(RetargetedAssets.AssetType)' == 'generic'" Include="@(RetargetedAssets)" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(XamarinProjectType)'=='android'">
+	  <AndroidResource Condition="'%(RetargetedAssets.AssetType)' =='image'" Include="@(RetargetedAssets)" />
+	  <AndroidAsset Condition="'%(RetargetedAssets.AssetType)' =='generic'" Include="@(RetargetedAssets)" />
+	</ItemGroup>
   </Target>
 
   <!--

--- a/src/T4Generator/T4Generator.csproj
+++ b/src/T4Generator/T4Generator.csproj
@@ -5,6 +5,7 @@
 		<TargetFramework>net472</TargetFramework>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -12,6 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="System.Memory" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="16.3.2" />
 		<PackageReference Include="microsoft.visualstudio.texttemplating.15.0">

--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
@@ -9,7 +9,7 @@
 
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>
-
+		
 		<IsBindingProject Condition="'$(TargetFramework)' == 'MonoAndroid90' or '$(TargetFramework)' == 'MonoAndroid10.0'">true</IsBindingProject>
 		<_isWindows>$([MSBuild]::IsOsPlatform(Windows))</_isWindows>
 	</PropertyGroup>
@@ -28,15 +28,15 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4"/>
-		<PackageReference Include="Xamarin.AndroidX.AppCompat"/>
-		<PackageReference Include="Xamarin.AndroidX.RecyclerView"/>
+		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
+		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
+		<PackageReference Include="Xamarin.AndroidX.RecyclerView" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid10.0'">
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4"/>
-		<PackageReference Include="Xamarin.AndroidX.AppCompat"/>
-		<PackageReference Include="Xamarin.AndroidX.RecyclerView"/>
+		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
+		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
+		<PackageReference Include="Xamarin.AndroidX.RecyclerView" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -53,9 +53,7 @@
 
 	<Import Project="..\Uno.CrossTargetting.props" />
 
-	<Target Name="_CompileUnoJavaCreateOutputs"
-					BeforeTargets="Build"
-					AfterTargets="Restore">
+	<Target Name="_CompileUnoJavaCreateOutputs" BeforeTargets="Build" AfterTargets="Restore">
 		<!--
 		Create the EmbeddedJar itemgroup here so the Xamarin tooling picks it up,
 		but in the obj folder so we don't have rebuild and git ignore issues.
@@ -75,7 +73,7 @@
 	</Target>
 
 	<!-- Workaround for https://github.com/unoplatform/uno/issues/986 -->
-	<Target Name="Issue986Workaround" BeforeTargets="ExportJarToXml">
+	<Target Name="Issue986Workaround" BeforeTargets="ExportJarToXml" Condition="'$(MSBuildVersion)' &lt; '16.8'">
 
 		<!--
 		This is required to ensure the first pass of the BindingsGenerator task is
@@ -88,12 +86,12 @@
 	</Target>
 
 	<ItemGroup>
-		<_CompileUnoJavaBeforeTargets Include="ExportJarToXml"/>
-		<_CompileUnoJavaBeforeTargets Include="GenerateBindings"/>
-		<_CompileUnoJavaBeforeTargets Include="_GetLibraryImports"/>
-		<_CompileUnoJavaBeforeTargets Include="ExportJarToXml"/>
+		<_CompileUnoJavaBeforeTargets Include="ExportJarToXml" />
+		<_CompileUnoJavaBeforeTargets Include="GenerateBindings" />
+		<_CompileUnoJavaBeforeTargets Include="_GetLibraryImports" />
+		<_CompileUnoJavaBeforeTargets Include="ExportJarToXml" />
 
-		<_CompileUnoJavaAfterTargets Include="_ExtractLibraryProjectImports"/> <!-- This target generates the \lp\**\classes.jar -->
+		<_CompileUnoJavaAfterTargets Include="_ExtractLibraryProjectImports" /> <!-- This target generates the \lp\**\classes.jar -->
 	</ItemGroup>
 
 	<Target Name="_CompileUnoJava" Condition="'$(DesignTimeBuild)' != 'true'" BeforeTargets="@(_CompileUnoJavaBeforeTargets)" AfterTargets="@(_CompileUnoJavaAfterTargets)" Inputs="@(_JavaFile)" Outputs="@(EmbeddedJar)" DependsOnTargets="_CompileUnoJavaCreateOutputs;@(XamarinBuildRestoreResources)">

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationStorage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationStorage.cs
@@ -19,5 +19,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 
 			Assert.AreEqual("<SomeContent/>", content);
 		}
+
+		[TestMethod]
+		public async Task When_GetFileFromApplicationUriAsync_Nested()
+		{
+			var file = await Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/Asset_GetFileFromApplicationUriAsync_Nested.xml"));
+
+			var content = await FileIO.ReadTextAsync(file);
+
+			Assert.AreEqual("<SomeContent/>", content);
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationStorage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationStorage.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Storage;
+using Windows.UI.Xaml.Input;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
+{
+	[TestClass]
+	public class Given_ApplicationStorage
+	{
+		[TestMethod]
+		public async Task When_GetFileFromApplicationUriAsync_RootPath()
+		{
+			var file = await Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Asset_GetFileFromApplicationUriAsync.xml"));
+
+			var content = await FileIO.ReadTextAsync(file);
+
+			Assert.AreEqual("<SomeContent/>", content);
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Resources/Given_AndroidResourceConverter.cs
+++ b/src/Uno.UI.Tests/Resources/Given_AndroidResourceConverter.cs
@@ -61,18 +61,17 @@ namespace Uno.UI.Tests.Resources
 
 		[TestMethod]
 
-		[DataRow(@"logo.png", @"Assets/logo.png")]
-		[DataRow(@"test/logo.png", @"Assets/test/logo.png")]
-		[DataRow(@"test/logo-1.png", @"Assets/test/logo_1.png")]
-		[DataRow(@"test/logo-1.png", @"Assets/test/logo_1.png")]
-		[DataRow(@"test/test2/logo-1.png", @"Assets/test/test2/logo_1.png")]
-		[DataRow(@"test/test2/test-3/logo-1.png", @"Assets/test/test2/test_3/logo_1.png")]
-		[DataRow(@"1test/logo-1.png", @"Assets/__1test/logo_1.png")]
+		[DataRow(@"logo.png", @"logo.png")]
+		[DataRow(@"test/logo.png", @"test/logo.png")]
+		[DataRow(@"test/logo-1.png", @"test/logo_1.png")]
+		[DataRow(@"test/logo-1.png", @"test/logo_1.png")]
+		[DataRow(@"test/test2/logo-1.png", @"test/test2/logo_1.png")]
+		[DataRow(@"test/test2/test-3/logo-1.png", @"test/test2/test_3/logo_1.png")]
+		[DataRow(@"1test/logo-1.png", @"__1test/logo_1.png")]
 		public void When_EncodeResourcePath(string input, string expected)
 		{
 			Assert.AreEqual(expected, AndroidResourceNameEncoder.EncodeResourcePath(input));
 		}
-
 
 		[TestMethod]
 

--- a/src/Uno.UI.Tests/Resources/Given_AndroidResourceConverter.cs
+++ b/src/Uno.UI.Tests/Resources/Given_AndroidResourceConverter.cs
@@ -48,4 +48,44 @@ namespace Uno.UI.Tests.Resources
 			Assert.AreEqual(expectedPath, actualPath);
 		}
     }
+
+	[TestClass]
+	public class Given_AndroidResourceNameEncoder
+	{
+		[TestMethod]
+		[DataRow(@"logo", @"logo")]
+		public void When_Encode(string input, string expected)
+		{
+			Assert.AreEqual(expected, AndroidResourceNameEncoder.Encode(input));
+		}
+
+		[TestMethod]
+
+		[DataRow(@"logo.png", @"Assets/logo.png")]
+		[DataRow(@"test/logo.png", @"Assets/test/logo.png")]
+		[DataRow(@"test/logo-1.png", @"Assets/test/logo_1.png")]
+		[DataRow(@"test/logo-1.png", @"Assets/test/logo_1.png")]
+		[DataRow(@"test/test2/logo-1.png", @"Assets/test/test2/logo_1.png")]
+		[DataRow(@"test/test2/test-3/logo-1.png", @"Assets/test/test2/test_3/logo_1.png")]
+		[DataRow(@"1test/logo-1.png", @"Assets/__1test/logo_1.png")]
+		public void When_EncodeResourcePath(string input, string expected)
+		{
+			Assert.AreEqual(expected, AndroidResourceNameEncoder.EncodeResourcePath(input));
+		}
+
+
+		[TestMethod]
+
+		[DataRow(@"logo.png", @"Assets\logo.png")]
+		[DataRow(@"test\logo.png", @"Assets\test\logo.png")]
+		[DataRow(@"test\logo-1.png", @"Assets\test\logo_1.png")]
+		[DataRow(@"test\logo-1.png", @"Assets\test\logo_1.png")]
+		[DataRow(@"test\test2\logo-1.png", @"Assets\test\test2\logo_1.png")]
+		[DataRow(@"test\test2\test-3\logo-1.png", @"Assets\test\test2\test_3\logo_1.png")]
+		[DataRow(@"1test\logo-1.png", @"Assets\__1test\logo_1.png")]
+		public void When_EncodeFileSystemPath(string input, string expected)
+		{
+			Assert.AreEqual(expected, AndroidResourceNameEncoder.EncodeFileSystemPath(input));
+		}
+	}
 }

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -73,6 +73,10 @@
 
 	<ItemGroup>
 		<None Include="Extensions\CGSizeExtensions.iOSmacOS.cs" />
+		<None Include="Mixins\Wasm\VisualStatesMixins.g.cs">
+		  <DesignTime>True</DesignTime>
+		  <AutoGen>True</AutoGen>
+		</None>
 		<None Include="Resources\AboutResources.txt" />
 		<None Include="Resources\Values\Attrs.xml" />
 		<None Include="Resources\Values\Styles.xml" />
@@ -153,7 +157,6 @@
 		<Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
 	</ItemGroup>
 	<ItemGroup>
-		<Folder Include="Mixins\Wasm\" />
 		<Folder Include="UI\Xaml\Maps\Presenters\" />
 	</ItemGroup>
 
@@ -179,7 +182,18 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <Compile Include="Mixins\Android\BaseActivity.Callbacks.g.cs" />
+	  <Compile Include="Mixins\Android\FrameworkElementMixins.g.cs" />
+	  <Compile Include="Mixins\Android\FrameworkElementMixins.g.cs" />
+	  <Compile Include="Mixins\Android\VisualStatesMixins.g.cs" />
 	  <Compile Include="Mixins\DependencyPropertyMixins.g.cs" />
+	  <Compile Include="Mixins\DependencyPropertyMixins.g.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Update="Mixins\Wasm\VisualStatesMixins.tt">
+	    <LastGenOutput>VisualStatesMixins.g.cs</LastGenOutput>
+	  </None>
 	</ItemGroup>
 
 	<Target Name="GetPackagingOutputs" Condition=" '$(TargetFramework)' == 'uap10.0' " />

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -952,6 +952,12 @@ declare namespace Windows.Storage {
         private static getValueByIndex;
     }
 }
+declare namespace Windows.Storage {
+    class AssetManager {
+        static DownloadAssetsManifest(path: string): Promise<string>;
+        static DownloadAsset(path: string): Promise<string>;
+    }
+}
 declare namespace Windows.Storage.Pickers {
     class FileSavePicker {
         static SaveAs(fileName: string, dataPtr: any, size: number): void;

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -3073,6 +3073,33 @@ var Windows;
         Storage.ApplicationDataContainer = ApplicationDataContainer;
     })(Storage = Windows.Storage || (Windows.Storage = {}));
 })(Windows || (Windows = {}));
+// eslint-disable-next-line @typescript-eslint/no-namespace
+var Windows;
+(function (Windows) {
+    var Storage;
+    (function (Storage) {
+        class AssetManager {
+            static DownloadAssetsManifest(path) {
+                return __awaiter(this, void 0, void 0, function* () {
+                    var response = yield fetch(path);
+                    return response.text();
+                });
+            }
+            static DownloadAsset(path) {
+                return __awaiter(this, void 0, void 0, function* () {
+                    const response = yield fetch(path);
+                    const arrayBuffer = yield response.blob().then(b => b.arrayBuffer());
+                    const size = arrayBuffer.byteLength;
+                    const responseArray = new Uint8ClampedArray(arrayBuffer);
+                    const pData = Module._malloc(size);
+                    Module.HEAPU8.set(responseArray, pData);
+                    return `${pData};${size}`;
+                });
+            }
+        }
+        Storage.AssetManager = AssetManager;
+    })(Storage = Windows.Storage || (Windows.Storage = {}));
+})(Windows || (Windows = {}));
 var Windows;
 (function (Windows) {
     var Storage;

--- a/src/Uno.UI/ts/Windows/Storage/AssetManager.ts
+++ b/src/Uno.UI/ts/Windows/Storage/AssetManager.ts
@@ -4,7 +4,7 @@ namespace Windows.Storage {
 
 	export class AssetManager {
 		public static async DownloadAssetsManifest(path: string): Promise<string> {
-			var response = await fetch(path);
+			const response = await fetch(path);
 			return response.text();
 		}
 

--- a/src/Uno.UI/ts/Windows/Storage/AssetManager.ts
+++ b/src/Uno.UI/ts/Windows/Storage/AssetManager.ts
@@ -1,0 +1,24 @@
+﻿
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace Windows.Storage {
+
+	export class AssetManager {
+		public static async DownloadAssetsManifest(path: string): Promise<string> {
+			var response = await fetch(path);
+			return response.text();
+		}
+
+		public static async DownloadAsset(path: string): Promise<string> {
+			const response = await fetch(path);
+			const arrayBuffer = await response.blob().then(b => <ArrayBuffer>(<any>b).arrayBuffer());
+			const size = arrayBuffer.byteLength;
+			const responseArray = new Uint8ClampedArray(arrayBuffer);
+
+			const pData = Module._malloc(size);
+
+			Module.HEAPU8.set(responseArray, pData);
+
+			return `${pData};${size}`;
+		}
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
@@ -288,14 +288,6 @@ namespace Windows.Storage
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.GetFileFromPathForUserAsync(User user, string path) is not implemented in Uno.");
 		}
 		#endif
-		// Skipping already declared method Windows.Storage.StorageFile.GetFileFromPathAsync(string)
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> GetFileFromApplicationUriAsync( global::System.Uri uri)
-		{
-			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.GetFileFromApplicationUriAsync(Uri uri) is not implemented in Uno.");
-		}
-		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CreateStreamedFileAsync( string displayNameWithExtension,  global::Windows.Storage.StreamedFileDataRequestedHandler dataRequested,  global::Windows.Storage.Streams.IRandomAccessStreamReference thumbnail)

--- a/src/Uno.UWP/Helpers/AndroidResourceNameEncoder.cs
+++ b/src/Uno.UWP/Helpers/AndroidResourceNameEncoder.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,6 +44,33 @@ namespace Uno
 			}
 
 			return key;
+		}
+
+		public static string EncodeFileSystemPath(string path)
+			=> global::System.IO.Path.Combine("Assets", EncodePath(path, global::System.IO.Path.DirectorySeparatorChar));
+
+		public static string EncodeResourcePath(string path)
+			=> EncodePath(path, '/');
+
+		private static string EncodePath(string path, char separator)
+		{
+			var localSeparation = global::System.IO.Path.DirectorySeparatorChar;
+
+			var alignedPath = path.Replace(separator, localSeparation);
+
+			var directoryName = global::System.IO.Path.GetDirectoryName(alignedPath);
+			var fileName = global::System.IO.Path.GetFileNameWithoutExtension(alignedPath);
+			var extension = global::System.IO.Path.GetExtension(alignedPath);
+
+			var encodedDirectoryParts = directoryName
+				.Split(new[] { localSeparation }, StringSplitOptions.RemoveEmptyEntries)
+				.Select(Encode)
+				.ToArray();
+
+			var encodedDirectory = global::System.IO.Path.Combine(encodedDirectoryParts);
+			var encodedFileName = Encode(fileName);
+
+			return global::System.IO.Path.Combine(encodedDirectory, encodedFileName + extension).Replace(localSeparation, separator);
 		}
 	}
 }

--- a/src/Uno.UWP/Helpers/AndroidResourceNameEncoder.cs
+++ b/src/Uno.UWP/Helpers/AndroidResourceNameEncoder.cs
@@ -47,6 +47,7 @@ namespace Uno
 		}
 
 		public static string EncodeFileSystemPath(string path)
+			// Android assets need to placed in the Assets folder
 			=> global::System.IO.Path.Combine("Assets", EncodePath(path, global::System.IO.Path.DirectorySeparatorChar));
 
 		public static string EncodeResourcePath(string path)

--- a/src/Uno.UWP/Storage/AssetsManager.wasm.cs
+++ b/src/Uno.UWP/Storage/AssetsManager.wasm.cs
@@ -1,0 +1,133 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Disposables;
+using Uno.Extensions;
+using Uno.Foundation;
+using Uno.Threading;
+using Windows.Devices.AllJoyn;
+using Windows.Foundation;
+using Windows.Media.Streaming.Adaptive;
+using Windows.Security.Cryptography.Core;
+using Windows.Storage.FileProperties;
+using Windows.Storage.Streams;
+using Windows.UI.WebUI;
+
+namespace Windows.Storage
+{
+	internal partial class AssetsManager
+	{
+		private static readonly string UNO_BOOTSTRAP_APP_BASE = Environment.GetEnvironmentVariable(nameof(UNO_BOOTSTRAP_APP_BASE));
+
+		private static readonly Lazy<Task<HashSet<string>>> _assets = new Lazy<Task<HashSet<string>>>(() => GetAssets(CancellationToken.None));
+		private static readonly Dictionary<string, DownloadEntry> _assetsGate = new Dictionary<string, DownloadEntry>();
+
+		private static async Task<HashSet<string>> GetAssets(CancellationToken ct)
+		{
+			var assetsUri = !string.IsNullOrEmpty(UNO_BOOTSTRAP_APP_BASE) ? $"{UNO_BOOTSTRAP_APP_BASE}/uno-assets.txt" : "uno-assets.txt";
+
+			var assets = await WebAssemblyRuntime.InvokeAsync($"Windows.Storage.AssetManager.DownloadAssetsManifest(\'{assetsUri}\')");
+
+			return new HashSet<string>(Regex.Split(assets, "\r\n|\r|\n"), StringComparer.OrdinalIgnoreCase);
+		}
+
+		public static async Task<string> DownloadAsset(CancellationToken ct, string assetPath)
+		{
+			var updatedPath = assetPath.TrimStart("/");
+			var assetSet = await _assets.Value;
+
+			if (assetSet.Contains(updatedPath))
+			{
+				var localPath = Path.Combine(Windows.Storage.ApplicationData.Current.LocalFolder.Path, ".assetsCache", UNO_BOOTSTRAP_APP_BASE, updatedPath);
+
+				using var assetLock = await LockForAsset(ct, updatedPath);
+
+				if (!File.Exists(localPath))
+				{
+					var assetUri = !string.IsNullOrEmpty(UNO_BOOTSTRAP_APP_BASE) ? $"{UNO_BOOTSTRAP_APP_BASE}/{updatedPath}" : updatedPath;
+					var assetInfo = await WebAssemblyRuntime.InvokeAsync($"Windows.Storage.AssetManager.DownloadAsset(\'{assetUri}\')");
+
+					var parts = assetInfo.Split(';');
+					if (parts.Length == 2)
+					{
+						var ptr = (IntPtr)int.Parse(parts[0], CultureInfo.InvariantCulture);
+						var length = int.Parse(parts[1], CultureInfo.InvariantCulture);
+
+						try
+						{
+							var buffer = new byte[length];
+							Marshal.Copy(ptr, buffer, 0, length);
+
+							Directory.CreateDirectory(Path.GetDirectoryName(localPath));
+							File.WriteAllBytes(localPath, buffer);
+						}
+						finally
+						{
+							Marshal.FreeHGlobal(ptr);
+						}
+					}
+					else
+					{
+						throw new InvalidOperationException($"Invalid Windows.Storage.AssetManager.DownloadAsset return value");
+					}
+				}
+
+				return localPath;
+			}
+			else
+			{
+				throw new FileNotFoundException($"The file [{assetPath}] cannot be found");
+			}
+		}
+
+		private static async Task<IDisposable> LockForAsset(CancellationToken ct, string updatedPath)
+		{
+			DownloadEntry GetEntry()
+			{
+				lock (_assetsGate)
+				{
+					if (!_assetsGate.TryGetValue(updatedPath, out var entry))
+					{
+						_assetsGate[updatedPath] = entry = new DownloadEntry();
+					}
+
+					entry.ReferenceCount++;
+
+					return entry;
+				}
+			}
+
+			var entry = GetEntry();
+
+			var disposable = await entry.Gate.LockAsync(ct);
+
+			void ReleaseEntry()
+			{
+				lock (_assetsGate)
+				{
+					disposable.Dispose();
+
+					if(--entry.ReferenceCount == 0)
+					{
+						_assetsGate.Remove(updatedPath);
+					}
+				}
+			}
+
+			return Disposable.Create(ReleaseEntry);
+		}
+
+		private class DownloadEntry
+		{
+			public int ReferenceCount;
+			public AsyncLock Gate { get; } = new AsyncLock();
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/Helpers/ConcurrentEntryManager.cs
+++ b/src/Uno.UWP/Storage/Helpers/ConcurrentEntryManager.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Disposables;
+using Uno.Threading;
+
+namespace Windows.Storage.Helpers
+{
+	internal partial class ConcurrentEntryManager
+	{
+		private readonly Dictionary<string, DownloadEntry> _assetsGate = new Dictionary<string, DownloadEntry>();
+
+		public async Task<IDisposable> LockForAsset(CancellationToken ct, string updatedPath)
+		{
+			DownloadEntry GetEntry()
+			{
+				lock (_assetsGate)
+				{
+					if (!_assetsGate.TryGetValue(updatedPath, out var entry))
+					{
+						_assetsGate[updatedPath] = entry = new DownloadEntry();
+					}
+
+					entry.ReferenceCount++;
+
+					return entry;
+				}
+			}
+
+			var entry = GetEntry();
+
+			var disposable = await entry.Gate.LockAsync(ct);
+
+			void ReleaseEntry()
+			{
+				lock (_assetsGate)
+				{
+					disposable.Dispose();
+
+					if(--entry.ReferenceCount == 0)
+					{
+						_assetsGate.Remove(updatedPath);
+					}
+				}
+			}
+
+			return Disposable.Create(ReleaseEntry);
+		}
+
+		private class DownloadEntry
+		{
+			public int ReferenceCount;
+			public AsyncLock Gate { get; } = new AsyncLock();
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/NameCollisionOption.cs
+++ b/src/Uno.UWP/Storage/NameCollisionOption.cs
@@ -1,0 +1,27 @@
+﻿#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+
+namespace Windows.Storage
+{
+	public enum NameCollisionOption
+	{
+		// Summary:
+		//     Automatically generate a unique name by appending a number to the name of
+		//     the file or folder.
+		GenerateUniqueName = 0,
+		//
+		// Summary:
+		//     Replace the existing file or folder. Your app must have permission to access
+		//     the location that contains the existing file or folder. Access to a location
+		//     can be granted in several ways, for example, by a capability declared in
+		//     your application's manifest, or by the user through the file picker. You
+		//     can use Windows.Storage.AccessCache to manage the list of locations that
+		//     are accessible to your app via the file picker.
+		ReplaceExisting = 1,
+		//
+		// Summary:
+		//     Return an error if another file or folder exists with the same name and abort
+		//     the operation.
+		FailIfExists = 2,
+	}
+}

--- a/src/Uno.UWP/Storage/StorageFile.android.cs
+++ b/src/Uno.UWP/Storage/StorageFile.android.cs
@@ -1,0 +1,44 @@
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Android.Content.Res;
+using Uno;
+using Uno.Extensions;
+using Uno.UI;
+using Windows.Foundation;
+using Windows.Storage.FileProperties;
+using Windows.Storage.Streams;
+using Windows.UI.Composition.Interactions;
+
+namespace Windows.Storage
+{
+	public partial class StorageFile : StorageItem, IStorageFile
+	{
+		private static async Task<StorageFile> GetFileFromApplicationUriAsyncTask(CancellationToken ct, Uri uri)
+		{
+			if(uri.Scheme != "ms-appx")
+			{
+				throw new InvalidOperationException("Uri is not using the ms-appx scheme");
+			}
+
+			var path = AndroidResourceNameEncoder.EncodeResourcePath(uri.PathAndQuery.TrimStart(new char[] { '/' }));
+
+			// Read the contents of our asset
+			var assets = global::Android.App.Application.Context.Assets;
+			var outputCachePath = global::System.IO.Path.Combine(Android.App.Application.Context.CacheDir.AbsolutePath, path);
+
+			using var input = assets.Open(path);
+
+			using var output = File.OpenWrite(outputCachePath);
+			await input.CopyToAsync(output);
+
+			return await StorageFile.GetFileFromPathAsync(outputCachePath);
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -215,32 +215,4 @@ namespace Windows.Storage
 			return new BasicProperties(this);
 		}
 	}
-
-	public enum ThumbnailMode
-	{
-		MusicView,
-		VideosView
-	}
-
-	public enum NameCollisionOption
-	{
-		// Summary:
-		//     Automatically generate a unique name by appending a number to the name of
-		//     the file or folder.
-		GenerateUniqueName = 0,
-		//
-		// Summary:
-		//     Replace the existing file or folder. Your app must have permission to access
-		//     the location that contains the existing file or folder. Access to a location
-		//     can be granted in several ways, for example, by a capability declared in
-		//     your application's manifest, or by the user through the file picker. You
-		//     can use Windows.Storage.AccessCache to manage the list of locations that
-		//     are accessible to your app via the file picker.
-		ReplaceExisting = 1,
-		//
-		// Summary:
-		//     Return an error if another file or folder exists with the same name and abort
-		//     the operation.
-		FailIfExists = 2,
-	}
 }

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -221,7 +221,7 @@ namespace Windows.Storage
 			return AsyncOperation.FromTask(ct => GetFileFromApplicationUriAsyncTask(ct, uri));
 		}
 
-#if __IOS__ || NET461 || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if NET461 || __SKIA__ || __NETSTD_REFERENCE__
 		private static Task<StorageFile> GetFileFromApplicationUriAsyncTask(CancellationToken ct, Uri uri)
 		{
 			throw new NotImplementedException();

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -221,7 +221,7 @@ namespace Windows.Storage
 			return AsyncOperation.FromTask(ct => GetFileFromApplicationUriAsyncTask(ct, uri));
 		}
 
-#if __ANDROID__ || __IOS__ || NET461 || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if __IOS__ || NET461 || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		private static Task<StorageFile> GetFileFromApplicationUriAsyncTask(CancellationToken ct, Uri uri)
 		{
 			throw new NotImplementedException();

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -214,5 +214,18 @@ namespace Windows.Storage
 		{
 			return new BasicProperties(this);
 		}
+
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> GetFileFromApplicationUriAsync( global::System.Uri uri)
+		{
+			return AsyncOperation.FromTask(ct => GetFileFromApplicationUriAsyncTask(ct, uri));
+		}
+
+#if __ANDROID__ || __IOS__ || NET461 || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		private static Task<StorageFile> GetFileFromApplicationUriAsyncTask(CancellationToken ct, Uri uri)
+		{
+			throw new NotImplementedException();
+		}
+#endif
 	}
 }

--- a/src/Uno.UWP/Storage/StorageFile.iOSmacOS.cs
+++ b/src/Uno.UWP/Storage/StorageFile.iOSmacOS.cs
@@ -1,0 +1,38 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundation;
+
+namespace Windows.Storage
+{
+	public partial class StorageFile : StorageItem, IStorageFile
+	{
+		private static async Task<StorageFile> GetFileFromApplicationUriAsyncTask(CancellationToken ct, Uri uri)
+		{
+			if(uri.Scheme != "ms-appx")
+			{
+				throw new InvalidOperationException("Uri is not using the ms-appx scheme");
+			}
+
+			var path = uri.PathAndQuery.TrimStart(new char[] { '/' });
+
+			var directoryName = global::System.IO.Path.GetDirectoryName(path);
+			var fileName = global::System.IO.Path.GetFileNameWithoutExtension(path);
+			var fileExtension = global::System.IO.Path.GetExtension(path);
+
+			var resourcePathname = NSBundle.MainBundle.PathForResource(global::System.IO.Path.Combine(directoryName, fileName), fileExtension.Substring(1));
+
+			if (resourcePathname != null)
+			{
+				return await StorageFile.GetFileFromPathAsync(resourcePathname);
+			}
+			else
+			{
+				throw new FileNotFoundException($"The file [{path}] cannot be found in the bundle");
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/StorageFile.wasm.cs
+++ b/src/Uno.UWP/Storage/StorageFile.wasm.cs
@@ -1,0 +1,29 @@
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions;
+using Windows.Foundation;
+using Windows.Storage.FileProperties;
+using Windows.Storage.Streams;
+
+namespace Windows.Storage
+{
+	public partial class StorageFile : StorageItem, IStorageFile
+	{
+		private static async Task<StorageFile> GetFileFromApplicationUriAsyncTask(CancellationToken ct, Uri uri)
+		{
+			if(uri.Scheme != "ms-appx")
+			{
+				throw new InvalidOperationException("Uri is not using the ms-appx scheme");
+			}
+
+			var path = uri.PathAndQuery;
+
+			return await StorageFile.GetFileFromPathAsync(await AssetsManager.DownloadAsset(ct, path));
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/StorageFile.wasm.cs
+++ b/src/Uno.UWP/Storage/StorageFile.wasm.cs
@@ -9,6 +9,7 @@ using Uno.Extensions;
 using Windows.Foundation;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Streams;
+using Windows.Storage.Helpers;
 
 namespace Windows.Storage
 {

--- a/src/Uno.UWP/Storage/ThumbnailMode.cs
+++ b/src/Uno.UWP/Storage/ThumbnailMode.cs
@@ -1,0 +1,11 @@
+﻿#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+
+namespace Windows.Storage
+{
+	public enum ThumbnailMode
+	{
+		MusicView,
+		VideosView
+	}
+}

--- a/src/Uno.UWP/Storage/ThumbnailMode.cs
+++ b/src/Uno.UWP/Storage/ThumbnailMode.cs
@@ -1,7 +1,4 @@
-﻿#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-
-
-namespace Windows.Storage
+﻿namespace Windows.Storage
 {
 	public enum ThumbnailMode
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): fix #3887 

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Add support for `StorageFile.GetFileFromApplicationUriAsync` for iOS/macOS, Android, and WebAssembly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
