### PR TITLE
[Android] NativeScrollViewerPresenter was clipping its children.

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.ExpectedPixels.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.ExpectedPixels.cs
@@ -24,6 +24,13 @@ namespace SamplesApp.UITests.TestFramework
 		public ExpectedPixels Named(string name)
 			=> new ExpectedPixels(name, Location, SourceLocation, Values, Tolerance);
 
+		public ExpectedPixels Pixel(string color)
+		{
+			var colors = new [,] {{GetColorFromString(color)}};
+
+			return new ExpectedPixels(Name, Location, SourceLocation, colors, Tolerance);
+		}
+
 		public ExpectedPixels Pixels(string[,] pixels)
 		{
 			var colors = new Color[pixels.GetLength(0), pixels.GetLength(1)];
@@ -31,13 +38,16 @@ namespace SamplesApp.UITests.TestFramework
 			for (var px = 0; px < pixels.GetLength(1); px++)
 			{
 				var colorCode = pixels[py, px];
-				colors[py, px] = string.IsNullOrWhiteSpace(colorCode)
-					? Color.Empty
-					: ColorCodeParser.Parse(colorCode);
+				colors[py, px] = GetColorFromString(colorCode);
 			}
 
 			return new ExpectedPixels(Name, Location, SourceLocation, colors, Tolerance);
 		}
+
+		private static Color GetColorFromString(string colorCode) =>
+			string.IsNullOrWhiteSpace(colorCode)
+				? Color.Empty
+				: ColorCodeParser.Parse(colorCode);
 
 		public ExpectedPixels Pixels(Bitmap source, Rectangle rect)
 		{
@@ -145,8 +155,10 @@ namespace SamplesApp.UITests.TestFramework
 		public (uint x, uint y) DiscreteValidation { get; }
 
 		/// <inheritdoc />
-		public override string ToString()
-			=> $"Color {ColorKind} tolerance of {Color} | Location {OffsetKind} tolerance of {Offset.x},{Offset.y} pixels.";
+		public override string ToString() =>
+			Color > 0
+				? $"Color {ColorKind} tolerance of {Color} | Location {OffsetKind} tolerance of {Offset.x},{Offset.y} pixels."
+				: "No color tolerance";
 	}
 
 	public enum ColorToleranceKind

--- a/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.ElevatedView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.ElevatedView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -33,6 +34,69 @@ namespace SamplesApp.UITests.Toolkit
 				elevatedView.FirstResult().Rect.Width.Should().Be(200f);
 				elevatedView.FirstResult().Rect.Height.Should().Be(160f);
 			}
