### PR TITLE
First <Setter> on a <Style> were potentially applying values using wrong precedence

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
@@ -1578,8 +1578,6 @@ namespace Uno.UI.Tests.BinderTests
 			sut.Tag.Should().BeNull("Before applying style");
 
 			sut.Tag = style;
-
-			sut.Style = style;
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
@@ -165,6 +165,23 @@ namespace Windows.UI.Xaml
 		}
 
 		/// <summary>
+		/// The the value for all precedences.
+		/// </summary>
+		/// <remarks>
+		/// This should only be used for diagnostics and testing purposes.
+		/// </remarks>
+		internal static (object value, DependencyPropertyValuePrecedences precedence)[] GetValueForEachPrecedences(
+			this DependencyObject instance, DependencyProperty property)
+		{
+			var propertyDetails = GetStore(instance).GetPropertyDetails(property).ToList();
+
+			return Enum.GetValues(typeof(DependencyPropertyValuePrecedences))
+				.Cast<DependencyPropertyValuePrecedences>()
+				.Select(precedence => (propertyDetails[(int)precedence], precedence))
+				.ToArray();
+		}
+
+		/// <summary>
 		/// Clears the value for the specified dependency property on the specified instance.
 		/// </summary>
 		/// <param name="instance">The instance on which the property is attached</param>

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -347,7 +347,11 @@ namespace Windows.UI.Xaml
 
 		public void SetResourceBinding(DependencyProperty dependencyProperty, object resourceKey, bool isTheme, object context)
 		{
-			var binding = new ResourceBinding(resourceKey, isTheme, context, _precedenceOverride ?? DependencyPropertyValuePrecedences.Local);
+			var precedence = _overridenPrecedences?.Count > 0
+				? _overridenPrecedences.Peek()
+				: default;
+
+			var binding = new ResourceBinding(resourceKey, isTheme, context, precedence ?? DependencyPropertyValuePrecedences.Local);
 			SetBinding(dependencyProperty, binding);
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -347,8 +347,8 @@ namespace Windows.UI.Xaml
 
 		public void SetResourceBinding(DependencyProperty dependencyProperty, object resourceKey, bool isTheme, object context)
 		{
-			var precedence = _overridenPrecedences?.Count > 0
-				? _overridenPrecedences.Peek()
+			var precedence = _overriddenPrecedences?.Count > 0
+				? _overriddenPrecedences.Peek()
 				: default;
 
 			var binding = new ResourceBinding(resourceKey, isTheme, context, precedence ?? DependencyPropertyValuePrecedences.Local);

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -92,7 +92,7 @@ namespace Windows.UI.Xaml
 		private readonly SerialDisposable _inheritedProperties = new SerialDisposable();
 		private ManagedWeakReference? _parentRef;
 		private readonly Dictionary<DependencyProperty, ManagedWeakReference> _inheritedForwardedProperties = new Dictionary<DependencyProperty, ManagedWeakReference>(DependencyPropertyComparer.Default);
-		private Stack<DependencyPropertyValuePrecedences?>? _overridenPrecedences;
+		private Stack<DependencyPropertyValuePrecedences?>? _overriddenPrecedences;
 
 		private static long _propertyChangedToken = 0;
 		private readonly Dictionary<long, IDisposable> _propertyChangedTokens = new Dictionary<long, IDisposable>();
@@ -314,22 +314,22 @@ namespace Windows.UI.Xaml
 		/// <returns>A disposable to dispose to cancel the override.</returns>
 		internal IDisposable? OverrideLocalPrecedence(DependencyPropertyValuePrecedences? precedence)
 		{
-			_overridenPrecedences ??= new Stack<DependencyPropertyValuePrecedences?>(2);
-			if (_overridenPrecedences.Count > 0 && _overridenPrecedences.Peek() == precedence)
+			_overriddenPrecedences ??= new Stack<DependencyPropertyValuePrecedences?>(2);
+			if (_overriddenPrecedences.Count > 0 && _overriddenPrecedences.Peek() == precedence)
 			{
 				return null; // this precedence is already set, no need to set a new one
 			}
 
-			_overridenPrecedences.Push(precedence);
+			_overriddenPrecedences.Push(precedence);
 
 			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 			{
-				this.Log().Debug($"OverrideLocalPrecedence({precedence}) - stack is {string.Join(", ", _overridenPrecedences)}");
+				this.Log().Debug($"OverrideLocalPrecedence({precedence}) - stack is {string.Join(", ", _overriddenPrecedences)}");
 			}
 
 			return Disposable.Create(() =>
 			{
-				var popped = _overridenPrecedences.Pop();
+				var popped = _overriddenPrecedences.Pop();
 				if (popped != precedence)
 				{
 					throw new InvalidOperationException($"Error while unstacking precedence. Should be {precedence}, got {popped}.");
@@ -337,7 +337,7 @@ namespace Windows.UI.Xaml
 
 				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 				{
-					var newPrecedence = _overridenPrecedences.Count == 0 ? "<none>" : _overridenPrecedences.Peek().ToString();
+					var newPrecedence = _overriddenPrecedences.Count == 0 ? "<none>" : _overriddenPrecedences.Peek().ToString();
 					this.Log().Debug($"OverrideLocalPrecedence({precedence}).Dispose() ==> new overriden precedence is {newPrecedence})");
 				}
 			});
@@ -595,9 +595,9 @@ namespace Windows.UI.Xaml
 		private IDisposable? ApplyPrecedenceOverride(ref DependencyPropertyValuePrecedences precedence)
 		{
 			var currentlyOverridenPrecedence =
-				_overridenPrecedences?.Count > 0
-					? _overridenPrecedences.Peek()
-					: default(DependencyPropertyValuePrecedences?);
+				_overriddenPrecedences?.Count > 0
+					? _overriddenPrecedences.Peek()
+					: default;
 
 			if (currentlyOverridenPrecedence is {} current)
 			{

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -48,7 +48,7 @@ namespace Windows.UI.Xaml
 	{
 		public static class TraceProvider
 		{
-			public readonly static Guid Id = Guid.Parse("{430FC851-E917-4587-AF7B-5A1CE5A1941D}");
+			public static readonly Guid Id = Guid.Parse("{430FC851-E917-4587-AF7B-5A1CE5A1941D}");
 			public const int GetValue = 1;
 			public const int SetValueStart = 2;
 			public const int SetValueStop = 3;
@@ -57,8 +57,7 @@ namespace Windows.UI.Xaml
 			public const int DataContextChangedStop = 6;
 		}
 
-		private readonly static IEventProvider _trace = Tracing.Get(TraceProvider.Id);
-
+		private static readonly IEventProvider _trace = Tracing.Get(TraceProvider.Id);
 
 		/// <summary>
 		/// A global static counter that is used to uniquely identify objects.
@@ -90,18 +89,18 @@ namespace Windows.UI.Xaml
 		private ManagedWeakReference? _thisWeakRef;
 
 		private readonly Type _originalObjectType;
-		private SerialDisposable _inheritedProperties = new SerialDisposable();
+		private readonly SerialDisposable _inheritedProperties = new SerialDisposable();
 		private ManagedWeakReference? _parentRef;
-		private Dictionary<DependencyProperty, ManagedWeakReference> _inheritedForwardedProperties = new Dictionary<DependencyProperty, ManagedWeakReference>(DependencyPropertyComparer.Default);
-		private DependencyPropertyValuePrecedences? _precedenceOverride;
+		private readonly Dictionary<DependencyProperty, ManagedWeakReference> _inheritedForwardedProperties = new Dictionary<DependencyProperty, ManagedWeakReference>(DependencyPropertyComparer.Default);
+		private Stack<DependencyPropertyValuePrecedences?>? _overridenPrecedences;
 
 		private static long _propertyChangedToken = 0;
-		private Dictionary<long, IDisposable> _propertyChangedTokens = new Dictionary<long, IDisposable>();
+		private readonly Dictionary<long, IDisposable> _propertyChangedTokens = new Dictionary<long, IDisposable>();
 
 		private bool _registeringInheritedProperties;
 		private bool _unregisteringInheritedProperties;
 
-		private static bool _validatePropertyOwner = Debugger.IsAttached;
+		private static readonly bool _validatePropertyOwner = Debugger.IsAttached;
 
 		private uint _propertySettingDepth;
 
@@ -307,48 +306,47 @@ namespace Windows.UI.Xaml
 			return _properties.GetPropertyDetails(property).CurrentHighestValuePrecedence;
 		}
 
-
 		/// <summary>
 		/// Creates a SetValue precedence scoped override. All calls to SetValue
 		/// on the specified instance will be set to the specified precedence.
 		/// </summary>
-		/// <param name="instance">The instance to override</param>
 		/// <param name="precedence">The precedence to set</param>
 		/// <returns>A disposable to dispose to cancel the override.</returns>
-		internal IDisposable? OverrideLocalPrecedence(DependencyPropertyValuePrecedences precedence)
+		internal IDisposable? OverrideLocalPrecedence(DependencyPropertyValuePrecedences? precedence)
 		{
-			if (_precedenceOverride != null)
+			_overridenPrecedences ??= new Stack<DependencyPropertyValuePrecedences?>(2);
+			if (_overridenPrecedences.Count > 0 && _overridenPrecedences.Peek() == precedence)
 			{
-				// Keep the current precedence override, which affects application of styles
-				// with BasedOn set.
-				return null;
+				return null; // this precedence is already set, no need to set a new one
 			}
-			else
+
+			_overridenPrecedences.Push(precedence);
+
+			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 			{
-				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				this.Log().Debug($"OverrideLocalPrecedence({precedence}) - stack is {string.Join(", ", _overridenPrecedences)}");
+			}
+
+			return Disposable.Create(() =>
+			{
+				var popped = _overridenPrecedences.Pop();
+				if (popped != precedence)
 				{
-					this.Log().Debug($"OverrideLocalPrecedence({precedence})");
+					throw new InvalidOperationException($"Error while unstacking precedence. Should be {precedence}, got {popped}.");
 				}
 
-				_precedenceOverride = precedence;
-
-				return Disposable.Create(() =>
+				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 				{
-
-					_precedenceOverride = null;
-
-					if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
-					{
-						this.Log().Debug("OverrideLocalPrecedence(None)");
-					}
-				});
-			}
+					var newPrecedence = _overridenPrecedences.Count == 0 ? "<none>" : _overridenPrecedences.Peek().ToString();
+					this.Log().Debug($"OverrideLocalPrecedence({precedence}).Dispose() ==> new overriden precedence is {newPrecedence})");
+				}
+			});
 		}
 
-		private static List<DependencyPropertyPath> _propagationBypass =
+		private static readonly List<DependencyPropertyPath> _propagationBypass =
 			new List<DependencyPropertyPath>();
 
-		private static Dictionary<DependencyPropertyPath, object> _propagationBypassed =
+		private static readonly Dictionary<DependencyPropertyPath, object> _propagationBypassed =
 			new Dictionary<DependencyPropertyPath, object>(DependencyPropertyPath.Comparer.Default);
 
 		internal static IDisposable? BypassPropagation(DependencyObject instance, DependencyProperty property)
@@ -434,8 +432,7 @@ namespace Windows.UI.Xaml
 
 			if (actualInstanceAlias != null)
 			{
-				ApplyPrecedenceOverride(ref precedence);
-				_propertySettingDepth++;
+				var overrideDisposable = ApplyPrecedenceOverride(ref precedence);
 
 #if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/mono/mono/issues/13653
 				try
@@ -449,7 +446,7 @@ namespace Windows.UI.Xaml
 					ValidatePropertyOwner(property);
 
 					// Resolve the stack once for the instance, for performance.
-					propertyDetails = propertyDetails ?? _properties.GetPropertyDetails(property);
+					propertyDetails ??= _properties.GetPropertyDetails(property);
 
 					var previousValue = GetValue(propertyDetails);
 					var previousPrecedence = GetCurrentHighestValuePrecedence(propertyDetails);
@@ -486,7 +483,7 @@ namespace Windows.UI.Xaml
 				finally
 #endif
 				{
-					_propertySettingDepth--;
+					overrideDisposable?.Dispose();
 				}
 			}
 			else
@@ -592,33 +589,26 @@ namespace Windows.UI.Xaml
 		/// Applies the precedence override that has been set through <seealso cref="OverrideLocalPrecedence(object, DependencyPropertyValuePrecedences)" />
 		/// Used to ambiently change the precedence specified when using standard DependencyProperty accessors, particularly when applying styles.
 		/// </summary>
-		/// <param name="property">The property being set</param>
-		/// <param name="value"></param>
 		/// <param name="precedence"></param>
 		/// <returns></returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private void ApplyPrecedenceOverride(ref DependencyPropertyValuePrecedences precedence)
+		private IDisposable? ApplyPrecedenceOverride(ref DependencyPropertyValuePrecedences precedence)
 		{
-			if(_precedenceOverride == DependencyPropertyValuePrecedences.ExplicitStyle)
-			{
-				// **WHEN OVERRIDE IS SET ON EXPLICIT STYLE**
-				// It means we need to propagate the "ExplicitStyle" precedence for the styling system to work well:
-				// we don't want style's setters to overwrite local values.
-			}
-			else if (!_precedenceOverride.HasValue || _propertySettingDepth > 0)
-			{
-				// We only want to override the precedence of properties set directly from a style. Nested sets (within property changed callbacks, etc)
-				// should be applied with the normal (usually "local") precedence.
+			var currentlyOverridenPrecedence =
+				_overridenPrecedences?.Count > 0
+					? _overridenPrecedences.Peek()
+					: default(DependencyPropertyValuePrecedences?);
 
-				return;
-			}
-
-			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+			if (currentlyOverridenPrecedence is {} current)
 			{
-				this.Log().Debug($"Overriding {precedence} precedence with {_precedenceOverride}.");
+				precedence = current;
+
+				// The ambient precedence is also set to "Local" for affected properties
+				// (that means if properties are set in any callback, this override won't apply)
+				return OverrideLocalPrecedence(null);
 			}
 
-			precedence = _precedenceOverride.Value;
+			return null;
 		}
 
 		/// <summary>
@@ -662,9 +652,7 @@ namespace Windows.UI.Xaml
 
 		public void UnregisterPropertyChangedCallback(DependencyProperty property, long token)
 		{
-			IDisposable registration;
-
-			if (_propertyChangedTokens.TryGetValue(token, out registration))
+			if (_propertyChangedTokens.TryGetValue(token, out var registration))
 			{
 				registration.Dispose();
 
@@ -676,7 +664,7 @@ namespace Windows.UI.Xaml
 		{
 			var weakDelegate = CreateWeakDelegate(callback);
 
-			propertyDetails = propertyDetails ?? _properties.GetPropertyDetails(property);
+			propertyDetails ??= _properties.GetPropertyDetails(property);
 
 			var cookie = propertyDetails.CallbackManager.RegisterCallback(weakDelegate.callback);
 
@@ -935,19 +923,19 @@ namespace Windows.UI.Xaml
 
 		private readonly struct InheritedPropertiesDisposable : IDisposable
 		{
-			private readonly IDisposable InheritedPropertiesCallback;
-			private readonly DependencyObjectStore Owner;
+			private readonly IDisposable _inheritedPropertiesCallback;
+			private readonly DependencyObjectStore _owner;
 
 			public InheritedPropertiesDisposable(DependencyObjectStore owner, IDisposable inheritedPropertiesCallback)
 			{
-				Owner = owner;
-				InheritedPropertiesCallback = inheritedPropertiesCallback;
+				_owner = owner;
+				_inheritedPropertiesCallback = inheritedPropertiesCallback;
 			}
 
 			public void Dispose()
 			{
-				InheritedPropertiesCallback.Dispose();
-				Owner.CleanupInheritedProperties();
+				_inheritedPropertiesCallback.Dispose();
+				_owner.CleanupInheritedProperties();
 			}
 		}
 
@@ -1063,26 +1051,26 @@ namespace Windows.UI.Xaml
 
 			var bindings = _resourceBindings.GetAllBindings().ToList(); //The original collection may be mutated during DP assignations
 
-			foreach (var tuple in bindings)
+			foreach (var (property, binding) in bindings)
 			{
 				try
 				{
 					var wasSet = false;
 					foreach (var dict in dictionariesInScope)
 					{
-						if (dict.TryGetValue(tuple.Binding.ResourceKey, out var value, shouldCheckSystem: false))
+						if (dict.TryGetValue(binding.ResourceKey, out var value, shouldCheckSystem: false))
 						{
 							wasSet = true;
-							SetValue(tuple.Property, BindingPropertyHelper.Convert(() => tuple.Property.Type, value), tuple.Binding.Precedence);
+							SetValue(property, BindingPropertyHelper.Convert(() => property.Type, value), binding.Precedence);
 							break;
 						}
 					}
 
-					if (!wasSet && isThemeChangedUpdate && tuple.Binding.IsThemeResourceExtension)
+					if (!wasSet && isThemeChangedUpdate && binding.IsThemeResourceExtension)
 					{
-						if (ResourceResolver.TryTopLevelRetrieval(tuple.Binding.ResourceKey, tuple.Binding.ParseContext, out var value))
+						if (ResourceResolver.TryTopLevelRetrieval(binding.ResourceKey, binding.ParseContext, out var value))
 						{
-							SetValue(tuple.Property, BindingPropertyHelper.Convert(() => tuple.Property.Type, value), tuple.Binding.Precedence);
+							SetValue(property, BindingPropertyHelper.Convert(() => property.Type, value), binding.Precedence);
 						}
 					}
 				}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -102,8 +102,6 @@ namespace Windows.UI.Xaml
 
 		private static readonly bool _validatePropertyOwner = Debugger.IsAttached;
 
-		private uint _propertySettingDepth;
-
 		/// <summary>
 		/// Provides the parent Dependency Object of this dependency object
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -846,6 +846,11 @@ namespace Windows.UI.Xaml
 			return stack.GetValueUnderPrecedence(precedence);
 		}
 
+		internal DependencyPropertyDetails GetPropertyDetails(DependencyProperty property)
+		{
+			return _properties.GetPropertyDetails(property);
+		}
+
 		// Keep a list of inherited properties that have been updated so they can be reset.
 		HashSet<DependencyProperty> _updatedProperties = new HashSet<DependencyProperty>(DependencyPropertyComparer.Default);
 

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml
 	{
 		private DependencyPropertyValuePrecedences _highestPrecedence = DependencyPropertyValuePrecedences.DefaultValue;
 		private BindingExpression _lastBindings;
-		private readonly static ArrayPool<object> _pool = ArrayPool<object>.Create(100, 100);
+		private static readonly ArrayPool<object> _pool = ArrayPool<object>.Create(100, 100);
 		private readonly object[] _stack;
 		private readonly bool _hasWeakStorage;
 		private readonly List<BindingExpression> _bindings = new List<BindingExpression>();


### PR DESCRIPTION
# Bugfix
There's a mechanism in Uno to force all properties set during a _property changed_ callback to be set using the `Local` precedence. This is correct for all cases except one: when this property itself is the `Style`. In this case, the _property changed_ MUST apply the `ExplicitStyle` precedence.

Details: in the previous version, while manually setting the Style property (which uses Local precedence), it was setting both _precedenceOverride to ExplicitStyle and the _isSettingAProperty to true, preventing the setters from applying there values under correct explicit precedence.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- ~~[ ] Validated PR `Screenshots Compare Test Run` results.~~
- [X] Contains **NO** breaking changes **I HOPE**
- ~~[ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords]~~(https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
