### PR TITLE
feat(wasm): added a font-face override for Segoe to add some cross-pl…

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/Wasm/WasmCSS/Fonts.css
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Wasm/WasmCSS/Fonts.css
@@ -19,3 +19,9 @@ body::before {
   pointer-events: none;
   position: absolute;
 }
+
+/* https://github.com/unoplatform/uno/issues/4304 */
+@font-face {
+  font-family: 'Segoe UI';
+  src: local('system-ui'), local('Segoe UI'), local('-apple-system'), local('BlinkMacSystemFont'), local('Inter'), local('Cantarell'), local('Ubuntu'), local('Roboto'), local('Open Sans'), local('Noto Sans'), local('Helvetica Neue'), local('sans-serif');
+}


### PR DESCRIPTION
…atform font consistency

GitHub Issue (If applicable): closes #4304

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Segoe is not supported on macos, ios or linux, where Segoe gets replaced by a serif font. (See #4304 for more details)

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Adding multiple fallback fonts in case segoe is not available on the system.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->
Should note that we may want to revert this and add an actual cross-platform font once we add support for #4228  