### PR TITLE
XAML Generation performance improvements

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/SymbolExtensions.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/SymbolExtensions.cs
@@ -53,6 +53,25 @@ namespace Microsoft.CodeAnalysis
 			} while (symbol.SpecialType != SpecialType.System_Object);
 		}
 
+		public static IEnumerable<ISymbol> GetAllMembersWithName(this ITypeSymbol symbol, string name)
+		{
+			do
+			{
+				foreach (var member in symbol.GetMembers(name))
+				{
+					yield return member;
+				}
+
+				symbol = symbol.BaseType;
+
+				if (symbol == null)
+				{
+					break;
+				}
+
+			} while (symbol.SpecialType != SpecialType.System_Object);
+		}
+
 		public static IEnumerable<IEventSymbol> GetEvents(INamedTypeSymbol symbol) => symbol.GetMembers().OfType<IEventSymbol>();
 
 		/// <summary>
@@ -123,35 +142,55 @@ namespace Microsoft.CodeAnalysis
 			);
 
 		public static IEnumerable<IMethodSymbol> GetMethods(this INamedTypeSymbol resolvedType)
-		{
-			return resolvedType.GetMembers().OfType<IMethodSymbol>();
-		}
+			=> resolvedType.GetMembers().OfType<IMethodSymbol>();
+
+		public static IEnumerable<IMethodSymbol> GetMethodsWithName(this INamedTypeSymbol resolvedType, string name)
+			=> resolvedType.GetMembers(name).OfType<IMethodSymbol>();
 
 		public static IEnumerable<IFieldSymbol> GetFields(this INamedTypeSymbol resolvedType)
+			=> resolvedType.GetMembers().OfType<IFieldSymbol>();
+
+		public static IEnumerable<IFieldSymbol> GetFieldsWithName(this INamedTypeSymbol resolvedType, string name)
+			=> resolvedType.GetMembers(name).OfType<IFieldSymbol>();
+
+		/// <summary>
+		/// Return fields of the current type and all of its ancestors
+		/// </summary>
+		/// <param name="symbol"></param>
+		/// <returns></returns>
+		public static IEnumerable<IFieldSymbol> GetAllFields(this INamedTypeSymbol symbol)
 		{
-			return resolvedType.GetMembers().OfType<IFieldSymbol>();
+			while (symbol != null)
+			{
+				foreach (var property in symbol.GetMembers().OfType<IFieldSymbol>())
+				{
+					yield return property;
+				}
+
+				symbol = symbol.BaseType;
+			}
 		}
 
