### PR TITLE
feat: Add NavigationViewPaneDisplayMode enum

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/NavigationViewPaneDisplayMode.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/NavigationViewPaneDisplayMode.cs
@@ -2,25 +2,25 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum NavigationViewPaneDisplayMode 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Auto,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Left,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Top,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		LeftCompact,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		LeftMinimal,
 		#endif
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewPaneDisplayMode.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewPaneDisplayMode.cs
@@ -1,0 +1,11 @@
+namespace Windows.UI.Xaml.Controls
+{
+	public enum NavigationViewPaneDisplayMode 
+	{
+		Auto,
+		Left,
+		Top,
+		LeftCompact,
+		LeftMinimal
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #

Relates to discussion in #4317 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

NavigationViewPaneDisplayMode enum is not implemented although modes are supported by the NavigationView

## What is the new behavior?

NavigationViewPaneDisplayMode enum is implemented.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~
- [ ] ~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~
- [ ] ~Validated PR `Screenshots Compare Test Run` results.~
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
