### PR TITLE
fix[Android]: Drawable error message made more clear

### DIFF
--- a/src/Uno.UWP/Helpers/DrawableHelper.Android.cs
+++ b/src/Uno.UWP/Helpers/DrawableHelper.Android.cs
@@ -37,7 +37,8 @@ namespace Uno.Helpers
 			var key = AndroidResourceNameEncoder.Encode(System.IO.Path.GetFileNameWithoutExtension(imageName));
 			if (_drawablesLookup == null)
 			{
-				throw new Exception("Drawable resources were not initialized.");
+				throw new InvalidOperationException("Drawable resources were not initialized. "
+					+ "On Android, local assets are only available after App.InitializeComponent() has been called.");
 			}
 			var id = _drawablesLookup.UnoGetValueOrDefault(key, 0);
 			if (id == 0)


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #4204 

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)


## What is the current behavior?

## What is the new behavior?

`InvalidOperationException` is thrown instead of `Exception` as specified in the issue.
Error message is more clear now, as it specifies why the error may have happened.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~Validated PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

Internal Issue (If applicable):