+		}
+
+		[Test]
+		[AutoRetry]
+		public void ElevatedView_Corners_Validation()
+		{
+			Run("UITests.Toolkit.ElevatedView_Corners");
+
+			_app.WaitForElement("Elevation");
+
+			var elevationRect = _app.GetRect("Elevation");
+
+			var snapshot = this.TakeScreenshot("check", ignoreInSnapshotCompare: true);
+
+			const string white = "#FFFFFF";
+			const string gray = "#A9A9A9"; // DarkGray
+			const string pink = "#FFE0E0"; // Red shadow mixed with white background
+
+			ImageAssert.HasPixels(
+				snapshot,
+				ExpectedPixels
+					.At("top-middle", elevationRect.CenterX, elevationRect.Y)
+					.WithPixelTolerance(1, 1)
+					.Pixel(gray),
+				ExpectedPixels
+					.At("bottom-middle", elevationRect.CenterX, elevationRect.Bottom)
+					.WithPixelTolerance(1, 1)
+					.Pixel(gray),
+				ExpectedPixels
+					.At("left-middle", elevationRect.X, elevationRect.CenterY)
+					.WithPixelTolerance(1, 1)
+					.Pixel(gray),
+				ExpectedPixels
+					.At("right-middle", elevationRect.Right, elevationRect.CenterY)
+					.WithPixelTolerance(1, 1)
+					.Pixel(gray),
+				ExpectedPixels
+					.At("right-middle-shadow", elevationRect.Right + 1, elevationRect.CenterY)
+					.WithPixelTolerance(1, 1)
+					.WithColorTolerance(22)
+					.Pixel(pink),
+				ExpectedPixels
+					.At("bottom-middle-shadow", elevationRect.CenterX, elevationRect.Bottom + 1)
+					.WithPixelTolerance(1, 1)
+					.WithColorTolerance(22)
+					.Pixel(pink),
+				ExpectedPixels
+					.At("top-left", elevationRect.X, elevationRect.Y)
+					.WithPixelTolerance(1, 1)
+					.Pixel(white),
+				ExpectedPixels
+					.At("top-right", elevationRect.Right, elevationRect.Y)
+					.WithPixelTolerance(1, 1)
+					.Pixel(white),
+				ExpectedPixels
+					.At("bottom-left", elevationRect.X, elevationRect.Bottom)
+					.WithPixelTolerance(1, 1)
+					.Pixel(white),
+				ExpectedPixels
+					.At("bottom-right", elevationRect.Right, elevationRect.Bottom)
+					.WithPixelTolerance(1, 1)
+					.Pixel(white)
+			);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.ElevatedView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.ElevatedView.cs
@@ -72,12 +72,12 @@ namespace SamplesApp.UITests.Toolkit
 					.Pixel(gray),
 				ExpectedPixels
 					.At("right-middle-shadow", elevationRect.Right + 1, elevationRect.CenterY)
-					.WithPixelTolerance(1, 1)
+					.WithPixelTolerance(5, 1)
 					.WithColorTolerance(22)
 					.Pixel(pink),
 				ExpectedPixels
 					.At("bottom-middle-shadow", elevationRect.CenterX, elevationRect.Bottom + 1)
-					.WithPixelTolerance(1, 1)
+					.WithPixelTolerance(1, 5)
 					.WithColorTolerance(22)
 					.Pixel(pink),
 				ExpectedPixels

--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedViewTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedViewTests.xaml
@@ -8,69 +8,79 @@
 	mc:Ignorable="d"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<StackPanel Spacing="10" Margin="15">
-		<Slider x:Name="elevation1" Minimum="0" Maximum="50" Value="10" />
-		<StackPanel Orientation="Horizontal" Spacing="10">
-			<Button x:Name="noElevation" Tag="0" Click="SetElevationClick">NO ELEVATION</Button>
-			<Button x:Name="lowElevation" Tag="4" Click="SetElevationClick">LOW ELEVATION (4)</Button>
-			<Button x:Name="highElevation" Tag="20" Click="SetElevationClick">HIGH ELEVATION (20)</Button>
+	<Grid RowSpacing="10" Margin="15">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<StackPanel Spacing="10">
+			<Slider x:Name="elevation1" Minimum="0" Maximum="50" Value="10" />
+			<StackPanel Orientation="Horizontal" Spacing="10">
+				<Button x:Name="noElevation" Tag="0" Click="SetElevationClick">NO ELEVATION</Button>
+				<Button x:Name="lowElevation" Tag="4" Click="SetElevationClick">LOW ELEVATION (4)</Button>
+				<Button x:Name="highElevation" Tag="20" Click="SetElevationClick">HIGH ELEVATION (20)</Button>
+			</StackPanel>
 		</StackPanel>
-		<TextBlock>
-			ElevatedView With Default Color
-		</TextBlock>
-		<Grid Padding="16">
-			<toolkit:ElevatedView Background="Orange" Elevation="{Binding Value, ElementName=elevation1}">
-				<Rectangle Fill="Red"  Width="60" Height="60" />
-			</toolkit:ElevatedView>
-		</Grid>
-		<StackPanel Orientation="Horizontal" Spacing="10">
-			<Button x:Name="blackColor" Tag="Black" Click="SetColor" Background="Black" Foreground="White">BLACK SHADOW</Button>
-			<Button x:Name="yellowColor" Tag="Yellow" Click="SetColor" Background="Yellow">YELLOW SHADOW</Button>
-			<Button x:Name="redColor" Tag="Red" Click="SetColor" Background="Red">RED SHADOW</Button>
-			<Button x:Name="blueColor" Tag="Blue" Click="SetColor" Background="Blue" Foreground="White">BLUE SHADOW</Button>
-		</StackPanel>
-		<TextBlock FontSize="15">
-			ElevatedView, some with rounded corners...
-		</TextBlock>
-		<StackPanel Orientation="Horizontal" Spacing="10">
-			<toolkit:ElevatedView Width="60" Height="60" Background="Orange" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}" />
-			<toolkit:ElevatedView Width="60" Height="60" Background="Orange" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
-				<Rectangle Fill="Red" />
-			</toolkit:ElevatedView>
-			<toolkit:ElevatedView Width="60" Height="60" CornerRadius="20" Background="Orange" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
-				<Rectangle Fill="Red" Stroke="Blue" StrokeThickness="6" />
-			</toolkit:ElevatedView>
-			<toolkit:ElevatedView Width="60" Height="60" CornerRadius="10,5,10,35" Background="Orange" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
-				<Rectangle Fill="Red" Stroke="Blue" StrokeThickness="6" />
-			</toolkit:ElevatedView>
-		</StackPanel>
-		<TextBlock FontSize="15">
-			ElevatedView with Button in them...
-		</TextBlock>
-		<StackPanel Orientation="Horizontal" Spacing="10">
-			<toolkit:ElevatedView Background="Orange" VerticalAlignment="Top" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
-				<Button>Nice Elevated Button</Button>
-			</toolkit:ElevatedView>
-			<toolkit:ElevatedView Background="White" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
-				<Button Height="120" Width="120">BIG BUTTON</Button>
-			</toolkit:ElevatedView>
-		</StackPanel>
-		<TextBlock FontSize="15">
-			ElevatedView Without background (shouldn't be elevated)
-		</TextBlock>
-		<StackPanel Orientation="Horizontal" Spacing="10">
-			<toolkit:ElevatedView Width="60" Height="60" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
-				<Rectangle Fill="Red" />
-			</toolkit:ElevatedView>
-			<toolkit:ElevatedView Width="60" Height="60" CornerRadius="10,5,10,35" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
-				<Rectangle Fill="Red" />
-			</toolkit:ElevatedView>
-			<toolkit:ElevatedView VerticalAlignment="Top" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
-				<Button>Nice Elevated Button</Button>
-			</toolkit:ElevatedView>
-			<toolkit:ElevatedView ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
-				<Button Height="120" Width="120">BIG BUTTON</Button>
-			</toolkit:ElevatedView>
-		</StackPanel>
-	</StackPanel>
+		<ScrollViewer VerticalScrollMode="Enabled" Grid.Row="1">
+			<StackPanel Spacing="10">
+				<TextBlock>
+					ElevatedView With Default Color
+				</TextBlock>
+				<Grid Padding="16">
+					<toolkit:ElevatedView Background="Orange" Elevation="{Binding Value, ElementName=elevation1}">
+						<Rectangle Fill="Red"  Width="60" Height="60" />
+					</toolkit:ElevatedView>
+				</Grid>
+				<StackPanel Orientation="Horizontal" Spacing="10">
+					<Button x:Name="blackColor" Tag="Black" Click="SetColor" Background="Black" Foreground="White">BLACK SHADOW</Button>
+					<Button x:Name="yellowColor" Tag="Yellow" Click="SetColor" Background="Yellow">YELLOW SHADOW</Button>
+					<Button x:Name="redColor" Tag="Red" Click="SetColor" Background="Red">RED SHADOW</Button>
+					<Button x:Name="blueColor" Tag="Blue" Click="SetColor" Background="Blue" Foreground="White">BLUE SHADOW</Button>
+				</StackPanel>
+				<TextBlock FontSize="15">
+					ElevatedView, some with rounded corners...
+				</TextBlock>
+				<StackPanel Orientation="Horizontal" Spacing="10">
+					<toolkit:ElevatedView Width="60" Height="60" Background="Orange" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}" />
+					<toolkit:ElevatedView Width="60" Height="60" Background="Orange" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
+						<Rectangle Fill="Red" />
+					</toolkit:ElevatedView>
+					<toolkit:ElevatedView Width="60" Height="60" CornerRadius="20" Background="Orange" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
+						<Rectangle Fill="Red" Stroke="Blue" StrokeThickness="6" />
+					</toolkit:ElevatedView>
+					<toolkit:ElevatedView Width="60" Height="60" CornerRadius="10,5,10,35" Background="Orange" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
+						<Rectangle Fill="Red" Stroke="Blue" StrokeThickness="6" />
+					</toolkit:ElevatedView>
+				</StackPanel>
+				<TextBlock FontSize="15">
+					ElevatedView with Button in them...
+				</TextBlock>
+				<StackPanel Orientation="Horizontal" Spacing="10">
+					<toolkit:ElevatedView Background="Orange" VerticalAlignment="Top" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
+						<Button>Nice Elevated Button</Button>
+					</toolkit:ElevatedView>
+					<toolkit:ElevatedView Background="White" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
+						<Button Height="120" Width="120">BIG BUTTON</Button>
+					</toolkit:ElevatedView>
+				</StackPanel>
+				<TextBlock FontSize="15">
+					ElevatedView Without background (shouldn't be elevated)
+				</TextBlock>
+				<StackPanel Orientation="Horizontal" Spacing="10">
+					<toolkit:ElevatedView Width="60" Height="60" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
+						<Rectangle Fill="Red" />
+					</toolkit:ElevatedView>
+					<toolkit:ElevatedView Width="60" Height="60" CornerRadius="10,5,10,35" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
+						<Rectangle Fill="Red" />
+					</toolkit:ElevatedView>
+					<toolkit:ElevatedView VerticalAlignment="Top" ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
+						<Button>Nice Elevated Button</Button>
+					</toolkit:ElevatedView>
+					<toolkit:ElevatedView ShadowColor="{Binding Tag, ElementName=elevation1}" Elevation="{Binding Value, ElementName=elevation1}">
+						<Button Height="120" Width="120">BIG BUTTON</Button>
+					</toolkit:ElevatedView>
+				</StackPanel>
+			</StackPanel>
+		</ScrollViewer>
+	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_CornerRadius.cs
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_CornerRadius.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Toolkit
+{
+	[Sample]
+	public sealed partial class ElevatedView_CornerRadius : Page
+	{
+		public ElevatedView_CornerRadius()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_CornerRadius.xaml
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_CornerRadius.xaml
@@ -1,0 +1,61 @@
+﻿<Page
+	x:Class="UITests.Toolkit.ElevatedView_CornerRadius"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:toolkit="using:Uno.UI.Toolkit"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="10" Margin="12">
+		<Slider x:Name="elevation" Minimum="0" Maximum="50" Value="10" />
+		<Slider x:Name="radius" Minimum="0" Maximum="50" Value="25" />
+		<TextBlock FontSize="15">Those elevated views should all be identical</TextBlock>
+
+		<StackPanel Spacing="15" Orientation="Horizontal">
+			<toolkit:ElevatedView
+				Background="Transparent"
+				Elevation="{Binding Value, ElementName=elevation}"
+				Width="120"
+				Height="120"
+				Margin="0,30"
+				CornerRadius="{Binding Value, ElementName=radius}">
+				<Rectangle Fill="Orange" Width="120" Height="120" />
+			</toolkit:ElevatedView>
+			<toolkit:ElevatedView
+				Background="Orange"
+				Elevation="{Binding Value, ElementName=elevation}"
+				Width="120"
+				Height="120"
+				Margin="0,30"
+				CornerRadius="{Binding Value, ElementName=radius}" />
+			<StackPanel Margin="0,30">
+				<toolkit:ElevatedView
+					Background="Orange"
+					Elevation="{Binding Value, ElementName=elevation}"
+					Width="120"
+					Height="120"
+					CornerRadius="{Binding Value, ElementName=radius}" />
+			</StackPanel>
+			<ScrollViewer Padding="30">
+				<toolkit:ElevatedView
+					Background="Orange"
+					Elevation="{Binding Value, ElementName=elevation}"
+					Width="120"
+					Height="120"
+					CornerRadius="{Binding Value, ElementName=radius}" />
+			</ScrollViewer>
+			<ScrollViewer>
+				<toolkit:ElevatedView
+					Background="Orange"
+					Elevation="8"
+					Width="120"
+					Height="120"
+					Margin="0,30"
+					CornerRadius="{Binding Value, ElementName=radius}" />
+			</ScrollViewer>
+		</StackPanel>
+
+</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_Corners.xaml
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_Corners.xaml
@@ -1,0 +1,20 @@
+﻿<Page
+	x:Class="UITests.Toolkit.ElevatedView_Corners"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Toolkit"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	xmlns:toolkit="using:Uno.UI.Toolkit"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Background="White">
+		<toolkit:ElevatedView Width="300" Height="300" Elevation="10" CornerRadius="110" Background="DarkGray" ShadowColor="Red" x:Name="Elevation">
+			<TextBlock VerticalAlignment="Center" Margin="25" Foreground="White" FontWeight="Bold" TextWrapping="Wrap" FontSize="18">
+				This sample is used by automated unit tests to ensure the
+				elevation's drop shadow is drawn properly on all platforms.
+			</TextBlock>
+		</toolkit:ElevatedView>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_Corners.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_Corners.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Toolkit
+{
+	[Sample]
+	public sealed partial class ElevatedView_Corners : Page
+	{
+		public ElevatedView_Corners()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -105,6 +105,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_CornerRadius.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_Dimensions.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3619,6 +3623,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedViewTests.xaml.cs">
       <DependentUpon>ElevatedViewTests.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_CornerRadius.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_Dimensions.xaml.cs">
       <DependentUpon>ElevatedView_Dimensions.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -109,6 +109,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_Corners.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_Dimensions.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3624,6 +3628,9 @@
       <DependentUpon>ElevatedViewTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_CornerRadius.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_Corners.xaml.cs">
+      <DependentUpon>ElevatedView_Corners.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_Dimensions.xaml.cs">
       <DependentUpon>ElevatedView_Dimensions.xaml</DependentUpon>
     </Compile>

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -58,7 +58,6 @@ namespace Uno.UI.Toolkit
 		public ElevatedView()
 		{
 			DefaultStyleKey = typeof(ElevatedView);
-			Background = new SolidColorBrush(Colors.Transparent);
 
 #if !NETFX_CORE
 			Loaded += (snd, evt) => SynchronizeContentTemplatedParent();

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -25,20 +25,20 @@ namespace Uno.UI.Toolkit
 #endif
 	{
 		/*
-		 *  +-ElevatedView------------+
-		 *  |                         |
-		 *  |  +-Grid--------------+  |
-		 *  |  |                   |  |
-		 *  |  +-------------------+  |
-		 *  |  +-Border------------+  |
-		 *  |  |                   |  |
-		 *  |  |  +-Content-----+  |  |
-		 *  |  |  | (...)       |  |  |
-		 *  |  |  +-------------+  |  |
-		 *  |  |                   |  |
-		 *  |  +-------------------+  |
-		 *  |                         |
-		 *  +-------------------------+
+		 *  +-ElevatedView---------------------+
+		 *  |                                  |
+		 *  |  +-Canvas (PART_ShadowHost)---+  |
+		 *  |  |                            |  |
+		 *  |  +----------------------------+  |
+		 *  |  +-Border (PART_Border)-------+  |
+		 *  |  |                            |  |
+		 *  |  |  +-Content--------------+  |  |
+		 *  |  |  | (...)                |  |  |
+		 *  |  |  +----------------------+  |  |
+		 *  |  |                            |  |
+		 *  |  +----------------------------+  |
+		 *  |                                  |
+		 *  +----------------------------------+
 		 *
 		 * UWP - Grid is responsible for the shadow
 		 * Other Platforms - Elevated is responsible for the shadow
@@ -53,7 +53,7 @@ namespace Uno.UI.Toolkit
 #endif
 
 		private Border _border;
-		private Canvas _shadowHost;
+		private Panel _shadowHost;
 
 		public ElevatedView()
 		{
@@ -72,7 +72,7 @@ namespace Uno.UI.Toolkit
 		protected override void OnApplyTemplate()
 		{
 			_border = GetTemplateChild("PART_Border") as Border;
-			_shadowHost = GetTemplateChild("PART_ShadowHost") as Canvas;
+			_shadowHost = GetTemplateChild("PART_ShadowHost") as Panel;
 
 			UpdateElevation();
 		}
@@ -172,6 +172,8 @@ namespace Uno.UI.Toolkit
 #elif __IOS__ || __MACOS__
 				this.SetElevationInternal(Elevation, ShadowColor, _border.BoundsPath);
 #elif __ANDROID__
+				// The elevation must be applied on the border, since
+				// it will get the right shape (with rounded corners)
 				_border.SetElevationInternal(Elevation, ShadowColor);
 #elif NETFX_CORE
 				(ElevatedContent as DependencyObject).SetElevationInternal(Elevation, ShadowColor, _shadowHost as DependencyObject, CornerRadius);

--- a/src/Uno.UI.Toolkit/UIElementExtensions.cs
+++ b/src/Uno.UI.Toolkit/UIElementExtensions.cs
@@ -117,8 +117,9 @@ namespace Uno.UI.Toolkit
 					const double x = 0.25d;
 					const double y = 0.92f * 0.5f; // Looks more accurate than the recommended 0.92f.
 					const double blur = 0.5f;
+					var color = Color.FromArgb((byte)(shadowColor.A * .35), shadowColor.R, shadowColor.G, shadowColor.B);
 
-					var str = $"{(x * elevation).ToStringInvariant()}px {(y * elevation).ToStringInvariant()}px {(blur * elevation).ToStringInvariant()}px {shadowColor.ToCssString()}";
+					var str = $"{(x * elevation).ToStringInvariant()}px {(y * elevation).ToStringInvariant()}px {(blur * elevation).ToStringInvariant()}px {color.ToCssString()}";
 					uiElement.SetStyle("box-shadow", str);
 				}
 				else

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Wasm.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Wasm.csproj
@@ -47,6 +47,11 @@
 		</ProjectReference>
 	</ItemGroup>
 
+	<ItemGroup>
+		<Page Remove="Themes\Generic.xaml" />
+		<Page Include="Themes\Generic.xaml" />
+	</ItemGroup>
+
 	<!-- Override existing target, this project cannot be published -->
 	<Target Name="Publish" />
 

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -100,7 +100,8 @@
 		<None Include="$(MSBuildThisFileDirectory)**/*.xaml" Exclude="bin/**/*.xaml;obj/**/*.xaml" />
 
 		<!-- Remove all xaml files as netstandard2.0 is the reference target and won't be used at runtime -->
-		<Page Remove="@(Page)" />
+		<PageToRemove Remove="@(Page)" />
+		<Page Remove="@(PageToRemove)" />
 	</ItemGroup>
 
 	<!-- Override existing target, this project cannot be published -->

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.Android.cs
@@ -55,6 +55,7 @@ namespace Windows.UI.Xaml.Controls
 			SetForegroundGravity(GravityFlags.Fill);
 
 			SetClipToPadding(false);
+			SetClipChildren(false);
 			ScrollBarStyle = ScrollbarStyles.OutsideOverlay; // prevents padding from affecting scrollbar position
 
 			_layouter = new ScrollViewerLayouter(this);


### PR DESCRIPTION
Fixes https://github.com/unoplatform/nventive-private/issues/31
# Bugfix

[Android] `NativeScrollViewerPresenter` were clipping its children. This is the role of the `ScrollViewer` itself, not the presenter.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
