### PR TITLE
fix: Fix bug where ResourceDictionary with only ThemeDictionaries would not be generated

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2227,7 +2227,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					writer.AppendLineInvariant("new {0}()", GetGlobalizedTypeName(type.ToDisplayString()));
 					writer.AppendLineInvariant(isInInitializer ? "," : ";");
 				}
-				else if (resourcesRoot != null || mergedDictionaries != null)
+				else if (resourcesRoot != null || mergedDictionaries != null || themeDictionaries != null)
 				{
 					if (isInInitializer)
 					{

--- a/src/Uno.UI.Tests/App/Xaml/Test_Page_Other.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_Page_Other.xaml
@@ -48,5 +48,21 @@
 		<Border x:Name="SpaceInKeyBorder"
 				x:FieldModifier="public"
 				Background="{StaticResource Resource With Space In Key}" />
+		<Border>
+			<Border.Resources>
+				<ResourceDictionary>
+					<ResourceDictionary.ThemeDictionaries>
+						<ResourceDictionary x:Key="Default">
+							<SolidColorBrush x:Key="KeyInDictionaryWithOnlyThemeDictionaries"
+											 Color="MediumPurple" />
+						</ResourceDictionary>
+					</ResourceDictionary.ThemeDictionaries>
+				</ResourceDictionary>
+			</Border.Resources>
+			<TextBlock x:Name="ThemeDictionaryOnlyTextBlock"
+					   x:FieldModifier="public"
+					   Text="Warfarin' terrapin"
+					   Foreground="{StaticResource KeyInDictionaryWithOnlyThemeDictionaries}" />
+		</Border>
 	</Grid>
 </Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
@@ -701,5 +701,13 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			var border = page.SpaceInKeyBorder;
 			Assert.AreEqual(Colors.SlateBlue, (border.Background as SolidColorBrush).Color);
 		}
+
+		[TestMethod]
+		public void When_Only_Theme_Dictionaries()
+		{
+			var page = new Test_Page_Other();
+			var tb = page.ThemeDictionaryOnlyTextBlock;
+			Assert.AreEqual(Colors.MediumPurple, (tb.Foreground as SolidColorBrush).Color);
+		}
 	}
 }


### PR DESCRIPTION
This was happening specifically for inline FrameworkElement.Resources declarations.

GitHub Issue (If applicable): fixes #3753, fixes #3780

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
