### PR TITLE
ScrollViewer performance

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/TappedTapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/TappedTapped_Tests.cs
@@ -122,6 +122,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // Disabled on WASM: False failure
 		public void When_InListViewWithoutItemClick()
 		{
 			Run(_xamlTestPage);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/TappedTapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/TappedTapped_Tests.cs
@@ -122,7 +122,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)] // Disabled on WASM: False failure
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // Disabled on WASM: False failure: https://github.com/unoplatform/uno/issues/2739
 		public void When_InListViewWithoutItemClick()
 		{
 			Run(_xamlTestPage);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_ScrollViewer
+	{
+#if __SKIA__ || __WASM__
+		[TestMethod]
+		public async Task When_CreateVerticalScroller_Then_DoNotLoadAllTemplate()
+		{
+			var sut = new ScrollViewer
+			{
+				VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+				VerticalScrollMode = ScrollMode.Enabled,
+				HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+				HorizontalScrollMode = ScrollMode.Disabled,
+				Height = 100,
+				Width = 100,
+				Content = new Border {Height = 200, Width = 50}
+			};
+			WindowHelper.WindowContent = sut;
+
+			await WindowHelper.WaitForIdle();
+
+			var buttons = sut
+				.EnumerateAllChildren(maxDepth: 256)
+				.OfType<RepeatButton>()
+				.Count();
+
+			Assert.IsTrue(buttons > 0); // We make sure that we really loaded the right template
+			Assert.IsTrue(buttons <= 8); // Ideally it should be 4
+		}
+#endif
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -39,7 +39,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				.Count();
 
 			Assert.IsTrue(buttons > 0); // We make sure that we really loaded the right template
-			Assert.IsTrue(buttons <= 8); // Ideally it should be 4
+			Assert.IsTrue(buttons <= 4);
 		}
 #endif
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollBar/ScrollBar.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollBar/ScrollBar.cs
@@ -595,43 +595,45 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				return;
 			}
 
+			var prefix = IsFixedOrientation ? $"{Orientation}_" : "";
+
 			var scrollingIndicator = IndicatorMode;
 			var isEnabled = IsEnabled;
 			bool isSuccessful;
 			if (!isEnabled)
 			{
-				VisualStateManager.GoToState(this, "Disabled", bUseTransitions);
+				VisualStateManager.GoToState(this, prefix + "Disabled", bUseTransitions);
 			}
 			else if (m_isPointerOver)
 			{
-				isSuccessful = VisualStateManager.GoToState(this, "PointerOver", bUseTransitions);
+				isSuccessful = VisualStateManager.GoToState(this, prefix + "PointerOver", bUseTransitions);
 				//Default to Normal if PointerOver state isn't available.
 				if (!isSuccessful)
 				{
-					VisualStateManager.GoToState(this, "Normal", bUseTransitions);
+					VisualStateManager.GoToState(this, prefix + "Normal", bUseTransitions);
 				}
 			}
 			else
 			{
-				VisualStateManager.GoToState(this, "Normal", bUseTransitions);
+				VisualStateManager.GoToState(this, prefix + "Normal", bUseTransitions);
 			}
 
 			if (!m_blockIndicators && (!IsConscious() || scrollingIndicator == ScrollingIndicatorMode.MouseIndicator))
 			{
-				VisualStateManager.GoToState(this, "MouseIndicator", bUseTransitions);
+				VisualStateManager.GoToState(this, prefix + "MouseIndicator", bUseTransitions);
 			}
 			else if (!m_blockIndicators && scrollingIndicator == ScrollingIndicatorMode.TouchIndicator)
 			{
-				isSuccessful = VisualStateManager.GoToState(this, "TouchIndicator", bUseTransitions);
+				isSuccessful = VisualStateManager.GoToState(this, prefix + "TouchIndicator", bUseTransitions);
 				//Default to MouseActiveState if Panning state isn't available.
 				if (!isSuccessful)
 				{
-					VisualStateManager.GoToState(this, "MouseIndicator", bUseTransitions);
+					VisualStateManager.GoToState(this, prefix + "MouseIndicator", bUseTransitions);
 				}
 			}
 			else
 			{
-				VisualStateManager.GoToState(this, "NoIndicator", bUseTransitions);
+				VisualStateManager.GoToState(this, prefix + "NoIndicator", bUseTransitions);
 			}
 
 			// Expanded/Collapsed States were added in RS3 and ExpandedWithoutAnimation/CollapsedWithoutAnimation states
