### PR TITLE
Added support for `Canvas.ZIndex` to Wasm platform

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
@@ -53,20 +53,28 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)] // Canvas.ZIndex isn't implemented for WASM yet
 		public void Verify_Canvas_ZIndex()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.Canvas.Canvas_ZIndex");
 
 			var screenshot = TakeScreenshot("Rendered");
 
-			var redBorderRect = _app.GetRect("CanvasBorderRed");
+			var redBorderRect1 = _app.GetRect("CanvasBorderRed1");
+			ImageAssert.HasColorAt(screenshot, redBorderRect1.CenterX, redBorderRect1.CenterY, Color.Green /*psych*/);
+			var redBorderRect2 = _app.GetRect("CanvasBorderRed2");
+			ImageAssert.HasColorAt(screenshot, redBorderRect2.CenterX, redBorderRect2.CenterY, Color.Green /*psych*/);
+			var redBorderRect3 = _app.GetRect("CanvasBorderRed3");
+			ImageAssert.HasColorAt(screenshot, redBorderRect3.CenterX, redBorderRect3.CenterY, Color.Green /*psych*/);
 
-			ImageAssert.HasColorAt(screenshot, redBorderRect.CenterX, redBorderRect.CenterY, Color.Green /*psych*/);
-
-			var greenBorderRect = _app.GetRect("CanvasBorderGreen");
-
-			ImageAssert.HasColorAt(screenshot, greenBorderRect.CenterX, greenBorderRect.CenterY, Color.Blue);
+			var greenBorderRect1 = _app.GetRect("CanvasBorderGreen1");
+			ImageAssert.HasColorAt(screenshot, greenBorderRect1.CenterX, greenBorderRect1.CenterY, Color.Brown);
+			ImageAssert.HasColorAt(screenshot, greenBorderRect1.Right - 1, greenBorderRect1.CenterY, Color.Blue);
+			var greenBorderRect2 = _app.GetRect("CanvasBorderGreen2");
+			ImageAssert.HasColorAt(screenshot, greenBorderRect2.CenterX, greenBorderRect2.CenterY, Color.Brown);
+			ImageAssert.HasColorAt(screenshot, greenBorderRect2.Right-1, greenBorderRect2.CenterY, Color.Blue);
+			var CanvasBorderGreen3 = _app.GetRect("CanvasBorderGreen3");
+			ImageAssert.HasColorAt(screenshot, CanvasBorderGreen3.CenterX, CanvasBorderGreen3.CenterY, Color.Brown);
+			ImageAssert.HasColorAt(screenshot, CanvasBorderGreen3.Right-1, CanvasBorderGreen3.CenterY, Color.Blue);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
+using Uno.UITests.Helpers;
 
 namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 {
@@ -63,8 +64,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 			ImageAssert.HasColorAt(screenshot, redBorderRect1.CenterX, redBorderRect1.CenterY, Color.Green /*psych*/);
 			var redBorderRect2 = _app.GetRect("CanvasBorderRed2");
 			ImageAssert.HasColorAt(screenshot, redBorderRect2.CenterX, redBorderRect2.CenterY, Color.Green /*psych*/);
-			var redBorderRect3 = _app.GetRect("CanvasBorderRed3");
-			ImageAssert.HasColorAt(screenshot, redBorderRect3.CenterX, redBorderRect3.CenterY, Color.Green /*psych*/);
+
+			if (AppInitializer.GetLocalPlatform() != Platform.Android) // Android doesn't support Canvas.ZIndex on any panel
+			{
+				var redBorderRect3 = _app.GetRect("CanvasBorderRed3");
+				ImageAssert.HasColorAt(screenshot, redBorderRect3.CenterX, redBorderRect3.CenterY, Color.Green /*psych*/);
+			}
 
 			var greenBorderRect1 = _app.GetRect("CanvasBorderGreen1");
 			ImageAssert.HasColorAt(screenshot, greenBorderRect1.CenterX, greenBorderRect1.CenterY, Color.Brown);
@@ -72,9 +77,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 			var greenBorderRect2 = _app.GetRect("CanvasBorderGreen2");
 			ImageAssert.HasColorAt(screenshot, greenBorderRect2.CenterX, greenBorderRect2.CenterY, Color.Brown);
 			ImageAssert.HasColorAt(screenshot, greenBorderRect2.Right-1, greenBorderRect2.CenterY, Color.Blue);
-			var CanvasBorderGreen3 = _app.GetRect("CanvasBorderGreen3");
-			ImageAssert.HasColorAt(screenshot, CanvasBorderGreen3.CenterX, CanvasBorderGreen3.CenterY, Color.Brown);
-			ImageAssert.HasColorAt(screenshot, CanvasBorderGreen3.Right-1, CanvasBorderGreen3.CenterY, Color.Blue);
+
+			if (AppInitializer.GetLocalPlatform() != Platform.Android) // Android doesn't support Canvas.ZIndex on any panel
+			{
+				var CanvasBorderGreen3 = _app.GetRect("CanvasBorderGreen3");
+				ImageAssert.HasColorAt(screenshot, CanvasBorderGreen3.CenterX, CanvasBorderGreen3.CenterY, Color.Brown);
+				ImageAssert.HasColorAt(screenshot, CanvasBorderGreen3.Right - 1, CanvasBorderGreen3.CenterY, Color.Blue);
+			}
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Canvas/Canvas_ZIndex.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Canvas/Canvas_ZIndex.xaml
@@ -8,46 +8,131 @@
 			 d:DesignHeight="300"
 			 d:DesignWidth="400">
 
-	<Grid>
-		<Canvas Width="240"
-				Height="240">
-			<Border x:Name="CanvasBorderBlue"
-					Width="80"
-					Height="40"
-					CornerRadius="10"
-					Background="Blue"
-					Canvas.Left="100"
-					Canvas.Top="80"
-					Canvas.ZIndex="30" />
-			<Border x:Name="CanvasBorderGreen"
-					Width="40"
-					Height="120"
-					CornerRadius="10"
-					Background="Green"
-					Canvas.Left="100"
-					Canvas.Top="40"
-					Canvas.ZIndex="20" />
-			<Border x:Name="CanvasBorderRed"
-					Width="120"
-					Height="40"
-					CornerRadius="10"
-					Background="Red"
-					Canvas.Left="60"
-					Canvas.Top="40"
-					Canvas.ZIndex="10" />
-			<ContentControl Content="7"
-							Canvas.ZIndex="60"
-							Canvas.Top="10"
-							Canvas.Left="10">
-				<ContentControl.ContentTemplate>
-					<DataTemplate>
-						<Ellipse Fill="Brown"
-								 Height="18"
-								 Width="18"
-								 IsHitTestVisible="False" />
-					</DataTemplate>
-				</ContentControl.ContentTemplate>
-			</ContentControl>
-		</Canvas>
-	</Grid>
+	<StackPanel>
+		<TextBlock FontSize="25">These 3 drawings should be identical:</TextBlock>
+
+		<StackPanel Orientation="Horizontal">
+			<Canvas Width="170"
+					Height="240">
+				<ContentControl Content="7"
+								Canvas.ZIndex="60"
+								Canvas.Top="90"
+								Canvas.Left="110">
+					<ContentControl.ContentTemplate>
+						<DataTemplate>
+							<Ellipse Fill="Brown"
+									Height="18"
+									Width="18"
+									IsHitTestVisible="False" />
+						</DataTemplate>
+					</ContentControl.ContentTemplate>
+				</ContentControl>
+				<Border x:Name="CanvasBorderBlue1"
+						Width="80"
+						Height="40"
+						CornerRadius="10"
+						Canvas.Left="100"
+						Canvas.Top="80"
+						Canvas.ZIndex="30">
+					<Rectangle Fill="Blue" Canvas.ZIndex="4000" />
+				</Border>
+				<Border x:Name="CanvasBorderGreen1"
+						Width="40"
+						Height="120"
+						CornerRadius="10"
+						Background="Green"
+						Canvas.Left="100"
+						Canvas.Top="40"
+						Canvas.ZIndex="20" />
+				<Border x:Name="CanvasBorderRed1"
+						Width="120"
+						Height="40"
+						CornerRadius="10"
+						Background="Red"
+						Canvas.Left="60"
+						Canvas.Top="40"
+						Canvas.ZIndex="10" />
+			</Canvas>
+			<Canvas Width="170"
+					Height="240">
+				<Border x:Name="CanvasBorderRed2"
+						Width="120"
+						Height="40"
+						CornerRadius="10"
+						Background="Red"
+						Canvas.Left="60"
+						Canvas.Top="40" />
+				<Border x:Name="CanvasBorderGreen2"
+						Width="40"
+						Height="120"
+						CornerRadius="10"
+						Background="Green"
+						Canvas.Left="100"
+						Canvas.Top="40" />
+				<Border x:Name="CanvasBorderBlue2"
+						Width="80"
+						Height="40"
+						CornerRadius="10"
+						Background="Blue"
+						Canvas.Left="100"
+						Canvas.Top="80" />
+				<ContentControl Content="7"
+								Canvas.Top="90"
+								Canvas.Left="110">
+					<ContentControl.ContentTemplate>
+						<DataTemplate>
+							<Ellipse Fill="Brown"
+									Height="18"
+									Width="18"
+									Canvas.ZIndex="-10000"
+									IsHitTestVisible="False" />
+						</DataTemplate>
+					</ContentControl.ContentTemplate>
+				</ContentControl>
+			</Canvas>
+			<Grid Width="180"
+					Height="240">
+				<ContentControl Content="7"
+								Canvas.ZIndex="60"
+								Margin="110,90,0,0">
+					<ContentControl.ContentTemplate>
+						<DataTemplate>
+							<Ellipse Fill="Brown"
+									Height="18"
+									Width="18"
+									IsHitTestVisible="False" />
+						</DataTemplate>
+					</ContentControl.ContentTemplate>
+				</ContentControl>
+				<Border x:Name="CanvasBorderBlue3"
+						Width="80"
+						Height="40"
+						CornerRadius="10"
+						Canvas.ZIndex="30"
+						Margin="100,80,0,0"
+						HorizontalAlignment="Left"
+						VerticalAlignment="Top">
+					<Rectangle Fill="Blue" Canvas.ZIndex="4000" />
+				</Border>
+				<Border x:Name="CanvasBorderGreen3"
+						Width="40"
+						Height="120"
+						CornerRadius="10"
+						Background="Green"
+						Margin="100,40,0,0"
+						HorizontalAlignment="Left"
+						VerticalAlignment="Top"
+						Canvas.ZIndex="20" />
+				<Border x:Name="CanvasBorderRed3"
+						Width="120"
+						Height="40"
+						CornerRadius="10"
+						Background="Red"
+						Margin="60,40,0,0"
+						HorizontalAlignment="Left"
+						VerticalAlignment="Top"
+						Canvas.ZIndex="10" />
+			</Grid>
+		</StackPanel>
+	</StackPanel>
 </UserControl>

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.cs
@@ -84,10 +84,19 @@ namespace Windows.UI.Xaml.Controls
 
 		private static void OnZIndexChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
+#if !__WASM__
 			(dependencyObject as IFrameworkElement)?.InvalidateArrange();
+#endif
+			if (dependencyObject is UIElement element)
+			{
+				var zindex = args.NewValue is double d ? (double?)d : null;
+				OnZIndexChangedPartial(element, zindex);
+			}
 		}
 
-		#endregion
+		static partial void OnZIndexChangedPartial(UIElement element, double? zindex);
+
+#endregion
 
 		public Canvas()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.wasm.cs
@@ -1,0 +1,17 @@
+namespace Windows.UI.Xaml.Controls
+{
+	partial class Canvas
+	{
+		static partial void OnZIndexChangedPartial(UIElement element, double? zindex)
+		{
+			if (zindex is {} d)
+			{
+				element.SetStyle("z-index", d);
+			}
+			else
+			{
+				element.ResetStyle("z-index");
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes https://github.com/unoplatform/uno/issues/3544

# Feature
Added support for `Canvas.ZIndex` to the WASM (HTML) Platform.

## Difficulty
At first look, implementing the [CSS `z-index`](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index) [seems complicated](https://philipwalton.com/articles/what-no-one-told-you-about-z-index/) because we need to deal with [_Stacking Contexts_](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context).

But the good news is whe're already creating a new _Stacking Context_ each time we're creating a UIElement on WASM.  That means we directly map the `Canvas.ZIndex` to the `CSS z-index:` style and it's working as expected.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
