### PR TITLE
fix(wasm|droid): Textblock can be constrained by maxlines

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -34,7 +34,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
-    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
     <AotAssemblies>false</AotAssemblies>
     <EnableLLVM>false</EnableLLVM>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -365,7 +365,10 @@ namespace SamplesApp
 			=> SampleControl.Presentation.SampleChooserViewModel.Instance.GetAllSamplesNames();
 
 		public static string GetDisplayScreenScaling(string displayId)
-			=> (DisplayInformation.GetForCurrentView().LogicalDpi * 100f / 96f).ToString(CultureInfo.InvariantCulture);
+		{
+			var screenScaling = Android.App.Application.Context.Resources.DisplayMetrics.Density * 100f;
+			return screenScaling.ToString(CultureInfo.InvariantCulture);
+		}
 
 		public static string RunTest(string metadataName)
 		{

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -365,10 +365,7 @@ namespace SamplesApp
 			=> SampleControl.Presentation.SampleChooserViewModel.Instance.GetAllSamplesNames();
 
 		public static string GetDisplayScreenScaling(string displayId)
-		{
-			var screenScaling = Android.App.Application.Context.Resources.DisplayMetrics.Density * 100f;
-			return screenScaling.ToString(CultureInfo.InvariantCulture);
-		}
+			=> (DisplayInformation.GetForCurrentView().LogicalDpi * 100f / 96f).ToString(CultureInfo.InvariantCulture);
 
 		public static string RunTest(string metadataName)
 		{

--- a/src/SamplesApp/SamplesApp.UITests/Constants.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Constants.cs
@@ -15,6 +15,6 @@ namespace SamplesApp.UITests
 		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";
 
 		// Default active platform when running under Visual Studio test runner
-		public const Platform CurrentPlatform = Platform.Browser;
+		public const Platform CurrentPlatform = Platform.Android;
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Constants.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Constants.cs
@@ -15,6 +15,6 @@ namespace SamplesApp.UITests
 		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";
 
 		// Default active platform when running under Visual Studio test runner
-		public const Platform CurrentPlatform = Platform.Android;
+		public const Platform CurrentPlatform = Platform.Browser;
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Extensions/AppRectExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Extensions/AppRectExtensions.cs
@@ -13,5 +13,30 @@ namespace SamplesApp.UITests
 			);
 
 		public static IAppRect UnapplyScale(this IAppRect rect, float scale) => rect.ApplyScale(1f / scale);
+
+		public static IAppRect InflateBy(this IAppRect rect, float thickness) => rect.DeflateBy(-thickness);
+
+		public static IAppRect DeflateBy(this IAppRect rect, float thickness)
+		{
+			var doubleThickness = thickness * 2f;
+			var x = rect.X + thickness;
+			var y = rect.Y + thickness;
+			var w = rect.Width - doubleThickness;
+			var h = rect.Height - doubleThickness;
+
+			if (w <= 0f)
+			{
+				x = rect.CenterX;
+				w = 0f;
+			}
+
+			if (h <= 0f)
+			{
+				y = rect.CenterY;
+				h = 0f;
+			}
+
+			return new AppRect(x, y, w, h);
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -317,24 +317,9 @@ namespace SamplesApp.UITests
 
 		internal float GetDisplayScreenScaling() => _app.GetDisplayScreenScaling();
 
-		/// <summary>
-		/// Get the center of <paramref name="rect"/> adjusted for the display scale, appropriate for screenshot analysis.
-		/// </summary>
-		protected PointF GetScaledCenter(IAppRect rect)
-		{
-			var scale = (float)GetDisplayScreenScaling();
-			return new PointF(rect.CenterX * scale, rect.CenterY * scale);
-		}
+		internal float LogicalToPhysical(float logical) => logical * GetDisplayScreenScaling();
 
-		/// <summary>
-		/// Get centre of the bounds rect of element <paramref name="elementName"/> adjusted for the display scale, appropriate for
-		/// screenshot analysis.
-		/// </summary>
-		protected PointF GetRectCenterScaled(string elementName)
-		{
-			var rect = _app.GetRect(elementName);
-			return GetScaledCenter(rect);
-		}
+		internal float PhysicalToLogical(float physical) => physical / GetDisplayScreenScaling();
 
 		protected bool GetIsCurrentRotationLandscape(string elementName)
 		{

--- a/src/SamplesApp/SamplesApp.UITests/ScreenshotInfo.cs
+++ b/src/SamplesApp/SamplesApp.UITests/ScreenshotInfo.cs
@@ -1,9 +1,13 @@
-﻿using System.IO;
+﻿#nullable enable
+using System;
+using System.Drawing;
+using System.IO;
 
 namespace SamplesApp.UITests
 {
-	public class ScreenshotInfo
+	public class ScreenshotInfo : IDisposable
 	{
+		private Bitmap? _bitmap;
 		public FileInfo File { get; }
 
 		public string StepName { get; }
@@ -17,5 +21,17 @@ namespace SamplesApp.UITests
 		public static implicit operator FileInfo(ScreenshotInfo si) => si.File;
 
 		public static implicit operator ScreenshotInfo(FileInfo fi) => new ScreenshotInfo(fi, fi.Name);
+
+		public Bitmap GetBitmap() => _bitmap ??= new Bitmap(File.FullName);
+		public void Dispose()
+		{
+			_bitmap?.Dispose();
+			_bitmap = null;
+		}
+
+		~ScreenshotInfo()
+		{
+			Dispose();
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.ElevatedView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.ElevatedView.cs
@@ -44,9 +44,9 @@ namespace SamplesApp.UITests.Toolkit
 
 			_app.WaitForElement("Elevation");
 
-			var elevationRect = _app.GetRect("Elevation");
+			var elevationRect = _app.GetPhysicalRect("Elevation");
 
-			var snapshot = this.TakeScreenshot("check", ignoreInSnapshotCompare: true);
+			using var snapshot = this.TakeScreenshot("check", ignoreInSnapshotCompare: true);
 
 			const string white = "#FFFFFF";
 			const string gray = "#A9A9A9"; // DarkGray

--- a/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.Elevation.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.Elevation.cs
@@ -35,8 +35,8 @@ namespace SamplesApp.UITests.Toolkit
 			// Take ScreenShot of with elevation
 			using var screenshot_WithElevation = TakeScreenshot("Elevation - With Elevation");
 
-			var img1 = screenshot_NoElevation.GetBitmap();
-			var img2 = screenshot_WithElevation.GetBitmap();
+			using var img1 = screenshot_NoElevation.GetBitmap();
+			using var img2 = screenshot_WithElevation.GetBitmap();
 
 			float diffPercentage = 0;
 			float diff = 0;

--- a/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.Elevation.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Toolkit/UnoSamples_Tests.Elevation.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NUnit.Framework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
@@ -18,7 +19,6 @@ namespace SamplesApp.UITests.Toolkit
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.iOS)] // Android is disabled https://github.com/unoplatform/uno/issues/1635
 		public void Elevation_Validation()
 		{
 			Run("UITests.Shared.Toolkit.Elevation");
@@ -28,15 +28,15 @@ namespace SamplesApp.UITests.Toolkit
 			var turnElevation_ON_Button = _app.Marked("TurnElevation_ON_Button");
 			
 			// Take ScreenShot with no elevation
-			var screenshot_NoElevation = TakeScreenshot("Elevation - No Elevation");
+			using var screenshot_NoElevation = TakeScreenshot("Elevation - No Elevation");
 
-			turnElevation_ON_Button.FastTap();
+			turnElevation_ON_Button.Tap();
 
 			// Take ScreenShot of with elevation
-			var screenshot_WithElevation = TakeScreenshot("Elevation - With Elevation");
+			using var screenshot_WithElevation = TakeScreenshot("Elevation - With Elevation");
 
-			Bitmap img1 = new Bitmap(screenshot_NoElevation.ToString());
-			Bitmap img2 = new Bitmap(screenshot_WithElevation.ToString());
+			var img1 = screenshot_NoElevation.GetBitmap();
+			var img2 = screenshot_WithElevation.GetBitmap();
 
 			float diffPercentage = 0;
 			float diff = 0;
@@ -61,10 +61,8 @@ namespace SamplesApp.UITests.Toolkit
 				}
 
 				diffPercentage = 100 * (diff / 255) / (img1.Width * img1.Height * 3);
-				if (diffPercentage < 0.5)
-				{
-					Assert.Fail("Images are the same");
-				}
+
+				diffPercentage.Should().BeGreaterThan(0.01f, "Before/After are too similar");
 			}
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
@@ -431,7 +431,7 @@ namespace SamplesApp.UITests
 
 			_app.WaitForElement(singleTextBox);
 
-			var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
+			using var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
 
 			singleTextBox.FastTap();
 			_app.Wait(2);
@@ -444,7 +444,7 @@ namespace SamplesApp.UITests
 			_app.Wait(3);
 			_app.Back();
 
-			var final = TakeScreenshot("final", ignoreInSnapshotCompare: true);
+			using var final = TakeScreenshot("final", ignoreInSnapshotCompare: true);
 
 			// We only validate that the bottom of the screen is the same (so the keyboard is no longer visible).
 			// This is to avoid content offset if the status bar was opened by the keyboard or the message box.

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
@@ -25,7 +25,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ClippingTests
 			var rect1 = grid1.FirstResult().Rect;
 			var rect2 = grid2.FirstResult().Rect;
 
-			var screenshot = TakeScreenshot("Clipping");
+			using var screenshot = TakeScreenshot("Clipping");
 
 			ImageAssert.HasColorAt(screenshot, rect1.Right + 8, rect1.Y + 75, Color.Blue);
 			ImageAssert.HasColorAt(screenshot, rect1.X + 75, rect1.Bottom + 8, Color.Blue);
@@ -42,16 +42,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ClippingTests
 
 			_app.WaitForElement("RoundedGrid");
 
-			var rect = _app.GetRect("RoundedGrid");
+			var rect = _app.GetPhysicalRect("RoundedGrid");
 
-			var centre = GetScaledCenter(rect);
-			var scale = GetDisplayScreenScaling();
-			var offset = 5 * (float)scale;
+			var offset = LogicalToPhysical(5);
 			var innerCornerX = rect.X + offset;
 			var innerCornerY = rect.Y + offset;
 
-			var screenshot = TakeScreenshot("ClippedCorners");
-			ImageAssert.HasColorAt(screenshot, centre.X, centre.Y, Color.Blue);
+			using var screenshot = TakeScreenshot("ClippedCorners");
+			ImageAssert.HasColorAt(screenshot, rect.X, rect.Y, Color.Blue);
 			ImageAssert.HasColorAt(screenshot, innerCornerX, innerCornerY, Color.Red);
 
 		}
@@ -64,7 +62,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ClippingTests
 
 			_app.WaitForElement("TestRoot");
 
-			var snapshot = this.TakeScreenshot("validation", ignoreInSnapshotCompare: false);
+			using var snapshot = this.TakeScreenshot("validation", ignoreInSnapshotCompare: false);
 
 			using (new AssertionScope("Rounded corners"))
 			{
@@ -86,7 +84,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ClippingTests
 
 			void CheckRoundedCorners(string s)
 			{
-				var rectCtl = _app.GetRect(s);
+				var rectCtl = _app.GetPhysicalRect(s);
 
 				var green = "#FF008000";
 				var white = "#FFFFFFFF";
@@ -126,7 +124,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ClippingTests
 
 			void CheckNoRoundedCorners(string s)
 			{
-				var rectCtl = _app.GetRect(s);
+				var rectCtl = _app.GetPhysicalRect(s);
 
 				var green = "#FF008000";
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
@@ -42,15 +42,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ClippingTests
 
 			_app.WaitForElement("RoundedGrid");
 
-			var rect = _app.GetPhysicalRect("RoundedGrid");
-
 			var offset = LogicalToPhysical(5);
-			var innerCornerX = rect.X + offset;
-			var innerCornerY = rect.Y + offset;
+			var rect = _app.GetPhysicalRect("RoundedGrid").DeflateBy(offset);
 
-			using var screenshot = TakeScreenshot("ClippedCorners");
-			ImageAssert.HasColorAt(screenshot, rect.X, rect.Y, Color.Blue);
-			ImageAssert.HasColorAt(screenshot, innerCornerX, innerCornerY, Color.Red);
+			using var screenshot = TakeScreenshot("ClippedCorners", ignoreInSnapshotCompare: true);
+			ImageAssert.HasColorAt(screenshot, rect.CenterX, rect.CenterY, Color.Blue);
+			ImageAssert.HasColorAt(screenshot, rect.X, rect.Y, Color.Red);
 
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/UIElementTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/UIElementTests.cs
@@ -45,7 +45,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml
 			_app.WaitForElement("SpacerBorder");
 			var spacerRect = _app.GetRect("SpacerBorder");
 
-			var scrn = TakeScreenshot("Ready");
+			using var scrn = TakeScreenshot("Ready");
 
 			ImageAssert.HasColorAt(scrn, spacerRect.X, spacerRect.Y, Color.Red);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BorderTests/Border_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BorderTests/Border_Tests.cs
@@ -20,13 +20,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests
 
 			_app.WaitForElement("ClippedBorder");
 
-			var before = TakeScreenshot("Before property change");
+			using var before = TakeScreenshot("Before property change");
 
 			_app.FastTap("ClippedBorder");
 
 			_app.WaitForDependencyPropertyValue(_app.Marked("ClippedBorder"), "ManipulationMode", "None");
 
-			var after = TakeScreenshot("After property change");
+			using var after = TakeScreenshot("After property change");
 
 			ImageAssert.AreEqual(before, after);
 		}
@@ -42,13 +42,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests
 
 			var verificationRect = _app.GetRect("SnapshotBorder");
 
-			var scrBefore = TakeScreenshot("No CornerRadius");
+			using var scrBefore = TakeScreenshot("No CornerRadius");
 
 			_app.FastTap("ToggleCornerRadiusButton");
 
 			_app.WaitForText("StatusTextBlock", "5");
 
-			var scrAfter = TakeScreenshot("CornerRadius=5");
+			using var scrAfter = TakeScreenshot("CornerRadius=5");
 
 			ImageAssert.AreAlmostEqual(scrBefore, scrAfter, verificationRect, permittedPixelError: 5);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CanvasTests/Canvas_Measurement_Tests.cs
@@ -4,6 +4,8 @@ using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
@@ -21,18 +23,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 			Run("SamplesApp.Windows_UI_Xaml_Controls.Canvas.Measure_Children_In_Canvas");
 
 			_app.WaitForElement("BBorderInCanvas");
-			_app.WaitForElement("BBorderOutCanvas");
 
-			var BorderInWidth = _app.Query(_app.Marked("BBorderInCanvas")).First().Rect.Width;
-			var BorderInHeight = _app.Query(_app.Marked("BBorderInCanvas")).First().Rect.Height;
+			var inRect = _app.GetLogicalRect("BBorderInCanvas");
+			var outRect = _app.GetLogicalRect("BBorderOutCanvas");
 
-			var BorderOutWidth = _app.Query(_app.Marked("BBorderOutCanvas")).First().Rect.Width;
-			var BorderOutHeight = _app.Query(_app.Marked("BBorderOutCanvas")).First().Rect.Height;
+			using var _ = new AssertionScope();
 
-			if (BorderInWidth != BorderOutWidth || BorderInHeight != BorderOutHeight)
-				Assert.Fail("Border in canvas measurement failed");
-
-			TakeScreenshot($"Measure_Children_In_Canvas - Measure Border");
+			inRect.Width.Should().Be(outRect.Width, "Border in canvas measurement failed");
+			inRect.Height.Should().Be(outRect.Height, "Border in canvas measurement failed");
 		}
 
 		[Test]
@@ -41,13 +39,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.Canvas.Canvas_With_Outer_Clip");
 
-			var screenshot = TakeScreenshot("Rendered");
+			using var screenshot = TakeScreenshot("Rendered");
 
-			var clippedLocation = _app.GetRect("LocatorBorder1");
+			var clippedLocation = _app.GetPhysicalRect("LocatorBorder1");
 
 			ImageAssert.HasColorAt(screenshot, clippedLocation.CenterX, clippedLocation.CenterY, Color.Red);
 
-			var unclippedLocation = _app.GetRect("LocatorBorder2");
+			var unclippedLocation = _app.GetPhysicalRect("LocatorBorder2");
 
 			ImageAssert.HasColorAt(screenshot, unclippedLocation.CenterX, unclippedLocation.CenterY, Color.Blue);
 		}
@@ -58,29 +56,29 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CanvasTests
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.Canvas.Canvas_ZIndex");
 
-			var screenshot = TakeScreenshot("Rendered");
+			using var screenshot = TakeScreenshot("Rendered");
 
-			var redBorderRect1 = _app.GetRect("CanvasBorderRed1");
+			var redBorderRect1 = _app.GetPhysicalRect("CanvasBorderRed1");
 			ImageAssert.HasColorAt(screenshot, redBorderRect1.CenterX, redBorderRect1.CenterY, Color.Green /*psych*/);
-			var redBorderRect2 = _app.GetRect("CanvasBorderRed2");
+			var redBorderRect2 = _app.GetPhysicalRect("CanvasBorderRed2");
 			ImageAssert.HasColorAt(screenshot, redBorderRect2.CenterX, redBorderRect2.CenterY, Color.Green /*psych*/);
 
 			if (AppInitializer.GetLocalPlatform() != Platform.Android) // Android doesn't support Canvas.ZIndex on any panel
 			{
-				var redBorderRect3 = _app.GetRect("CanvasBorderRed3");
+				var redBorderRect3 = _app.GetPhysicalRect("CanvasBorderRed3");
 				ImageAssert.HasColorAt(screenshot, redBorderRect3.CenterX, redBorderRect3.CenterY, Color.Green /*psych*/);
 			}
 
-			var greenBorderRect1 = _app.GetRect("CanvasBorderGreen1");
+			var greenBorderRect1 = _app.GetPhysicalRect("CanvasBorderGreen1");
 			ImageAssert.HasColorAt(screenshot, greenBorderRect1.CenterX, greenBorderRect1.CenterY, Color.Brown);
 			ImageAssert.HasColorAt(screenshot, greenBorderRect1.Right - 1, greenBorderRect1.CenterY, Color.Blue);
-			var greenBorderRect2 = _app.GetRect("CanvasBorderGreen2");
+			var greenBorderRect2 = _app.GetPhysicalRect("CanvasBorderGreen2");
 			ImageAssert.HasColorAt(screenshot, greenBorderRect2.CenterX, greenBorderRect2.CenterY, Color.Brown);
 			ImageAssert.HasColorAt(screenshot, greenBorderRect2.Right-1, greenBorderRect2.CenterY, Color.Blue);
 
 			if (AppInitializer.GetLocalPlatform() != Platform.Android) // Android doesn't support Canvas.ZIndex on any panel
 			{
-				var CanvasBorderGreen3 = _app.GetRect("CanvasBorderGreen3");
+				var CanvasBorderGreen3 = _app.GetPhysicalRect("CanvasBorderGreen3");
 				ImageAssert.HasColorAt(screenshot, CanvasBorderGreen3.CenterX, CanvasBorderGreen3.CenterY, Color.Brown);
 				ImageAssert.HasColorAt(screenshot, CanvasBorderGreen3.Right - 1, CanvasBorderGreen3.CenterY, Color.Blue);
 			}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/ComboxBox_DropDownPlacement.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/ComboxBox_DropDownPlacement.cs
@@ -43,26 +43,28 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ComboBox.ComboBox_DropDownPlacement", skipInitialScreenshot: true);
 
-			var sut = _app.WaitForElement(test).Single();
+			_app.WaitForElement(test);
 
-			var notOpened = TakeScreenshot("not_opened", ignoreInSnapshotCompare: true);
+			var rect = _app.GetPhysicalRect(test);
+
+			using var notOpened = TakeScreenshot("not_opened", ignoreInSnapshotCompare: true);
 
 			// Open the combo
-			_app.TapCoordinates(sut.Rect.Right - 10, sut.Rect.CenterY);
+			_app.TapCoordinates(rect.Right - 10, rect.CenterY);
 
 			// Wait for popup to open
 			_app.WaitForElement("PopupBorder");
 
-			var opened = TakeScreenshot("opened", ignoreInSnapshotCompare: true);
+			using var opened = TakeScreenshot("opened", ignoreInSnapshotCompare: true);
 
 			// Make sure to close the combo
-			_app.TapCoordinates(sut.Rect.X - 10, sut.Rect.Y - 10);
+			_app.TapCoordinates(rect.X - 10, rect.Y - 10);
 
 			// Assertions
 			const int testHeight = 50;
 			const int tolerance = 10; // Margins, etc
-			var above = new Rectangle((int)sut.Rect.X, (int)sut.Rect.Y - testHeight - tolerance, (int)sut.Rect.Width, testHeight);
-			var below = new Rectangle((int)sut.Rect.X, (int)sut.Rect.Bottom + tolerance, (int)sut.Rect.Width, testHeight);
+			var above = new Rectangle((int)rect.X, (int)rect.Y - testHeight - tolerance, (int)rect.Width, testHeight);
+			var below = new Rectangle((int)rect.X, (int)rect.Bottom + tolerance, (int)rect.Width, testHeight);
 
 			if (aboveEquals)
 			{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
@@ -65,10 +65,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 			try
 			{
-				using var firstScreenShot = TakeScreenshot("FirstOrientation");
+				var firstScreenShot = TakeScreenshot("FirstOrientation");
 
-				var firstCommandBarRect = _app.GetPhysicalRect("TheCommandBar");
-				var firstYellowBorderRect = _app.GetPhysicalRect("TheBorder");
+				var firstCommandBarRect = _app.GetRect("TheCommandBar");
+				var firstYellowBorderRect = _app.GetRect("TheBorder");
 				firstCommandBarRect.Bottom.Should().Be(firstYellowBorderRect.Y);
 
 				var firstCommandBarPhysicalRect = ToPhysicalRect(firstCommandBarRect);
@@ -84,10 +84,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 				await ToggleOrientation();
 
-				using var secondScreenShot = TakeScreenshot("SecondOrientation");
+				var secondScreenShot = TakeScreenshot("SecondOrientation");
 
-				var secondCommandBarRect = _app.GetPhysicalRect("TheCommandBar");
-				var secondYellowBorderRect = _app.GetPhysicalRect("TheBorder");
+				var secondCommandBarRect = _app.GetRect("TheCommandBar");
+				var secondYellowBorderRect = _app.GetRect("TheBorder");
 				secondCommandBarRect.Bottom.Should().Be(secondYellowBorderRect.Y);
 
 				var secondCommandBarPhysicalRect = ToPhysicalRect(secondCommandBarRect);
@@ -97,10 +97,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 				await ToggleOrientation();
 
-				using var thirdScreenShot = TakeScreenshot("thirdOrientation");
+				var thirdScreenShot = TakeScreenshot("thirdOrientation");
 
-				var thirdCommandBarRect = _app.GetPhysicalRect("TheCommandBar");
-				var thirdYellowBorderRect = _app.GetPhysicalRect("TheBorder");
+				var thirdCommandBarRect = _app.GetRect("TheCommandBar");
+				var thirdYellowBorderRect = _app.GetRect("TheBorder");
 				thirdCommandBarRect.Bottom.Should().Be(thirdYellowBorderRect.Y);
 
 				var thirdCommandBarPhysicalRect = ToPhysicalRect(thirdCommandBarRect);
@@ -195,11 +195,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 			_app.WaitForElement("Page2CommandBar");
 
-			using var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
+			var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
 
 			_app.Wait(TimeSpan.FromMilliseconds(500));
 
-			using var final = TakeScreenshot("final", ignoreInSnapshotCompare: true);
+			var final = TakeScreenshot("final", ignoreInSnapshotCompare: true);
 
 			ImageAssert.AreEqual(initial, final);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
@@ -65,10 +65,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 			try
 			{
-				var firstScreenShot = TakeScreenshot("FirstOrientation");
+				using var firstScreenShot = TakeScreenshot("FirstOrientation");
 
-				var firstCommandBarRect = _app.GetRect("TheCommandBar");
-				var firstYellowBorderRect = _app.GetRect("TheBorder");
+				var firstCommandBarRect = _app.GetPhysicalRect("TheCommandBar");
+				var firstYellowBorderRect = _app.GetPhysicalRect("TheBorder");
 				firstCommandBarRect.Bottom.Should().Be(firstYellowBorderRect.Y);
 
 				var firstCommandBarPhysicalRect = ToPhysicalRect(firstCommandBarRect);
@@ -84,10 +84,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 				await ToggleOrientation();
 
-				var secondScreenShot = TakeScreenshot("SecondOrientation");
+				using var secondScreenShot = TakeScreenshot("SecondOrientation");
 
-				var secondCommandBarRect = _app.GetRect("TheCommandBar");
-				var secondYellowBorderRect = _app.GetRect("TheBorder");
+				var secondCommandBarRect = _app.GetPhysicalRect("TheCommandBar");
+				var secondYellowBorderRect = _app.GetPhysicalRect("TheBorder");
 				secondCommandBarRect.Bottom.Should().Be(secondYellowBorderRect.Y);
 
 				var secondCommandBarPhysicalRect = ToPhysicalRect(secondCommandBarRect);
@@ -97,10 +97,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 				await ToggleOrientation();
 
-				var thirdScreenShot = TakeScreenshot("thirdOrientation");
+				using var thirdScreenShot = TakeScreenshot("thirdOrientation");
 
-				var thirdCommandBarRect = _app.GetRect("TheCommandBar");
-				var thirdYellowBorderRect = _app.GetRect("TheBorder");
+				var thirdCommandBarRect = _app.GetPhysicalRect("TheCommandBar");
+				var thirdYellowBorderRect = _app.GetPhysicalRect("TheBorder");
 				thirdCommandBarRect.Bottom.Should().Be(thirdYellowBorderRect.Y);
 
 				var thirdCommandBarPhysicalRect = ToPhysicalRect(thirdCommandBarRect);
@@ -195,11 +195,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 			_app.WaitForElement("Page2CommandBar");
 
-			var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
+			using var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
 
 			_app.Wait(TimeSpan.FromMilliseconds(500));
 
-			var final = TakeScreenshot("final", ignoreInSnapshotCompare: true);
+			using var final = TakeScreenshot("final", ignoreInSnapshotCompare: true);
 
 			ImageAssert.AreEqual(initial, final);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -156,18 +156,18 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 
 			// initial state
 			_app.WaitForElement(testableFlyoutButtons.First().Value);
-			var initialScreenshot = TakeScreenshot($"{majorStepIndex++} Initial State", ignoreInSnapshotCompare: true);
+			using var initialScreenshot = TakeScreenshot($"{majorStepIndex++} Initial State", ignoreInSnapshotCompare: true);
 
 			var dismissArea = GetDismissAreaCenter();
 			foreach (var button in testableFlyoutButtons)
 			{
 				// show flyout
 				button.Value.Tap();
-				var flyoutOpenedScreenshot = TakeScreenshot($"{majorStepIndex} {button.Key} 0 Opened", ignoreInSnapshotCompare: true);
+				using var flyoutOpenedScreenshot = TakeScreenshot($"{majorStepIndex} {button.Key} 0 Opened", ignoreInSnapshotCompare: true);
 
 				// dismiss flyout
 				_app.TapCoordinates(dismissArea.X, dismissArea.Y);
-				var flyoutDismissedScreenshot = TakeScreenshot($"{majorStepIndex} {button.Key} 1 Dismissed", ignoreInSnapshotCompare: true);
+				using var flyoutDismissedScreenshot = TakeScreenshot($"{majorStepIndex} {button.Key} 1 Dismissed", ignoreInSnapshotCompare: true);
 
 				// compare
 				ImageAssert.AreNotEqual(flyoutOpenedScreenshot, initialScreenshot);
@@ -184,10 +184,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 				 * [FullOverlayFlyoutButton]
 				 *         (dismiss area)
 				 *       [WithOffsetFlyoutButton margin=100] */
-				var rect1 = _app.GetRect("FullOverlayFlyoutButton");
-				var rect2 = _app.GetRect("WithOffsetFlyoutButton");
+				var rect1 = _app.GetPhysicalRect("FullOverlayFlyoutButton");
+				var rect2 = _app.GetPhysicalRect("WithOffsetFlyoutButton");
 
-				return (rect2.CenterX, (rect1.Bottom + rect2.Y) / 2);
+				return (rect2.CenterX + rect2.Width, (rect1.Bottom + rect2.Y) / 2);
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -122,7 +122,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 				picker.SetDependencyPropertyValue("Mode", "S" + i);
 				_app.WaitForDependencyPropertyValue(currentModeButton, "Content", (i * 16).ToString("00"));
 
-				base.TakeScreenshot("Mode-" + i);
+				TakeScreenshot("Mode-" + i);
 			}
 		}
 
@@ -139,11 +139,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 			_app.WaitForElement("secondControl");
 
-			var bmp = TakeScreenshot("After");
+			using var bmp = TakeScreenshot("After");
 
-			var expectedRect = _app.GetRect("simpleImage");
-			var firstControlRect = _app.GetRect("firstControl");
-			var secondControlRect = _app.GetRect("secondControl");
+			var expectedRect = _app.GetPhysicalRect("simpleImage");
+			var firstControlRect = _app.GetPhysicalRect("firstControl");
+			var secondControlRect = _app.GetPhysicalRect("secondControl");
 
 			ImageAssert.AreAlmostEqual(bmp, expectedRect, bmp, firstControlRect, permittedPixelError: 20);
 			ImageAssert.AreAlmostEqual(bmp, expectedRect, bmp, secondControlRect, permittedPixelError: 20);
@@ -151,7 +151,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Browser)] // Images sometimes fail to load on iOS https://github.com/unoplatform/uno/issues/2295
+		[ActivePlatforms(Platform.Android, Platform.Browser)] // Images sometimes fail to load on iOS https://github.com/unoplatform/uno/issues/2295
 		public void Late_With_Fixed_Dimensions()
 		{
 			Run("UITests.Windows_UI_Xaml_Controls.ImageTests.ImageWithLateSourceFixedDimensions");
@@ -160,18 +160,18 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 			_app.WaitForElement("lateImage");
 
-			var bmp = TakeScreenshot("Source set");
+			using var bmp = TakeScreenshot("Source set");
 
-			var expectedRect = _app.GetRect("refImage");
+			var expectedRect = _app.GetPhysicalRect("refImage");
 
-			var lateRect = _app.GetRect("lateImage");
+			var lateRect = _app.GetPhysicalRect("lateImage");
 
 			ImageAssert.AreAlmostEqual(bmp, expectedRect, bmp, lateRect, permittedPixelError: 20);
 		}
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Browser)] // Images sometimes fail to load on iOS https://github.com/unoplatform/uno/issues/2295
+		[ActivePlatforms(Platform.Android, Platform.Browser)] // Images sometimes fail to load on iOS https://github.com/unoplatform/uno/issues/2295
 		public void Late_With_UniformToFill()
 		{
 			Run("UITests.Windows_UI_Xaml_Controls.ImageTests.ImageWithLateSourceUniformToFill");
@@ -180,11 +180,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 			_app.WaitForElement("lateImage");
 
-			var bmp = TakeScreenshot("Source set");
+			using var bmp = TakeScreenshot("Source set");
 
-			var expectedRect = _app.GetRect("refImage");
+			var expectedRect = _app.GetPhysicalRect("refImage");
 
-			var lateRect = _app.GetRect("lateImage");
+			var lateRect = _app.GetPhysicalRect("lateImage");
 
 			ImageAssert.AreAlmostEqual(bmp, expectedRect, bmp, lateRect, permittedPixelError: 20);
 		}