@@ -643,7 +645,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			// animations are enabled. When animations are disabled, the framework does not run transitions.
 			if (!IsConscious())
 			{
-				VisualStateManager.GoToState(this, isEnabled ? "Expanded" : "Collapsed", true /* useTransitions */);
+				VisualStateManager.GoToState(this, prefix + (isEnabled ? "Expanded" : "Collapsed"), true /* useTransitions */);
 			}
 			else
 			{
@@ -653,22 +655,22 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				{
 					if (!animate)
 					{
-						isSuccessful = VisualStateManager.GoToState(this, "ExpandedWithoutAnimation", true /* useTransitions */);
+						isSuccessful = VisualStateManager.GoToState(this, prefix + "ExpandedWithoutAnimation", true /* useTransitions */);
 					}
 					if (!isSuccessful)
 					{
-						VisualStateManager.GoToState(this, "Expanded", true /* useTransitions */);
+						VisualStateManager.GoToState(this, prefix + "Expanded", true /* useTransitions */);
 					}
 				}
 				else
 				{
 					if (!animate)
 					{
-						isSuccessful = VisualStateManager.GoToState(this, "CollapsedWithoutAnimation", true /* useTransitions */);
+						isSuccessful = VisualStateManager.GoToState(this, prefix + "CollapsedWithoutAnimation", true /* useTransitions */);
 					}
 					if (!isSuccessful)
 					{
-						VisualStateManager.GoToState(this, "Collapsed", true /* useTransitions */);
+						VisualStateManager.GoToState(this, prefix + "Collapsed", true /* useTransitions */);
 					}
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollBar/ScrollBar.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollBar/ScrollBar.cs
@@ -104,6 +104,17 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			Unloaded += DetachEvents;
 		}
 
+		/// <summary>
+		/// Indicates if this scrollbar supports to change its orientation once its template has been applied (cf. remarks).
+		/// This is false by default (which means that the ScrollBar will support dynamic orientation changes).
+		/// </summary>
+		/// <remarks>
+		/// This flag is for performance consideration, it allows ScrollBar to load only half of its template.
+		/// It's used by core controls (e.g. ScrollViewer) where the ScrollBar's orientation will never change.
+		/// It's required as, unlike UWP, a control which is Visibility = Collapsed will get its template applied anyway.
+		/// </remarks>
+		internal bool IsFixedOrientation { get; set; } = false;
+
 		// Update the visual states when the Visibility property is changed.
 		protected override void OnVisibilityChanged(Visibility oldValue, Visibility newValue)
 		{
@@ -150,151 +161,157 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			base.OnApplyTemplate();
 
 			// Get the parts
-			spElementHorizontalTemplate = GetTemplateChildHelper<FrameworkElement>("HorizontalRoot");
-			m_tpElementHorizontalTemplate = spElementHorizontalTemplate;
-			spElementHorizontalLargeIncrease = GetTemplateChildHelper<RepeatButton>("HorizontalLargeIncrease");
-			m_tpElementHorizontalLargeIncrease = spElementHorizontalLargeIncrease;
-			if (m_tpElementHorizontalLargeIncrease != null)
+			if (!IsFixedOrientation || Orientation == Orientation.Horizontal)
 			{
-				strAutomationName = AutomationProperties.GetName(m_tpElementHorizontalLargeIncrease);
-
-				if (strAutomationName == null)
+				spElementHorizontalTemplate = GetTemplateChildHelper<FrameworkElement>("HorizontalRoot");
+				m_tpElementHorizontalTemplate = spElementHorizontalTemplate;
+				spElementHorizontalLargeIncrease = GetTemplateChildHelper<RepeatButton>("HorizontalLargeIncrease");
+				m_tpElementHorizontalLargeIncrease = spElementHorizontalLargeIncrease;
+				if (m_tpElementHorizontalLargeIncrease != null)
 				{
-					// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_HORIZONTALLARGEINCREASE, strAutomationName));
-					AutomationProperties.SetName(m_tpElementHorizontalLargeIncrease as RepeatButton, strAutomationName);
+					strAutomationName = AutomationProperties.GetName(m_tpElementHorizontalLargeIncrease);
+
+					if (strAutomationName == null)
+					{
+						// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_HORIZONTALLARGEINCREASE, strAutomationName));
+						AutomationProperties.SetName(m_tpElementHorizontalLargeIncrease as RepeatButton, strAutomationName);
+					}
 				}
-			}
-			spElementHorizontalSmallIncrease =GetTemplateChildHelper<RepeatButton>("HorizontalSmallIncrease");
-			m_tpElementHorizontalSmallIncrease = spElementHorizontalSmallIncrease;
-			if (m_tpElementHorizontalSmallIncrease != null)
-			{
-				strAutomationName = AutomationProperties.GetName(m_tpElementHorizontalSmallIncrease);
-
-				if (strAutomationName == null)
+				spElementHorizontalSmallIncrease = GetTemplateChildHelper<RepeatButton>("HorizontalSmallIncrease");
+				m_tpElementHorizontalSmallIncrease = spElementHorizontalSmallIncrease;
+				if (m_tpElementHorizontalSmallIncrease != null)
 				{
-					// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_HORIZONTALSMALLINCREASE, strAutomationName));
-					AutomationProperties.SetName(m_tpElementHorizontalSmallIncrease, strAutomationName);
+					strAutomationName = AutomationProperties.GetName(m_tpElementHorizontalSmallIncrease);
 
+					if (strAutomationName == null)
+					{
+						// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_HORIZONTALSMALLINCREASE, strAutomationName));
+						AutomationProperties.SetName(m_tpElementHorizontalSmallIncrease, strAutomationName);
+
+					}
 				}
-			}
-			spElementHorizontalLargeDecrease = GetTemplateChildHelper<RepeatButton>("HorizontalLargeDecrease");
-			m_tpElementHorizontalLargeDecrease = spElementHorizontalLargeDecrease;
-			if (m_tpElementHorizontalLargeDecrease != null)
-			{
-				strAutomationName = AutomationProperties.GetName(m_tpElementHorizontalLargeDecrease);
-
-				if (strAutomationName == null)
+				spElementHorizontalLargeDecrease = GetTemplateChildHelper<RepeatButton>("HorizontalLargeDecrease");
+				m_tpElementHorizontalLargeDecrease = spElementHorizontalLargeDecrease;
+				if (m_tpElementHorizontalLargeDecrease != null)
 				{
-					// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_HORIZONTALLARGEDECREASE, strAutomationName));
-					AutomationProperties.SetName(m_tpElementHorizontalLargeDecrease, strAutomationName);
-	
+					strAutomationName = AutomationProperties.GetName(m_tpElementHorizontalLargeDecrease);
+
+					if (strAutomationName == null)
+					{
+						// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_HORIZONTALLARGEDECREASE, strAutomationName));
+						AutomationProperties.SetName(m_tpElementHorizontalLargeDecrease, strAutomationName);
+
+					}
 				}
-			}
-			spElementHorizontalSmallDecrease = GetTemplateChildHelper<RepeatButton>("HorizontalSmallDecrease");
-			m_tpElementHorizontalSmallDecrease = spElementHorizontalSmallDecrease;
-			if (m_tpElementHorizontalSmallDecrease != null)
-			{
-				strAutomationName = AutomationProperties.GetName(m_tpElementHorizontalSmallDecrease);
-
-				if (strAutomationName == null)
+				spElementHorizontalSmallDecrease = GetTemplateChildHelper<RepeatButton>("HorizontalSmallDecrease");
+				m_tpElementHorizontalSmallDecrease = spElementHorizontalSmallDecrease;
+				if (m_tpElementHorizontalSmallDecrease != null)
 				{
-					// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_HORIZONTALSMALLDECREASE, strAutomationName));
-					AutomationProperties.SetName(m_tpElementHorizontalSmallDecrease, strAutomationName);
+					strAutomationName = AutomationProperties.GetName(m_tpElementHorizontalSmallDecrease);
 
+					if (strAutomationName == null)
+					{
+						// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_HORIZONTALSMALLDECREASE, strAutomationName));
+						AutomationProperties.SetName(m_tpElementHorizontalSmallDecrease, strAutomationName);
+
+					}
 				}
-			}
-			spElementHorizontalThumb = GetTemplateChildHelper<Thumb>("HorizontalThumb");
-			m_tpElementHorizontalThumb = spElementHorizontalThumb;
-			if (m_tpElementHorizontalThumb != null)
-			{
-				strAutomationName = AutomationProperties.GetName(m_tpElementHorizontalThumb);
-
-				if (strAutomationName == null)
+				spElementHorizontalThumb = GetTemplateChildHelper<Thumb>("HorizontalThumb");
+				m_tpElementHorizontalThumb = spElementHorizontalThumb;
+				if (m_tpElementHorizontalThumb != null)
 				{
-					// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_HORIZONTALTHUMB, strAutomationName));
-					AutomationProperties.SetName(m_tpElementHorizontalThumb, strAutomationName);
+					strAutomationName = AutomationProperties.GetName(m_tpElementHorizontalThumb);
 
-				}
-			}
+					if (strAutomationName == null)
+					{
+						// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_HORIZONTALTHUMB, strAutomationName));
+						AutomationProperties.SetName(m_tpElementHorizontalThumb, strAutomationName);
 
-			spElementVerticalTemplate = GetTemplateChildHelper<FrameworkElement>("VerticalRoot");
-			m_tpElementVerticalTemplate = spElementVerticalTemplate;
-
-			spElementVerticalLargeIncrease = GetTemplateChildHelper<RepeatButton>("VerticalLargeIncrease");
-			m_tpElementVerticalLargeIncrease = spElementVerticalLargeIncrease;
-			if (m_tpElementVerticalLargeIncrease != null)
-			{
-				strAutomationName = AutomationProperties.GetName(m_tpElementVerticalLargeIncrease);
-
-				if (strAutomationName == null)
-				{
-					// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_VERTICALALLARGEINCREASE, strAutomationName));
-					AutomationProperties.SetName(m_tpElementVerticalLargeIncrease, strAutomationName);
-
+					}
 				}
 			}
 
-			spElementVerticalSmallIncrease = GetTemplateChildHelper<RepeatButton>("VerticalSmallIncrease");
-			m_tpElementVerticalSmallIncrease = spElementVerticalSmallIncrease;
-			if (m_tpElementVerticalSmallIncrease != null)
+			if (!IsFixedOrientation || Orientation == Orientation.Vertical)
 			{
-				strAutomationName = AutomationProperties.GetName(m_tpElementVerticalSmallIncrease);
+				spElementVerticalTemplate = GetTemplateChildHelper<FrameworkElement>("VerticalRoot");
+				m_tpElementVerticalTemplate = spElementVerticalTemplate;
 
-				if (strAutomationName == null)
+				spElementVerticalLargeIncrease = GetTemplateChildHelper<RepeatButton>("VerticalLargeIncrease");
+				m_tpElementVerticalLargeIncrease = spElementVerticalLargeIncrease;
+				if (m_tpElementVerticalLargeIncrease != null)
 				{
-					// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_VERTICALSMALLINCREASE, strAutomationName));
-					AutomationProperties.SetName(m_tpElementVerticalSmallIncrease, strAutomationName);
+					strAutomationName = AutomationProperties.GetName(m_tpElementVerticalLargeIncrease);
 
+					if (strAutomationName == null)
+					{
+						// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_VERTICALALLARGEINCREASE, strAutomationName));
+						AutomationProperties.SetName(m_tpElementVerticalLargeIncrease, strAutomationName);
+
+					}
 				}
-			}
-			spElementVerticalLargeDecrease = GetTemplateChildHelper<RepeatButton>("VerticalLargeDecrease");
-			m_tpElementVerticalLargeDecrease = spElementVerticalLargeDecrease;
-			if (m_tpElementVerticalLargeDecrease != null)
-			{
-				strAutomationName = AutomationProperties.GetName(m_tpElementVerticalLargeDecrease);
 
-				if (strAutomationName == null)
+				spElementVerticalSmallIncrease = GetTemplateChildHelper<RepeatButton>("VerticalSmallIncrease");
+				m_tpElementVerticalSmallIncrease = spElementVerticalSmallIncrease;
+				if (m_tpElementVerticalSmallIncrease != null)
 				{
-					// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_VERTICALLARGEDECREASE, strAutomationName));
-					AutomationProperties.SetName(m_tpElementVerticalLargeDecrease, strAutomationName);
+					strAutomationName = AutomationProperties.GetName(m_tpElementVerticalSmallIncrease);
 
+					if (strAutomationName == null)
+					{
+						// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_VERTICALSMALLINCREASE, strAutomationName));
+						AutomationProperties.SetName(m_tpElementVerticalSmallIncrease, strAutomationName);
+
+					}
 				}
-			}
-			spElementVerticalSmallDecrease = GetTemplateChildHelper<RepeatButton>("VerticalSmallDecrease");
-			m_tpElementVerticalSmallDecrease = spElementVerticalSmallDecrease;
-			if (m_tpElementVerticalSmallDecrease != null)
-			{
-				strAutomationName = AutomationProperties.GetName(m_tpElementVerticalSmallDecrease);
-
-				if (strAutomationName == null)
+				spElementVerticalLargeDecrease = GetTemplateChildHelper<RepeatButton>("VerticalLargeDecrease");
+				m_tpElementVerticalLargeDecrease = spElementVerticalLargeDecrease;
+				if (m_tpElementVerticalLargeDecrease != null)
 				{
-					// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_VERTICALSMALLDECREASE, strAutomationName));
-					AutomationProperties.SetName(m_tpElementVerticalSmallDecrease, strAutomationName);
+					strAutomationName = AutomationProperties.GetName(m_tpElementVerticalLargeDecrease);
 
+					if (strAutomationName == null)
+					{
+						// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_VERTICALLARGEDECREASE, strAutomationName));
+						AutomationProperties.SetName(m_tpElementVerticalLargeDecrease, strAutomationName);
+
+					}
 				}
-			}
-			spElementVerticalThumb = GetTemplateChildHelper<Thumb>("VerticalThumb");
-			m_tpElementVerticalThumb = spElementVerticalThumb;
-			if (m_tpElementVerticalThumb != null)
-			{
-				strAutomationName = AutomationProperties.GetName(m_tpElementVerticalThumb);
-
-				if (strAutomationName == null)
+				spElementVerticalSmallDecrease = GetTemplateChildHelper<RepeatButton>("VerticalSmallDecrease");
+				m_tpElementVerticalSmallDecrease = spElementVerticalSmallDecrease;
+				if (m_tpElementVerticalSmallDecrease != null)
 				{
-					// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_VERTICALTHUMB, strAutomationName));
-					AutomationProperties.SetName(m_tpElementVerticalThumb as Thumb, strAutomationName);
+					strAutomationName = AutomationProperties.GetName(m_tpElementVerticalSmallDecrease);
 
+					if (strAutomationName == null)
+					{
+						// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_VERTICALSMALLDECREASE, strAutomationName));
+						AutomationProperties.SetName(m_tpElementVerticalSmallDecrease, strAutomationName);
+
+					}
 				}
-			}
+				spElementVerticalThumb = GetTemplateChildHelper<Thumb>("VerticalThumb");
+				m_tpElementVerticalThumb = spElementVerticalThumb;
+				if (m_tpElementVerticalThumb != null)
+				{
+					strAutomationName = AutomationProperties.GetName(m_tpElementVerticalThumb);
 
-			spElementHorizontalPanningRoot = GetTemplateChildHelper<FrameworkElement>("HorizontalPanningRoot");
-			m_tpElementHorizontalPanningRoot = spElementHorizontalPanningRoot;
-			spElementHorizontalPanningThumb = GetTemplateChildHelper<FrameworkElement>("HorizontalPanningThumb");
-			m_tpElementHorizontalPanningThumb = spElementHorizontalPanningThumb;
-			spElementVerticalPanningRoot = GetTemplateChildHelper<FrameworkElement>("VerticalPanningRoot");
-			m_tpElementVerticalPanningRoot = spElementVerticalPanningRoot;
-			spElementVerticalPanningThumb = GetTemplateChildHelper<FrameworkElement>("VerticalPanningThumb");
-			m_tpElementVerticalPanningThumb = spElementVerticalPanningThumb;
+					if (strAutomationName == null)
+					{
+						// (DXamlCore.GetCurrentNoCreate().GetLocalizedResourceString(UIA_SCROLLBAR_VERTICALTHUMB, strAutomationName));
+						AutomationProperties.SetName(m_tpElementVerticalThumb as Thumb, strAutomationName);
+
+					}
+				}
+
+				spElementHorizontalPanningRoot = GetTemplateChildHelper<FrameworkElement>("HorizontalPanningRoot");
+				m_tpElementHorizontalPanningRoot = spElementHorizontalPanningRoot;
+				spElementHorizontalPanningThumb = GetTemplateChildHelper<FrameworkElement>("HorizontalPanningThumb");
+				m_tpElementHorizontalPanningThumb = spElementHorizontalPanningThumb;
+				spElementVerticalPanningRoot = GetTemplateChildHelper<FrameworkElement>("VerticalPanningRoot");
+				m_tpElementVerticalPanningRoot = spElementVerticalPanningRoot;
+				spElementVerticalPanningThumb = GetTemplateChildHelper<FrameworkElement>("VerticalPanningThumb");
+				m_tpElementVerticalPanningThumb = spElementVerticalPanningThumb;
+			}
 
 			// Attach the event handlers
 			AttachEvents();

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -622,12 +622,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			ViewportArrangeSize = finalSize;
 
-			var s =  base.ArrangeOverride(finalSize);
-
-			//UpdateDimensionProperties();
-			//UpdateZoomedContentAlignment();
-
-			return s;
+			return base.ArrangeOverride(finalSize);
 		}
 
 		internal override void OnLayoutUpdated()

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -622,12 +622,16 @@ namespace Windows.UI.Xaml.Controls
 		{
 			ViewportArrangeSize = finalSize;
 
-			var size = base.ArrangeOverride(finalSize);
+			return base.ArrangeOverride(finalSize);
+		}
+
+		/// <inheritdoc />
+		internal override void OnLayoutUpdated()
+		{
+			base.OnLayoutUpdated();
 
 			UpdateDimensionProperties();
 			UpdateZoomedContentAlignment();
-
-			return size;
 		}
 
 		private void UpdateDimensionProperties()
