### PR TITLE
fix(LinkerFailure): Add missing AndroidX.Activity reference to avoid linker failure when using Uno.UI.BaseActivity.OnRetainCustomNonConfigurationInstance

### DIFF
--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -22,6 +22,7 @@
 		<dependency id="Xamarin.AndroidX.AppCompat" version="1.1.0" />
 		<dependency id="Xamarin.AndroidX.RecyclerView" version="1.1.0" />
 		<dependency id="Xamarin.AndroidX.Fragment" version="1.1.0" />
+		<dependency id="Xamarin.AndroidX.Activity" version="1.1.0" />
 		<dependency id="Uno.SourceGenerationTasks" version="3.0.0-dev.18" />
 		<dependency id="Uno.Core" version="2.0.0" />
 		<dependency id="Uno.Core.Build" version="2.0.0" />
@@ -33,6 +34,7 @@
 		<dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0" />
 		<dependency id="Xamarin.AndroidX.AppCompat" version="1.1.0" />
 		<dependency id="Xamarin.AndroidX.RecyclerView" version="1.1.0" />
+		<dependency id="Xamarin.AndroidX.Activity" version="1.1.0" />
 		<dependency id="Uno.SourceGenerationTasks" version="3.0.0-dev.18" />
 		<dependency id="Uno.Core" version="2.0.0" />
 		<dependency id="Uno.Core.Build" version="2.0.0" />


### PR DESCRIPTION
GitHub Issue (If applicable): #4307 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When using Uno.UI.BaseActivity::OnRetainCustomNonConfigurationInstance, the linker mail fail with the following error:

> error XALNK7000: Mono.Linker.MarkException: Error processing method:
> 'Java.Lang.Object Uno.UI.BaseActivity::OnRetainCustomNonConfigurationInstance()' in assembly: 'Uno.UI.dll' 
> ---> Mono.Cecil.ResolutionException: Failed to resolve Java.Lang.Object AndroidX.Activity.ComponentActivity::OnRetainCustomNonConfigurationInstance() 


## What is the new behavior?

Added workaround by adding an explicit reference to the Xamarin.AndroidX.Activity package for Android.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
