### PR TITLE
feat(storage): Improve coverage of the Windows.Storage namespace

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3068,9 +3068,9 @@
 	</IgnoreSet>
 	<IgnoreSet baseVersion="3.0.17">
 		<Methods>
-      		<Member 
-			  	fullName="System.Void Windows.System.UserProfile.UserProfilePersonalizationSettings..ctor()"
-           		reason="Parameter-less ctor does not exist in UWP"/>
+			<Member 
+				fullName="System.Void Windows.System.UserProfile.UserProfilePersonalizationSettings..ctor()"
+				reason="Parameter-less ctor does not exist in UWP"/>
 			<Member
 				fullName="System.Void Windows.UI.Xaml.Controls.CalendarDatePickerDateChangedEventArgs..ctor()"
 				reason="Parameter-less ctor does not exist in UWP"/>
@@ -3080,11 +3080,113 @@
 			<Member
 				fullName="System.Void Windows.ApplicationModel.Activation.ToastNotificationActivatedEventArgs..ctor()"
 				reason="Parameter-less ctor does not exist in UWP"/>
+			<Member
+				fullName="System.Void Windows.Media.Capture.CapturedFrame.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Graphics.Imaging.ImageStream.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Devices.Enumeration.DeviceThumbnail.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Threading.Tasks.Task`1&lt;Windows.Storage.StorageFile&gt; Windows.Storage.StorageFile.GetFileFromPathAsync(System.String path)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Threading.Tasks.Task Windows.Storage.StorageFile.DeleteAsync(System.Threading.CancellationToken ct)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Threading.Tasks.Task`1&lt;System.IO.Stream&gt; Windows.Storage.StorageFile.OpenStreamForReadAsync(System.Threading.CancellationToken ct)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Threading.Tasks.Task`1&lt;Windows.Storage.StorageStreamTransaction&gt; Windows.Storage.StorageFile.OpenTransactedWriteAsync(System.Threading.CancellationToken ct)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Threading.Tasks.Task Windows.Storage.StorageFile.CopyAndReplaceAsync(System.Threading.CancellationToken ct, Windows.Storage.StorageFile destination)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Threading.Tasks.Task Windows.Storage.StorageFile.MoveAsync(System.Threading.CancellationToken ct, Windows.Storage.StorageFolder targetFolder)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Threading.Tasks.Task Windows.Storage.StorageFile.MoveAsync(System.Threading.CancellationToken ct, Windows.Storage.StorageFolder targetFolder, System.String desiredNewName)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Threading.Tasks.Task Windows.Storage.StorageFile.MoveAsync(System.Threading.CancellationToken ct, Windows.Storage.StorageFolder targetFolder, System.String desiredNewName, Windows.Storage.NameCollisionOption option)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Threading.Tasks.Task`1&lt;Windows.Storage.FileProperties.BasicProperties&gt; Windows.Storage.StorageFile.GetBasicPropertiesAsync(System.Threading.CancellationToken ct)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.StorageStreamTransaction..ctor(Windows.Storage.StorageFile file)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.IO.Stream Windows.Storage.StorageStreamTransaction.GetStream()"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Threading.Tasks.Task Windows.Storage.StorageStreamTransaction.CommitAsync(System.Threading.CancellationToken ct)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.StreamedFileDataRequest..ctor()"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.FileInputStream..ctor()"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.FileOutputStream..ctor()"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.FileRandomAccessStream.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.FileRandomAccessStream..ctor()"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.InMemoryRandomAccessStream.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.InputStreamOverStream..ctor()"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.IRandomAccessStream.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.OutputStreamOverStream..ctor()"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.RandomAccessStreamOverStream.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.RandomAccessStreamOverStream..ctor()"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.Streams.RandomAccessStreamReference..ctor()"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Storage.FileProperties.StorageItemThumbnail.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Media.SpeechSynthesis.SpeechSynthesisStream.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Media.Capture.CapturedFrame.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Graphics.Imaging.ImageStream.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
+			<Member
+				fullName="System.Void Windows.Devices.Enumeration.DeviceThumbnail.set_Size(System.UInt64 value)"
+				reason="Not part of the UWP API"/>
 		</Methods>
 		<Fields>
 			<Member
 				fullName="System.Int32 Windows.ApplicationModel.Contacts.ContactQuerySearchFields::value__"
 				reason="The enum is backed by uint" />
+			<Member
+				fullName="System.Int32 Windows.Storage.Streams.InputStreamOptions::value__"
+				reason="The enum is backed by uint"/>
+			<Member
+				fullName="System.Int32 Windows.Storage.Streams.InputStreamOptions::value__"
+				reason="The enum is backed by uint"/>
 		</Fields>
 	</IgnoreSet>
   </IgnoreSets>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3067,6 +3067,11 @@
 		</Fields>
 	</IgnoreSet>
 	<IgnoreSet baseVersion="3.0.17">
+		<Types>
+			<Member 
+				fullName="Windows.Storage.StorageItem"
+				reason="Not part of the UWP API"/>
+		  </Types>
 		<Methods>
 			<Member 
 				fullName="System.Void Windows.System.UserProfile.UserProfilePersonalizationSettings..ctor()"

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3162,6 +3162,9 @@
 				fullName="System.Void Windows.Storage.Streams.RandomAccessStreamReference..ctor()"
 				reason="Not part of the UWP API"/>
 			<Member
+				fullName="System.Void Windows.Storage.StorageItem..ctor()"
+				reason="Not part of the UWP API"/>
+			<Member
 				fullName="System.Void Windows.Storage.FileProperties.StorageItemThumbnail.set_Size(System.UInt64 value)"
 				reason="Not part of the UWP API"/>
 			<Member

--- a/doc/articles/features/windows-storage.md
+++ b/doc/articles/features/windows-storage.md
@@ -4,6 +4,9 @@ Uno supports some of the APIs from the `Windows.Storage` namespace, such as `Win
 
 Both `Windows.Storage` and `System.IO` APIs are available, with some platform specifics defined below. In general, it is best to use `Windows.Storage` APIs when available, as their async nature allows for transparent interactions with the underlying file system implementations.
 
+Note that only `BasicProperties` are barely supported for now. 
+`FileAttributes` and all "advanced properties" (`StorageItemContentProperties`) related to the content of the file, including thumbnail, are not supported.
+
 ## WebAssembly support
 
 WebAssembly file system APIs are built using [emscripten's POSIX file system APIs](https://emscripten.org/docs/api_reference/Filesystem-API.html). The persistence is done through the use of browser APIs, such as IndexedDB through [emscripten's IDBFS](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-idbfs).
@@ -48,4 +51,8 @@ Given than in the project there's the following declaration:
 </ItemGroup>
 ```
 
+## Support for StorageFile.CreateStreamedFileAsync and StorageFile.CreateStreamedFileFromUriAsync
+
+Those methods are not supported yet, however Uno supports to create a `RandomAccessStreamReference` from an `Uri` (`RandomAccessStreamReference.CreateFromUri`), but note that on WASM downloading a file from a random server usually causes some issues with [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS). 
+Make sure to configure the server that hosts the file accordingly.
 

--- a/src/Uno.Foundation/AsyncAction.cs
+++ b/src/Uno.Foundation/AsyncAction.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 
 namespace Windows.Foundation
 {
-	internal class AsyncAction : IAsyncAction
+	internal class AsyncAction : IAsyncAction, IAsyncActionInternal
 	{
 		private CancellationTokenSource _cts = new CancellationTokenSource();
 		private AsyncActionCompletedHandler _onCompleted;

--- a/src/Uno.Foundation/AsyncOperation.TResult.cs
+++ b/src/Uno.Foundation/AsyncOperation.TResult.cs
@@ -1,33 +1,39 @@
-﻿using Uno.Diagnostics.Eventing;
+﻿#nullable enable
+
+using Uno.Diagnostics.Eventing;
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
+using Uno;
 
 namespace Windows.Foundation
 {
-	internal class AsyncOperation<TResult> : IAsyncOperation<TResult>
+	internal class AsyncOperation<TResult> : IAsyncOperation<TResult>, IAsyncOperationInternal<TResult>
 	{
-		private CancellationTokenSource _cts = new CancellationTokenSource();
-		private AsyncOperationCompletedHandler<TResult> _onCompleted;
-		private Task<TResult> _task;
-		private AsyncStatus _status;
-		private uint _id = 0;
+		public static AsyncOperation<TResult> FromTask(FuncAsync<AsyncOperation<TResult>, TResult> builder)
+			=> new AsyncOperation<TResult>(builder);
 
-		public AsyncOperation(Func<CancellationToken, Task<TResult>> taskBuilder)
+		private static long _nextId;
+
+		private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+		private AsyncOperationCompletedHandler<TResult>? _onCompleted;
+		private AsyncStatus _status;
+
+		public AsyncOperation(FuncAsync<AsyncOperation<TResult>, TResult> taskBuilder)
 		{
-			_task = BuildTaskAsync(taskBuilder);
+			Task = BuildTaskAsync(taskBuilder);
 		}
 
-		private async Task<TResult> BuildTaskAsync(Func<CancellationToken, Task<TResult>> taskBuilder)
+		private async Task<TResult> BuildTaskAsync(FuncAsync<AsyncOperation<TResult>, TResult> taskBuilder)
 		{
 			Status = AsyncStatus.Started;
 
 			try
 			{
-				var result = await taskBuilder(_cts.Token);
+				var result = await taskBuilder(_cts.Token, this);
 				Status = AsyncStatus.Completed;
 				return result;
 			}
@@ -39,23 +45,28 @@ namespace Windows.Foundation
 			}
 		}
 
-		public AsyncOperationCompletedHandler<TResult> Completed
+		public AsyncOperationCompletedHandler<TResult>? Completed
 		{
-			get { return _onCompleted; }
+			get => _onCompleted;
 			set
 			{
 				_onCompleted = value;
-				if (Status != AsyncStatus.Started) { value?.Invoke(this, Status); }
+				if (Status != AsyncStatus.Started)
+				{
+					value?.Invoke(this, Status);
+				}
 			}
 		}
 
-		public Exception ErrorCode { get; private set; }
+		public uint Id { get; } = (uint)Interlocked.Increment(ref _nextId);
 
-		public uint Id => _id;
+		public Task<TResult> Task { get; }
+
+		public Exception? ErrorCode { get; private set; }
 
 		public AsyncStatus Status
 		{
-			get { return _status; }
+			get => _status;
 			set
 			{
 				_status = value;
@@ -64,20 +75,12 @@ namespace Windows.Foundation
 		}
 
 		public void Cancel()
-		{
-			_cts.Cancel();
-		}
+			=> _cts.Cancel();
 
 		public void Close()
-		{
-			_cts.Cancel();
-		}
+			=> _cts.Cancel();
 
 		public TResult GetResults()
-		{
-			return _task.Result;
-		}
-
-		public Task<TResult> Task => _task;
+			=> Task.Result;
 	}
 }

--- a/src/Uno.Foundation/AsyncOperation.TResult.cs
+++ b/src/Uno.Foundation/AsyncOperation.TResult.cs
@@ -16,8 +16,6 @@ namespace Windows.Foundation
 		public static AsyncOperation<TResult> FromTask(FuncAsync<AsyncOperation<TResult>, TResult> builder)
 			=> new AsyncOperation<TResult>(builder);
 
-		private static long _nextId;
-
 		private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 		private AsyncOperationCompletedHandler<TResult>? _onCompleted;
 		private AsyncStatus _status;
@@ -58,7 +56,7 @@ namespace Windows.Foundation
 			}
 		}
 
-		public uint Id { get; } = (uint)Interlocked.Increment(ref _nextId);
+		public uint Id { get; } = AsyncOperation.CreateId();
 
 		public Task<TResult> Task { get; }
 

--- a/src/Uno.Foundation/AsyncOperation.cs
+++ b/src/Uno.Foundation/AsyncOperation.cs
@@ -12,6 +12,10 @@ namespace Windows.Foundation
 {
 	internal static class AsyncOperation
 	{
+		private static long _nextId;
+		internal static uint CreateId()
+			=> (uint)Interlocked.Increment(ref _nextId);
+
 		public static AsyncOperation<TResult> FromTask<TResult>(Func<CancellationToken, Task<TResult>> builder)
 			=> new AsyncOperation<TResult>((ct, _) => builder(ct));
 	}

--- a/src/Uno.Foundation/AsyncOperation.cs
+++ b/src/Uno.Foundation/AsyncOperation.cs
@@ -6,11 +6,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using System.Runtime.CompilerServices;
+using Uno;
 
 namespace Windows.Foundation
 {
 	internal static class AsyncOperation
 	{
-		public static AsyncOperation<TResult> FromTask<TResult>(Func<CancellationToken, Task<TResult>> builder) => new AsyncOperation<TResult>(builder);
- 	}
+		public static AsyncOperation<TResult> FromTask<TResult>(Func<CancellationToken, Task<TResult>> builder)
+			=> new AsyncOperation<TResult>((ct, _) => builder(ct));
+	}
 }

--- a/src/Uno.Foundation/AsyncOperationCompletedHandler.cs
+++ b/src/Uno.Foundation/AsyncOperationCompletedHandler.cs
@@ -1,7 +1,5 @@
-#pragma warning disable 108 // new keyword hiding
-#pragma warning disable 114 // new keyword hiding
 
 namespace Windows.Foundation
 {
-	public delegate void AsyncOperationCompletedHandler<TResult>(global::Windows.Foundation.IAsyncOperation<TResult> @asyncInfo, global::Windows.Foundation.AsyncStatus @asyncStatus);
+	public delegate void AsyncOperationCompletedHandler<TResult>(IAsyncOperation<TResult> asyncInfo, AsyncStatus asyncStatus);
 }

--- a/src/Uno.Foundation/AsyncOperationWithProgress.T.cs
+++ b/src/Uno.Foundation/AsyncOperationWithProgress.T.cs
@@ -1,0 +1,46 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno;
+
+namespace Windows.Foundation
+{
+	internal class AsyncOperationWithProgress<TResult, TProgress> : AsyncOperation<TResult>, IAsyncOperationWithProgress<TResult, TProgress>, IAsyncOperationWithProgressInternal<TResult, TProgress>
+	{
+		private AsyncOperationWithProgressCompletedHandler<TResult, TProgress>? _completed;
+
+		/// <inheritdoc />
+		public AsyncOperationWithProgress(FuncAsync<AsyncOperationWithProgress<TResult, TProgress>, TResult> taskBuilder)
+			: base(Wrap(taskBuilder))
+		{
+		}
+
+		/// <inheritdoc />
+		public AsyncOperationProgressHandler<TResult, TProgress>? Progress { get; set; }
+
+		/// <inheritdoc />
+		public new AsyncOperationWithProgressCompletedHandler<TResult, TProgress>? Completed
+		{
+			get => _completed;
+			set
+			{
+				_completed = value;
+				base.Completed = Wrap(value);
+			}
+		}
+
+		internal void NotifyProgress(TProgress progressInfo)
+			=> Progress?.Invoke(this, progressInfo);
+
+		private static FuncAsync<AsyncOperation<TResult>, TResult> Wrap(FuncAsync<AsyncOperationWithProgress<TResult, TProgress>, TResult> taskBuilder)
+			=> (ct, that) => taskBuilder(ct, (AsyncOperationWithProgress<TResult, TProgress>)that);
+
+		private static AsyncOperationCompletedHandler<TResult>? Wrap(AsyncOperationWithProgressCompletedHandler<TResult, TProgress>? handler)
+			=> handler is null
+				? default(AsyncOperationCompletedHandler<TResult>)
+				: (that, status) => handler!((IAsyncOperationWithProgress<TResult, TProgress>)that, status);
+	}
+}

--- a/src/Uno.Foundation/AsyncOperationWithProgress.T.cs
+++ b/src/Uno.Foundation/AsyncOperationWithProgress.T.cs
@@ -32,7 +32,7 @@ namespace Windows.Foundation
 			}
 		}
 
-		internal void NotifyProgress(TProgress progressInfo)
+		public void NotifyProgress(TProgress progressInfo)
 			=> Progress?.Invoke(this, progressInfo);
 
 		private static FuncAsync<AsyncOperation<TResult>, TResult> Wrap(FuncAsync<AsyncOperationWithProgress<TResult, TProgress>, TResult> taskBuilder)

--- a/src/Uno.Foundation/AsyncOperationWithProgress.cs
+++ b/src/Uno.Foundation/AsyncOperationWithProgress.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno;
+
+namespace Windows.Foundation
+{
+	internal static class AsyncOperationWithProgress
+	{
+		public static AsyncOperationWithProgress<TResult, TProgress> FromFuncAsync<TResult, TProgress>(FuncAsync<AsyncOperationWithProgress<TResult, TProgress>, TResult> builder)
+			=> new AsyncOperationWithProgress<TResult, TProgress>(builder);
+	}
+}

--- a/src/Uno.Foundation/Generated/2.0.0.0/Windows.Foundation/AsyncOperationCompletedHandler.cs
+++ b/src/Uno.Foundation/Generated/2.0.0.0/Windows.Foundation/AsyncOperationCompletedHandler.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Foundation
 {
-	#if false
+	#if false || false
 	public delegate void AsyncOperationCompletedHandler<TResult>(global::Windows.Foundation.IAsyncOperation<TResult> @asyncInfo, global::Windows.Foundation.AsyncStatus @asyncStatus);
 	#endif
 }

--- a/src/Uno.Foundation/IAsyncAction.cs
+++ b/src/Uno.Foundation/IAsyncAction.cs
@@ -1,13 +1,16 @@
+using System.Threading.Tasks;
+
 namespace Windows.Foundation
 {
-	public partial interface IAsyncAction : global::Windows.Foundation.IAsyncInfo
+	public partial interface IAsyncAction : IAsyncInfo
 	{
-		global::Windows.Foundation.AsyncActionCompletedHandler Completed
-		{
-			get;
-			set;
-		}
+		AsyncActionCompletedHandler Completed { get; set; }
 
 		void GetResults();
+	}
+
+	internal interface IAsyncActionInternal : IAsyncAction
+	{
+		Task Task { get; }
 	}
 }

--- a/src/Uno.Foundation/IAsyncAction.cs
+++ b/src/Uno.Foundation/IAsyncAction.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace Windows.Foundation
 {
 	public partial interface IAsyncAction : IAsyncInfo
@@ -7,10 +5,5 @@ namespace Windows.Foundation
 		AsyncActionCompletedHandler Completed { get; set; }
 
 		void GetResults();
-	}
-
-	internal interface IAsyncActionInternal : IAsyncAction
-	{
-		Task Task { get; }
 	}
 }

--- a/src/Uno.Foundation/IAsyncActionInternal.cs
+++ b/src/Uno.Foundation/IAsyncActionInternal.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Windows.Foundation
+{
+	internal interface IAsyncActionInternal : IAsyncAction
+	{
+		Task Task { get; }
+	}
+}

--- a/src/Uno.Foundation/IAsyncActionWithProgress.cs
+++ b/src/Uno.Foundation/IAsyncActionWithProgress.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Windows.Foundation
 {
@@ -10,19 +11,15 @@ namespace Windows.Foundation
 
 	public partial interface IAsyncActionWithProgress<TProgress> : IAsyncInfo
 	{
-		global::Windows.Foundation.AsyncActionProgressHandler<TProgress> Progress
-		{
-			get;
-			set;
-		}
+		AsyncActionProgressHandler<TProgress> Progress { get; set; }
 
-		global::Windows.Foundation.AsyncActionWithProgressCompletedHandler<TProgress> Completed
-		{
-			get;
-			set;
-		}
+		AsyncActionWithProgressCompletedHandler<TProgress> Completed { get; set; }
 
 		void GetResults();
+	}
 
+	internal interface IAsyncActionWithProgressInternal<TProgress> : IAsyncActionWithProgress<TProgress>
+	{
+		Task Task { get; }
 	}
 }

--- a/src/Uno.Foundation/IAsyncActionWithProgress.cs
+++ b/src/Uno.Foundation/IAsyncActionWithProgress.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Windows.Foundation
 {
@@ -16,10 +15,5 @@ namespace Windows.Foundation
 		AsyncActionWithProgressCompletedHandler<TProgress> Completed { get; set; }
 
 		void GetResults();
-	}
-
-	internal interface IAsyncActionWithProgressInternal<TProgress> : IAsyncActionWithProgress<TProgress>
-	{
-		Task Task { get; }
 	}
 }

--- a/src/Uno.Foundation/IAsyncActionWithProgressInternal.cs
+++ b/src/Uno.Foundation/IAsyncActionWithProgressInternal.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Windows.Foundation
+{
+	internal interface IAsyncActionWithProgressInternal<TProgress> : IAsyncActionWithProgress<TProgress>
+	{
+		Task Task { get; }
+	}
+}

--- a/src/Uno.Foundation/IAsyncInfo.cs
+++ b/src/Uno.Foundation/IAsyncInfo.cs
@@ -1,21 +1,15 @@
+using System;
+using System.Threading.Tasks;
+
 namespace Windows.Foundation
 {
-	public  partial interface IAsyncInfo 
+	public partial interface IAsyncInfo 
 	{
-		global::System.Exception ErrorCode
-		{
-			get;
-		}
+		Exception ErrorCode { get; }
 
-		uint Id
-		{
-			get;
-		}
+		uint Id { get; }
 
-		global::Windows.Foundation.AsyncStatus Status
-		{
-			get;
-		}
+		AsyncStatus Status { get; }
 
 		void Cancel();
 

--- a/src/Uno.Foundation/IAsyncOperation.cs
+++ b/src/Uno.Foundation/IAsyncOperation.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace Windows.Foundation
 {
 	public partial interface IAsyncOperation<TResult> : IAsyncInfo
@@ -7,10 +5,5 @@ namespace Windows.Foundation
 		AsyncOperationCompletedHandler<TResult> Completed { get; set; }
 
 		TResult GetResults();
-	}
-
-	internal interface IAsyncOperationInternal<TResult> : IAsyncOperation<TResult>
-	{
-		Task<TResult> Task { get; }
 	}
 }

--- a/src/Uno.Foundation/IAsyncOperation.cs
+++ b/src/Uno.Foundation/IAsyncOperation.cs
@@ -1,13 +1,16 @@
+using System.Threading.Tasks;
+
 namespace Windows.Foundation
 {
-	public  partial interface IAsyncOperation<TResult> : global::Windows.Foundation.IAsyncInfo
+	public partial interface IAsyncOperation<TResult> : IAsyncInfo
 	{
-		AsyncOperationCompletedHandler<TResult> Completed
-		{
-			get;
-			set;
-		}
+		AsyncOperationCompletedHandler<TResult> Completed { get; set; }
 
 		TResult GetResults();
+	}
+
+	internal interface IAsyncOperationInternal<TResult> : IAsyncOperation<TResult>
+	{
+		Task<TResult> Task { get; }
 	}
 }

--- a/src/Uno.Foundation/IAsyncOperationInternal.cs
+++ b/src/Uno.Foundation/IAsyncOperationInternal.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Windows.Foundation
+{
+	internal interface IAsyncOperationInternal<TResult> : IAsyncOperation<TResult>
+	{
+		Task<TResult> Task { get; }
+	}
+}

--- a/src/Uno.Foundation/IAsyncOperationWithProgress.cs
+++ b/src/Uno.Foundation/IAsyncOperationWithProgress.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 using Windows.Foundation.Metadata;
 
 namespace Windows.Foundation
@@ -11,6 +12,11 @@ namespace Windows.Foundation
 
 	public partial interface IAsyncOperationWithProgress<TResult, TProgress> : IAsyncInfo
 	{
+	}
+
+	internal interface IAsyncOperationWithProgressInternal<TResult, TProgress> : IAsyncOperationWithProgress<TResult, TProgress>
+	{
+		Task<TResult> Task { get; }
 	}
 }
 

--- a/src/Uno.Foundation/IAsyncOperationWithProgress.cs
+++ b/src/Uno.Foundation/IAsyncOperationWithProgress.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 using Windows.Foundation.Metadata;
 
 namespace Windows.Foundation
@@ -12,11 +11,6 @@ namespace Windows.Foundation
 
 	public partial interface IAsyncOperationWithProgress<TResult, TProgress> : IAsyncInfo
 	{
-	}
-
-	internal interface IAsyncOperationWithProgressInternal<TResult, TProgress> : IAsyncOperationWithProgress<TResult, TProgress>
-	{
-		Task<TResult> Task { get; }
 	}
 }
 