@@ -637,6 +641,17 @@ namespace Windows.UI.Xaml.Controls
 			)
 			{
 				this.Log().LogDebug($"ScrollViewer setting ViewportHeight={ActualHeight}, ViewportWidth={ActualWidth}");
+			}
+
+			if (ActualWidth == 0 || ActualHeight == 0)
+			{
+				// Do not update properties if we don't have any valid size yet.
+				// This is useful essentially for the first size changed on the Content,
+				// where it already have its final size while the SV doesn't.
+				// This would cause a Scrollable<Width|Height> greater than 0,
+				// which will cause the materialization of the managed scrollbar
+				// which might not be needed after next layout pass.
+				return;
 			}
 
 			ViewportHeight = ActualHeight;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -946,15 +946,18 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			_verticalScrollbar = (GetTemplateChild(Parts.WinUI3.VerticalScrollBar) ?? GetTemplateChild(Parts.Uwp.VerticalScrollBar)) as ScrollBar;
-			_isVerticalScrollBarMaterialized = true;
+			using (ScrollBar.MaterializingFixed(Orientation.Vertical))
+			{
+				_verticalScrollbar = (GetTemplateChild(Parts.WinUI3.VerticalScrollBar) ?? GetTemplateChild(Parts.Uwp.VerticalScrollBar)) as ScrollBar;
+				_isVerticalScrollBarMaterialized = true;
+			}
 
 			if (_verticalScrollbar is null)
 			{
 				return;
 			}
 
