### PR TITLE
fix(ProgressRing): Fixes IsEnabled should not remove the progress ring

### DIFF
--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -42,6 +42,7 @@ else
 			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Input.VisualState_Tests' or \
 			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests' or \
 			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' or \
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.WUXProgressRingTests' or \
 			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests'
 		"
 	elif [ "$UITEST_AUTOMATED_GROUP" == '2' ];

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
@@ -18,45 +18,45 @@ namespace SamplesApp.UITests.TestFramework
 		public static Rectangle FirstQuadrant { get; } = new Rectangle(0, 0, int.MaxValue, int.MaxValue);
 
 		#region Are[Almost]Equal
-		public static void AreEqual(ScreenshotInfo expected, ScreenshotInfo actual, IAppRect rect, [CallerLineNumber] int line = 0)
-			=> AreEqualImpl(expected, rect.ToRectangle(), actual, rect.ToRectangle(), 1, PixelTolerance.None, line);
+		public static void AreEqual(ScreenshotInfo expected, ScreenshotInfo actual, IAppRect rect, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreEqualImpl(expected, rect.ToRectangle(), actual, rect.ToRectangle(), expectedToActualScale, PixelTolerance.None, line);
 
-		public static void AreEqual(ScreenshotInfo expected, ScreenshotInfo actual, Rectangle? rect = null, [CallerLineNumber] int line = 0)
-			=> AreEqualImpl(expected, rect ?? FirstQuadrant, actual, rect ?? FirstQuadrant, 1, PixelTolerance.None, line);
+		public static void AreEqual(ScreenshotInfo expected, ScreenshotInfo actual, Rectangle? rect = null, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreEqualImpl(expected, rect ?? FirstQuadrant, actual, rect ?? FirstQuadrant, expectedToActualScale, PixelTolerance.None, line);
 
-		public static void AreEqual(ScreenshotInfo expected, IAppRect expectedRect, ScreenshotInfo actual, IAppRect actualRect, [CallerLineNumber] int line = 0)
-			=> AreEqualImpl(expected, expectedRect.ToRectangle(), actual, actualRect.ToRectangle(), 1, PixelTolerance.None, line);
+		public static void AreEqual(ScreenshotInfo expected, IAppRect expectedRect, ScreenshotInfo actual, IAppRect actualRect, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreEqualImpl(expected, expectedRect.ToRectangle(), actual, actualRect.ToRectangle(), expectedToActualScale, PixelTolerance.None, line);
 
-		public static void AreEqual(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, [CallerLineNumber] int line = 0)
-			=> AreEqualImpl(expected, expectedRect, actual, actualRect, 1, PixelTolerance.None, line);
-
-		/// <summary>
-		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
-		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
-		/// </summary>
-		public static void AreAlmostEqual(ScreenshotInfo expected, ScreenshotInfo actual, IAppRect rect, int permittedPixelError, [CallerLineNumber] int line = 0)
-			=> AreEqualImpl(expected, rect.ToRectangle(), actual, rect.ToRectangle(), 1, PixelTolerance.Cummulative(permittedPixelError), line);
+		public static void AreEqual(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreEqualImpl(expected, expectedRect, actual, actualRect, expectedToActualScale, PixelTolerance.None, line);
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
 		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
-		public static void AreAlmostEqual(ScreenshotInfo expected, ScreenshotInfo actual, Rectangle? rect = null, int permittedPixelError = 5, [CallerLineNumber] int line = 0)
-			=> AreEqualImpl(expected, rect ?? FirstQuadrant, actual, rect ?? FirstQuadrant, 1, PixelTolerance.Cummulative(permittedPixelError), line);
+		public static void AreAlmostEqual(ScreenshotInfo expected, ScreenshotInfo actual, IAppRect rect, int permittedPixelError, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreEqualImpl(expected, rect.ToRectangle(), actual, rect.ToRectangle(), expectedToActualScale, PixelTolerance.Cummulative(permittedPixelError), line);
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
 		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
-		public static void AreAlmostEqual(ScreenshotInfo expected, IAppRect expectedRect, ScreenshotInfo actual, IAppRect actualRect, int permittedPixelError, [CallerLineNumber] int line = 0)
-			=> AreEqualImpl(expected, expectedRect.ToRectangle(), actual, actualRect.ToRectangle(), 1, PixelTolerance.Cummulative(permittedPixelError), line);
+		public static void AreAlmostEqual(ScreenshotInfo expected, ScreenshotInfo actual, Rectangle? rect = null, int permittedPixelError = 5, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreEqualImpl(expected, rect ?? FirstQuadrant, actual, rect ?? FirstQuadrant, expectedToActualScale, PixelTolerance.Cummulative(permittedPixelError), line);
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
 		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
 		/// </summary>
-		public static void AreAlmostEqual(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, int permittedPixelError, [CallerLineNumber] int line = 0)
-			=> AreEqualImpl(expected, expectedRect, actual, actualRect, 1, PixelTolerance.Cummulative(permittedPixelError), line);
+		public static void AreAlmostEqual(ScreenshotInfo expected, IAppRect expectedRect, ScreenshotInfo actual, IAppRect actualRect, int permittedPixelError, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreEqualImpl(expected, expectedRect.ToRectangle(), actual, actualRect.ToRectangle(), expectedToActualScale, PixelTolerance.Cummulative(permittedPixelError), line);
+
+		/// <summary>
+		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
+		/// (ie, the A, R, G, or B values cumulatively differ by more than the permitted error for any pixel).
+		/// </summary>
+		public static void AreAlmostEqual(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, int permittedPixelError, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreEqualImpl(expected, expectedRect, actual, actualRect, expectedToActualScale, PixelTolerance.Cummulative(permittedPixelError), line);
 
 		/// <summary>
 		/// Asserts that two screenshots are equal to each other inside the area of the nominated rect to within the given pixel error
@@ -75,12 +75,10 @@ namespace SamplesApp.UITests.TestFramework
 			Rectangle actualRect,
 			double expectedToActualScale,
 			PixelTolerance tolerance,
-			int line)
+			[CallerLineNumber] int line = 0)
 		{
-			using (var actualBitmap = new Bitmap(actual.File.FullName))
-			{
-				AreEqualImpl(expected, expectedRect, actual, actualBitmap, actualRect, expectedToActualScale, tolerance, line);
-			}
+			using var actualBitmap = new Bitmap(actual.File.FullName);
+			AreEqualImpl(expected, expectedRect, actual, actualBitmap, actualRect, expectedToActualScale, tolerance, line);
 		}
 
 		private static void AreEqualImpl(
@@ -91,7 +89,29 @@ namespace SamplesApp.UITests.TestFramework
 			Rectangle actualRect,
 			double expectedToActualScale,
 			PixelTolerance tolerance,
-			int line)
+			[CallerLineNumber] int line = 0)
+		{
+			var (areEqual, context) = EqualityCheck(expected, expectedRect, actual, actualBitmap, actualRect, expectedToActualScale, tolerance, line);
+
+			if (areEqual)
+			{
+				Console.WriteLine(context.ToString());
+			}
+			else
+			{
+				Assert.Fail(context.ToString());
+			}
+		}
+
+		private static (bool areEqual, string context) EqualityCheck(
+			ScreenshotInfo expected,
+			Rectangle expectedRect,
+			ScreenshotInfo actual,
+			Bitmap actualBitmap,
+			Rectangle actualRect,
+			double expectedToActualScale,
+			PixelTolerance tolerance,
+			[CallerLineNumber] int line = 0)
 		{
 			if (expectedRect != FirstQuadrant && actualRect != FirstQuadrant)
 			{
@@ -118,14 +138,9 @@ namespace SamplesApp.UITests.TestFramework
 					.WithTolerance(tolerance);
 
 				var report = GetContext();
-				if (Validate(expectedPixels, actualBitmap, expectedToActualScale, report))
-				{
-					Console.WriteLine(report.ToString());
-				}
-				else
-				{
-					Assert.Fail(report.ToString());
-				}
+				var result = Validate(expectedPixels, actualBitmap, expectedToActualScale, report);
+
+				return (result, report.ToString());
 			}
 
 			StringBuilder GetContext()
@@ -144,61 +159,50 @@ namespace SamplesApp.UITests.TestFramework
 		#endregion
 
 		#region AreNotEqual
-		public static void AreNotEqual(ScreenshotInfo expected, ScreenshotInfo actual, IAppRect rect, [CallerLineNumber] int line = 0)
-			=> AreNotEqualImpl(expected, rect.ToRectangle(), actual, rect.ToRectangle(), line);
+		public static void AreNotEqual(ScreenshotInfo expected, ScreenshotInfo actual, IAppRect rect, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreNotEqualImpl(expected, rect.ToRectangle(), actual, rect.ToRectangle(), expectedToActualScale, PixelTolerance.None, line);
 
-		public static void AreNotEqual(ScreenshotInfo expected, ScreenshotInfo actual, Rectangle? rect = null, [CallerLineNumber] int line = 0)
-			=> AreNotEqualImpl(expected, rect ?? FirstQuadrant, actual, rect ?? FirstQuadrant, line);
+		public static void AreNotEqual(ScreenshotInfo expected, ScreenshotInfo actual, Rectangle? rect = null, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreNotEqualImpl(expected, rect ?? FirstQuadrant, actual, rect ?? FirstQuadrant, expectedToActualScale, PixelTolerance.None, line);
 
-		public static void AreNotEqual(ScreenshotInfo expected, IAppRect expectedRect, ScreenshotInfo actual, IAppRect actualRect, [CallerLineNumber] int line = 0)
-			=> AreNotEqualImpl(expected, expectedRect.ToRectangle(), actual, actualRect.ToRectangle(), line);
+		public static void AreNotEqual(ScreenshotInfo expected, IAppRect expectedRect, ScreenshotInfo actual, IAppRect actualRect, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreNotEqualImpl(expected, expectedRect.ToRectangle(), actual, actualRect.ToRectangle(), expectedToActualScale, PixelTolerance.None, line);
 
-		public static void AreNotEqual(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, [CallerLineNumber] int line = 0)
-			=> AreNotEqualImpl(expected, expectedRect, actual, actualRect, line);
+		public static void AreNotEqual(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, double expectedToActualScale = 1, [CallerLineNumber] int line = 0)
+			=> AreNotEqualImpl(expected, expectedRect, actual, actualRect, expectedToActualScale, PixelTolerance.None, line);
 
-		private static void AreNotEqualImpl(ScreenshotInfo expected, Rectangle expectedRect, ScreenshotInfo actual, Rectangle actualRect, int line)
+		private static void AreNotEqualImpl(
+			ScreenshotInfo expected,
+			Rectangle expectedRect,
+			ScreenshotInfo actual,
+			Rectangle actualRect,
+			double expectedToActualScale,
+			PixelTolerance tolerance,
+			int line)
 		{
-			Assert.AreEqual(expectedRect.Size, actualRect.Size, WithContext("Compare rects don't have the same size"));
+			using var actualBitmap = new Bitmap(actual.File.FullName);
+			AreNotEqualImpl(expected, expectedRect, actual, actualBitmap, actualRect, expectedToActualScale, tolerance, line);
+		}
 
-			using (var expectedBitmap = new Bitmap(expected.File.FullName))
-			using (var actualBitmap = new Bitmap(actual.File.FullName))
+		private static void AreNotEqualImpl(
+					ScreenshotInfo expected,
+					Rectangle expectedRect,
+					ScreenshotInfo actual,
+					Bitmap actualBitmap,
+					Rectangle actualRect,
+					double expectedToActualScale,
+					PixelTolerance tolerance,
+					int line)
+		{
+			var result = EqualityCheck(expected, expectedRect, actual, actualBitmap, actualRect, expectedToActualScale, tolerance, line);
+
+			if (!result.areEqual)
 			{
-				Assert.AreEqual(expectedBitmap.Size, actualBitmap.Size, WithContext("Screenshots don't have the same size"));
-
-				var width = Math.Min(expectedRect.Width, expectedBitmap.Size.Width);
-				var height = Math.Min(expectedRect.Height, expectedBitmap.Size.Height);
-
-				(int x, int y) expectedOffset = (
-					expectedRect.X < 0 ? expectedBitmap.Size.Width + expectedRect.X : expectedRect.X,
-					expectedRect.Y < 0 ? expectedBitmap.Size.Height + expectedRect.Y : expectedRect.Y
-				);
-				(int x, int y) actualOffset = (
-					actualRect.X < 0 ? actualBitmap.Size.Width + actualRect.X : actualRect.X,
-					actualRect.Y < 0 ? actualBitmap.Size.Height + actualRect.Y : actualRect.Y
-				);
-
-				for (var x = 0; x < width; x++)
-				for (var y = 0; y < height; y++)
-				{
-					if (expectedBitmap.GetPixel(x + expectedOffset.x, y + expectedOffset.y) != actualBitmap.GetPixel(x + actualOffset.x, y + actualOffset.y))
-					{
-						return;
-					}
-				}
-
-				Assert.Fail(WithContext("Screenshots are equals."));
+				Console.WriteLine(result.context.ToString());
 			}
-
-			string WithContext(string message = null, Action<StringBuilder> builder = null)
+			else
 			{
-				return new StringBuilder()
-					.AppendLine($"ImageAssert.AreNotEqual @ line {line}")
-					.AppendLine($"expected: {expected?.StepName} ({expected?.File.Name}){(expectedRect == FirstQuadrant ? null : $" in {expectedRect}")}")
-					.AppendLine($"actual  : {actual?.StepName ?? "--unknown--"} ({actual?.File.Name}){(actualRect == FirstQuadrant ? null : $" in {actualRect}")}")
-					.AppendLine("====================")
-					.ApplyIf(message != null, x => x.AppendLine(message))
-					.ApplyIf(builder != null, builder)
-					.ToString();
+				Assert.Fail(result.context.ToString());
 			}
 		}
 		#endregion

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WUXProgressRingTests/UnoSamples_WUXProgressRing_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WUXProgressRingTests/UnoSamples_WUXProgressRing_Tests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.WUXProgressRingTests
+{
+	public class UnoSamples_WUXProgressRing_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry()]
+		[ActivePlatforms(Platform.iOS, Platform.Android)]
+		public void ProgressRing_IsEnabled_Running()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ProgressRing.WindowsProgressRing_GH1220");
+
+			var isEnabledTest = _app.Marked("isEnabledTest");
+			var placeHolder = _app.Marked("placeHolder");
+
+			var before = TakeScreenshot("before", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+			var placeholderRect = _app.Query(placeHolder).First().Rect;
+			var isEnabledTestRect = _app.Query(isEnabledTest).First().Rect;
+
+			ImageAssert.AreNotEqual(before, placeholderRect, before, isEnabledTestRect);
+
+			isEnabledTest.SetDependencyPropertyValue("IsEnabled", "True");
+
+			var after = TakeScreenshot("after", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+
+			ImageAssert.AreNotEqual(before, placeholderRect, after, isEnabledTestRect);
+		}
+
+		[Test]
+		[AutoRetry()]
+		[ActivePlatforms(Platform.iOS, Platform.Android)]
+		public void ProgressRing_Visibility_Collapsed()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ProgressRing.WindowsProgressRing_GH1220");
+
+			var isVisible = _app.Marked("isVisible");
+			var visibilityTest = _app.Marked("visibilityTest");
+			var placeHolder = _app.Marked("placeHolder");
+			var collapsedTestBorder = _app.Marked("collapsedTestBorder");
+
+			var placeholderRect = _app.Query(placeHolder).First().Rect;
+			var collapsedTestBorderRect = _app.Query(collapsedTestBorder).FirstOrDefault()?.Rect;
+
+			Assert.AreEqual(0f, collapsedTestBorderRect?.Height ?? 0f);
+
+			isVisible.SetDependencyPropertyValue("IsChecked", "True");
+
+			collapsedTestBorderRect = _app.Query(collapsedTestBorder).First().Rect;
+			Assert.AreNotEqual(0f, collapsedTestBorderRect.Height);
+
+			var after = TakeScreenshot("after", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+
+			var visibilityTestRect = _app.Query(visibilityTest).First().Rect;
+			ImageAssert.AreNotEqual(after, placeholderRect, after, visibilityTestRect);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ProgressRing/WindowsProgressRing_GH1220.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ProgressRing/WindowsProgressRing_GH1220.xaml
@@ -11,10 +11,18 @@
 		<TextBlock FontSize="15">This is an illustration of GH bug #1220 - ProgressRing doesn't collapse on iOS.</TextBlock>
 		<TextBlock FontSize="15">The following ProgressRing should NOT be visible. If you see a ProgressRing, there's a problem.</TextBlock>
 
-		<ProgressRing Width="200" Height="200" Foreground="Red" IsActive="True" Visibility="Collapsed"/>
+		<ProgressRing Width="100" Height="100" Foreground="Red" IsActive="True" Visibility="Collapsed"/>
 
 		<TextBlock FontSize="15">Another ProgressRing, but visibility is dynamic:</TextBlock>
 		<ToggleButton x:Name="isVisible">IS VISIBLE</ToggleButton>
-		<ProgressRing Width="200" Height="200" Foreground="Red" IsActive="True" Visibility="{Binding IsChecked, ElementName=isVisible}"/>
+		<Border x:Name="collapsedTestBorder">
+			<ProgressRing x:Name="visibilityTest" Width="100" Height="100" Foreground="Red" IsActive="True" Visibility="{Binding IsChecked, ElementName=isVisible}"/>
+		</Border>
+
+		<TextBlock FontSize="15">Another ProgressRing, but IsEnabled is changing:</TextBlock>
+		<ToggleButton x:Name="isEnabled">IS ENABLED</ToggleButton>
+		<ProgressRing x:Name="isEnabledTest" Width="100" Height="100" Foreground="Red" IsActive="True" IsEnabled="{Binding IsChecked, ElementName=isEnabled}"/>
+
+		<Border x:Name="placeHolder" Width="100" Height="100" />
 	</StackPanel>
 </Page>

--- a/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOS.cs
@@ -30,21 +30,14 @@ namespace Windows.UI.Xaml.Controls
 		partial void OnLoadedPartial() => TrySetNativeAnimating();
 
 		partial void OnUnloadedPartial() => TrySetNativeAnimating();
-
-		protected override void OnIsEnabledChanged(bool oldValue, bool newValue)
-		{
-			base.OnIsEnabledChanged(oldValue, newValue);
-
-			TrySetNativeAnimating();
-		}
-
+	
 		partial void OnIsActiveChangedPartial(bool _) => TrySetNativeAnimating();
 
-		private void TrySetNativeAnimating()
+		partial void TrySetNativeAnimating()
 		{
 			if (_native != null)
 			{
-				if (IsActive && IsEnabled && IsLoaded)
+				if (IsActive && IsLoaded)
 				{
 					_native.StartAnimating();
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOSAndroid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOSAndroid.cs
@@ -28,7 +28,11 @@ namespace Windows.UI.Xaml.Controls
 			{
 				ApplyForeground();
 			}
+
+			TrySetNativeAnimating();
 		}
+
+		partial void TrySetNativeAnimating();
 
 		protected override void OnForegroundColorChanged(Brush oldValue, Brush newValue)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/nventive-private/issues/18

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The WUX progress ring should not disappear if `IsEnabled` is set to false.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
