### PR TITLE
fix(skia): FontFamily may return null and fail TextBlock rendering

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextVisual.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextVisual.Skia.cs
@@ -1,8 +1,13 @@
-﻿using SkiaSharp;
+﻿#nullable enable
+
+using Microsoft.Extensions.Logging;
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Uno;
+using Uno.Extensions;
 using Uno.UI.Xaml;
 using Windows.Foundation;
 using Windows.Storage;
@@ -39,7 +44,25 @@ namespace Windows.UI.Composition
 			}
 			else
 			{
-				return SKTypeface.FromFamilyName(name, weight, width, slant);
+				if(string.Equals(name, "XamlAutoFontFamily", StringComparison.OrdinalIgnoreCase))
+				{
+					return SKTypeface.FromFamilyName(null, weight, width, slant);
+				}
+
+				var typeFace = SKTypeface.FromFamilyName(name, weight, width, slant);
+
+				// FromFontFamilyName may return null: https://github.com/mono/SkiaSharp/issues/1058
+				if (typeFace == null)
+				{
+					if (typeof(TextVisual).Log().IsEnabled(LogLevel.Warning))
+					{
+						typeof(TextVisual).Log().LogWarning($"The font {name} could not be found, using system default");
+					}
+
+					typeFace = SKTypeface.FromFamilyName(null, weight, width, slant);
+				}
+
+				return typeFace;
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/calculator/issues/319

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

On some systems, asking for fonts by family may return null, failing to render textblocks.

## What is the new behavior?

The default system font is used instead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
