### PR TITLE
docs: dotnet Uno in ArchLinux

### DIFF
--- a/doc/articles/get-started-with-linux.md
+++ b/doc/articles/get-started-with-linux.md
@@ -85,7 +85,7 @@ Now let's run the application:
     ```bash
     pacman -Syu
     ```
-- install the necessary dependencies
+- Install the necessary dependencies
     ```bash
     sudo pacman -S gtk3 dotnet-targeting-pack dotnet-sdk dotnet-host dotnet-runtime mono python mono-msbuild ninja gn aspnet-runtime 
     ```

--- a/doc/articles/get-started-with-linux.md
+++ b/doc/articles/get-started-with-linux.md
@@ -77,3 +77,46 @@ Now let's run the application:
     cd MyUnoApp.Skia.Gtk
     dotnet run
     ```
+    
+    
+    
+Using ArchLinux 5.8.14 or later / Manjaro:
+- update system and packages
+    ```bash
+    pacman -Syu
+    ```
+- install the necessary dependencies
+    ```bash
+    sudo pacman -S gtk3 dotnet-targeting-pack dotnet-sdk dotnet-host dotnet-runtime mono python mono-msbuild ninja gn aspnet-runtime 
+    ```
+- Install the `dotnet new` templates:
+    ```bash
+    dotnet new -i Uno.ProjectTemplates.Dotnet::3.1-dev*
+    ```
+- Then create a new project using:
+    ```bash
+    dotnet new unoapp -o MyUnoApp
+    ```
+
+Now let's run the application:
+- Open the folder created by `dotnet new`
+- In the terminal, build and run the application:
+    ```bash
+    cd MyUnoApp.Skia.Gtk
+    dotnet run
+    ```
+Now let's try wasm
+    ```bash
+    cd .. 
+    cd MyUnoApp.Wasm
+    dotnet run
+    ```
+    
+turns on the browser and type
+```
+http://localhost:5000/
+```  
+    
+    
+    
+ 

--- a/doc/articles/get-started-with-linux.md
+++ b/doc/articles/get-started-with-linux.md
@@ -80,7 +80,7 @@ Now let's run the application:
     
     
     
-Using ArchLinux 5.8.14 or later / Manjaro:
+## Setting up for ArchLinux 5.8.14 or later / Manjaro:
 - update system and packages
     ```bash
     pacman -Syu

--- a/doc/articles/get-started-with-linux.md
+++ b/doc/articles/get-started-with-linux.md
@@ -116,7 +116,3 @@ turns on the browser and type
 ```
 http://localhost:5000/
 ```  
-    
-    
-    
- 

--- a/doc/articles/get-started-with-linux.md
+++ b/doc/articles/get-started-with-linux.md
@@ -98,7 +98,7 @@ Now let's run the application:
     dotnet new unoapp -o MyUnoApp
     ```
 
-Now let's run the application:
+Run the GTK based application:
 - Open the folder created by `dotnet new`
 - In the terminal, build and run the application:
     ```bash

--- a/doc/articles/get-started-with-linux.md
+++ b/doc/articles/get-started-with-linux.md
@@ -81,7 +81,7 @@ Now let's run the application:
     
     
 ## Setting up for ArchLinux 5.8.14 or later / Manjaro:
-- update system and packages
+- Update system and packages
     ```bash
     pacman -Syu
     ```

--- a/doc/articles/get-started-with-linux.md
+++ b/doc/articles/get-started-with-linux.md
@@ -105,7 +105,7 @@ Now let's run the application:
     cd MyUnoApp.Skia.Gtk
     dotnet run
     ```
-Now let's try wasm
+Run the WebAssembly head with:
     ```bash
     cd .. 
     cd MyUnoApp.Wasm


### PR DESCRIPTION
ArchLinux and other distributions that are based on archlinux: Manjaro. A way to install the necessary dependencies to run uno.