-			_verticalScrollbar.IsFixedOrientation = true;
+			_verticalScrollbar.IsFixedOrientation = true; // Redundant with ScrollBar.MaterializingFixed, but twice is safer
 			DetachScrollBars();
 			AttachScrollBars();
 		}
@@ -966,15 +969,18 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			_horizontalScrollbar = (GetTemplateChild(Parts.WinUI3.HorizontalScrollBar) ?? GetTemplateChild(Parts.Uwp.HorizontalScrollBar)) as ScrollBar;
-			_isHorizontalScrollBarMaterialized = true;
+			using (ScrollBar.MaterializingFixed(Orientation.Horizontal))
+			{
+				_horizontalScrollbar = (GetTemplateChild(Parts.WinUI3.HorizontalScrollBar) ?? GetTemplateChild(Parts.Uwp.HorizontalScrollBar)) as ScrollBar;
+				_isHorizontalScrollBarMaterialized = true;
+			}
 
 			if (_horizontalScrollbar is null)
 			{
 				return;
 			}
 
-			_horizontalScrollbar.IsFixedOrientation = true;
+			_horizontalScrollbar.IsFixedOrientation = true; // Redundant with ScrollBar.MaterializingFixed, but twice is safer
 			DetachScrollBars();
 			AttachScrollBars();
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.xaml
@@ -265,6 +265,7 @@
 
 							<netstdref:ScrollBar
 								x:Name="VerticalScrollBar"
