### PR TITLE
Set PreferredDatePickerStyle on iOS 14

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -34,6 +34,12 @@ namespace Windows.UI.Xaml.Controls
 			_picker.Mode = UIDatePickerMode.Date;
 			_picker.TimeZone = NSTimeZone.LocalTimeZone;
 			_picker.Calendar = new NSCalendar(NSCalendarType.Gregorian);
+
+			if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0))
+			{
+				_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
+			}
+
 			UpdatePickerValue(Date, animated: false);
 
 			_picker.ValueChanged += OnPickerValueChanged;

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -37,6 +37,11 @@ namespace Windows.UI.Xaml.Controls
 			_picker.Calendar = new NSCalendar(NSCalendarType.Gregorian);
 			_picker.Mode = UIDatePickerMode.Time;
 
+			if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0))
+			{
+				_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
+			}
+
 			_picker.ValueChanged += OnValueChanged;
 			
 			var parent = _picker.FindFirstParent<FrameworkElement>();


### PR DESCRIPTION
closes #4131 
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
![broken](https://user-images.githubusercontent.com/1330995/94209092-be22f680-fecb-11ea-84b8-fc623bd4696e.png)


## What is the new behavior?

DatePicker/TimePicker look normal like iOS 13

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
