### PR TITLE
fix(webassembly): [WASM] remove UTF8 BOM for CSS fonts file

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3066,7 +3066,7 @@
 			<!-- End Skia Import -->
 		</Fields>
 	</IgnoreSet>
-	<IgnoreSet baseVersion="3.0.17">
+	<IgnoreSet baseVersion="3.1.6">
 		<Types>
 			<Member 
 				fullName="Windows.Storage.StorageItem"

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Wasm/WasmCSS/Fonts.css
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Wasm/WasmCSS/Fonts.css
@@ -1,4 +1,4 @@
-﻿/**
+/**
   When adding fonts here, make sure to add them using a base64 data uri, otherwise
   fonts loading are delayed, and text may get displayed incorrectly.
 */

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoXFQuickStart.Wasm/WasmCSS/Fonts.css
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoXFQuickStart.Wasm/WasmCSS/Fonts.css
@@ -1,4 +1,4 @@
-﻿/**
+/**
   When adding fonts here, make sure to add them using a base64 data uri, otherwise
   fonts loading are delayed, and text may get displayed incorrectly.
 */

--- a/src/SolutionTemplate/UnoSolutionTemplate/Wasm/WasmCSS/Fonts.css
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Wasm/WasmCSS/Fonts.css
@@ -1,4 +1,4 @@
-﻿/**
+/**
   When adding fonts here, make sure to add them using a base64 data uri, otherwise
   fonts loading are delayed, and text may get displayed incorrectly.
 */


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The Font.css file is silently ignored by the browser if the UTF8 BOM is present and the file is not specified as UT8.

## What is the new behavior?

The file is loaded properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
