### PR TITLE
fix(unix): Adjust `ApplicationData.Local` path to use proper locations under unix

### DIFF
--- a/src/Uno.UWP/Storage/ApplicationData.skia.cs
+++ b/src/Uno.UWP/Storage/ApplicationData.skia.cs
@@ -12,7 +12,8 @@ namespace Windows.Storage
 			=> Path.GetTempPath();
 
 		private static string GetLocalFolder()
-			=> AppDomain.CurrentDomain.BaseDirectory;
+			// Uses XDG_DATA_HOME on Unix: https://github.com/dotnet/runtime/blob/b5705587347d29d79cec830dc22b389e1ad9a9e0/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs#L105
+			=> Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
 		private static string GetRoamingFolder()
 			=> Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);


### PR DESCRIPTION

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The `ApplicationData.Local` under skia does not point to the proper directory.

## What is the new behavior?

Uses `Environment.GetFolderPath` which points to the `XDG_DATA_HOME` standard environment variable.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
