### PR TITLE
fix(dotnetnew): Skia WPF head is not referenced properly in sln

### DIFF
--- a/build/run-template-tests.ps1
+++ b/build/run-template-tests.ps1
@@ -14,6 +14,8 @@ function Get-TemplateConfiguration(
     [bool]$iOS = $false,
     [bool]$macOS = $false,
     [bool]$wasm = $false,
+    [bool]$skiaGtk = $false,
+    [bool]$skiaWpf = $false,
     [bool]$wasmVsCode = $false)
 {
     $uwpFlag = '-uwp'
@@ -22,6 +24,8 @@ function Get-TemplateConfiguration(
     $macOSFlag = '-macos'
     $wasmFlag = '-wasm'
     $wasmVsCodeFlag = '--vscodeWasm'
+    $skiaWpfFlag = '--skia-wpf'
+    $skiaGtkFlag = '--skia-gtk'
 
     $a = If ($uwp)        { $uwpFlag }        Else { $uwpFlag        + '=false' }
     $b = If ($android)    { $androidFlag }    Else { $androidFlag    + '=false' }
@@ -29,8 +33,10 @@ function Get-TemplateConfiguration(
     $d = If ($macOS)      { $macOSFlag }      Else { $macOSFlag      + '=false' }
     $e = If ($wasm)       { $wasmFlag }       Else { $wasmFlag       + '=false' }
     $f = If ($wasmVsCode) { $wasmVsCodeFlag } Else { $wasmVsCodeFlag + '=false' }
+    $g = If ($skiaWpf)    { $skiaWpfFlag    } Else { $skiaWpfFlag    + '=false' }
+    $h = If ($skiaGtk)    { $skiaGtkFlag    } Else { $skiaGtkFlag    + '=false' }
 
-    @($a, $b, $c, $d, $e, $f)
+    @($a, $b, $c, $d, $e, $f, $g, $h)
 }
 
 $msbuild = vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe
@@ -50,7 +56,9 @@ $templateConfigurations =
     (Get-TemplateConfiguration -android 1),
     (Get-TemplateConfiguration -iOS 1),
     (Get-TemplateConfiguration -macOS 1),
-    (Get-TemplateConfiguration -wasm 1)
+    (Get-TemplateConfiguration -wasm 1),
+    (Get-TemplateConfiguration -skiaGtk 1),
+    (Get-TemplateConfiguration -skiaWpf 1)
 )
 
 $configurations =

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/UnoQuickStart.sln
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/UnoQuickStart.sln
@@ -27,7 +27,7 @@ EndProject
 #//#endif
 
 #//#if (macOS)
-Project("{FCC8D2E7-3137-4432-B623-163BC51B21E7}") = "UnoQuickStart.macOS", "UnoQuickStart.macOS\UnoQuickStart.macOS.csproj", "{$guid3$}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnoQuickStart.macOS", "UnoQuickStart.macOS\UnoQuickStart.macOS.csproj", "{$guid3$}"
 EndProject
 #//#endif
 
@@ -39,15 +39,17 @@ EndProject
 #//#if (skia-wpf)
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnoQuickStart.Skia.WPF", "UnoQuickStart.Skia.WPF\UnoQuickStart.Skia.WPF.csproj", "{$guid5$}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnoQuickStart.Wpf.Host", "UnoQuickStart.Skia.WPF.Host\UnoQuickStart.Wpf.Host.csproj", "{6CF284A4-22B1-4F05-97F4-F095C07A598E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnoQuickStart.Skia.Wpf.Host", "UnoQuickStart.Skia.WPF.Host\UnoQuickStart.Skia.Wpf.Host.csproj", "{6CF284A4-22B1-4F05-97F4-F095C07A598E}"
 EndProject
 #//#endif
 
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		UnoQuickStart.Shared\UnoQuickStart.Shared.projitems*{$guid2$}*SharedItemsImports = 4
+		UnoQuickStart.Shared\UnoQuickStart.Shared.projitems*{$guid5$}*SharedItemsImports = 5
 		UnoQuickStart.Shared\UnoQuickStart.Shared.projitems*{$guid3$}*SharedItemsImports = 4
 		UnoQuickStart.Shared\UnoQuickStart.Shared.projitems*{40ea03f7-8a22-4143-b251-79bac3eb13d2}*SharedItemsImports = 5
+		UnoQuickStart.Shared\UnoQuickStart.Shared.projitems*{a5b8155a-118f-4794-b551-c6f3cf7e5411}*SharedItemsImports = 5
 		UnoQuickStart.Shared\UnoQuickStart.Shared.projitems*{$guid4$}*SharedItemsImports = 4
 		UnoQuickStart.Shared\UnoQuickStart.Shared.projitems*{6279c845-92f8-4333-ab99-3d213163593c}*SharedItemsImports = 13
 		UnoQuickStart.Shared\UnoQuickStart.Shared.projitems*{$guid1$}*SharedItemsImports = 4
@@ -90,6 +92,7 @@ Global
 		{$guid2$}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{$guid2$}.Debug|x86.Build.0 = Debug|Any CPU
 		{$guid2$}.Debug|x86.Deploy.0 = Debug|Any CPU
+
 		{$guid2$}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{$guid2$}.Release|Any CPU.Build.0 = Release|Any CPU
 		{$guid2$}.Release|Any CPU.Deploy.0 = Release|Any CPU
@@ -138,6 +141,7 @@ Global
 		{$guid4$}.Release|x64.Deploy.0 = Release|iPhoneSimulator
 		{$guid4$}.Release|x86.ActiveCfg = Release|iPhoneSimulator
 		{$guid4$}.Release|x86.Build.0 = Release|iPhoneSimulator
+
 		{$guid1$}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{$guid1$}.Debug|Any CPU.Build.0 = Debug|x86
 		{$guid1$}.Debug|Any CPU.Deploy.0 = Debug|x86
@@ -177,6 +181,134 @@ Global
 		{$guid1$}.Release|x86.ActiveCfg = Release|x86
 		{$guid1$}.Release|x86.Build.0 = Release|x86
 		{$guid1$}.Release|x86.Deploy.0 = Release|x86
+
+		{$guid5$}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{$guid5$}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{$guid5$}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{$guid5$}.Debug|ARM.ActiveCfg = Debug|ARM
+		{$guid5$}.Debug|ARM.Build.0 = Debug|ARM
+		{$guid5$}.Debug|ARM.Deploy.0 = Debug|ARM
+		{$guid5$}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{$guid5$}.Debug|ARM64.Build.0 = Debug|ARM64
+		{$guid5$}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{$guid5$}.Debug|iPhone.ActiveCfg = Debug|x86
+		{$guid5$}.Debug|iPhone.Build.0 = Debug|x86
+		{$guid5$}.Debug|iPhone.Deploy.0 = Debug|x86
+		{$guid5$}.Debug|iPhoneSimulator.ActiveCfg = Debug|x86
+		{$guid5$}.Debug|iPhoneSimulator.Build.0 = Debug|x86
+		{$guid5$}.Debug|iPhoneSimulator.Deploy.0 = Debug|x86
+		{$guid5$}.Debug|x64.ActiveCfg = Debug|x64
+		{$guid5$}.Debug|x64.Build.0 = Debug|x64
+		{$guid5$}.Debug|x64.Deploy.0 = Debug|x64
+		{$guid5$}.Debug|x86.ActiveCfg = Debug|x86
+		{$guid5$}.Debug|x86.Build.0 = Debug|x86
+		{$guid5$}.Debug|x86.Deploy.0 = Debug|x86
+		{$guid5$}.Release|Any CPU.ActiveCfg = Release|x86
+		{$guid5$}.Release|ARM.ActiveCfg = Release|ARM
+		{$guid5$}.Release|ARM.Build.0 = Release|ARM
+		{$guid5$}.Release|ARM.Deploy.0 = Release|ARM
+		{$guid5$}.Release|ARM64.ActiveCfg = Release|ARM64
+		{$guid5$}.Release|ARM64.Build.0 = Release|ARM64
+		{$guid5$}.Release|ARM64.Deploy.0 = Release|ARM64
+		{$guid5$}.Release|iPhone.ActiveCfg = Release|x86
+		{$guid5$}.Release|iPhone.Build.0 = Release|x86
+		{$guid5$}.Release|iPhoneSimulator.ActiveCfg = Release|x86
+		{$guid5$}.Release|iPhoneSimulator.Build.0 = Release|x86
+		{$guid5$}.Release|iPhoneSimulator.Deploy.0 = Release|x86
+		{$guid5$}.Release|x64.ActiveCfg = Release|x64
+		{$guid5$}.Release|x64.Build.0 = Release|x64
+		{$guid5$}.Release|x64.Deploy.0 = Release|x64
+		{$guid5$}.Release|x86.ActiveCfg = Release|x86
+		{$guid5$}.Release|x86.Build.0 = Release|x86
+		{$guid5$}.Release|x86.Deploy.0 = Release|x86
+
+		{$guid5$}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{$guid5$}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{$guid5$}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{$guid5$}.Debug|ARM.Build.0 = Debug|Any CPU
+		{$guid5$}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{$guid5$}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{$guid5$}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{$guid5$}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{$guid5$}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{$guid5$}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{$guid5$}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{$guid5$}.Debug|x64.Build.0 = Debug|Any CPU
+		{$guid5$}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{$guid5$}.Debug|x86.Build.0 = Debug|Any CPU
+		{$guid5$}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{$guid5$}.Release|Any CPU.Build.0 = Release|Any CPU
+		{$guid5$}.Release|ARM.ActiveCfg = Release|Any CPU
+		{$guid5$}.Release|ARM.Build.0 = Release|Any CPU
+		{$guid5$}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{$guid5$}.Release|ARM64.Build.0 = Release|Any CPU
+		{$guid5$}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{$guid5$}.Release|iPhone.Build.0 = Release|Any CPU
+		{$guid5$}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{$guid5$}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{$guid5$}.Release|x64.ActiveCfg = Release|Any CPU
+		{$guid5$}.Release|x64.Build.0 = Release|Any CPU
+		{$guid5$}.Release|x86.ActiveCfg = Release|Any CPU
+		{$guid5$}.Release|x86.Build.0 = Release|Any CPU
+
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|ARM.Build.0 = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|x64.Build.0 = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Debug|x86.Build.0 = Debug|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|ARM.ActiveCfg = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|ARM.Build.0 = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|ARM64.Build.0 = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|iPhone.Build.0 = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|x64.ActiveCfg = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|x64.Build.0 = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|x86.ActiveCfg = Release|Any CPU
+		{A5B8155A-118F-4794-B551-C6F3CF7E5411}.Release|x86.Build.0 = Release|Any CPU
+
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|ARM.Build.0 = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|x64.Build.0 = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Debug|x86.Build.0 = Debug|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|ARM.ActiveCfg = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|ARM.Build.0 = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|ARM64.Build.0 = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|iPhone.Build.0 = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|x64.ActiveCfg = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|x64.Build.0 = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|x86.ActiveCfg = Release|Any CPU
+		{6CF284A4-22B1-4F05-97F4-F095C07A598E}.Release|x86.Build.0 = Release|Any CPU
+
 		{40EA03F7-8A22-4143-B251-79BAC3EB13D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{40EA03F7-8A22-4143-B251-79BAC3EB13D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{40EA03F7-8A22-4143-B251-79BAC3EB13D2}.Debug|ARM.ActiveCfg = Debug|Any CPU

--- a/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml.cs
@@ -21,7 +21,7 @@ namespace $ext_safeprojectname$
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
-    sealed partial class App : Application
+    public sealed partial class App : Application
 	{
 		/// <summary>
 		/// Initializes the singleton application object.  This is the first line of authored code

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
@@ -6,7 +6,7 @@
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="exists('..\$ext_safeprojectname$.UWP')">
 		<EmbeddedResource Include="..\$ext_safeprojectname$.UWP\Package.appxmanifest" LogicalName="Package.appxmanifest" />
 		<Content Include="..\$ext_safeprojectname$.UWP\Assets\StoreLogo.png" Link="Assets\StoreLogo.png" />
 	</ItemGroup>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.WPF.Host/MainWindow.xaml.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.WPF.Host/MainWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace $ext_safeprojectname$.WPF.Host
 		{
 			InitializeComponent();
 	
-			root.Content = new Uno.UI.Skia.Platform.WpfHost(Dispatcher, () => new $ext_safeprojectname$.App());
+			root.Content = new global::Uno.UI.Skia.Platform.WpfHost(Dispatcher, () => new $ext_safeprojectname$.App());
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
The Skia WPF head is referenced properly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