@@ -195,9 +195,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 		{
 			Run("UITests.Windows_UI_Xaml_Controls.ImageTests.Image_Margin_Large");
 
-			var bmp = TakeScreenshot("Ready");
+			using var bmp = TakeScreenshot("Ready");
 
-			var rect = _app.GetRect("outerBorder");
+			var rect = _app.GetPhysicalRect("outerBorder");
 
 			ImageAssert.DoesNotHaveColorAt(bmp, rect.CenterX, rect.CenterY, Color.Black);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -182,9 +182,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 			using var bmp = TakeScreenshot("Source set");
 
-			var expectedRect = _app.GetPhysicalRect("refImage");
+			var borderThickness = LogicalToPhysical(3);
 
-			var lateRect = _app.GetPhysicalRect("lateImage");
+			var expectedRect = _app.GetPhysicalRect("refImage").DeflateBy(borderThickness);
+			var lateRect = _app.GetPhysicalRect("lateImage").DeflateBy(borderThickness);
 
 			ImageAssert.AreAlmostEqual(bmp, expectedRect, bmp, lateRect, permittedPixelError: 20);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Margins.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Margins.cs
@@ -22,12 +22,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			_app.WaitForElement("rect4");
 
 			var imageRects = new[] { "img0", "img1", "img2", "img3", "img4" }
-				.Select(x => _app.GetRect(x))
+				.Select(x => _app.GetPhysicalRect(x))
 				.ToArray();
 
 			var rects = new[] { "rect0", "rect1", "rect2", "rect3", "rect4" }
-				.Select(x => _app.GetRect(x))
+				.Select(x => _app.GetPhysicalRect(x))
 				.ToArray();
+
+			var logicalRect4 = _app.GetLogicalRect("rect4");
 
 			using (new AssertionScope())
 			{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using FluentAssertions;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
@@ -130,9 +132,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			TakeScreenshot("after layout");
 
 			var heightStr = _app.GetText("HeightTextBlock");
-			var height = int.Parse(heightStr);
+			var height = float.Parse(heightStr, NumberStyles.Float, NumberFormatInfo.InvariantInfo);
 
-			Assert.AreEqual(224, height);
+			height.Should().BeApproximately(224f, 0.5f);
 		}
 
 		[Test]
@@ -146,7 +148,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			TakeScreenshot("1 item");
 
 			var heightStrBefore = _app.GetText("HeightTextBlock");
-			var heightBefore = int.Parse(heightStrBefore);
+			var heightBefore = float.Parse(heightStrBefore, NumberStyles.Float, NumberFormatInfo.InvariantInfo);
 
 			_app.FastTap("AddItemsButton");
 
@@ -155,7 +157,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			TakeScreenshot("3 items");
 
 			var heightStrAfter = _app.GetText("HeightTextBlock");
-			var heightAfter = int.Parse(heightStrAfter);
+			var heightAfter = float.Parse(heightStrAfter, NumberStyles.Float, NumberFormatInfo.InvariantInfo);
 
 			Assert.Greater(heightBefore, 0);
 
@@ -173,16 +175,16 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			_app.WaitForElement(checkBox);
 
 			// Save initial state(not expanded)
-			var screenshot1 = TakeScreenshot("Initial State");
+			using var screenshot1 = TakeScreenshot("Initial State");
 
 			// Expand and compare
 			ClickCheckBoxAt(0);
-			var screenshot2 = TakeScreenshot("Expanded State");
+			using var screenshot2 = TakeScreenshot("Expanded State");
 			ImageAssert.AreNotEqual(screenshot1, screenshot2);
 
 			// Collapse and compare
 			ClickCheckBoxAt(0);
-			var screenshot3 = TakeScreenshot("Collapsed State");
+			using var screenshot3 = TakeScreenshot("Collapsed State");
 			ImageAssert.AreEqual(screenshot1, screenshot3);
 		}
 
