### PR TITLE
fix(Pivot): Remove TabView.TabItems setter, not part of public API.

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3244,6 +3244,9 @@
 			<Member
 				fullName="System.Void Windows.UI.Xaml.DropCompletedEventArgs..ctor()"
 				reason="Not part of the UWP API"/>
+			<Member
+			  fullName="System.Void Microsoft.UI.Xaml.Controls.TabView.set_TabItems(System.Collections.Generic.IList`1&lt;System.Object&gt; value)"
+			  reason="Not part of the UWP API"/>
 		</Methods>
 		<Fields>
 			<Member

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -715,6 +715,17 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.AreEqual("Result is 42", r.Resources["myString"]);
 		}
 
+		[TestMethod]
+		public void When_IList_TabView()
+		{
+			var s = GetContent(nameof(When_IList_TabView));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			var tabView1 = r.FindName("tabView1") as Microsoft.UI.Xaml.Controls.TabView;
+
+			Assert.AreEqual(2, tabView1.TabItems.Count);
+		}
+
 		private string GetContent(string testName)
 		{
 			var assembly = this.GetType().Assembly;

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_IList_TabView.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_IList_TabView.xamltest
@@ -1,0 +1,23 @@
+﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:wux="using:Microsoft.Toolkit.Uwp.UI.Controls"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+      Name="rootPage"
+      mc:Ignorable="d">
+
+  <muxc:TabView x:Name="tabView1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+	<muxc:TabViewItem Header="Home" IsClosable="False">
+	  <muxc:TabViewItem.IconSource>
+		<muxc:SymbolIconSource Symbol="Home" />
+	  </muxc:TabViewItem.IconSource>
+	</muxc:TabViewItem>
+	<muxc:TabViewItem Header="Document 1">
+	  <muxc:TabViewItem.IconSource>
+		<muxc:SymbolIconSource Symbol="Document" />
+	  </muxc:TabViewItem.IconSource>
+	</muxc:TabViewItem>
+  </muxc:TabView>
+
+</Page>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.Properties.cs
@@ -111,7 +111,7 @@ namespace Microsoft.UI.Xaml.Controls
 		public IList<object> TabItems
 		{
 			get => (IList<object>)GetValue(TabItemsProperty);
-			set => SetValue(TabItemsProperty, value);
+			private set => SetValue(TabItemsProperty, value);
 		}
 
 		public static DependencyProperty TabItemsProperty { get; } =

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -426,7 +426,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 				}
 				else
 				{
-					throw new InvalidOperationException("Invalid collection");
+					throw new InvalidOperationException($"Unsupported collection type {propertyInfo.PropertyType} on {propertyInfo}");
 				}
 			}
 			else


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes the ability for `TabView` to use using in `XamlReader`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
