### PR TITLE
feat(pointers): Complete support of pointers for skia

### DIFF
--- a/src/Uno.Foundation/Point.cs
+++ b/src/Uno.Foundation/Point.cs
@@ -30,6 +30,9 @@ namespace Windows.Foundation
 			return "[{0}, {1}]".InvariantCultureFormat(X, Y);
 		}
 
+		internal string ToDebugString()
+			=> FormattableString.Invariant($"{X:F2},{Y:F2}");
+
 		public static bool operator ==(Point left, Point right)
 		{
 			return left.Equals(right);

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -190,10 +190,14 @@ namespace Windows.Foundation
 		}
 
 		public bool Contains(Point point)
+			// We include points on the edge as "contained".
+			// We do "point.X - Width <= X" instead of "point.X <= X + Width"
+			// so that this check works when Width is PositiveInfinity
+			// and X is NegativeInfinity.
 			=> point.X >= X
-			&& (point.X <= X + Width || (double.IsNegativeInfinity(X) && double.IsPositiveInfinity(Width)))
-			&& point.Y >= Y
-			&& (point.Y <= Y + Height || (double.IsNegativeInfinity(Y) && double.IsPositiveInfinity(Height)));
+				&& point.X - Width <= X
+				&& point.Y >= Y
+				&& point.Y - Height <= Y;
 
 		/// <summary>
 		/// Finds the intersection of the rectangle represented by the current Windows.Foundation.Rect

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -21,6 +21,14 @@ namespace Windows.Foundation
 			Height = double.NegativeInfinity
 		};
 
+		internal static Rect Infinite { get; } = new Rect
+		{
+			X = double.NegativeInfinity,
+			Y = double.NegativeInfinity,
+			Width = double.PositiveInfinity,
+			Height = double.PositiveInfinity
+		};
+
 		public Rect(Point point, Size size) : this(point.X, point.Y, size.Width, size.Height) { }
 
 		public Rect(double x, double y, double width, double height)
@@ -126,6 +134,9 @@ namespace Windows.Foundation
 
 		public override string ToString() => (string)this;
 
+		internal string ToDebugString()
+			=> FormattableString.Invariant($"{Width:F2},{Height:F2}@{Location.ToDebugString()}");
+
 		/// <summary>
 		/// Provides the size of this rectangle.
 		/// </summary>
@@ -165,24 +176,24 @@ namespace Windows.Foundation
 				throw new InvalidOperationException("Can't inflate empty rectangle");
 			}
 
-			this.X -= width;
-			this.Y -= height;
-			this.Width += width;
-			this.Width += width;
-			this.Height += height;
-			this.Height += height;
+			X -= width;
+			Y -= height;
+			Width += width;
+			Width += width;
+			Height += height;
+			Height += height;
 
-			if (this.Width < 0.0 || this.Height < 0.0)
+			if (Width < 0.0 || Height < 0.0)
 			{
 				this = Rect.Empty;
 			}
 		}
 
-		public bool Contains(Point point) =>
-			point.X >= X
-			&& point.X <= X + Width
+		public bool Contains(Point point)
+			=> point.X >= X
+			&& (point.X <= X + Width || (double.IsNegativeInfinity(X) && double.IsPositiveInfinity(Width)))
 			&& point.Y >= Y
-			&& point.Y <= Y + Height;
+			&& (point.Y <= Y + Height || (double.IsNegativeInfinity(Y) && double.IsPositiveInfinity(Height)));
 
 		/// <summary>
 		/// Finds the intersection of the rectangle represented by the current Windows.Foundation.Rect

--- a/src/Uno.UI.Toolkit/UIElementExtensions.cs
+++ b/src/Uno.UI.Toolkit/UIElementExtensions.cs
@@ -208,7 +208,7 @@ namespace Uno.UI.Toolkit
 				return padding;
 			}
 
-			var property = uiElement.GetDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
+			var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
 			return property != null && uiElement.GetValue(property) is Thickness t ? t : default;
 		}
 
@@ -219,7 +219,7 @@ namespace Uno.UI.Toolkit
 				return true;
 			}
 
-			var property = uiElement.GetDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
+			var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
 			if (property != null)
 			{
 				uiElement.SetValue(property, padding);
@@ -288,15 +288,13 @@ namespace Uno.UI.Toolkit
 
 		private static Dictionary<(Type type, string property), DependencyProperty> _dependencyPropertyReflectionCache;
 
-		internal static DependencyProperty GetDependencyPropertyUsingReflection<TProperty>(this UIElement uiElement, string propertyName)
+		internal static DependencyProperty FindDependencyPropertyUsingReflection<TProperty>(this UIElement uiElement, string propertyName)
 		{
 			var type = uiElement.GetType();
 			var propertyType = typeof(TProperty);
 			var key = (ownerType: type, propertyName);
 
-			_dependencyPropertyReflectionCache =
-				_dependencyPropertyReflectionCache
-				?? new Dictionary<(Type, string), DependencyProperty>(2);
+			_dependencyPropertyReflectionCache ??= new Dictionary<(Type, string), DependencyProperty>(2);
 
 			if (_dependencyPropertyReflectionCache.TryGetValue(key, out var property))
 			{

--- a/src/Uno.UI/Extensions/UIElementExtensions.cs
+++ b/src/Uno.UI/Extensions/UIElementExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Windows.UI.Xaml;
@@ -22,7 +24,7 @@ namespace Uno.UI.Extensions
 				return padding;
 			}
 
-			var property = uiElement.GetDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
+			var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
 			return property != null && uiElement.GetValue(property) is Thickness t ? t : default;
 		}
 
@@ -33,7 +35,7 @@ namespace Uno.UI.Extensions
 				return borderThickness;
 			}
 
-			var property = uiElement.GetDependencyPropertyUsingReflection<Thickness>("BorderThicknessProperty");
+			var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("BorderThicknessProperty");
 			return property != null && uiElement.GetValue(property) is Thickness t ? t : default;
 		}
 
@@ -44,7 +46,7 @@ namespace Uno.UI.Extensions
 				return true;
 			}
 