+								x:Load="False"
 								Grid.Column="1"
 								IsTabStop="False"
 								Maximum="{TemplateBinding ScrollableHeight}"
@@ -277,6 +278,7 @@
 
 							<netstdref:ScrollBar
 								x:Name="HorizontalScrollBar"
+								x:Load="False"
 								IsTabStop="False"
 								Maximum="{TemplateBinding ScrollableWidth}"
 								Orientation="Horizontal"

--- a/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
@@ -299,7 +299,7 @@ namespace Windows.UI.Xaml.Media
 				// No needs to adjust the position on Skia:
 				// the scrolling is achieved using a RenderTransform on the content of the ScrollContentPresenter,
 				// so it will already be taken in consideration by the case above.
-#if __SKIA__
+#if !__SKIA__
 				posRelToElement.X += sv.HorizontalOffset;
 				posRelToElement.Y += sv.VerticalOffset;
 #endif

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -7573,6 +7573,8 @@
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="CommonStates">
 								<VisualState x:Name="Normal" />
+								<VisualState x:Name="Vertical_Normal" />
+								<VisualState x:Name="Horizontal_Normal" />
 
 								<VisualState x:Name="Disabled">
 									<VisualState.Setters>
@@ -7587,6 +7589,26 @@
 										<Setter Target="VerticalPanningThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundDisabled}" />
 									</VisualState.Setters>
 								</VisualState>
+								<VisualState x:Name="Vertical_Disabled">
+									<VisualState.Setters>
+										<Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundDisabled}" />
+										<Setter Target="Root.BorderBrush" Value="{ThemeResource ScrollBarBorderBrushDisabled}" />
+										<Setter Target="Root.Opacity" Value="0.5" />
+										<Setter Target="VerticalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokeDisabled}" />
+										<Setter Target="VerticalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillDisabled}" />
+										<Setter Target="VerticalPanningThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundDisabled}" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Horizontal_Disabled">
+									<VisualState.Setters>
+										<Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundDisabled}" />
+										<Setter Target="Root.BorderBrush" Value="{ThemeResource ScrollBarBorderBrushDisabled}" />
+										<Setter Target="Root.Opacity" Value="0.5" />
+										<Setter Target="HorizontalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokeDisabled}" />
+										<Setter Target="HorizontalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillDisabled}" />
+										<Setter Target="HorizontalPanningThumb.Background" Value="{ThemeResource ScrollBarPanningThumbBackgroundDisabled}" />
+									</VisualState.Setters>
+								</VisualState>
 
 							</VisualStateGroup>
 							<VisualStateGroup x:Name="ScrollingIndicatorStates">
@@ -7598,6 +7620,19 @@
 										<Setter Target="VerticalPanningRoot.Opacity" Value="1" />
 									</VisualState.Setters>
 								</VisualState>
+								<VisualState x:Name="Vertical_TouchIndicator">
+									<VisualState.Setters>
+										<Setter Target="VerticalRoot.Visibility" Value="Collapsed" />
+										<Setter Target="VerticalPanningRoot.Opacity" Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Horizontal_TouchIndicator">
+									<VisualState.Setters>
+										<Setter Target="VerticalRoot.Visibility" Value="Collapsed" />
+										<Setter Target="VerticalPanningRoot.Opacity" Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+
 								<VisualState x:Name="MouseIndicator">
 									<VisualState.Setters>
 										<Setter Target="HorizontalPanningRoot.Visibility" Value="Collapsed" />
@@ -7608,6 +7643,21 @@
 										<Setter Target="VerticalThumb.Opacity" Value="1" />
 									</VisualState.Setters>
 								</VisualState>
+								<VisualState x:Name="Vertical_MouseIndicator">
+									<VisualState.Setters>
+										<Setter Target="VerticalPanningRoot.Visibility" Value="Collapsed" />
+										<Setter Target="VerticalRoot.IsHitTestVisible" Value="True" />
+										<Setter Target="VerticalThumb.Opacity" Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="Horizontal_MouseIndicator">
+									<VisualState.Setters>
+										<Setter Target="HorizontalPanningRoot.Visibility" Value="Collapsed" />
+										<Setter Target="HorizontalRoot.IsHitTestVisible" Value="True" />
+										<Setter Target="HorizontalThumb.Opacity" Value="1" />
+									</VisualState.Setters>
+								</VisualState>
+
 								<netstdref:VisualState x:Name="NoIndicator">
 									<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
 									<VisualState.Setters>