@@ -197,20 +199,20 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			_app.WaitForElement(checkBox);
 
 			// Save initial state(not expanded)
-			var screenshot1 = TakeScreenshot("Initial State");
+			using var screenshot1 = TakeScreenshot("Initial State");
 
 			// Expand multiple items and compare
 			ClickCheckBoxAt(0);
 			ClickCheckBoxAt(1);
 			ClickCheckBoxAt(2);
-			var screenshot2 = TakeScreenshot("Expanded State");
+			using var screenshot2 = TakeScreenshot("Expanded State");
 			ImageAssert.AreNotEqual(screenshot1, screenshot2);
 
 			// Collapse all and compare 
 			ClickCheckBoxAt(0);
 			ClickCheckBoxAt(1);
 			ClickCheckBoxAt(2);
-			var screenshot3 = TakeScreenshot("Collapsed State");
+			using var screenshot3 = TakeScreenshot("Collapsed State");
 			ImageAssert.AreEqual(screenshot1, screenshot3);
 		}
 
@@ -311,16 +313,16 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			_app.WaitForElement(checkBoxHeader);
 
 			// Save initial state(not expanded)
-			var screenshot1 = TakeScreenshot("Initial State");
+			using var screenshot1 = TakeScreenshot("Initial State");
 
 			// Expand and compare
 			checkBoxHeader.Tap();
