### PR TITLE
doc: Document prefix differences for cross target libraries.

### DIFF
--- a/doc/articles/platform-specific-xaml.md
+++ b/doc/articles/platform-specific-xaml.md
@@ -133,3 +133,15 @@ More visually, platform support for the pre-defined prefixes is shown in the bel
 Where:
  * 'Win' represents Windows, and
  * 'Droid' represents Android
+
+### XAML prefixes in cross-targeted libraries
+For Uno 3.0 and above, Xaml prefixes behave differently in class libraries than when used directly in application code. Specifically, it isn't possible to distinguish Skia and Wasm in a library, since both platforms use the .NET Standard 2.0 target. The `wasm` and `skia` prefixes will always evaluate to false inside of a library.
+
+The prefix `netstdref` is available and will include the objects or properties in both Skia and Wasm build. A prefix `not_nestdref` can also be used to exclude them. Since Skia and Wasm are similar, it is often not necessary to make the distinction. 
+
+In cases where it is needed (fonts are one example) then the XAML files must be placed directly in the platform specific project or a shared project.
+
+| Prefix          | Namespace                                                   | Put in `mc:Ignorable`? |
+|-----------------|-------------------------------------------------------------|------------------------|
+| `netstdref`     | `http:/uno.ui/netstdref`                                    | yes                    |
+| `not_netstdref` | `http:/uno.ui/not_netstdref`                                | yes                    |


### PR DESCRIPTION
GitHub Issue (If applicable): #3656

## PR Type

What kind of change does this PR introduce?
- Documentation content changes


## What is the current behavior?
The modification to the prefix was not documented

## What is the new behavior?
Now it is.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~
- [ ] ~Validated PR `Screenshots Compare Test Run` results.~
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
