### PR TITLE
ci: Temporarily disable Skia runtime times

### DIFF
--- a/build/ci/.azure-devops-skia-tests.yml
+++ b/build/ci/.azure-devops-skia-tests.yml
@@ -31,12 +31,12 @@ jobs:
 
     displayName: Install GTK3 runtime
 
-  - script: |
-        set PATH=C:\Program Files\GTK3-Runtime Win64\bin;%PATH%
-        cd $(Build.SourcesDirectory)\src\SamplesApp\SamplesApp.Skia.Gtk\bin\Release\netcoreapp3.1
-        SamplesApp.Skia.Gtk.exe --auto-screenshots=$(build.artifactstagingdirectory)/screenshots/skia-gtk-screenshots
-
-    displayName: Run Skia UI Tests
+  #- script: |
+  #      set PATH=C:\Program Files\GTK3-Runtime Win64\bin;%PATH%
+  #      cd $(Build.SourcesDirectory)\src\SamplesApp\SamplesApp.Skia.Gtk\bin\Release\netcoreapp3.1
+  #      SamplesApp.Skia.Gtk.exe --auto-screenshots=$(build.artifactstagingdirectory)/screenshots/skia-gtk-screenshots
+  #
+  #  displayName: Run Skia UI Tests
 
   - task: PublishBuildArtifacts@1
     condition: always()


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Tests are stalling builds, disabling to avoid CI slow downs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