-			var screenshot2 = TakeScreenshot("Expanded State");
+			using var screenshot2 = TakeScreenshot("Expanded State");
 			ImageAssert.AreNotEqual(screenshot1, screenshot2);
 
 			// Collapse and compare 
 			checkBoxHeader.Tap();
-			var screenshot3 = TakeScreenshot("Collapsed State");
+			using var screenshot3 = TakeScreenshot("Collapsed State");
 			ImageAssert.AreAlmostEqual(screenshot1, screenshot3);
 		}
 
@@ -335,14 +337,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			_app.WaitForElement(checkBoxHeader);
 
 			// Save initial state(not expanded)
-			var screenshot1 = TakeScreenshot("Initial State");
+			using var screenshot1 = TakeScreenshot("Initial State");
 
 			// Expand and compare
 			checkBoxHeader.Tap();
 			ClickCheckBoxAt(0);
 			ClickCheckBoxAt(1);
 			ClickCheckBoxAt(2);
-			var screenshot2 = TakeScreenshot("Expanded State");
+			using var screenshot2 = TakeScreenshot("Expanded State");
 			ImageAssert.AreNotEqual(screenshot1, screenshot2);
 
 			// Collapse and compare
@@ -350,7 +352,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			ClickCheckBoxAt(0);
 			ClickCheckBoxAt(1);
 			ClickCheckBoxAt(2);
-			var screenshot3 = TakeScreenshot("Collapsed State");
+			using var screenshot3 = TakeScreenshot("Collapsed State");
 			ImageAssert.AreEqual(screenshot1, screenshot3);
 		}
 
@@ -365,18 +367,18 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			_app.WaitForElement(checkBoxHeader);
 
 			// Save initial state(not expanded)
-			var screenshot1 = TakeScreenshot("Initial State");
+			using var screenshot1 = TakeScreenshot("Initial State");
 
 			// Expand multiple items, header and compare
 			checkBoxHeader.Tap();
 			ClickCheckBoxAt(0);
-			var screenshot2 = TakeScreenshot("Expanded State");
+			using var screenshot2 = TakeScreenshot("Expanded State");
 			ImageAssert.AreNotEqual(screenshot1, screenshot2);
 
 			// Collapse all and compare 
 			checkBoxHeader.Tap();
 			ClickCheckBoxAt(0);
-			var screenshot3 = TakeScreenshot("Collapsed State");
+			using var screenshot3 = TakeScreenshot("Collapsed State");
 			ImageAssert.AreEqual(screenshot1, screenshot3);
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_Tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
@@ -73,24 +74,28 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.NavigationViewTests
 
 			var descendants = _app.Marked("nvSample").Descendant();
 
-			var lightDismissLayer = descendants.Marked("LightDismissLayer").FirstResult();
-			var paneRoot = descendants.Marked("PaneRoot").FirstResult();
-			var togglePaneButton = descendants.Marked("TogglePaneButton").FirstResult();
+			var lightDismissLayer = descendants.Marked("LightDismissLayer");
+			var dismissRect = _app.GetLogicalRect(lightDismissLayer);
 
-			Assert.AreEqual(paneRoot.Rect.Width, togglePaneButton.Rect.Width, "when NavigationView is opened, PaneRoot and TogglePaneButton should shared the same width");
+			var paneRoot = descendants.Marked("PaneRoot");
+			var paneRootRect = _app.GetLogicalRect(paneRoot);
+			var togglePaneButton = descendants.Marked("TogglePaneButton");
+
+			var togglePaneRect = _app.GetLogicalRect(togglePaneButton);
+			paneRootRect.Width.Should().Be(togglePaneRect.Width, "when NavigationView is opened, PaneRoot and TogglePaneButton should shared the same width");
 
 			// to light-dismiss the flyout, we need to tap the right side of LightDismissLayer that isnt occupied by PaneRoot
 			var dismissibleArea = new
 			{
-				CenterX = (paneRoot.Rect.GetRight() + lightDismissLayer.Rect.GetRight()) / 2,
-				CenterY = lightDismissLayer.Rect.CenterY,
+				CenterX = (paneRootRect.GetRight() + dismissRect.GetRight()) / 2,
+				CenterY = dismissRect.CenterY,
 			};
 			_app.TapCoordinates(dismissibleArea.CenterX, dismissibleArea.CenterY);
 
 			// refresh because FirstResult snapshots values
-			togglePaneButton = descendants.Marked("TogglePaneButton").FirstResult();
+			togglePaneRect = _app.GetLogicalRect(togglePaneButton);
 
-			Assert.Less(togglePaneButton.Rect.Width, paneRoot.Rect.Width, "when NavigationView is closed, TogglePaneButton should not take the width of PaneRoot");
+			togglePaneRect.Width.Should().BeLessThan(paneRootRect.Width, "when NavigationView is closed, TogglePaneButton should not take the width of PaneRoot");
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationView_Tests.cs
@@ -66,10 +66,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.NavigationViewTests
 
 		[Test]
 		[AutoRetry()]
