### PR TITLE
feat(dragdrop): Drag-and-drop integration with macOS

### DIFF
--- a/doc/articles/features/pointers-keyboard-and-other-user-inputs.md
+++ b/doc/articles/features/pointers-keyboard-and-other-user-inputs.md
@@ -167,7 +167,7 @@ While intra-app _drag and drop_ is supported on all platforms without limitation
 | Android  | No _in progress_                                 | No _in progress_                                |
 | iOS      | No                                               | No                                              |
 | Wasm     | No                                               | No                                              |
-| MacOS    | No _in progress_                                 | No _in progress_                                |
+| MacOS    | Yes (Text, Link, Image, Html, Rtf)               | Yes (Text, Link, Image, File, Html, Rtf)        |
 | Skia WPF | Yes (Text, Link (1), Image (2), File, Html, Rtf) | Yes (Text, WebLink (1), Image, File, Html, Rtf) |
 | Skia GTK | No                                               | No                                              |
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TestPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TestPage.xaml.cs
@@ -175,21 +175,7 @@ namespace UITests.Windows_UI_Xaml.DragAndDrop
 			// Only one data format can be displayed at once.
 			// Therefore, the order/priority here is used to determine which should be displayed.
 			// It should be ordered most specific to least generally speaking.
-			if (args.DataView.Contains(StandardDataFormats.ApplicationLink))
-			{
-				title += " (ApplicationLink)";
-
-				var appLink = await args.DataView.GetApplicationLinkAsync();
-				details = appLink.ToString();
-			}
-			else if (args.DataView.Contains(StandardDataFormats.WebLink))
-			{
-				title += " (WebLink)";
-
-				var webLink = await args.DataView.GetWebLinkAsync();
-				details = webLink.ToString();
-			}
-			else if (args.DataView.Contains(StandardDataFormats.Bitmap))
+			if (args.DataView.Contains(StandardDataFormats.Bitmap))
 			{
 				title += " (Bitmap)";
 
@@ -202,6 +188,20 @@ namespace UITests.Windows_UI_Xaml.DragAndDrop
 				this.DropDetailsImage.Visibility = Visibility.Visible;
 
 				this.DropDetailsTextBlock.Visibility = Visibility.Collapsed;
+			}
+			else if (args.DataView.Contains(StandardDataFormats.ApplicationLink))
+			{
+				title += " (ApplicationLink)";
+
+				var appLink = await args.DataView.GetApplicationLinkAsync();
+				details = appLink.ToString();
+			}
+			else if (args.DataView.Contains(StandardDataFormats.WebLink))
+			{
+				title += " (WebLink)";
+
+				var webLink = await args.DataView.GetWebLinkAsync();
+				details = webLink.ToString();
 			}
 			else if (args.DataView.Contains(StandardDataFormats.Html))
 			{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TestPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TestPage.xaml.cs
@@ -182,6 +182,13 @@ namespace UITests.Windows_UI_Xaml.DragAndDrop
 				var appLink = await args.DataView.GetApplicationLinkAsync();
 				details = appLink.ToString();
 			}
