### PR TITLE
fix(fips): Use SHA256 for sourcegenerator path hashing

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/HashBuilder.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/HashBuilder.cs
@@ -18,26 +18,35 @@ namespace Uno.UI.SourceGenerators.Helpers
 		public static string BuildIDFromSymbol(ITypeSymbol typeSymbol)
 			=> typeSymbol.GetFullName() + "_" + Build(typeSymbol.MetadataName + typeSymbol.ContainingAssembly.MetadataName);
 
+		/// <summary>
+		/// Creates a non-cryptographically secure hash of the provided string, clamped to 16 bytes.
+		/// </summary>
+		/// <remarks>
+		/// The 16 bytes clamping is required on some platforms combinations to avoid having long file paths. The hash is used
+		/// to limit collisions for duplicate file names in different folders, used in the same generator.
+		/// </remarks>
+		/// <param name="input">The string to hash</param>
+		/// <param name="algoritm">The algorithm to use</param>
+		/// <returns>A hex-formatted string of the hash</returns>
 		public static string Build(string input, HashAlgorithm algoritm = null)
 		{
-			using (algoritm = algoritm ?? MD5.Create())
+			using (algoritm ??= SHA256.Create())
 			{
 				// Convert the input string to a byte array and compute the hash.
 				var data = algoritm.ComputeHash(Encoding.UTF8.GetBytes(input));
 
 				// Create a new Stringbuilder to collect the bytes
 				// and create a string.
-				var sBuilder = new StringBuilder();
+				var builder = new StringBuilder();
 
-				// Loop through each byte of the hashed data 
-				// and format each one as a hexadecimal string.
-				for (int i = 0; i < data.Length; i++)
+				// Use the first 16 bytes of the hash
+				for (int i = 0; i < Math.Min(data.Length, 16); i++)
 				{
-					sBuilder.Append(data[i].ToString("x2", CultureInfo.InvariantCulture));
+					builder.Append(data[i].ToString("x2", CultureInfo.InvariantCulture));
 				}
 
 				// Return the hexadecimal string.
-				return sBuilder.ToString();
+				return builder.ToString();
 			}
 		}
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/4154

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Building an uno app on a FIPS enable system fails because of the use of MD5 hashing.

## What is the new behavior?

SHA256 is used instead for collision limiting in source generators.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
