### PR TITLE
Adjust x:Load behavior to not require visibility binding

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4990,6 +4990,19 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									BuildComplexPropertyValue(innerWriter, def, closureName + ".", closureName);
 								}
 
+								if (nameMember != null)
+								{
+									innerWriter.AppendLineInvariant(
+										$"{closureName}.Name = \"{nameMember.Value}\";"
+									);
+
+									// Set the element name to the stub, then when the stub will be replaced
+									// the actual target control will override it.
+									innerWriter.AppendLineInvariant(
+										$"_{nameMember.Value}Subject.ElementInstance = {closureName};"
+									);
+								}
+
 								if (hasVisibilityMarkup)
 								{
 									var def = new XamlMemberDefinition(
@@ -5030,19 +5043,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 											"{0}.Visibility = {1};",
 											closureName,
 											BuildLiteralValue(visibilityMember)
-										);
-									}
-
-									if (nameMember != null)
-									{
-										innerWriter.AppendLineInvariant(
-											$"{closureName}.Name = \"{nameMember.Value}\";"
-										);
-
-										// Set the element name to the stub, then when the stub will be replaced
-										// the actual target control will override it.
-										innerWriter.AppendLineInvariant(
-											$"_{nameMember.Value}Subject.ElementInstance = {closureName};"
 										);
 									}
 								}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1572,7 +1572,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private bool HasMarkupExtension(XamlMemberDefinition valueNode)
 		{
 			// Return false if the Owner is a custom markup extension
-			if (IsCustomMarkupExtensionType(valueNode.Owner?.Type))
+			if (valueNode == null || IsCustomMarkupExtensionType(valueNode.Owner?.Type))
 			{
 				return false;
 			}
@@ -4953,10 +4953,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					return null;
 				}
 