@@ -7635,6 +7685,40 @@
 										<Setter Target="VerticalPanningRoot.Opacity" Value="0" />
 										<Setter Target="HorizontalPanningRoot.Visibility" Value="Collapsed" />
 										<Setter Target="VerticalPanningRoot.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</netstdref:VisualState>
+								<netstdref:VisualState x:Name="Vertical_NoIndicator">
+									<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+									<VisualState.Setters>
+										<Setter Target="VerticalThumb.Background.Color" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
+										<Setter Target="VerticalThumbTransform.ScaleX" Value="{ThemeResource SmallScrollThumbScale}" />
+										<Setter Target="VerticalThumbTransform.TranslateX" Value="{ThemeResource SmallScrollThumbOffset}" />
+										<Setter Target="VerticalSmallIncrease.Opacity" Value="0" />
+										<Setter Target="VerticalLargeIncrease.Opacity" Value="0" />
+										<Setter Target="VerticalLargeDecrease.Opacity" Value="0" />
+										<Setter Target="VerticalThumb.Opacity" Value="0" />
+										<Setter Target="VerticalSmallDecrease.Opacity" Value="0" />
+										<Setter Target="VerticalTrackRect.Opacity" Value="0" />
+										<Setter Target="VerticalRoot.Visibility" Value="Collapsed" />
+										<Setter Target="VerticalPanningRoot.Opacity" Value="0" />
+										<Setter Target="VerticalPanningRoot.Visibility" Value="Collapsed" />
+									</VisualState.Setters>
+								</netstdref:VisualState>
+								<netstdref:VisualState x:Name="Horizontal_NoIndicator">
+									<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+									<VisualState.Setters>
+										<Setter Target="HorizontalThumb.Background.Color" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
+										<Setter Target="HorizontalThumbTransform.ScaleY" Value="{ThemeResource SmallScrollThumbScale}" />
+										<Setter Target="HorizontalThumbTransform.TranslateY" Value="{ThemeResource SmallScrollThumbOffset}" />
+										<Setter Target="HorizontalSmallIncrease.Opacity" Value="0" />
+										<Setter Target="HorizontalLargeIncrease.Opacity" Value="0" />
+										<Setter Target="HorizontalLargeDecrease.Opacity" Value="0" />
+										<Setter Target="HorizontalThumb.Opacity" Value="0" />
+										<Setter Target="HorizontalSmallDecrease.Opacity" Value="0" />
+										<Setter Target="HorizontalTrackRect.Opacity" Value="0" />
+										<Setter Target="HorizontalRoot.Visibility" Value="Collapsed" />
+										<Setter Target="HorizontalPanningRoot.Opacity" Value="0" />
+										<Setter Target="HorizontalPanningRoot.Visibility" Value="Collapsed" />
 									</VisualState.Setters>
 								</netstdref:VisualState>
 								<not_netstdref:VisualState x:Name="NoIndicator">
@@ -7718,7 +7802,10 @@
 										</Storyboard>
 									</VisualTransition>
 								</not_netstdref:VisualStateGroup.Transitions>
+
 								<VisualState x:Name="Collapsed" />
+								<VisualState x:Name="Vertical_Collapsed" />
+								<VisualState x:Name="Horizontal_Collapsed" />
 
 								<netstdref:VisualState x:Name="Expanded">
 									<VisualState.Setters>
@@ -7741,6 +7828,42 @@
 										<Setter Target="VerticalLargeDecrease.Opacity" Value="1" />
 										<Setter Target="VerticalSmallDecrease.Opacity" Value="1" />
 										<Setter Target="VerticalTrackRect.Opacity" Value="1" />
+										<Setter Target="HorizontalSmallIncrease.Opacity" Value="1" />
+										<Setter Target="HorizontalLargeIncrease.Opacity" Value="1" />
+										<Setter Target="HorizontalLargeDecrease.Opacity" Value="1" />
+										<Setter Target="HorizontalSmallDecrease.Opacity" Value="1" />
+										<Setter Target="HorizontalTrackRect.Opacity" Value="1" />
+									</VisualState.Setters>
+								</netstdref:VisualState>
+								<netstdref:VisualState x:Name="Vertical_Expanded">
+									<VisualState.Setters>
+										<Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundPointerOver}" />
+										<Setter Target="Root.BorderBrush" Value="{ThemeResource ScrollBarBorderBrushPointerOver}" />
+										<Setter Target="VerticalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
+										<Setter Target="VerticalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
+
+										<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+										<Setter Target="VerticalThumb.Background.Color" Value="{ThemeResource ScrollBarThumbBackgroundColor}" />
+										<Setter Target="VerticalThumbTransform.ScaleX" Value="1.0" />
+										<Setter Target="VerticalThumbTransform.TranslateX" Value="0" />
+										<Setter Target="VerticalSmallIncrease.Opacity" Value="1" />
+										<Setter Target="VerticalLargeIncrease.Opacity" Value="1" />
+										<Setter Target="VerticalLargeDecrease.Opacity" Value="1" />
+										<Setter Target="VerticalSmallDecrease.Opacity" Value="1" />
+										<Setter Target="VerticalTrackRect.Opacity" Value="1" />
+									</VisualState.Setters>
+								</netstdref:VisualState>
+								<netstdref:VisualState x:Name="Horizontal_Expanded">
+									<VisualState.Setters>
+										<Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundPointerOver}" />
+										<Setter Target="Root.BorderBrush" Value="{ThemeResource ScrollBarBorderBrushPointerOver}" />
+										<Setter Target="HorizontalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
+										<Setter Target="HorizontalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
+
+										<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+										<Setter Target="HorizontalThumb.Background.Color" Value="{ThemeResource ScrollBarThumbBackgroundColor}" />
+										<Setter Target="HorizontalThumbTransform.ScaleY" Value="1.0" />
+										<Setter Target="HorizontalThumbTransform.TranslateY" Value="0" />
 										<Setter Target="HorizontalSmallIncrease.Opacity" Value="1" />
 										<Setter Target="HorizontalLargeIncrease.Opacity" Value="1" />
 										<Setter Target="HorizontalLargeDecrease.Opacity" Value="1" />
