### PR TITLE
fix(reg): Fix lazy-initialized ElementName bindings

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template.xaml
@@ -1,0 +1,19 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls.Binding_ElementName_In_Template"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	
+	<Grid>
+		<ContentControl x:Name="topLevel" x:FieldModifier="public"  Tag="42">
+			<ContentControl.ContentTemplate>
+				<DataTemplate>
+					<TextBlock x:Name="innerTextBlock" Text="{Binding Tag, ElementName=topLevel}" />
+				</DataTemplate>
+			</ContentControl.ContentTemplate>
+		</ContentControl>
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_ElementName_In_Template : Page
+	{
+		public Binding_ElementName_In_Template()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests
+{
+	[TestClass]
+	public class Given_Binding
+	{
+		[TestMethod]
+		public void When_ElementName_In_Template()
+		{
+			var SUT = new Binding_ElementName_In_Template();
+
+			SUT.ForceLoaded();
+
+			var tb = SUT.FindName("innerTextBlock") as Windows.UI.Xaml.Controls.TextBlock;
+
+			Assert.AreEqual(SUT.topLevel.Tag, tb.Text);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Data/BindingHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Data/BindingHelper.cs
@@ -25,6 +25,12 @@ namespace Uno.UI.Xaml
 			=> (instance as IDependencyObjectStoreProvider)?.Store.ApplyCompiledBindings();
 
 		public static void UpdateResourceBindings(this DependencyObject instance)
-			=> (instance as IDependencyObjectStoreProvider)?.Store.UpdateResourceBindings(false);
+		{
+			if(instance is IDependencyObjectStoreProvider provider)
+			{
+				provider.Store.ApplyElementNameBindings();
+				provider.Store.UpdateResourceBindings(false);
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -146,10 +146,13 @@ namespace Windows.UI.Xaml
 		/// Apply load-time binding updates. Processes the x:Bind markup for the current FrameworkElement, applies load-time ElementName bindings, and updates ResourceBindings.
 		/// </summary>
 		public void ApplyCompiledBindings()
-		{
-			_properties.ApplyCompiledBindings();
-			UpdateResourceBindings(isThemeChangedUpdate: false);
-		}
+			=> _properties.ApplyCompiledBindings();
+
+		/// <summary>
+		/// Apply load-time binding updates. Processes the x:Bind markup for the current FrameworkElement, applies load-time ElementName bindings, and updates ResourceBindings.
+		/// </summary>
+		internal void ApplyElementNameBindings()
+			=> _properties.ApplyElementNameBindings();
 
 		private string GetOwnerDebugString()
 			=> ActualInstance?.GetType().ToString() ?? "[collected]";

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.Bindings.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.Bindings.cs
@@ -59,6 +59,18 @@ namespace Windows.UI.Xaml
 			for (int i = 0; i < bindings.Length; i++)
 			{
 				bindings[i].ApplyCompiledSource();
+			}
+		}
+
+		/// <summary>
+		/// Applies the <see cref="Binding"/> instances which contain an ElementName property
+		/// </summary>
+		internal void ApplyElementNameBindings()
+		{
+			var bindings = _bindings.Data;
+
+			for (int i = 0; i < bindings.Length; i++)
+			{
 				bindings[i].ApplyElementName();
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/4100

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

ElementName bindings in side `DataTemplate` instances are now lazy initialized during `Loading`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