-				if (visibilityMember != null)
+				if (visibilityMember != null || loadElement?.Value != null)
 				{
 					var hasVisibilityMarkup = HasMarkupExtension(visibilityMember);
-					var isLiteralVisible = !hasVisibilityMarkup && (visibilityMember.Value?.ToString() == "Visible");
+					var isLiteralVisible = !hasVisibilityMarkup && (visibilityMember?.Value?.ToString() == "Visible");
 
 					var hasDataContextMarkup = dataContextMember != null && HasMarkupExtension(dataContextMember);
 
@@ -5024,11 +5024,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								}
 								else
 								{
-									innerWriter.AppendLineInvariant(
-										"{0}.Visibility = {1};",
-										closureName,
-										BuildLiteralValue(visibilityMember)
-									);
+									if (visibilityMember != null)
+									{
+										innerWriter.AppendLineInvariant(
+											"{0}.Visibility = {1};",
+											closureName,
+											BuildLiteralValue(visibilityMember)
+										);
+									}
 
 									if (nameMember != null)
 									{

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_StaticCollapsed.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_StaticCollapsed.xaml
@@ -1,0 +1,13 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad_Deferred_StaticCollapsed"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+		<Border x:Name="border6" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="Collapsed" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_StaticCollapsed.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_StaticCollapsed.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_Deferred_StaticCollapsed : UserControl
+	{
+		public When_xLoad_Deferred_StaticCollapsed()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_VisibilityBinding.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_VisibilityBinding.xaml
@@ -1,0 +1,13 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad_Deferred_VisibilityBinding"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+		<Border x:Name="border7" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="{Binding ., FallbackValue=Collapsed,TargetNullValue=Collapsed}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_VisibilityBinding.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_VisibilityBinding.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_Deferred_VisibilityBinding : UserControl
+	{
+		public When_xLoad_Deferred_VisibilityBinding()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_VisibilityxBind.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_VisibilityxBind.xaml
@@ -1,0 +1,13 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad_Deferred_VisibilityxBind"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+		<Border x:Name="border8" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="{x:Bind MyVisibility, Mode=OneWay}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_VisibilityxBind.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Deferred_VisibilityxBind.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_Deferred_VisibilityxBind : UserControl
+	{
+		public When_xLoad_Deferred_VisibilityxBind()
+		{
+			this.InitializeComponent();
+		}
+
+		public bool MyVisibility
+		{
+			get { return (bool)GetValue(MyVisibilityProperty); }
+			set { SetValue(MyVisibilityProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for MyVisibility.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyVisibilityProperty =
+			DependencyProperty.Register("MyVisibility", typeof(bool), typeof(When_xLoad_Deferred_VisibilityxBind), new PropertyMetadata(false));
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_LoadSingle.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_LoadSingle.xaml
@@ -1,0 +1,13 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad_LoadSingle"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+		<Border x:Name="border1" x:FieldModifier="public" x:Load="false" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_LoadSingle.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_LoadSingle.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_LoadSingle : UserControl
+	{
+		public When_xLoad_LoadSingle()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Multiple.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Multiple.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+		<Border x:Name="border1" x:FieldModifier="public" x:Load="false" />
+		<Border x:Name="border2" x:FieldModifier="public" x:Load="false" />
+		<Border x:Name="border3" x:FieldModifier="public" x:Load="false" />
+		<Border x:Name="border4" x:FieldModifier="public" x:Load="false" />
+		<Border x:Name="border5" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" />
+		<Border x:Name="border6" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="Collapsed" />
+		<Border x:Name="border7" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="{Binding ., FallbackValue=Collapsed,TargetNullValue=Collapsed}" />
+		<Border x:Name="border8" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="{x:Bind MyVisibility, Mode=OneWay}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Multiple.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Multiple.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad : UserControl
+	{
+		public When_xLoad()
+		{
+			this.InitializeComponent();
+		}
+
+		public bool MyVisibility
+		{
+			get { return (bool)GetValue(MyVisibilityProperty); }
+			set { SetValue(MyVisibilityProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for MyVisibility.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyVisibilityProperty =
+			DependencyProperty.Register("MyVisibility", typeof(bool), typeof(When_xLoad), new PropertyMetadata(false));
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Tests.App.Xaml;
+using Uno.UI.Tests.Helpers;
+using Uno.UI.Tests.Windows_UI_Xaml.Controls;
+using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Uno.UI.Extensions;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_xLoad
+	{
+		[TestInitialize]
+		public void Init()
+		{
+			UnitTestsApp.App.EnsureApplication();
+		}
+
+		[TestMethod]
+		public void When_xLoad_Multiple()
+		{
+			var SUT = new When_xLoad();
+
+			var stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+
+			Assert.AreEqual(7, stubs.Count());
+		}
+
+		[TestMethod]
+		public void When_xLoad_LoadSingle()
+		{
+			var SUT = new When_xLoad_LoadSingle();
+
+			var stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+			Assert.AreEqual(1, stubs.Count());
+
+			Assert.IsNull(SUT.border1);
+
+			var border1 = SUT.FindName("border1");
+			Assert.AreEqual(SUT.border1, border1);
+		}
+
+		[TestMethod]
+		public void When_xLoad_Deferred_StaticCollapsed()
+		{
+			var SUT = new When_xLoad_Deferred_StaticCollapsed();
+
+			var stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+			Assert.AreEqual(1, stubs.Count());
+
+			Assert.IsNull(SUT.border6);
+
+			var border1 = SUT.FindName("border6");
+			Assert.AreEqual(SUT.border6, border1);
+		}
+
+		[TestMethod]
+		public void When_xLoad_Deferred_VisibilityBinding()
+		{
+			var SUT = new When_xLoad_Deferred_VisibilityBinding();
+			SUT.ForceLoaded();
+
+			var stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+			Assert.AreEqual(1, stubs.Count());
+
+			Assert.IsNull(SUT.border7);
+
+			SUT.DataContext = true;
+
+			Assert.IsNotNull(SUT.border7);
+
+			var border = SUT.FindName("border7");
+			Assert.AreEqual(SUT.border7, border);
+		}
+
+		[TestMethod]
+		public void When_xLoad_Deferred_VisibilityxBind()
+		{
+			var SUT = new When_xLoad_Deferred_VisibilityxBind();
+			SUT.ForceLoaded();
+			SUT.Measure(new Size(42, 42));
+
+			var stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+			Assert.AreEqual(1, stubs.Count());
+
+			Assert.IsNull(SUT.border8);
+
+			SUT.MyVisibility = true;
+			SUT.Measure(new Size(42, 42));
+
+			Assert.IsNotNull(SUT.border8);
+
+			var border1 = SUT.FindName("border8");
+			Assert.AreEqual(SUT.border8, border1);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.net.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.net.cs
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml
 				OnPostLoading();
 				OnLoaded();
 
-				foreach (var child in _children.OfType<FrameworkElement>())
+				foreach (var child in _children.OfType<FrameworkElement>().ToArray())
 				{
 					child.IsLoaded = IsLoaded;
 					child.EnterTree();


### PR DESCRIPTION
GitHub Issue (If applicable): #4323

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Using `x:Load` requries the use of a visibility binding, which is not in line with the original WinUI behavior.

## What is the new behavior?

`x:Load` can be used along with an `x:Name` to be materialized on call to `FindName`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
