### PR TITLE
fix: Do not throw exception on navigation after first page failed to load

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -289,7 +289,7 @@ namespace Windows.UI.Xaml.Controls
 					return false;
 				}
 
-				CurrentEntry?.Instance.OnNavigatingFrom(navigatingFromArgs);
+				CurrentEntry?.Instance?.OnNavigatingFrom(navigatingFromArgs);
 
 				if (navigatingFromArgs.Cancel)
 				{


### PR DESCRIPTION
GitHub Issue (If applicable):

Closes #4412

## PR Type

- Bugfix?

## What is the current behavior?

See issue #4412

## What is the new behavior?

Frame.Navigate() is more robust and will not fail to navigate to a new page if the first/previous page failed to load.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~Docs have been added/updated which fit [documentation template]~(https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~
- [ ] ~Validated PR `Screenshots Compare Test Run` results.~
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
