### PR TITLE
docs: Update conditional code/Xaml to include Skia

### DIFF
--- a/doc/articles/platform-specific-csharp.md
+++ b/doc/articles/platform-specific-csharp.md
@@ -1,6 +1,6 @@
 # Platform-specific C# code in Uno
 
-Uno allows you to reuse views and business logic across platforms. Sometimes though you may want to write different code per platform, either because you need to access platform-specific native APIs and 3rd-party libraries, or because you want your app to look and behave differently depending on the platform. 
+Uno allows you to reuse views and business logic across platforms. Sometimes though you may want to write different code per platform. You may need to access platform-specific native APIs and 3rd-party libraries, or want your app to look and behave differently depending on the platform. 
 
 This guide covers multiple approaches to managing per-platform code in C#. See [this guide for managing per-platform XAML](platform-specific-xaml.md).
 
@@ -34,6 +34,7 @@ The structure of an Uno app created with the default [Visual Studio template](ht
  | iOS         | `__IOS__`     |
  | WebAssembly | `__WASM__`    |
  | MacOS       | `__MACOS__`   |
+ | Skia        | `__SKIA__`    |
  
 Note that you can combine conditionals with boolean operators, e.g. `#if __ANDROID__ || __IOS__`. 
 

--- a/doc/articles/platform-specific-xaml.md
+++ b/doc/articles/platform-specific-xaml.md
@@ -99,7 +99,7 @@ The pre-defined prefixes are listed below:
 | Prefix        | Included platforms                 | Excluded platforms                 | Namespace                                                   | Put in `mc:Ignorable`? |
 |---------------|------------------------------------|------------------------------------|-------------------------------------------------------------|------------------------|
 | `win`         | Windows                            | Android, iOS, web, macOS, Skia     | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
-| `xamarin`     | Android, iOS, web, macOS           | Windows, Skia                      | `http:/uno.ui/xamarin`                                      | yes                    |
+| `xamarin`     | Android, iOS, web, macOS, Skia     | Windows                            | `http:/uno.ui/xamarin`                                      | yes                    |
 | `not_win`     | Android, iOS, web, macOS, Skia     | Windows                            | `http:/uno.ui/not_win`                                      | yes                    |
 | `android`     | Android                            | Windows, iOS, web, macOS, Skia     | `http:/uno.ui/android`                                      | yes                    |
 | `ios`         | iOS                                | Windows, Android, web, macOS, Skia | `http:/uno.ui/ios`                                          | yes                    |
@@ -122,7 +122,7 @@ More visually, platform support for the pre-defined prefixes is shown in the bel
 | `wasm`        | ✖ | ✖ | ✖ | ✔ | ✖ | ✖ |
 | `macos`       | ✖ | ✖ | ✖ | ✖ | ✔ | ✖ |
 | `skia`        | ✖ | ✖ | ✖ | ✖ | ✖ | ✔ |
-| `xamarin`     | ✖ | ✔ | ✔ | ✔ | ✔ | ✖ |
+| `xamarin`     | ✖ | ✔ | ✔ | ✔ | ✔ | ✔ |
 | `not_win`     | ✖ | ✔ | ✔ | ✔ | ✔ | ✔ |
 | `not_android` | ✔ | ✖ | ✔ | ✔ | ✔ | ✔ |
 | `not_ios`     | ✔ | ✔ | ✖ | ✔ | ✔ | ✔ |

--- a/doc/articles/platform-specific-xaml.md
+++ b/doc/articles/platform-specific-xaml.md
@@ -96,16 +96,17 @@ Consider the following XAML which is using the Windows Community Toolkit's [Blur
 
 The pre-defined prefixes are listed below:
 
-| Prefix        | Included platforms           | Excluded platforms           | Namespace                                                   | Put in `mc:Ignorable`? |
-|---------------|------------------------------|------------------------------|-------------------------------------------------------------|------------------------|
-| `win`         | Windows                      | Android, iOS, web, macOS     | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
-| `xamarin`     | Android, iOS, web, macOS     | Windows                      | `http:/uno.ui/xamarin`                | yes                    |
-| `not_win`     | Android, iOS, web, macOS     | Windows                      | `http:/uno.ui/not_win`                | yes                    |
-| `android`     | Android                      | Windows, iOS, web, macOS     | `http:/uno.ui/android`                | yes                    |
-| `ios`         | iOS                          | Windows, Android, web, macOS | `http:/uno.ui/ios`                    | yes                    |
-| `wasm`        | web                          | Windows, Android, iOS, macOS | `http:/uno.ui/wasm`                   | yes                    |
-| `macos`       | macOS                        | Windows, Android, iOS, web   | `http:/uno.ui/macos`                  | yes                    |
-| `not_android` | Windows, iOS, web, macOS     | Android                      | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
-| `not_ios`     | Windows, Android, web, macOS | iOS                          | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
-| `not_wasm`    | Windows, Android, iOS, macOS | web                          | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
-| `not_macos`   | Windows, Android, iOS, web   | macOS                        | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
+| Prefix        | Included platforms                 | Excluded platforms                 | Namespace                                                   | Put in `mc:Ignorable`? |
+|---------------|------------------------------------|------------------------------------|-------------------------------------------------------------|------------------------|
+| `win`         | Windows                            | Android, iOS, web, macOS, Skia     | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
+| `xamarin`     | Android, iOS, web, macOS           | Windows, Skia                      | `http:/uno.ui/xamarin`                                      | yes                    |
+| `not_win`     | Android, iOS, web, macOS, Skia     | Windows                            | `http:/uno.ui/not_win`                                      | yes                    |
+| `android`     | Android                            | Windows, iOS, web, macOS, Skia     | `http:/uno.ui/android`                                      | yes                    |
+| `ios`         | iOS                                | Windows, Android, web, macOS, Skia | `http:/uno.ui/ios`                                          | yes                    |
+| `wasm`        | web                                | Windows, Android, iOS, macOS, Skia | `http:/uno.ui/wasm`                                         | yes                    |
+| `macos`       | macOS                              | Windows, Android, iOS, web, Skia   | `http:/uno.ui/macos`                                        | yes                    |
+| `not_android` | Windows, iOS, web, macOS, Skia     | Android                            | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
+| `not_ios`     | Windows, Android, web, macOS, Skia | iOS                                | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
+| `not_wasm`    | Windows, Android, iOS, macOS, Skia | web                                | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
+| `not_macos`   | Windows, Android, iOS, web, Skia   | macOS                              | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
+| `not_skia`    | Windows, Android, iOS, web, macOS  | Skia                               | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |

--- a/doc/articles/platform-specific-xaml.md
+++ b/doc/articles/platform-specific-xaml.md
@@ -105,8 +105,31 @@ The pre-defined prefixes are listed below:
 | `ios`         | iOS                                | Windows, Android, web, macOS, Skia | `http:/uno.ui/ios`                                          | yes                    |
 | `wasm`        | web                                | Windows, Android, iOS, macOS, Skia | `http:/uno.ui/wasm`                                         | yes                    |
 | `macos`       | macOS                              | Windows, Android, iOS, web, Skia   | `http:/uno.ui/macos`                                        | yes                    |
+| `skia`        | Skia                               | Windows, Android, iOS, web, macOs  | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
 | `not_android` | Windows, iOS, web, macOS, Skia     | Android                            | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
 | `not_ios`     | Windows, Android, web, macOS, Skia | iOS                                | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
 | `not_wasm`    | Windows, Android, iOS, macOS, Skia | web                                | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
 | `not_macos`   | Windows, Android, iOS, web, Skia   | macOS                              | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
 | `not_skia`    | Windows, Android, iOS, web, macOS  | Skia                               | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
+
+More visually, platform support for the pre-defined prefixes is shown in the below table:
+
+| Prefix        |  Win  | Droid |  iOS  |  Web  | macOS | Skia  | 
+|---------------|-------|-------|-------|-------|-------|-------|
+| `win`         | ✔ | ✖ | ✖ | ✖ | ✖ | ✖ |
+| `android`     | ✖ | ✔ | ✖ | ✖ | ✖ | ✖ |
+| `ios`         | ✖ | ✖ | ✔ | ✖ | ✖ | ✖ |
+| `wasm`        | ✖ | ✖ | ✖ | ✔ | ✖ | ✖ |
+| `macos`       | ✖ | ✖ | ✖ | ✖ | ✔ | ✖ |
+| `skia`        | ✖ | ✖ | ✖ | ✖ | ✖ | ✔ |
+| `xamarin`     | ✖ | ✔ | ✔ | ✔ | ✔ | ✖ |
+| `not_win`     | ✖ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| `not_android` | ✔ | ✖ | ✔ | ✔ | ✔ | ✔ |
+| `not_ios`     | ✔ | ✔ | ✖ | ✔ | ✔ | ✔ |
+| `not_wasm`    | ✔ | ✔ | ✔ | ✖ | ✔ | ✔ |
+| `not_macos`   | ✔ | ✔ | ✔ | ✔ | ✖ | ✔ |
+| `not_skia`    | ✔ | ✔ | ✔ | ✔ | ✔ | ✖ |
+
+Where:
+ * 'Win' represents Windows, and
+ * 'Droid' represents Android


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

Skia is excluded from condition code and Xaml docs.

## What is the new behavior?

Skia is included.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~
- [ ] ~Validated PR `Screenshots Compare Test Run` results.~
- [x] Contains **NO** breaking changes
- [ ] ~Associated with an issue (GitHub or internal) and uses the [automatic close keywords]~(https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

* Someone needs to double check the pre-defined prefixes table for conditional Xaml. I added Skia for all entries and made some assumptions (like `xamarin` should exclude Skia).
