### PR TITLE
Fix memory issues, enable XAML ScrollBar on Wasm ScrollViewer

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -819,6 +819,9 @@ description:
 				RecentSamples = recents;
 			}
 
+			GC.Collect(2);
+			GC.WaitForPendingFinalizers();
+
 			return container;
 		}
 

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.cs
@@ -30,17 +30,8 @@ namespace Private.Infrastructure
 
 			internal static async Task WaitForIdle()
 			{
-#if __WASM__
-				await Task.Yield();
-#else
-				await Task.Yield();
-				var tcs = new TaskCompletionSource<bool>();
-				await RootControl.Dispatcher.RunIdleAsync(_ => tcs.SetResult(true));
-				tcs = new TaskCompletionSource<bool>();
-				await RootControl.Dispatcher.RunIdleAsync(_ => tcs.SetResult(true));
-
-				await tcs.Task;
-#endif
+				await RootControl.Dispatcher.RunIdleAsync(_ => { /* Empty to wait for the idle queue to be reached */ });
+				await RootControl.Dispatcher.RunIdleAsync(_ => { /* Empty to wait for the idle queue to be reached */ });
 			}
 
 			/// <summary>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -19,7 +19,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 	[RunsOnUIThread]
 	public class Given_FrameworkElement_And_Leak
 	{
-#if !__WASM__ // Deactivated until https://github.com/unoplatform/uno/pull/3728 is merged
 		[TestMethod]
 		[DataRow(typeof(XamlEvent_Leak_UserControl), 15)]
 		[DataRow(typeof(XamlEvent_Leak_UserControl_xBind), 15)]
@@ -45,7 +44,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(typeof(Border), 15)]
 		[DataRow(typeof(ContentControl), 15)]
 		[DataRow(typeof(ContentDialog), 15)]
-#endif
 		public async Task When_Add_Remove(Type controlType, int count)
 		{
 			var _holders = new ConditionalWeakTable<FrameworkElement, Holder>();
@@ -69,7 +67,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				rootContainer.Content = null;
 				GC.Collect();
 				GC.WaitForPendingFinalizers();
-				await Task.Yield();
+
+				// Waiting for idle is required for collection of
+				// DispatcherConditionalDisposable to be executed
+				await TestServices.WindowHelper.WaitForIdle();
 			}
 
 			void HolderUpdate(int value)
@@ -90,7 +91,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			{
 				GC.Collect();
 				GC.WaitForPendingFinalizers();
-				await Task.Yield();
+
+				// Waiting for idle is required for collection of
+				// DispatcherConditionalDisposable to be executed
+				await TestServices.WindowHelper.WaitForIdle();
 			}
 
 			Assert.AreEqual(0, activeControls);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.xaml
@@ -50,7 +50,7 @@
 						BorderBrush="{TemplateBinding BorderBrush}"
 						BorderThickness="{TemplateBinding BorderThickness}"
 						CornerRadius="{TemplateBinding CornerRadius}">
-						<skia:VisualStateManager.VisualStateGroups>
+						<netstdref:VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="ScrollingIndicatorStates">
 								<VisualStateGroup.Transitions>
 									<VisualTransition From="MouseIndicator" To="NoIndicator">
@@ -245,25 +245,25 @@
 									</Storyboard>
 								</VisualState>
 							</VisualStateGroup>
-						</skia:VisualStateManager.VisualStateGroups>
+						</netstdref:VisualStateManager.VisualStateGroups>
 
 						<Grid Background="{TemplateBinding Background}" x:Name="Root">
-							<skia:Grid.ColumnDefinitions>
+							<netstdref:Grid.ColumnDefinitions>
 								<ColumnDefinition Width="*" />
 								<ColumnDefinition Width="Auto" />
-							</skia:Grid.ColumnDefinitions>
-							<skia:Grid.RowDefinitions>
+							</netstdref:Grid.ColumnDefinitions>
+							<netstdref:Grid.RowDefinitions>
 								<RowDefinition Height="*" />
 								<RowDefinition Height="Auto" />
-							</skia:Grid.RowDefinitions>
+							</netstdref:Grid.RowDefinitions>
 							<!-- ContentTemplate not yet supported for ScrollContentPresenter-->
 							<ScrollContentPresenter
 								x:Name="ScrollContentPresenter"
-								skia:Grid.RowSpan="2"
-								skia:Grid.ColumnSpan="2"
+								netstdref:Grid.RowSpan="2"
+								netstdref:Grid.ColumnSpan="2"
 								Margin="{TemplateBinding Padding}" />
 
-							<skia:ScrollBar
+							<netstdref:ScrollBar
 								x:Name="VerticalScrollBar"
 								Grid.Column="1"
 								IsTabStop="False"
@@ -275,7 +275,7 @@
 								HorizontalAlignment="Right"
 								skia:Width="16"/>
 
-							<skia:ScrollBar
+							<netstdref:ScrollBar
 								x:Name="HorizontalScrollBar"
 								IsTabStop="False"
 								Maximum="{TemplateBinding ScrollableWidth}"
@@ -286,7 +286,7 @@
 								ViewportSize="{TemplateBinding ViewportWidth}"
 								skia:Height="16"/>
 
-							<skia:Border
+							<netstdref:Border
 								x:Name="ScrollBarSeparator"
 								Grid.Row="1"
 								Grid.Column="1"

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -209,7 +209,10 @@ namespace Windows.UI.Xaml
 			}
 
 #if USE_HARD_REFERENCES
-			_activeInstances.Add(instance);
+			if (IsPoolingEnabled)
+			{
+				_activeInstances.Add(instance);
+			}
 #endif
 			return instance;
 		}
@@ -233,6 +236,11 @@ namespace Windows.UI.Xaml
 
 		private void OnParentChanged(object instance, object? key, DependencyObjectParentChangedEventArgs? args)
 		{
+			if (!IsPoolingEnabled)
+			{
+				return;
+			}
+
 			var list = GetTemplatePool(key as FrameworkTemplate ?? throw new InvalidOperationException($"Received {key} but expecting {typeof(FrameworkElement)}"));
 
 			if (args?.NewParent == null)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4167, fixes https://github.com/unoplatform/uno/issues/3783

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the new behavior?

- Restore the managed `ScrollBar` in default`ScrollViewer`
- Adjust `WindowHelper.WaitForIdle` to actually wait for Idle on Wasm
- Adjust `SampleChooserViewModel` to run a GC collect after setting a sample
- Fix `TemplatePooling` may still be active when disabled
- Fix Leak runtime tests and wait for Idle for the GC to run properly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