-		[ActivePlatforms(Platform.iOS, Platform.Browser)]
 		public void NavigationView_OnLightDismiss_TogglePaneButton_IsSizedCorrectly()
 		{
-			// android: disabled because the device isnt wide enough for CompactMode that uses the flyout
 			Run("SamplesApp.Samples.NavigationViewSample.NavigationViewSample");
 
 			var descendants = _app.Marked("nvSample").Descendant();

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PageTests/UnoSamples_Page_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PageTests/UnoSamples_Page_Tests.cs
@@ -21,17 +21,16 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PivotTests
 
 			_app.WaitForElement(_app.Marked("_empty"));
 
-			var content = TakeScreenshot("afterColor");
+			using var content = TakeScreenshot("afterColor", ignoreInSnapshotCompare: true);
 
-			var scale = (float)GetDisplayScreenScaling();
-			var emptyRect = _app.GetRect("_empty");
-			var transparentRect = _app.GetRect("_transparent");
-			var solidRect = _app.GetRect("_colored");
+			var emptyRect = _app.GetPhysicalRect("_empty");
+			var transparentRect = _app.GetPhysicalRect("_transparent");
+			var solidRect = _app.GetPhysicalRect("_colored");
 
-			const int offset = 30;
-			ImageAssert.HasColorAt(content, (emptyRect.X + offset) * scale, (emptyRect.Y + offset) * scale, Color.Red);
-			ImageAssert.HasColorAt(content, (transparentRect.X + offset) * scale, (transparentRect.Y + offset) * scale, Color.Red);
-			ImageAssert.HasColorAt(content, (solidRect.X + offset) * scale, (solidRect.Y + offset) * scale, Color.Blue);
+			var offset = LogicalToPhysical(30);
+			ImageAssert.HasColorAt(content, (emptyRect.X + offset), (emptyRect.Y + offset), Color.Red);
+			ImageAssert.HasColorAt(content, (transparentRect.X + offset), (transparentRect.Y + offset), Color.Red);
+			ImageAssert.HasColorAt(content, (solidRect.X + offset), (solidRect.Y + offset), Color.Blue);
 		}
 
 		[Test]
@@ -42,17 +41,17 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PivotTests
 
 			_app.WaitForElement("TargetPage");
 
-			var pageRectCenter = GetRectCenterScaled("TargetPage");
+			var rect = _app.GetPhysicalRect("TargetPage");
 
-			var before = TakeScreenshot("Before SolidColorBrush.Color update");
-			ImageAssert.HasColorAt(before, pageRectCenter.X, pageRectCenter.Y, Color.Blue);
+			using var before = TakeScreenshot("Before SolidColorBrush.Color update", ignoreInSnapshotCompare: true);
+			ImageAssert.HasColorAt(before, rect.CenterX, rect.CenterY, Color.Blue);
 			
 			_app.FastTap("AdvanceTestButton");
 
 			_app.WaitForText("StatusTextBlock", "Color changed");
 
-			var after = TakeScreenshot("After SolidColorBrush.Color update");
-			ImageAssert.HasColorAt(after, pageRectCenter.X, pageRectCenter.Y, Color.Green);
+			using var after = TakeScreenshot("After SolidColorBrush.Color update");
+			ImageAssert.HasColorAt(after, rect.CenterX, rect.CenterY, Color.Green);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
@@ -109,15 +109,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.Popup.Popup_Overlay_On");
 
-			var before = TakeScreenshot("Before");
-			var rect = _app.GetRect("LocatorRectangle");
+			using var before = TakeScreenshot("Before", ignoreInSnapshotCompare: true);
+			var rect = _app.GetPhysicalRect("LocatorRectangle");
 			ImageAssert.HasColorAt(before, rect.CenterX, rect.CenterY, Color.Blue);
 
 			_app.FastTap("PopupCheckBox");
 
 			_app.WaitForElement("PopupChild");
 
-			var during = TakeScreenshot("During", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Status bar appears with clock*/);
+			using var during = TakeScreenshot("During", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Status bar appears with clock*/);
 
 			ImageAssert.DoesNotHaveColorAt(during, rect.CenterX, rect.CenterY, Color.Blue);
 
@@ -127,7 +127,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 
 			_app.WaitForNoElement("PopupChild");
 
-			var after = TakeScreenshot("After");
+			using var after = TakeScreenshot("After");
 
 			ImageAssert.HasColorAt(after, rect.CenterX, rect.CenterY, Color.Blue);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
@@ -78,7 +78,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 			//Drag upward
 			_app.DragCoordinates(sut.Rect.CenterX, sut.Rect.CenterY, sut.Rect.CenterX, sut.Rect.CenterY - (sut.Rect.Height / 2));
 
-			var res = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+			using var res = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 
 			ImageAssert.AreNotEqual(
 				expected: res,

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SplitViewTests/SplitViewTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SplitViewTests/SplitViewTests.cs
@@ -22,21 +22,21 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.SplitViewTests
 
 			_app.WaitForElement("Split");
 
-			var targetGridRectangle = _app.GetRect("TargetRect");
+			var targetGridRectangle = _app.GetPhysicalRect("TargetRect");
 
-			var compactScreenshot = TakeScreenshot("Compact");
+			using var compactScreenshot = TakeScreenshot("Compact", ignoreInSnapshotCompare: true);
 			// Compact pane is 48 pixels wide
 			ImageAssert.HasColorAt(compactScreenshot, targetGridRectangle.Right - 4, targetGridRectangle.CenterY, Color.Blue);
 
 			var toggleButton = _app.Marked("PaneToggle");
 			toggleButton.Tap();
 
-			var expandedScreenshot = TakeScreenshot("Expanded");
+			using var expandedScreenshot = TakeScreenshot("Expanded");
 			ImageAssert.HasColorAt(expandedScreenshot, targetGridRectangle.Right - 4, targetGridRectangle.CenterY, Color.Red);
 
 			toggleButton.Tap();
 
-			var compactAgainScreenshot = TakeScreenshot("Compact again");
+			using var compactAgainScreenshot = TakeScreenshot("Compact again");
 			ImageAssert.HasColorAt(compactAgainScreenshot, targetGridRectangle.Right - 4, targetGridRectangle.CenterY, Color.Blue);
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -48,14 +48,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			_app.WaitForElement(rightControls.Last());
 
+			using var _ = new AssertionScope();
+
 			for (var i = 0; i < leftControls.Length; i++)
 			{
-				var left = leftControls[i].FirstResult().Rect;
-				var right = rightControls[i].FirstResult().Rect;
+				var left = _app.GetLogicalRect(leftControls[i]);
+				var right = _app.GetLogicalRect(rightControls[i]);
 
-				left.Width.Should().Be(right.Width, "Width");
-				left.Height.Should().Be(right.Height, "Height");
-				left.Y.Should().Be(right.Y, "Y position");
+				using var __ = new AssertionScope("ctl" + i);
+
+				const float tolerance = 1f;
+				left.Width.Should().BeApproximately(right.Width, tolerance, "Width");
+				left.Height.Should().BeApproximately(right.Height, tolerance, "Height");
+				left.Y.Should().BeApproximately(right.Y, tolerance, "Y position");
 			}
 		}
 
@@ -252,7 +257,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 						x: textRect.Right,
 						y: sampleRect.Y,
 						width: sampleRect.Right - textRect.Right,
-						height: sampleRect.Height);
+						height: sampleRect.Height)
+						.DeflateBy(1f);
 
 					ImageAssert.AreEqual(sampleScreenshot, rect1, afterScreenshot, rect1);
 				}
@@ -264,7 +270,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 						x: textRect.X,
 						y: textRect.Bottom,
 						width: textRect.Width,
-						height: sampleRect.Height - textRect.Bottom);
+						height: sampleRect.Height - textRect.Bottom)
+						.DeflateBy(1f);
 
 					ImageAssert.AreEqual(sampleScreenshot, rect2, afterScreenshot, rect2);
 				}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -265,5 +265,65 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 				}
 			}
 		}
+
+		[Test]
+		[AutoRetry]
+		public void When_MaxLines_Changed_On_Stack_Container()
+		{
+			Run("Uno.UI.Samples.Content.UITests.TextBlockControl.SimpleText_MaxLines_Multiple_Containers");
+
+			var stackTextBlockName = "stackTextBlock";
+			var maxLineSlider = _app.Marked("slider");
+			
+			_app.WaitForElement(maxLineSlider);
+
+			var numberOfLines = 1;
+			maxLineSlider.SetDependencyPropertyValue("Value", $"{numberOfLines}");
+			var rectBefore = _app.GetRect(stackTextBlockName);
+			var lineHeight = rectBefore.Height;
+
+			numberOfLines = 3;
+			maxLineSlider.SetDependencyPropertyValue("Value", $"{numberOfLines}");
+
+			var rectAfter = _app.GetRect(stackTextBlockName);
+			var textBlockHeight = rectAfter.Height;
+
+			var actualNumberOfLines = (int)Math.Ceiling(textBlockHeight / lineHeight);
+			Assert.IsTrue(actualNumberOfLines == numberOfLines,
+				"Results \n" +
+				$"Expected Number of lines: {numberOfLines}. \n" +
+				$"Actual Number of lines:{actualNumberOfLines}. \n" +
+				$"Line height: {lineHeight}. \n");
+		}
+
+		[Test]
+		[AutoRetry]
+		public void When_MaxLines_Changed_On_Grid_Container()
+		{
+			Run("Uno.UI.Samples.Content.UITests.TextBlockControl.SimpleText_MaxLines_Multiple_Containers");
+
+			var gridTextBlockName = "gridTextBlock";
+			var maxLineSlider = _app.Marked("slider");
+
+			_app.WaitForElement(maxLineSlider);
+
+			var numberOfLines = 1;
+			maxLineSlider.SetDependencyPropertyValue("Value", $"{numberOfLines}");
+			var rectBefore = _app.GetRect(gridTextBlockName);
+			var lineHeight = rectBefore.Height;
+
+			numberOfLines = 2;
+			maxLineSlider.SetDependencyPropertyValue("Value", $"{numberOfLines}");
+
+			var rectAfter = _app.GetRect(gridTextBlockName);
+			var textBlockHeight = rectAfter.Height;
+
+			var actualNumberOfLines = (int)Math.Ceiling(textBlockHeight / lineHeight);
+			Assert.IsTrue(actualNumberOfLines == numberOfLines,
+				"Results \n" +
+				$"Expected Number of lines: {numberOfLines}. \n" +
+				$"Actual Number of lines:{actualNumberOfLines}. \n" +
+				$"Line height: {lineHeight}. \n");
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -67,13 +67,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			_app.WaitForText("FunnyTextBlock", "Look at me now");
 
-			var blueBefore = TakeScreenshot("Before - blue");
+			using var blueBefore = TakeScreenshot("Before - blue", ignoreInSnapshotCompare: true);
 
 			_app.FastTap("ChangeTextBlockButton");
 
-			var blackBefore = TakeScreenshot("Before - black");
+			using var blackBefore = TakeScreenshot("Before - black");
 
-			var textRect = _app.GetRect("FunnyTextBlock");
+			var textRect = _app.GetPhysicalRect("FunnyTextBlock");
 
 			ImageAssert.AreNotEqual(blueBefore, blackBefore, textRect);
 
@@ -85,7 +85,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			_app.WaitForElement("FunnyTextBlock");
 
-			var blueAfter = TakeScreenshot("After - blue");
+			using var blueAfter = TakeScreenshot("After - blue");
 
 			ImageAssert.AreEqual(blueBefore, blueAfter, textRect);
 		}
