### PR TITLE
fix: Adjust roslyn override inclusion for legacy projects

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -48,14 +48,6 @@
 	<PackageReference Update="GtkSharp" Version="3.22.25.128" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(MicrosoftNetCompilerVersionOverride)'!=''">
-	<!-- This override is used to validate the user of specific version of the C# Compiler -->
-	<PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilerVersionOverride)">
-	  <PrivateAssets>all</PrivateAssets>
-	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-	</PackageReference>
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 	<PackageReference Update="Xamarin.AndroidX.Legacy.Support.v4" Version="1.0.0" />
 	<PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.1.0" />
@@ -71,4 +63,6 @@
 	<PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.2" />
   </ItemGroup>
 
+  <!-- Import the override as the nuget tooling in VS is skipping ItemGroup conditions for legacy projects -->
+  <Import Project="roslyn-override.targets" Condition="'$(MicrosoftNetCompilerVersionOverride)'!=''"/>
 </Project>

--- a/src/roslyn-override.targets
+++ b/src/roslyn-override.targets
@@ -1,0 +1,16 @@
+<Project ToolsVersion="15.0">
+
+  <!--
+  This file is imported from Directory.Build.props as the nuget tooling
+  in VS is skipping ItemGroup conditions for legacy projects (iOS, Android, ...).
+  -->
+
+  <ItemGroup Condition="'$(MicrosoftNetCompilerVersionOverride)'!=''">
+	 <!--This override is used to validate the user of specific version of the C# Compiler--> 
+	<PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilerVersionOverride)">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+	</PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Building from Visual Studio may show the `Invalid version ""` with iOS or Android.

## What is the new behavior?

No error.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [xc] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
