### PR TITLE
Update debugging-uno-ui.md - add info about long paths

### DIFF
--- a/doc/articles/uno-development/building-uno-ui.md
+++ b/doc/articles/uno-development/building-uno-ui.md
@@ -22,7 +22,8 @@ It involves two things - setting an override for the target framework that will 
 
 The step by step process is:
 
-1. Clone the Uno.UI repository locally.
+1. Clone the Uno.UI repository locally, and ensure using a short target path, e.g. _D:\uno_ etc.  
+This is due to limitations in the legacy .NET versions used by Xamarin projects. This issue has been addressed in .NET 5, and will come to the rest of the projects in the future.
 2. Make sure you don't have the Uno.UI solution open in any Visual Studio instances. (Visual Studio may crash or behave inconsistently if it's open when the target override is changed.)
 3. Make a copy of the [src/crosstargeting_override.props.sample](https://github.com/unoplatform/uno/blob/master/src/crosstargeting_override.props.sample) file and name this copy `src/crosstargeting_override.props`.
 4. In `crosstargeting_override.props`, uncomment the line `<UnoTargetFrameworkOverride>netstandard2.0</UnoTargetFrameworkOverride>`

--- a/doc/articles/uno-development/debugging-uno-ui.md
+++ b/doc/articles/uno-development/debugging-uno-ui.md
@@ -7,9 +7,11 @@
 
 To debug the SamplesApp in the Uno.UI solution, which includes an extensive set of samples and test cases for the controls supported by Uno.UI, as well as non-UI features:
 
-1. Open the solution filter in Visual Studio for the target platform you wish to run on, [as detailed here](building-uno-ui.md).
-2. Set `SamplesApp.[TargetPlatform]` as the selected Startup Project.
-3. Launch the samples app from Visual Studio.
+1. Clone the repo, and ensure using a short target path, e.g. _D:\uno_ etc.  
+This is due to limitations in the legacy .NET versions used by Xamarin projects. This issue has been addressed in .NET 5, and will come to the rest of the projects in the future.
+2. Open the solution filter in Visual Studio for the target platform you wish to run on, [as detailed here](building-uno-ui.md).
+3. Set `SamplesApp.[TargetPlatform]` as the selected Startup Project.
+4. Launch the samples app from Visual Studio.
 
 See [this article](working-with-the-samples-apps.md) for more information on working with the SamplesApp and authoring new samples.
 


### PR DESCRIPTION
This PR adds a recommendation to use a short path when cloning Uno, to avoid build errors.