@@ -99,19 +99,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 			var text01 = _app.Marked("text01");
 			var text02 = _app.Marked("text02");
 
-			var before = TakeScreenshot("Before");
+			using var before = TakeScreenshot("Before", ignoreInSnapshotCompare: true);
 
 			text01.SetDependencyPropertyValue("TextDecorations", "1"); // Underline
 			text02.SetDependencyPropertyValue("TextDecorations", "2"); // Strikethrough
 
-			var after = TakeScreenshot("Updated");
+			using var after = TakeScreenshot("Updated");
 
 			ImageAssert.AreNotEqual(before, after);
 
 			text01.SetDependencyPropertyValue("TextDecorations", "0"); // None
 			text02.SetDependencyPropertyValue("TextDecorations", "0"); // None
 
-			var restored = TakeScreenshot("Restored");
+			using var restored = TakeScreenshot("Restored");
 
 			ImageAssert.AreEqual(before, restored);
 		}
@@ -125,17 +125,18 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 			var testBlock = _app.Marked("testBlock");
 
 			testBlock.SetDependencyPropertyValue("FontWeight", "Thin");
-			var rectBefore = _app.GetRect("testBlock");
+			var rectBefore = _app.GetLogicalRect("testBlock");
 			var widthBefore = rectBefore.Width;
 			var heightBefore = rectBefore.Height;
 
 			testBlock.SetDependencyPropertyValue("FontWeight", "Heavy");
-			var rectAfter = _app.GetRect("testBlock");
+			var rectAfter = _app.GetLogicalRect("testBlock");
 			var widthAfter = rectAfter.Width;
 			var heightAfter = rectAfter.Height;
 
-			Assert.IsTrue(widthBefore < widthAfter);
-			Assert.IsTrue(heightBefore == heightAfter);
+			using var _ = new AssertionScope();
+			widthBefore.Should().BeLessThan(widthAfter);
+			heightBefore.Should().Be(heightAfter);
 		}
 
 		[Test]
@@ -146,16 +147,20 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			var textColor = _app.Marked("textColor");
 
-			var rectBefore = _app.GetRect("textResult");
-			var beforeColorChanged = TakeScreenshot("beforeColor");
+			var rect = _app.GetPhysicalRect("textResult");
+			var xCheck = rect.CenterX;
+			var yCheck = rect.CenterY;
+
+			using var beforeColorChanged = TakeScreenshot("beforeColor", ignoreInSnapshotCompare: true);
+			ImageAssert.HasColorAt(beforeColorChanged, xCheck, yCheck, Color.Red);
 
 			textColor.SetDependencyPropertyValue("Text", "Blue");
 
-			var afterColorChanged = TakeScreenshot("afterColor");
+			using var afterColorChanged = TakeScreenshot("afterColor");
+
 			ImageAssert.AreNotEqual(afterColorChanged, beforeColorChanged);
 
-			var scale = (float)GetDisplayScreenScaling();
-			ImageAssert.HasColorAt(afterColorChanged, (rectBefore.X + 10) * scale, (rectBefore.Y + 10) * scale, Color.Blue);
+			ImageAssert.HasColorAt(afterColorChanged, xCheck, yCheck, Color.Blue);
 		}
 
 		[Test]
@@ -165,14 +170,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.SimpleText_MaxLines_Different_Font_Size");
 			var maxLineContainer = _app.Marked("container3");
 
-			var rectBefore = _app.GetRect("container3");
+			var rectBefore = _app.GetLogicalRect("container3");
 			var heightBefore = rectBefore.Height;
 
 			maxLineContainer.SetDependencyPropertyValue("MaxLines", "2");
-			var rectAfter = _app.GetRect("container3");
+			var rectAfter = _app.GetLogicalRect("container3");
 			var heightAfter = rectAfter.Height;
 
-			Assert.IsTrue(heightAfter > heightBefore);
+			heightAfter.Should().BeGreaterThan(heightBefore);
 		}
 
 		[Test]
@@ -183,14 +188,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 			var maxLineContainer = _app.Marked("container3");
 			maxLineContainer.SetDependencyPropertyValue("TextWrapping", "NoWrap");
 
-			var rectBefore = _app.GetRect("container3");
+			var rectBefore = _app.GetLogicalRect("container3");
 			var heightBefore = rectBefore.Height;
 
 			maxLineContainer.SetDependencyPropertyValue("MaxLines", "2");
-			var rectAfter = _app.GetRect("container3");
+			var rectAfter = _app.GetLogicalRect("container3");
 			var heightAfter = rectAfter.Height;
 
-			Assert.IsTrue(heightAfter == heightBefore);
+			heightAfter.Should().Be(heightBefore);
 		}
 
 		[Test]
@@ -218,7 +223,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 			// +----+-----------------------+--------------+
 
 			// (1)
-			var sampleScreenshot = this.TakeScreenshot("fullSample", ignoreInSnapshotCompare: true);
+			using var sampleScreenshot = this.TakeScreenshot("fullSample", ignoreInSnapshotCompare: true);
 			var sampleRect = _app.GetPhysicalRect("sampleRootPanel");
 
 			using var _ = new AssertionScope();
@@ -238,7 +243,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 				_app.Marked(textControl).SetDependencyPropertyValue("Opacity", "0");
 
 				// (3)
-				var afterScreenshot = this.TakeScreenshot("sample-" + textControl, ignoreInSnapshotCompare: true);
+				using var afterScreenshot = this.TakeScreenshot("sample-" + textControl, ignoreInSnapshotCompare: true);
 
 				// (4)
 				using (var s = new AssertionScope("Right zone"))
@@ -279,13 +284,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			var numberOfLines = 1;
 			maxLineSlider.SetDependencyPropertyValue("Value", $"{numberOfLines}");
-			var rectBefore = _app.GetRect(stackTextBlockName);
+			var rectBefore = _app.GetLogicalRect(stackTextBlockName);
 			var lineHeight = rectBefore.Height;
 
 			numberOfLines = 3;
 			maxLineSlider.SetDependencyPropertyValue("Value", $"{numberOfLines}");
 
-			var rectAfter = _app.GetRect(stackTextBlockName);
+			var rectAfter = _app.GetLogicalRect(stackTextBlockName);
 			var textBlockHeight = rectAfter.Height;
 
 			var actualNumberOfLines = (int)Math.Ceiling(textBlockHeight / lineHeight);
@@ -309,13 +314,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			var numberOfLines = 1;
 			maxLineSlider.SetDependencyPropertyValue("Value", $"{numberOfLines}");
-			var rectBefore = _app.GetRect(gridTextBlockName);
+			var rectBefore = _app.GetLogicalRect(gridTextBlockName);
 			var lineHeight = rectBefore.Height;
 
 			numberOfLines = 2;
 			maxLineSlider.SetDependencyPropertyValue("Value", $"{numberOfLines}");
 
-			var rectAfter = _app.GetRect(gridTextBlockName);
+			var rectAfter = _app.GetLogicalRect(gridTextBlockName);
 			var textBlockHeight = rectAfter.Height;
 
 			var actualNumberOfLines = (int)Math.Ceiling(textBlockHeight / lineHeight);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -252,23 +252,24 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 		{
 			Run("Uno.UI.Samples.Content.UITests.TextBoxControl.PasswordBox_Reveal_Scroll");
 
-			var passwordBox = _app.WaitForElement("MyPasswordBox").Single();
+			var passwordBox = _app.Marked("MyPasswordBox");
+			var passwordBoxRect = _app.GetRect(passwordBox);
 			_app.Wait(TimeSpan.FromMilliseconds(500)); // Make sure to show the status bar
-			var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
+			using var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
 
 			// Focus the PasswordBox
-			_app.TapCoordinates(passwordBox.Rect.X + 10, passwordBox.Rect.Y);
+			passwordBox.Tap();
 
 			// Press the reveal button, and move up (so the ScrollViewer will kick in and cancel the pointer), then release
-			_app.DragCoordinates(passwordBox.Rect.X + 10, passwordBox.Rect.Right - 10, passwordBox.Rect.X - 100, passwordBox.Rect.Right - 10);
+			_app.DragCoordinates(passwordBoxRect.X + 10, passwordBoxRect.Right - 10, passwordBoxRect.X - 100, passwordBoxRect.Right - 10);
 
-			var result = TakeScreenshot("result", ignoreInSnapshotCompare: true);
+			using var result = TakeScreenshot("result", ignoreInSnapshotCompare: true);
 
 			ImageAssert.AreEqual(initial, result, new Rectangle(
-				(int)passwordBox.Rect.X + 8, // +8 : ignore borders (as we are still focused)
-				(int)passwordBox.Rect.Y + 8,
+				(int)passwordBoxRect.X + 8, // +8 : ignore borders (as we are still focused)
+				(int)passwordBoxRect.Y + 8,
 				100, // Ignore the reveal button on right (as we are still focused)
-				(int)passwordBox.Rect.Height - 16));
+				(int)passwordBoxRect.Height - 16));
 		}
 
 		[Test]
@@ -499,20 +500,20 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			// initial state
 			_app.WaitForElement(target);
-			var screenshot1 = TakeScreenshot("textbox readonly", ignoreInSnapshotCompare: true);
+			using var screenshot1 = TakeScreenshot("textbox readonly", ignoreInSnapshotCompare: true);
 
 			// remove readonly and focus textbox
 			readonlyToggle.Tap(); // now: unchecked
 			target.Tap();
 			_app.Wait(seconds: 1); // allow keyboard to fully open
-			var screenshot2 = TakeScreenshot("textbox focused with keyboard", ignoreInSnapshotCompare: true);
+			using var screenshot2 = TakeScreenshot("textbox focused with keyboard", ignoreInSnapshotCompare: true);
 
 			// reapply readonly and try focus textbox
 			readonlyToggle.Tap(); // now: checked
 			target.Tap();
 			_app.Wait(seconds: 1); // allow keyboard to fully open (if ever possible)
 			_app.WaitForElement(target);
