### PR TITLE
DO NOT MERGE fix!: Adjust Loading, DataContextChanged event types to match UWP

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
@@ -542,7 +542,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 					private readonly static IEventProvider _binderTrace = Tracing.Get(DependencyObjectStore.TraceProvider.Id);
 					private BinderReferenceHolder _refHolder;
 
-					public event Windows.Foundation.TypedEventHandler<DependencyObject, DataContextChangedEventArgs> DataContextChanged;
+					public event Windows.Foundation.TypedEventHandler<FrameworkElement, DataContextChangedEventArgs> DataContextChanged;
 
 					partial void InitializeBinder();
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Skia.cs
@@ -228,8 +228,8 @@ namespace Windows.UI.Xaml
 			OnGenericPropertyUpdatedPartial(args);
 		}
 
-		private event RoutedEventHandler _loading;
-		public event RoutedEventHandler Loading
+		private event TypedEventHandler<FrameworkElement, object> _loading;
+		public event TypedEventHandler<FrameworkElement, object> Loading
 		{
 			add
 			{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.netstdref.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.netstdref.cs
@@ -57,10 +57,10 @@ namespace Windows.UI.Xaml
 		private protected virtual double GetActualHeight() => throw new NotSupportedException("Reference assembly");
 
 #pragma warning disable 67
-		private event RoutedEventHandler _loading;
+		private event TypedEventHandler<FrameworkElement, object> _loading;
 		private event RoutedEventHandler _loaded;
 		private event RoutedEventHandler _unloaded;
-		public event RoutedEventHandler Loading;
+		public event TypedEventHandler<FrameworkElement, object> Loading;
 		public event RoutedEventHandler Loaded;
 		public event RoutedEventHandler Unloaded;
 #pragma warning restore 67

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
@@ -113,8 +113,8 @@ namespace Windows.UI.Xaml
 
 		partial void OnGenericPropertyUpdatedPartial(DependencyPropertyChangedEventArgs args);
 
-		private event RoutedEventHandler _loading;
-		public event RoutedEventHandler Loading
+		private event TypedEventHandler<FrameworkElement, object> _loading;
+		public event TypedEventHandler<FrameworkElement, object> Loading
 		{
 			add
 			{

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -44,7 +44,7 @@ namespace <#= mixin.NamespaceName #>
 
 		public event DependencyPropertyChangedEventHandler IsEnabledChanged;
 
-		public event TypedEventHandler<DependencyObject, object> Loading;
+		public event TypedEventHandler<FrameworkElement, object> Loading;
 
 		public event RoutedEventHandler Loaded;
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -147,7 +147,7 @@ namespace <#= mixin.NamespaceName #>
 			}
 		}
 
-		public event TypedEventHandler<DependencyObject, object> Loading;
+		public event TypedEventHandler<FrameworkElement, object> Loading;
 
 		public event RoutedEventHandler Loaded;
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
@@ -142,7 +142,7 @@ namespace <#= mixin.NamespaceName #>
 			}
 		}
 
-		public event TypedEventHandler<DependencyObject, object> Loading;
+		public event TypedEventHandler<FrameworkElement, object> Loading;
 
 		public event RoutedEventHandler Loaded;
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #2870

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The event types don't match UWP.

## What is the new behavior?

Match UWP.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

**Although this is a breaking change, existing Uno apps must already use `DependencyObject` as sender for both changed events, which will continue to work even after the change (as `FrameworkElement` derives from `DependencyObject`).**