### PR TITLE
feat: Add support Setter.Target in style declaration

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -373,7 +373,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			var type = FindType(ownerType);
 
-			if (type != null)
+			if (type != null && !string.IsNullOrEmpty(propertyName))
 			{
 				do
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1377,7 +1377,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						{
 							if (child.Type.Name == "Setter")
 							{
-								var propertyNode = FindMember(child, "Property");
+								var propertyNode = FindMember(child, "Property") ?? FindMember(child, "Target");
 								var valueNode = FindMember(child, "Value");
 								var property = propertyNode?.Value.SelectOrDefault(p => p.ToString());
 

--- a/src/Uno.UI.Tests/App/Xaml/Test_SetterTarget.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_SetterTarget.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="Uno.UI.Tests.App.Xaml.Test_SetterTarget"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Tests.App.Xaml"
+			 xmlns:views="using:Uno.UI.Tests.App.Views"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d">
+	<UserControl.Resources>
+		<Style x:Key="TestTargetStyle" TargetType="Button">
+			<Setter Target="Width" Value="42"/>
+			<Setter Target="Height" Value="42"/>
+			<Setter Target="VerticalAlignment" Value="Center"/>
+			<Setter Target="Margin" Value="42"/>
+		</Style>
+	</UserControl.Resources>
+
+	<Button Style="{StaticResource TestTargetStyle}"
+			x:Name="myButton"
+			x:FieldModifier="public">
+	</Button>
+</UserControl>

--- a/src/Uno.UI.Tests/App/Xaml/Test_SetterTarget.xaml.cs
+++ b/src/Uno.UI.Tests/App/Xaml/Test_SetterTarget.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Tests.App.Views;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.App.Xaml
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class Test_SetterTarget : UserControl
+    {
+		public Test_SetterTarget()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_StaticResource.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_StaticResource.cs
@@ -469,5 +469,13 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			AssertEx.AssertHasColor(tx.Foreground, (Color)Colors.Honeydew);
 			AssertEx.AssertHasColor(tx.Background, (Color)Colors.AntiqueWhite);
 		}
+
+		[TestMethod]
+		public void When_Explicit_And_TargetProperty()
+		{
+			var page = new Test_SetterTarget();
+			Assert.AreEqual(page.myButton.Width, 42.0);
+			Assert.AreEqual(page.myButton.Height, 42.0);
+		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

- Using Setter.Target is now supported
- Fixes FindPropertyByName may receive a null name.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