+			else if (args.DataView.Contains(StandardDataFormats.WebLink))
+			{
+				title += " (WebLink)";
+
+				var webLink = await args.DataView.GetWebLinkAsync();
+				details = webLink.ToString();
+			}
 			else if (args.DataView.Contains(StandardDataFormats.Bitmap))
 			{
 				title += " (Bitmap)";
@@ -237,21 +244,7 @@ namespace UITests.Windows_UI_Xaml.DragAndDrop
 			{
 				title += " (UserActivityJsonArray)";
 
-				// TODO
-			}
-			else if (args.DataView.Contains(StandardDataFormats.Uri))
-			{
-				title += " (Uri)";
-
-				var uri = await args.DataView.GetUriAsync();
-				details = uri.ToString();
-			}
-			else if (args.DataView.Contains(StandardDataFormats.WebLink))
-			{
-				title += " (WebLink)";
-
-				var webLink = await args.DataView.GetWebLinkAsync();
-				details = webLink.ToString();
+				// Not supported
 			}
 			else if (args.DataView.Contains(StandardDataFormats.Text))
 			{
@@ -259,6 +252,14 @@ namespace UITests.Windows_UI_Xaml.DragAndDrop
 
 				var text = await args.DataView.GetTextAsync();
 				details = text;
+			}
+			// URI is deprecated so last in priority
+			else if (args.DataView.Contains(StandardDataFormats.Uri))
+			{
+				title += " (Uri)";
+
+				var uri = await args.DataView.GetUriAsync();
+				details = uri.ToString();
 			}
 
 			// Determine the drop position

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -164,11 +164,24 @@ namespace Uno.UI.Controls
 		[Export("draggingEnded:")] // Do not remove
 		public virtual void DraggingEnded(NSDraggingInfo draggingInfo)
 		{
-			// Not used in this context.
-			// These methods within NSWindow are only used for external drop into Uno apps.
-			// If Uno doesn't accept and handle the drop it doesn't need to be aware of when it ends.
+			try
+			{
+				DraggingEndedAction.Invoke(draggingInfo);
+			}
+			catch { }
+
 			return;
 		}
+
+		/// <summary>
+		/// Code to execute when the <see cref="DraggingEnded(NSDraggingInfo)"/> method is invoked.
+		/// This can be used in a similar way to <see cref="UIElement.DropCompleted"/>.
+		/// </summary>
+		public Action<NSDraggingInfo> DraggingEndedAction { get; set; } =
+			(NSDraggingInfo draggingInfo) =>
+			{
+				return;
+			};
 
 		/// <summary>
 		/// Method invoked when a drag operation exited the <see cref="NSWindow"/>.

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -100,7 +100,7 @@ namespace Uno.UI.Controls
 		/// </remarks>
 		/// <param name="info">Information about the dragging session from the sender.</param>
 		/// <returns>The accepted drag operation(s).</returns>
-		[Export("draggingEntered:")]
+		[Export("draggingEntered:")] // Do not remove
 		public virtual NSDragOperation DraggingEntered(NSDraggingInfo draggingInfo)
 		{
 			try
@@ -131,7 +131,7 @@ namespace Uno.UI.Controls
 		/// See remarks in <see cref="DraggingEntered(NSDraggingInfo)"/>
 		/// </remarks>
 		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
-		[Export("draggingUpdated:")]
+		[Export("draggingUpdated:")] // Do not remove
 		public virtual NSDragOperation DraggingUpdated(NSDraggingInfo draggingInfo)
 		{
 			try
@@ -161,7 +161,7 @@ namespace Uno.UI.Controls
 		/// See remarks in <see cref="DraggingEntered(NSDraggingInfo)"/>
 		/// </remarks>
 		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
-		[Export("draggingEnded:")]
+		[Export("draggingEnded:")] // Do not remove
 		public virtual void DraggingEnded(NSDraggingInfo draggingInfo)
 		{
 			// Not used in this context.
@@ -177,7 +177,7 @@ namespace Uno.UI.Controls
 		/// See remarks in <see cref="DraggingEntered(NSDraggingInfo)"/>
 		/// </remarks>
 		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
-		[Export("draggingExited:")]
+		[Export("draggingExited:")] // Do not remove
 		public virtual void DraggingExited(NSDraggingInfo draggingInfo)
 		{
 			return;
@@ -199,7 +199,7 @@ namespace Uno.UI.Controls
 		/// </summary>
 		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
 		/// <returns>True if the destination accepts the drag operation; otherwise, false. </returns>
-		[Export("prepareForDragOperation:")]
+		[Export("prepareForDragOperation:")] // Do not remove
 		public virtual bool PrepareForDragOperation(AppKit.NSDraggingInfo draggingInfo)
 		{
 			// Always return true as UWP doesn't really have an equivalent step.
@@ -212,7 +212,7 @@ namespace Uno.UI.Controls
 		/// </summary>
 		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
 		/// <returns>True if the destination accepts the data; otherwise, false.</returns>
-		[Export("performDragOperation:")]
+		[Export("performDragOperation:")] // Do not remove
 		public virtual bool PerformDragOperation(NSDraggingInfo draggingInfo)
 		{
 			try

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -94,7 +94,7 @@ namespace Uno.UI.Controls
 		///      give no examples.
 		/// 
 		/// The Export "method_name" attribute is fundamentally important to make this work, removing it will
-		/// break functionality and the method will never be called by macOS. Again, this seemly is because
+		/// break functionality and the method will never be called by macOS. Again, this seemingly is because
 		/// Xamarin.macOS is not aware of it.
 		/// 
 		/// </remarks>
@@ -170,7 +170,7 @@ namespace Uno.UI.Controls
 			}
 			catch
 			{
-				// Simply return if an error occured, it is unrecoverable
+				// Simply return if an error occurred, it is unrecoverable
 			}
 
 			return;
@@ -196,6 +196,15 @@ namespace Uno.UI.Controls
 		[Export("draggingExited:")] // Do not remove
 		public virtual void DraggingExited(NSDraggingInfo draggingInfo)
 		{
+			try
+			{
+				DraggingExitedAction.Invoke(draggingInfo);
+			}
+			catch
+			{
+				// Simply return if an error occurred, it is unrecoverable
+			}
+
 			return;
 		}
 

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -44,7 +44,196 @@ namespace Uno.UI.Controls
 			Delegate = new WindowDelegate(this);
 			_inputPane = InputPane.GetForCurrentView();
 			_inputPane.Window = this;
+
+			// Register the types that can be dragging into the window (effectively 'AllowDrop').
+			// This must be done before dragging enters the window or dragging methods won't be invoked.
+			// We register for all possible types and then confirm whether they
+			// are actually supported within the draggingEntered and draggingUpdated methods.
+			// This has a minor side effect in the standard UI (zoom effect) but is considered acceptable.
+			RegisterForDraggedTypes(new string[]
+				{
+					NSPasteboard.NSPasteboardTypeUrl,
+					NSPasteboard.NSPasteboardTypeTIFF,
+					NSPasteboard.NSPasteboardTypePNG,
+					NSPasteboard.NSPasteboardTypeHTML,
+					NSPasteboard.NSPasteboardTypeRTF,
+					NSPasteboard.NSPasteboardTypeRTFD,
+					NSPasteboard.NSPasteboardTypeFileUrl,
+					NSPasteboard.NSPasteboardTypeString
+
+					/* For future use
+					UTType.URL,
+					UTType.Image,
+					UTType.HTML,
+					UTType.RTF,
+					UTType.FileURL,
+					UTType.PlainText,
+					*/
+				});
 		}
+
+		/// <summary>
+		/// Method invoked when a drag operation enters the <see cref="NSWindow"/>.
+		/// </summary>
+		/// <remarks>
+		/// 
+		/// While it is never documented directly, DraggingEntered can be added to NSWindow just like NSView.
+		/// Key docs telling this story include:
+		/// 
+		///  (1) NSWindow documentation does not include most NSView drag/drop methods
+		///      https://developer.apple.com/documentation/appkit/nswindow
+		///  (2) Since NSWindow documentation doesn't reference them, they also aren't included in Xamarin
+		///      https://docs.microsoft.com/en-us/dotnet/api/appkit.nswindow?view=xamarin-mac-sdk-14
+		///  (3) However, the 'draggingEntered' method docs reference 'Window' at the very end
+		///      "Invoked when the mouse pointer enters the destination’s bounds rectangle (if it is a view object)
+		///       or its frame rectangle (if it is a window object). "
+		///      https://developer.apple.com/documentation/appkit/nsdraggingdestination/1416019-draggingentered
+		///  (4) In legacy macOS docs this is a little more explitly stated:
+		///      https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/DragandDrop/Concepts/dragdestination.html#//apple_ref/doc/uid/20000977-BAJBJFBG
+		///  (5) Other macOS drag/drop articles and blogs refer to dragging/dropping directly from Window - although
+		///      give no examples.
+		/// 
+		/// The Export "method_name" attribute is fundamentally important to make this work, removing it will
+		/// break functionality and the method will never be called by macOS. Again, this seemly is because
+		/// Xamarin.macOS is not aware of it.
+		/// 
+		/// </remarks>
+		/// <param name="info">Information about the dragging session from the sender.</param>
+		/// <returns>The accepted drag operation(s).</returns>
+		[Export("draggingEntered:")]
+		public virtual NSDragOperation DraggingEntered(NSDraggingInfo draggingInfo)
+		{
+			try
+			{
+				return DraggingEnteredAction.Invoke(draggingInfo);
+			}
+			catch
+			{
+				return NSDragOperation.None;
+			}
+		}
+
+		/// <summary>
+		/// Code to execute when the <see cref="DraggingEntered(NSDraggingInfo)"/> method is invoked.
+		/// This can be used in a similar way to <see cref="UIElement.DragEnter"/>.
+		/// </summary>
+		public Func<NSDraggingInfo, NSDragOperation> DraggingEnteredAction { get; set; } =
+			(NSDraggingInfo draggingInfo) =>
+			{
+				return NSDragOperation.None;
+			};
+
+		/// <summary>
+		/// Method invoked when a drag operation updates over the <see cref="NSWindow"/>.
+		/// This is periodically called when the pointer is moved.
+		/// </summary>
+		/// <remarks>
+		/// See remarks in <see cref="DraggingEntered(NSDraggingInfo)"/>
+		/// </remarks>
+		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
+		[Export("draggingUpdated:")]
+		public virtual NSDragOperation DraggingUpdated(NSDraggingInfo draggingInfo)
+		{
+			try
+			{
+				return DraggingUpdatedAction.Invoke(draggingInfo);
+			}
+			catch
+			{
+				return NSDragOperation.None;
+			}
+		}
+
+		/// <summary>
+		/// Code to execute when the <see cref="DraggingUpdated(NSDraggingInfo)"/> method is invoked.
+		/// This can be used in a similar way to <see cref="UIElement.DragOver"/>.
+		/// </summary>
+		public Func<NSDraggingInfo, NSDragOperation> DraggingUpdatedAction { get; set; } =
+			(NSDraggingInfo draggingInfo) =>
+			{
+				return NSDragOperation.None;
+			};
+
+		/// <summary>
+		/// Method invoked when a drag operation ends.
+		/// </summary>
+		/// <remarks>
+		/// See remarks in <see cref="DraggingEntered(NSDraggingInfo)"/>
+		/// </remarks>
+		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
+		[Export("draggingEnded:")]
+		public virtual void DraggingEnded(NSDraggingInfo draggingInfo)
+		{
+			// Not used in this context.
+			// These methods within NSWindow are only used for external drop into Uno apps.
+			// If Uno doesn't accept and handle the drop it doesn't need to be aware of when it ends.
+			return;
+		}
+
+		/// <summary>
+		/// Method invoked when a drag operation exited the <see cref="NSWindow"/>.
+		/// </summary>
+		/// <remarks>
+		/// See remarks in <see cref="DraggingEntered(NSDraggingInfo)"/>
+		/// </remarks>
+		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
+		[Export("draggingExited:")]
+		public virtual void DraggingExited(NSDraggingInfo draggingInfo)
+		{
+			return;
+		}
+
+		/// <summary>
+		/// Code to execute when the <see cref="DraggingExited(NSDraggingInfo)"/> method is invoked.
+		/// This can be used in a similar way to <see cref="UIElement.DragLeave"/>.
+		/// </summary>
+		public Action<NSDraggingInfo> DraggingExitedAction { get; set; } =
+			(NSDraggingInfo draggingInfo) =>
+			{
+				return;
+			};
+
+		/// <summary>
+		/// Method invoked when the pointer is released over the <see cref="NSWindow"/> during a drag operation
+		/// This is the last chance to reject a drop.
+		/// </summary>
+		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
+		/// <returns>True if the destination accepts the drag operation; otherwise, false. </returns>
+		[Export("prepareForDragOperation:")]
+		public virtual bool PrepareForDragOperation(AppKit.NSDraggingInfo draggingInfo)
+		{
+			// Always return true as UWP doesn't really have an equivalent step.
+			// Drop is accepted within DraggingEntered (drag entered event in UWP).
+			return true;
+		}
+
+		/// <summary>
+		/// Method invoked when the pointer is released and data is dropped over the the <see cref="NSWindow"/>.
+		/// </summary>
+		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
+		/// <returns>True if the destination accepts the data; otherwise, false.</returns>
+		[Export("performDragOperation:")]
+		public virtual bool PerformDragOperation(NSDraggingInfo draggingInfo)
+		{
+			try
+			{
+				return PerformDragOperationAction.Invoke(draggingInfo);
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Code to execute when the <see cref="PerformDragOperation(NSDraggingInfo)"/> method is invoked.
+		/// This can be used in a similar way to <see cref="UIElement.Drop"/>.
+		/// </summary>
+		public Func<NSDraggingInfo, bool> PerformDragOperationAction { get; set; } =
+			(NSDraggingInfo draggingInfo) =>
+			{
+				return false;
+			};
 
 		public static void SetNeedsKeyboard(NSView view, bool needsKeyboard)
 		{

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -29,6 +29,10 @@ namespace Uno.UI.Controls
 	/// </summary>
 	public partial class Window : NSWindow
 	{
+		internal delegate NSDragOperation DraggingStage1Handler(NSDraggingInfo draggingInfo);
+		internal delegate void DraggingStage2Handler(NSDraggingInfo draggingInfo);
+		internal delegate bool PerformDragOperationHandler(NSDraggingInfo draggingInfo);
+
 		private static readonly WeakAttachedDictionary<NSView, string> _attachedProperties = new WeakAttachedDictionary<NSView, string>();
 		private const string NeedsKeyboardAttachedPropertyKey = "NeedsKeyboard";
 
@@ -101,7 +105,7 @@ namespace Uno.UI.Controls
 		/// <param name="info">Information about the dragging session from the sender.</param>
 		/// <returns>The accepted drag operation(s).</returns>
 		[Export("draggingEntered:")] // Do not remove
-		public virtual NSDragOperation DraggingEntered(NSDraggingInfo draggingInfo)
+		internal virtual NSDragOperation DraggingEntered(NSDraggingInfo draggingInfo)
 		{
 			try
 			{
@@ -117,7 +121,7 @@ namespace Uno.UI.Controls
 		/// Code to execute when the <see cref="DraggingEntered(NSDraggingInfo)"/> method is invoked.
 		/// This can be used in a similar way to <see cref="UIElement.DragEnter"/>.
 		/// </summary>
-		public Func<NSDraggingInfo, NSDragOperation> DraggingEnteredAction { get; set; } =
+		internal DraggingStage1Handler DraggingEnteredAction { get; set; } =
 			(NSDraggingInfo draggingInfo) =>
 			{
 				return NSDragOperation.None;
@@ -132,7 +136,7 @@ namespace Uno.UI.Controls
 		/// </remarks>
 		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
 		[Export("draggingUpdated:")] // Do not remove
-		public virtual NSDragOperation DraggingUpdated(NSDraggingInfo draggingInfo)
+		internal virtual NSDragOperation DraggingUpdated(NSDraggingInfo draggingInfo)
 		{
 			try
 			{
@@ -148,7 +152,7 @@ namespace Uno.UI.Controls
 		/// Code to execute when the <see cref="DraggingUpdated(NSDraggingInfo)"/> method is invoked.
 		/// This can be used in a similar way to <see cref="UIElement.DragOver"/>.
 		/// </summary>
-		public Func<NSDraggingInfo, NSDragOperation> DraggingUpdatedAction { get; set; } =
+		internal DraggingStage1Handler DraggingUpdatedAction { get; set; } =
 			(NSDraggingInfo draggingInfo) =>
 			{
 				return NSDragOperation.None;
@@ -162,7 +166,7 @@ namespace Uno.UI.Controls
 		/// </remarks>
 		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
 		[Export("draggingEnded:")] // Do not remove
-		public virtual void DraggingEnded(NSDraggingInfo draggingInfo)
+		internal virtual void DraggingEnded(NSDraggingInfo draggingInfo)
 		{
 			try
 			{
@@ -180,7 +184,7 @@ namespace Uno.UI.Controls
 		/// Code to execute when the <see cref="DraggingEnded(NSDraggingInfo)"/> method is invoked.
 		/// This can be used in a similar way to <see cref="UIElement.DropCompleted"/>.
 		/// </summary>
-		public Action<NSDraggingInfo> DraggingEndedAction { get; set; } =
+		internal DraggingStage2Handler DraggingEndedAction { get; set; } =
 			(NSDraggingInfo draggingInfo) =>
 			{
 				// Available for use
@@ -194,7 +198,7 @@ namespace Uno.UI.Controls
 		/// </remarks>
 		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
 		[Export("draggingExited:")] // Do not remove
-		public virtual void DraggingExited(NSDraggingInfo draggingInfo)
+		internal virtual void DraggingExited(NSDraggingInfo draggingInfo)
 		{
 			try
 			{
@@ -212,7 +216,7 @@ namespace Uno.UI.Controls
 		/// Code to execute when the <see cref="DraggingExited(NSDraggingInfo)"/> method is invoked.
 		/// This can be used in a similar way to <see cref="UIElement.DragLeave"/>.
 		/// </summary>
-		public Action<NSDraggingInfo> DraggingExitedAction { get; set; } =
+		internal DraggingStage2Handler DraggingExitedAction { get; set; } =
 			(NSDraggingInfo draggingInfo) =>
 			{
 				// Available for use
@@ -225,7 +229,7 @@ namespace Uno.UI.Controls
 		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
 		/// <returns>True if the destination accepts the drag operation; otherwise, false. </returns>
 		[Export("prepareForDragOperation:")] // Do not remove
-		public virtual bool PrepareForDragOperation(AppKit.NSDraggingInfo draggingInfo)
+		internal virtual bool PrepareForDragOperation(AppKit.NSDraggingInfo draggingInfo)
 		{
 			// Always return true as UWP doesn't really have an equivalent step.
 			// Drop is accepted within DraggingEntered (drag entered event in UWP).
@@ -238,7 +242,7 @@ namespace Uno.UI.Controls
 		/// <param name="draggingInfo">Information about the dragging session from the sender.</param>
 		/// <returns>True if the destination accepts the data; otherwise, false.</returns>
 		[Export("performDragOperation:")] // Do not remove
-		public virtual bool PerformDragOperation(NSDraggingInfo draggingInfo)
+		internal virtual bool PerformDragOperation(NSDraggingInfo draggingInfo)
 		{
 			try
 			{
@@ -254,7 +258,7 @@ namespace Uno.UI.Controls
 		/// Code to execute when the <see cref="PerformDragOperation(NSDraggingInfo)"/> method is invoked.
 		/// This can be used in a similar way to <see cref="UIElement.Drop"/>.
 		/// </summary>
-		public Func<NSDraggingInfo, bool> PerformDragOperationAction { get; set; } =
+		internal PerformDragOperationHandler PerformDragOperationAction { get; set; } =
 			(NSDraggingInfo draggingInfo) =>
 			{
 				return false;

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -88,7 +88,7 @@ namespace Uno.UI.Controls
 		///      "Invoked when the mouse pointer enters the destination’s bounds rectangle (if it is a view object)
 		///       or its frame rectangle (if it is a window object). "
 		///      https://developer.apple.com/documentation/appkit/nsdraggingdestination/1416019-draggingentered
-		///  (4) In legacy macOS docs this is a little more explitly stated:
+		///  (4) In legacy macOS docs this is a little more explicitly stated:
 		///      https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/DragandDrop/Concepts/dragdestination.html#//apple_ref/doc/uid/20000977-BAJBJFBG
 		///  (5) Other macOS drag/drop articles and blogs refer to dragging/dropping directly from Window - although
 		///      give no examples.

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -168,7 +168,10 @@ namespace Uno.UI.Controls
 			{
 				DraggingEndedAction.Invoke(draggingInfo);
 			}
-			catch { }
+			catch
+			{
+				// Simply return if an error occured, it is unrecoverable
+			}
 
 			return;
 		}
@@ -180,7 +183,7 @@ namespace Uno.UI.Controls
 		public Action<NSDraggingInfo> DraggingEndedAction { get; set; } =
 			(NSDraggingInfo draggingInfo) =>
 			{
-				return;
+				// Available for use
 			};
 
 		/// <summary>
@@ -203,7 +206,7 @@ namespace Uno.UI.Controls
 		public Action<NSDraggingInfo> DraggingExitedAction { get; set; } =
 			(NSDraggingInfo draggingInfo) =>
 			{
-				return;
+				// Available for use
 			};
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/DragDropExtension.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/DragDropExtension.macOS.cs
@@ -1,0 +1,107 @@
+#if __MACOS__
+#nullable enable
+
+using System;
+using System.Numerics;
+using System.Threading;
+using AppKit;
+using Foundation;
+using MobileCoreServices;
+using Uno.Extensions;
+using Uno.Logging;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Point = Windows.Foundation.Point;
+using UIElement = Windows.UI.Xaml.UIElement;
+
+namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
+{
+	internal class MacOSDragDropExtension : IDragDropExtension
+	{
+		private readonly DragDropManager _manager;
+		private NSWindow _nativeWindowHost;
+		private Uno.UI.Controls.Window _window;
+
+		public MacOSDragDropExtension(DragDropManager owner)
+		{
+			_manager = (DragDropManager)owner;
+
+			_nativeWindowHost = AppKit.NSApplication.SharedApplication.DangerousWindows[0];
+			_window = (Uno.UI.Controls.Window)CoreWindow.GetForCurrentThread()!._window;
+
+			_window.DraggingEnteredAction = OnDraggingEnteredEvent;
+			_window.DraggingUpdatedAction = OnDraggingUpdated;
+			_window.DraggingExitedAction = OnDraggingExited;
+			_window.PerformDragOperationAction = OnPerformDragOperation;
+		}
+
+		private NSDragOperation OnDraggingEnteredEvent(NSDraggingInfo draggingInfo)
+		{
+			return NSDragOperation.Copy;
+		}
+
+		private NSDragOperation OnDraggingUpdated(NSDraggingInfo draggingInfo)
+		{
+			return NSDragOperation.Copy;
+		}
+
+		private void OnDraggingExited(NSDraggingInfo draggingInfo)
+		{
+			return;
+		}
+
+		private bool OnPerformDragOperation(NSDraggingInfo draggingInfo)
+		{
+			return true;
+		}
+
+		public void StartNativeDrag(CoreDragInfo info)
+			=> CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.High, async () =>
+			{
+				try
+				{
+					NSDraggingSource source = new NSDraggingSource();
+					NSEvent sourceEvent = new NSEvent();
+
+					var text = await info.Data.GetTextAsync();
+
+					var draggingItem = new NSDraggingItem((NSString)text);
+					draggingItem.DraggingFrame = new CoreGraphics.CGRect(0, 0, 1, 1);
+
+					//_nativeView?.BeginDraggingSession(new[] { draggingItem }, sourceEvent, source);
+				}
+				catch (Exception e)
+				{
+					this.Log().Error("Failed to start native Drag and Drop.", e);
+				}
+			});
+
+		private class DragEventSource : IDragEventSource
+		{
+			private static long _nextFrameId;
+
+			public DragEventSource(long pointerId)
+			{
+				Id = pointerId;
+			}
+
+			public long Id { get; }
+
+			public uint FrameId { get; } = (uint)Interlocked.Increment(ref _nextFrameId);
+
+			/// <inheritdoc />
+			public (Point location, DragDropModifiers modifier) GetState()
+			{
+				return (new Windows.Foundation.Point(0, 0), DragDropModifiers.None);
+			}
+
+			/// <inheritdoc />
+			public Point GetPosition(object? relativeTo)
+			{
+				return new Point(0, 0);
+			}
+		}
+	}
+}
+
+#endif

--- a/src/Uno.UI/UI/Xaml/DragDropExtension.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/DragDropExtension.macOS.cs
@@ -24,7 +24,7 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 		public MacOSDragDropExtension(DragDropManager owner)
 		{
 			_manager = (DragDropManager)owner;
-			_window = (Uno.UI.Controls.Window)CoreWindow.GetForCurrentThread()!._window;
+			_window = (Uno.UI.Controls.Window)CoreWindow.GetForCurrentThread()!.NativeWindow;
 
 			_window.DraggingEnteredAction = OnDraggingEnteredEvent;
 			_window.DraggingUpdatedAction = OnDraggingUpdated;

--- a/src/Uno.UI/UI/Xaml/DragDropExtension.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/DragDropExtension.macOS.cs
@@ -5,8 +5,6 @@ using System;
 using System.Numerics;
 using System.Threading;
 using AppKit;
-using Foundation;
-using MobileCoreServices;
 using Uno.Extensions;
 using Uno.Logging;
 using Windows.UI.Core;
@@ -83,7 +81,7 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 					NSEvent sourceEvent = new NSEvent();
 
 					_window.ContentView.BeginDraggingSession(
-						await DataPackage.CreateNativeDragDropData(info.Data),
+						await DataPackage.CreateNativeDragDropData(info.Data, info.GetPosition(null)),
 						sourceEvent,
 						source);
 				}

--- a/src/Uno.UI/UI/Xaml/DragDropExtension.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/DragDropExtension.macOS.cs
@@ -32,6 +32,7 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 			_window.DraggingUpdatedAction = OnDraggingUpdated;
 			_window.DraggingExitedAction = OnDraggingExited;
 			_window.PerformDragOperationAction = OnPerformDragOperation;
+			_window.DraggingEndedAction = OnDraggingEnded;
 		}
 
 		private NSDragOperation OnDraggingEnteredEvent(NSDraggingInfo draggingInfo)
@@ -66,6 +67,11 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 		{
 			var operation = _manager.ProcessDropped(new DragEventSource(_fakePointerId, draggingInfo, _window));
 			return (operation != DataPackageOperation.None);
+		}
+
+		private void OnDraggingEnded(NSDraggingInfo draggingInfo)
+		{
+			return;
 		}
 
 		public void StartNativeDrag(CoreDragInfo info)

--- a/src/Uno.UI/UI/Xaml/DragDropManager.cs
+++ b/src/Uno.UI/UI/Xaml/DragDropManager.cs
@@ -23,10 +23,16 @@ namespace Windows.UI.Xaml
 		public DragDropManager(Window window)
 		{
 			_window = window;
+
+#if __MACOS__
+			// Dependency injection not currently supported on macOS
+			_hostExtension = new MacOSDragDropExtension(this);
+#else
 			if (ApiExtensibility.CreateInstance<IDragDropExtension>(this, out var extension))
 			{
 				_hostExtension = extension;
 			}
+#endif
 		}
 
 		/// <inheritdoc />

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
@@ -37,25 +37,25 @@ namespace Windows.UI.Xaml.Media
 		const string MsAppXScheme = "ms-appx";
 		const string MsAppDataScheme = "ms-appdata";
 
-        /// <summary>
-        /// The default downloader instance used by all the new instances of <see cref="ImageSource"/>.
-        /// </summary>
-        public static IImageSourceDownloader DefaultDownloader;
+		/// <summary>
+		/// The default downloader instance used by all the new instances of <see cref="ImageSource"/>.
+		/// </summary>
+		public static IImageSourceDownloader DefaultDownloader;
 
-        /// <summary>
-        /// The image downloader for the current instance.
-        /// </summary>
-        public IImageSourceDownloader Downloader;
+		/// <summary>
+		/// The image downloader for the current instance.
+		/// </summary>
+		public IImageSourceDownloader Downloader;
 
-        /// <summary>
-        /// Initializes the Uno image downloader.
-        /// </summary>
-        private void InitializeDownloader()
-        {
-            Downloader = DefaultDownloader;
-        }
+		/// <summary>
+		/// Initializes the Uno image downloader.
+		/// </summary>
+		private void InitializeDownloader()
+		{
+			Downloader = DefaultDownloader;
+		}
 
-        internal Stream Stream { get; set; }
+		internal Stream Stream { get; set; }
 
 		internal string FilePath { get; private set; }
 
@@ -74,7 +74,7 @@ namespace Windows.UI.Xaml.Media
 			}
 			else
 			{
-				if(this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 				{
 					this.Log().DebugFormat("The uri [{0}] is not valid, skipping.", url);
 				}
@@ -139,10 +139,10 @@ namespace Windows.UI.Xaml.Media
 		{
 			return new BitmapImage(uri);
 		}
-        
+
 		static public implicit operator ImageSource(Stream stream)
 		{
-            throw new NotSupportedException("Implicit conversion from Stream to ImageSource is not supported");
+			throw new NotSupportedException("Implicit conversion from Stream to ImageSource is not supported");
 		}
 
 		partial void DisposePartial();
@@ -151,10 +151,10 @@ namespace Windows.UI.Xaml.Media
 			DisposePartial();
 		}
 
-        /// <summary>
-        /// Downloads an image from the provided Uri.
-        /// </summary>
-        /// <returns>n Uri containing a local path for the downloaded image.</returns>
+		/// <summary>
+		/// Downloads an image from the provided Uri.
+		/// </summary>
+		/// <returns>n Uri containing a local path for the downloaded image.</returns>
 		private async Task<Uri> Download(CancellationToken ct, Uri uri)
 		{
 			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
@@ -162,14 +162,14 @@ namespace Windows.UI.Xaml.Media
 				this.Log().DebugFormat("Initiated download from {0}", uri);
 			}
 
-            if(Downloader != null)
-            {
-                return await Downloader.Download(ct, uri);
-            }
-            else
-            {
-                throw new InvalidOperationException("No Downloader has been specified for this ImageSource. An IImageSourceDownloader may be provided to enable image downloads.");
-            }
+			if (Downloader != null)
+			{
+				return await Downloader.Download(ct, uri);
+			}
+			else
+			{
+				throw new InvalidOperationException("No Downloader has been specified for this ImageSource. An IImageSourceDownloader may be provided to enable image downloads.");
+			}
 		}
 
 		private Uri _webUri;

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Android.cs
@@ -55,10 +55,13 @@ namespace Windows.ApplicationModel.DataTransfer
 					data.Contains(StandardDataFormats.ApplicationLink) ? (await data.GetApplicationLinkAsync()).ToString() : null,
 					data.Contains(StandardDataFormats.Uri) ? (await data.GetUriAsync()).ToString() : null);
 
-				var androidUri = Android.Net.Uri.Parse(uri);
+				if (string.IsNullOrEmpty(uri) == false)
+				{
+					var androidUri = Android.Net.Uri.Parse(uri);
 
-				items.Add(new ClipData.Item(androidUri));
-				mimeTypes.Add("text/uri-list");
+					items.Add(new ClipData.Item(androidUri));
+					mimeTypes.Add("text/uri-list");
+				}
 			}
 
 			if (data?.Contains(StandardDataFormats.Html) ?? false)

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.cs
@@ -121,9 +121,13 @@ namespace Windows.ApplicationModel.DataTransfer
 		}
 
 		/// <summary>
-		/// Separated a single URI/URL into separate URI's for WebLink and ApplicationLink (Uri format is deprecated).
+		/// Separates a single URI/URL into separate URI's for WebLink and ApplicationLink (Uri format is deprecated).
 		/// This is useful for converting a platform-specific URI/URL into formats supported by the <see cref="DataPackage"/>.
 		/// </summary>
+		/// <remarks>
+		/// This method is intended for use during integration with other platforms.
+		/// Therefore, it uses strings as the intermediate type instead of a Uri or native URL class.
+		/// </remarks>
 		/// <param name="uri">The platform-specific URI/URL.</param>
 		/// <param name="webLink">
 		/// The <see cref="StandardDataFormats.WebLink"/> format Uri intended for use in a <see cref="DataPackage"/>.
@@ -181,6 +185,10 @@ namespace Windows.ApplicationModel.DataTransfer
 		/// Combines separate URI's for WebLink, ApplicationLink and Uri (deprecated) into a single URI/URL.
 		/// This is useful for converting formats supported by the <see cref="DataPackage"/> into a platform-specific URI/URL.
 		/// </summary>
+		/// <remarks>
+		/// This method is intended for use during integration with other platforms.
+		/// Therefore, it uses strings as the intermediate type instead of a Uri or native URL class.
+		/// </remarks>
 		/// <param name="webLink">
 		/// Data from a <see cref="DataPackage"/> for the <see cref="StandardDataFormats.WebLink"/> format.
 		/// Set to null if this format does not exist in the package.

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.macOS.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.macOS.cs
@@ -179,7 +179,7 @@ namespace Windows.ApplicationModel.DataTransfer
 				if (!string.IsNullOrEmpty(html))
 				{
 					var pasteboardItem = new NSPasteboardItem();
-					pasteboardItem.SetStringForType(html ?? string.Empty, NSPasteboard.NSPasteboardTypeHTML);
+					pasteboardItem.SetStringForType(html, NSPasteboard.NSPasteboardTypeHTML);
 
 					draggingItem = new NSDraggingItem(pasteboardItem);
 					draggingItem.DraggingFrame = defaultFrameRect; // Must be set
@@ -195,7 +195,7 @@ namespace Windows.ApplicationModel.DataTransfer
 				{
 					// Use `NSPasteboardTypeRTF` instead of `NSPasteboardTypeRTFD` for max compatiblity
 					var pasteboardItem = new NSPasteboardItem();
-					pasteboardItem.SetStringForType(rtf ?? string.Empty, NSPasteboard.NSPasteboardTypeRTF);
+					pasteboardItem.SetStringForType(rtf, NSPasteboard.NSPasteboardTypeRTF);
 
 					draggingItem = new NSDraggingItem(pasteboardItem);
 					draggingItem.DraggingFrame = defaultFrameRect; // Must be set

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.macOS.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.macOS.cs
@@ -69,22 +69,56 @@ namespace Windows.ApplicationModel.DataTransfer
 		}
 
 		/// <summary>
-		/// Sets the contents of the <see cref="DataPackage"/> to the native drag and drop manager.
+		/// Creates new, native drag and drop data from the contents of the given <see cref="DataPackageView"/>.
 		/// </summary>
-		/// <param name="content">The contents to set to the native drag and drop manager.</param>
-		internal static void SetForNativeDragDrop(DataPackage content)
+		/// <param name="data">The content to create the native drag and drop data from.</param>
+		internal static async Task<NSDraggingItem[]> CreateNativeDragDropData(DataPackageView data)
 		{
-			return;
+			NSDraggingItem draggingItem;
+			var items = new List<NSDraggingItem>();
+
+			if (data?.Contains(StandardDataFormats.Html) ?? false)
+			{
+				var html = await data.GetHtmlFormatAsync();
+
+				if (!string.IsNullOrEmpty(html))
+				{
+
+				}
+			}
+
+			if (data?.Contains(StandardDataFormats.Rtf) ?? false)
+			{
+				var rtf = await data.GetRtfAsync();
+
+				if (!string.IsNullOrEmpty(rtf))
+				{
+					
+				}
+			}
+
+			if (data?.Contains(StandardDataFormats.Text) ?? false)
+			{
+				var text = await data.GetTextAsync();
+
+				if (!string.IsNullOrEmpty(text))
+				{
+					draggingItem = new NSDraggingItem((NSString)text);
+					draggingItem.DraggingFrame = new CoreGraphics.CGRect(0, 0, 1, 1); // Must be set
+					items.Add(draggingItem);
+				}
+			}
+
+			return items.ToArray();
 		}
 
 		/// <summary>
-		/// Gets the contents of the native drag and drop manager.
+		/// Creates a new <see cref="DataPackageView"/> from the native drag and drop data.
 		/// </summary>
-		/// <returns>A new <see cref="DataPackageView"/> representing the native drag and drop manager contents.</returns>
-		internal static DataPackageView GetFromNativeDragDrop()
+		/// <returns>A new <see cref="DataPackageView"/> representing the native drag and drop data.</returns>
+		internal static DataPackageView CreateFromNativeDragDropData(NSDraggingInfo draggingInfo)
 		{
-			// More worked needed, signature may change
-			return (new DataPackage()).GetView();
+			return GetFromNative(draggingInfo.DraggingPasteboard);
 		}
 
 		private static void SetToNative(DataPackage content, NSPasteboard pasteboard)

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.macOS.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.macOS.cs
@@ -137,20 +137,20 @@ namespace Windows.ApplicationModel.DataTransfer
 			if (data?.Contains(StandardDataFormats.Bitmap) ?? false)
 			{
 				NSImage? image = null;
-				var stream = (await (await data.GetBitmapAsync()).OpenReadAsync()).AsStream();
 
-				if (stream != null)
+				using (var stream = (await (await data.GetBitmapAsync()).OpenReadAsync()).AsStream())
 				{
-					using (MemoryStream ms = new MemoryStream())
+					if (stream != null)
 					{
-						await stream.CopyToAsync(ms);
-						ms.Flush();
-						ms.Position = 0;
+						using (var ms = new MemoryStream())
+						{
+							await stream.CopyToAsync(ms);
+							ms.Flush();
+							ms.Position = 0;
 
-						image = NSImage.FromStream(ms);
+							image = NSImage.FromStream(ms);
+						}
 					}
-
-					stream.Close();
 				}	
 
 				if (image != null)

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.macOS.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.macOS.cs
@@ -43,31 +43,6 @@ namespace Windows.ApplicationModel.DataTransfer
 		 *  
 		 *  *1 : macOS 10.6 and later
 		 *
-		 * Below are more specific notes when converting types to/from macOS.
-		 *
-		 * --- UWP to macOS ---
-		 *
-		 * UWP has the following standard data formats that correspond with a macOS Url:
-		 *
-		 *  1. Uri, now deprecated in favor of:
-		 *  2. ApplicationLink and
-		 *  3. WebLink
-		 *
-		 * For maximum compatibility all are mapped to Url.
-		 * However, when applying data to the clipboard or drag/drop DataPackage, 
-		 * only one may be used at a time in the above defined priority. 
-		 * WebLink is considered more specific than ApplicationLink.
-		 *
-		 * --- macOS to UWP ---
-		 *
-		 * A macOS URL must be specially mapped for UWP as UWP's direct equivalent 
-		 * standard data format 'Uri' is deprecated.
-		 *
-		 * 1. WebLink is used if the macOS URL has a scheme of http or https 
-		 * 2. ApplicationLink is used if not #1
-		 *
-		 * For full compatibility, Uri is still populated regardless of #1 or #2.
-		 *
 		 */
 
 		// An Uno-internal abstraction is used to simplify native drag/drop & clipboard integration

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.macOS.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.macOS.cs
@@ -60,7 +60,7 @@ namespace Windows.ApplicationModel.DataTransfer
 		 *
 		 * --- macOS to UWP ---
 		 *
-		 * A macOS URL must be specially mapped for UWP as the UWP's direct equivalent 
+		 * A macOS URL must be specially mapped for UWP as UWP's direct equivalent 
 		 * standard data format 'Uri' is deprecated.
 		 *
 		 * 1. WebLink is used if the macOS URL has a scheme of http or https 
@@ -76,7 +76,7 @@ namespace Windows.ApplicationModel.DataTransfer
 		/// Sets the contents of the <see cref="DataPackage"/> to the native clipboard.
 		/// Any conversion between supported standard types is done automatically.
 		/// </summary>
-		/// <param name="content">The contents to set to the native cipboard.</param>
+		/// <param name="content">The contents to set to the native clipboard.</param>
 		internal static void SetToNativeClipboard(DataPackage content)
 		{
 			SetToNative(content, NSPasteboard.GeneralPasteboard);
@@ -86,7 +86,7 @@ namespace Windows.ApplicationModel.DataTransfer
 		/// Asynchronously sets the contents of the <see cref="DataPackage"/> to the native clipboard.
 		/// Any conversion between supported standard types is done automatically.
 		/// </summary>
-		/// <param name="content">The contents to set to the native cipboard.</param>
+		/// <param name="content">The contents to set to the native clipboard.</param>
 		internal static Task SetToNativeClipboardAsync(DataPackage content)
 			=> SetToNativeAsync(content, NSPasteboard.GeneralPasteboard);
 
@@ -193,7 +193,7 @@ namespace Windows.ApplicationModel.DataTransfer
 
 				if (!string.IsNullOrEmpty(rtf))
 				{
-					// Use `NSPasteboardTypeRTF` instead of `NSPasteboardTypeRTFD` for max compatiblity
+					// Use `NSPasteboardTypeRTF` instead of `NSPasteboardTypeRTFD` for max compatibility
 					var pasteboardItem = new NSPasteboardItem();
 					pasteboardItem.SetStringForType(rtf, NSPasteboard.NSPasteboardTypeRTF);
 
@@ -314,7 +314,7 @@ namespace Windows.ApplicationModel.DataTransfer
 
 			if (data?.Contains(StandardDataFormats.Rtf) ?? false)
 			{
-				// Use `NSPasteboardTypeRTF` instead of `NSPasteboardTypeRTFD` for max compatiblity
+				// Use `NSPasteboardTypeRTF` instead of `NSPasteboardTypeRTFD` for max compatibility
 				declaredTypes.Add(NSPasteboard.NSPasteboardTypeRTF);
 			}
 
@@ -395,7 +395,7 @@ namespace Windows.ApplicationModel.DataTransfer
 					item.Types.Contains(NSPasteboard.NSPasteboardTypePNG))
 				{
 					// Images may be very large, we never want to load them until they are needed.
-					// Therefore, create a data provider used to asyncronously fetch the image.
+					// Therefore, create a data provider used to asynchronously fetch the image.
 					dataPackage.SetDataProvider(
 						StandardDataFormats.Bitmap,
 						async cancellationToken =>
@@ -408,7 +408,7 @@ namespace Windows.ApplicationModel.DataTransfer
 							 * To get around this an image is read as follows:
 							 *   (1) If the pasteboard contains an image type then:
 							 *   (2) Attempt to read the image as an object (NSImage).
-							 *       This may fail as some tested apps provide a URL althouth declare an image (Photos).
+							 *       This may fail as some tested apps provide a URL although declare an image (Photos).
 							 *       With other apps (such as web browsers) an image will be read correctly here.
 							 *   (3) If reading as an NSImage object fails, attempt to read the image from a file URL (local images)
 							 *   (4) If reading from a file URL fails, attempt to read the image from a URL (remote images)
@@ -493,11 +493,11 @@ namespace Windows.ApplicationModel.DataTransfer
 
 				if (item.Types.Contains(NSPasteboard.NSPasteboardTypeFileUrl))
 				{
-					// Drag and drop will use temporary URL's similar to: file:///.file/id=1234567.1234567
+					// Drag and drop will use temporary URLs similar to: file:///.file/id=1234567.1234567
 					var tempFileUrl = item.GetStringForType(NSPasteboard.NSPasteboardTypeFileUrl);
 
 					// Files may be very large, we never want to load them until they are needed.
-					// Therefore, create a data provider used to asyncronously fetch the file.
+					// Therefore, create a data provider used to asynchronously fetch the file.
 					dataPackage.SetDataProvider(
 						StandardDataFormats.StorageItems,
 						async cancellationToken =>

--- a/src/Uno.UWP/UI/Core/CoreWindow.macOS.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.macOS.cs
@@ -13,8 +13,7 @@ namespace Windows.UI.Core
 {
 	public partial class CoreWindow 
 	{
-		// HACK: TODO: Find a better way to get this reference
-		public readonly NSWindow _window;
+		private readonly NSWindow _window;
 
 		private bool _cursorHidden = false;
 		private CoreCursor _pointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);
@@ -23,6 +22,11 @@ namespace Windows.UI.Core
         {
             _window = window;			
         }
+
+		/// <summary>
+		/// Gets a reference to the native macOS Window behind the <see cref="CoreWindow"/> abstraction.
+		/// </summary>
+		internal NSWindow NativeWindow => _window;
 
 		public CoreCursor PointerCursor
 		{

--- a/src/Uno.UWP/UI/Core/CoreWindow.macOS.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.macOS.cs
@@ -13,7 +13,8 @@ namespace Windows.UI.Core
 {
 	public partial class CoreWindow 
 	{
-        private readonly NSWindow _window;
+		// HACK: TODO: Find a better way to get this reference
+		public readonly NSWindow _window;
 
 		private bool _cursorHidden = false;
 		private CoreCursor _pointerCursor = new CoreCursor(CoreCursorType.Arrow, 0);


### PR DESCRIPTION
GitHub Issue fixes https://github.com/unoplatform/uno/issues/4311

Relates to Issue #1480 and PR #4270 

## PR Type

Adds support 

- Feature

## What is the current behavior?

Drag and drop is not integrated with macOS and other apps.

## What is the new behavior?

Drag and drop is integrated with macOS supporting inter-app drag and drop:
 - Drop of external content on an Uno App is fully supported (images, files, text, etc.)
 - Drag of Uno App content to external macOS apps is supported but has some limitations/issues.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~
- [ ] ~Validated PR `Screenshots Compare Test Run` results.~
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

ToDo:
 - [x] Add back `internal static Task SetToNativeClipboardAsync(DataPackage content)` to DataPackage.macOS.cs to fix tests (temporarily removed to allow cherry-picking commits without conflicts).
 - [x] Update docs indicating macOS support for inter-app drag/drop
 - [ ] Drag and drop of images is fully supported but images are not redrawn when a stream is updated async. This was fixed for development with a temporary work-around not included in this PR. An additional PR is planned to fully fix this issue on supported platforms.

Other open questions are commented in code.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