@@ -7777,6 +7900,7 @@
 										<DoubleAnimation Duration="{ThemeResource ScrollBarExpandDuration}" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalTrackRect" Storyboard.TargetProperty="Opacity" To="1" />
 									</Storyboard>
 								</not_netstdref:VisualState>
+
 								<netstdref:VisualState x:Name="ExpandedWithoutAnimation">
 									<VisualState.Setters>
 										<Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundPointerOver}" />
@@ -7804,6 +7928,42 @@
 										<Setter Target="HorizontalSmallDecrease.Opacity" Value="1" />
 										<Setter Target="HorizontalTrackRect.Opacity" Value="1" />
 
+									</VisualState.Setters>
+								</netstdref:VisualState>
+								<netstdref:VisualState x:Name="Vertical_ExpandedWithoutAnimation">
+									<VisualState.Setters>
+										<Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundPointerOver}" />
+										<Setter Target="Root.BorderBrush" Value="{ThemeResource ScrollBarBorderBrushPointerOver}" />
+										<Setter Target="VerticalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
+										<Setter Target="VerticalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
+
+										<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+										<Setter Target="VerticalThumb.Background.Color" Value="{ThemeResource ScrollBarThumbBackgroundColor}" />
+										<Setter Target="VerticalThumbTransform.ScaleX" Value="1.0" />
+										<Setter Target="VerticalThumbTransform.TranslateX" Value="0" />
+										<Setter Target="VerticalSmallIncrease.Opacity" Value="1" />
+										<Setter Target="VerticalLargeIncrease.Opacity" Value="1" />
+										<Setter Target="VerticalLargeDecrease.Opacity" Value="1" />
+										<Setter Target="VerticalSmallDecrease.Opacity" Value="1" />
+										<Setter Target="VerticalTrackRect.Opacity" Value="1" />
+									</VisualState.Setters>
+								</netstdref:VisualState>
+								<netstdref:VisualState x:Name="Horizontal_ExpandedWithoutAnimation">
+									<VisualState.Setters>
+										<Setter Target="Root.Background" Value="{ThemeResource ScrollBarBackgroundPointerOver}" />
+										<Setter Target="Root.BorderBrush" Value="{ThemeResource ScrollBarBorderBrushPointerOver}" />
+										<Setter Target="HorizontalTrackRect.Stroke" Value="{ThemeResource ScrollBarTrackStrokePointerOver}" />
+										<Setter Target="HorizontalTrackRect.Fill" Value="{ThemeResource ScrollBarTrackFillPointerOver}" />
+
+										<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+										<Setter Target="HorizontalThumb.Background.Color" Value="{ThemeResource ScrollBarThumbBackgroundColor}" />
+										<Setter Target="HorizontalThumbTransform.ScaleY" Value="1.0" />
+										<Setter Target="HorizontalThumbTransform.TranslateY" Value="0" />
+										<Setter Target="HorizontalSmallIncrease.Opacity" Value="1" />
+										<Setter Target="HorizontalLargeIncrease.Opacity" Value="1" />
+										<Setter Target="HorizontalLargeDecrease.Opacity" Value="1" />
+										<Setter Target="HorizontalSmallDecrease.Opacity" Value="1" />
+										<Setter Target="HorizontalTrackRect.Opacity" Value="1" />
 									</VisualState.Setters>
 								</netstdref:VisualState>
 								<not_netstdref:VisualState x:Name="ExpandedWithoutAnimation">
@@ -7837,6 +7997,7 @@
 										<DoubleAnimation Duration="0" BeginTime="{ThemeResource ScrollBarExpandBeginTime}" Storyboard.TargetName="HorizontalTrackRect" Storyboard.TargetProperty="Opacity" To="1" />
 									</Storyboard>
 								</not_netstdref:VisualState>
+
 								<netstdref:VisualState x:Name="CollapsedWithoutAnimation">
 									<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
 
@@ -7855,6 +8016,40 @@
 										<Setter Target="VerticalLargeDecrease.Opacity" Value="0" />
 										<Setter Target="VerticalSmallDecrease.Opacity" Value="0" />
 										<Setter Target="VerticalTrackRect.Opacity" Value="0" />
+										<Setter Target="HorizontalSmallIncrease.Opacity" Value="0" />
+										<Setter Target="HorizontalLargeIncrease.Opacity" Value="0" />
+										<Setter Target="HorizontalLargeDecrease.Opacity" Value="0" />
+										<Setter Target="HorizontalSmallDecrease.Opacity" Value="0" />
+										<Setter Target="HorizontalTrackRect.Opacity" Value="0" />
+									</VisualState.Setters>
+								</netstdref:VisualState>
+								<netstdref:VisualState x:Name="Vertical_CollapsedWithoutAnimation">
+									<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+
+									<!-- The storyboard below cannot be moved to a transition since transitions
+                                             will not be run by the framework when animations are disabled in the system -->
+
+									<VisualState.Setters>
+										<Setter Target="VerticalThumb.Background.Color" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
+										<Setter Target="VerticalThumbTransform.ScaleX" Value="{ThemeResource SmallScrollThumbScale}" />
+										<Setter Target="VerticalThumbTransform.TranslateX" Value="{ThemeResource SmallScrollThumbOffset}" />
+										<Setter Target="VerticalSmallIncrease.Opacity" Value="0" />
+										<Setter Target="VerticalLargeIncrease.Opacity" Value="0" />
+										<Setter Target="VerticalLargeDecrease.Opacity" Value="0" />
+										<Setter Target="VerticalSmallDecrease.Opacity" Value="0" />
+										<Setter Target="VerticalTrackRect.Opacity" Value="0" />
+									</VisualState.Setters>
+								</netstdref:VisualState>
+								<netstdref:VisualState x:Name="Horizontal_CollapsedWithoutAnimation">
+									<!-- Animations are disbaled on WASM : https://github.com/unoplatform/uno/issues/3378 -->
+
+									<!-- The storyboard below cannot be moved to a transition since transitions
+                                             will not be run by the framework when animations are disabled in the system -->
+
+									<VisualState.Setters>
+										<Setter Target="HorizontalThumb.Background.Color" Value="{ThemeResource ScrollBarPanningThumbBackgroundColor}" />
+										<Setter Target="HorizontalThumbTransform.ScaleY" Value="{ThemeResource SmallScrollThumbScale}" />
+										<Setter Target="HorizontalThumbTransform.TranslateY" Value="{ThemeResource SmallScrollThumbOffset}" />
 										<Setter Target="HorizontalSmallIncrease.Opacity" Value="0" />
 										<Setter Target="HorizontalLargeIncrease.Opacity" Value="0" />
 										<Setter Target="HorizontalLargeDecrease.Opacity" Value="0" />