-			var screenshot3 = TakeScreenshot("textbox readonly again", ignoreInSnapshotCompare: true);
+			using var screenshot3 = TakeScreenshot("textbox readonly again", ignoreInSnapshotCompare: true);
 
 			// the bottom half should only contains the keyboard and some blank space,
 			// but not the textbox nor the toggle buttons that needs to be excluded.

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToolTipTests/ToolTip_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToolTipTests/ToolTip_Tests.cs
@@ -67,14 +67,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ToolTipTests
 			var upperRect = _app.GetRect("UpperLocator");
 			var lowerRect = _app.GetRect("LowerLocator");
 
-			var before = TakeScreenshot("Before");
+			using var before = TakeScreenshot("Before", ignoreInSnapshotCompare: true);
 
 			var lowerHoverY = buttonRect.Bottom - buttonRect.Height / 10;
 			_app.TapCoordinates(buttonRect.CenterX, lowerHoverY);
 
 			_app.WaitForElement(BorderInsideToolTip);
 
-			var lowerToolTip = TakeScreenshot("Lower ToolTip");
+			using var lowerToolTip = TakeScreenshot("Lower ToolTip");
 
 			ImageAssert.AreEqual(before, lowerToolTip, lowerRect);
 			ImageAssert.AreEqual(before, lowerToolTip, upperRect); // ToolTip should be just above mouse, shouldn't extend above Button bounds
@@ -89,7 +89,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ToolTipTests
 
 			_app.WaitForElement(BorderInsideToolTip);
 
-			var upperToolTip = TakeScreenshot("Upper ToolTip");
+			using var upperToolTip = TakeScreenshot("Upper ToolTip");
 
 			ImageAssert.AreEqual(before, upperToolTip, lowerRect);
 			ImageAssert.AreNotEqual(before, upperToolTip, upperRect); // Mouse is close to top of button, ToolTip should extend above Button bounds

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
@@ -108,13 +108,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 		{
 			Run("UITests.Shared.Windows_UI_Input.VisualStatesTests.ListViewItem");
 
-			var initial = TakeScreenshot("Initial");
+			using var initial = TakeScreenshot("Initial", ignoreInSnapshotCompare: true);
 			var rect = _app.WaitForElement("MyListView").Single().Rect;
 
 			// Press over and move out to release
 			_app.DragCoordinates(rect.X + 10, rect.Y + 10, rect.X - 30, rect.Y);
 
-			var final = TakeScreenshot("Final");
+			using var final = TakeScreenshot("Final");
 			ImageAssert.AreEqual(initial, final, rect);
 		}
 
@@ -153,12 +153,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		private void TestVisualTests(string targetName, Action<IAppRect> act, bool validateFinalStateScreenShot, params string[] expectedStates)
 		{
-			var initial = TakeScreenshot("Initial", ignoreInSnapshotCompare: true);
+			using var initial = TakeScreenshot("Initial", ignoreInSnapshotCompare: true);
 			var target = _app.WaitForElement(targetName).Single().Rect;
 
 			act(target);
 
-			var final = TakeScreenshot("Final", ignoreInSnapshotCompare: true);
+			using var final = TakeScreenshot("Final", ignoreInSnapshotCompare: true);
 			var actualStates = _app
 				.Marked("VisualStatesLog")
 				.GetDependencyPropertyValue<string>("Text")

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.ClosedFigurePage.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.ClosedFigurePage.cs
@@ -23,7 +23,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 
 			// if closed path, there should be black color on left hand side
 
-			var screenshot = TakeScreenshot("Closed state");
+			using var screenshot = TakeScreenshot("Closed state");
 
 			ImageAssert.HasColorAt(screenshot, 50, 300, Color.Black);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.LineSegmentPage.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.LineSegmentPage.cs
@@ -26,7 +26,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 			_app.WaitForElement(path);
 
 			// Take an initial screenshot
-			TakeScreenshot("Initial State");
+			TakeScreenshot("Initial State", ignoreInSnapshotCompare: true);
 		}
 
 		[Test]
@@ -40,11 +40,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 
 			_app.WaitForElement(path);
 
-			var before = TakeScreenshot("Before point movement");
+			using var before = TakeScreenshot("Before point movement", ignoreInSnapshotCompare: true);
 
 			button.Tap();
 
-			var after = TakeScreenshot("After point movement");
+			using var after = TakeScreenshot("After point movement");
 
 			ImageAssert.AreNotEqual(before, after);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GradientBrushTests/LinearGradientBrush_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GradientBrushTests/LinearGradientBrush_Tests.cs
@@ -24,15 +24,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GradientBrushTests
 
 			_app.WaitForElement(rectangle);
 
-			var screenRect = _app.GetRect(rectangle);
+			var screenRect = _app.GetPhysicalRect(rectangle);
 
-			var before = TakeScreenshot("Before");
+			using var before = TakeScreenshot("Before", ignoreInSnapshotCompare: true);
 
 			_app.FastTap("ChangeBrushButton");
 
 			_app.WaitForText("StatusTextBlock", "Changed");
 
-			var after = TakeScreenshot("After");
+			using var after = TakeScreenshot("After");
 
 			ImageAssert.AreNotEqual(before, after, screenRect);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_WriteableBitmap.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_WriteableBitmap.cs
@@ -19,7 +19,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.ImageBrushTests
 			Run("UITests.Windows_UI_Xaml_Media.ImageBrushTests.ImageBrush_WriteableBitmap");
 
 			var sut = _app.WaitForElement("SUT").Single().Rect;
-			var result = TakeScreenshot("Result", ignoreInSnapshotCompare: false);
+			using var result = TakeScreenshot("Result", ignoreInSnapshotCompare: false);
 
 			ImageAssert.HasColorAt(result, sut.CenterX, sut.CenterY, Color.BlueViolet);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/Transform_Tests/Basics_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/Transform_Tests/Basics_Automated.cs
@@ -213,5 +213,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.Transform_Tests
 
 			ImageAssert.HasColorAt(_result, x, y, color ?? Color.White, tolerance: 25);
 		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			_result?.Dispose();
+			_result = null;
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/ColorAnimation_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/ColorAnimation_Tests.cs
@@ -38,7 +38,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 
 			var indepRect = _app.GetRect("IndependentBorder");
 
-			var bmp = TakeScreenshot("Completed");
+			using var bmp = TakeScreenshot("Completed");
 
 			ImageAssert.HasColorAt(bmp, targetRect.CenterX, targetRect.CenterY, Color.Red);
 
@@ -60,7 +60,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 
 			var targetRect = _app.GetRect("TargetRectangle");
 
-			var bmp = TakeScreenshot("Completed");
+			using var bmp = TakeScreenshot("Completed");
 
 			ImageAssert.HasColorAt(bmp, targetRect.CenterX, targetRect.CenterY, Color.Brown);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Opacity.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Opacity.cs
@@ -63,14 +63,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 
 			Run(_finalStateOpacityTestControl, skipInitialScreenshot: true);
 
-			var initial = TakeScreenshot("Initial", ignoreInSnapshotCompare: true);
+			using var initial = TakeScreenshot("Initial", ignoreInSnapshotCompare: true);
 			var element = _app.WaitForElement($"{type}AnimationHost_{fill}").Single().Rect;
 
 			_app.Marked("StartButton").FastTap();
 			_app.WaitForDependencyPropertyValue(_app.Marked("Status"), "Text", "Completed");
 
 			// Assert
