### PR TITLE
feat: Add SelectionMode enum

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SelectionMode.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SelectionMode.cs
@@ -2,19 +2,19 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum SelectionMode 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Single,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Multiple,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Extended,
 		#endif
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/SelectionMode.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SelectionMode.cs
@@ -1,0 +1,23 @@
+namespace Windows.UI.Xaml.Controls
+{
+	/// <summary>
+	/// Defines values used to specify how items can be selected.
+	/// </summary>
+	public enum SelectionMode 
+	{
+		/// <summary>
+		/// Only a single item can be selected.
+		/// </summary>
+		Single,
+
+		/// <summary>
+		/// Multiple items can be selected (no special mode required).
+		/// </summary>
+		Multiple,
+
+		/// <summary>
+		/// Multiple items can be selected within a special mode (such as with a modifier key).
+		/// </summary>
+		Extended
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #

None

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Windows.UI.Xaml.Controls.SelectionMode is not implemented.

## What is the new behavior?

Windows.UI.Xaml.Controls.SelectionMode is implemented. This is needed for some custom controls in an Uno app that use this enum.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~Docs have been added/updated which fit [documentation template]~(https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~
- [ ] ~Validated PR `Screenshots Compare Test Run` results.~
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