@@ -7889,7 +8084,7 @@
 							</VisualStateGroup>
 
 						</VisualStateManager.VisualStateGroups>
-						<Grid x:Name="HorizontalRoot" x:Load="False" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" IsHitTestVisible="False">
+						<Grid x:Name="HorizontalRoot" x:Load="False" Visibility="Collapsed" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" IsHitTestVisible="False">
 
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="Auto" />
@@ -7913,7 +8108,7 @@
 							<Border x:Name="HorizontalPanningThumb" VerticalAlignment="Bottom" HorizontalAlignment="Left" Background="{ThemeResource ScrollBarPanningThumbBackground}" BorderThickness="0" Height="2" MinWidth="32" Margin="0,2,0,2" />
 
 						</Grid>
-						<Grid x:Name="VerticalRoot" x:Load="False" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" IsHitTestVisible="False">
+						<Grid x:Name="VerticalRoot" x:Load="False" Visibility="Collapsed" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" IsHitTestVisible="False">
 
 							<Grid.RowDefinitions>
 								<RowDefinition Height="Auto" />

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -7628,8 +7628,8 @@
 								</VisualState>
 								<VisualState x:Name="Horizontal_TouchIndicator">
 									<VisualState.Setters>
-										<Setter Target="VerticalRoot.Visibility" Value="Collapsed" />
-										<Setter Target="VerticalPanningRoot.Opacity" Value="1" />
+										<Setter Target="HorizontalRoot.Visibility" Value="Collapsed" />
+										<Setter Target="HorizontalPanningRoot.Opacity" Value="1" />
 									</VisualState.Setters>
 								</VisualState>
 

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -7889,7 +7889,7 @@
 							</VisualStateGroup>
 
 						</VisualStateManager.VisualStateGroups>
-						<Grid x:Name="HorizontalRoot" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" IsHitTestVisible="False">
+						<Grid x:Name="HorizontalRoot" x:Load="False" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" IsHitTestVisible="False">
 
 							<Grid.ColumnDefinitions>
 								<ColumnDefinition Width="Auto" />
@@ -7909,11 +7909,11 @@
 							<RepeatButton x:Name="HorizontalLargeIncrease" Opacity="0" Grid.Column="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsTabStop="False" Interval="50" AllowFocusOnInteraction="False" Template="{StaticResource XamlDefaultScrollBar_RepeatButtonTemplate}" />
 							<RepeatButton x:Name="HorizontalSmallIncrease" Opacity="0" Grid.Column="4" MinHeight="{ThemeResource ScrollBarSize}" IsTabStop="False" Interval="50" Margin="0" Template="{StaticResource XamlDefaultScrollBar_HorizontalIncrementTemplate}" Width="{ThemeResource ScrollBarSize}" AllowFocusOnInteraction="False" VerticalAlignment="Center" />
 						</Grid>
-						<Grid x:Name="HorizontalPanningRoot" MinWidth="24" Visibility="Collapsed" Opacity="0">
+						<Grid x:Name="HorizontalPanningRoot" x:Load="False" MinWidth="24" Visibility="Collapsed" Opacity="0">
 							<Border x:Name="HorizontalPanningThumb" VerticalAlignment="Bottom" HorizontalAlignment="Left" Background="{ThemeResource ScrollBarPanningThumbBackground}" BorderThickness="0" Height="2" MinWidth="32" Margin="0,2,0,2" />
 
 						</Grid>
-						<Grid x:Name="VerticalRoot" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" IsHitTestVisible="False">
+						<Grid x:Name="VerticalRoot" x:Load="False" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" IsHitTestVisible="False">
 
 							<Grid.RowDefinitions>
 								<RowDefinition Height="Auto" />
@@ -7933,7 +7933,7 @@
 							<RepeatButton x:Name="VerticalLargeIncrease" Opacity="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsTabStop="False" Interval="50" Grid.Row="3" AllowFocusOnInteraction="False" Template="{StaticResource XamlDefaultScrollBar_RepeatButtonTemplate}" />
 							<RepeatButton x:Name="VerticalSmallIncrease" Opacity="0" Height="{ThemeResource ScrollBarSize}" MinWidth="{ThemeResource ScrollBarSize}" IsTabStop="False" Interval="50" Margin="0" Grid.Row="4" Template="{StaticResource XamlDefaultScrollBar_VerticalIncrementTemplate}" HorizontalAlignment="Center" />
 						</Grid>
-						<Grid x:Name="VerticalPanningRoot" MinHeight="24" Visibility="Collapsed" Opacity="0">
+						<Grid x:Name="VerticalPanningRoot" x:Load="False" MinHeight="24" Visibility="Collapsed" Opacity="0">
 							<Border x:Name="VerticalPanningThumb" VerticalAlignment="Top" HorizontalAlignment="Right" Background="{ThemeResource ScrollBarPanningThumbBackground}" BorderThickness="0" Width="2" MinHeight="32" Margin="2,0,2,0" />
 						</Grid>
 					</Grid>


### PR DESCRIPTION
GitHub Issue: fixes #4323 

## Performance / Bugfix
* Improve performance of the `ScrollViewer` by deferring the load of is managed scrollbars, and by loading only partially the template of the `ScrollBar`
* Fix regression introduced by https://github.com/unoplatform/uno/pull/4270 which broke hit testing (used by pointers) when in a `ScrollViewer` with a non zero `<horizontal|Vertical>Offset`.

## What is the current behavior?
Too slow 🐢

## What is the new behavior?
Faster 🐇

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