-			var final = TakeScreenshot("Final", ignoreInSnapshotCompare: true);
+			using var final = TakeScreenshot("Final", ignoreInSnapshotCompare: true);
 
 			if (isSame)
 			{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Transforms.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Transforms.cs
@@ -62,7 +62,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 
 			Run(_finalStateTransformsTestControl, skipInitialScreenshot: true);
 
-			var initial = TakeScreenshot("Initial", ignoreInSnapshotCompare: true);
+			using var initial = TakeScreenshot("Initial", ignoreInSnapshotCompare: true);
 			var initialLocation = _app.WaitForElement($"{type}AnimationHost_{fill}").Single().Rect;
 
 			var scale = ((int)initialLocation.Width) / 50;
@@ -73,7 +73,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 			_app.WaitForDependencyPropertyValue(_app.Marked("Status"), "Text", "Completed");
 
 			// Assert
-			var final = TakeScreenshot("Final", ignoreInSnapshotCompare: true);
+			using var final = TakeScreenshot("Final", ignoreInSnapshotCompare: true);
 			var finalLocation = _app.WaitForElement($"{type}AnimationHost_{fill}").Single().Rect;
 			var actualDelta = finalLocation.Y - initialLocation.Y;
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.TransformGroup.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.TransformGroup.cs
@@ -504,7 +504,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 		private (Rectangle host, float scale, ScreenshotInfo half, ScreenshotInfo final) BeginTransformGroupTest(string elementName)
 		{
 			Run(_transformGroupTestControl, skipInitialScreenshot: true);
-			TakeScreenshot("Initial", ignoreInSnapshotCompare: true);
 
 			var status = _app.Marked("Status");
 			var host = _app.GetRect(elementName);
@@ -517,13 +516,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 			_app.Marked("StartButton").Tap();
 			_app.WaitForDependencyPropertyValue(status, "Text", "Paused");
 
-			var half = TakeScreenshot("half", ignoreInSnapshotCompare: true);
+			using var half = TakeScreenshot("half", ignoreInSnapshotCompare: true);
 
 			// Complete the animation
 			_app.Marked("ResumeButton").Tap();
 			_app.WaitForDependencyPropertyValue(status, "Text", "Completed");
 
-			var final = TakeScreenshot("final", ignoreInSnapshotCompare: true);
+			using var final = TakeScreenshot("final", ignoreInSnapshotCompare: true);
 
 			return (immutableHostRect, scale, half, final);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Mesaure_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Mesaure_Tests.cs
@@ -18,13 +18,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			Run("UITests.Shared.Windows_UI_Xaml_Shapes.MeasurePage");
 
 			var sut = _app.WaitForElement("CollapsedInSmallScrollViewer").Single();
-			var initial = TakeScreenshot("initial");
+			using var initial = TakeScreenshot("initial");
 
 			// Try to scroll up
 			_app.DragCoordinates(sut.Rect.CenterX, sut.Rect.Bottom - 5, sut.Rect.CenterX, sut.Rect.Y + 5); // Touch scroll
 			for (var i = 0; i < 10; i++) _app.TapCoordinates(sut.Rect.Right - 5, sut.Rect.Bottom - 5); // Mouse scroll
 
-			var final = TakeScreenshot("final");
+			using var final = TakeScreenshot("final");
 
 			ImageAssert.AreEqual(initial, final, sut.Rect);
 		}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1157,6 +1157,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Multiple_Containers.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_BrushColorChanging.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4323,6 +4327,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Different_Font_Size.xaml.cs">
       <DependentUpon>SimpleText_MaxLines_Different_Font_Size.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Multiple_Containers.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_Multiple_Containers.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_BrushColorChanging.xaml.cs">
       <DependentUpon>TextBlock_BrushColorChanging.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationViewSample.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationViewSample.xaml
@@ -9,7 +9,7 @@
 	mc:Ignorable="d xamarin"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<Grid>
+	<Grid MaxWidth="750" HorizontalAlignment="Left"> <!-- Max Width to force compact mode -->
 		<NavigationView Loaded="NavigationView_Loaded"
 						Margin="0,12,0,0"
 						SelectionChanged="NavigationView_SelectionChanged"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationViewSample.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/NavigationViewTests/NavigationViewSample.xaml
@@ -9,15 +9,17 @@
 	mc:Ignorable="d xamarin"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<Grid MaxWidth="750" HorizontalAlignment="Left"> <!-- Max Width to force compact mode -->
+	<Grid MaxWidth="850" BorderBrush="LightGray" BorderThickness="3"> <!-- Max Width to force compact mode -->
 		<NavigationView Loaded="NavigationView_Loaded"
 						Margin="0,12,0,0"
+						HorizontalAlignment="Stretch" 
 						SelectionChanged="NavigationView_SelectionChanged"
 						ItemInvoked="NvSample_ItemInvoked"
 						xamarin:BackRequested="NvSample_BackRequested"
 						x:Name="nvSample"
 						IsSettingsVisible="true"
 						IsTabStop="False"
+						CompactModeThresholdWidth="900"
 						Windows10version1803:IsBackButtonVisible="Visible"
 						Windows10version1803:PaneTitle="This the pane title"
 						Header="This is header text.">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Multiple_Containers.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Multiple_Containers.xaml
@@ -1,0 +1,59 @@
+﻿<UserControl
+		x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.SimpleText_MaxLines_Multiple_Containers"
+		xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		xmlns:local="using:Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlockControl"
+		xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+		mc:Ignorable="d"
+		d:DesignHeight="300"
+		d:DesignWidth="400">
+	<Grid Width="200">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<Grid Grid.Row="0">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="7*" />
+				<ColumnDefinition Width="3*" />
+			</Grid.ColumnDefinitions>
+			<Slider
+					Minimum="1"
+					Maximum="10"
+					x:Name="slider"
+					Grid.Column="0" />
+			<TextBlock
+					Text="{Binding Value, ElementName=slider}"
+					Grid.Column="1"
+					Foreground="Black" />
+		</Grid>
+
+		<Grid
+				Background="Cyan"
+				Grid.Row="1"
+				x:Name="grid1">
+			<TextBlock
+					x:Name="gridTextBlock"
+					Text="Grid container. This is a very very very very long WRAPPING (Wrap) text that *should* wrap because it goes out of the screen. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+					FontSize="20"
+					TextWrapping="Wrap"
+					MaxLines="{Binding Value, ElementName=slider}"
+					Foreground="Black" />
+		</Grid>
+		<StackPanel
+				Background="Yellow"
+				Grid.Row="2"
+				x:Name="stack1">
+			<TextBlock
+                    x:Name="stackTextBlock"
+					Text="Stack container. This is a very very very very long WRAPPING (Wrap) text that *should* wrap because it goes out of the screen. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+					FontSize="20"
+					TextWrapping="Wrap"
+					MaxLines="{Binding Value, ElementName=slider}"
+					Foreground="Black" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Multiple_Containers.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Multiple_Containers.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[Sample]
+	public sealed partial class SimpleText_MaxLines_Multiple_Containers : UserControl
+	{
+		public SimpleText_MaxLines_Multiple_Containers()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Toolkit/UIElementExtensions.cs
+++ b/src/Uno.UI.Toolkit/UIElementExtensions.cs
@@ -121,10 +121,12 @@ namespace Uno.UI.Toolkit
 
 					var str = $"{(x * elevation).ToStringInvariant()}px {(y * elevation).ToStringInvariant()}px {(blur * elevation).ToStringInvariant()}px {color.ToCssString()}";
 					uiElement.SetStyle("box-shadow", str);
+					uiElement.SetCssClasses("noclip");
 				}
 				else
 				{
 					uiElement.ResetStyle("box-shadow");
+					uiElement.UnsetCssClasses("noclip");
 				}
 			}
 #elif NETFX_CORE

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -157,7 +157,6 @@ namespace Windows.UI.Xaml.Controls
 			UpdateTextTrimming();
 			UpdateTextFormatted();
 			UpdatePaint();
-			UpdateMaxLines();
 		}
 
 		private void UpdateLayoutAlignment()
@@ -241,22 +240,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			_textFormatted = GetTextFormatted();
-		}
-
-		/// <summary>
-		/// Sets ellipsize to truncateAt.END when a number of line is specified.
-		/// If ellipsize is another value, the text won't truncate.
-		/// </summary>
-		private void UpdateMaxLines()
-		{
-			if (_ellipsize != null)
-			{
-				return;
-			}
-
-			_ellipsize = this.IsLayoutConstrainedByMaxLines
-				? TruncateEnd
-				: null;
 		}
 
 		private Java.Lang.ICharSequence GetTextFormatted()
@@ -414,7 +397,7 @@ namespace Windows.UI.Xaml.Controls
 			var newLayout = new LayoutBuilder(
 				_textFormatted,
 				_paint,
-				_ellipsize,
+				IsLayoutConstrainedByMaxLines ? TruncateEnd : _ellipsize, // .SetMaxLines() won't work on Android unless the ellipsize "END" is used.
 				_layoutAlignment,
 				TextWrapping,
 				MaxLines,
@@ -724,13 +707,10 @@ namespace Windows.UI.Xaml.Controls
 				}
 				else
 				{
-					// .SetMaxLines() won't work on Android unless the ellipsize "END" is used.
-					var ellipsize = _maxLines > 0 && _ellipsize == null ? TextUtils.TruncateAt.End : _ellipsize;
-
 					Layout = StaticLayout.Builder.Obtain(_textFormatted, 0, _textFormatted.Length(), _paint, width)
 					.SetLineSpacing(_addedSpacing = GetSpacingAdd(_paint), 1)
 					.SetMaxLines(maxLines)
-					.SetEllipsize(ellipsize)
+					.SetEllipsize(_ellipsize)
 					.SetEllipsizedWidth(width)
 					.SetAlignment(_layoutAlignment)
 					.SetIncludePad(true)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -141,6 +141,7 @@ namespace Windows.UI.Xaml.Controls
 
 		// Invalidate _ellipsize
 		partial void OnTextTrimmingChangedPartial() => _ellipsize = null;
+		partial void OnMaxLinesChangedPartial() => _ellipsize = null;
 
 		// Invalidate _layoutAlignment
 		partial void OnTextAlignmentChangedPartial() => _layoutAlignment = null;
@@ -156,6 +157,7 @@ namespace Windows.UI.Xaml.Controls
 			UpdateTextTrimming();
 			UpdateTextFormatted();
 			UpdatePaint();
+			UpdateMaxLines();
 		}
 
 		private void UpdateLayoutAlignment()
@@ -239,6 +241,22 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			_textFormatted = GetTextFormatted();
+		}
+
+		/// <summary>
+		/// Sets ellipsize to truncateAt.END when a number of line is specified.
+		/// If ellipsize is another value, the text won't truncate.
+		/// </summary>
+		private void UpdateMaxLines()
+		{
+			if (_ellipsize != null)
+			{
+				return;
+			}
+
+			_ellipsize = this.IsLayoutConstrainedByMaxLines
+				? TruncateEnd
+				: null;
 		}
 
 		private Java.Lang.ICharSequence GetTextFormatted()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -636,6 +636,11 @@ namespace Windows.UI.Xaml.Controls
 		private bool UseInlinesFastPath => _inlines == null;
 
 		/// <summary>
+		/// Returns if the TextBlock is constrained by a maximum number of lines.
+		/// </summary>
+		private bool IsLayoutConstrainedByMaxLines => MaxLines > 0;
+
+		/// <summary>
 		/// Gets the inlines which affect the typography of the TextBlock.
 		/// </summary>
 		private IEnumerable<(Inline inline, int start, int end)> GetEffectiveInlines()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -45,7 +45,18 @@ namespace Windows.UI.Xaml.Controls
 			OnTextAlignmentChangedPartial();
 			OnTextWrappingChangedPartial();
 			OnIsTextSelectionEnabledChangedPartial();
+			InitializeDefaultValues();
+
 		}
+
+		/// <summary>
+		/// Set default properties to vertical top.
+		/// In wasm, this behavior is closer to the default textblock property than stretch.
+		/// </summary>
+		private void InitializeDefaultValues()
+		{
+            this.SetValue(VerticalAlignmentProperty, VerticalAlignment.Top, DependencyPropertyValuePrecedences.DefaultValue);
+        }
 
 		private void ConditionalUpdate(ref bool condition, Action action)
 		{
@@ -113,6 +124,20 @@ namespace Windows.UI.Xaml.Controls
 
 				return desizedSize;
 			}
+		}
+
+		/// <summary>
+		/// When the control is constrained, it should only take it's desired size or
+		/// it will show all of it's content.
+		/// </summary>
+		/// <param name="finalSize"></param>
+		/// <returns></returns>
+		protected override Size ArrangeOverride(Size finalSize)
+		{
+			var arrangeSize = IsLayoutConstrainedByMaxLines
+				? DesiredSize
+				: finalSize;
+			return base.ArrangeOverride(arrangeSize);
 		}
 
 		private int GetCharacterIndexAtPoint(Point point) => throw new NotSupportedException();

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -39,6 +39,13 @@ body {
   transform: translate(0, 0);
 }
 
+.uno-uielement .noclip {
+  /* Used when we need to force the element to be unclipped.
+      --> Used by the toolkit for elevation
+  */
+  clip: auto !important;
+}
+
 svg.uno-uielement {
   /*
     The SVG elements are not intended to be a touch target (they are only a holder collection of child shapes),


### PR DESCRIPTION
GitHub Issue (If applicable): Closing #3714

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Max lines was not working in wasm, except in a stack panel, and it was not working in android.

## What is the new behavior?
The max line works.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~
- [ ] ~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~
- [ ] ~Validated PR `Screenshots Compare Test Run` results.~
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information