### PR TITLE
Add null check for GetMethod in case of write-only property

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -541,12 +541,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				var property = type.GetAllPropertiesWithName(name).FirstOrDefault();
 				var setMethod = type.GetMethods().FirstOrDefault(p => p.Name == "Set" + name);
 
-				if (property != null && property.GetMethod.IsStatic)
+				if (property?.GetMethod?.IsStatic ?? false)
 				{
 					return true;
 				}
 
-				if (setMethod != null && setMethod.IsStatic)
+				if (setMethod?.IsStatic ?? false)
 				{
 					return true;
 				}

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -86,6 +86,9 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <EmbeddedResource Include="Windows_Data_Xml\DomTests\basictest.xml" />
+	  <EmbeddedResource Include="Windows_UI_XAML_Controls\UserControlTests\UserControl_WriteOnlyProperty_UserControl.xaml">
+	    <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+	  </EmbeddedResource>
 	</ItemGroup>
 	
 	<ItemGroup>
@@ -146,6 +149,9 @@
 		<None Update="ResourceLoader\Strings\fr\Resources.resw">
 			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
 			<Generator>ResXFileCodeGenerator</Generator>
+		</None>
+		<None Update="Windows_UI_XAML_Controls\UserControlTests\UserControl_WriteOnlyProperty.xaml">
+		  <Generator>MSBuild:Compile</Generator>
 		</None>
 	</ItemGroup>
 

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/Given_UserControl.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/Given_UserControl.cs
@@ -30,5 +30,19 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.xLoad
 			Assert.AreEqual(1, UserControl_TopLevelBinding_AttachedProperty.MyPropertyChangedCount);
 			Assert.AreEqual(42, UserControl_TopLevelBinding_AttachedProperty.GetMyProperty(uc01));
 		}
+
+		[TestMethod]
+		public void When_UserControl_WriteOnlyProperty_Binding()
+		{
+			var sut = new UserControl_WriteOnlyProperty();
+			sut.ForceLoaded();
+
+			var textBlock = sut.FindName("TextDisplay") as TextBlock;
+			var uc02 = sut.FindName("uc02") as UserControl_WriteOnlyProperty_UserControl;
+
+			Assert.AreEqual("Hello, World!", textBlock.Text);
+			uc02.Text = "Test";
+			Assert.AreEqual("Test", textBlock.Text);
+		}
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_WriteOnlyProperty.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_WriteOnlyProperty.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests.UserControl_WriteOnlyProperty"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid x:Name="test02">
+		<local:UserControl_WriteOnlyProperty_UserControl x:Name="uc02" Text="Hello, World!"/>
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_WriteOnlyProperty.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_WriteOnlyProperty.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class UserControl_WriteOnlyProperty : Page
+	{
+		public UserControl_WriteOnlyProperty()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_WriteOnlyProperty_UserControl.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_WriteOnlyProperty_UserControl.xaml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests.UserControl_WriteOnlyProperty_UserControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Grid>
+		<TextBlock x:Name="TextDisplay" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_WriteOnlyProperty_UserControl.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/UserControlTests/UserControl_WriteOnlyProperty_UserControl.xaml.cs
@@ -1,0 +1,18 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_XAML_Controls.UserControlTests
+{
+	public sealed partial class UserControl_WriteOnlyProperty_UserControl : UserControl
+	{
+		public string Text
+		{
+			set => TextDisplay.Text = value;
+		}
+
+		public UserControl_WriteOnlyProperty_UserControl()
+		{
+			InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
closes #4080 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Setting a public write-only property on a custom control causes the build to fail for Uno targets, though it does succeed for UWP.

## What is the new behavior?

Project builds and XAML code gen succeeds

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

