### PR TITLE
ci(storage): Fix CI build by moving storage related diff ignores to new version

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3067,11 +3067,6 @@
 		</Fields>
 	</IgnoreSet>
 	<IgnoreSet baseVersion="3.0.17">
-		<Types>
-			<Member 
-				fullName="Windows.Storage.StorageItem"
-				reason="Not part of the UWP API"/>
-		  </Types>
 		<Methods>
 			<Member 
 				fullName="System.Void Windows.System.UserProfile.UserProfilePersonalizationSettings..ctor()"
@@ -3085,6 +3080,20 @@
 			<Member
 				fullName="System.Void Windows.ApplicationModel.Activation.ToastNotificationActivatedEventArgs..ctor()"
 				reason="Parameter-less ctor does not exist in UWP"/>
+		</Methods>
+		<Fields>
+			<Member
+				fullName="System.Int32 Windows.ApplicationModel.Contacts.ContactQuerySearchFields::value__"
+				reason="The enum is backed by uint" />
+		</Fields>
+	</IgnoreSet>
+	<IgnoreSet baseVersion="3.1.0">
+		<Types>
+			<Member 
+				fullName="Windows.Storage.StorageItem"
+				reason="Not part of the UWP API"/>
+		  </Types>
+		<Methods>
 			<Member
 				fullName="System.Void Windows.Media.Capture.CapturedFrame.set_Size(System.UInt64 value)"
 				reason="Not part of the UWP API"/>
@@ -3186,9 +3195,6 @@
 				reason="Not part of the UWP API"/>
 		</Methods>
 		<Fields>
-			<Member
-				fullName="System.Int32 Windows.ApplicationModel.Contacts.ContactQuerySearchFields::value__"
-				reason="The enum is backed by uint" />
 			<Member
 				fullName="System.Int32 Windows.Storage.Streams.InputStreamOptions::value__"
 				reason="The enum is backed by uint"/>


### PR DESCRIPTION
## CI
Since a new package has been released on an internal nuget feed, the diff ignore tool is failing on CI

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
