### PR TITLE
Handle const fields in XAML code generation

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3377,7 +3377,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				.Where(p => !p.StartsWith("global::"))  // Don't include paths that start with global:: (e.g. Enums)
 				.Select(p => $"\"{p}\"");
 
-			var pathsArray = propertyPaths.properties.Any()
+			var pathsArray = formattedPaths.Any()
 				? ", new [] {" + string.Join(", ", formattedPaths) + "}"
 				: "";
 
@@ -3519,38 +3519,30 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private bool IsStaticMember(string fullMemberName)
 		{
 			fullMemberName = fullMemberName.TrimStart("global::");
-
 			var lastDotIndex = fullMemberName.LastIndexOf(".");
 
-			if (lastDotIndex != -1)
+			var isTopLevelMember = lastDotIndex == -1;
+
+			var className = isTopLevelMember
+				? _className.ns + "." + _className.className
+				: fullMemberName.Substring(0, lastDotIndex);
+
+			var memberName = isTopLevelMember
+				? fullMemberName
+				: fullMemberName.Substring(lastDotIndex + 1);
+
+			if (_metadataHelper.FindTypeByFullName(className) is INamedTypeSymbol typeSymbol)
 			{
-				var className = lastDotIndex != -1 ? fullMemberName.Substring(0, lastDotIndex) : fullMemberName;
-				var memberName = lastDotIndex != -1 ? fullMemberName.Substring(lastDotIndex + 1) : fullMemberName;
+				var isStaticMethod = typeSymbol.GetMethods().Any(m => m.IsStatic && m.Name == memberName);
+				var isStaticProperty = typeSymbol.GetProperties().Any(m => m.Name == memberName && m.IsStatic);
+				var isStaticField = typeSymbol.GetFields().Any(m => m.Name == memberName && m.IsStatic);
+				var isEnum = typeSymbol.TypeKind == TypeKind.Enum;
 
-				if (_metadataHelper.FindTypeByFullName(className) is INamedTypeSymbol typeSymbol)
-				{
-					var hasStaticMethod = typeSymbol.GetMethods().Any(m => m.IsStatic && m.Name == memberName);
-					var hasStaticProperty = typeSymbol.GetProperties().Any(m => m.Name == memberName && m.IsStatic);
-					var isEnum = typeSymbol.TypeKind == TypeKind.Enum;
-
-					return hasStaticMethod || hasStaticProperty || isEnum;
-				}
-
-				return false;
+				return isStaticMethod || isStaticProperty || isStaticField || (!isTopLevelMember && isEnum);
 			}
-			else
-			{
-				if (_metadataHelper.FindTypeByFullName(_className.ns + "." + _className.className) is INamedTypeSymbol typeSymbol)
-				{
-					var hasStaticMethod = typeSymbol.GetMethods().Any(m => m.IsStatic && m.Name == fullMemberName);
-					var isStaticProperty = typeSymbol.GetProperties().Any(m => m.Name == fullMemberName && m.IsStatic);
-					var isStaticField = typeSymbol.GetFields().Any(m => m.Name == fullMemberName && m.IsStatic);
 
-					return isStaticProperty || isStaticField || hasStaticMethod;
-				}
-
-				return false;
-			}
+			return false;
+			
 		}
 
 		private string RewriteNamespaces(string xamlString)

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Functions_Control.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Functions_Control.xaml
@@ -33,6 +33,19 @@
 				   x:FieldModifier="public"
 				   Text="{x:Bind local:StaticClass.PublicStaticProperty}" />
 
+		<!-- const fields -->
+		<TextBlock x:Name="_StaticPrivateConstField"
+		   x:FieldModifier="public"
+		   Text="{x:Bind PrivateConstField}" />
+		
+		<TextBlock x:Name="_StaticClass_PublicConstField"
+		   x:FieldModifier="public"
+		   Text="{x:Bind local:StaticClass.PublicConstField}" />
+
+		<TextBlock x:Name="_InnerConstField"
+		   x:FieldModifier="public"
+		   Text="{x:Bind local:MyxBindClass.MyConst, Mode=OneWay}" />
+
 		<!-- functions --> 
 		<TextBlock x:Name="_InstanceFunction_Parameterless"
 				   x:FieldModifier="public"

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Functions_Control.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Functions_Control.xaml.cs
@@ -40,6 +40,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
 
 		private static readonly int StaticPrivateReadonlyField = 45;
 
+		private const int PrivateConstField = 46;
+
 		public int InstanceDP
 		{
 			get => (int)GetValue(InstanceDPProperty);
@@ -80,7 +82,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
 
 		private string _myproperty = "Initial";
 		private int _myIntProperty = -3;
-
+		public const int MyConst = -5;
 		public string MyProperty
 		{
 			get { return _myproperty; }
@@ -104,6 +106,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
 
 	public static class StaticClass
 	{
-		public static int PublicStaticProperty => 46;
+		public static int PublicStaticProperty => 47;
+
+		public const int PublicConstField = 48;
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Functions.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Functions.cs
@@ -29,6 +29,10 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 			Assert.AreEqual(string.Empty, SUT._StaticFunction_Parameterless.Text);
 			Assert.AreEqual(string.Empty, SUT._InstanceFunction_Boolean_False.Text);
 			Assert.AreEqual(string.Empty, SUT._InstanceFunction_Boolean_True.Text);
+			Assert.AreEqual(string.Empty, SUT._StaticClass_PublicConstField.Text);
+			Assert.AreEqual(string.Empty, SUT._StaticPrivateConstField.Text);
+			Assert.AreEqual(string.Empty, SUT._InnerConstField.Text);
+
 
 			SUT.ForceLoaded();
 
@@ -38,7 +42,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 			Assert.AreEqual("45", SUT._StaticPrivateReadonlyField.Text);
 			Assert.AreEqual("-1", SUT._InstanceDP.Text);
 			Assert.AreEqual("Initial", SUT._InnerProperty.Text);
-			Assert.AreEqual("46", SUT._StaticClass_PublicStaticProperty.Text);
+			Assert.AreEqual("47", SUT._StaticClass_PublicStaticProperty.Text);
 			Assert.AreEqual("52", SUT._InstanceFunction_OneParam.Text);
 			Assert.AreEqual("9", SUT._InstanceFunction_OneParam_DP_Update_OneWay.Text);
 			Assert.AreEqual("9", SUT._InstanceFunction_OneParam_DP_Update_OneTime.Text);
@@ -50,6 +54,10 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 			Assert.AreEqual("Static Parameter-less result", SUT._StaticFunction_Parameterless.Text);
 			Assert.AreEqual("Was false", SUT._InstanceFunction_Boolean_False.Text);
 			Assert.AreEqual("Was true", SUT._InstanceFunction_Boolean_True.Text);
+			Assert.AreEqual("48", SUT._StaticClass_PublicConstField.Text);
+			Assert.AreEqual("46", SUT._StaticPrivateConstField.Text);
+			Assert.AreEqual("-5", SUT._InnerConstField.Text);
+
 
 			Assert.AreEqual(1, SUT.AddDoubleCallCount);
 			Assert.AreEqual(2, SUT.AddIntCallCount);


### PR DESCRIPTION
closes #4247 

## PR Type
- Bugfix

## What is the current behavior?

Using x:Bind against a constant is raising an error:

`error CS7000: Unexpected use of an aliased name`


## What is the new behavior?

Using x:Bind against a constant shouldn't raise an error

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.