--- a/src/Uno.Foundation/IAsyncOperationWithProgressInternal.cs
+++ b/src/Uno.Foundation/IAsyncOperationWithProgressInternal.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Windows.Foundation
+{
+	internal interface IAsyncOperationWithProgressInternal<TResult, TProgress> : IAsyncOperationWithProgress<TResult, TProgress>
+	{
+		Task<TResult> Task { get; }
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile.cs
@@ -2,65 +2,173 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Windows.ApplicationModel.Resources;
 using Windows.ApplicationModel.Resources.Core;
+using Windows.Storage;
+using Uno.UI.RuntimeTests.Tests.Windows_Storage.Streams;
 
 namespace Uno.UI.RuntimeTests.Tests
 {
-    [TestClass]
-    public class Given_StorageFile
-    {
-        
-        String _filename;
-        
-        [TestInitialize]
-        public void Init()
-        {
-            _filename = "deletefile-" + DateTime.Now.ToString("yyyyMMddHHmmss") + ".txt";
-        }
+	[TestClass]
+	public class Given_StorageFile
+	{
+		String _filename;
+		
+		[TestInitialize]
+		public void Init()
+		{
+			_filename = "deletefile-" + DateTime.Now.ToString("yyyyMMddHHmmss") + ".txt";
+		}
 
-        [TestCleanup]
-        public void Cleanup()
-        {
-        }
+		[TestCleanup]
+		public void Cleanup()
+		{
+		}
 
-        [TestMethod]
-        public async void When_DeleteFile()
-        {
-            
-            var _folder = Windows.Storage.ApplicationData.Current.LocalFolder;
-            Assert.IsNotNull(_folder, "cannot get LocalFolder - error outside tested method");
+		[TestMethod]
+		public async Task When_DeleteFile()
+		{
+			
+			var _folder = Windows.Storage.ApplicationData.Current.LocalFolder;
+			Assert.IsNotNull(_folder, "cannot get LocalFolder - error outside tested method");
 
-            Windows.Storage.StorageFile _file = null;
-            
-            try
-            {
-                _file = await _folder.CreateFileAsync( _filename, Windows.Storage.CreationCollisionOption.FailIfExists);
-                Assert.IsNotNull(_file, "cannot create file - error outside tested method");
-            }
-            catch
-            {
-                  Assert.Fail("CreateFile exception - error outside tested method");
-            }
+			Windows.Storage.StorageFile _file = null;
+			
+			try
+			{
+				_file = await _folder.CreateFileAsync( _filename, Windows.Storage.CreationCollisionOption.FailIfExists);
+				Assert.IsNotNull(_file, "cannot create file - error outside tested method");
+			}
+			catch
+			{
+				  Assert.Fail("CreateFile exception - error outside tested method");
+			}
 
-            // try delete file
-            try
-            {
-                  await _file.DeleteAsync();
-            }
-            catch
-            {
-                Assert.Fail("DeleteAsync exception - error in tested method");
-            }
+			// try delete file
+			try
+			{
+				  await _file.DeleteAsync();
+			}
+			catch
+			{
+				Assert.Fail("DeleteAsync exception - error in tested method");
+			}
 
-            // check if method works
-            var _fileAfter = await _folder.TryGetItemAsync("test-deletingfile.txt");
-            Assert.IsNull(_fileAfter, "file is not deleted - tested method fails");
-      
-        }
+			// check if method works
+			var _fileAfter = await _folder.TryGetItemAsync("test-deletingfile.txt");
+			Assert.IsNull(_fileAfter, "file is not deleted - tested method fails");
+		}
 
+		[TestMethod]
+		public async Task When_OpenRead()
+		{
+			var path = GetRandomFilePath();
+			var file = await (await GetFile(path)).OpenReadAsync();
+			var direct = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
 
-    }
+			await StreamTestHelper.Test(writeTo: direct, readOn: file);
+
+			try
+			{
+				await StreamTestHelper.WriteData(file);
+				Assert.Fail("should have failed");
+			}
+			catch (NotSupportedException)
+			{
+			}
+		}
+
+		[TestMethod]
+		public async Task When_Open_Read()
+		{
+			var path = GetRandomFilePath();
+			var file = await (await GetFile(path)).OpenAsync(FileAccessMode.Read);
+			var direct = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+			await StreamTestHelper.Test(writeTo: direct, readOn: file);
+
+			try
+			{
+				await StreamTestHelper.WriteData(file);
+				Assert.Fail("should have failed");
+			}
+			catch (NotSupportedException)
+			{
+			}
+		}
+
+		[TestMethod]
+		public async Task When_Open_ReadWrite()
+		{
+			var path = GetRandomFilePath();
+			var file = await (await GetFile(path)).OpenAsync(FileAccessMode.ReadWrite);
+			var direct = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+			await StreamTestHelper.Test(writeTo: direct, readOn: file);
+			await StreamTestHelper.Test(writeTo: file, readOn: direct);
+		}
+
+		[TestMethod]
+		public async Task When_Open_Read_AndGetInputStream()
+		{
+			var path = GetRandomFilePath();
+			var file = (await (await GetFile(path)).OpenAsync(FileAccessMode.Read)).GetInputStreamAt(0);
+			var direct = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+			await StreamTestHelper.Test(writeTo: direct, readOn: file);
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(NotSupportedException))]
+		public async Task When_Open_Read_AndGetOutputStream()
+		{
+			var path = GetRandomFilePath();
+			var file = (await (await GetFile(path)).OpenAsync(FileAccessMode.Read)).GetOutputStreamAt(0);
+		}
+
+		[TestMethod]
+		public async Task When_Open_ReadWrite_AndGetInputStream()
+		{
+			var path = GetRandomFilePath();
+			var file = (await (await GetFile(path)).OpenAsync(FileAccessMode.ReadWrite)).GetInputStreamAt(0);
+			var direct = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+			await StreamTestHelper.Test(writeTo: direct, readOn: file);
+		}
+
+		[TestMethod]
+		public async Task When_Open_ReadWrite_AndGetOutputStream()
+		{
+			var path = GetRandomFilePath();
+			var file = (await (await GetFile(path)).OpenAsync(FileAccessMode.ReadWrite)).GetOutputStreamAt(0);
+			var direct = File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+			await StreamTestHelper.Test(writeTo: file, readOn: direct);
+		}
+
+		[TestMethod]
+		public async Task When_CloneStream_Then_PositionAreNotShared()
+		{
+			var path = GetRandomFilePath();
+
+			await StreamTestHelper.WriteData(File.Open(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite));
+
+			var file1 = await (await GetFile(path)).OpenAsync(FileAccessMode.ReadWrite);
+			var file2 = file1.CloneStream();
+
+			file1.Seek(5);
+
+			Assert.AreNotEqual(file1.Position, file2.Position);
+		}
+
+		private string GetRandomFilePath()
+			=> Path.Combine(ApplicationData.Current.LocalFolder.Path, $"{Guid.NewGuid()}.txt");
+
+		public async Task<StorageFile> GetFile(string filePath)
+			=> await StorageFile.GetFileFromPathAsync(filePath);
+	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_TemporaryFile.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_TemporaryFile.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETFX_CORE
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -48,3 +49,4 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		}
 	}
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_TemporaryFile.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_TemporaryFile.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Windows.Storage;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
+{
+	[TestClass]
+	public class Given_TemporaryFile
+	{
+		[TestMethod]
+		public void When_CloseLast_Then_FileDeleted()
+		{
+			var sut = new TemporaryFile();
+			var tempFilePath = sut.ToString().Substring("[TEMP]".Length); // I'm not even ashamed of this hack
+
+			var weak = sut.OpenWeak(FileAccess.Write);
+			var strong = sut.Open(FileAccess.Read);
+
+			Assert.IsTrue(File.Exists(tempFilePath));
+
+			var expected = Encoding.UTF8.GetBytes("Hello world");
+
+			weak.Write(expected, 0, expected.Length);
+			weak.Flush();
+
+			var actualBytes = new byte[512];
+			var actualRead = strong.Read(actualBytes, 0, actualBytes.Length);
+			var actual = Encoding.UTF8.GetString(actualBytes, 0, actualRead);
+
+			Assert.AreEqual("Hello world", actual);
+
+			strong.Dispose();
+
+			try
+			{
+				weak.Write(expected, 0, expected.Length);
+				weak.Flush();
+				Assert.Fail("Write should have failed");
+			}
+			catch (IOException)
+			{
+			}
+
+			Assert.IsFalse(File.Exists(tempFilePath));
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_Buffer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_Buffer.cs
@@ -139,7 +139,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage.Streams
 			var copy = sut.ToArray();
 
 			// Then if we change the content of the source, it does not change the copy
-			sut.Span.Fill(E);
+			sut.Fill(E);
 
 			Assert.AreEqual(E, sut.GetByte(10));
 			Assert.AreEqual(D, copy[10]);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_Buffer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_Buffer.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Buffer = Windows.Storage.Streams.Buffer;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Storage.Streams
+{
+	[TestClass]
+	public class Given_Buffer
+	{
+		private const byte D = 0b1010_1010; // D as Data ... not the D ANSI code ;)
+		private const byte E = 0b0101_0101;
+
+		[TestMethod]
+		public void When_Create_Then_LengthIsZero()
+		{
+			var sut = new Buffer(42);
+
+			Assert.AreEqual(0U, sut.Length);
+			Assert.AreEqual(42U, sut.Capacity);
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentException))]
+		public void When_SetLengthGreaterThanCapacity()
+		{
+			var sut = new Buffer(42);
+
+			sut.Length = 43;
+		}
+
+		[TestMethod]
+		public void When_Write_Then_LengthUpdated()
+		{
+			var sut = new Buffer(42);
+
+			Assert.AreEqual(0U, sut.Length);
+
+			sut.Write(0, new byte[42], 0, 21);
+
+			Assert.AreEqual(21U, sut.Length);
+		}
+
+		[TestMethod]
+		public void When_CopyToArray_Then_DataCopied()
+		{
+			var sut = GetFilledBuffer();
+
+			Assert.AreEqual(D, sut.GetByte(10));
+
+			var copy = new byte[sut.Length];
+			sut.CopyTo(0, copy, 0, copy.Length);
+
+			// Then if we change the content of the source, it does not change the copy
+			sut.Span.Fill(E);
+
+			Assert.AreEqual(E, sut.GetByte(10));
+			Assert.AreEqual(D, copy[10]);
+		}
+
+		[TestMethod]
+		public void When_CopyToBuffer_Then_DstLengthUpdated()
+		{
+			var src = GetFilledBuffer();
+			var dst = new Buffer(42);
+
+			Assert.AreEqual(42U, src.Length);
+			Assert.AreEqual(0U, dst.Length);
+
+			src.CopyTo(0, dst, 10, 10);
+
+			Assert.AreEqual(10U + 10U, dst.Length);
+		}
+
+		[TestMethod]
+		public void When_CopyToBuffer_Then_DataCopied()
+		{
+			var sut = GetFilledBuffer();
+
+			Assert.AreEqual(D, sut.GetByte(10));
+
+			var copy = GetFilledBuffer(data: 0);
+			sut.CopyTo(0, copy, 0, copy.Capacity);
+
+			// Then if we change the content of the source, it does not change the copy
+			sut.Span.Fill(E);
+
+			Assert.AreEqual(E, sut.GetByte(10));
+			Assert.AreEqual(D, copy.GetByte(10));
+		}
+
+		[TestMethod]
+		public void When_GetByte()
+		{
+			var sut = GetFilledBuffer();
+
+			Assert.AreEqual(D, sut.GetByte(10));
+		}
+
+		[TestMethod]
+		public void When_GetByteGreaterThanLength()
+		{
+			var sut = new Buffer(42) {Length = 21};
+
+			sut.GetByte(41); // We only assert this won't fail
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentException))]
+		public void When_GetByteGreaterThanCapacity()
+		{
+			var sut = new Buffer(42);
+
+			sut.GetByte(42);
+		}
+
+		[TestMethod]
+		public void When_ToArray()
+		{
+			var sut = GetFilledBuffer();
+			var expected = new byte[42];
+			Array.Fill(expected, D);
+
+			var actual = sut.ToArray();
+
+			Assert.IsTrue(expected.SequenceEqual(actual));
+		}
+
+		[TestMethod]
+		public void When_ToArray_Then_DataCopied()
+		{
+			var sut = GetFilledBuffer();
+
+			Assert.AreEqual(D, sut.GetByte(10));
+
+			var copy = sut.ToArray();
+
+			// Then if we change the content of the source, it does not change the copy
+			sut.Span.Fill(E);
+
+			Assert.AreEqual(E, sut.GetByte(10));
+			Assert.AreEqual(D, copy[10]);
+		}
+
+		[TestMethod]
+		public void When_ToArray_Then_ResultLengthIsBufferLength()
+		{
+			// Buffer's length equals
+			Assert.AreEqual(42, new Buffer(42) { Length = 42 }.ToArray().Length);
+
+			// Buffer's length lower
+			Assert.AreEqual(21, new Buffer(42) { Length = 21 }.ToArray().Length);
+
+			// Empty buffer
+			Assert.AreEqual(0, new Buffer(42) { Length = 0 }.ToArray().Length);
+		}
+
+		[TestMethod]
+		public void When_ToArrayWithCount_Then_ResultLengthIsCount()
+		{
+			// Buffer's length equals
+			Assert.AreEqual(42, new Buffer(42){Length = 42}.ToArray(0, 42).Length);
+
+			// Buffer's length lower
+			Assert.AreEqual(42, new Buffer(42) { Length = 21 }.ToArray(0, 42).Length);
+
+			// Empty buffer
+			Assert.AreEqual(42, new Buffer(42) { Length = 0 }.ToArray(0, 42).Length);
+		}
+
+		[TestMethod]
+		public void When_ToStream_Then_DataNotCopied()
+		{
+			var sut = GetFilledBuffer();
+			var stream = sut.AsStream();
+
+			Assert.AreEqual(D, stream.ReadByte());
+
+			sut.Span.Fill(E);
+
+			Assert.AreEqual(E, stream.ReadByte());
+		}
+
+		[TestMethod]
+		public void When_ToStreamAndWriteTo_Then_LengthUpdated()
+		{
+			var sut = GetFilledBuffer();
+			sut.Length = 0;
+
+			var stream = sut.AsStream();
+
+			var data = new byte[21];
+			Array.Fill(data, E);
+			stream.Write(data);
+
+			Assert.AreEqual(21U, sut.Length);
+			Assert.AreEqual(21L, stream.Position);
+		}
+
+		private static Buffer GetFilledBuffer(uint capacity = 42, uint length = 42, byte data = D)
+		{
+			var buffer = new Buffer(capacity) { Length = length };
+			buffer.Span.Slice(0, (int)length).Fill(data);
+			return buffer;
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_RandomAccessStreamReference.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_RandomAccessStreamReference.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.Storage.Streams;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Storage.Streams
+{
+	[TestClass]
+	public class Given_RandomAccessStreamReference
+	{
+		private const string _unoStaticTestFileContent = "https://platform.uno/\r\n";
+
+		[TestMethod]
+		public async Task When_FromUri()
+		{
+			var sut = RandomAccessStreamReference.CreateFromUri(new Uri("https://nv-assets.azurewebsites.net/uno-unit-tests.txt"));
+			var actual = await ReadToEnd(sut);
+
+			Assert.AreEqual(_unoStaticTestFileContent, actual);
+		}
+
+		[TestMethod]
+		public async Task When_FromFile()
+		{
+			var temp = await GetTempFile();
+			var sut = RandomAccessStreamReference.CreateFromFile(temp); // We create the ref even before writing anything in it.
+
+			var tempContent = Guid.NewGuid().ToString("N");
+			var tempOutStream = await temp.OpenStream(CancellationToken.None, FileAccessMode.ReadWrite, StorageOpenOptions.AllowReadersAndWriters);
+			using (var writer = new StreamWriter(tempOutStream))
+			{
+				writer.Write(tempContent);
+			}
+
+			var actual = await ReadToEnd(sut);
+
+			Assert.AreEqual(tempContent, actual);
+		}
+
+		[TestMethod]
+		public async Task When_FromStream()
+		{
+			var temp = new MemoryStream();
+			var sut = RandomAccessStreamReference.CreateFromStream(temp.AsRandomAccessStream()); // We create the ref even before writing anything in it.
+
+			var tempContent = Guid.NewGuid().ToString("N");
+			var tempContentBytes = Encoding.UTF8.GetBytes(tempContent);
+			temp.Write(tempContentBytes, 0, tempContentBytes.Length);
+			temp.Position = 0;
+			
+			var actual = await ReadToEnd(sut);
+
+			Assert.AreEqual(tempContent, actual);
+		}
+
+		private static async Task<StorageFile> GetTempFile()
+			=> await ApplicationData.Current.LocalFolder.CreateFileAsync($"{Guid.NewGuid()}.txt", CreationCollisionOption.ReplaceExisting);
+
+		private static async Task<string> ReadToEnd(IRandomAccessStreamReference streamRef)
+		{
+			var stream = await streamRef.OpenReadAsync();
+			using var reader = new StreamReader(stream.AsStreamForRead(), Encoding.UTF8);
+			var content = await reader.ReadToEndAsync();
+
+			return content;
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_RandomAccessStreamReference.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_RandomAccessStreamReference.cs
@@ -24,6 +24,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage.Streams
 			Assert.AreEqual(_unoStaticTestFileContent, actual);
 		}
 
+#if !NETFX_CORE
 		[TestMethod]
 		public async Task When_FromFile()
 		{
@@ -41,6 +42,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage.Streams
 
 			Assert.AreEqual(tempContent, actual);
 		}
+#endif
 
 		[TestMethod]
 		public async Task When_FromStream()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_WindowsRuntimeStreamExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_WindowsRuntimeStreamExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Storage.Streams
+{
+	[TestClass]
+	public class Given_WindowsRuntimeStreamExtensions
+	{
+		[TestMethod]
+		public async Task When_StreamAsRandomAccessStream()
+		{
+			var src = new MemoryStream();
+			var sut = src.AsRandomAccessStream();
+
+			await StreamTestHelper.Test(writeTo: src, readOn: sut, directWrapper: true);
+			await StreamTestHelper.Test(writeTo: sut, readOn: src, directWrapper: true);
+		}
+
+		[TestMethod]
+		public async Task When_StreamAsInputStream()
+		{
+			var src = new MemoryStream();
+			var sut = src.AsInputStream();
+
+			await StreamTestHelper.Test(writeTo: src, readOn: sut, directWrapper: true);
+		}
+
+		[TestMethod]
+		public async Task When_StreamAsOutputStream()
+		{
+			var src = new MemoryStream();
+			var sut = src.AsOutputStream();
+
+			await StreamTestHelper.Test(writeTo: sut, readOn: src, directWrapper: true);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/StreamTestHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/StreamTestHelper.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage.Streams;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Storage.Streams
+{
+	public class StreamTestHelper
+	{
+		public const string Data = "Hello world";
+
+		public static async Task Test(Stream writeTo, IInputStream readOn, bool directWrapper = false)
+		{
+			var ras = readOn as IRandomAccessStream;
+
+			// Clear
+			writeTo.Position = 0;
+			writeTo.SetLength(0);
+			ras?.Seek(0);
+
+			if (directWrapper && ras is {})
+			{
+				Assert.AreEqual((ulong)0, ras.Position);
+				Assert.AreEqual((ulong)writeTo.Position, ras.Position); // Those should always be equals
+				Assert.AreEqual((ulong)0, ras.Size);
+			}
+
+			await WriteData(writeTo);
+
+			if (directWrapper && ras is {})
+			{
+				Assert.AreEqual((ulong)0, ras.Position);
+				Assert.AreEqual((ulong)writeTo.Position, ras.Position); // Those should always be equals
+				Assert.AreEqual((ulong)writeTo.Length, ras.Size);
+			}
+
+			var actual = await ReadData(readOn); // The data read on the wrapper should be the data written on the src
+
+			Assert.AreEqual<string>(Data, actual);
+
+			if (directWrapper && ras is {})
+			{
+				Assert.AreEqual((ulong)writeTo.Position, ras.Position); // Those should always be equals
+				Assert.AreEqual((ulong)writeTo.Length, ras.Size);
+			}
+		}
+
+		public static async Task Test(IOutputStream writeTo, Stream readOn, bool directWrapper = false)
+		{
+			var ras = writeTo as IRandomAccessStream;
+
+			// Clear
+			readOn.Position = 0;
+			readOn.SetLength(0);
+			ras?.Seek(0);
+
+			if (directWrapper && ras is { })
+			{
+				Assert.AreEqual((ulong)0, ras.Position);
+				Assert.AreEqual((ulong)readOn.Position, ras.Position); // Those should always be equals
+				Assert.AreEqual((ulong)0, ras.Size);
+			}
+
+			await WriteData(writeTo);
+
+			if (directWrapper && ras is { })
+			{
+				Assert.AreEqual((ulong)0, ras.Position);
+				Assert.AreEqual((ulong)readOn.Position, ras.Position); // Those should always be equals
+				Assert.AreEqual((ulong)readOn.Length, ras.Size);
+			}
+
+			var actual = await ReadData(readOn); // The data read on the source should be the data written on the wrapper
+
+			Assert.AreEqual<string>(Data, actual);
+
+			if (directWrapper && ras is { })
+			{
+				Assert.AreEqual((ulong)readOn.Position, ras.Position); // Those should always be equals
+				Assert.AreEqual((ulong)readOn.Length, ras.Size);
+			}
+		}
+
+		public static async Task WriteData(Stream stream, bool resetPos = true)
+		{
+			if (resetPos)
+			{
+				stream.Seek(0, SeekOrigin.Begin);
+			}
+
+			var bytes = Encoding.UTF8.GetBytes(Data);
+			await stream.WriteAsync(bytes, 0, bytes.Length);
+			await stream.FlushAsync();
+
+			if (resetPos)
+			{
+				stream.Seek(0, SeekOrigin.Begin);
+			}
+		}
+
+		public static async Task WriteData(IOutputStream stream, bool resetPos = true)
+		{
+			var ras = stream as IRandomAccessStream;
+			if (resetPos)
+			{
+				ras?.Seek(0);
+			}
+
+			var bytes = Encoding.UTF8.GetBytes(Data);
+			var buffer = new Windows.Storage.Streams.Buffer((uint)bytes.Length);
+			bytes.CopyTo(buffer);
+			await stream.WriteAsync(buffer);
+			await stream.FlushAsync();
+
+			if (resetPos)
+			{
+				ras?.Seek(0);
+			}
+		}
+
+		public static async Task<string> ReadData(Stream stream, bool resetPos = true)
+		{
+			if (resetPos)
+			{
+				stream.Seek(0, SeekOrigin.Begin);
+			}
+
+			var raw = new byte[512];
+			var read = await stream.ReadAsync(raw, 0, raw.Length);
+			var data = Encoding.UTF8.GetString(raw, 0, read);
+
+			if (resetPos)
+			{
+				stream.Seek(0, SeekOrigin.Begin);
+			}
+
+			return data;
+		}
+
+		public static async Task<string> ReadData(IInputStream stream, bool resetPos = true)
+		{
+			var ras = stream as IRandomAccessStream;
+			if (resetPos)
+			{
+				ras?.Seek(0);
+			}
+
+			var raw = await stream.ReadAsync(new Windows.Storage.Streams.Buffer(512), 512, InputStreamOptions.None);
+			var data = Encoding.UTF8.GetString(raw.ToArray(), 0, (int)raw.Length);
+
+			if (resetPos)
+			{
+				ras?.Seek(0);
+			}
+
+			return data;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.Android.cs
@@ -14,7 +14,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 		private protected override bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out Bitmap image)
 		{
 			var drawableBuffer = new int[PixelWidth * PixelHeight];
-			var sourceBuffer = _buffer.Data;
+			var sourceBuffer = _buffer.ToArray();
 
 			// WriteableBitmap PixelBuffer is using BGRA format, Android's bitmap input buffer
 			// requires Argb8888, so we swap bytes to conform to this format.

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.cs
@@ -14,7 +14,11 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 		public WriteableBitmap(int pixelWidth, int pixelHeight) : base()
 		{
-			_buffer = new UwpBuffer((uint)(pixelWidth * pixelHeight * 4));
+			var pixelsBufferSize = (uint)(pixelWidth * pixelHeight * 4);
+			_buffer = new UwpBuffer(pixelsBufferSize)
+			{
+				Length = pixelsBufferSize
+			};
 
 			PixelWidth = pixelWidth;
 			PixelHeight = pixelHeight;

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.iOSmacOS.cs
@@ -20,7 +20,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 		private protected override bool TryOpenSourceSync(out _NativeImage image)
 		{
 			// Convert RGB colorspace.
-			var bgraBuffer = _buffer.Data;
+			var bgraBuffer = _buffer.ToArray();
 			var rgbaBuffer = new byte[bgraBuffer.Length];
 
 			for (var i = 0; i < bgraBuffer.Length; i += 4)

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.skia.cs
@@ -16,9 +16,10 @@ namespace Windows.UI.Xaml.Media.Imaging
 		{
 			_surface ??= new SkiaCompositionSurface();
 
-			_surface.SetPixels(PixelWidth, PixelHeight, _buffer.Data);
+			_surface.SetPixels(PixelWidth, PixelHeight, _buffer.ToArray());
 
-			image = new ImageData {
+			image = new ImageData
+			{
 				Value = _surface
 			};
 

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.wasm.cs
@@ -11,7 +11,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 	{
 		private protected override bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out ImageData image)
 		{
-			var handle = GCHandle.Alloc(_buffer.Data, GCHandleType.Pinned);
+			var handle = GCHandle.Alloc(_buffer.ToArray(), GCHandleType.Pinned);
 			var pinnedData = handle.AddrOfPinnedObject();
 
 			try

--- a/src/Uno.UWP/Devices/Midi/MidiChannelPressureMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiChannelPressureMessage.cs
@@ -47,12 +47,12 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the channel from 0-15 that this message applies to.
 		/// </summary>
-		public byte Channel => MidiHelpers.GetChannel(_buffer.Data[0]);
+		public byte Channel => MidiHelpers.GetChannel(_buffer.GetByte(0));
 
 		/// <summary>
 		/// Gets the pressure from 0-127.
 		/// </summary>
-		public byte Pressure => _buffer.Data[1];
+		public byte Pressure => _buffer.GetByte(0);
 
 		/// <summary>
 		/// Gets the array of bytes associated with the MIDI message, including status byte.

--- a/src/Uno.UWP/Devices/Midi/MidiChannelPressureMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiChannelPressureMessage.cs
@@ -52,7 +52,7 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the pressure from 0-127.
 		/// </summary>
-		public byte Pressure => _buffer.GetByte(0);
+		public byte Pressure => _buffer.GetByte(1);
 
 		/// <summary>
 		/// Gets the array of bytes associated with the MIDI message, including status byte.

--- a/src/Uno.UWP/Devices/Midi/MidiControlChangeMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiControlChangeMessage.cs
@@ -51,17 +51,17 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the channel from 0-15 that this message applies to.
 		/// </summary>
-		public byte Channel => MidiHelpers.GetChannel(_buffer.Data[0]);
+		public byte Channel => MidiHelpers.GetChannel(_buffer.GetByte(0));
 
 		/// <summary>
 		/// Gets the value from 0-127 to apply to the controller.
 		/// </summary>
-		public byte ControlValue => _buffer.Data[2];
+		public byte ControlValue => _buffer.GetByte(2);
 
 		/// <summary>
 		/// Gets controller from 0-127 to receive this message.
 		/// </summary>
-		public byte Controller => _buffer.Data[1];
+		public byte Controller => _buffer.GetByte(1);
 
 		/// <summary>
 		/// Gets the array of bytes associated with the MIDI message, including status byte.

--- a/src/Uno.UWP/Devices/Midi/MidiNoteOffMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiNoteOffMessage.cs
@@ -50,17 +50,17 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the channel from 0-15 that this message applies to.
 		/// </summary>
-		public byte Channel => MidiHelpers.GetChannel(_buffer.Data[0]);
+		public byte Channel => MidiHelpers.GetChannel(_buffer.GetByte(0));
 
 		/// <summary>
 		/// Gets the note to turn off which is specified as a value from 0-127.
 		/// </summary>
-		public byte Note => _buffer.Data[1];
+		public byte Note => _buffer.GetByte(1);
 
 		/// <summary>
 		/// Gets the value of the velocity from 0-127.
 		/// </summary>
-		public byte Velocity => _buffer.Data[2];
+		public byte Velocity => _buffer.GetByte(2);
 
 		/// <summary>
 		/// Gets the array of bytes associated with the MIDI message, including status byte.

--- a/src/Uno.UWP/Devices/Midi/MidiNoteOnMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiNoteOnMessage.cs
@@ -50,17 +50,17 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the channel from 0-15 that this message applies to.
 		/// </summary>
-		public byte Channel => MidiHelpers.GetChannel(_buffer.Data[0]);
+		public byte Channel => MidiHelpers.GetChannel(_buffer.GetByte(0));
 
 		/// <summary>
 		/// Gets the note to turn off which is specified as a value from 0-127.
 		/// </summary>
-		public byte Note => _buffer.Data[1];
+		public byte Note => _buffer.GetByte(1);
 
 		/// <summary>
 		/// Gets the value of the velocity from 0-127.
 		/// </summary>
-		public byte Velocity => _buffer.Data[2];
+		public byte Velocity => _buffer.GetByte(2);
 
 		/// <summary>
 		/// Gets the array of bytes associated with the MIDI message, including status byte.

--- a/src/Uno.UWP/Devices/Midi/MidiPitchBendChangeMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiPitchBendChangeMessage.cs
@@ -48,12 +48,12 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the channel from 0-15 that this message applies to.
 		/// </summary>
-		public byte Channel => MidiHelpers.GetChannel(_buffer.Data[0]);
+		public byte Channel => MidiHelpers.GetChannel(_buffer.GetByte(0));
 
 		/// <summary>
 		/// Gets the pitch bend value which is specified as a 14-bit value from 0-16383.
 		/// </summary>
-		public ushort Bend => MidiHelpers.GetBend(_buffer.Data[1], _buffer.Data[2]);
+		public ushort Bend => MidiHelpers.GetBend(_buffer.GetByte(1), _buffer.GetByte(2));
 
 		/// <summary>
 		/// Gets the array of bytes associated with the MIDI message, including status byte.

--- a/src/Uno.UWP/Devices/Midi/MidiPolyphonicKeyPressureMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiPolyphonicKeyPressureMessage.cs
@@ -51,17 +51,17 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the channel from 0-15 that this message applies to.
 		/// </summary>
-		public byte Channel => MidiHelpers.GetChannel(_buffer.Data[0]);
+		public byte Channel => MidiHelpers.GetChannel(_buffer.GetByte(0));
 
 		/// <summary>
 		/// Gets the note which is specified as a value from 0-127.
 		/// </summary>
-		public byte Note => _buffer.Data[1];
+		public byte Note => _buffer.GetByte(1);
 
 		/// <summary>
 		/// Gets the polyphonic key pressure which is specified as a value from 0-127.
 		/// </summary>
-		public byte Pressure => _buffer.Data[2];
+		public byte Pressure => _buffer.GetByte(2);
 
 		/// <summary>
 		/// Gets the array of bytes associated with the MIDI message, including status byte.

--- a/src/Uno.UWP/Devices/Midi/MidiProgramChangeMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiProgramChangeMessage.cs
@@ -47,12 +47,12 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the channel from 0-15 that this message applies to.
 		/// </summary>
-		public byte Channel => MidiHelpers.GetChannel(_buffer.Data[0]);
+		public byte Channel => MidiHelpers.GetChannel(_buffer.GetByte(0));
 
 		/// <summary>
 		/// Gets the program to change from 0-127.
 		/// </summary>
-		public byte Program => _buffer.Data[1];
+		public byte Program => _buffer.GetByte(1);
 
 		/// <summary>
 		/// Gets the array of bytes associated with the MIDI message, including status byte.

--- a/src/Uno.UWP/Devices/Midi/MidiSongPositionPointerMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiSongPositionPointerMessage.cs
@@ -45,7 +45,7 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the song position pointer encoded in a 14-bit value from 0-16383.
 		/// </summary>
-		public ushort Beats => MidiHelpers.GetBeats(_buffer.Data[1], _buffer.Data[2]);
+		public ushort Beats => MidiHelpers.GetBeats(_buffer.GetByte(1), _buffer.GetByte(2));
 
 		/// <summary>
 		/// Gets the array of bytes associated with the MIDI message, including status byte.

--- a/src/Uno.UWP/Devices/Midi/MidiSongSelectMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiSongSelectMessage.cs
@@ -50,7 +50,7 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the song to select from 0-127.
 		/// </summary>
-		public byte Song => _buffer.Data[1];
+		public byte Song => _buffer.GetByte(1);
 
 		/// <summary>
 		/// Gets the duration from when the MidiInPort was created to the time the message was received.

--- a/src/Uno.UWP/Devices/Midi/MidiSystemExclusiveMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiSystemExclusiveMessage.cs
@@ -25,7 +25,7 @@ namespace Windows.Devices.Midi
 			}
 
 			if (rawData is Storage.Streams.Buffer inMemory &&
-				inMemory.Data[0] == (byte)MidiMessageType.EndSystemExclusive)
+				inMemory.GetByte(0) == (byte)MidiMessageType.EndSystemExclusive)
 			{
 				Type = MidiMessageType.EndSystemExclusive;
 			}

--- a/src/Uno.UWP/Devices/Midi/MidiTimeCodeMessage.cs
+++ b/src/Uno.UWP/Devices/Midi/MidiTimeCodeMessage.cs
@@ -47,12 +47,12 @@ namespace Windows.Devices.Midi
 		/// <summary>
 		/// Gets the value of the frame type from 0-7.
 		/// </summary>
-		public byte FrameType => MidiHelpers.GetFrame(_buffer.Data[1]);
+		public byte FrameType => MidiHelpers.GetFrame(_buffer.GetByte(1));
 
 		/// <summary>
 		/// Gets the time code value from 0-15.
 		/// </summary>
-		public byte Values => MidiHelpers.GetFrameValues(_buffer.Data[1]);
+		public byte Values => MidiHelpers.GetFrameValues(_buffer.GetByte(1));
 
 		/// <summary>
 		/// Gets the array of bytes associated with the MIDI message, including status byte.

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/FileInputStream.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/FileInputStream.cs
@@ -2,19 +2,19 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class FileInputStream : global::Windows.Storage.Streams.IInputStream,global::System.IDisposable
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Storage.Streams.IBuffer, uint> ReadAsync( global::Windows.Storage.Streams.IBuffer buffer,  uint count,  global::Windows.Storage.Streams.InputStreamOptions options)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<IBuffer, uint> FileInputStream.ReadAsync(IBuffer buffer, uint count, InputStreamOptions options) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Dispose()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/FileOutputStream.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/FileOutputStream.cs
@@ -2,26 +2,26 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class FileOutputStream : global::Windows.Storage.Streams.IOutputStream,global::System.IDisposable
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperationWithProgress<uint, uint> WriteAsync( global::Windows.Storage.Streams.IBuffer buffer)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<uint, uint> FileOutputStream.WriteAsync(IBuffer buffer) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<bool> FlushAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> FileOutputStream.FlushAsync() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Dispose()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/FileRandomAccessStream.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/FileRandomAccessStream.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class FileRandomAccessStream : global::Windows.Storage.Streams.IRandomAccessStream,global::Windows.Storage.Streams.IOutputStream,global::System.IDisposable,global::Windows.Storage.Streams.IInputStream
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  ulong Size
 		{
@@ -21,7 +21,7 @@ namespace Windows.Storage.Streams
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool CanRead
 		{
@@ -31,7 +31,7 @@ namespace Windows.Storage.Streams
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool CanWrite
 		{
@@ -41,7 +41,7 @@ namespace Windows.Storage.Streams
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  ulong Position
 		{
@@ -53,14 +53,14 @@ namespace Windows.Storage.Streams
 		#endif
 		// Forced skipping of method Windows.Storage.Streams.FileRandomAccessStream.Size.get
 		// Forced skipping of method Windows.Storage.Streams.FileRandomAccessStream.Size.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Storage.Streams.IInputStream GetInputStreamAt( ulong position)
 		{
 			throw new global::System.NotImplementedException("The member IInputStream FileRandomAccessStream.GetInputStreamAt(ulong position) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Storage.Streams.IOutputStream GetOutputStreamAt( ulong position)
 		{
@@ -68,14 +68,14 @@ namespace Windows.Storage.Streams
 		}
 		#endif
 		// Forced skipping of method Windows.Storage.Streams.FileRandomAccessStream.Position.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Seek( ulong position)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.Streams.FileRandomAccessStream", "void FileRandomAccessStream.Seek(ulong position)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Storage.Streams.IRandomAccessStream CloneStream()
 		{
@@ -84,28 +84,28 @@ namespace Windows.Storage.Streams
 		#endif
 		// Forced skipping of method Windows.Storage.Streams.FileRandomAccessStream.CanRead.get
 		// Forced skipping of method Windows.Storage.Streams.FileRandomAccessStream.CanWrite.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Dispose()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.Streams.FileRandomAccessStream", "void FileRandomAccessStream.Dispose()");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Storage.Streams.IBuffer, uint> ReadAsync( global::Windows.Storage.Streams.IBuffer buffer,  uint count,  global::Windows.Storage.Streams.InputStreamOptions options)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<IBuffer, uint> FileRandomAccessStream.ReadAsync(IBuffer buffer, uint count, InputStreamOptions options) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperationWithProgress<uint, uint> WriteAsync( global::Windows.Storage.Streams.IBuffer buffer)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<uint, uint> FileRandomAccessStream.WriteAsync(IBuffer buffer) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<bool> FlushAsync()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IContentTypeProvider.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IContentTypeProvider.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IContentTypeProvider 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		string ContentType
 		{
 			get;

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IInputStream.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IInputStream.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IInputStream : global::System.IDisposable
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Storage.Streams.IBuffer, uint> ReadAsync( global::Windows.Storage.Streams.IBuffer buffer,  uint count,  global::Windows.Storage.Streams.InputStreamOptions options);
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IOutputStream.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IOutputStream.cs
@@ -2,15 +2,15 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IOutputStream : global::System.IDisposable
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperationWithProgress<uint, uint> WriteAsync( global::Windows.Storage.Streams.IBuffer buffer);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperation<bool> FlushAsync();
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IRandomAccessStream.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IRandomAccessStream.cs
@@ -2,30 +2,30 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IRandomAccessStream : global::System.IDisposable,global::Windows.Storage.Streams.IInputStream,global::Windows.Storage.Streams.IOutputStream
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		bool CanRead
 		{
 			get;
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		bool CanWrite
 		{
 			get;
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		ulong Position
 		{
 			get;
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		ulong Size
 		{
 			get;
@@ -34,17 +34,17 @@ namespace Windows.Storage.Streams
 		#endif
 		// Forced skipping of method Windows.Storage.Streams.IRandomAccessStream.Size.get
 		// Forced skipping of method Windows.Storage.Streams.IRandomAccessStream.Size.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Storage.Streams.IInputStream GetInputStreamAt( ulong position);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Storage.Streams.IOutputStream GetOutputStreamAt( ulong position);
 		#endif
 		// Forced skipping of method Windows.Storage.Streams.IRandomAccessStream.Position.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		void Seek( ulong position);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Storage.Streams.IRandomAccessStream CloneStream();
 		#endif
 		// Forced skipping of method Windows.Storage.Streams.IRandomAccessStream.CanRead.get

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IRandomAccessStreamReference.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IRandomAccessStreamReference.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IRandomAccessStreamReference 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Streams.IRandomAccessStreamWithContentType> OpenReadAsync();
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IRandomAccessStreamWithContentType.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/IRandomAccessStreamWithContentType.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IRandomAccessStreamWithContentType : global::Windows.Storage.Streams.IRandomAccessStream,global::System.IDisposable,global::Windows.Storage.Streams.IInputStream,global::Windows.Storage.Streams.IOutputStream,global::Windows.Storage.Streams.IContentTypeProvider

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/InputStreamOverStream.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/InputStreamOverStream.cs
@@ -2,19 +2,19 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class InputStreamOverStream : global::Windows.Storage.Streams.IInputStream,global::System.IDisposable
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Storage.Streams.IBuffer, uint> ReadAsync( global::Windows.Storage.Streams.IBuffer buffer,  uint count,  global::Windows.Storage.Streams.InputStreamOptions options)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<IBuffer, uint> InputStreamOverStream.ReadAsync(IBuffer buffer, uint count, InputStreamOptions options) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Dispose()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/OutputStreamOverStream.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/OutputStreamOverStream.cs
@@ -2,26 +2,26 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class OutputStreamOverStream : global::Windows.Storage.Streams.IOutputStream,global::System.IDisposable
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperationWithProgress<uint, uint> WriteAsync( global::Windows.Storage.Streams.IBuffer buffer)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<uint, uint> OutputStreamOverStream.WriteAsync(IBuffer buffer) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<bool> FlushAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> OutputStreamOverStream.FlushAsync() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Dispose()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/RandomAccessStreamOverStream.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/RandomAccessStreamOverStream.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class RandomAccessStreamOverStream : global::Windows.Storage.Streams.IRandomAccessStream,global::Windows.Storage.Streams.IOutputStream,global::System.IDisposable,global::Windows.Storage.Streams.IInputStream
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  ulong Size
 		{
@@ -21,7 +21,7 @@ namespace Windows.Storage.Streams
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool CanRead
 		{
@@ -31,7 +31,7 @@ namespace Windows.Storage.Streams
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool CanWrite
 		{
@@ -41,7 +41,7 @@ namespace Windows.Storage.Streams
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  ulong Position
 		{
@@ -53,14 +53,14 @@ namespace Windows.Storage.Streams
 		#endif
 		// Forced skipping of method Windows.Storage.Streams.RandomAccessStreamOverStream.Size.get
 		// Forced skipping of method Windows.Storage.Streams.RandomAccessStreamOverStream.Size.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Storage.Streams.IInputStream GetInputStreamAt( ulong position)
 		{
 			throw new global::System.NotImplementedException("The member IInputStream RandomAccessStreamOverStream.GetInputStreamAt(ulong position) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Storage.Streams.IOutputStream GetOutputStreamAt( ulong position)
 		{
@@ -68,14 +68,14 @@ namespace Windows.Storage.Streams
 		}
 		#endif
 		// Forced skipping of method Windows.Storage.Streams.RandomAccessStreamOverStream.Position.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Seek( ulong position)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.Streams.RandomAccessStreamOverStream", "void RandomAccessStreamOverStream.Seek(ulong position)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Storage.Streams.IRandomAccessStream CloneStream()
 		{
@@ -84,28 +84,28 @@ namespace Windows.Storage.Streams
 		#endif
 		// Forced skipping of method Windows.Storage.Streams.RandomAccessStreamOverStream.CanRead.get
 		// Forced skipping of method Windows.Storage.Streams.RandomAccessStreamOverStream.CanWrite.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Dispose()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.Streams.RandomAccessStreamOverStream", "void RandomAccessStreamOverStream.Dispose()");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Storage.Streams.IBuffer, uint> ReadAsync( global::Windows.Storage.Streams.IBuffer buffer,  uint count,  global::Windows.Storage.Streams.InputStreamOptions options)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<IBuffer, uint> RandomAccessStreamOverStream.ReadAsync(IBuffer buffer, uint count, InputStreamOptions options) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperationWithProgress<uint, uint> WriteAsync( global::Windows.Storage.Streams.IBuffer buffer)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<uint, uint> RandomAccessStreamOverStream.WriteAsync(IBuffer buffer) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<bool> FlushAsync()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/RandomAccessStreamReference.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Streams/RandomAccessStreamReference.cs
@@ -2,33 +2,33 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class RandomAccessStreamReference : global::Windows.Storage.Streams.IRandomAccessStreamReference
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Streams.IRandomAccessStreamWithContentType> OpenReadAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IRandomAccessStreamWithContentType> RandomAccessStreamReference.OpenReadAsync() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Storage.Streams.RandomAccessStreamReference CreateFromFile( global::Windows.Storage.IStorageFile file)
 		{
 			throw new global::System.NotImplementedException("The member RandomAccessStreamReference RandomAccessStreamReference.CreateFromFile(IStorageFile file) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Storage.Streams.RandomAccessStreamReference CreateFromUri( global::System.Uri uri)
 		{
 			throw new global::System.NotImplementedException("The member RandomAccessStreamReference RandomAccessStreamReference.CreateFromUri(Uri uri) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Storage.Streams.RandomAccessStreamReference CreateFromStream( global::Windows.Storage.Streams.IRandomAccessStream stream)
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/FileAccessMode.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/FileAccessMode.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageFile.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageFile.cs
@@ -7,13 +7,13 @@ namespace Windows.Storage
 	#endif
 	public  partial interface IStorageFile : global::Windows.Storage.IStorageItem,global::Windows.Storage.Streams.IRandomAccessStreamReference,global::Windows.Storage.Streams.IInputStreamReference
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		string ContentType
 		{
 			get;
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		string FileType
 		{
 			get;
@@ -21,34 +21,34 @@ namespace Windows.Storage
 		#endif
 		// Forced skipping of method Windows.Storage.IStorageFile.FileType.get
 		// Forced skipping of method Windows.Storage.IStorageFile.ContentType.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Streams.IRandomAccessStream> OpenAsync( global::Windows.Storage.FileAccessMode accessMode);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageStreamTransaction> OpenTransactedWriteAsync();
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CopyAsync( global::Windows.Storage.IStorageFolder destinationFolder);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CopyAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CopyAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName,  global::Windows.Storage.NameCollisionOption option);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncAction CopyAndReplaceAsync( global::Windows.Storage.IStorageFile fileToReplace);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncAction MoveAsync( global::Windows.Storage.IStorageFolder destinationFolder);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncAction MoveAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncAction MoveAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName,  global::Windows.Storage.NameCollisionOption option);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncAction MoveAndReplaceAsync( global::Windows.Storage.IStorageFile fileToReplace);
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageItem.cs
@@ -2,55 +2,55 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IStorageItem 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Storage.FileAttributes Attributes
 		{
 			get;
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::System.DateTimeOffset DateCreated
 		{
 			get;
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		string Name
 		{
 			get;
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		string Path
 		{
 			get;
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncAction RenameAsync( string desiredName);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncAction RenameAsync( string desiredName,  global::Windows.Storage.NameCollisionOption option);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncAction DeleteAsync();
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncAction DeleteAsync( global::Windows.Storage.StorageDeleteOption option);
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.FileProperties.BasicProperties> GetBasicPropertiesAsync();
 		#endif
 		// Forced skipping of method Windows.Storage.IStorageItem.Name.get
 		// Forced skipping of method Windows.Storage.IStorageItem.Path.get
 		// Forced skipping of method Windows.Storage.IStorageItem.Attributes.get
 		// Forced skipping of method Windows.Storage.IStorageItem.DateCreated.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		bool IsOfType( global::Windows.Storage.StorageItemTypes type);
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageItem2.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/IStorageItem2.cs
@@ -2,15 +2,15 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IStorageItem2 : global::Windows.Storage.IStorageItem
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFolder> GetParentAsync();
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		bool IsEqual( global::Windows.Storage.IStorageItem item);
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageDeleteOption.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageDeleteOption.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageFile.cs
@@ -7,7 +7,7 @@ namespace Windows.Storage
 	#endif
 	public  partial class StorageFile : global::Windows.Storage.IStorageFile,global::Windows.Storage.Streams.IInputStreamReference,global::Windows.Storage.Streams.IRandomAccessStreamReference,global::Windows.Storage.IStorageItem,global::Windows.Storage.IStorageItemProperties,global::Windows.Storage.IStorageItemProperties2,global::Windows.Storage.IStorageItem2,global::Windows.Storage.IStorageItemPropertiesWithProvider,global::Windows.Storage.IStorageFilePropertiesWithAvailability,global::Windows.Storage.IStorageFile2
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string ContentType
 		{
@@ -17,7 +17,7 @@ namespace Windows.Storage
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string FileType
 		{
@@ -94,77 +94,77 @@ namespace Windows.Storage
 		// Forced skipping of method Windows.Storage.StorageFile.FileType.get
 		// Forced skipping of method Windows.Storage.StorageFile.ContentType.get
 		// Skipping already declared method Windows.Storage.StorageFile.OpenAsync(Windows.Storage.FileAccessMode)
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageStreamTransaction> OpenTransactedWriteAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageStreamTransaction> StorageFile.OpenTransactedWriteAsync() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CopyAsync( global::Windows.Storage.IStorageFolder destinationFolder)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.CopyAsync(IStorageFolder destinationFolder) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CopyAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.CopyAsync(IStorageFolder destinationFolder, string desiredNewName) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> CopyAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName,  global::Windows.Storage.NameCollisionOption option)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> StorageFile.CopyAsync(IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncAction CopyAndReplaceAsync( global::Windows.Storage.IStorageFile fileToReplace)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.CopyAndReplaceAsync(IStorageFile fileToReplace) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncAction MoveAsync( global::Windows.Storage.IStorageFolder destinationFolder)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.MoveAsync(IStorageFolder destinationFolder) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncAction MoveAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.MoveAsync(IStorageFolder destinationFolder, string desiredNewName) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncAction MoveAsync( global::Windows.Storage.IStorageFolder destinationFolder,  string desiredNewName,  global::Windows.Storage.NameCollisionOption option)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.MoveAsync(IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncAction MoveAndReplaceAsync( global::Windows.Storage.IStorageFile fileToReplace)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.MoveAndReplaceAsync(IStorageFile fileToReplace) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncAction RenameAsync( string desiredName)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncAction StorageFile.RenameAsync(string desiredName) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncAction RenameAsync( string desiredName,  global::Windows.Storage.NameCollisionOption option)
 		{
@@ -172,7 +172,7 @@ namespace Windows.Storage
 		}
 		#endif
 		// Skipping already declared method Windows.Storage.StorageFile.DeleteAsync()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncAction DeleteAsync( global::Windows.Storage.StorageDeleteOption option)
 		{
@@ -184,14 +184,14 @@ namespace Windows.Storage
 		// Forced skipping of method Windows.Storage.StorageFile.Path.get
 		// Forced skipping of method Windows.Storage.StorageFile.Attributes.get
 		// Forced skipping of method Windows.Storage.StorageFile.DateCreated.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool IsOfType( global::Windows.Storage.StorageItemTypes type)
 		{
 			throw new global::System.NotImplementedException("The member bool StorageFile.IsOfType(StorageItemTypes type) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Streams.IRandomAccessStreamWithContentType> OpenReadAsync()
 		{
@@ -251,14 +251,14 @@ namespace Windows.Storage
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageItemThumbnail> StorageFile.GetScaledImageAsThumbnailAsync(ThumbnailMode mode, uint requestedSize, ThumbnailOptions options) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFolder> GetParentAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFolder> StorageFile.GetParentAsync() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool IsEqual( global::Windows.Storage.IStorageItem item)
 		{
@@ -267,14 +267,14 @@ namespace Windows.Storage
 		#endif
 		// Forced skipping of method Windows.Storage.StorageFile.Provider.get
 		// Forced skipping of method Windows.Storage.StorageFile.IsAvailable.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Streams.IRandomAccessStream> OpenAsync( global::Windows.Storage.FileAccessMode accessMode,  global::Windows.Storage.StorageOpenOptions options)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IRandomAccessStream> StorageFile.OpenAsync(FileAccessMode accessMode, StorageOpenOptions options) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageStreamTransaction> OpenTransactedWriteAsync( global::Windows.Storage.StorageOpenOptions options)
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageItemTypes.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageItemTypes.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageOpenOptions.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageOpenOptions.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageStreamTransaction.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StorageStreamTransaction.cs
@@ -7,7 +7,7 @@ namespace Windows.Storage
 	#endif
 	public  partial class StorageStreamTransaction : global::System.IDisposable
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Storage.Streams.IRandomAccessStream Stream
 		{
@@ -18,7 +18,7 @@ namespace Windows.Storage
 		}
 		#endif
 		// Forced skipping of method Windows.Storage.StorageStreamTransaction.Stream.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncAction CommitAsync()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StreamedFileDataRequest.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StreamedFileDataRequest.cs
@@ -2,33 +2,33 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class StreamedFileDataRequest : global::Windows.Storage.Streams.IOutputStream,global::System.IDisposable,global::Windows.Storage.IStreamedFileDataRequest
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperationWithProgress<uint, uint> WriteAsync( global::Windows.Storage.Streams.IBuffer buffer)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<uint, uint> StreamedFileDataRequest.WriteAsync(IBuffer buffer) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.IAsyncOperation<bool> FlushAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> StreamedFileDataRequest.FlushAsync() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Dispose()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.StreamedFileDataRequest", "void StreamedFileDataRequest.Dispose()");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void FailAndClose( global::Windows.Storage.StreamedFileFailureMode failureMode)
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StreamedFileDataRequestedHandler.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/StreamedFileDataRequestedHandler.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	public delegate void StreamedFileDataRequestedHandler(global::Windows.Storage.StreamedFileDataRequest @stream);
 	#endif
 }

--- a/src/Uno.UWP/Storage/FileAccessMode.cs
+++ b/src/Uno.UWP/Storage/FileAccessMode.cs
@@ -1,0 +1,10 @@
+
+namespace Windows.Storage
+{
+	public enum FileAccessMode 
+	{
+		Read,
+
+		ReadWrite,
+	}
+}

--- a/src/Uno.UWP/Storage/FileIO.cs
+++ b/src/Uno.UWP/Storage/FileIO.cs
@@ -143,7 +143,7 @@ namespace Windows.Storage
 		/// <param name="buffer">The array of bytes to write.</param>
 		/// <returns>No object or value is returned when this method completes.</returns>
 		public static IAsyncAction WriteBytesAsync(IStorageFile file, byte[] buffer) =>
-			WriteBytesTaskAsync(file, buffer).AsAsyncAction();
+			WriteBytesTaskAsync(file, buffer, 0, buffer.Length).AsAsyncAction();
 
 		/// <summary>
 		/// Reads the contents of the specified file and returns a buffer.
@@ -249,7 +249,7 @@ namespace Windows.Storage
 			await streamWriter.WriteAsync(contents);
 		}
 
-		private static async Task WriteBytesTaskAsync(IStorageFile file, byte[] buffer)
+		private static async Task WriteBytesTaskAsync(IStorageFile file, byte[] buffer, int index, int count)
 		{
 			if (file is null)
 			{
@@ -269,12 +269,8 @@ namespace Windows.Storage
 
 		private static async Task WriteBufferTaskAsync(IStorageFile file, IBuffer buffer)
 		{
-			if (!(buffer is UwpBuffer inMemoryBuffer))
-			{
-				throw new NotSupportedException("The current implementation can only write a UwpBuffer");
-			}
-
-			await WriteBytesTaskAsync(file, inMemoryBuffer.Data);
+			var data = UwpBuffer.Cast(buffer).GetSegment();
+			await WriteBytesTaskAsync(file, data.Array!, data.Offset, data.Count);
 		}
 
 		private static async Task<Encoding> GetEncodingFromFileAsync(IStorageFile file)

--- a/src/Uno.UWP/Storage/FileProperties/BasicProperties.cs
+++ b/src/Uno.UWP/Storage/FileProperties/BasicProperties.cs
@@ -14,10 +14,7 @@ namespace Windows.Storage.FileProperties
 			_fileInfo = new FileInfo(file.Path);
 		}
 
-		public ulong Size
-		{
-			get { return (ulong)_fileInfo.Length; }
-		}
+		public ulong Size => (ulong)_fileInfo.Length;
 
 		public DateTimeOffset DateModified => File.GetLastWriteTime(_fileInfo.FullName);
 	}

--- a/src/Uno.UWP/Storage/IStorageFile.cs
+++ b/src/Uno.UWP/Storage/IStorageFile.cs
@@ -1,7 +1,22 @@
+using Windows.Foundation;
+using Windows.Storage.Streams;
+
 namespace Windows.Storage
 {
 	public  partial interface IStorageFile
 	{
+		string ContentType { get; }
+		string FileType { get; }
 
+		IAsyncOperation<IRandomAccessStream> OpenAsync(FileAccessMode accessMode);
+		IAsyncOperation<StorageStreamTransaction> OpenTransactedWriteAsync();
+		IAsyncOperation<StorageFile> CopyAsync(IStorageFolder destinationFolder);
+		IAsyncOperation<StorageFile> CopyAsync(IStorageFolder destinationFolder, string desiredNewName);
+		IAsyncOperation<StorageFile> CopyAsync(IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option);
+		IAsyncAction CopyAndReplaceAsync(IStorageFile fileToReplace);
+		IAsyncAction MoveAsync(IStorageFolder destinationFolder);
+		IAsyncAction MoveAsync(IStorageFolder destinationFolder, string desiredNewName);
+		IAsyncAction MoveAsync(IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option);
+		IAsyncAction MoveAndReplaceAsync(IStorageFile fileToReplace);
 	}
 }

--- a/src/Uno.UWP/Storage/IStorageItem.cs
+++ b/src/Uno.UWP/Storage/IStorageItem.cs
@@ -1,0 +1,20 @@
+using System;
+using Windows.Foundation;
+using Windows.Storage.FileProperties;
+
+namespace Windows.Storage
+{
+	public partial interface IStorageItem 
+	{
+		FileAttributes Attributes { get; }
+		DateTimeOffset DateCreated { get; }
+		string Name { get; }
+		string Path { get; }
+		IAsyncAction RenameAsync( string desiredName);
+		IAsyncAction RenameAsync( string desiredName, NameCollisionOption option);
+		IAsyncAction DeleteAsync();
+		IAsyncAction DeleteAsync(StorageDeleteOption option);
+		IAsyncOperation<BasicProperties> GetBasicPropertiesAsync();
+		bool IsOfType(StorageItemTypes type);
+	}
+}

--- a/src/Uno.UWP/Storage/IStorageItem2.cs
+++ b/src/Uno.UWP/Storage/IStorageItem2.cs
@@ -1,0 +1,10 @@
+using Windows.Foundation;
+
+namespace Windows.Storage
+{
+	public partial interface IStorageItem2 : IStorageItem
+	{
+		IAsyncOperation<StorageFolder> GetParentAsync();
+		bool IsEqual(IStorageItem item);
+	}
+}

--- a/src/Uno.UWP/Storage/OwnedStream.cs
+++ b/src/Uno.UWP/Storage/OwnedStream.cs
@@ -25,54 +25,32 @@ namespace Windows.Storage
 		}
 
 		public override void Flush()
-		{
-			_stream.Flush();
-		}
+			=> _stream.Flush();
 
 		public override int Read(byte[] buffer, int offset, int count)
-		{
-			return _stream.Read(buffer, offset, count);
-		}
+			=> _stream.Read(buffer, offset, count);
 
 		public override long Seek(long offset, SeekOrigin origin)
-		{
-			return _stream.Seek(offset, origin);
-		}
+			=> _stream.Seek(offset, origin);
 
 		public override void SetLength(long value)
-		{
-			_stream.SetLength(value);
-		}
+			=> _stream.SetLength(value);
 
 		public override void Write(byte[] buffer, int offset, int count)
-		{
-			_stream.Write(buffer, offset, count);
-		}
+			=> _stream.Write(buffer, offset, count);
 
-		public override bool CanRead
-		{
-			get { return _stream.CanRead; }
-		}
+		public override bool CanRead => _stream.CanRead;
 
-		public override bool CanSeek
-		{
-			get { return _stream.CanSeek; }
-		}
+		public override bool CanSeek => _stream.CanSeek;
 
-		public override bool CanWrite
-		{
-			get { return _stream.CanWrite; }
-		}
+		public override bool CanWrite => _stream.CanWrite;
 
-		public override long Length
-		{
-			get { return _stream.Length; }
-		}
+		public override long Length => _stream.Length;
 
 		public override long Position
 		{
-			get { return _stream.Position; }
-			set { _stream.Position = value; }
+			get => _stream.Position;
+			set => _stream.Position = value;
 		}
 	}
 }

--- a/src/Uno.UWP/Storage/StorageDeleteOption.cs
+++ b/src/Uno.UWP/Storage/StorageDeleteOption.cs
@@ -1,0 +1,8 @@
+namespace Windows.Storage
+{
+	public enum StorageDeleteOption 
+	{
+		Default,
+		PermanentDelete,
+	}
+}

--- a/src/Uno.UWP/Storage/StorageFile.Base.cs
+++ b/src/Uno.UWP/Storage/StorageFile.Base.cs
@@ -12,7 +12,7 @@ using Buffer = Windows.Storage.Streams.Buffer;
 
 namespace Windows.Storage
 {
-	public sealed partial class StorageFile
+	partial class StorageFile
 	{
 		private abstract class ImplementationBase
 		{

--- a/src/Uno.UWP/Storage/StorageFile.Base.cs
+++ b/src/Uno.UWP/Storage/StorageFile.Base.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Streams;
+using Buffer = Windows.Storage.Streams.Buffer;
 
 namespace Windows.Storage
 {
@@ -71,7 +72,7 @@ namespace Windows.Storage
 				using (var src = await Owner.OpenStreamForReadAsync())
 				using (var dst = await target.OpenStreamForReadAsync())
 				{
-					await src.CopyToAsync(dst, 8192, ct);
+					await src.CopyToAsync(dst, Buffer.DefaultCapacity, ct);
 				}
 			}
 
@@ -86,7 +87,7 @@ namespace Windows.Storage
 				using (var src = await Owner.OpenStreamForReadAsync())
 				using (var dst = await target.OpenStreamForReadAsync())
 				{
-					await src.CopyToAsync(dst, 8192, ct);
+					await src.CopyToAsync(dst, Buffer.DefaultCapacity, ct);
 				}
 
 				await Delete(ct, StorageDeleteOption.PermanentDelete);

--- a/src/Uno.UWP/Storage/StorageFile.Base.cs
+++ b/src/Uno.UWP/Storage/StorageFile.Base.cs
@@ -48,7 +48,7 @@ namespace Windows.Storage
 			public abstract Task<IRandomAccessStreamWithContentType> Open(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options);
 
 			public virtual async Task<Stream> OpenStream(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options)
-				=> (await Open(ct, accessMode, options)).AsStream();
+				=> (await Open(ct, accessMode, options).AsTask(ct)).AsStream();
 
 			public abstract Task<StorageStreamTransaction> OpenTransactedWrite(CancellationToken ct, StorageOpenOptions option);
 

--- a/src/Uno.UWP/Storage/StorageFile.Base.cs
+++ b/src/Uno.UWP/Storage/StorageFile.Base.cs
@@ -1,0 +1,101 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Storage.FileProperties;
+using Windows.Storage.Streams;
+
+namespace Windows.Storage
+{
+	public sealed partial class StorageFile
+	{
+		private abstract class ImplementationBase
+		{
+			protected ImplementationBase(string path)
+				=> Path = path;
+
+			public void InitOwner(StorageFile owner)
+				=> Owner = owner; // Lazy initialized to avoid delegate in StorageFile ctor
+
+			protected StorageFile Owner { get; private set; } = null!; // Should probably be private
+
+			public virtual string Path { get; protected set; }
+
+			public virtual string FileType => global::System.IO.Path.GetExtension(Path);
+
+			public virtual string Name => global::System.IO.Path.GetFileName(Path);
+
+			public virtual string DisplayName => global::System.IO.Path.GetFileNameWithoutExtension(Path);
+
+			public virtual string ContentType => GetContentTypeFromFileType(FileType);
+
+			public abstract DateTimeOffset DateCreated { get; }
+
+			public bool IsEqual(IStorageItem item)
+				=> item is StorageFile sf && IsEqual(sf._impl);
+
+			protected abstract bool IsEqual(ImplementationBase impl);
+
+			public abstract Task<StorageFolder> GetParent(CancellationToken ct);
+
+			public abstract Task<BasicProperties> GetBasicProperties(CancellationToken ct);
+
+			public abstract Task<IRandomAccessStreamWithContentType> Open(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options);
+
+			public virtual async Task<Stream> OpenStream(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options)
+				=> (await Open(ct, accessMode, options)).AsStream();
+
+			public abstract Task<StorageStreamTransaction> OpenTransactedWrite(CancellationToken ct, StorageOpenOptions option);
+
+			public abstract Task Delete(CancellationToken ct, StorageDeleteOption options);
+
+			public virtual async Task Rename(CancellationToken ct, string desiredName, NameCollisionOption option)
+			{
+				var parent = await GetParent(ct);
+				await Move(ct, parent, desiredName, option);
+			}
+
+			public virtual async Task<StorageFile> Copy(CancellationToken ct, IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option)
+			{
+				var dst = await CreateDestination(ct, destinationFolder, desiredNewName, option);
+				await CopyAndReplace(ct, dst);
+				return dst;
+			}
+
+			public virtual async Task CopyAndReplace(CancellationToken ct, IStorageFile target)
+			{
+				using (var src = await Owner.OpenStreamForReadAsync())
+				using (var dst = await target.OpenStreamForReadAsync())
+				{
+					await src.CopyToAsync(dst, 8192, ct);
+				}
+			}
+
+			public virtual async Task Move(CancellationToken ct, IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option)
+			{
+				var dst = await CreateDestination(ct, destinationFolder, desiredNewName, option);
+				await MoveAndReplace(ct, dst);
+			}
+
+			public virtual async Task MoveAndReplace(CancellationToken ct, IStorageFile target)
+			{
+				using (var src = await Owner.OpenStreamForReadAsync())
+				using (var dst = await target.OpenStreamForReadAsync())
+				{
+					await src.CopyToAsync(dst, 8192, ct);
+				}
+
+				await Delete(ct, StorageDeleteOption.PermanentDelete);
+
+				Path = target.Path;
+			}
+
+			protected Exception NotImplemented([CallerMemberName] string? method = null)
+				=> new NotSupportedException($"{method} is not supported yet for {GetType().Name}");
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/StorageFile.Local.cs
+++ b/src/Uno.UWP/Storage/StorageFile.Local.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Storage.FileProperties;
+using Windows.Storage.Streams;
+
+namespace Windows.Storage
+{
+	public sealed partial class StorageFile
+	{
+		private sealed class Local : ImplementationBase
+		{
+			public Local(string path)
+				: base(path)
+			{
+			}
+
+			public override DateTimeOffset DateCreated => File.GetCreationTime(Path);
+
+			protected override bool IsEqual(ImplementationBase impl)
+				=> impl is Local other && Path.Equals(other.Path);
+
+			public override async Task<StorageFolder> GetParent(CancellationToken ct)
+				=> new StorageFolder(global::System.IO.Path.GetDirectoryName(Path));
+
+			public override async Task<BasicProperties> GetBasicProperties(CancellationToken ct)
+				=> new BasicProperties(Owner);
+
+			public override async Task<IRandomAccessStreamWithContentType> Open(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options)
+				=> new RandomAccessStreamWithContentType(new FileRandomAccessStream(Path, ToFileAccess(accessMode), ToFileShare(options)), ContentType);
+
+			public override async Task<Stream> OpenStream(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options)
+				=> File.Open(Path, FileMode.Open, ToFileAccess(accessMode), ToFileShare(options));
+
+			public override async Task<StorageStreamTransaction> OpenTransactedWrite(CancellationToken ct, StorageOpenOptions option)
+				=> new StorageStreamTransaction(Owner);
+
+			public override async Task Delete(CancellationToken ct, StorageDeleteOption options)
+				=> File.Delete(Path);
+
+			public override async Task CopyAndReplace(CancellationToken ct, IStorageFile target)
+			{
+				switch (target)
+				{
+					case StorageFile file when file._impl is Local:
+						File.Copy(Path, file.Path, overwrite: true);
+						break;
+
+					default:
+						await base.CopyAndReplace(ct, target);
+						break;
+				}
+			}
+
+			public override async Task MoveAndReplace(CancellationToken ct, IStorageFile target)
+			{
+				switch (target)
+				{
+					case StorageFile file when file._impl is Local:
+						File.Delete(file.Path);
+						File.Move(Path, file.Path);
+						Path = target.Path;
+						break;
+
+					default:
+						await base.MoveAndReplace(ct, target);
+						break;
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/StorageFile.Local.cs
+++ b/src/Uno.UWP/Storage/StorageFile.Local.cs
@@ -35,7 +35,7 @@ namespace Windows.Storage
 				=> File.Open(Path, FileMode.Open, ToFileAccess(accessMode), ToFileShare(options));
 
 			public override async Task<StorageStreamTransaction> OpenTransactedWrite(CancellationToken ct, StorageOpenOptions option)
-				=> new StorageStreamTransaction(Owner);
+				=> new StorageStreamTransaction(Owner, ToFileShare(option));
 
 			public override async Task Delete(CancellationToken ct, StorageDeleteOption options)
 				=> File.Delete(Path);

--- a/src/Uno.UWP/Storage/StorageFile.Local.cs
+++ b/src/Uno.UWP/Storage/StorageFile.Local.cs
@@ -8,7 +8,7 @@ using Windows.Storage.Streams;
 
 namespace Windows.Storage
 {
-	public sealed partial class StorageFile
+	partial class StorageFile
 	{
 		private sealed class Local : ImplementationBase
 		{

--- a/src/Uno.UWP/Storage/StorageFile.android.cs
+++ b/src/Uno.UWP/Storage/StorageFile.android.cs
@@ -24,7 +24,7 @@ namespace Windows.Storage
 	{
 		private static ConcurrentEntryManager _assetGate = new ConcurrentEntryManager();
 
-		private static async Task<StorageFile> GetFileFromApplicationUriAsyncTask(CancellationToken ct, Uri uri)
+		private static async Task<StorageFile> GetFileFromApplicationUri(CancellationToken ct, Uri uri)
 		{
 			if(uri.Scheme != "ms-appx")
 			{

--- a/src/Uno.UWP/Storage/StorageFile.android.cs
+++ b/src/Uno.UWP/Storage/StorageFile.android.cs
@@ -20,7 +20,7 @@ using Windows.Storage.Helpers;
 
 namespace Windows.Storage
 {
-	public partial class StorageFile : StorageItem, IStorageFile
+	partial class StorageFile
 	{
 		private static ConcurrentEntryManager _assetGate = new ConcurrentEntryManager();
 

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -21,6 +21,9 @@ namespace Windows.Storage
 		public static IAsyncOperation<StorageFile> GetFileFromPathAsync(string path)
 			=> AsyncOperation.FromTask(async ct => new StorageFile(new Local(path)));
 
+		internal static StorageFile GetFileFromPath(string path)
+			=> new StorageFile(new Local(path));
+
 		internal static StorageFile GetFileFromLocalPath(string path)
 			=> new StorageFile(new Local(path));
 

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -16,7 +16,7 @@ using Uno;
 
 namespace Windows.Storage
 {
-	public sealed partial class StorageFile : StorageItem, IStorageFile
+	public sealed partial class StorageFile : IStorageFile, IStorageFile2, IStorageItem, IStorageItem2
 	{
 		public static IAsyncOperation<StorageFile> GetFileFromPathAsync(string path)
 			=> AsyncOperation.FromTask(async ct => new StorageFile(new Local(path)));

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -24,9 +24,6 @@ namespace Windows.Storage
 		internal static StorageFile GetFileFromPath(string path)
 			=> new StorageFile(new Local(path));
 
-		internal static StorageFile GetFileFromLocalPath(string path)
-			=> new StorageFile(new Local(path));
-
 		[NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public static IAsyncOperation<StorageFile> GetFileFromApplicationUriAsync(Uri uri)
 			=> AsyncOperation.FromTask(ct => GetFileFromApplicationUri(ct, uri));

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -1,58 +1,159 @@
+#nullable enable
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
 using System;
 using System.Globalization;
 using System.IO;
+using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Uno.Extensions;
 using Windows.Foundation;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Streams;
+using Uno;
 
 namespace Windows.Storage
 {
-	public partial class StorageFile : StorageItem, IStorageFile
+	public sealed partial class StorageFile : StorageItem, IStorageFile
 	{
-		private Uri _fileUri;
+		public static IAsyncOperation<StorageFile> GetFileFromPathAsync(string path)
+			=> AsyncOperation.FromTask(async ct => new StorageFile(new Local(path)));
 
-		private string Scheme => _fileUri.Scheme.ToUpperInvariant();
+		internal static StorageFile GetFileFromLocalPath(string path)
+			=> new StorageFile(new Local(path));
 
-		public string Path => _fileUri.LocalPath;
+		[NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
+		public static IAsyncOperation<StorageFile> GetFileFromApplicationUriAsync(Uri uri)
+			=> AsyncOperation.FromTask(ct => GetFileFromApplicationUri(ct, uri));
 
-		public string Name => global::System.IO.Path.GetFileName(Path);
+#if NET461 || __SKIA__ || __NETSTD_REFERENCE__
+		private static Task<StorageFile> GetFileFromApplicationUri(CancellationToken ct, Uri uri)
+			=> throw new NotImplementedException();
+#endif
 
-		public string DisplayName => global::System.IO.Path.GetFileNameWithoutExtension(Path);
+		private readonly ImplementationBase _impl;
 
-		public static async Task<StorageFile> GetFileFromPathAsync(string path)
+		private StorageFile(ImplementationBase impl)
 		{
-			return new StorageFile(new Uri("file://" + path));
+			_impl = impl;
+			_impl.InitOwner(this);
 		}
 
-		private StorageFile(Uri uri)
-		{
-			_fileUri = uri;
-		}
+		public string Path => _impl.Path;
 
-		public IAsyncAction DeleteAsync() =>
-			AsyncAction.FromTask(async ct =>
-			{
-				await DeleteAsync(CancellationToken.None);
-			});
-			
-		public async Task DeleteAsync(CancellationToken ct)
-		{
-			if (Scheme != "FILE")
-			{
-				throw new InvalidOperationException("Cannot delete a file on a non local storage.");
-			}
+		public string FileType => _impl.FileType;
 
-			var fileInfo = new FileInfo(Path);
+		public string Name => _impl.Name;
 
-			fileInfo.Delete();
-		}
+		public string DisplayName => _impl.DisplayName;
 
-		public global::System.DateTimeOffset DateCreated => File.GetCreationTime(Path);
+		public string ContentType => _impl.ContentType;
+
+		public DateTimeOffset DateCreated => _impl.DateCreated;
+
+		public bool IsOfType(StorageItemTypes type)
+			=> type == StorageItemTypes.File;
+
+		public bool IsEqual(IStorageItem item)
+			=> _impl.IsEqual(item);
+
+		#region internal API (Task)
+		internal Task<StorageFolder> GetParent(CancellationToken ct)
+			=> _impl.GetParent(ct);
+
+		internal Task<BasicProperties> GetBasicProperties(CancellationToken ct)
+			=> _impl.GetBasicProperties(ct);
+
+		internal Task<IRandomAccessStreamWithContentType> Open(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options)
+			=> _impl.Open(ct, accessMode, options);
+
+		internal Task<Stream> OpenStream(CancellationToken ct, FileAccessMode accessMode, StorageOpenOptions options)
+			=> _impl.OpenStream(ct, accessMode, options);
+
+		internal Task<StorageStreamTransaction> OpenTransactedWrite(CancellationToken ct, StorageOpenOptions option)
+			=> _impl.OpenTransactedWrite(ct, option);
+
+		internal Task Delete(CancellationToken ct, StorageDeleteOption options)
+			=> _impl.Delete(ct, options);
+
+		internal Task Rename(CancellationToken ct, string desiredName, NameCollisionOption option)
+			=> _impl.Rename(ct, desiredName, option);
+
+		internal Task<StorageFile> Copy(CancellationToken ct, IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option)
+			=> _impl.Copy(ct, destinationFolder, desiredNewName, option);
+
+		internal Task CopyAndReplace(CancellationToken ct, IStorageFile target)
+			=> _impl.CopyAndReplace(ct, target);
+
+		internal Task Move(CancellationToken ct, IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option)
+			=> _impl.Move(ct, destinationFolder, desiredNewName, option);
+
+		internal Task MoveAndReplace(CancellationToken ct, IStorageFile target)
+			=> _impl.MoveAndReplace(ct, target);
+		#endregion
+
+		#region public API (IAsync<Action|Operation>)
+		public IAsyncOperation<StorageFolder> GetParentAsync()
+			=> AsyncOperation.FromTask(_impl.GetParent);
+
+		public IAsyncOperation<BasicProperties> GetBasicPropertiesAsync()
+			=> AsyncOperation.FromTask(_impl.GetBasicProperties);
+
+		public IAsyncOperation<IRandomAccessStreamWithContentType> OpenReadAsync()
+			=> AsyncOperation<IRandomAccessStreamWithContentType>.FromTask((ct, _) => _impl.Open(ct, FileAccessMode.Read, StorageOpenOptions.None));
+
+		public IAsyncOperation<IRandomAccessStream> OpenAsync(FileAccessMode accessMode)
+			=> AsyncOperation<IRandomAccessStream>.FromTask(async (ct, _) => await _impl.Open(ct, accessMode, StorageOpenOptions.None));
+
+		public IAsyncOperation<IRandomAccessStream> OpenAsync(FileAccessMode accessMode, StorageOpenOptions options)
+			=> AsyncOperation<IRandomAccessStream>.FromTask(async (ct, _) => await _impl.Open(ct, accessMode, options));
+
+		public IAsyncOperation<StorageStreamTransaction> OpenTransactedWriteAsync()
+			=> AsyncOperation<StorageStreamTransaction>.FromTask((ct, _) => _impl.OpenTransactedWrite(ct, StorageOpenOptions.None));
+
+		[NotImplemented] // The options is ignored, we implement this only to increase compatibility
+		public IAsyncOperation<StorageStreamTransaction> OpenTransactedWriteAsync(StorageOpenOptions options)
+			=> AsyncOperation<StorageStreamTransaction>.FromTask((ct, _) => _impl.OpenTransactedWrite(ct, options));
+
+		public IAsyncOperation<StorageFile> CopyAsync(IStorageFolder destinationFolder)
+			=> AsyncOperation<StorageFile>.FromTask((ct, _) => _impl.Copy(ct, destinationFolder, global::System.IO.Path.GetFileName(Path), NameCollisionOption.FailIfExists));
+
+		public IAsyncOperation<StorageFile> CopyAsync(IStorageFolder destinationFolder, string desiredNewName)
+			=> AsyncOperation<StorageFile>.FromTask((ct, _) => _impl.Copy(ct, destinationFolder, desiredNewName, NameCollisionOption.FailIfExists));
+
+		public IAsyncOperation<StorageFile> CopyAsync(IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option)
+			=> AsyncOperation<StorageFile>.FromTask((ct, _) => _impl.Copy(ct, destinationFolder, desiredNewName, option));
+
+		public IAsyncAction CopyAndReplaceAsync(IStorageFile fileToReplace)
+			=> AsyncAction.FromTask(ct => _impl.CopyAndReplace(ct, fileToReplace));
+
+		public IAsyncAction RenameAsync(string desiredName)
+			=> AsyncAction.FromTask(ct => _impl.Rename(ct, desiredName, NameCollisionOption.FailIfExists));
+
+		public IAsyncAction RenameAsync(string desiredName, NameCollisionOption option)
+			=> AsyncAction.FromTask(ct => _impl.Rename(ct, desiredName, option));
+
+		public IAsyncAction MoveAsync(IStorageFolder destinationFolder)
+			=> AsyncAction.FromTask(ct => _impl.Move(ct, destinationFolder, Name, NameCollisionOption.FailIfExists));
+
+		public IAsyncAction MoveAsync(IStorageFolder destinationFolder, string desiredNewName)
+			=> AsyncAction.FromTask(ct => _impl.Move(ct, destinationFolder, desiredNewName, NameCollisionOption.FailIfExists));
+
+		public IAsyncAction MoveAsync(IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option)
+			=> AsyncAction.FromTask(ct => _impl.Move(ct, destinationFolder, desiredNewName, option));
+
+		public IAsyncAction MoveAndReplaceAsync(IStorageFile fileToReplace)
+			=> AsyncAction.FromTask(ct => _impl.MoveAndReplace(ct, fileToReplace));
+
+		public IAsyncAction DeleteAsync()
+			=> AsyncAction.FromTask(ct => _impl.Delete(ct, StorageDeleteOption.Default));
+
+		[NotImplemented] // The options is ignored, we implement this only to increase compatibility
+		public IAsyncAction DeleteAsync(StorageDeleteOption option)
+			=> AsyncAction.FromTask(ct => _impl.Delete(ct, option));
+		#endregion
 
 #if false
 		public async Task<Stream> GetThumbnailAsync(CancellationToken ct, ThumbnailMode mode, int size)
@@ -90,142 +191,117 @@ namespace Windows.Storage
 		}
 #endif
 
-		[Uno.NotImplemented]
-        public global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Streams.IRandomAccessStream> OpenAsync(global::Windows.Storage.FileAccessMode accessMode)
-        {
-            throw new global::System.NotImplementedException("The member IAsyncOperation<IRandomAccessStream> StorageFile.OpenAsync(FileAccessMode accessMode) is not implemented in Uno.");
-        }
-
-        private class FileRandomAccessStream : Windows.Storage.Streams.IRandomAccessStream
-        {
-            private readonly string _path;
-            private readonly FileAccessMode _accessMode;
-            private readonly Stream _source;
-
-            public FileRandomAccessStream(string path, global::Windows.Storage.FileAccessMode accessMode)
-            {
-                _path = path;
-                _accessMode = accessMode;
-                _source = File.OpenRead(path);
-            }
-
-            public bool CanRead => _source.CanRead;
-
-            public bool CanWrite => _source.CanWrite;
-
-            public ulong Position => (ulong)_source.Position;
-
-            public ulong Size {
-                get => (ulong)_source.Length;
-                set => throw new NotSupportedException("Setting the stream size is not supported");
-            }
-
-            public IRandomAccessStream CloneStream() => new FileRandomAccessStream(_path, _accessMode);
-            public void Dispose() => _source.Dispose();
-            public IAsyncOperation<bool> FlushAsync() => AsyncOperation.FromTask(async ct => { await _source.FlushAsync(); return true; });
-            public IInputStream GetInputStreamAt(ulong position) => throw new NotImplementedException();
-            public IOutputStream GetOutputStreamAt(ulong position) => throw new NotImplementedException();
-            public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options) => throw new NotImplementedException();
-            public void Seek(ulong position) => throw new NotImplementedException();
-            public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer) => throw new NotImplementedException();
-        }
-
-
-        public async Task<Stream> OpenStreamForReadAsync(CancellationToken ct)
-		{
-			switch (Scheme)
+		#region Helpers
+		private static FileAccess ToFileAccess(FileAccessMode accessMode)
+			=> accessMode switch
 			{
-				default:
-					return File.OpenRead(Path);
-			}
-		}
+				FileAccessMode.Read => FileAccess.Read,
+				FileAccessMode.ReadWrite => FileAccess.ReadWrite,
+				_ => throw new ArgumentOutOfRangeException(nameof(accessMode))
+			};
 
-		public async Task<StorageStreamTransaction> OpenTransactedWriteAsync(CancellationToken ct)
-		{
-			if (Scheme != "FILE")
+		private static FileShare ToFileShare(StorageOpenOptions options)
+			=> options switch
 			{
-				throw new InvalidOperationException("Cannot write on a non local file.");
-			}
+				StorageOpenOptions.None => FileShare.None,
+				StorageOpenOptions.AllowOnlyReaders => FileShare.Read,
+				StorageOpenOptions.AllowReadersAndWriters => FileShare.ReadWrite,
+				_ => throw new ArgumentOutOfRangeException(nameof(options))
+			};
 
-			return new StorageStreamTransaction(this);
-		}
-
-		public async Task CopyAndReplaceAsync(CancellationToken ct, StorageFile destination)
+		private static async Task<StorageFile> CreateDestination(CancellationToken ct, IStorageFolder destinationFolder, string desiredNewName, NameCollisionOption option)
 		{
-			switch (Scheme)
+			var creationOption = option switch
 			{
-				default:
-					File.Copy(this.Name, destination.Name, true);
-					break;
-			}
+				NameCollisionOption.FailIfExists => CreationCollisionOption.FailIfExists,
+				NameCollisionOption.GenerateUniqueName => CreationCollisionOption.GenerateUniqueName,
+				NameCollisionOption.ReplaceExisting => CreationCollisionOption.ReplaceExisting,
+				_ => throw new ArgumentOutOfRangeException(nameof(option)),
+			};
+
+			return await destinationFolder.CreateFileAsync(desiredNewName, creationOption).AsTask(ct);
 		}
 
-		public async Task MoveAsync(CancellationToken ct, StorageFolder targetFolder)
-		{
-			await MoveAsync(ct, targetFolder, Name, NameCollisionOption.FailIfExists);
-		}
-
-		public async Task MoveAsync(CancellationToken ct, StorageFolder targetFolder, string desiredNewName)
-		{
-			await MoveAsync(ct, targetFolder, desiredNewName, NameCollisionOption.FailIfExists);
-		}
-
-		public async Task MoveAsync(CancellationToken ct, StorageFolder targetFolder, string desiredNewName, NameCollisionOption option)
-		{
-			// TODO: Check the _scheme of the target folder
-			var targetPath = global::System.IO.Path.Combine(targetFolder.Path, desiredNewName);
-
-			if (File.Exists(targetPath))
+		private static string GetContentTypeFromFileType(string fileType)
+			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+			=> fileType.ToLowerInvariant() switch
 			{
-				switch (option)
-				{
-					case NameCollisionOption.FailIfExists:
-						throw new IOException("File {0} already exists".InvariantCultureFormat(targetPath));
-
-					case NameCollisionOption.GenerateUniqueName:
-						var extension = global::System.IO.Path.GetExtension(desiredNewName);
-						desiredNewName = global::System.IO.Path.ChangeExtension(desiredNewName, Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture) + extension);
-						await MoveAsync(ct, targetFolder, desiredNewName, option);
-						return;
-
-					case NameCollisionOption.ReplaceExisting:
-						File.Delete(targetPath);
-						break;
-
-					default:
-						throw new ArgumentOutOfRangeException("option");
-				}
-			}
-
-			switch (Scheme)
-			{
-				default:
-					File.Move(Path, targetPath);
-					break;
-			}
-
-			_fileUri = new Uri("file://" + targetPath);
-		}
-
-		public IAsyncOperation<BasicProperties> GetBasicPropertiesAsync()
-			=> GetBasicPropertiesAsync(new CancellationToken()).AsAsyncOperation<BasicProperties>();
-
-		public async Task<BasicProperties> GetBasicPropertiesAsync(CancellationToken ct)
-		{
-			return new BasicProperties(this);
-		}
-
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> GetFileFromApplicationUriAsync( global::System.Uri uri)
-		{
-			return AsyncOperation.FromTask(ct => GetFileFromApplicationUriAsyncTask(ct, uri));
-		}
-
-#if NET461 || __SKIA__ || __NETSTD_REFERENCE__
-		private static Task<StorageFile> GetFileFromApplicationUriAsyncTask(CancellationToken ct, Uri uri)
-		{
-			throw new NotImplementedException();
-		}
-#endif
+				".aac" => "audio/aac",
+				".abw" => "application/x-abiword",
+				".arc" => "application/x-freearc",
+				".avi" => "video/x-msvideo",
+				".azw" => "application/vnd.amazon.ebook",
+				".bin" => "application/octet-stream",
+				".bmp" => "image/bmp",
+				".bz" => "application/x-bzip",
+				".bz2" => "application/x-bzip2",
+				".csh" => "application/x-csh",
+				".css" => "text/css",
+				".csv" => "text/csv",
+				".doc" => "application/msword",
+				".docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				".eot" => "application/vnd.ms-fontobject",
+				".epub" => "application/epub+zip",
+				".gz" => "application/gzip",
+				".gif" => "image/gif",
+				".htm" => "text/html",
+				".html" => "text/html",
+				".ico" => "image/vnd.microsoft.icon",
+				".ics" => "text/calendar",
+				".jar" => "application/java-archive",
+				".jpeg" => "image/jpeg",
+				".jpg" => "image/jpeg",
+				".js" => "text/javascript",
+				".json" => "application/json",
+				".jsonld" => "application/ld+json",
+				".mid" => "audio/midi",
+				".midi" => "audio/midi",
+				".mjs" => "text/javascript",
+				".mp3" => "audio/mpeg",
+				".mpeg" => "video/mpeg",
+				".mpkg" => "application/vnd.apple.installer+xml",
+				".odp" => "application/vnd.oasis.opendocument.presentation",
+				".ods" => "application/vnd.oasis.opendocument.spreadsheet",
+				".odt" => "application/vnd.oasis.opendocument.text",
+				".oga" => "audio/ogg",
+				".ogv" => "video/ogg",
+				".ogx" => "application/ogg",
+				".opus" => "audio/opus",
+				".otf" => "font/otf",
+				".png" => "image/png",
+				".pdf" => "application/pdf",
+				".php" => "application/x-httpd-php",
+				".ppt" => "application/vnd.ms-powerpoint",
+				".pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+				".rar" => "application/vnd.rar",
+				".rtf" => "application/rtf",
+				".sh" => "application/x-sh",
+				".svg" => "image/svg+xml",
+				".swf" => "application/x-shockwave-flash",
+				".tar" => "application/x-tar",
+				".tif" => "image/tiff",
+				".tiff" => "image/tiff",
+				".ts" => "video/mp2t",
+				".ttf" => "font/ttf",
+				".txt" => "text/plain",
+				".vsd" => "application/vnd.visio",
+				".wav" => "audio/wav",
+				".weba" => "audio/webm",
+				".webm" => "video/webm",
+				".webp" => "image/webp",
+				".woff" => "font/woff",
+				".woff2" => "font/woff2",
+				".xhtml" => "application/xhtml+xml",
+				".xls" => "application/vnd.ms-excel",
+				".xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+				".xml" => "application/xml",
+				".xul" => "application/vnd.mozilla.xul+xml",
+				".zip" => "application/zip",
+				".3gp" => "video/3gpp",
+				".3g2" => "video/3gpp2",
+				".7z" => "application/x-7z-compressed",
+				_ => "application/octet-stream",
+			};
+		#endregion
 	}
 }

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -102,16 +102,16 @@ namespace Windows.Storage
 			=> AsyncOperation.FromTask(_impl.GetBasicProperties);
 
 		public IAsyncOperation<IRandomAccessStreamWithContentType> OpenReadAsync()
-			=> AsyncOperation<IRandomAccessStreamWithContentType>.FromTask((ct, _) => _impl.Open(ct, FileAccessMode.Read, StorageOpenOptions.None));
+			=> AsyncOperation<IRandomAccessStreamWithContentType>.FromTask((ct, _) => _impl.Open(ct, FileAccessMode.Read, StorageOpenOptions.AllowReadersAndWriters));
 
 		public IAsyncOperation<IRandomAccessStream> OpenAsync(FileAccessMode accessMode)
-			=> AsyncOperation<IRandomAccessStream>.FromTask(async (ct, _) => await _impl.Open(ct, accessMode, StorageOpenOptions.None));
+			=> AsyncOperation<IRandomAccessStream>.FromTask(async (ct, _) => await _impl.Open(ct, accessMode, StorageOpenOptions.AllowReadersAndWriters));
 
 		public IAsyncOperation<IRandomAccessStream> OpenAsync(FileAccessMode accessMode, StorageOpenOptions options)
 			=> AsyncOperation<IRandomAccessStream>.FromTask(async (ct, _) => await _impl.Open(ct, accessMode, options));
 
 		public IAsyncOperation<StorageStreamTransaction> OpenTransactedWriteAsync()
-			=> AsyncOperation<StorageStreamTransaction>.FromTask((ct, _) => _impl.OpenTransactedWrite(ct, StorageOpenOptions.None));
+			=> AsyncOperation<StorageStreamTransaction>.FromTask((ct, _) => _impl.OpenTransactedWrite(ct, StorageOpenOptions.AllowReadersAndWriters));
 
 		[NotImplemented] // The options is ignored, we implement this only to increase compatibility
 		public IAsyncOperation<StorageStreamTransaction> OpenTransactedWriteAsync(StorageOpenOptions options)

--- a/src/Uno.UWP/Storage/StorageFile.iOSmacOS.cs
+++ b/src/Uno.UWP/Storage/StorageFile.iOSmacOS.cs
@@ -10,7 +10,7 @@ namespace Windows.Storage
 {
 	public partial class StorageFile : StorageItem, IStorageFile
 	{
-		private static async Task<StorageFile> GetFileFromApplicationUriAsyncTask(CancellationToken ct, Uri uri)
+		private static async Task<StorageFile> GetFileFromApplicationUri(CancellationToken ct, Uri uri)
 		{
 			if(uri.Scheme != "ms-appx")
 			{

--- a/src/Uno.UWP/Storage/StorageFile.iOSmacOS.cs
+++ b/src/Uno.UWP/Storage/StorageFile.iOSmacOS.cs
@@ -8,7 +8,7 @@ using Foundation;
 
 namespace Windows.Storage
 {
-	public partial class StorageFile : StorageItem, IStorageFile
+	partial class StorageFile
 	{
 		private static async Task<StorageFile> GetFileFromApplicationUri(CancellationToken ct, Uri uri)
 		{

--- a/src/Uno.UWP/Storage/StorageFile.wasm.cs
+++ b/src/Uno.UWP/Storage/StorageFile.wasm.cs
@@ -15,7 +15,7 @@ namespace Windows.Storage
 {
 	public partial class StorageFile : StorageItem, IStorageFile
 	{
-		private static async Task<StorageFile> GetFileFromApplicationUriAsyncTask(CancellationToken ct, Uri uri)
+		private static async Task<StorageFile> GetFileFromApplicationUri(CancellationToken ct, Uri uri)
 		{
 			if(uri.Scheme != "ms-appx")
 			{

--- a/src/Uno.UWP/Storage/StorageFile.wasm.cs
+++ b/src/Uno.UWP/Storage/StorageFile.wasm.cs
@@ -13,7 +13,7 @@ using Windows.Storage.Helpers;
 
 namespace Windows.Storage
 {
-	public partial class StorageFile : StorageItem, IStorageFile
+	partial class StorageFile
 	{
 		private static async Task<StorageFile> GetFileFromApplicationUri(CancellationToken ct, Uri uri)
 		{

--- a/src/Uno.UWP/Storage/StorageFolder.cs
+++ b/src/Uno.UWP/Storage/StorageFolder.cs
@@ -132,7 +132,7 @@ namespace Windows.Storage
 					throw new FileNotFoundException(filePath);
 				}
 
-				return StorageFile.GetFileFromLocalPath(filePath);
+				return StorageFile.GetFileFromPath(filePath);
 			});
 
 		public IAsyncOperation<global::Windows.Storage.IStorageItem> GetItemAsync(string name) =>

--- a/src/Uno.UWP/Storage/StorageFolder.cs
+++ b/src/Uno.UWP/Storage/StorageFolder.cs
@@ -18,229 +18,229 @@ using Foundation;
 
 namespace Windows.Storage
 {
-    public partial class StorageFolder : StorageItem, IStorageFolder
-    {
-        public string Path { get; private set; }
-        public string Name { get; private set; }
+	public partial class StorageFolder : StorageItem, IStorageFolder
+	{
+		public string Path { get; private set; }
+		public string Name { get; private set; }
 
-        internal StorageFolder(string fullPath)
-        {
-            Path = fullPath;
-            Name = global::System.IO.Path.GetFileName(fullPath);
-        }
+		internal StorageFolder(string fullPath)
+		{
+			Path = fullPath;
+			Name = global::System.IO.Path.GetFileName(fullPath);
+		}
 
-        internal StorageFolder(string name, string path)
-        {
-            Path = path;
-            Name = name;
-        }
+		internal StorageFolder(string name, string path)
+		{
+			Path = path;
+			Name = name;
+		}
 
 #if !__WASM__
 		private static async Task TryInitializeStorage() { }
 #endif
 
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFolder> GetFolderFromPathAsync(string path) =>
-            AsyncOperation.FromTask(async ct =>
-            {
+			AsyncOperation.FromTask(async ct =>
+			{
 				await TryInitializeStorage();
 
 				if (Directory.Exists(path))
-                {
-                    return new StorageFolder(path);
-                }
-                else
-                {
-                    throw new DirectoryNotFoundException($"The folder {path} does not exist");
-                }
-            }
-        );
+				{
+					return new StorageFolder(path);
+				}
+				else
+				{
+					throw new DirectoryNotFoundException($"The folder {path} does not exist");
+				}
+			}
+		);
 
-        public IAsyncOperation<StorageFolder> CreateFolderAsync(string folderName) => CreateFolderAsync(folderName, CreationCollisionOption.FailIfExists);
+		public IAsyncOperation<StorageFolder> CreateFolderAsync(string folderName) => CreateFolderAsync(folderName, CreationCollisionOption.FailIfExists);
 
-        public IAsyncOperation<StorageFolder> CreateFolderAsync(string folderName, CreationCollisionOption option) =>
-            AsyncOperation.FromTask(async ct =>
-            {
+		public IAsyncOperation<StorageFolder> CreateFolderAsync(string folderName, CreationCollisionOption option) =>
+			AsyncOperation.FromTask(async ct =>
+			{
 				await TryInitializeStorage();
 
 				var path = global::System.IO.Path.Combine(Path, folderName);
-                DirectoryInfo di;
-                switch (option)
-                {
-                    case CreationCollisionOption.ReplaceExisting:
-                        if (Directory.Exists(path))
-                        {
-                            Directory.Delete(path, true);
-                        }
+				DirectoryInfo di;
+				switch (option)
+				{
+					case CreationCollisionOption.ReplaceExisting:
+						if (Directory.Exists(path))
+						{
+							Directory.Delete(path, true);
+						}
 
-                        di = Directory.CreateDirectory(path);
-                        return new StorageFolder(di.Name, path);
+						di = Directory.CreateDirectory(path);
+						return new StorageFolder(di.Name, path);
 
-                    case CreationCollisionOption.FailIfExists:
-                        if (Directory.Exists(path))
-                        {
-                            throw new UnauthorizedAccessException();
-                        }
+					case CreationCollisionOption.FailIfExists:
+						if (Directory.Exists(path))
+						{
+							throw new UnauthorizedAccessException();
+						}
 
-                        di = Directory.CreateDirectory(path);
-                        return new StorageFolder(di.Name, path);
+						di = Directory.CreateDirectory(path);
+						return new StorageFolder(di.Name, path);
 
-                    case CreationCollisionOption.OpenIfExists:
-                        if (Directory.Exists(path))
-                        {
-                            return new StorageFolder(folderName, path);
-                        }
+					case CreationCollisionOption.OpenIfExists:
+						if (Directory.Exists(path))
+						{
+							return new StorageFolder(folderName, path);
+						}
 
-                        di = Directory.CreateDirectory(path);
-                        return new StorageFolder(di.Name, path);
+						di = Directory.CreateDirectory(path);
+						return new StorageFolder(di.Name, path);
 
-                    case CreationCollisionOption.GenerateUniqueName:
-                        if (Directory.Exists(path))
-                        {
-                            di = Directory.CreateDirectory(path += Guid.NewGuid().ToStringInvariant());
-                            return new StorageFolder(di.Name, path);
-                        }
-                        else
-                        {
-                            di = Directory.CreateDirectory(path);
-                            return new StorageFolder(di.Name, path);
-                        }
-                }
+					case CreationCollisionOption.GenerateUniqueName:
+						if (Directory.Exists(path))
+						{
+							di = Directory.CreateDirectory(path += Guid.NewGuid().ToStringInvariant());
+							return new StorageFolder(di.Name, path);
+						}
+						else
+						{
+							di = Directory.CreateDirectory(path);
+							return new StorageFolder(di.Name, path);
+						}
+				}
 
-                return null;
-            });
+				return null;
+			});
 
-        /// <summary>
-        /// WARNING This method should not be used because it doesn't match the StorageFile API
-        /// </summary>
-        public IAsyncOperation<StorageFile> SafeGetFileAsync(string path) =>
-            AsyncOperation.FromTask(async ct =>
-            {
+		/// <summary>
+		/// WARNING This method should not be used because it doesn't match the StorageFile API
+		/// </summary>
+		public IAsyncOperation<StorageFile> SafeGetFileAsync(string path) =>
+			AsyncOperation.FromTask(async ct =>
+			{
 				await TryInitializeStorage();
 
 				return await StorageFile.GetFileFromPathAsync(global::System.IO.Path.Combine(Path, path));
-            });
+			});
 
-        public IAsyncOperation<StorageFile> GetFileAsync(string path) =>
-            AsyncOperation.FromTask(async ct =>
-            {
+		public IAsyncOperation<StorageFile> GetFileAsync(string path) =>
+			AsyncOperation.FromTask(async ct =>
+			{
 				await TryInitializeStorage();
 
 				var filePath = global::System.IO.Path.Combine(Path, path);
 
-                if (!File.Exists(filePath))
-                {
-                    throw new FileNotFoundException(filePath);
-                }
+				if (!File.Exists(filePath))
+				{
+					throw new FileNotFoundException(filePath);
+				}
 
-                return await StorageFile.GetFileFromPathAsync(filePath);
-            });
+				return StorageFile.GetFileFromLocalPath(filePath);
+			});
 
-        public IAsyncOperation<global::Windows.Storage.IStorageItem> GetItemAsync(string name) =>
-            AsyncOperation.FromTask(async ct =>
-            {
+		public IAsyncOperation<global::Windows.Storage.IStorageItem> GetItemAsync(string name) =>
+			AsyncOperation.FromTask(async ct =>
+			{
 				await TryInitializeStorage();
 
 				var itemPath = global::System.IO.Path.Combine(Path, name);
 
-                var fileExists = File.Exists(itemPath);
-                var directoryExists = Directory.Exists(itemPath);
+				var fileExists = File.Exists(itemPath);
+				var directoryExists = Directory.Exists(itemPath);
 
-                if (!fileExists && !directoryExists)
-                {
-                    throw new FileNotFoundException(itemPath);
-                }
+				if (!fileExists && !directoryExists)
+				{
+					throw new FileNotFoundException(itemPath);
+				}
 
-                if (fileExists)
-                {
-                    return (IStorageItem)await StorageFile.GetFileFromPathAsync(itemPath);
-                }
-                else
-                {
-                    return (IStorageItem)await StorageFolder.GetFolderFromPathAsync(itemPath);
-                }
-            });
+				if (fileExists)
+				{
+					return (IStorageItem)await StorageFile.GetFileFromPathAsync(itemPath);
+				}
+				else
+				{
+					return (IStorageItem)await StorageFolder.GetFolderFromPathAsync(itemPath);
+				}
+			});
 
-        public global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFolder> GetFolderAsync(string name) =>
-            AsyncOperation.FromTask(async ct =>
-            {
+		public global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFolder> GetFolderAsync(string name) =>
+			AsyncOperation.FromTask(async ct =>
+			{
 				await TryInitializeStorage();
 
 				var itemPath = global::System.IO.Path.Combine(Path, name);
 
-                var directoryExists = Directory.Exists(itemPath);
+				var directoryExists = Directory.Exists(itemPath);
 
-                if (!directoryExists)
-                {
-                    throw new FileNotFoundException(itemPath);
-                }
+				if (!directoryExists)
+				{
+					throw new FileNotFoundException(itemPath);
+				}
 
-                return await StorageFolder.GetFolderFromPathAsync(itemPath);
-            });
+				return await StorageFolder.GetFolderFromPathAsync(itemPath);
+			});
 
-        public IAsyncOperation<IStorageItem> TryGetItemAsync(string path) =>
-                AsyncOperation.FromTask(async ct =>
-                {
+		public IAsyncOperation<IStorageItem> TryGetItemAsync(string path) =>
+				AsyncOperation.FromTask(async ct =>
+				{
 					await TryInitializeStorage();
 
 					var filePath = global::System.IO.Path.Combine(Path, path);
 
-                    var result = File.Exists(filePath)
-                        ? await StorageFile.GetFileFromPathAsync(filePath)
-                        : default(StorageFile);
+					var result = File.Exists(filePath)
+						? await StorageFile.GetFileFromPathAsync(filePath)
+						: default(StorageFile);
 
-                    return (IStorageItem)result;
-                });
+					return (IStorageItem)result;
+				});
 
 		public IAsyncOperation<StorageFile> CreateFileAsync(string desiredName) => CreateFileAsync(desiredName, CreationCollisionOption.FailIfExists);
 
-        public IAsyncOperation<StorageFile> CreateFileAsync(string desiredName, CreationCollisionOption options) =>
-            AsyncOperation.FromTask(async ct =>
-            {
-                await TryInitializeStorage();
+		public IAsyncOperation<StorageFile> CreateFileAsync(string desiredName, CreationCollisionOption options) =>
+			AsyncOperation.FromTask(async ct =>
+			{
+				await TryInitializeStorage();
 
-                if (File.Exists(global::System.IO.Path.Combine(Path, desiredName)))
-                {
-                    switch (options)
-                    {
+				if (File.Exists(global::System.IO.Path.Combine(Path, desiredName)))
+				{
+					switch (options)
+					{
 						case CreationCollisionOption.FailIfExists:
 							throw new Exception("Cannot create a file when that file already exists.");
-                        case CreationCollisionOption.OpenIfExists:
+						case CreationCollisionOption.OpenIfExists:
 							break;
-                        case CreationCollisionOption.ReplaceExisting:
+						case CreationCollisionOption.ReplaceExisting:
 							File.Create(global::System.IO.Path.Combine(Path, desiredName)).Close();
 							break;
-                        case CreationCollisionOption.GenerateUniqueName:
+						case CreationCollisionOption.GenerateUniqueName:
 
-                            var pathExtension = global::System.IO.Path.GetExtension(desiredName);
-                            if (!string.IsNullOrEmpty(pathExtension))
-                            {
-                                desiredName = desiredName.Replace(pathExtension, "_" + Guid.NewGuid().ToStringInvariant().Replace("-", "") + pathExtension);
-                            }
-                            else
-                            {
-                                desiredName = desiredName + "_" + Guid.NewGuid();
-                            }
+							var pathExtension = global::System.IO.Path.GetExtension(desiredName);
+							if (!string.IsNullOrEmpty(pathExtension))
+							{
+								desiredName = desiredName.Replace(pathExtension, "_" + Guid.NewGuid().ToStringInvariant().Replace("-", "") + pathExtension);
+							}
+							else
+							{
+								desiredName = desiredName + "_" + Guid.NewGuid();
+							}
 
-                            File.Create(global::System.IO.Path.Combine(Path, desiredName)).Close();
-                            break;
-                        default:
-                            throw new ArgumentOutOfRangeException(nameof(options));
-                    }
-                }
-                else
-                {
-                    File.Create(global::System.IO.Path.Combine(Path, desiredName)).Close();
-                }
+							File.Create(global::System.IO.Path.Combine(Path, desiredName)).Close();
+							break;
+						default:
+							throw new ArgumentOutOfRangeException(nameof(options));
+					}
+				}
+				else
+				{
+					File.Create(global::System.IO.Path.Combine(Path, desiredName)).Close();
+				}
 
-                return await StorageFile.GetFileFromPathAsync(global::System.IO.Path.Combine(Path, desiredName));
-            });
+				return await StorageFile.GetFileFromPathAsync(global::System.IO.Path.Combine(Path, desiredName));
+			});
 
-        public IAsyncAction DeleteAsync() =>
-            AsyncAction.FromTask(async ct =>
-            {
+		public IAsyncAction DeleteAsync() =>
+			AsyncAction.FromTask(async ct =>
+			{
 				await TryInitializeStorage();
 
 				Directory.Delete(this.Path, true);
-            });
-    }
+			});
+	}
 }

--- a/src/Uno.UWP/Storage/StorageFolder.cs
+++ b/src/Uno.UWP/Storage/StorageFolder.cs
@@ -18,7 +18,7 @@ using Foundation;
 
 namespace Windows.Storage
 {
-	public partial class StorageFolder : StorageItem, IStorageFolder
+	public partial class StorageFolder : IStorageFolder, IStorageItem, IStorageItem2
 	{
 		public string Path { get; private set; }
 		public string Name { get; private set; }

--- a/src/Uno.UWP/Storage/StorageItem.cs
+++ b/src/Uno.UWP/Storage/StorageItem.cs
@@ -1,7 +1,0 @@
-namespace Windows.Storage
-{
-	public class StorageItem
-	{
-
-	}
-} 

--- a/src/Uno.UWP/Storage/StorageItemTypes.cs
+++ b/src/Uno.UWP/Storage/StorageItemTypes.cs
@@ -1,0 +1,9 @@
+namespace Windows.Storage
+{
+	public enum StorageItemTypes 
+	{
+		None,
+		File,
+		Folder,
+	}
+}

--- a/src/Uno.UWP/Storage/StorageOpenOptions.cs
+++ b/src/Uno.UWP/Storage/StorageOpenOptions.cs
@@ -1,0 +1,9 @@
+namespace Windows.Storage
+{
+	public enum StorageOpenOptions 
+	{
+		None,
+		AllowOnlyReaders,
+		AllowReadersAndWriters,
+	}
+}

--- a/src/Uno.UWP/Storage/StreamedFileDataRequest.cs
+++ b/src/Uno.UWP/Storage/StreamedFileDataRequest.cs
@@ -1,0 +1,58 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Threading;
+using Windows.ApplicationModel.Appointments;
+using Windows.Foundation;
+using Windows.Storage.Streams;
+
+namespace Windows.Storage
+{
+	public sealed partial class StreamedFileDataRequest : IOutputStream, IDisposable, IStreamedFileDataRequest
+	{
+		private readonly StreamedRandomAccessStream _owner;
+		private readonly Stream _tempFile;
+		private readonly CancellationTokenSource _ct;
+
+		internal StreamedFileDataRequest(StreamedRandomAccessStream owner, Stream tempFile)
+		{
+			_owner = owner;
+			_tempFile = tempFile;
+			_ct = new CancellationTokenSource();
+		}
+
+		internal CancellationToken CancellationToken => _ct.Token;
+
+		internal void Abort() => _ct.Cancel();
+
+		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
+			=> new AsyncOperationWithProgress<uint, uint>(async (ct, op) =>
+			{
+				var write = _tempFile.WriteAsync(buffer);
+				write.Progress = (snd, p) => op.NotifyProgress(p);
+
+				var written = await write.AsTask(ct);
+
+				// We make sure to write the data to the disk before allow read to access it
+				_tempFile.FlushAsync(ct);
+				//_owner.OnDataLoadProgress(written);
+
+				return written;
+			});
+
+		public IAsyncOperation<bool> FlushAsync()
+			=> _tempFile.FlushAsyncOp(); // This is actually useless as we flush on each Write.
+
+		public void FailAndClose(StreamedFileFailureMode failureMode)
+		{
+			//_owner.OnDataLoadCompleted(failureMode);
+		}
+
+		public void Dispose()
+		{
+			_ct.Dispose();
+			//_owner.OnDataLoadCompleted(default);
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/StreamedFileDataRequest.cs
+++ b/src/Uno.UWP/Storage/StreamedFileDataRequest.cs
@@ -29,7 +29,7 @@ namespace Windows.Storage
 		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
 			=> new AsyncOperationWithProgress<uint, uint>(async (ct, op) =>
 			{
-				var write = _tempFile.WriteAsync(buffer);
+				var write = _tempFile.WriteAsyncOperation(buffer);
 				write.Progress = (snd, p) => op.NotifyProgress(p);
 
 				var written = await write.AsTask(ct);
@@ -42,7 +42,7 @@ namespace Windows.Storage
 			});
 
 		public IAsyncOperation<bool> FlushAsync()
-			=> _tempFile.FlushAsyncOp(); // This is actually useless as we flush on each Write.
+			=> _tempFile.FlushAsyncOperation(); // This is actually useless as we flush on each Write.
 
 		public void FailAndClose(StreamedFileFailureMode failureMode)
 		{

--- a/src/Uno.UWP/Storage/StreamedFileDataRequestedHandler.cs
+++ b/src/Uno.UWP/Storage/StreamedFileDataRequestedHandler.cs
@@ -1,80 +1,8 @@
 #nullable enable
 
 using System;
-using System.IO;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Uno;
-using Uno.Extensions;
 
 namespace Windows.Storage
 {
 	public delegate void StreamedFileDataRequestedHandler(StreamedFileDataRequest stream);
-
-	//internal static class StreamedFileDataRequestedHandlerHelper
-	//{
-	//	public static StreamedFileDataRequestedHandler CreateFromUri(
-	//		Uri uri,
-	//		HttpMethod? method = null,
-	//		HttpClient? client = null,
-	//		ActionAsync<HttpResponseMessage?, Exception?>? onReady = null)
-	//	{
-	//		method ??= HttpMethod.Get;
-	//		client ??= new HttpClient();
-
-	//		return req => Task.Run(() => FetchAsync(req, uri, method, client, onReady, req.CancellationToken));
-	//	}
-
-	//	private static async Task FetchAsync(
-	//		StreamedFileDataRequest req,
-	//		Uri uri,
-	//		HttpMethod method,
-	//		HttpClient client,
-	//		ActionAsync<HttpResponseMessage?, Exception?>? onReady,
-	//		CancellationToken ct)
-	//	{
-	//		try
-	//		{
-	//			HttpResponseMessage response;
-	//			try
-	//			{
-	//				var request = new HttpRequestMessage(method, uri);
-	//				response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
-
-	//				response.EnsureSuccessStatusCode();
-
-	//				if (onReady is {})
-	//				{
-	//					await onReady(ct, response, null);
-	//				}
-	//			}
-	//			catch (Exception e) when (onReady is {})
-	//			{
-	//				await onReady(ct, null, e);
-	//				throw;
-	//			}
-
-	//			if (response.Content is { } content)
-	//			{
-	//				var responseStream = await content.ReadAsStreamAsync();
-	//				await responseStream.CopyToAsync(req.AsStreamForWrite(), global::Windows.Storage.Streams.Buffer.DefaultCapacity, ct);
-	//			}
-	//		}
-	//		catch (Exception e)
-	//		{
-	//			if (req.Log().IsEnabled(LogLevel.Warning))
-	//			{
-	//				req.Log().LogWarning("Failed to load content", e);
-	//			}
-
-	//			req.FailAndClose(StreamedFileFailureMode.Failed);
-	//		}
-	//		finally
-	//		{
-	//			req.Dispose();
-	//		}
-	//	}
-	//}
 }

--- a/src/Uno.UWP/Storage/StreamedFileDataRequestedHandler.cs
+++ b/src/Uno.UWP/Storage/StreamedFileDataRequestedHandler.cs
@@ -1,0 +1,80 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Uno;
+using Uno.Extensions;
+
+namespace Windows.Storage
+{
+	public delegate void StreamedFileDataRequestedHandler(StreamedFileDataRequest stream);
+
+	//internal static class StreamedFileDataRequestedHandlerHelper
+	//{
+	//	public static StreamedFileDataRequestedHandler CreateFromUri(
+	//		Uri uri,
+	//		HttpMethod? method = null,
+	//		HttpClient? client = null,
+	//		ActionAsync<HttpResponseMessage?, Exception?>? onReady = null)
+	//	{
+	//		method ??= HttpMethod.Get;
+	//		client ??= new HttpClient();
+			
+	//		return req => Task.Run(() => FetchAsync(req, uri, method, client, onReady, req.CancellationToken));
+	//	}
+
+	//	private static async Task FetchAsync(
+	//		StreamedFileDataRequest req,
+	//		Uri uri,
+	//		HttpMethod method,
+	//		HttpClient client,
+	//		ActionAsync<HttpResponseMessage?, Exception?>? onReady,
+	//		CancellationToken ct)
+	//	{
+	//		try
+	//		{
+	//			HttpResponseMessage response;
+	//			try
+	//			{
+	//				var request = new HttpRequestMessage(method, uri);
+	//				response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+	//				response.EnsureSuccessStatusCode();
+
+	//				if (onReady is {})
+	//				{
+	//					await onReady(ct, response, null);
+	//				}
+	//			}
+	//			catch (Exception e) when (onReady is {})
+	//			{
+	//				await onReady(ct, null, e);
+	//				throw;
+	//			}
+
+	//			if (response.Content is { } content)
+	//			{
+	//				var responseStream = await content.ReadAsStreamAsync();
+	//				await responseStream.CopyToAsync(req.AsStreamForWrite(), 8192, ct);
+	//			}
+	//		}
+	//		catch (Exception e)
+	//		{
+	//			if (req.Log().IsEnabled(LogLevel.Warning))
+	//			{
+	//				req.Log().LogWarning("Failed to load content", e);
+	//			}
+
+	//			req.FailAndClose(StreamedFileFailureMode.Failed);
+	//		}
+	//		finally
+	//		{
+	//			req.Dispose();
+	//		}
+	//	}
+	//}
+}

--- a/src/Uno.UWP/Storage/StreamedFileDataRequestedHandler.cs
+++ b/src/Uno.UWP/Storage/StreamedFileDataRequestedHandler.cs
@@ -23,7 +23,7 @@ namespace Windows.Storage
 	//	{
 	//		method ??= HttpMethod.Get;
 	//		client ??= new HttpClient();
-			
+
 	//		return req => Task.Run(() => FetchAsync(req, uri, method, client, onReady, req.CancellationToken));
 	//	}
 
@@ -59,7 +59,7 @@ namespace Windows.Storage
 	//			if (response.Content is { } content)
 	//			{
 	//				var responseStream = await content.ReadAsStreamAsync();
-	//				await responseStream.CopyToAsync(req.AsStreamForWrite(), 8192, ct);
+	//				await responseStream.CopyToAsync(req.AsStreamForWrite(), global::Windows.Storage.Streams.Buffer.DefaultCapacity, ct);
 	//			}
 	//		}
 	//		catch (Exception e)

--- a/src/Uno.UWP/Storage/StreamedFileFailureMode.cs
+++ b/src/Uno.UWP/Storage/StreamedFileFailureMode.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage
 {
-	#if false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif

--- a/src/Uno.UWP/Storage/StreamedFileFailureMode.cs
+++ b/src/Uno.UWP/Storage/StreamedFileFailureMode.cs
@@ -1,22 +1,16 @@
-#pragma warning disable 108 // new keyword hiding
-#pragma warning disable 114 // new keyword hiding
+
+using Uno;
+
 namespace Windows.Storage
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
-	#endif
-	public   enum StreamedFileFailureMode 
+	public enum StreamedFileFailureMode 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		Failed,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+
+		[NotImplemented] // We don't have any specific support fo this failure kind, all failures are handled the same way
 		CurrentlyUnavailable,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+
+		[NotImplemented] // We don't have any specific support fo this failure kind, all failures are handled the same way
 		Incomplete,
-		#endif
 	}
-	#endif
 }

--- a/src/Uno.UWP/Storage/Streams/Buffer.cs
+++ b/src/Uno.UWP/Storage/Streams/Buffer.cs
@@ -6,6 +6,11 @@ namespace Windows.Storage.Streams
 {
 	public partial class Buffer : IBuffer
 	{
+		/// <summary>
+		/// A default length to use for buffer copy when none specified
+		/// </summary>
+		internal const int DefaultCapacity = 1024 * 1024; // 1M
+
 		private readonly Memory<byte> _data;
 
 		internal static Buffer Cast(IBuffer impl)

--- a/src/Uno.UWP/Storage/Streams/Buffer.cs
+++ b/src/Uno.UWP/Storage/Streams/Buffer.cs
@@ -1,27 +1,90 @@
 ﻿using System;
+using System.Runtime.InteropServices;
+using Windows.Foundation;
 
 namespace Windows.Storage.Streams
 {
 	public partial class Buffer : IBuffer
 	{
+		private readonly Memory<byte> _data;
+
+		internal static Buffer Cast(IBuffer impl)
+		{
+			if (impl is Buffer buffer)
+			{
+				return buffer;
+			}
+			else
+			{
+				throw new NotSupportedException("This type of buffer is not supported.");
+			}
+		}
+
 		public Buffer(uint capacity)
 		{
-			Data = new byte[capacity];
+			_data = new Memory<byte>(new byte[capacity]);
 		}
 
 		internal Buffer(byte[] data)
 		{
-			Data = data;
+			_data = new Memory<byte>(data);
+			Length = Capacity;
 		}
 
-		internal byte[] Data { get; }
-
-		public uint Capacity => (uint)Data.Length;
-
-		public uint Length
+		internal Buffer(Memory<byte> data)
 		{
-			get => (uint)Data.Length;
-			set => throw new NotSupportedException();
+			_data = data;
+			Length = (uint)data.Length;
 		}
+
+		internal Span<byte> Span => _data.Span;
+
+		internal byte GetByte(int index)
+		{
+			return _data.Span[index];
+		}
+
+		/// <summary>
+		/// Retrieve the underlying data array
+		/// </summary>
+		internal ArraySegment<byte> GetSegment()
+		{
+			if (MemoryMarshal.TryGetArray<byte>(_data, out var array))
+			{
+				return array;
+			}
+			else
+			{
+				throw new InvalidOperationException("Cannot get the segment from buffer.");
+			}
+		}
+
+		/// <summary>
+		/// **CLONES** the content of this buffer into a new byte[]
+		/// </summary>
+		internal byte[] ToArray()
+		{
+			return _data.ToArray();
+		}
+
+		/// <summary>
+		/// **CLONES** a part of the content of this buffer into a new byte[]
+		/// </summary>
+		internal byte[] ToArray(int start, int count)
+		{
+			return _data.Slice(start, count).ToArray();
+		}
+
+		internal void CopyTo(int index, byte[] destination, int destinationIndex, int count)
+		{
+			var src = _data.Slice(index, count);
+			var dst = new Memory<byte>(destination, destinationIndex, count);
+
+			src.CopyTo(dst);
+		}
+
+		public uint Capacity => (uint)_data.Length;
+
+		public uint Length { get; set; }
 	}
 }

--- a/src/Uno.UWP/Storage/Streams/Buffer.cs
+++ b/src/Uno.UWP/Storage/Streams/Buffer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Windows.Foundation;
 
@@ -52,9 +53,14 @@ namespace Windows.Storage.Streams
 		/// <summary>
 		/// Retrieve the underlying data array
 		/// </summary>
+		/// <remarks>
+		/// The <see cref="ArraySegment{T}.Array"/> of the return cannot be null.
+		/// This method will throw an <see cref="InvalidOperationException"/> in that case.
+		/// </remarks>
 		internal ArraySegment<byte> GetSegment()
 		{
-			if (MemoryMarshal.TryGetArray<byte>(_data, out var array))
+			if (MemoryMarshal.TryGetArray<byte>(_data, out var array)
+				&& array.Array != null)
 			{
 				return array;
 			}

--- a/src/Uno.UWP/Storage/Streams/DataReader.cs
+++ b/src/Uno.UWP/Storage/Streams/DataReader.cs
@@ -11,13 +11,13 @@ namespace Windows.Storage.Streams
 	public sealed partial class DataReader : IDataReader, IDisposable
 	{
 		private readonly static ArrayPool<byte> _pool = ArrayPool<byte>.Create();
-		private readonly IBuffer _buffer;
+		private readonly Buffer _buffer;
 
 		private int _bufferPosition = 0;
 
 		private DataReader(IBuffer buffer)
 		{
-			_buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+			_buffer = Buffer.Cast(buffer ?? throw new ArgumentNullException(nameof(buffer)));
 		}
 
 		/// <summary>
@@ -247,22 +247,19 @@ namespace Windows.Storage.Streams
 			int length = (int)codeUnitCount;
 			VerifyRead(length);
 
-			if (!(_buffer is Buffer buffer))
-			{
-				throw new NotSupportedException("This type of buffer is not supported.");
-			}
+			var data = _buffer.GetSegment();
 
 			string result;
 			switch (UnicodeEncoding)
 			{
 				case UnicodeEncoding.Utf8:
-					result = Encoding.UTF8.GetString(buffer.Data, _bufferPosition, length);
+					result = Encoding.UTF8.GetString(data.Array!, data.Offset + _bufferPosition, length);
 					break;
 				case UnicodeEncoding.Utf16LE:
-					result = Encoding.Unicode.GetString(buffer.Data, _bufferPosition, length * 2);
+					result = Encoding.Unicode.GetString(data.Array!, data.Offset + _bufferPosition, length * 2);
 					break;
 				case UnicodeEncoding.Utf16BE:
-					result = Encoding.BigEndianUnicode.GetString(buffer.Data, _bufferPosition, length * 2);
+					result = Encoding.BigEndianUnicode.GetString(data.Array!, data.Offset + _bufferPosition, length * 2);
 					break;
 				default:
 					throw new InvalidOperationException("Unsupported UnicodeEncoding value.");
@@ -301,29 +298,12 @@ namespace Windows.Storage.Streams
 
 		private byte ReadByteFromBuffer()
 		{
-			byte nextByte;
-			switch (_buffer)
-			{
-				case Buffer buffer:
-					nextByte = buffer.Data[_bufferPosition];
-					break;
-				default:
-					throw new NotSupportedException("This buffer is not supported");
-			}
-			_bufferPosition++;
-			return nextByte;
+			return _buffer.GetByte(_bufferPosition++);
 		}
 
 		private void ReadBytesFromBuffer(byte[] data, int length)
 		{
-			switch (_buffer)
-			{
-				case Buffer buffer:
-					Array.Copy(buffer.Data, _bufferPosition, data, 0, length);
-					break;
-				default:
-					throw new NotSupportedException("This buffer is not supported");
-			}
+			_buffer.CopyTo(_bufferPosition, data, 0, length);
 			_bufferPosition += length;
 		}
 

--- a/src/Uno.UWP/Storage/Streams/DataReader.cs
+++ b/src/Uno.UWP/Storage/Streams/DataReader.cs
@@ -298,12 +298,12 @@ namespace Windows.Storage.Streams
 
 		private byte ReadByteFromBuffer()
 		{
-			return _buffer.GetByte(_bufferPosition++);
+			return _buffer.GetByte((uint)(_bufferPosition++));
 		}
 
 		private void ReadBytesFromBuffer(byte[] data, int length)
 		{
-			_buffer.CopyTo(_bufferPosition, data, 0, length);
+			_buffer.CopyTo((uint)_bufferPosition, data, 0, length);
 			_bufferPosition += length;
 		}
 

--- a/src/Uno.UWP/Storage/Streams/DataWriter.cs
+++ b/src/Uno.UWP/Storage/Streams/DataWriter.cs
@@ -73,14 +73,8 @@ namespace Windows.Storage.Streams
 				throw new ArgumentNullException(nameof(buffer));
 			}
 
-			switch (buffer)
-			{
-				case Buffer mb:
-					WriteBytes(mb.Data);
-					break;
-				default:
-					throw new NotSupportedException("This buffer is not supported");
-			}
+			var data = Buffer.Cast(buffer).GetSegment();
+			_memoryStream.Write(data.Array!, data.Offset, data.Count);
 		}
 
 		/// <summary>
@@ -101,14 +95,13 @@ namespace Windows.Storage.Streams
 				throw new ArgumentOutOfRangeException(nameof(start));
 			}
 
-			switch (buffer)
+			var data = Buffer.Cast(buffer).GetSegment();
+			if (count > data.Count)
 			{
-				case Buffer mb:
-					_memoryStream.Write(mb.Data, (int)start, (int)count);
-					break;
-				default:
-					throw new NotSupportedException("This buffer is not supported");
+				throw new ArgumentOutOfRangeException(nameof(count));
 			}
+
+			_memoryStream.Write(data.Array!, data.Offset + (int)start, (int)count);
 		}
 
 		/// <summary>

--- a/src/Uno.UWP/Storage/Streams/FileInputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileInputStream.cs
@@ -16,7 +16,7 @@ namespace Windows.Storage.Streams
 			_stream.Seek((long)position, SeekOrigin.Begin);
 		}
 
-		Stream IStreamWrapper.GetStream() => _stream;
+		Stream IStreamWrapper.FindStream() => _stream;
 
 		/// <inheritdoc />
 		public void Dispose()
@@ -24,6 +24,6 @@ namespace Windows.Storage.Streams
 
 		/// <inheritdoc />
 		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
-			=> _stream.ReadAsync(buffer, count, options);
+			=> _stream.ReadAsyncOperation(buffer, count, options);
 	}
 }

--- a/src/Uno.UWP/Storage/Streams/FileInputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileInputStream.cs
@@ -10,9 +10,9 @@ namespace Windows.Storage.Streams
 	{
 		private readonly Stream _stream;
 
-		internal FileInputStream(string path, ulong position)
+		internal FileInputStream(string path, FileShare fileShare, ulong position)
 		{
-			_stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+			_stream = File.Open(path, FileMode.Open, FileAccess.Read, fileShare);
 			_stream.Seek((long)position, SeekOrigin.Begin);
 		}
 

--- a/src/Uno.UWP/Storage/Streams/FileInputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileInputStream.cs
@@ -1,0 +1,29 @@
+#nullable enable
+
+using System;
+using System.IO;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	public sealed partial class FileInputStream : IInputStream, IDisposable, IStreamWrapper
+	{
+		private readonly Stream _stream;
+
+		internal FileInputStream(string path, ulong position)
+		{
+			_stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+			_stream.Seek((long)position, SeekOrigin.Begin);
+		}
+
+		Stream IStreamWrapper.GetStream() => _stream;
+
+		/// <inheritdoc />
+		public void Dispose()
+			=> _stream.Dispose();
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
+			=> _stream.ReadAsync(buffer, count, options);
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/FileInputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileInputStream.cs
@@ -12,7 +12,7 @@ namespace Windows.Storage.Streams
 
 		internal FileInputStream(string path, FileShare fileShare, ulong position)
 		{
-			_stream = File.Open(path, FileMode.Open, FileAccess.Read, fileShare);
+			_stream = File.Open(path, FileMode.OpenOrCreate, FileAccess.Read, fileShare);
 			_stream.Seek((long)position, SeekOrigin.Begin);
 		}
 

--- a/src/Uno.UWP/Storage/Streams/FileOutputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileOutputStream.cs
@@ -16,7 +16,7 @@ namespace Windows.Storage.Streams
 			_stream.Seek((long)position, SeekOrigin.Begin);
 		}
 
-		Stream IStreamWrapper.GetStream() => _stream;
+		Stream IStreamWrapper.FindStream() => _stream;
 
 		/// <inheritdoc />
 		public void Dispose()
@@ -24,10 +24,10 @@ namespace Windows.Storage.Streams
 
 		/// <inheritdoc />
 		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
-			=> _stream.WriteAsync(buffer);
+			=> _stream.WriteAsyncOperation(buffer);
 
 		/// <inheritdoc />
 		public IAsyncOperation<bool> FlushAsync()
-			=> _stream.FlushAsyncOp();
+			=> _stream.FlushAsyncOperation();
 	}
 }

--- a/src/Uno.UWP/Storage/Streams/FileOutputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileOutputStream.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+using System;
+using System.IO;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	public sealed partial class FileOutputStream : IOutputStream, IDisposable, IStreamWrapper
+	{
+		private readonly Stream _stream;
+
+		internal FileOutputStream(string path, ulong position)
+		{
+			_stream = File.Open(path, FileMode.Open, FileAccess.Write, FileShare.Write);
+			_stream.Seek((long)position, SeekOrigin.Begin);
+		}
+
+		Stream IStreamWrapper.GetStream() => _stream;
+
+		/// <inheritdoc />
+		public void Dispose()
+			=> _stream.Dispose();
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
+			=> _stream.WriteAsync(buffer);
+
+		/// <inheritdoc />
+		public IAsyncOperation<bool> FlushAsync()
+			=> _stream.FlushAsyncOp();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/FileOutputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileOutputStream.cs
@@ -12,7 +12,7 @@ namespace Windows.Storage.Streams
 
 		internal FileOutputStream(string path, FileShare fileShare, ulong position)
 		{
-			_stream = File.Open(path, FileMode.Open, FileAccess.Write, fileShare);
+			_stream = File.Open(path, FileMode.OpenOrCreate, FileAccess.Write, fileShare);
 			_stream.Seek((long)position, SeekOrigin.Begin);
 		}
 

--- a/src/Uno.UWP/Storage/Streams/FileOutputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileOutputStream.cs
@@ -10,9 +10,9 @@ namespace Windows.Storage.Streams
 	{
 		private readonly Stream _stream;
 
-		internal FileOutputStream(string path, ulong position)
+		internal FileOutputStream(string path, FileShare fileShare, ulong position)
 		{
-			_stream = File.Open(path, FileMode.Open, FileAccess.Write, FileShare.Write);
+			_stream = File.Open(path, FileMode.Open, FileAccess.Write, fileShare);
 			_stream.Seek((long)position, SeekOrigin.Begin);
 		}
 

--- a/src/Uno.UWP/Storage/Streams/FileRandomAccessStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileRandomAccessStream.cs
@@ -1,0 +1,84 @@
+#nullable enable
+
+using System;
+using System.IO;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	public sealed partial class FileRandomAccessStream : IRandomAccessStream, IInputStream, IOutputStream, IDisposable, IStreamWrapper
+	{
+		private readonly string _path;
+		private readonly FileAccess _access;
+		private readonly FileShare _share;
+
+		private readonly Stream _source;
+
+		internal FileRandomAccessStream(string path, FileAccess access, FileShare share)
+		{
+			_path = path;
+			_access = access;
+			_share = share;
+
+			// In order to be able to CloneStream() and Get<Input|Output>Stream(),
+			// no matter the provided share, we enforce to 'share' the 'access'.
+			var readWriteAccess = (FileShare)(access & FileAccess.ReadWrite);
+			share &= ~readWriteAccess;
+			share |= readWriteAccess;
+
+			_source = File.Open(_path, FileMode.Open, access, share);
+		}
+
+		Stream IStreamWrapper.GetStream() => _source;
+
+		public ulong Size
+		{
+			get => (ulong)_source.Length;
+			set => throw new NotSupportedException("Setting the stream size is not supported");
+		}
+
+		public bool CanRead => _source.CanRead;
+
+		public bool CanWrite => _source.CanWrite;
+
+		public ulong Position => (ulong)_source.Position;
+
+		public IInputStream GetInputStreamAt(ulong position)
+		{
+			if (!CanRead)
+			{
+				throw new InvalidOperationException("The file has been opened for read.");
+			}
+
+			return new FileInputStream(_path, position);
+		}
+
+		public IOutputStream GetOutputStreamAt(ulong position)
+		{
+			if (!CanWrite)
+			{
+				throw new InvalidOperationException("The file has been opened for write.");
+			}
+
+			return new FileOutputStream(_path, position);
+		}
+
+		public void Seek(ulong position)
+			=> _source.Seek((long)position, SeekOrigin.Begin);
+
+		public IRandomAccessStream CloneStream()
+			=> new FileRandomAccessStream(_path, _access, _share);
+
+		public void Dispose()
+			=> _source.Dispose();
+
+		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
+			=> _source.ReadAsync(buffer, count, options);
+
+		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
+			=> _source.WriteAsync(buffer);
+
+		public IAsyncOperation<bool> FlushAsync()
+			=> _source.FlushAsyncOp();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/FileRandomAccessStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileRandomAccessStream.cs
@@ -29,12 +29,12 @@ namespace Windows.Storage.Streams
 			_source = File.Open(_path, FileMode.Open, access, share);
 		}
 
-		Stream IStreamWrapper.GetStream() => _source;
+		Stream IStreamWrapper.FindStream() => _source;
 
 		public ulong Size
 		{
 			get => (ulong)_source.Length;
-			set => throw new NotSupportedException("Setting the stream size is not supported");
+			set => _source.SetLength((long)value);
 		}
 
 		public bool CanRead => _source.CanRead;
@@ -73,12 +73,12 @@ namespace Windows.Storage.Streams
 			=> _source.Dispose();
 
 		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
-			=> _source.ReadAsync(buffer, count, options);
+			=> _source.ReadAsyncOperation(buffer, count, options);
 
 		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
-			=> _source.WriteAsync(buffer);
+			=> _source.WriteAsyncOperation(buffer);
 
 		public IAsyncOperation<bool> FlushAsync()
-			=> _source.FlushAsyncOp();
+			=> _source.FlushAsyncOperation();
 	}
 }

--- a/src/Uno.UWP/Storage/Streams/FileRandomAccessStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileRandomAccessStream.cs
@@ -18,7 +18,6 @@ namespace Windows.Storage.Streams
 		{
 			_path = path;
 			_access = access;
-			_share = share;
 
 			// In order to be able to CloneStream() and Get<Input|Output>Stream(),
 			// no matter the provided share, we enforce to 'share' the 'access'.
@@ -26,6 +25,7 @@ namespace Windows.Storage.Streams
 			share &= ~readWriteAccess;
 			share |= readWriteAccess;
 
+			_share = share;
 			_source = File.Open(_path, FileMode.Open, access, share);
 		}
 
@@ -50,7 +50,7 @@ namespace Windows.Storage.Streams
 				throw new InvalidOperationException("The file has been opened for read.");
 			}
 
-			return new FileInputStream(_path, position);
+			return new FileInputStream(_path, _share, position);
 		}
 
 		public IOutputStream GetOutputStreamAt(ulong position)
@@ -60,7 +60,7 @@ namespace Windows.Storage.Streams
 				throw new InvalidOperationException("The file has been opened for write.");
 			}
 
-			return new FileOutputStream(_path, position);
+			return new FileOutputStream(_path, _share, position);
 		}
 
 		public void Seek(ulong position)

--- a/src/Uno.UWP/Storage/Streams/FileRandomAccessStream.cs
+++ b/src/Uno.UWP/Storage/Streams/FileRandomAccessStream.cs
@@ -26,7 +26,7 @@ namespace Windows.Storage.Streams
 			share |= readWriteAccess;
 
 			_share = share;
-			_source = File.Open(_path, FileMode.Open, access, share);
+			_source = File.Open(_path, FileMode.OpenOrCreate, access, share);
 		}
 
 		Stream IStreamWrapper.FindStream() => _source;
@@ -47,7 +47,7 @@ namespace Windows.Storage.Streams
 		{
 			if (!CanRead)
 			{
-				throw new InvalidOperationException("The file has been opened for read.");
+				throw new NotSupportedException("The file has been opened for read.");
 			}
 
 			return new FileInputStream(_path, _share, position);
@@ -57,7 +57,7 @@ namespace Windows.Storage.Streams
 		{
 			if (!CanWrite)
 			{
-				throw new InvalidOperationException("The file has been opened for write.");
+				throw new NotSupportedException("The file has been opened for write.");
 			}
 
 			return new FileOutputStream(_path, _share, position);

--- a/src/Uno.UWP/Storage/Streams/IContentTypeProvider.cs
+++ b/src/Uno.UWP/Storage/Streams/IContentTypeProvider.cs
@@ -2,21 +2,17 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Streams
 {
-	#if false
 	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
-	public   enum InputStreamOptions 
+	public  partial interface IContentTypeProvider 
 	{
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		None,
+		string ContentType
+		{
+			get;
+		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		Partial,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		ReadAhead,
-		#endif
+		// Forced skipping of method Windows.Storage.Streams.IContentTypeProvider.ContentType.get
 	}
-	#endif
 }

--- a/src/Uno.UWP/Storage/Streams/IInputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/IInputStream.cs
@@ -1,0 +1,11 @@
+
+using System;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	public  partial interface IInputStream : IDisposable
+	{
+		IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options);
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/IOutputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/IOutputStream.cs
@@ -1,0 +1,12 @@
+using System;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	public partial interface IOutputStream : IDisposable
+	{
+		IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer);
+
+		IAsyncOperation<bool> FlushAsync();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/IRandomAccessStream.cs
+++ b/src/Uno.UWP/Storage/Streams/IRandomAccessStream.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Windows.Storage.Streams
+{
+	public partial interface IRandomAccessStream : IDisposable, IInputStream, IOutputStream
+	{
+		bool CanRead { get; }
+
+		bool CanWrite { get; }
+
+		ulong Position { get; }
+
+		ulong Size { get; }
+
+		IInputStream GetInputStreamAt( ulong position);
+
+		IOutputStream GetOutputStreamAt( ulong position);
+
+		void Seek( ulong position);
+
+		IRandomAccessStream CloneStream();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/IRandomAccessStreamReference.cs
+++ b/src/Uno.UWP/Storage/Streams/IRandomAccessStreamReference.cs
@@ -1,0 +1,9 @@
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	public  partial interface IRandomAccessStreamReference 
+	{
+		IAsyncOperation<IRandomAccessStreamWithContentType> OpenReadAsync();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/IRandomAccessStreamWithContentType.cs
+++ b/src/Uno.UWP/Storage/Streams/IRandomAccessStreamWithContentType.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Windows.Storage.Streams
+{
+	public  partial interface IRandomAccessStreamWithContentType : IRandomAccessStream, IDisposable, IInputStream, IOutputStream, IContentTypeProvider
+	{
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/IStreamWrapper.cs
+++ b/src/Uno.UWP/Storage/Streams/IStreamWrapper.cs
@@ -8,21 +8,21 @@ namespace Windows.Storage.Streams
 {
 	internal interface IStreamWrapper
 	{
-		Stream GetStream();
+		Stream? FindStream();
 	}
 
 	interface IInputStreamWrapper
 	{
-		IInputStream GetStream();
+		IInputStream? FindStream();
 	}
 
 	interface IOutputStreamWrapper
 	{
-		IOutputStream GetStream();
+		IOutputStream? FindStream();
 	}
 
 	internal interface IRandomStreamWrapper : IInputStreamWrapper, IOutputStreamWrapper
 	{
-		new IRandomAccessStream GetStream();
+		new IRandomAccessStream? FindStream();
 	}
 }

--- a/src/Uno.UWP/Storage/Streams/IStreamWrapper.cs
+++ b/src/Uno.UWP/Storage/Streams/IStreamWrapper.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Windows.Storage.Streams
+{
+	internal interface IStreamWrapper
+	{
+		Stream GetStream();
+	}
+
+	interface IInputStreamWrapper
+	{
+		IInputStream GetStream();
+	}
+
+	interface IOutputStreamWrapper
+	{
+		IOutputStream GetStream();
+	}
+
+	internal interface IRandomStreamWrapper : IInputStreamWrapper, IOutputStreamWrapper
+	{
+		new IRandomAccessStream GetStream();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/IStreamedDataLoader.cs
+++ b/src/Uno.UWP/Storage/Streams/IStreamedDataLoader.cs
@@ -1,0 +1,46 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	/// <summary>
+	/// This is responsible to asynchronously load the content of a remote content into a temporary file
+	/// </summary>
+	/// <remarks>
+	/// The temporary file belong to this downloader.
+	/// It's is responsibility to delete it on dispose.
+	/// Users have to keep an active reference on this downloader to maintain the file alive.
+	/// It might however has to share the file with an <see cref="IStreamedDataUploader"/>.
+	/// </remarks>
+	internal interface IStreamedDataLoader
+	{
+		/// <summary>
+		/// An event raised when some data has been saved into the temporary file.
+		/// </summary>
+		public event TypedEventHandler<IStreamedDataLoader, object?>? DataUpdated;
+
+		/// <summary>
+		/// Gets the temporary file in which data is loaded
+		/// </summary>
+		TemporaryFile File { get; }
+
+		/// <summary>
+		/// The content type of the loaded data
+		/// </summary>
+		string? ContentType { get; }
+
+		/// <summary>
+		/// Throws an exception if the load failed
+		/// </summary>
+		void CheckState();
+
+		/// <summary>
+		/// Indicates if the given position has been or not yet,
+		/// **or** the load is now completed and the given position will never be present.
+		/// </summary>
+		bool CanRead(ulong position);
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/IStreamedDataUploader.cs
+++ b/src/Uno.UWP/Storage/Streams/IStreamedDataUploader.cs
@@ -1,0 +1,36 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Windows.Storage.Streams
+{
+	/// <summary>
+	/// This is responsible to asynchronously upload the content of a remote
+	/// </summary>
+	/// <remarks>
+	/// The temporary file belong to this uploader.
+	/// It's is responsibility to delete it on dispose.
+	/// Users have to keep an active reference on this uploader to maintain the file alive.
+	/// It might however has to share the file with an <see cref="IStreamedDataLoader"/>.
+	/// </remarks>
+	internal interface IStreamedDataUploader
+	{
+		/// <summary>
+		/// Gets the temporary file in which data is loaded
+		/// </summary>
+		TemporaryFile File { get; }
+
+		/// <summary>
+		/// Throws an exception if the load failed
+		/// </summary>
+		void CheckState();
+
+		/// <summary>
+		/// Send a chunk of data to the remote
+		/// </summary>
+		public Task<bool> Push(ulong index, ulong length, CancellationToken ct);
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/InputStreamOptions.cs
+++ b/src/Uno.UWP/Storage/Streams/InputStreamOptions.cs
@@ -1,0 +1,17 @@
+using System;
+using Uno;
+
+namespace Windows.Storage.Streams
+{
+	[Flags]
+	public enum InputStreamOptions : uint
+	{
+		None = 0,
+
+		[NotImplemented]
+		Partial = 1,
+
+		[NotImplemented]
+		ReadAhead = 2,
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/InputStreamOverStream.cs
+++ b/src/Uno.UWP/Storage/Streams/InputStreamOverStream.cs
@@ -1,0 +1,29 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	public partial class InputStreamOverStream : IInputStream, IDisposable, IStreamWrapper
+	{
+		private readonly Stream _stream;
+
+		internal InputStreamOverStream(Stream stream)
+		{
+			_stream = stream;
+		}
+
+		Stream IStreamWrapper.GetStream() => _stream;
+
+		/// <inheritdoc />
+		public void Dispose()
+			=> _stream.Dispose();
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
+			=> _stream.ReadAsync(buffer, count, options);
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/InputStreamOverStream.cs
+++ b/src/Uno.UWP/Storage/Streams/InputStreamOverStream.cs
@@ -16,7 +16,7 @@ namespace Windows.Storage.Streams
 			_stream = stream;
 		}
 
-		Stream IStreamWrapper.GetStream() => _stream;
+		Stream IStreamWrapper.FindStream() => _stream;
 
 		/// <inheritdoc />
 		public void Dispose()
@@ -24,6 +24,6 @@ namespace Windows.Storage.Streams
 
 		/// <inheritdoc />
 		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
-			=> _stream.ReadAsync(buffer, count, options);
+			=> _stream.ReadAsyncOperation(buffer, count, options);
 	}
 }

--- a/src/Uno.UWP/Storage/Streams/OutputStreamOverStream.cs
+++ b/src/Uno.UWP/Storage/Streams/OutputStreamOverStream.cs
@@ -16,7 +16,7 @@ namespace Windows.Storage.Streams
 			_stream = stream;
 		}
 
-		Stream IStreamWrapper.GetStream() => _stream;
+		Stream IStreamWrapper.FindStream() => _stream;
 
 		/// <inheritdoc />
 		public void Dispose()
@@ -24,10 +24,10 @@ namespace Windows.Storage.Streams
 
 		/// <inheritdoc />
 		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
-			=> _stream.WriteAsync(buffer);
+			=> _stream.WriteAsyncOperation(buffer);
 
 		/// <inheritdoc />
 		public IAsyncOperation<bool> FlushAsync()
-			=> _stream.FlushAsyncOp();
+			=> _stream.FlushAsyncOperation();
 	}
 }

--- a/src/Uno.UWP/Storage/Streams/OutputStreamOverStream.cs
+++ b/src/Uno.UWP/Storage/Streams/OutputStreamOverStream.cs
@@ -1,0 +1,33 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	public partial class OutputStreamOverStream : IOutputStream, IDisposable, IStreamWrapper
+	{
+		private readonly Stream _stream;
+
+		public OutputStreamOverStream(Stream stream)
+		{
+			_stream = stream;
+		}
+
+		Stream IStreamWrapper.GetStream() => _stream;
+
+		/// <inheritdoc />
+		public void Dispose()
+			=> _stream.Dispose();
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
+			=> _stream.WriteAsync(buffer);
+
+		/// <inheritdoc />
+		public IAsyncOperation<bool> FlushAsync()
+			=> _stream.FlushAsyncOp();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/RandomAccessStreamOverStream.cs
+++ b/src/Uno.UWP/Storage/Streams/RandomAccessStreamOverStream.cs
@@ -34,7 +34,7 @@ namespace Windows.Storage.Streams
 		public ulong Size
 		{
 			get => (ulong)_stream.Length;
-			set => throw new NotSupportedException();
+			set => _stream.SetLength((long)value);
 		}
 
 		public IInputStream GetInputStreamAt(ulong position)

--- a/src/Uno.UWP/Storage/Streams/RandomAccessStreamOverStream.cs
+++ b/src/Uno.UWP/Storage/Streams/RandomAccessStreamOverStream.cs
@@ -1,0 +1,75 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http.Headers;
+using Windows.Foundation;
+using Windows.Storage.Streams;
+using Uno;
+
+namespace Windows.Storage.Streams
+{
+	public partial class RandomAccessStreamOverStream : IRandomAccessStream, IInputStream, IOutputStream, IDisposable, IStreamWrapper
+	{
+		private readonly Stream _stream;
+
+		internal RandomAccessStreamOverStream(Stream stream)
+		{
+			_stream = stream;
+		}
+
+		Stream IStreamWrapper.GetStream() => _stream;
+
+		/// <inheritdoc />
+		public bool CanRead => _stream.CanRead;
+
+		/// <inheritdoc />
+		public bool CanWrite => _stream.CanWrite;
+
+		/// <inheritdoc />
+		public ulong Position => (ulong)_stream.Position;
+
+		/// <inheritdoc />
+		public ulong Size
+		{
+			get => (ulong)_stream.Length;
+			set => throw new NotSupportedException();
+		}
+
+		public IInputStream GetInputStreamAt(ulong position)
+		{
+			Seek(position);
+			return this;
+		}
+
+		public IOutputStream GetOutputStreamAt(ulong position)
+		{
+			Seek(position);
+			return this;
+		}
+
+		public void Seek(ulong position)
+			=> _stream.Seek((long)position, SeekOrigin.Begin);
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
+			=> _stream.ReadAsync(buffer, count, options);
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
+			=> _stream.WriteAsync(buffer);
+
+		/// <inheritdoc />
+		public IAsyncOperation<bool> FlushAsync()
+			=> _stream.FlushAsyncOp();
+
+		/// <inheritdoc />
+		public IRandomAccessStream CloneStream()
+			=> throw new NotSupportedException($"Cannot clone a {nameof(RandomAccessStreamOverStream)}");
+
+		/// <inheritdoc />
+		public virtual void Dispose()
+			=> _stream.Dispose();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/RandomAccessStreamOverStream.cs
+++ b/src/Uno.UWP/Storage/Streams/RandomAccessStreamOverStream.cs
@@ -19,7 +19,7 @@ namespace Windows.Storage.Streams
 			_stream = stream;
 		}
 
-		Stream IStreamWrapper.GetStream() => _stream;
+		Stream IStreamWrapper.FindStream() => _stream;
 
 		/// <inheritdoc />
 		public bool CanRead => _stream.CanRead;
@@ -54,15 +54,15 @@ namespace Windows.Storage.Streams
 
 		/// <inheritdoc />
 		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
-			=> _stream.ReadAsync(buffer, count, options);
+			=> _stream.ReadAsyncOperation(buffer, count, options);
 
 		/// <inheritdoc />
 		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
-			=> _stream.WriteAsync(buffer);
+			=> _stream.WriteAsyncOperation(buffer);
 
 		/// <inheritdoc />
 		public IAsyncOperation<bool> FlushAsync()
-			=> _stream.FlushAsyncOp();
+			=> _stream.FlushAsyncOperation();
 
 		/// <inheritdoc />
 		public IRandomAccessStream CloneStream()

--- a/src/Uno.UWP/Storage/Streams/RandomAccessStreamReference.cs
+++ b/src/Uno.UWP/Storage/Streams/RandomAccessStreamReference.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,17 +26,17 @@ namespace Windows.Storage.Streams
 		public static RandomAccessStreamReference CreateFromStream(IRandomAccessStream stream)
 			=> new RandomAccessStreamReference(async ct =>
 			{
-				return new RandomAccessStreamWithContentType(stream.CloneStream());
+				return stream.TrySetContentType();
 			});
 
 		private readonly Func<IAsyncOperation<IRandomAccessStreamWithContentType>> _open;
 
-		private RandomAccessStreamReference(Func<IAsyncOperation<IRandomAccessStreamWithContentType>> open)
+		internal RandomAccessStreamReference(Func<IAsyncOperation<IRandomAccessStreamWithContentType>> open)
 		{
 			_open = open;
 		}
 
-		public RandomAccessStreamReference(Func<CancellationToken, Task<IRandomAccessStreamWithContentType>> open)
+		internal RandomAccessStreamReference(Func<CancellationToken, Task<IRandomAccessStreamWithContentType>> open)
 			: this(() => AsyncOperation.FromTask(open))
 		{
 		}

--- a/src/Uno.UWP/Storage/Streams/RandomAccessStreamReference.cs
+++ b/src/Uno.UWP/Storage/Streams/RandomAccessStreamReference.cs
@@ -1,0 +1,46 @@
+#nullable enable
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Uno;
+
+namespace Windows.Storage.Streams
+{
+	public partial class RandomAccessStreamReference : IRandomAccessStreamReference
+	{
+		public static RandomAccessStreamReference CreateFromFile(IStorageFile file)
+			=> new RandomAccessStreamReference(file.OpenReadAsync);
+
+		public static RandomAccessStreamReference CreateFromUri(Uri uri)
+			=> new RandomAccessStreamReference(async ct
+				=>
+			{
+				var downloader = await StreamedUriDataLoader.Create(ct, uri);
+				return new StreamedRandomAccessStream(downloader);
+			});
+
+		public static RandomAccessStreamReference CreateFromStream(IRandomAccessStream stream)
+			=> new RandomAccessStreamReference(async ct =>
+			{
+				return new RandomAccessStreamWithContentType(stream.CloneStream());
+			});
+
+		private readonly Func<IAsyncOperation<IRandomAccessStreamWithContentType>> _open;
+
+		private RandomAccessStreamReference(Func<IAsyncOperation<IRandomAccessStreamWithContentType>> open)
+		{
+			_open = open;
+		}
+
+		public RandomAccessStreamReference(Func<CancellationToken, Task<IRandomAccessStreamWithContentType>> open)
+			: this(() => AsyncOperation.FromTask(open))
+		{
+		}
+
+		public IAsyncOperation<IRandomAccessStreamWithContentType> OpenReadAsync()
+			=> _open();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/RandomAccessStreamWithContentType.cs
+++ b/src/Uno.UWP/Storage/Streams/RandomAccessStreamWithContentType.cs
@@ -1,0 +1,66 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	internal class RandomAccessStreamWithContentType : IRandomAccessStreamWithContentType
+	{
+		private readonly IRandomAccessStream _stream;
+
+		public RandomAccessStreamWithContentType(IRandomAccessStream stream, string contentType = "application/octet-stream")
+		{
+			ContentType = contentType;
+			_stream = stream;
+		}
+
+		/// <inheritdoc />
+		public string ContentType { get; }
+
+		/// <inheritdoc />
+		public void Dispose()
+			=> _stream.Dispose();
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
+			=> _stream.ReadAsync(buffer, count, options);
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
+			=> _stream.WriteAsync(buffer);
+
+		/// <inheritdoc />
+		public IAsyncOperation<bool> FlushAsync()
+			=> _stream.FlushAsync();
+
+		/// <inheritdoc />
+		public bool CanRead => _stream.CanRead;
+
+		/// <inheritdoc />
+		public bool CanWrite => _stream.CanWrite;
+
+		/// <inheritdoc />
+		public ulong Position => _stream.Position;
+
+		/// <inheritdoc />
+		public ulong Size => _stream.Size;
+
+		/// <inheritdoc />
+		public IInputStream GetInputStreamAt(ulong position)
+			=> _stream.GetInputStreamAt(position);
+
+		/// <inheritdoc />
+		public IOutputStream GetOutputStreamAt(ulong position)
+			=> _stream.GetOutputStreamAt(position);
+
+		/// <inheritdoc />
+		public void Seek(ulong position)
+			=> _stream.Seek(position);
+
+		/// <inheritdoc />
+		public IRandomAccessStream CloneStream()
+			=> _stream.CloneStream();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamOverBuffer.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamOverBuffer.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+
+namespace Windows.Storage.Streams
+{
+	internal class StreamOverBuffer : Stream
+	{
+		private readonly Buffer _buffer;
+		private long _position;
+
+		public StreamOverBuffer(Buffer buffer)
+		{
+			_buffer = buffer;
+		}
+
+		/// <inheritdoc />
+		public override bool CanRead { get; } = true;
+
+		/// <inheritdoc />
+		public override bool CanSeek { get; } = true;
+
+		/// <inheritdoc />
+		public override bool CanWrite { get; } = true;
+
+		/// <inheritdoc />
+		public override long Length => _buffer.Length;
+
+		/// <inheritdoc />
+		public override long Position
+		{
+			get => _position;
+			set
+			{
+				if (value < 0) throw new ArgumentOutOfRangeException(nameof(value), "Position cannot be lower than 0");
+				if (value > Length) throw new ArgumentOutOfRangeException(nameof(value), "Position cannot be equals or greater than Length");
+				_position = value;
+			}
+		}
+
+		public override void Flush() { }
+
+		/// <inheritdoc />
+		public override long Seek(long offset, SeekOrigin origin)
+			=> origin switch
+			{
+				SeekOrigin.Begin => Position = offset,
+				SeekOrigin.Current => Position += offset,
+				SeekOrigin.End => Position = Length - 1,
+				_ => throw new ArgumentOutOfRangeException(nameof(origin), "Unknown SeekOrigin " + origin),
+			};
+
+		/// <inheritdoc />
+		public override void SetLength(long value)
+		{
+			if (value > _buffer.Capacity)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), "Cannot set a length greater than the underlying buffer");
+			}
+
+			_buffer.Length = (uint)value;
+		}
+
+		/// <inheritdoc />
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			var read = (int)Math.Min(Length - Position, count);
+			_buffer.CopyTo((uint)Position, buffer, offset, read);
+			Position += read;
+			return read;
+		}
+
+		/// <inheritdoc />
+		public override void Write(byte[] buffer, int offset, int count)
+		{
+			_buffer.Write((uint)Position, buffer, offset, count);
+			Position += count;
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamOverInputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamOverInputStream.cs
@@ -19,7 +19,7 @@ namespace Windows.Storage.Streams
 			_bufferSize = bufferSize;
 		}
 
-		IInputStream IInputStreamWrapper.GetStream() => _raStream;
+		IInputStream IInputStreamWrapper.FindStream() => _raStream;
 
 		/// <inheritdoc />
 		public override bool CanRead => true;

--- a/src/Uno.UWP/Storage/Streams/StreamOverInputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamOverInputStream.cs
@@ -1,0 +1,75 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Windows.Storage.Streams
+{
+	internal class StreamOverInputStream : Stream, IInputStreamWrapper
+	{
+		private readonly IInputStream _raStream;
+		private readonly int _bufferSize;
+
+		public StreamOverInputStream(IInputStream raStream, int bufferSize)
+		{
+			_raStream = raStream;
+			_bufferSize = bufferSize;
+		}
+
+		IInputStream IInputStreamWrapper.GetStream() => _raStream;
+
+		/// <inheritdoc />
+		public override bool CanRead => true;
+
+		/// <inheritdoc />
+		public override bool CanSeek => false;
+
+		/// <inheritdoc />
+		public override bool CanWrite => false;
+
+		/// <inheritdoc />
+		public override long Length => throw new NotSupportedException("Cannot get Length of an input stream.");
+
+		/// <inheritdoc />
+		public override long Position
+		{
+			get => throw new NotSupportedException("Cannot Seek an input stream.");
+			set => throw new NotSupportedException("Cannot get Position of an input stream.");
+		}
+
+		/// <inheritdoc />
+		public override long Seek(long offset, SeekOrigin origin)
+			=> throw new NotSupportedException("Cannot Seek an input stream.");
+
+		/// <inheritdoc />
+		public override void SetLength(long value)
+			=> throw new NotSupportedException("Cannot SetLength of a input stream.");
+
+		/// <inheritdoc />
+		public override int Read(byte[] buffer, int offset, int count)
+			=> ReadAsync(buffer, offset, count, CancellationToken.None).Result;
+
+		/// <inheritdoc />
+		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			=> _raStream.ReadAsync(buffer, offset, count, cancellationToken);
+
+		/// <inheritdoc />
+		public override void Write(byte[] buffer, int offset, int count)
+			=> WriteAsync(buffer, offset, count, CancellationToken.None).Wait();
+
+		/// <inheritdoc />
+		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			=> throw new NotSupportedException("Cannot Write an input stream.");
+
+		/// <inheritdoc />
+		public override void Flush()
+			=> FlushAsync(CancellationToken.None).Wait();
+
+		/// <inheritdoc />
+		public override Task FlushAsync(CancellationToken cancellationToken)
+			=> throw new NotSupportedException("Cannot Flush an input stream.");
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamOverOutputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamOverOutputStream.cs
@@ -1,0 +1,75 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Windows.Storage.Streams
+{
+	internal class StreamOverOutputStream : Stream, IOutputStreamWrapper
+	{
+		private readonly IOutputStream _raStream;
+		private readonly int _bufferSize;
+
+		public StreamOverOutputStream(IOutputStream raStream, int bufferSize)
+		{
+			_raStream = raStream;
+			_bufferSize = bufferSize;
+		}
+
+		IOutputStream IOutputStreamWrapper.GetStream() => _raStream;
+
+		/// <inheritdoc />
+		public override bool CanRead => false;
+
+		/// <inheritdoc />
+		public override bool CanSeek => false;
+
+		/// <inheritdoc />
+		public override bool CanWrite => true;
+
+		/// <inheritdoc />
+		public override long Length => throw new NotSupportedException("Cannot get Length of an output stream.");
+
+		/// <inheritdoc />
+		public override long Position
+		{
+			get => throw new NotSupportedException("Cannot Seek an output stream.");
+			set => throw new NotSupportedException("Cannot get Position of an output stream.");
+		}
+
+		/// <inheritdoc />
+		public override long Seek(long offset, SeekOrigin origin)
+			=> throw new NotSupportedException("Cannot Seek an output stream.");
+
+		/// <inheritdoc />
+		public override void SetLength(long value)
+			=> throw new NotSupportedException("Cannot SetLength of an output stream.");
+
+		/// <inheritdoc />
+		public override int Read(byte[] buffer, int offset, int count)
+			=> ReadAsync(buffer, offset, count, CancellationToken.None).Result;
+
+		/// <inheritdoc />
+		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			=> throw new NotSupportedException("Cannot Read an output stream.");
+
+		/// <inheritdoc />
+		public override void Write(byte[] buffer, int offset, int count)
+			=> WriteAsync(buffer, offset, count, CancellationToken.None).Wait();
+
+		/// <inheritdoc />
+		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			=> _raStream.WriteAsync(buffer, offset, count, cancellationToken);
+
+		/// <inheritdoc />
+		public override void Flush()
+			=> FlushAsync(CancellationToken.None).Wait();
+
+		/// <inheritdoc />
+		public override Task FlushAsync(CancellationToken cancellationToken)
+			=> _raStream.FlushAsync().AsTask(cancellationToken);
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamOverOutputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamOverOutputStream.cs
@@ -19,7 +19,7 @@ namespace Windows.Storage.Streams
 			_bufferSize = bufferSize;
 		}
 
-		IOutputStream IOutputStreamWrapper.GetStream() => _raStream;
+		IOutputStream IOutputStreamWrapper.FindStream() => _raStream;
 
 		/// <inheritdoc />
 		public override bool CanRead => false;

--- a/src/Uno.UWP/Storage/Streams/StreamOverRandomAccessStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamOverRandomAccessStream.cs
@@ -19,9 +19,9 @@ namespace Windows.Storage.Streams
 			_bufferSize = bufferSize;
 		}
 
-		IRandomAccessStream IRandomStreamWrapper.GetStream() => _raStream;
-		IInputStream IInputStreamWrapper.GetStream() => _raStream;
-		IOutputStream IOutputStreamWrapper.GetStream() => _raStream;
+		IRandomAccessStream IRandomStreamWrapper.FindStream() => _raStream;
+		IInputStream IInputStreamWrapper.FindStream() => _raStream;
+		IOutputStream IOutputStreamWrapper.FindStream() => _raStream;
 
 		/// <inheritdoc />
 		public override bool CanRead => _raStream.CanRead;

--- a/src/Uno.UWP/Storage/Streams/StreamOverRandomAccessStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamOverRandomAccessStream.cs
@@ -1,0 +1,95 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Windows.Storage.Streams
+{
+	internal class StreamOverRandomAccessStream : Stream, IRandomStreamWrapper
+	{
+		private readonly IRandomAccessStream _raStream;
+		private readonly int _bufferSize;
+
+		public StreamOverRandomAccessStream(IRandomAccessStream raStream, int bufferSize)
+		{
+			_raStream = raStream;
+			_bufferSize = bufferSize;
+		}
+
+		IRandomAccessStream IRandomStreamWrapper.GetStream() => _raStream;
+		IInputStream IInputStreamWrapper.GetStream() => _raStream;
+		IOutputStream IOutputStreamWrapper.GetStream() => _raStream;
+
+		/// <inheritdoc />
+		public override bool CanRead => _raStream.CanRead;
+
+		/// <inheritdoc />
+		public override bool CanSeek => true;
+
+		/// <inheritdoc />
+		public override bool CanWrite => _raStream.CanWrite;
+
+		/// <inheritdoc />
+		public override long Length => (long)_raStream.Size;
+
+		/// <inheritdoc />
+		public override long Position
+		{
+			get => (long)_raStream.Position;
+			set => _raStream.Seek((ulong)value);
+		}
+
+		/// <inheritdoc />
+		public override long Seek(long offset, SeekOrigin origin)
+		{
+			switch (origin)
+			{
+				case SeekOrigin.Begin:
+					_raStream.Seek((ulong)offset);
+					break;
+
+				case SeekOrigin.Current:
+					_raStream.Seek(_raStream.Position + (ulong)offset);
+					break;
+
+				case SeekOrigin.End:
+					_raStream.Seek(_raStream.Size - (ulong)offset);
+					break;
+			}
+
+			return (long)_raStream.Position;
+		}
+
+		/// <inheritdoc />
+		public override void SetLength(long value)
+			=> throw new NotSupportedException("Cannot set length.");
+
+
+		/// <inheritdoc />
+		public override int Read(byte[] buffer, int offset, int count)
+			=> ReadAsync(buffer, offset, count, CancellationToken.None).Result;
+
+		/// <inheritdoc />
+		public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			=> _raStream.ReadAsync(buffer, offset, count, cancellationToken);
+
+		/// <inheritdoc />
+		public override void Write(byte[] buffer, int offset, int count)
+			=> WriteAsync(buffer, offset, count, CancellationToken.None).Wait();
+
+		/// <inheritdoc />
+		public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			=> _raStream.WriteAsync(buffer, offset, count, cancellationToken);
+
+		/// <inheritdoc />
+		public override void Flush()
+			=> FlushAsync(CancellationToken.None).Wait();
+
+		/// <inheritdoc />
+		public override Task FlushAsync(CancellationToken cancellationToken)
+			=> _raStream.FlushAsync().AsTask(cancellationToken);
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamedCustomDataLoader.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedCustomDataLoader.cs
@@ -1,0 +1,64 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	internal class StreamedCustomDataLoader : IStreamedDataLoader
+	{
+		private uint _loaded;
+		private bool _isCompleted;
+		private StreamedFileFailureMode? _failure;
+
+		public StreamedCustomDataLoader(StreamedFileDataRequestedHandler handler, TemporaryFile? tempFile = null)
+		{
+			File = tempFile ?? new TemporaryFile();
+
+			handler(new StreamedFileDataRequest(this));
+		}
+
+		/// <inheritdoc />
+		public event TypedEventHandler<IStreamedDataLoader, object?>? DataUpdated;
+
+		/// <inheritdoc />
+		public TemporaryFile File { get; }
+
+		/// <inheritdoc />
+		public string? ContentType { get; } = RandomAccessStreamWithContentType.DefaultContentType;
+
+		/// <inheritdoc />
+		public void CheckState()
+		{
+			if (_failure.HasValue)
+			{
+				throw new InvalidOperationException($"The async load of the data has failed ('{_failure.Value}')");
+			}
+		}
+
+		/// <inheritdoc />
+		public bool CanRead(ulong position)
+			=> _isCompleted || position < _loaded;
+
+		internal void ReportDataWritten(uint length)
+		{
+			_loaded += length;
+			DataUpdated?.Invoke(this, default);
+		}
+
+		internal void ReportLoadCompleted(StreamedFileFailureMode? failure = null)
+		{
+			// Note: this is expected to be invoke more than once!
+
+			_failure ??= failure;
+
+			if (!_isCompleted)
+			{
+				_isCompleted = true;
+
+				DataUpdated?.Invoke(this, default);
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamedInputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedInputStream.cs
@@ -70,7 +70,7 @@ namespace Windows.Storage.Streams
 					_initialPosition = null;
 				}
 
-				var read = _stream.ReadAsync(buffer, count, options);
+				var read = _stream.ReadAsyncOperation(buffer, count, options);
 				read.Progress = (_, progress) => op.NotifyProgress(progress);
 
 				return await read.AsTask(ct);

--- a/src/Uno.UWP/Storage/Streams/StreamedInputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedInputStream.cs
@@ -1,0 +1,92 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	internal class StreamedInputStream : IInputStream
+	{
+		private readonly IStreamedDataLoader _loader;
+		private readonly Stream _stream;
+		private readonly bool _hasStreamOwnership;
+
+		private ulong? _initialPosition;
+
+		public StreamedInputStream(IStreamedDataLoader loader, ulong position)
+		{
+			_loader = loader;
+			_stream = loader.File.Open(FileAccess.Read);
+			_hasStreamOwnership = true;
+			_initialPosition = position;
+		}
+
+		public StreamedInputStream(Stream stream, IStreamedDataLoader loader)
+		{
+			_loader = loader;
+			_stream = stream;
+			_hasStreamOwnership = false;
+		}
+
+		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
+			=> new AsyncOperationWithProgress<IBuffer, uint>(async (ct, op) =>
+			{
+				var endPosition = (ulong)_stream.Position + (_initialPosition ?? 0) + count;
+				if (!_loader.CanRead(endPosition))
+				{
+					// The data is not ready yet.
+					// We have to wait for the data to be written into the temporary file before reading the value.
+
+					var asyncLoad = new TaskCompletionSource<object?>();
+					try
+					{
+						_loader.DataUpdated += OnDataLoaded;
+						if (!_loader.CanRead(endPosition))
+						{
+							using var ctReg = ct.Register(() => asyncLoad.TrySetCanceled(ct));
+							await asyncLoad.Task;
+						}
+					}
+					finally
+					{
+						_loader.DataUpdated -= OnDataLoaded;
+					}
+
+					void OnDataLoaded(IStreamedDataLoader loader, object? _)
+					{
+						if (_loader.CanRead(endPosition))
+						{
+							asyncLoad.TrySetResult(_);
+						}
+					}
+				}
+
+				if (_initialPosition.HasValue)
+				{
+					_stream.Seek((long)_initialPosition.Value, SeekOrigin.Begin);
+					_initialPosition = null;
+				}
+
+				var read = _stream.ReadAsync(buffer, count, options);
+				read.Progress = (_, progress) => op.NotifyProgress(progress);
+
+				return await read.AsTask(ct);
+			});
+
+		public void Dispose()
+		{
+			// Note: We DO NOT dispose the _loader as it might been used by some other stream (it's designed to be self-disposable)
+
+			if (_hasStreamOwnership)
+			{
+				_stream.Dispose();
+			}
+		}
+
+		~StreamedInputStream()
+			=> Dispose();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamedOutputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedOutputStream.cs
@@ -1,0 +1,90 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	internal class StreamedOutputStream : IOutputStream
+	{
+		private readonly IStreamedDataUploader _uploader;
+		private readonly Stream _stream;
+		private readonly bool _hasOwnership;
+		private (ulong start, ulong end)? _editedRange;
+
+		/// <summary>
+		/// Creates a new StreamedOutputStream.
+		/// This will self-open the temporary file and will take ownership of the opened stream.
+		/// </summary>
+		public StreamedOutputStream(IStreamedDataUploader uploader, ulong position = 0)
+		{
+			_uploader = uploader;
+			_stream = uploader.File.Open(FileAccess.Write);
+			_hasOwnership = true;
+
+			_stream.Seek((long)position, SeekOrigin.Begin);
+		}
+
+		/// <summary>
+		/// Creates a new StreamedOutputStream using a **shared** file stream.
+		/// This stream won't have ownership of the file and won't close/dispose it.
+		/// </summary>
+		public StreamedOutputStream(Stream stream, IStreamedDataUploader uploader)
+		{
+			_uploader = uploader;
+			_stream = stream;
+			_hasOwnership = false;
+		}
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
+			=> new AsyncOperationWithProgress<uint, uint>(async (ct, op) =>
+			{
+				var from = _stream.Position;
+				var to = from + buffer.Length;
+
+				await _stream.WriteAsync(buffer, ct);
+
+				UpdateEditedRange(from, to);
+
+				return buffer.Length;
+			});
+
+		/// <inheritdoc />
+		public IAsyncOperation<bool> FlushAsync()
+			=> AsyncOperation.FromTask<bool>(async ct =>
+			{
+				if (!_editedRange.HasValue)
+				{
+					return true;
+				}
+
+				await _stream.FlushAsync(ct);
+				await _uploader.Push(_editedRange.Value.start, _editedRange.Value.end, ct);
+				_editedRange = null;
+
+				return false;
+			});
+
+		private void UpdateEditedRange(long from, long to)
+		{
+			var (start, end) = _editedRange.GetValueOrDefault((ulong.MaxValue, ulong.MinValue));
+			start = Math.Min(start, (ulong)from);
+			end = Math.Max(end, (ulong)to);
+			_editedRange = (start, end);
+		}
+
+		public void Dispose()
+		{
+			if (_hasOwnership)
+			{
+				_stream.Dispose();
+			}
+		}
+
+		~StreamedOutputStream()
+			=> Dispose();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamedRandomAccessStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedRandomAccessStream.cs
@@ -1,0 +1,166 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Windows.Foundation;
+
+namespace Windows.Storage.Streams
+{
+	internal class StreamedRandomAccessStream : IRandomAccessStreamWithContentType
+	{
+		private readonly IStreamedDataLoader? _loader;
+		private readonly IStreamedDataUploader? _uploader;
+		private readonly Stream _temp;
+		private readonly StreamedInputStream? _input;
+		private readonly StreamedOutputStream? _output;
+		private readonly string? _contentType;
+
+		private int _isDisposed;
+
+		public StreamedRandomAccessStream(
+			IStreamedDataLoader? loader = null,
+			IStreamedDataUploader? uploader = null,
+			string? contentType = null)
+		{
+			_loader = loader;
+			_uploader = uploader;
+			_contentType = contentType;
+
+			if (loader is null && uploader is null)
+			{
+				throw new InvalidOperationException("You must provide at one valid access mode (read of write).");
+			}
+
+			var file = loader?.File ?? uploader!.File;
+			if (uploader?.File is {} upFile && file != upFile)
+			{
+				throw new InvalidOperationException(
+					"If StreamedRandomAccessStream can be Read and Write, "
+					+ "provided loader and uploader must use the same temporary file.");
+			}
+
+			_temp = file.Open(FileAccess.ReadWrite);
+
+			if (_loader is {})
+			{
+				_input = new StreamedInputStream(_temp, _loader);
+			}
+
+			if (_uploader is {})
+			{
+				_output = new StreamedOutputStream(_temp, _uploader);
+			}
+		}
+
+		/// <inheritdoc />
+		public string ContentType => _contentType ?? _loader?.ContentType ?? "application/octet-stream";
+
+		/// <inheritdoc />
+		public bool CanRead => _input is {};
+
+		/// <inheritdoc />
+		public bool CanWrite => _output is { };
+
+		/// <inheritdoc />
+		public ulong Position => (ulong)_temp.Position;
+
+		/// <inheritdoc />
+		public ulong Size => (ulong)_temp.Length;
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(IBuffer buffer, uint count, InputStreamOptions options)
+		{
+			CheckCanRead();
+			return _input!.ReadAsync(buffer, count, options);
+		}
+
+		/// <inheritdoc />
+		public IAsyncOperationWithProgress<uint, uint> WriteAsync(IBuffer buffer)
+		{
+			CheckCanWrite();
+			return _output!.WriteAsync(buffer);
+		}
+
+		/// <inheritdoc />
+		public IAsyncOperation<bool> FlushAsync()
+		{
+			CheckCanWrite();
+			return _output!.FlushAsync();
+		}
+
+		/// <inheritdoc />
+		public IInputStream GetInputStreamAt(ulong position)
+		{
+			CheckCanRead();
+			return new StreamedInputStream(_loader!, position);
+		}
+
+		/// <inheritdoc />
+		public IOutputStream GetOutputStreamAt(ulong position)
+		{
+			CheckCanWrite();
+			return new StreamedOutputStream(_uploader!, position);
+		}
+
+		/// <inheritdoc />
+		public void Seek(ulong position)
+			=> _temp.Seek((long)position, SeekOrigin.Begin);
+
+		/// <inheritdoc />
+		public IRandomAccessStream CloneStream()
+			=> new StreamedRandomAccessStream(_loader, _uploader, _contentType);
+
+		/// <inheritdoc />
+		public void Dispose()
+		{
+			// Note: We DO NOT dispose the _loader as it might been used by some other stream (it's designed to be self-disposable)
+
+			if (Interlocked.Exchange(ref _isDisposed, 1) == 0)
+			{
+				_input?.Dispose();
+				_output?.Dispose();
+
+				_temp.Dispose();
+			}
+		}
+
+		private void CheckCanRead()
+		{
+			_loader?.CheckState();
+			_uploader?.CheckState();
+
+			if (_isDisposed != 0)
+			{
+				throw new ObjectDisposedException(nameof(StreamedRandomAccessStream));
+			}
+
+			if (!CanRead)
+			{
+				throw new InvalidOperationException("This stream does not support read operations");
+			}
+		}
+
+		private void CheckCanWrite()
+		{
+			_loader?.CheckState();
+			_uploader?.CheckState();
+
+			if (_isDisposed != 0)
+			{
+				throw new ObjectDisposedException(nameof(StreamedRandomAccessStream));
+			}
+
+			if (!CanWrite)
+			{
+				throw new InvalidOperationException("This stream does not support write operations");
+			}
+		}
+
+		~StreamedRandomAccessStream()
+		{
+			Dispose();
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamedRandomAccessStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedRandomAccessStream.cs
@@ -30,7 +30,7 @@ namespace Windows.Storage.Streams
 
 			if (loader is null && uploader is null)
 			{
-				throw new InvalidOperationException("You must provide at one valid access mode (read of write).");
+				throw new InvalidOperationException("You must provide at one valid access mode (read or write).");
 			}
 
 			var file = loader?.File ?? uploader!.File;

--- a/src/Uno.UWP/Storage/Streams/StreamedUriDataLoader.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedUriDataLoader.cs
@@ -1,0 +1,121 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+
+namespace Windows.Storage.Streams
+{
+	internal class StreamedUriDataLoader : IStreamedDataLoader, IDisposable
+	{
+		/// <summary>
+		/// Asynchronously creates a StreamedDataLoader.
+		/// </summary>
+		/// <remarks>This will make sure to have successfully contacted the server and loaded the ContentType before completing this async method.</remarks>
+		public static async Task<StreamedUriDataLoader> Create(
+			CancellationToken ct,
+			Uri uri,
+			HttpMethod? method = null,
+			HttpClient? client = null,
+			TemporaryFile? tempFile = null)
+		{
+			method ??= HttpMethod.Get;
+			client ??= new HttpClient();
+			tempFile ??= new TemporaryFile();
+
+			var cts = new CancellationTokenSource();
+			using (ct.Register(cts.Cancel))
+			{
+				var request = new HttpRequestMessage(method, uri);
+				var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+
+				response.EnsureSuccessStatusCode();
+
+				if (response.Content is null)
+				{
+					throw new InvalidOperationException("No content");
+				}
+
+				return new StreamedUriDataLoader(response, tempFile, cts);
+			}
+		}
+
+		public event TypedEventHandler<IStreamedDataLoader, object?>? DataUpdated;
+
+		private readonly CancellationTokenSource _ct;
+		private bool _isCompleted;
+		private bool _isFailed;
+		private ulong _totalLoaded;
+
+		private StreamedUriDataLoader(HttpResponseMessage response, TemporaryFile tempFile, CancellationTokenSource ct)
+		{
+			_ct = ct;
+			File = tempFile;
+			ContentType = response.Content.Headers.ContentType?.ToString();
+
+			Task.Run(() => Download(response, ct.Token), ct.Token);
+		}
+
+		public string? ContentType { get; }
+
+		public TemporaryFile File { get; }
+
+		public void CheckState()
+		{
+			if (_isFailed)
+			{
+				throw new InvalidOperationException("Failed to load content");
+			}
+		}
+
+		public bool CanRead(ulong position)
+			=> _isCompleted || _isFailed || position <= _totalLoaded;
+
+		private async Task Download(HttpResponseMessage response, CancellationToken ct)
+		{
+			try
+			{
+				using var responseStream = await response.Content.ReadAsStreamAsync();
+				using var file = File.OpenWeak(FileAccess.Write);
+
+				var buffer = new byte[8192];
+				int read;
+				while ((read = await responseStream.ReadAsync(buffer, 0, 8192, ct)) > 0)
+				{
+					await file.WriteAsync(buffer, 0, read, ct);
+
+					_totalLoaded += (ulong)read;
+					DataUpdated?.Invoke(this, default);
+				}
+
+				_isCompleted = true;
+			}
+			catch (Exception e)
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().LogWarning("Failed to load content", e);
+				}
+
+				_isFailed = true;
+			}
+			finally
+			{
+				DataUpdated?.Invoke(this, default);
+			}
+		}
+
+		/// <inheritdoc />
+		public void Dispose()
+			=> _ct.Cancel();
+
+		~StreamedUriDataLoader()
+			=> Dispose();
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamedUriDataLoader.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedUriDataLoader.cs
@@ -89,6 +89,7 @@ namespace Windows.Storage.Streams
 				while ((read = await responseStream.ReadAsync(buffer, 0, Buffer.DefaultCapacity, ct)) > 0)
 				{
 					await file.WriteAsync(buffer, 0, read, ct);
+					await file.FlushAsync(ct); // We make sure to write the data to the disk before allow read to access it
 
 					_totalLoaded += (ulong)read;
 					DataUpdated?.Invoke(this, default);

--- a/src/Uno.UWP/Storage/Streams/StreamedUriDataLoader.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedUriDataLoader.cs
@@ -84,9 +84,9 @@ namespace Windows.Storage.Streams
 				using var responseStream = await response.Content.ReadAsStreamAsync();
 				using var file = File.OpenWeak(FileAccess.Write);
 
-				var buffer = new byte[8192];
+				var buffer = new byte[Buffer.DefaultCapacity];
 				int read;
-				while ((read = await responseStream.ReadAsync(buffer, 0, 8192, ct)) > 0)
+				while ((read = await responseStream.ReadAsync(buffer, 0, Buffer.DefaultCapacity, ct)) > 0)
 				{
 					await file.WriteAsync(buffer, 0, read, ct);
 

--- a/src/Uno.UWP/Storage/Streams/StreamedUriDataLoader.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedUriDataLoader.cs
@@ -14,6 +14,12 @@ namespace Windows.Storage.Streams
 {
 	internal class StreamedUriDataLoader : IStreamedDataLoader, IDisposable
 	{
+#if __WASM__
+		private const string _errorMessage = "Failed to load content. Make sure that CORS has been properly configured on the server hosting the resource.";
+#else
+		private const string _errorMessage = "Failed to load content.";
+#endif
+
 		/// <summary>
 		/// Asynchronously creates a StreamedDataLoader.
 		/// </summary>
@@ -50,7 +56,7 @@ namespace Windows.Storage.Streams
 
 		private readonly CancellationTokenSource _ct;
 		private bool _isCompleted;
-		private bool _isFailed;
+		private Exception? _failure;
 		private ulong _totalLoaded;
 
 		private StreamedUriDataLoader(HttpResponseMessage response, TemporaryFile tempFile, CancellationTokenSource ct)
@@ -68,14 +74,14 @@ namespace Windows.Storage.Streams
 
 		public void CheckState()
 		{
-			if (_isFailed)
+			if (_failure is {})
 			{
-				throw new InvalidOperationException("Failed to load content");
+				throw new InvalidOperationException(_errorMessage, _failure);
 			}
 		}
 
 		public bool CanRead(ulong position)
-			=> _isCompleted || _isFailed || position <= _totalLoaded;
+			=> _isCompleted || _failure is {} || position <= _totalLoaded;
 
 		private async Task Download(HttpResponseMessage response, CancellationToken ct)
 		{
@@ -101,10 +107,10 @@ namespace Windows.Storage.Streams
 			{
 				if (this.Log().IsEnabled(LogLevel.Warning))
 				{
-					this.Log().LogWarning("Failed to load content", e);
+					this.Log().LogWarning(_errorMessage, e);
 				}
 
-				_isFailed = true;
+				_failure = e;
 			}
 			finally
 			{

--- a/src/Uno.UWP/Storage/Streams/StreamedUriDataUploader.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedUriDataUploader.cs
@@ -1,0 +1,64 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+
+namespace Windows.Storage.Streams
+{
+	internal class StreamedUriDataUploader : IStreamedDataUploader
+	{
+		private readonly Uri _uri;
+		private readonly HttpMethod _method;
+		private readonly HttpClient _client;
+
+		public StreamedUriDataUploader(Uri uri, HttpMethod? method = null, HttpClient? client = null, TemporaryFile? tempFile = null)
+		{
+			_uri = uri;
+			_method = method ?? HttpMethod.Put;
+			_client = client ??new HttpClient();
+			File = tempFile ?? new TemporaryFile();
+		}
+
+		/// <inheritdoc />
+		public TemporaryFile File { get; }
+
+		/// <inheritdoc />
+		public void CheckState()
+		{
+		}
+
+		/// <inheritdoc />
+		public async Task<bool> Push(ulong index, ulong length, CancellationToken ct)
+		{
+			try
+			{
+				var request = new HttpRequestMessage(_method, _uri)
+				{
+					// For now we don't use the range header!
+					Content = new StreamContent(File.Open(FileAccess.Read))
+				};
+
+				var response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+				response.EnsureSuccessStatusCode();
+
+				return true;
+			}
+			catch (Exception e)
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().LogWarning("Failed to push content", e);
+				}
+
+				return false;
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/Streams/StreamedUriDataUploader.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamedUriDataUploader.cs
@@ -21,7 +21,7 @@ namespace Windows.Storage.Streams
 		{
 			_uri = uri;
 			_method = method ?? HttpMethod.Put;
-			_client = client ??new HttpClient();
+			_client = client ?? new HttpClient();
 			File = tempFile ?? new TemporaryFile();
 		}
 

--- a/src/Uno.UWP/Storage/TemporaryFile.cs
+++ b/src/Uno.UWP/Storage/TemporaryFile.cs
@@ -1,0 +1,122 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+
+namespace Windows.Storage
+{
+	/// <summary>
+	/// A file that self deletes himself when no longer used
+	/// </summary>
+	internal class TemporaryFile
+	{
+		private readonly FileInfo _file;
+		private int _users;
+
+		public TemporaryFile()
+		{
+			_file = new FileInfo(Path.GetTempFileName());
+		}
+
+		/// <summary>
+		/// Opens a stream to the loaded data
+		/// </summary>
+		public Stream Open(FileAccess mode)
+		{
+			Interlocked.Increment(ref _users);
+
+			return new TempFileStream(this, _file.Open(FileMode.OpenOrCreate, mode, FileShare.ReadWrite));
+		}
+
+		public Stream OpenWeak(FileAccess mode)
+		{
+			return _file.Open(FileMode.OpenOrCreate, mode, FileShare.ReadWrite | FileShare.Delete);
+		}
+
+		private void OnClose()
+		{
+			if (Interlocked.Decrement(ref _users) == 0)
+			{
+				if (_file.Exists)
+				{
+					try
+					{
+						_file.Delete();
+					}
+					catch (Exception e)
+					{
+						this.Log().LogError($"Failed to delete temporary file {_file.FullName}", e);
+					}
+				}
+			}
+		}
+
+		private class TempFileStream : Stream
+		{
+			private readonly TemporaryFile _tempFile;
+			private readonly Stream _stream;
+			private int _released = 0;
+
+			public TempFileStream(TemporaryFile tempFile, Stream stream)
+			{
+				_tempFile = tempFile;
+				_stream = stream;
+			}
+
+			public override void Close()
+			{
+				if (Interlocked.Exchange(ref _released, 1) == 0)
+				{
+					_tempFile.OnClose();
+				}
+				_stream.Close();
+				base.Close();
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (Interlocked.Exchange(ref _released, 1) == 0)
+				{
+					_tempFile.OnClose();
+				}
+				base.Dispose(disposing);
+			}
+
+			public override void Flush()
+				=> _stream.Flush();
+
+			public override int Read(byte[] buffer, int offset, int count)
+				=> _stream.Read(buffer, offset, count);
+
+			public override long Seek(long offset, SeekOrigin origin)
+				=> _stream.Seek(offset, origin);
+
+			public override void SetLength(long value)
+				=> _stream.SetLength(value);
+
+			public override void Write(byte[] buffer, int offset, int count)
+				=> _stream.Write(buffer, offset, count);
+
+			public override bool CanRead => _stream.CanRead;
+
+			public override bool CanSeek => _stream.CanSeek;
+
+			public override bool CanWrite => _stream.CanWrite;
+
+			public override long Length => _stream.Length;
+
+			public override long Position
+			{
+				get => _stream.Position;
+				set => _stream.Position = value;
+			}
+
+			~TempFileStream()
+				=> Dispose();
+		}
+	}
+}

--- a/src/Uno.UWP/Storage/TemporaryFile.cs
+++ b/src/Uno.UWP/Storage/TemporaryFile.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Windows.Graphics.Capture;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
 
@@ -20,6 +21,7 @@ namespace Windows.Storage
 		public TemporaryFile()
 		{
 			_file = new FileInfo(Path.GetTempFileName());
+			_file.Directory?.Create();
 		}
 
 		/// <summary>

--- a/src/Uno.UWP/System.IO/WindowsRuntimeStorageExtensions.cs
+++ b/src/Uno.UWP/System.IO/WindowsRuntimeStorageExtensions.cs
@@ -1,5 +1,7 @@
-﻿#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+﻿#nullable enable
+
 using System.Security;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage;
 
@@ -9,51 +11,33 @@ namespace System.IO
 	{
 		public static async Task<Stream> OpenStreamForReadAsync(this IStorageFile windowsRuntimeFile)
 		{
-			return File.OpenRead(windowsRuntimeFile.Path);
+			if (windowsRuntimeFile is StorageFile file)
+			{
+				return await file.OpenStream(CancellationToken.None, FileAccessMode.Read, StorageOpenOptions.None);
+			}
+			else
+			{
+				var raStream = await windowsRuntimeFile.OpenReadAsync();
+				return raStream.AsStreamForRead();
+			}
 		}
 
 		public static async Task<Stream> OpenStreamForReadAsync(this IStorageFolder rootDirectory, string relativePath)
 		{
-			return File.OpenRead(Path.Combine(rootDirectory.Path, relativePath));
+			var file = await rootDirectory.GetFileAsync(relativePath);
+			return await file.OpenStreamForReadAsync();
 		}
 
 		public static async Task<Stream> OpenStreamForWriteAsync(this IStorageFile windowsRuntimeFile)
 		{
-			return File.OpenWrite(windowsRuntimeFile.Path);
+			var writeTransaction = await windowsRuntimeFile.OpenTransactedWriteAsync();
+			return writeTransaction.AsAutoCommitStream();
 		}
 
 		public static async Task<Stream> OpenStreamForWriteAsync(this IStorageFolder rootDirectory, string relativePath, CreationCollisionOption creationCollisionOption)
 		{
-			FileMode mode;
-			FileAccess access;
-
-			switch(creationCollisionOption)
-			{
-				case CreationCollisionOption.FailIfExists:
-					mode = FileMode.CreateNew;
-					access = FileAccess.Write;
-					break;
-
-				case CreationCollisionOption.GenerateUniqueName:
-					mode = FileMode.CreateNew;
-					access = FileAccess.Write;
-					break;
-
-				case CreationCollisionOption.OpenIfExists:
-					mode = FileMode.OpenOrCreate;
-					access = FileAccess.Write;
-					break;
-
-				case CreationCollisionOption.ReplaceExisting:
-					mode = FileMode.Truncate;
-					access = FileAccess.Write;
-					break;
-				default:
-					throw new NotSupportedException($"The {creationCollisionOption} CreationCollisionOption is not supported");
-			}
-
-			Directory.CreateDirectory(rootDirectory.Path);
-			return File.Open(Path.Combine(rootDirectory.Path, relativePath), mode, access);
+			var file = await rootDirectory.CreateFileAsync(relativePath, creationCollisionOption);
+			return await file.OpenStreamForWriteAsync();
 		}
 	}
 }

--- a/src/Uno.UWP/System.IO/WindowsRuntimeStorageExtensions.cs
+++ b/src/Uno.UWP/System.IO/WindowsRuntimeStorageExtensions.cs
@@ -36,8 +36,8 @@ namespace System.IO
 			}
 			else
 			{
-				var writeTransaction = await windowsRuntimeFile.OpenTransactedWriteAsync();
-				return writeTransaction.AsAutoCommitStream();
+				var raStream = await windowsRuntimeFile.OpenAsync(FileAccessMode.ReadWrite);
+				return raStream.AsStreamForWrite();
 			}
 		}
 

--- a/src/Uno.UWP/System.IO/WindowsRuntimeStorageExtensions.cs
+++ b/src/Uno.UWP/System.IO/WindowsRuntimeStorageExtensions.cs
@@ -30,8 +30,15 @@ namespace System.IO
 
 		public static async Task<Stream> OpenStreamForWriteAsync(this IStorageFile windowsRuntimeFile)
 		{
-			var writeTransaction = await windowsRuntimeFile.OpenTransactedWriteAsync();
-			return writeTransaction.AsAutoCommitStream();
+			if (windowsRuntimeFile is StorageFile file)
+			{
+				return await file.OpenStream(CancellationToken.None, FileAccessMode.ReadWrite, StorageOpenOptions.None);
+			}
+			else
+			{
+				var writeTransaction = await windowsRuntimeFile.OpenTransactedWriteAsync();
+				return writeTransaction.AsAutoCommitStream();
+			}
 		}
 
 		public static async Task<Stream> OpenStreamForWriteAsync(this IStorageFolder rootDirectory, string relativePath, CreationCollisionOption creationCollisionOption)

--- a/src/Uno.UWP/System.IO/WindowsRuntimeStreamExtensions.cs
+++ b/src/Uno.UWP/System.IO/WindowsRuntimeStreamExtensions.cs
@@ -1,27 +1,158 @@
-﻿
+﻿#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Foundation;
 using Windows.Storage.Streams;
 
 namespace System.IO
 {
 	public static class WindowsRuntimeStreamExtensions
 	{
-		[Uno.NotImplemented]
-		public static IInputStream AsInputStream(this Stream stream) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static IOutputStream AsOutputStream(this Stream stream) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static IRandomAccessStream AsRandomAccessStream(this Stream stream) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static Stream AsStream(this IRandomAccessStream windowsRuntimeStream) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static Stream AsStream(this IRandomAccessStream windowsRuntimeStream, int bufferSize) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static Stream AsStreamForRead(this IInputStream windowsRuntimeStream) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static Stream AsStreamForRead(this IInputStream windowsRuntimeStream, int bufferSize) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static Stream AsStreamForWrite(this IOutputStream windowsRuntimeStream) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static Stream AsStreamForWrite(this IOutputStream windowsRuntimeStream, int bufferSize) { throw new NotImplementedException(); }
+		public static IInputStream AsInputStream(this Stream stream)
+		{
+			if (!stream.CanRead)
+			{
+				throw new NotSupportedException("Cannot convert stream to a IInputStream because stream does not support reading");
+			}
+
+			if (stream is IInputStreamWrapper wrapper)
+			{
+				return wrapper.GetStream();
+			}
+
+			return new InputStreamOverStream(stream);
+		}
+
+		public static IOutputStream AsOutputStream(this Stream stream)
+		{
+			if (!stream.CanWrite)
+			{
+				throw new NotSupportedException("Cannot convert stream to a IOutputStream because stream does not support writing");
+			}
+
+			if (stream is IOutputStreamWrapper wrapper)
+			{
+				return wrapper.GetStream();
+			}
+
+			return new OutputStreamOverStream(stream);
+		}
+
+		public static IRandomAccessStream AsRandomAccessStream(this Stream stream)
+		{
+			if (!stream.CanSeek)
+			{
+				throw new NotSupportedException("Cannot convert stream to a IRandomAccessStream because stream does not support seeking");
+			}
+
+			if (stream is IRandomStreamWrapper wrapper)
+			{
+				return wrapper.GetStream();
+			}
+
+			return new RandomAccessStreamOverStream(stream);
+		}
+
+		public static Stream AsStream(this IRandomAccessStream windowsRuntimeStream)
+			=> AsStream(windowsRuntimeStream, 8192);
+
+		public static Stream AsStream(this IRandomAccessStream windowsRuntimeStream, int bufferSize)
+		{
+			if (windowsRuntimeStream is IStreamWrapper wrapper)
+			{
+				return wrapper.GetStream();
+			}
+
+			return new StreamOverRandomAccessStream(windowsRuntimeStream, bufferSize);
+		}
+
+		public static Stream AsStreamForRead(this IInputStream windowsRuntimeStream)
+			=> AsStreamForRead(windowsRuntimeStream, 8192);
+
+		public static Stream AsStreamForRead(this IInputStream windowsRuntimeStream, int bufferSize)
+		{
+			if (windowsRuntimeStream is IStreamWrapper wrapper)
+			{
+				return wrapper.GetStream();
+			}
+
+			return new StreamOverInputStream(windowsRuntimeStream, bufferSize);
+		}
+
+		public static Stream AsStreamForWrite(this IOutputStream windowsRuntimeStream)
+			=> AsStreamForWrite(windowsRuntimeStream, 8192);
+
+		public static Stream AsStreamForWrite(this IOutputStream windowsRuntimeStream, int bufferSize)
+		{
+			if (windowsRuntimeStream is IStreamWrapper wrapper)
+			{
+				return wrapper.GetStream();
+			}
+
+			return new StreamOverOutputStream(windowsRuntimeStream, bufferSize);
+		}
+
+		internal static IAsyncOperationWithProgress<IBuffer, uint> ReadAsync(this Stream stream, IBuffer buffer, uint count, InputStreamOptions options)
+			=> AsyncOperationWithProgress.FromFuncAsync<IBuffer, uint>(async (ct, op) =>
+			{
+				await stream.ReadAsync(buffer, count, options, ct);
+
+				return buffer;
+			});
+
+		internal static async Task ReadAsync(this Stream stream, IBuffer buffer, uint count, InputStreamOptions options, CancellationToken ct)
+		{
+			var data = global::Windows.Storage.Streams.Buffer.Cast(buffer).GetSegment();
+			if (count > data.Count)
+			{
+				throw new ArgumentOutOfRangeException(nameof(count), "Count is greater than the available space.");
+			}
+
+			buffer.Length = (uint)await stream.ReadAsync(data.Array, data.Offset, (int)count, ct);
+		}
+
+		internal static IAsyncOperationWithProgress<uint, uint> WriteAsync(this Stream stream, IBuffer buffer)
+			=> AsyncOperationWithProgress.FromFuncAsync<uint, uint>(async (ct, op) =>
+			{
+				await stream.WriteAsync(buffer, ct);
+
+				return buffer.Length;
+			});
+
+		internal static async Task WriteAsync(this Stream stream, IBuffer buffer, CancellationToken ct)
+		{
+			var data = global::Windows.Storage.Streams.Buffer.Cast(buffer).GetSegment();
+
+			await stream.WriteAsync(data.Array, data.Offset, (int)buffer.Length, ct);
+		}
+
+		public static IAsyncOperation<bool> FlushAsyncOp(this Stream stream)
+			=> AsyncOperation.FromTask(async ct =>
+			{
+				await stream.FlushAsync(ct);
+				return true;
+			});
+
+		internal static async Task<int> ReadAsync(this IInputStream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+		{
+			var dst = new global::Windows.Storage.Streams.Buffer(new Memory<byte>(buffer, offset, count));
+			var read = await stream.ReadAsync(dst, (uint)count, InputStreamOptions.None).AsTask(cancellationToken);
+
+			if (read != dst)
+			{
+				// Unfortunately the stream decided to not write data in the provided dst buffer.
+				// We now have to copy the data.
+				global::Windows.Storage.Streams.Buffer.Cast(read).CopyTo(0, buffer, offset, (int)read.Length);
+			}
+
+			return (int)read.Length;
+		}
+
+		internal static Task WriteAsync(this IOutputStream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+		{
+			var src = new global::Windows.Storage.Streams.Buffer(new Memory<byte>(buffer, offset, count));
+			return stream.WriteAsync(src).AsTask(cancellationToken);
+		}
 	}
 }

--- a/src/Uno.UWP/System.Runtime/WindowsRuntimeBufferExtensions.cs
+++ b/src/Uno.UWP/System.Runtime/WindowsRuntimeBufferExtensions.cs
@@ -8,7 +8,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 	public static class WindowsRuntimeBufferExtensions
 	{
 		public static IBuffer AsBuffer(this byte[] source)
-			=> source.AsBuffer(0, source.Length, source.Length);
+			=> AsBuffer(source, 0, source.Length, source.Length);
 		
 		public static IBuffer AsBuffer(this byte[] source, int offset, int length)
 			=> AsBuffer(source, offset, length, length);
@@ -41,18 +41,13 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 		}
 
 		public static Stream AsStream(this IBuffer source)
-		{
-			var data = UwpBuffer.Cast(source).GetSegment();
-			var stream = new MemoryStream(data.Array!, data.Offset, data.Count);
-
-			return stream;
-		}
+			=> new StreamOverBuffer(UwpBuffer.Cast(source));
 
 		public static void CopyTo(this byte[] source, IBuffer destination)
-			=> source.CopyTo(0, destination, 0, source.Length);
+			=> UwpBuffer.Cast(destination).Write(0, source, 0, source.Length);
 
 		public static void CopyTo(this byte[] source, int sourceIndex, IBuffer destination, uint destinationIndex, int count)
-			=> Array.Copy(source, sourceIndex, UwpBuffer.Cast(destination).GetSegment().Array!, destinationIndex, count);
+			=> UwpBuffer.Cast(destination).Write(destinationIndex, source, sourceIndex, count);
 
 		public static void CopyTo(this IBuffer source, byte[] destination)
 			=> UwpBuffer.Cast(source).CopyTo(0, destination, 0, destination.Length);

--- a/src/Uno.UWP/System.Runtime/WindowsRuntimeBufferExtensions.cs
+++ b/src/Uno.UWP/System.Runtime/WindowsRuntimeBufferExtensions.cs
@@ -8,17 +8,10 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 	public static class WindowsRuntimeBufferExtensions
 	{
 		public static IBuffer AsBuffer(this byte[] source)
-		{
-			if (source is null)
-			{
-				throw new ArgumentNullException(nameof(source));
-			}
-
-			return source.AsBuffer(0, source.Length);
-		}
-
-		public static IBuffer AsBuffer(this byte[] source, int offset, int length) =>
-			AsBuffer(source, offset, length, length);
+			=> source.AsBuffer(0, source.Length, source.Length);
+		
+		public static IBuffer AsBuffer(this byte[] source, int offset, int length)
+			=> AsBuffer(source, offset, length, length);
 
 		public static IBuffer AsBuffer(this byte[] source, int offset, int length, int capacity)
 		{
@@ -49,49 +42,44 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
 		public static Stream AsStream(this IBuffer source)
 		{
-			if (source is null)
-			{
-				throw new ArgumentNullException(nameof(source));
-			}
-
 			var data = UwpBuffer.Cast(source).GetSegment();
 			var stream = new MemoryStream(data.Array!, data.Offset, data.Count);
 
 			return stream;
 		}
 
-		[Uno.NotImplemented]
-		public static void CopyTo(this byte[] source, IBuffer destination) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static void CopyTo(this IBuffer source, byte[] destination) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static void CopyTo(this IBuffer source, IBuffer destination) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static void CopyTo(this byte[] source, int sourceIndex, IBuffer destination, uint destinationIndex, int count) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static void CopyTo(this IBuffer source, uint sourceIndex, byte[] destination, int destinationIndex, int count) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static void CopyTo(this IBuffer source, uint sourceIndex, IBuffer destination, uint destinationIndex, uint count) { throw new NotImplementedException(); }
+		public static void CopyTo(this byte[] source, IBuffer destination)
+			=> source.CopyTo(0, destination, 0, source.Length);
 
-		public static byte GetByte(this IBuffer source, uint byteOffset) => source.ToArray()[byteOffset];
+		public static void CopyTo(this byte[] source, int sourceIndex, IBuffer destination, uint destinationIndex, int count)
+			=> Array.Copy(source, sourceIndex, UwpBuffer.Cast(destination).GetSegment().Array!, destinationIndex, count);
 
-		[Uno.NotImplemented]
-		public static IBuffer GetWindowsRuntimeBuffer(this MemoryStream underlyingStream) { throw new NotImplementedException(); }
-		[Uno.NotImplemented]
-		public static IBuffer GetWindowsRuntimeBuffer(this MemoryStream underlyingStream, int positionInStream, int length) { throw new NotImplementedException(); }
+		public static void CopyTo(this IBuffer source, byte[] destination)
+			=> UwpBuffer.Cast(source).CopyTo(0, destination, 0, destination.Length);
 
-		public static bool IsSameData(this IBuffer buffer, IBuffer otherBuffer) =>
-			buffer.ToArray().SequenceEqual(otherBuffer.ToArray());
+		public static void CopyTo(this IBuffer source, uint sourceIndex, byte[] destination, int destinationIndex, int count)
+			=> UwpBuffer.Cast(source).CopyTo(sourceIndex, destination, destinationIndex, count);
+
+		public static void CopyTo(this IBuffer source, IBuffer destination)
+			=> UwpBuffer.Cast(source).CopyTo(0, UwpBuffer.Cast(destination), 0, destination.Capacity);
+
+		public static void CopyTo(this IBuffer source, uint sourceIndex, IBuffer destination, uint destinationIndex, uint count)
+			=> UwpBuffer.Cast(source).CopyTo(sourceIndex, UwpBuffer.Cast(destination), destinationIndex, count);
+
+		public static byte GetByte(this IBuffer source, uint byteOffset)
+			=> UwpBuffer.Cast(source).GetByte(byteOffset);
+
+		public static IBuffer GetWindowsRuntimeBuffer(this MemoryStream underlyingStream)
+			=> underlyingStream.GetBuffer().AsBuffer();
+
+		public static IBuffer GetWindowsRuntimeBuffer(this MemoryStream underlyingStream, int positionInStream, int length)
+			=> underlyingStream.GetBuffer().AsBuffer(positionInStream, length);
+
+		public static bool IsSameData(this IBuffer buffer, IBuffer otherBuffer)
+			=> UwpBuffer.Cast(buffer).Span.SequenceEqual(UwpBuffer.Cast(otherBuffer).Span);
 
 		public static byte[] ToArray(this IBuffer source)
-		{
-			if (source is null)
-			{
-				throw new ArgumentNullException(nameof(source));
-			}
-
-			return UwpBuffer.Cast(source).ToArray();
-		}
+			=> UwpBuffer.Cast(source).ToArray();
 
 		public static byte[] ToArray(this IBuffer source, uint sourceIndex, int count)
 		{

--- a/src/Uno.UWP/System.Runtime/WindowsRuntimeSystemExtensions.cs
+++ b/src/Uno.UWP/System.Runtime/WindowsRuntimeSystemExtensions.cs
@@ -1,4 +1,5 @@
-﻿
+﻿#nullable enable
+
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -11,56 +12,112 @@ namespace System
 {
 	public static class WindowsRuntimeSystemExtensions
 	{
-		public static IAsyncAction AsAsyncAction(this Task source) => AsyncAction.FromTask(_ => source);
-		public static IAsyncOperation<TResult> AsAsyncOperation<TResult>(this Task<TResult> source) => new AsyncOperation<TResult>(_ => source);
-		public static Task AsTask(this IAsyncAction source) => source.AsTask(CancellationToken.None);
-		public static Task AsTask(this Task source) => source;
-		public static Task<T> AsTask<T>(this Task<T> source) => source;
-		public static Task AsTask(this Task source, CancellationToken ct) => source;
-		public static Task<T> AsTask<T>(this Task<T> source, CancellationToken ct) => source;
+		public static IAsyncAction AsAsyncAction(this Task source)
+			=> AsyncAction.FromTask(_ => source);
+
+		public static IAsyncOperation<TResult> AsAsyncOperation<TResult>(this Task<TResult> source)
+			=> new AsyncOperation<TResult>((_, __) => source);
+
+		public static Task AsTask(this Task source)
+			=> source;
+
+		public static Task<T> AsTask<T>(this Task<T> source)
+			=> source;
+
+		public static Task AsTask(this Task source, CancellationToken ct)
+			=> source;
+
+		public static Task<T> AsTask<T>(this Task<T> source, CancellationToken ct)
+			=> source;
+
+		public static Task AsTask(this IAsyncAction source)
+			=> source.AsTaskCore(CancellationToken.None);
 
 		public static Task AsTask(this IAsyncAction source, CancellationToken cancellationToken)
+			=> source.AsTaskCore(cancellationToken);
+
+		private static Task AsTaskCore(this IAsyncAction source, CancellationToken ct)
 		{
-			if (source is AsyncAction action)
+			if (source is IAsyncActionInternal action)
 			{
-
-				cancellationToken.Register(() => action.Cancel());
-
+				using var _ = ct.CanBeCanceled ? ct.Register(action.Cancel) : default;
 				return action.Task;
 			}
 
 			throw new NotSupportedException("Custom IAsyncAction implementations are not supported.");
 		}
 
-		public static Task<TResult> AsTask<TResult>(this IAsyncOperation<TResult> source) => ((AsyncOperation<TResult>)source).Task;
-		[NotImplemented]
-		public static Task AsTask<TProgress>(this IAsyncActionWithProgress<TProgress> source) { throw new NotImplementedException(); }
-		[NotImplemented]
-		public static Task AsTask<TProgress>(this IAsyncActionWithProgress<TProgress> source, IProgress<TProgress> progress) { throw new NotImplementedException(); }
-		[NotImplemented]
-		public static Task AsTask<TProgress>(this IAsyncActionWithProgress<TProgress> source, CancellationToken cancellationToken) { throw new NotImplementedException(); }
-		public static Task<TResult> AsTask<TResult>(this IAsyncOperation<TResult> source, CancellationToken cancellationToken)
-		{
-			if (source is AsyncOperation<TResult> operation)
-			{
-				cancellationToken.Register(() => operation.Cancel());
+		public static Task<TResult> AsTask<TResult>(this IAsyncOperation<TResult> source)
+			=> source.AsTaskCore(CancellationToken.None);
 
-				return operation.Task;
+		public static Task<TResult> AsTask<TResult>(this IAsyncOperation<TResult> source, CancellationToken cancellationToken)
+			=> source.AsTaskCore(cancellationToken);
+
+		private static async Task<TResult> AsTaskCore<TResult>(this IAsyncOperation<TResult> source, CancellationToken ct)
+		{
+			if (source is IAsyncOperationInternal<TResult> operation)
+			{
+				using var _ = ct.CanBeCanceled ? ct.Register(operation.Cancel) : default;
+				return await operation.Task;
 			}
 
 			throw new NotSupportedException("Custom IAsyncOperation implementations are not supported.");
 		}
 
-		[NotImplemented]
-		public static Task AsTask<TProgress>(this IAsyncActionWithProgress<TProgress> source, CancellationToken cancellationToken, IProgress<TProgress> progress) { throw new NotImplementedException(); }
-		[NotImplemented]
-		public static Task<TResult> AsTask<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source) { throw new NotImplementedException(); }
-		[NotImplemented]
-		public static Task<TResult> AsTask<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source, IProgress<TProgress> progress) { throw new NotImplementedException(); }
-		[NotImplemented]
-		public static Task<TResult> AsTask<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source, CancellationToken cancellationToken) { throw new NotImplementedException(); }
-		[NotImplemented]
-		public static Task<TResult> AsTask<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source, CancellationToken cancellationToken, IProgress<TProgress> progress) { throw new NotImplementedException(); }
+		public static Task AsTask<TProgress>(this IAsyncActionWithProgress<TProgress> source)
+			=> source.AsTaskCore(CancellationToken.None);
+
+		public static Task AsTask<TProgress>(this IAsyncActionWithProgress<TProgress> source, IProgress<TProgress> progress)
+			=> source.AsTaskCore(CancellationToken.None, progress);
+
+		public static Task AsTask<TProgress>(this IAsyncActionWithProgress<TProgress> source, CancellationToken cancellationToken)
+			=> source.AsTaskCore(cancellationToken);
+
+		public static async Task AsTask<TProgress>(this IAsyncActionWithProgress<TProgress> source, CancellationToken cancellationToken, IProgress<TProgress> progress)
+			=> source.AsTaskCore(cancellationToken, progress);
+
+		private static async Task AsTaskCore<TProgress>(this IAsyncActionWithProgress<TProgress> source, CancellationToken ct, IProgress<TProgress>? progress = null)
+		{
+			if (source is IAsyncActionWithProgressInternal<TProgress> operation)
+			{
+				using var _ = ct.CanBeCanceled ? ct.Register(operation.Cancel) : default;
+				if (progress is {})
+				{
+					operation.Progress = (snd, p) => progress.Report(p);
+				}
+				await operation.Task;
+			}
+
+			throw new NotSupportedException("Custom IAsyncActionWithProgress implementations are not supported.");
+		}
+
+		public static Task<TResult> AsTask<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source)
+			=> source.AsTaskCore(CancellationToken.None);
+
+		public static Task<TResult> AsTask<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source, IProgress<TProgress> progress)
+			=> source.AsTaskCore(CancellationToken.None, progress);
+
+		public static Task<TResult> AsTask<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source, CancellationToken cancellationToken)
+			=> source.AsTaskCore(cancellationToken);
+
+		public static Task<TResult> AsTask<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source, CancellationToken cancellationToken, IProgress<TProgress> progress)
+			=> source.AsTaskCore(cancellationToken, progress);
+
+		private static async Task<TResult> AsTaskCore<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source, CancellationToken ct, IProgress<TProgress>? progress = null)
+		{
+			if (source is IAsyncOperationWithProgressInternal<TResult, TProgress> operation)
+			{
+				using var _ = ct.CanBeCanceled ? ct.Register(operation.Cancel) : default;
+				if (progress is { })
+				{
+					operation.Progress = (snd, p) => progress.Report(p);
+				}
+				return await operation.Task;
+			}
+
+			throw new NotSupportedException("Custom IAsyncActionWithProgress implementations are not supported.");
+		}
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static TaskAwaiter GetAwaiter(this IAsyncAction source)
 		{
@@ -68,22 +125,21 @@ namespace System
 			{
 				return uiAsyncOperation.GetAwaiter();
 			}
-			else if (source is AsyncAction asyncAction)
-			{
-				return asyncAction.Task.GetAwaiter();
-			}
 			else
 			{
-			  throw new NotSupportedException("Custom IAsyncOperation implementations are not supported.");
+				return source.AsTask().GetAwaiter();
 			}
 		}
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static TaskAwaiter<TResult> GetAwaiter<TResult>(this IAsyncOperation<TResult> source) => ((AsyncOperation<TResult>)source).Task.GetAwaiter();
+		public static TaskAwaiter<TResult> GetAwaiter<TResult>(this IAsyncOperation<TResult> source)
+			=> source.AsTask().GetAwaiter();
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		[NotImplemented]
-		public static TaskAwaiter GetAwaiter<TProgress>(this IAsyncActionWithProgress<TProgress> source) { throw new NotImplementedException(); }
+		public static TaskAwaiter GetAwaiter<TProgress>(this IAsyncActionWithProgress<TProgress> source)
+			=> source.AsTask().GetAwaiter();
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		[NotImplemented]
-		public static TaskAwaiter<TResult> GetAwaiter<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source) { throw new NotImplementedException(); }
+		public static TaskAwaiter<TResult> GetAwaiter<TResult, TProgress>(this IAsyncOperationWithProgress<TResult, TProgress> source)
+			=> source.AsTask().GetAwaiter();
 	}
 }

--- a/src/Uno.UWP/UI/Popups/MessageDialog.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.cs
@@ -54,7 +54,7 @@ namespace Windows.UI.Popups
 		{
 			var invokedCommand = new TaskCompletionSource<IUICommand>();
 
-			return new AsyncOperation<IUICommand>(async ct =>
+			return AsyncOperation.FromTask<IUICommand>(async ct =>
 			{
 				if (CoreDispatcher.Main.HasThreadAccess)
 				{

--- a/src/Uno.UWP/UI/Popups/MessageDialog.macOS.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.macOS.cs
@@ -49,7 +49,7 @@ namespace Windows.UI.Popups
 				actualCommandOrder.Add(command);
 			}
 
-			return new AsyncOperation<IUICommand>(async ct =>
+			return AsyncOperation.FromTask<IUICommand>(async ct =>
 			{
 				var response = await alert.BeginSheetAsync(NSApplication.SharedApplication.KeyWindow);
 

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
   
   <PropertyGroup>
     <TargetFrameworks>xamarinmac20;xamarinios10;MonoAndroid10.0;net461;netstandard2.0</TargetFrameworks>
@@ -50,6 +50,7 @@
 		<PackageReference Include="Uno.SourceGenerationTasks" />
 		<PackageReference Include="Uno.Core" />
 		<PackageReference Include="Uno.MonoAnalyzers" />
+		<PackageReference Include="System.Memory" Version="4.5.2" />
 	</ItemGroup>
 	
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
@@ -66,6 +67,7 @@
 	<ItemGroup Condition="$(IsMonoAndroid) or $(IsXamarinIOS) or '$(TargetFramework)'=='xamarinmac20'">
 		<Reference Include="System.Numerics" />
 		<Reference Include="System.Numerics.Vectors" />
+		<Reference Include="System.Memory" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -73,5 +75,25 @@
 	</ItemGroup>
 	
 	<Target Name="GetBuiltProjectOutputRecursive" Condition=" '$(TargetFramework)' == 'xamarinios10' " />
+
+	<Target Name="VS16Mac_RemoveSystemMemory" BeforeTargets="ResolveAssemblyReferences" Condition="'$(MSBuildVersion)' &gt;= '16.0' and $([MSBuild]::IsOsPlatform('OSX'))">
+		<!--
+				VS4Mac seems to process System.Memory differently, and removes
+				the System.Memory local reference if the package is transitively referenced.
+				We remove the Reference added by the nuget targets so that ResolveAssemblyReferences
+				is properly adding the local System.Memory to the Reference item group.
+		-->
+		<ItemGroup>
+			<_ReferenceToRemove Include="@(Reference)" Condition="'%(Reference.Identity)'=='System.Memory'" />
+			<Reference Remove="@(_ReferenceToRemove)" />
+		</ItemGroup>
+	</Target>
+
+	<Target Name="VS16_RemoveSystemMemory" BeforeTargets="FindReferenceAssembliesForReferences" Condition="'$(MSBuildVersion)' &gt;= '16.0' and ($(IsMonoAndroid) or $(IsXamarinIOS) or $(IsXamarinMac))">
+		<ItemGroup>
+			<_ReferencePathToRemove Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)'=='System.Memory'" />
+			<ReferencePath Remove="@(_ReferencePathToRemove)" />
+		</ItemGroup>
+	</Target>
 
 </Project>


### PR DESCRIPTION
GitHub Issue: https://github.com/unoplatform/uno/issues/1187

## Bugfix / Feature
Improve support of `Windows.Storage.*`

## What is the current behavior?
* `RandomAccessStreamOverStream`, `InputStreamOverStream`, `OutputStreamOverStream` were not implemented
* `FileRandomAccessStream`, `FileInputStream`, `FileOutputStream` were not implemented
* `RandomAccessStreamReference` was not implemented
* We were not able to build a `<RA|In|Out>Stream` for remote content (with real async loading)
* `Buffer` was requiring a `byte[]` which often forced use to make a copy, and was internally exposing this `Data` buffer for direct access
* We didn't support external implementation of the `IAsync<Action|Operation[WithProgess]>` in the `.AsTask` extensions (and we was often ignoring the `CancellationToken`)

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] **in progress** [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


## Breaking changes
The `StorageStreamTransaction.CommitAsync()` now returns `IAsyncAction` insteed of a `Task`