### PR TITLE
Wasm Rounded Corners were not clipping

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
@@ -32,5 +32,27 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ClippingTests
 			ImageAssert.HasColorAt(screenshot, rect2.Right + 8, rect2.Y + 75, Color.Blue);
 			ImageAssert.HasColorAt(screenshot, rect2.X + 75, rect2.Bottom + 8, Color.Blue);
 		}
+
+		[Test]
+		[AutoRetry]
+		public void When_Clipped_Rounded_Corners()
+		{
+			Run("UITests.Windows_UI_Xaml.Clipping.Clipping4273");
+
+			_app.WaitForElement("RoundedGrid");
+
+			var rect = _app.GetRect("RoundedGrid");
+
+			var centre = GetScaledCenter(rect);
+			var scale = GetDisplayScreenScaling();
+			var offset = 5 * (float)scale;
+			var innerCornerX = rect.X + offset;
+			var innerCornerY = rect.Y + offset;
+
+			var screenshot = TakeScreenshot("ClippedCorners");
+			ImageAssert.HasColorAt(screenshot, centre.X, centre.Y, Color.Blue);
+			ImageAssert.HasColorAt(screenshot, innerCornerX, innerCornerY, Color.Red);
+
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -389,6 +389,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\Clipping4273.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\Clipping652.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3782,6 +3786,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\ButtonWithClippingAndOffset.xaml.cs">
       <DependentUpon>ButtonWithClippingAndOffset.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\Clipping4273.xaml.cs">
+      <DependentUpon>Clipping4273.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\Clipping652.xaml.cs">
       <DependentUpon>Clipping652.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Clipping4273.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Clipping4273.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml.Clipping.Clipping4273"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml.Clipping"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="Should show a blue rounded rectangle, edged in red" />
+		<Grid Background="Red"
+			  VerticalAlignment="Top"
+			  HorizontalAlignment="Center">
+			<Grid Width="220"
+				  Height="140"
+				  CornerRadius="60"
+				  x:Name="RoundedGrid">
+				<Border Background="Blue"
+						HorizontalAlignment="Stretch"
+						VerticalAlignment="Stretch" />
+			</Grid>
+		</Grid>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Clipping4273.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/Clipping4273.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml.Clipping
+{
+	[Sample]
+	public sealed partial class Clipping4273 : UserControl
+	{
+		public Clipping4273()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.wasm.cs
@@ -33,7 +33,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void UpdateBorder()
 		{
-			SetBorder(BorderThickness, BorderBrush, CornerRadius);
+			SetBorder(BorderThickness, BorderBrush);
 		}
 			
 		private protected override void OnLoaded()
@@ -59,7 +59,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnCornerRadiusUpdatedPartial(CornerRadius oldValue, CornerRadius newValue)
 		{
-			UpdateBorder();
+			SetCornerRadius(newValue);
 		}
 
 		protected override void OnBackgroundChanged(DependencyPropertyChangedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.Android.cs
@@ -66,6 +66,8 @@ namespace Windows.UI.Xaml.Controls
 			AdjustCornerRadius(canvas, CornerRadius);
 		}
 
+		private void UpdateCornerRadius(CornerRadius radius) => UpdateBorder(false);
+
 		private void UpdateBorder()
 		{
 			UpdateBorder(false);

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.Skia.cs
@@ -43,6 +43,8 @@ namespace Windows.UI.Xaml.Controls
 			RemoveChild(ContentTemplateRoot);
 		}
 
+		private void UpdateCornerRadius(CornerRadius radius) => UpdateBorder();
+
 		private void UpdateBorder()
 		{
 			if (IsLoaded)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -545,7 +545,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnCornerRadiusChanged(CornerRadius oldValue, CornerRadius newValue)
 		{
-			UpdateBorder();
+			UpdateCornerRadius(newValue);
 		}
 
 		#endregion

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.iOS.cs
@@ -60,6 +60,8 @@ namespace Windows.UI.Xaml.Controls
 			UpdateBorder();
 		}
 
+		private void UpdateCornerRadius(CornerRadius radius) => UpdateBorder();
+
 		private void UpdateBorder()
 		{
 			if (IsLoaded)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.macOS.cs
@@ -59,6 +59,8 @@ namespace Windows.UI.Xaml.Controls
 			UpdateBorder();
 		}
 
+		private void UpdateCornerRadius(CornerRadius radius) => UpdateBorder();
+
 		private void UpdateBorder()
 		{
 			if (IsLoaded)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.net.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.net.cs
@@ -37,6 +37,10 @@ namespace Windows.UI.Xaml.Controls
 			RemoveChild(ContentTemplateRoot);
 		}
 
+		private void UpdateCornerRadius(CornerRadius radius)
+		{
+		}
+
 		private void UpdateBorder()
 		{
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.netstdref.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.netstdref.cs
@@ -37,6 +37,10 @@ namespace Windows.UI.Xaml.Controls
 			RemoveChild(ContentTemplateRoot);
 		}
 
+		private void UpdateCornerRadius(CornerRadius radius)
+		{
+		}
+
 		private void UpdateBorder()
 		{
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.wasm.cs
@@ -37,9 +37,14 @@ namespace Windows.UI.Xaml.Controls
 			RemoveChild(ContentTemplateRoot);
 		}
 
+		private void UpdateCornerRadius(CornerRadius radius)
+		{
+			SetCornerRadius(radius);
+		}
+
 		private void UpdateBorder()
 		{
-			SetBorder(BorderThickness, BorderBrush, CornerRadius);
+			SetBorder(BorderThickness, BorderBrush);
 			SetAndObserveBackgroundBrush(Background);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Page/Page.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Page/Page.wasm.cs
@@ -16,7 +16,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void UpdateBorder()
 		{
-			SetBorder(Thickness.Empty, null, CornerRadius.None);
+			SetBorder(Thickness.Empty, null);
 			SetAndObserveBackgroundBrush(Background);
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.wasm.cs
@@ -32,7 +32,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public void UpdateBorder()
 		{
-			SetBorder(BorderThickness, BorderBrush, CornerRadius);
+			SetBorder(BorderThickness, BorderBrush);
 		}
 
 		protected virtual void OnChildrenChanged()
@@ -57,7 +57,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnCornerRadiusChangedPartial(CornerRadius oldValue, CornerRadius newValue)
 		{
-			UpdateBorder();
+			SetCornerRadius(newValue);
 		}
 
 		/// <summary>        

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
@@ -159,13 +159,11 @@ namespace Windows.UI.Xaml
 			{
 				case SolidColorBrush solidColorBrush:
 					var color = solidColorBrush.ColorWithOpacity;
-					SetStyle("background-color", color.ToHexString());
-					ResetStyle("background-image");
+					SetStyle(("background-color", color.ToHexString()), ("background-image", ""));
 					RecalculateBrushOnSizeChanged(false);
 					break;
 				case GradientBrush gradientBrush:
-					ResetStyle("background-color");
-					SetStyle("background-image", gradientBrush.ToCssString(RenderSize));
+					SetStyle(("background-color", ""), ("background-image", gradientBrush.ToCssString(RenderSize)));
 					RecalculateBrushOnSizeChanged(true);
 					break;
 				default:

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
@@ -214,7 +214,7 @@ namespace Windows.UI.Xaml
 					$"{cornerRadius.TopLeft.ToStringInvariant()}px {cornerRadius.TopRight.ToStringInvariant()}px {cornerRadius.BottomRight.ToStringInvariant()}px {cornerRadius.BottomLeft.ToStringInvariant()}px";
 				SetStyle(
 					("border-radius", borderRadiusCssString),
-					("overflow", "hidden"));
+					("overflow", "hidden")); // overflow: hidden is required here because the clipping can't do its job when it's non-rectangular.
 			}
 
 		}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
@@ -204,11 +204,19 @@ namespace Windows.UI.Xaml
 
 		protected void SetCornerRadius(CornerRadius cornerRadius)
 		{
-			var borderRadius = cornerRadius == CornerRadius.None
-				? ""
-				: $"{cornerRadius.TopLeft}px {cornerRadius.TopRight}px {cornerRadius.BottomRight}px {cornerRadius.BottomLeft}px";
+			if (cornerRadius == CornerRadius.None)
+			{
+				ResetStyle("border-radius", "overflow");
+			}
+			else
+			{
+				var borderRadiusCssString =
+					$"{cornerRadius.TopLeft.ToStringInvariant()}px {cornerRadius.TopRight.ToStringInvariant()}px {cornerRadius.BottomRight.ToStringInvariant()}px {cornerRadius.BottomLeft.ToStringInvariant()}px";
+				SetStyle(
+					("border-radius", borderRadiusCssString),
+					("overflow", "hidden"));
+			}
 
-			SetStyle("border-radius", borderRadius);
 		}
 
 		protected void SetBorder(Thickness thickness, Brush brush)

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
@@ -211,19 +211,14 @@ namespace Windows.UI.Xaml
 			SetStyle("border-radius", borderRadius);
 		}
 
-		protected void SetBorder(Thickness thickness, Brush brush, CornerRadius cornerRadius)
+		protected void SetBorder(Thickness thickness, Brush brush)
 		{
-			var borderRadius = cornerRadius == CornerRadius.None
-				? ""
-				: $"{cornerRadius.TopLeft}px {cornerRadius.TopRight}px {cornerRadius.BottomRight}px {cornerRadius.BottomLeft}px";
-
 			if (thickness == Thickness.Empty)
 			{
 				SetStyle(
 					("border-style", "none"),
 					("border-color", ""),
-					("border-width", ""),
-					("border-radius", borderRadius));
+					("border-width", ""));
 			}
 			else
 			{
@@ -236,8 +231,7 @@ namespace Windows.UI.Xaml
 							("border", ""),
 							("border-style", "solid"),
 							("border-color", borderColor.ToHexString()),
-							("border-width", borderWidth),
-							("border-radius", borderRadius));
+							("border-width", borderWidth));
 						break;
 					case GradientBrush gradientBrush:
 						var border = gradientBrush.ToCssString(RenderSize); // TODO: Reevaluate when size is changing
@@ -245,8 +239,7 @@ namespace Windows.UI.Xaml
 							("border-style", "solid"),
 							("border-color", ""),
 							("border-image", border),
-							("border-width", borderWidth),
-							("border-radius", borderRadius));
+							("border-width", borderWidth));
 						break;
 					case AcrylicBrush acrylicBrush:
 						var acrylicFallbackColor = acrylicBrush.FallbackColorWithOpacity;
@@ -254,11 +247,10 @@ namespace Windows.UI.Xaml
 							("border", ""),
 							("border-style", "solid"),
 							("border-color", acrylicFallbackColor.ToHexString()),
-							("border-width", borderWidth),
-							("border-radius", borderRadius));
+							("border-width", borderWidth));
 						break;
 					default:
-						ResetStyle("border-style", "border-color", "border-image", "border-width", "border-radius");
+						ResetStyle("border-style", "border-color", "border-image", "border-width");
 						break;
 				}
 			}


### PR DESCRIPTION
Fixes #4273 

# Bugfix - Rounded Corners were not clipping
Applying rounded corners to an element were forcing the clipping to operate, but since it's only supporting rectangle clipping (UWP limitations), the CSS `overflow: hidden` is required for the corners to clip the content.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