-			var property = uiElement.GetDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
+			var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("PaddingProperty");
 			if(property != null)
 			{
 				uiElement.SetValue(property, padding);
@@ -61,7 +63,7 @@ namespace Uno.UI.Extensions
 				return true;
 			}
 
-			var property = uiElement.GetDependencyPropertyUsingReflection<Thickness>("BorderThicknessProperty");
+			var property = uiElement.FindDependencyPropertyUsingReflection<Thickness>("BorderThicknessProperty");
 			if (property != null)
 			{
 				uiElement.SetValue(property, borderThickness);
@@ -71,17 +73,15 @@ namespace Uno.UI.Extensions
 			return false;
 		}
 
-		private static Dictionary<(Type type, string property), DependencyProperty> _dependencyPropertyReflectionCache;
+		private static Dictionary<(Type type, string property), DependencyProperty?>? _dependencyPropertyReflectionCache;
 
-		internal static DependencyProperty GetDependencyPropertyUsingReflection<TProperty>(this UIElement uiElement, string propertyName)
+		internal static DependencyProperty? FindDependencyPropertyUsingReflection<TProperty>(this UIElement uiElement, string propertyName)
 		{
 			var type = uiElement.GetType();
 			var propertyType = typeof(TProperty);
 			var key = (ownerType: type, propertyName);
 
-			_dependencyPropertyReflectionCache =
-				_dependencyPropertyReflectionCache
-				?? new Dictionary<(Type, string), DependencyProperty>(2);
+			_dependencyPropertyReflectionCache ??= new Dictionary<(Type, string), DependencyProperty?>(2);
 
 			if (_dependencyPropertyReflectionCache.TryGetValue(key, out var property))
 			{

--- a/src/Uno.UI/Extensions/UIElementExtensions.cs
+++ b/src/Uno.UI/Extensions/UIElementExtensions.cs
@@ -9,6 +9,12 @@ namespace Uno.UI.Extensions
 {
 	public static partial class UIElementExtensions
 	{
+		/// <summary>
+		/// Get a display name for the element for debug purposes
+		/// </summary>
+		internal static string GetDebugName(this UIElement? elt)
+			=> elt is null ? "--null--" : $"{(elt as FrameworkElement)?.Name ?? elt.GetType().Name}-{elt.GetHashCode():X8}";
+
 		internal static Thickness GetPadding(this UIElement uiElement)
 		{
 			if(uiElement is FrameworkElement fe && fe.TryGetPadding(out var padding))

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -398,19 +398,6 @@ namespace Uno.UI
 			/// </remarks>
 			public static bool AlwaysClipNativeChildren { get; set; } = true;
 #endif
-#if __SKIA__
-			/// <summary>
-			/// When enabled, instead of navigating the visual tree from top to bottom to determine the `OriginalSource`
-			/// and the element to which the pointer args should be dispatched,
-			/// the hit-testing engine will start from the last known target element (except if the visual tree has been updated).
-			///
-			/// This could have a great performance impact on low end devices.
-			///
-			/// BUT if an element have been moved over the current element using an independent animation (i.e. Animating a RenderTransform)
-			/// this new element won't be detected and will not be used as original source.
-			/// </summary>
-			public static bool AllowHitTestCaching { get; set; } = true;
-#endif
 		}
 
 		public static class WebView

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -398,6 +398,19 @@ namespace Uno.UI
 			/// </remarks>
 			public static bool AlwaysClipNativeChildren { get; set; } = true;
 #endif
+#if __SKIA__
+			/// <summary>
+			/// When enabled, instead of navigating the visual tree from top to bottom to determine the `OriginalSource`
+			/// and the element to which the pointer args should be dispatched,
+			/// the hit-testing engine will start from the last known target element (except if the visual tree has been updated).
+			///
+			/// This could have a great performance impact on low end devices.
+			///
+			/// BUT if an element have been moved over the current element using an independent animation (i.e. Animating a RenderTransform)
+			/// this new element won't be detected and will not be used as original source.
+			/// </summary>
+			public static bool AllowHitTestCaching { get; set; } = true;
+#endif
 		}
 
 		public static class WebView

--- a/src/Uno.UI/UI/LayoutHelper.cs
+++ b/src/Uno.UI/UI/LayoutHelper.cs
@@ -223,6 +223,12 @@ namespace Uno.UI
 		}
 
 		[Pure]
+		internal static Size Divide(this Size left, double right)
+		{
+			return new Size(left.Width / right, left.Height / right);
+		}
+
+		[Pure]
 		internal static Rect InflateBy(this Rect left, Thickness right)
 		{
 			var newWidth = right.Left + left.Width + right.Right;

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -157,7 +157,7 @@ namespace Windows.UI.Xaml.Controls
 					{
 						RegisterContentTemplateRoot();
 
-						if (FeatureConfiguration.Control.UseDeferredOnApplyTemplate)
+						if (!IsLoaded && FeatureConfiguration.Control.UseDeferredOnApplyTemplate)
 						{
 							// It's too soon the call the ".OnApplyTemplate" method: it should be invoked after the "Loading" event.
 							_applyTemplateShouldBeInvoked = true;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.xaml
@@ -16,7 +16,7 @@
 
 	<!-- Default style for Windows.UI.Xaml.Controls.ScrollViewer -->
 	<Style TargetType="ScrollViewer"
-		   x:Key="DefaultScrollViewerStyle">
+				   x:Key="DefaultScrollViewerStyle">
 		<Setter Property="HorizontalScrollMode"
 				Value="Auto" />
 		<Setter Property="VerticalScrollMode"
@@ -43,6 +43,266 @@
 				Value="Transparent" />
 		<Setter Property="Background"
 				Value="Transparent" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="ScrollViewer">
+					<Border
+						BorderBrush="{TemplateBinding BorderBrush}"
+						BorderThickness="{TemplateBinding BorderThickness}"
+						CornerRadius="{TemplateBinding CornerRadius}">
+						<skia:VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="ScrollingIndicatorStates">
+								<VisualStateGroup.Transitions>
+									<VisualTransition From="MouseIndicator" To="NoIndicator">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalScrollBar" Storyboard.TargetProperty="IndicatorMode">
+												<DiscreteObjectKeyFrame KeyTime="0:0:3">
+													<DiscreteObjectKeyFrame.Value>
+														<ScrollingIndicatorMode>None</ScrollingIndicatorMode>
+													</DiscreteObjectKeyFrame.Value>
+												</DiscreteObjectKeyFrame>
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalScrollBar" Storyboard.TargetProperty="IndicatorMode">
+												<DiscreteObjectKeyFrame KeyTime="0:0:3">
+													<DiscreteObjectKeyFrame.Value>
+														<ScrollingIndicatorMode>None</ScrollingIndicatorMode>
+													</DiscreteObjectKeyFrame.Value>
+												</DiscreteObjectKeyFrame>
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+									<!--
+									State not supported by Uno yet
+									<VisualTransition From="MouseIndicatorFull" To="NoIndicator">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalScrollBar" Storyboard.TargetProperty="IndicatorMode">
+												<DiscreteObjectKeyFrame KeyTime="{ThemeResource ScrollViewerSeparatorContractDelay}">
+													<DiscreteObjectKeyFrame.Value>
+														<ScrollingIndicatorMode>None</ScrollingIndicatorMode>
+													</DiscreteObjectKeyFrame.Value>
+												</DiscreteObjectKeyFrame>
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalScrollBar" Storyboard.TargetProperty="IndicatorMode">
+												<DiscreteObjectKeyFrame KeyTime="{ThemeResource ScrollViewerSeparatorContractDelay}">
+													<DiscreteObjectKeyFrame.Value>
+														<ScrollingIndicatorMode>None</ScrollingIndicatorMode>
+													</DiscreteObjectKeyFrame.Value>
+												</DiscreteObjectKeyFrame>
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+									<VisualTransition From="MouseIndicatorFull" To="MouseIndicator">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalScrollBar" Storyboard.TargetProperty="IndicatorMode">
+												<DiscreteObjectKeyFrame KeyTime="{ThemeResource ScrollViewerSeparatorContractDelay}">
+													<DiscreteObjectKeyFrame.Value>
+														<ScrollingIndicatorMode>MouseIndicator</ScrollingIndicatorMode>
+													</DiscreteObjectKeyFrame.Value>
+												</DiscreteObjectKeyFrame>
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalScrollBar" Storyboard.TargetProperty="IndicatorMode">
+												<DiscreteObjectKeyFrame KeyTime="{ThemeResource ScrollViewerSeparatorContractDelay}">
+													<DiscreteObjectKeyFrame.Value>
+														<ScrollingIndicatorMode>MouseIndicator</ScrollingIndicatorMode>
+													</DiscreteObjectKeyFrame.Value>
+												</DiscreteObjectKeyFrame>
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>-->
+									<VisualTransition From="TouchIndicator" To="NoIndicator">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalScrollBar" Storyboard.TargetProperty="IndicatorMode">
+												<DiscreteObjectKeyFrame KeyTime="0:0:0.5">
+													<DiscreteObjectKeyFrame.Value>
+														<ScrollingIndicatorMode>None</ScrollingIndicatorMode>
+													</DiscreteObjectKeyFrame.Value>
+												</DiscreteObjectKeyFrame>
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalScrollBar" Storyboard.TargetProperty="IndicatorMode">
+												<DiscreteObjectKeyFrame KeyTime="0:0:0.5">
+													<DiscreteObjectKeyFrame.Value>
+														<ScrollingIndicatorMode>None</ScrollingIndicatorMode>
+													</DiscreteObjectKeyFrame.Value>
+												</DiscreteObjectKeyFrame>
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+								</VisualStateGroup.Transitions>
+
+								<VisualState x:Name="NoIndicator" />
+								<VisualState x:Name="TouchIndicator">
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames
+											Storyboard.TargetName="VerticalScrollBar"
+											Storyboard.TargetProperty="IndicatorMode"
+											Duration="0">
+											<DiscreteObjectKeyFrame KeyTime="0">
+												<DiscreteObjectKeyFrame.Value>
+													<ScrollingIndicatorMode>TouchIndicator</ScrollingIndicatorMode>
+												</DiscreteObjectKeyFrame.Value>
+											</DiscreteObjectKeyFrame>
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames
+											Storyboard.TargetName="HorizontalScrollBar"
+											Storyboard.TargetProperty="IndicatorMode"
+											Duration="0">
+											<DiscreteObjectKeyFrame KeyTime="0">
+												<DiscreteObjectKeyFrame.Value>
+													<ScrollingIndicatorMode>TouchIndicator</ScrollingIndicatorMode>
+												</DiscreteObjectKeyFrame.Value>
+											</DiscreteObjectKeyFrame>
+										</ObjectAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="MouseIndicator">
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames
+											Storyboard.TargetName="VerticalScrollBar"
+											Storyboard.TargetProperty="IndicatorMode"
+											Duration="0">
+											<DiscreteObjectKeyFrame KeyTime="0">
+												<DiscreteObjectKeyFrame.Value>
+													<ScrollingIndicatorMode>MouseIndicator</ScrollingIndicatorMode>
+												</DiscreteObjectKeyFrame.Value>
+											</DiscreteObjectKeyFrame>
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames
+											Storyboard.TargetName="HorizontalScrollBar"
+											Storyboard.TargetProperty="IndicatorMode"
+											Duration="0">
+											<DiscreteObjectKeyFrame KeyTime="0">
+												<DiscreteObjectKeyFrame.Value>
+													<ScrollingIndicatorMode>MouseIndicator</ScrollingIndicatorMode>
+												</DiscreteObjectKeyFrame.Value>
+											</DiscreteObjectKeyFrame>
+										</ObjectAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualState>
+								<!--
+								State not supported by Uno yet
+								<VisualState x:Name="MouseIndicatorFull">
+									<Storyboard>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalScrollBar" Storyboard.TargetProperty="IndicatorMode">
+											<DiscreteObjectKeyFrame KeyTime="0">
+												<DiscreteObjectKeyFrame.Value>
+													<ScrollingIndicatorMode>MouseIndicator</ScrollingIndicatorMode>
+												</DiscreteObjectKeyFrame.Value>
+											</DiscreteObjectKeyFrame>
+										</ObjectAnimationUsingKeyFrames>
+										<ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalScrollBar" Storyboard.TargetProperty="IndicatorMode">
+											<DiscreteObjectKeyFrame KeyTime="0">
+												<DiscreteObjectKeyFrame.Value>
+													<ScrollingIndicatorMode>MouseIndicator</ScrollingIndicatorMode>
+												</DiscreteObjectKeyFrame.Value>
+											</DiscreteObjectKeyFrame>
+										</ObjectAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualState>-->
+							</VisualStateGroup>
+
+							<VisualStateGroup x:Name="ScrollBarSeparatorStates">
+								<VisualStateGroup.Transitions>
+									<VisualTransition From="ScrollBarSeparatorExpanded" To="ScrollBarSeparatorCollapsed">
+										<Storyboard>
+											<DoubleAnimation
+												Duration="{ThemeResource ScrollViewerSeparatorContractDuration}"
+												BeginTime="{ThemeResource ScrollViewerSeparatorContractBeginTime}"
+												Storyboard.TargetName="ScrollBarSeparator"
+												Storyboard.TargetProperty="Opacity"
+												To="0" />
+										</Storyboard>
+									</VisualTransition>
+								</VisualStateGroup.Transitions>
+								<VisualState x:Name="ScrollBarSeparatorCollapsed" />
+								<VisualState x:Name="ScrollBarSeparatorExpanded">
+									<Storyboard>
+										<DoubleAnimation
+											Duration="{ThemeResource ScrollViewerSeparatorExpandDuration}"
+											BeginTime="{ThemeResource ScrollViewerSeparatorExpandBeginTime}"
+											Storyboard.TargetName="ScrollBarSeparator"
+											Storyboard.TargetProperty="Opacity"
+											To="1" />
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="ScrollBarSeparatorExpandedWithoutAnimation">
+									<Storyboard>
+										<DoubleAnimation
+											Duration="0"
+											BeginTime="{ThemeResource ScrollViewerSeparatorExpandBeginTime}"
+											Storyboard.TargetName="ScrollBarSeparator"
+											Storyboard.TargetProperty="Opacity"
+											To="1" />
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="ScrollBarSeparatorCollapsedWithoutAnimation">
+									<Storyboard>
+										<DoubleAnimation
+											Duration="0"
+											BeginTime="{ThemeResource ScrollViewerSeparatorContractBeginTime}"
+											Storyboard.TargetName="ScrollBarSeparator"
+											Storyboard.TargetProperty="Opacity"
+											To="0" />
+									</Storyboard>
+								</VisualState>
+							</VisualStateGroup>
+						</skia:VisualStateManager.VisualStateGroups>
+
+						<Grid Background="{TemplateBinding Background}" x:Name="Root">
+							<skia:Grid.ColumnDefinitions>
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+							</skia:Grid.ColumnDefinitions>
+							<skia:Grid.RowDefinitions>
+								<RowDefinition Height="*" />
+								<RowDefinition Height="Auto" />
+							</skia:Grid.RowDefinitions>
+							<!-- ContentTemplate not yet supported for ScrollContentPresenter-->
+							<ScrollContentPresenter
+								x:Name="ScrollContentPresenter"
+								skia:Grid.RowSpan="2"
+								skia:Grid.ColumnSpan="2"
+								Margin="{TemplateBinding Padding}" />
+
+							<skia:ScrollBar
+								x:Name="VerticalScrollBar"
+								Grid.Column="1"
+								IsTabStop="False"
+								Maximum="{TemplateBinding ScrollableHeight}"
+								Orientation="Vertical"
+								Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+								Value="{TemplateBinding VerticalOffset}"
+								ViewportSize="{TemplateBinding ViewportHeight}"
+								HorizontalAlignment="Right"
+								skia:Width="16"/>
+
+							<skia:ScrollBar
+								x:Name="HorizontalScrollBar"
+								IsTabStop="False"
+								Maximum="{TemplateBinding ScrollableWidth}"
+								Orientation="Horizontal"
+								Grid.Row="1"
+								Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
+								Value="{TemplateBinding HorizontalOffset}"
+								ViewportSize="{TemplateBinding ViewportWidth}"
+								skia:Height="16"/>
+
+							<skia:Border
+								x:Name="ScrollBarSeparator"
+								Grid.Row="1"
+								Grid.Column="1"
+								Opacity="0"
+								Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}" />
+						</Grid>
+					</Border>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style
+		TargetType="ScrollViewer"
+		BasedOn="{StaticResource DefaultScrollViewerStyle}"
+		x:Key="NativeScrollViewerStyle">
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="ScrollViewer">

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
@@ -62,7 +62,6 @@ namespace Windows.UI.Xaml.Input
 			Pointer = new Pointer(pointerId, pointerType, isInContact, isInRange: true);
 			KeyModifiers = keys;
 			OriginalSource = originalSource;
-			CanBubbleNatively = true;
 
 			_properties = GetProperties(nativePointerType, nativePointerAction, nativePointerButtons); // Last: we need the Pointer property to be set!
 		}

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.cs
@@ -13,10 +13,18 @@ namespace Windows.UI.Xaml.Input
 {
 	public sealed partial class PointerRoutedEventArgs : RoutedEventArgs, ICancellableRoutedEventArgs, CoreWindow.IPointerEventArgs
 	{
+#if __IOS__ || __MACOS__ || __ANDROID__ || __WASM__
+		internal const bool PlatformSupportsNativeBubbling = true;
+#else
+		internal const bool PlatformSupportsNativeBubbling = false;
+#endif
+
 		public PointerRoutedEventArgs()
 		{
 			// This is acceptable as all ctors of this class are internal
 			CoreWindow.GetForCurrentThread().SetLastPointerEvent(this);
+
+			CanBubbleNatively = PlatformSupportsNativeBubbling;
 		}
 
 		/// <inheritdoc />

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.iOS.cs
@@ -41,7 +41,6 @@ namespace Windows.UI.Xaml.Input
 			Pointer = new Pointer(pointerId, deviceType, isInContact, isInRange: true);
 			KeyModifiers = VirtualKeyModifiers.None;
 			OriginalSource = FindOriginalSource(_nativeTouch) ?? receiver;
-			CanBubbleNatively = true; // Required for native gesture recognition (i.e. ScrollViewer), and integration of native components in the visual tree
 		}
 
 		public PointerPoint GetCurrentPoint(UIElement relativeTo)

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.macOS.cs
@@ -40,7 +40,6 @@ namespace Windows.UI.Xaml.Input
 			Pointer = new Pointer(pointerId, pointerDeviceType, isInContact, isInRange: true);
 			KeyModifiers = GetVirtualKeyModifiers(nativeEvent);
 			OriginalSource = source;
-			CanBubbleNatively = true;
 		}
 
 		public PointerPoint GetCurrentPoint(UIElement relativeTo)

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.skia.cs
@@ -27,9 +27,6 @@ namespace Windows.UI.Xaml.Input
 			Pointer = GetPointer(pointerEventArgs);
 			KeyModifiers = pointerEventArgs.KeyModifiers;
 			OriginalSource = source;
-
-			// All events bubble in managed mode.
-			CanBubbleNatively = false;
 		}
 
 		public PointerPoint GetCurrentPoint(UIElement relativeTo)

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.wasm.cs
@@ -29,8 +29,7 @@ namespace Windows.UI.Xaml.Input
 			VirtualKeyModifiers keys,
 			double pressure,
 			(bool isHorizontalWheel, double delta) wheel,
-			UIElement source,
-			bool canBubbleNatively)
+			UIElement source)
 			: this()
 		{
 			_timestamp = timestamp;
@@ -44,7 +43,6 @@ namespace Windows.UI.Xaml.Input
 			Pointer = new Pointer(pointerId, pointerType, isInContact, isInRange: true);
 			KeyModifiers = keys;
 			OriginalSource = source;
-			CanBubbleNatively = canBubbleNatively;
 		}
 
 		public PointerPoint GetCurrentPoint(UIElement relativeTo)

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Skia.cs
@@ -222,7 +222,6 @@ namespace Windows.UI.Xaml
 				{
 					foreach (var target in capture.Targets.ToArray())
 					{
-						//Debug.WriteLine($"[MOVE] RE-ROUTED TO {GetTraceName(target.Element)}");
 						routedArgs.Handled = false;
 						target.Element.OnNativePointerMove(routedArgs);
 					}
@@ -230,7 +229,6 @@ namespace Windows.UI.Xaml
 				else
 				{
 					// Note: We prefer to use the "WithOverCheck" overload as we already know that the pointer is effectively over
-					//cDebug.WriteLine($"[MOVE] {GetTraceName(source.element)}");
 					routedArgs.Handled = false;
 					source.element.OnNativePointerMoveWithOverCheck(routedArgs, isOver: true);
 				}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -444,9 +444,6 @@ namespace Windows.UI.Xaml
 		{
 			// We override the isOver for the relevancy check as we will update it right after.
 			var isOverOrCaptured = ValidateAndUpdateCapture(args, isOver: true);
-			//var isHandled = PointerRoutedEventArgs.PlatformSupportsNativeBubbling
-			//	? isManagedBubblingEvent
-			//	: args.Handled;
 			var handledInManaged = SetOver(args, true, muteEvent: isManagedBubblingEvent || !isOverOrCaptured);
 
 			return handledInManaged;
@@ -463,10 +460,7 @@ namespace Windows.UI.Xaml
 			// it due to an invalid state. So here we make sure to not stay in an invalid state that would
 			// prevent any interaction with the application.
 			var isOverOrCaptured = ValidateAndUpdateCapture(args, isOver: true, forceRelease: true);
-			var isHandled = PointerRoutedEventArgs.PlatformSupportsNativeBubbling
-				? isManagedBubblingEvent
-				: args.Handled;
-			var handledInManaged = SetPressed(args, true, muteEvent: isHandled || !isOverOrCaptured);
+			var handledInManaged = SetPressed(args, true, muteEvent: isManagedBubblingEvent || !isOverOrCaptured);
 
 			if (PointerRoutedEventArgs.PlatformSupportsNativeBubbling && !isManagedBubblingEvent && !isOverOrCaptured)
 			{
@@ -535,11 +529,8 @@ namespace Windows.UI.Xaml
 		{
 			var handledInManaged = false;
 			var isOverOrCaptured = ValidateAndUpdateCapture(args);
-			var isHandled = PointerRoutedEventArgs.PlatformSupportsNativeBubbling
-				? isManagedBubblingEvent
-				: isManagedBubblingEvent || args.Handled;
 
-			if (!isHandled && isOverOrCaptured)
+			if (!isManagedBubblingEvent && isOverOrCaptured)
 			{
 				// If this pointer was wrongly dispatched here (out of the bounds and not captured),
 				// we don't raise the 'move' event
@@ -552,7 +543,7 @@ namespace Windows.UI.Xaml
 			{
 				// We need to process only events that were not handled by a child control,
 				// so we should not use them for gesture recognition.
-				_gestures.Value.ProcessMoveEvents(args.GetIntermediatePoints(this), !isHandled || isOverOrCaptured);
+				_gestures.Value.ProcessMoveEvents(args.GetIntermediatePoints(this), !isManagedBubblingEvent || isOverOrCaptured);
 			}
 
 			return handledInManaged;
@@ -565,11 +556,8 @@ namespace Windows.UI.Xaml
 		{
 			var handledInManaged = false;
 			var isOverOrCaptured = ValidateAndUpdateCapture(args, out var isOver);
-			var isHandled = PointerRoutedEventArgs.PlatformSupportsNativeBubbling
-				? isManagedBubblingEvent
-				: args.Handled;
 
-			handledInManaged |= SetPressed(args, false, muteEvent: isHandled || !isOverOrCaptured);
+			handledInManaged |= SetPressed(args, false, muteEvent: isManagedBubblingEvent || !isOverOrCaptured);
 
 			
 			// Note: We process the UpEvent between Release and Exited as the gestures like "Tap"
@@ -579,7 +567,7 @@ namespace Windows.UI.Xaml
 				// We need to process only events that are bubbling natively to this control (i.e. isOverOrCaptured == true),
 				// if they are bubbling in managed it means that they where handled a child control,
 				// so we should not use them for gesture recognition.
-				_gestures.Value.ProcessUpEvent(args.GetCurrentPoint(this), !isHandled || isOverOrCaptured);
+				_gestures.Value.ProcessUpEvent(args.GetCurrentPoint(this), !isManagedBubblingEvent || isOverOrCaptured);
 			}
 
 			// We release the captures on up but only after the released event and processed the gesture
@@ -600,9 +588,6 @@ namespace Windows.UI.Xaml
 		{
 			var handledInManaged = false;
 			var isOverOrCaptured = ValidateAndUpdateCapture(args);
-			//var isHandled = PointerRoutedEventArgs.PlatformSupportsNativeBubbling
-			//	? isManagedBubblingEvent
-			//	: args.Handled;
 
 			handledInManaged |= SetOver(args, false, muteEvent: isManagedBubblingEvent || !isOverOrCaptured);
 
@@ -633,9 +618,6 @@ namespace Windows.UI.Xaml
 		private bool OnPointerCancel(PointerRoutedEventArgs args, bool isManagedBubblingEvent)
 		{
 			var isOverOrCaptured = ValidateAndUpdateCapture(args); // Check this *before* updating the pressed / over states!
-			var isHandled = PointerRoutedEventArgs.PlatformSupportsNativeBubbling
-				? isManagedBubblingEvent
-				: args.Handled;
 
 			// When a pointer is cancelled / swallowed by the system, we don't even receive "Released" nor "Exited"
 			SetPressed(args, false, muteEvent: true);
@@ -659,7 +641,7 @@ namespace Windows.UI.Xaml
 			else
 			{
 				args.Handled = false;
-				handledInManaged |= !isHandled && RaisePointerEvent(PointerCanceledEvent, args);
+				handledInManaged |= !isManagedBubblingEvent && RaisePointerEvent(PointerCanceledEvent, args);
 				handledInManaged |= SetNotCaptured(args);
 			}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -166,7 +166,7 @@ namespace Windows.UI.Xaml
 		{
 			get
 			{
-#if NETSTANDARD
+#if __WASM__ || __SKIA__
 				return this.GetValue(HitTestVisibilityProperty) is HitTestVisibility visibility
 					&& visibility != HitTestVisibility.Collapsed;
 #else

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -171,7 +171,7 @@ namespace Windows.UI.Xaml
 					&& visibility != HitTestVisibility.Collapsed;
 #else
 				// This is a coalesced HitTestVisible and should be unified with it
-				// We should follow the WASM way an unify it on all platforms!
+				// We should follow the WASM way and unify it on all platforms!
 				if (Visibility != Visibility.Visible || !IsHitTestVisible)
 				{
 					return false;
@@ -193,9 +193,9 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-#region Gestures recognition (includes manipulation)
+		#region Gestures recognition (includes manipulation)
 
-#region Event to RoutedEvent handler adapters
+		#region Event to RoutedEvent handler adapters
 		// Note: For the manipulation and gesture event args, the original source has to be the element that raise the event
 		//		 As those events are bubbling in managed only, the original source will be right one for all.
 
@@ -253,7 +253,7 @@ namespace Windows.UI.Xaml
 			var that = (UIElement)sender.Owner;
 			that.SafeRaiseEvent(HoldingEvent, new HoldingRoutedEventArgs(that, args));
 		};
-#endregion
+		#endregion
 
 		private bool _isGestureCompleted;
 
@@ -278,7 +278,7 @@ namespace Windows.UI.Xaml
 
 		partial void OnGestureRecognizerInitialized(GestureRecognizer recognizer);
 
-#region Manipulation events wire-up
+		#region Manipulation events wire-up
 		partial void AddManipulationHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo)
 		{
 			if (handlersCount == 1)
@@ -323,9 +323,9 @@ namespace Windows.UI.Xaml
 
 			_gestures.Value.GestureSettings = settings;
 		}
-#endregion
+		#endregion
 
-#region Gesture events wire-up
+		#region Gesture events wire-up
 		partial void AddGestureHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo)
 		{
 			if (handlersCount == 1)
@@ -362,7 +362,7 @@ namespace Windows.UI.Xaml
 				_gestures.Value.GestureSettings |= GestureSettings.Hold; // Note: We do not set GestureSettings.HoldWithMouse as WinUI never raises Holding for mouse pointers
 			}
 		}
-#endregion
+		#endregion
 
 		partial void PrepareManagedPointerEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref bool isBubblingAllowed)
 		{
@@ -434,9 +434,9 @@ namespace Windows.UI.Xaml
 				_gestures.Value.CompleteGesture();
 			}
 		}
-#endregion
+		#endregion
 
-#region Partial API to raise pointer events and gesture recognition (OnNative***)
+		#region Partial API to raise pointer events and gesture recognition (OnNative***)
 		private bool OnNativePointerEnter(PointerRoutedEventArgs args) => OnPointerEnter(args, isManagedBubblingEvent: false);
 		private void OnManagedPointerEnter(PointerRoutedEventArgs args) => OnPointerEnter(args, isManagedBubblingEvent: true);
 
@@ -694,9 +694,9 @@ namespace Windows.UI.Xaml
 				_pendingRaisedEvent = (null, null, null);
 			}
 		}
-#endregion
+		#endregion
 
-#region Pointer over state (Updated by the partial API OnNative***)
+		#region Pointer over state (Updated by the partial API OnNative***)
 		/// <summary>
 		/// Indicates if a pointer (no matter the pointer) is currently over the element (i.e. OverState)
 		/// WARNING: This might not be maintained for all controls, cf. remarks.
@@ -743,9 +743,9 @@ namespace Windows.UI.Xaml
 				return RaisePointerEvent(PointerExitedEvent, args);
 			}
 		}