-        /// <summary>
-        /// Return fields of the current type and all of its ancestors
-        /// </summary>
-        /// <param name="symbol"></param>
-        /// <returns></returns>
-        public static IEnumerable<IFieldSymbol> GetAllFields(this INamedTypeSymbol symbol)
-        {
-            while (symbol != null)
-            {
-                foreach (var property in symbol.GetMembers().OfType<IFieldSymbol>())
-                {
-                    yield return property;
-                }
+		/// <summary>
+		/// Return fields of the current type and all of its ancestors
+		/// </summary>
+		/// <param name="symbol"></param>
+		/// <returns></returns>
+		public static IEnumerable<IFieldSymbol> GetAllFieldsWithName(this INamedTypeSymbol symbol, string name)
+		{
+			while (symbol != null)
+			{
+				foreach (var property in symbol.GetMembers(name).OfType<IFieldSymbol>())
+				{
+					yield return property;
+				}
 
-                symbol = symbol.BaseType;
-            }
-        }
+				symbol = symbol.BaseType;
+			}
+		}
 
 
-        public static IEnumerable<IFieldSymbol> GetFieldsWithAttribute(this ITypeSymbol resolvedType, string name)
+		public static IEnumerable<IFieldSymbol> GetFieldsWithAttribute(this ITypeSymbol resolvedType, string name)
 		{
 			return resolvedType
 				.GetMembers()
@@ -368,6 +407,24 @@ namespace Microsoft.CodeAnalysis
 			while (symbol != null)
 			{
 				foreach (var property in symbol.GetMembers().OfType<IPropertySymbol>())
+				{
+					yield return property;
+				}
+
+				symbol = symbol.BaseType;
+			}
+		}
+
+		/// <summary>
+		/// Return properties of the current type and all of its ancestors
+		/// </summary>
+		/// <param name="symbol"></param>
+		/// <returns></returns>
+		public static IEnumerable<IPropertySymbol> GetAllPropertiesWithName(this INamedTypeSymbol symbol, string name)
+		{
+			while (symbol != null)
+			{
+				foreach (var property in symbol.GetMembers(name).OfType<IPropertySymbol>())
 				{
 					yield return property;
 				}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -240,11 +240,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				var filesQuery = files
 					.ToArray();
 
-				IEnumerable<XamlFileDefinition> filesToProcess = filesQuery;
+				var filesToProcess = filesQuery.AsParallel();
 
-				if (!Debugger.IsAttached)
+				if (Debugger.IsAttached)
 				{
-					filesToProcess = filesToProcess.AsParallel();
+					filesToProcess = filesToProcess
+						.WithDegreeOfParallelism(1);
 				}
 
 				var outputFiles = filesToProcess.Select(file => new KeyValuePair<string, string>(

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -133,7 +133,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				do
 				{
-					if (type.GetAllProperties().Any(property => property.Name == propertyName))
+					if (type.GetAllPropertiesWithName(propertyName).Any())
 					{
 						return true;
 					}
@@ -268,8 +268,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			if (propertyOwner != null)
 			{
-				var propertyDependencyPropertyQuery = propertyOwner.GetAllProperties().Where(p => p.Name == name + "Property");
-				var fieldDependencyPropertyQuery = propertyOwner.GetAllFields().Where(p => p.Name == name + "Property");
+				var propertyDependencyPropertyQuery = propertyOwner.GetAllPropertiesWithName(name + "Property");
+				var fieldDependencyPropertyQuery = propertyOwner.GetAllFieldsWithName(name + "Property");
 
 				return propertyDependencyPropertyQuery.Any() || fieldDependencyPropertyQuery.Any();
 			}
@@ -381,7 +381,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 					var resolvedType = type;
 
-					var property = resolvedType.GetAllProperties().FirstOrDefault(p => p.Name == propertyName);
+					var property = resolvedType.GetAllPropertiesWithName(propertyName).FirstOrDefault();
 					var setMethod = resolvedType.GetMethods().FirstOrDefault(p => p.Name == "Set" + propertyName);
 
 					if (property != null)
@@ -512,7 +512,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			do
 			{
-				var property = type.GetAllProperties().FirstOrDefault(p => p.Name == name);
+				var property = type.GetAllPropertiesWithName(name).FirstOrDefault();
 				var setMethod = type.GetMethods().FirstOrDefault(p => p.Name == "Set" + name);
 
 				if (property != null && property.GetMethod.IsStatic)
@@ -583,7 +583,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// </summary>
 		private bool IsInitializableCollection(XamlType declaringType, string propertyName)
 		{
-			var property = GetPropertyByName(declaringType, propertyName);
+			var property = GetPropertyWithName(declaringType, propertyName);
 
 			if (property != null && IsInitializableProperty(property))
 			{
@@ -665,11 +665,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// <summary>
 		/// Gets the 
 		/// </summary>
-		private IPropertySymbol GetPropertyByName(XamlType declaringType, string propertyName)
+		private IPropertySymbol GetPropertyWithName(XamlType declaringType, string propertyName)
 		{
 			var type = FindType(declaringType);
-
-			return type?.GetAllProperties().FirstOrDefault(p => p.Name == propertyName);
+			return type?.GetAllPropertiesWithName(propertyName).FirstOrDefault();
 		}
 
 		private static bool IsDouble(string typeName)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -228,7 +228,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			_colorSymbol = GetType(XamlConstants.Types.Color);
 
 			_markupExtensionTypes = _metadataHelper.GetAllTypesDerivingFrom(_markupExtensionSymbol).ToList();
-			_xamlConversionTypes = _metadataHelper.GetAllTypesAttributedWith(XamlConstants.Types.CreateFromStringAttribute).ToList();
+			_xamlConversionTypes = _metadataHelper.GetAllTypesAttributedWith(GetType(XamlConstants.Types.CreateFromStringAttribute)).ToList();
 
 			_isWasm = isWasm;
 
@@ -2130,7 +2130,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					var name = nameProperty.Value.Value.ToString();
 
-					return elementType?.GetAllProperties().FirstOrDefault(p => p.Name == name);
+					return elementType?.GetAllPropertiesWithName(name).FirstOrDefault();
 				}
 			}
 
@@ -3484,7 +3484,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			foreach (var part in parts)
 			{
-				if (currentType.GetAllMembers().FirstOrDefault(m => m.Name == part) is ISymbol member)
+				if (currentType.GetAllMembersWithName(part).FirstOrDefault() is ISymbol member)
 				{
 					var propertySymbol = member as IPropertySymbol;
 					var fieldSymbol = member as IFieldSymbol;
@@ -4483,7 +4483,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			var declaringType = member.DeclaringType;
 			var propertyName = member.Name;
-			var property = GetPropertyByName(declaringType, propertyName);
+			var property = GetPropertyWithName(declaringType, propertyName);
 
 			if (property?.Type is INamedTypeSymbol collectionType)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

XAML Generation performance was significantly reduced by some uses of symbol string conversions and members enumerations. The new changes take into account the ability to lookup members by name, instead of performing a linear search.

Parallel file generation is also restored.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
