### PR TITLE
fix(publish): Fixes publish to azure may fail with locked files

### DIFF
--- a/src/Uno.UI.Runtime.WebAssembly/buildTransitive/Uno.UI.Runtime.WebAssembly.targets
+++ b/src/Uno.UI.Runtime.WebAssembly/buildTransitive/Uno.UI.Runtime.WebAssembly.targets
@@ -29,6 +29,7 @@
 	-->
 	<WriteLinesToFile
 		Overwrite="true"
+		WriteOnlyWhenDifferent="true"
 		Lines="[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] internal class __UnoUIRuntimeWasmKeepAlive : Uno.UI.Runtime.WebAssembly.CompileAnchor { }"
 		File="$(_unouiruntimewasm_keepalive)" />
 


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/Uno.Wasm.Bootstrap/issues/279

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Publishing to azure may result in locked files failure.

## What is the new behavior?

A second compilation is avoided by preventing a generated file to be overwritten incorrectly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
