### PR TITLE
fix(shapes): Invalid shape positioning for 1px thickness

### DIFF
--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.layout.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.layout.cs
@@ -221,7 +221,6 @@ namespace Windows.UI.Xaml.Shapes
 			var userSize = GetUserSizes();
 			var (userMinSize, userMaxSize) = GetMinMax(userSize);
 			var strokeThickness = StrokeThickness;
-			var halfStrokeThickness = GetHalfStrokeThickness();
 			var pathBounds = GetPathBoundingBox(path); // The BoundingBox does also contains bezier anchors even if out of geometry
 			var pathSize = (Size)pathBounds.Size;
 
@@ -242,6 +241,7 @@ namespace Windows.UI.Xaml.Shapes
 			{
 				default:
 				case Stretch.None:
+					var alignedHalfStrokeThickness = GetAlignedHalfStrokeThickness();
 					// If stretch is None, we have to keep the origin defined by the absolute coordinates of the path:
 					//
 					// This means that if you draw a line from 50,50 to 100,100 (so it's not starting at 0, 0),
@@ -267,8 +267,8 @@ namespace Windows.UI.Xaml.Shapes
 					// Note: The logic would say to include the full StrokeThickness as it will "overflow" half on booth side of the path,
 					//		 but WinUI does include only the half of it.
 					var pathNaturalSize = new Size(
-						pathBounds.X == 0 ? pathBounds.Width + strokeThickness : pathBounds.Right + halfStrokeThickness,
-						pathBounds.Y == 0 ? pathBounds.Height + strokeThickness : pathBounds.Bottom + halfStrokeThickness);
+						pathBounds.X == 0 ? pathBounds.Width + strokeThickness : pathBounds.Right + alignedHalfStrokeThickness,
+						pathBounds.Y == 0 ? pathBounds.Height + strokeThickness : pathBounds.Bottom + alignedHalfStrokeThickness);
 					size = pathNaturalSize.AtMost(userMaxSize).AtLeast(userMinSize); // The size defined on the Shape has priority over the size of the geometry itself!
 					break;
 
@@ -336,7 +336,7 @@ namespace Windows.UI.Xaml.Shapes
 			var stretch = Stretch;
 			var userSize = GetUserSizes();
 			var strokeThickness = StrokeThickness;
-			var halfStrokeThickness = GetHalfStrokeThickness();
+			var halfStrokeThickness = strokeThickness / 2.0;
 			var pathBounds = GetPathBoundingBox(path); // The BoundingBox does also contains bezier anchors even if out of geometry
 			var pathSize = (Size)pathBounds.Size;
 
@@ -357,9 +357,10 @@ namespace Windows.UI.Xaml.Shapes
 			{
 				default:
 				case Stretch.None:
+					var alignedHalfStrokeThickness = GetAlignedHalfStrokeThickness();
 					var pathNaturalSize = new Size(
-						pathBounds.X == 0 ? pathBounds.Width + strokeThickness : pathBounds.Right + halfStrokeThickness,
-						pathBounds.Y == 0 ? pathBounds.Height + strokeThickness : pathBounds.Bottom + halfStrokeThickness);
+						pathBounds.X == 0 ? pathBounds.Width + strokeThickness : pathBounds.Right + alignedHalfStrokeThickness,
+						pathBounds.Y == 0 ? pathBounds.Height + strokeThickness : pathBounds.Bottom + alignedHalfStrokeThickness);
 					var (userMinSize, userMaxSize) = GetMinMax(userSize);
 
 					var clampedSize = pathNaturalSize.AtMost(userMaxSize).AtLeast(userMinSize); // The size defined on the Shape has priority over the size of the geometry itself!
@@ -550,7 +551,7 @@ namespace Windows.UI.Xaml.Shapes
 		/// <summary>
 		/// Gets the rounded/adjusted half stroke thickness that should be used for measuring absolute shapes (Path, Line, Polyline and Polygon)
 		/// </summary>
-		private double GetHalfStrokeThickness()
+		private double GetAlignedHalfStrokeThickness()
 			=> Math.Floor((ActualStrokeThickness + .5) / 2.0);
 
 		private


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/nventive-private/issues/39

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Shapes using 1px thickness may get an invalid origin and get clipped.

## What is the new behavior?

Shapes are not clipped.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
