### PR TITLE
fix(skia): Fix symbols font is not registered

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
@@ -9,6 +9,7 @@
 	<ItemGroup Condition="exists('..\$ext_safeprojectname$.UWP')">
 		<EmbeddedResource Include="..\$ext_safeprojectname$.UWP\Package.appxmanifest" LogicalName="Package.appxmanifest" />
 		<Content Include="..\$ext_safeprojectname$.UWP\Assets\StoreLogo.png" Link="Assets\StoreLogo.png" />
+		<Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.WPF.Host/UnoQuickStart.Skia.Wpf.Host.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.WPF.Host/UnoQuickStart.Skia.Wpf.Host.csproj
@@ -12,7 +12,11 @@
     <PackageReference Include="Uno.UI.RemoteControl" Version="3.1.0-dev.568" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
 
-  <ItemGroup>
+	<ItemGroup>
+		<Content Include="Assets\Fonts\uno-fluentui-assets.ttf" />
+	</ItemGroup>
+
+	<ItemGroup>
     <ProjectReference Include="..\$ext_safeprojectname$.Skia.WPF\$ext_safeprojectname$.Skia.WPF.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

`dotnet new` experience does not include the symbol assets properly.

## What is the new behavior?

Symbols are working properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