-#endregion
+		#endregion
 
-#region Pointer pressed state (Updated by the partial API OnNative***)
+		#region Pointer pressed state (Updated by the partial API OnNative***)
 		private readonly HashSet<uint> _pressedPointers = new HashSet<uint>();
 
 		/// <summary>
@@ -817,9 +817,9 @@ namespace Windows.UI.Xaml
 		}
 
 		private void ClearPressed() => _pressedPointers.Clear();
-#endregion
+		#endregion
 
-#region Pointer capture state (Updated by the partial API OnNative***)
+		#region Pointer capture state (Updated by the partial API OnNative***)
 		/*
 		 * About pointer capture
 		 *
@@ -833,7 +833,7 @@ namespace Windows.UI.Xaml
 
 		private List<Pointer> _localExplicitCaptures;
 
-#region Capture public (and internal) API ==> This manages only Explicit captures
+		#region Capture public (and internal) API ==> This manages only Explicit captures
 		public static DependencyProperty PointerCapturesProperty { get; } = DependencyProperty.Register(
 			"PointerCaptures",
 			typeof(IReadOnlyList<Pointer>),
@@ -900,7 +900,7 @@ namespace Windows.UI.Xaml
 
 			Release(PointerCaptureKind.Explicit);
 		}
-#endregion
+		#endregion
 
 		partial void CapturePointerNative(Pointer pointer);
 		partial void ReleasePointerNative(Pointer pointer);
@@ -999,6 +999,6 @@ namespace Windows.UI.Xaml
 			relatedARgs.Handled = false;
 			return RaisePointerEvent(PointerCaptureLostEvent, relatedARgs);
 		}
-#endregion
+		#endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -110,10 +110,10 @@ namespace Windows.UI.Xaml
 		//	we just ensure that the managed code won't try to bubble it by its own.
 		//	However, if the event is Handled in managed, it will then bubble while it should not! https://github.com/unoplatform/uno/issues/3007
 		private static bool DispatchNativePointerEnter(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerEnter(ToPointerArgs(target, args, isInContact: false, canBubble: true));
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerEnter(ToPointerArgs(target, args, isInContact: false));
 
 		private static bool DispatchNativePointerLeave(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerExited(ToPointerArgs(target, args, isInContact: false, canBubble: true));
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerExited(ToPointerArgs(target, args, isInContact: false));
 
 		private static bool DispatchNativePointerDown(UIElement target, string eventPayload)
 			=> TryParse(eventPayload, out var args) && target.OnNativePointerDown(ToPointerArgs(target, args, isInContact: true));
@@ -183,8 +183,7 @@ namespace Windows.UI.Xaml
 			UIElement snd,
 			NativePointerEventArgs args,
 			bool? isInContact,
-			(bool isHorizontalWheel, double delta) wheel = default,
-			bool canBubble = true)
+			(bool isHorizontalWheel, double delta) wheel = default)
 		{
 			var pointerId = (uint)args.pointerId;
 			var src = GetElementFromHandle(args.srcHandle) ?? (UIElement)snd;
@@ -205,8 +204,7 @@ namespace Windows.UI.Xaml
 				keyModifiers,
 				args.pressure,
 				wheel,
-				src,
-				canBubble);
+				src);
 		}
 
 		private static PointerDeviceType ConvertPointerTypeString(string typeStr)

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -324,7 +324,7 @@ namespace Windows.UI.Xaml
 			}
 
 			// If we're not locally hit-test visible, visible, or enabled, we should be collapsed. Our children will be collapsed as well.
-			if (!element.IsHitTestVisible || element.Visibility != Visibility.Visible || !element.IsEnabledOverride())
+			if (!element.IsLoaded || !element.IsHitTestVisible || element.Visibility != Visibility.Visible || !element.IsEnabledOverride())
 			{
 				return HitTestVisibility.Collapsed;
 			}

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿// #define TRACE_ROUTED_EVENT_BUBBLING
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Windows.UI.Xaml.Input;
@@ -8,6 +10,7 @@ using Uno;
 using Uno.Extensions;
 using Uno.Logging;
 using Uno.UI;
+using Uno.UI.Extensions;
 using Uno.UI.Xaml;
 using Uno.UI.Xaml.Input;
 
@@ -528,6 +531,10 @@ namespace Windows.UI.Xaml
 		/// </remarks>
 		internal bool RaiseEvent(RoutedEvent routedEvent, RoutedEventArgs args)
 		{
+#if TRACE_ROUTED_EVENT_BUBBLING
+			Debug.Write(new string('\t', Depth) + $"[{routedEvent.Name.Trim().ToUpperInvariant()}] {this.GetDebugName()}\r\n");
+#endif
+
 			if (routedEvent.Flag == RoutedEventFlag.None)
 			{
 				throw new InvalidOperationException($"Flag not defined for routed event {routedEvent.Name}.");

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -595,7 +595,7 @@ namespace Windows.UI.Xaml
 			=> (int)Math.Floor(x + 0.5);
 
 #if HAS_UNO_WINUI
-#region FocusState DependencyProperty
+		#region FocusState DependencyProperty
 
 		public FocusState FocusState
 		{
@@ -613,9 +613,9 @@ namespace Windows.UI.Xaml
 				)
 			);
 
-#endregion
+		#endregion
 
-#region IsTabStop DependencyProperty
+		#region IsTabStop DependencyProperty
 
 		public bool IsTabStop
 		{
@@ -633,7 +633,7 @@ namespace Windows.UI.Xaml
 					(s, e) => ((Control)s)?.OnIsTabStopChanged((bool)e.OldValue, (bool)e.NewValue)
 				)
 			);
-#endregion
+		#endregion
 
 		private protected virtual void OnIsTabStopChanged(bool oldValue, bool newValue) { }
 #endif

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -196,6 +196,7 @@ namespace Windows.UI.Xaml
 					offsetY = layoutSlot.Y;
 				}
 
+#if !__SKIA__
 				if (elt is ScrollViewer sv)
 				{
 					var zoom = sv.ZoomFactor;
@@ -213,6 +214,7 @@ namespace Windows.UI.Xaml
 						offsetY -= sv.VerticalOffset;
 					}
 				}
+#endif
 			} while (elt.TryGetParentUIElementForTransformToVisual(out elt, ref offsetX, ref offsetY) && elt != to); // If possible we stop as soon as we reach 'to'
 
 			matrix *= Matrix3x2.CreateTranslation((float)offsetX, (float)offsetY);
@@ -582,7 +584,7 @@ namespace Windows.UI.Xaml
 			=> (int)Math.Floor(x + 0.5);
 
 #if HAS_UNO_WINUI
-		#region FocusState DependencyProperty
+#region FocusState DependencyProperty
 
 		public FocusState FocusState
 		{
@@ -600,9 +602,9 @@ namespace Windows.UI.Xaml
 				)
 			);
 
-		#endregion
+#endregion
 
-		#region IsTabStop DependencyProperty
+#region IsTabStop DependencyProperty
 
 		public bool IsTabStop
 		{
@@ -620,7 +622,7 @@ namespace Windows.UI.Xaml
 					(s, e) => ((Control)s)?.OnIsTabStopChanged((bool)e.OldValue, (bool)e.NewValue)
 				)
 			);
-		#endregion
+#endregion
 
 		private protected virtual void OnIsTabStopChanged(bool oldValue, bool newValue) { }
 #endif

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -162,9 +162,6 @@ namespace Windows.UI.Xaml
 			=> new MatrixTransform { Matrix = new Matrix(GetTransform(from: this, to: visual)) };
 
 		internal static Matrix3x2 GetTransform(UIElement from, UIElement to)
-			=> GetTransform(from, to, null);
-
-		private static Matrix3x2 GetTransform(UIElement from, UIElement to, IntermediateAggregator? intermediates)
 		{
 			if (from == to)
 			{
@@ -231,11 +228,6 @@ namespace Windows.UI.Xaml
 				}
 #endif
 
-				if (intermediates?.ShouldBeAdded(elt) ?? false)
-				{
-					intermediates.Value.Add(elt, matrix * Matrix3x2.CreateTranslation((float)offsetX, (float)offsetY));
-				}
-
 			} while (elt.TryGetParentUIElementForTransformToVisual(out elt, ref offsetX, ref offsetY) && elt != to); // If possible we stop as soon as we reach 'to'
 
 			matrix *= Matrix3x2.CreateTranslation((float)offsetX, (float)offsetY);
@@ -280,27 +272,6 @@ namespace Windows.UI.Xaml
 			}
 		}
 #endif
-
-		private struct IntermediateAggregator : IEnumerable<(UIElement element, Matrix3x2 transform)>
-		{
-			private readonly Predicate<UIElement> _predicate;
-			private readonly List<(UIElement element, Matrix3x2 transform)> _intermediates;
-
-			public IntermediateAggregator(Predicate<UIElement> predicate)
-			{
-				_predicate = predicate ?? (_ => true);
-				_intermediates = new List<(UIElement element, Matrix3x2 transform)>();
-			}
-
-			public bool ShouldBeAdded(UIElement elt) => _predicate.Invoke(elt);
-
-			public void Add(UIElement elt, Matrix3x2 fromToElt) => _intermediates.Add((elt, fromToElt));
-
-			IEnumerator IEnumerable.GetEnumerator() => _intermediates.GetEnumerator();
-			public IEnumerator<(UIElement element, Matrix3x2 transform)> GetEnumerator() => _intermediates.GetEnumerator();
-		}
-
-
 
 		protected virtual void OnIsHitTestVisibleChanged(bool oldValue, bool newValue)
 		{

--- a/src/Uno.UI/UI/Xaml/UIElement.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.netstd.cs
@@ -101,6 +101,7 @@ namespace Windows.UI.Xaml
 			IsLoaded = true;
 
 			OnFwEltLoaded();
+			UpdateHitTest();
 
 			foreach (var child in _children)
 			{
@@ -124,6 +125,7 @@ namespace Windows.UI.Xaml
 			}
 
 			OnFwEltUnloaded();
+			UpdateHitTest();
 		}
 
 		private void OnAddingChild(UIElement child)

--- a/src/Uno.UI/UI/Xaml/UIElement.netstdref.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.netstdref.cs
@@ -40,6 +40,7 @@ namespace Windows.UI.Xaml
 		internal void MoveChildTo(int oldIndex, int newIndex) => throw new NotSupportedException("Reference assembly");
 		internal bool RemoveChild(UIElement child) => throw new NotSupportedException("Reference assembly");
 		internal void ClearChildren() => throw new NotSupportedException("Reference assembly");
+		internal void UpdateHitTest() => throw new NotSupportedException("Reference assembly");
 
 		protected virtual void OnVisibilityChanged(Visibility oldValue, Visibility newVisibility)
 		{

--- a/src/Uno.UI/UI/Xaml/Window.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Skia.cs
@@ -144,11 +144,9 @@ namespace Windows.UI.Xaml
 				_rootBorder = new Border();
 				_popupRoot = new PopupRoot();
 
-				_window = new Grid {
-					Children = {
-						_rootBorder
-						, _popupRoot
-					}
+				_window = new Grid
+				{
+					Children = {_rootBorder, _popupRoot}
 				};
 
 				UIElement.LoadingRootElement(_window);


### PR DESCRIPTION
GitHub Issue: fixes #3817 

## Feature / Bugfix
Refactor the pointers support for Skia

## What is the current behavior?
The pointers support on skia was primitive and suffer some limitations:
* didn't support `RenderTransform`;
* `OriginalSource` was often not computed properly (especially for captured pointers)
* Enter/leave events was not raised properly

## What is the new behavior?
Only the clipping is not supported yet.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
