### PR TITLE
Fix multiline TextBox scrollbars

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -130,9 +130,6 @@ namespace Windows.UI.Xaml.Controls
 				scrollViewer.VerticalScrollMode = ScrollMode.Disabled;
 				scrollViewer.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
 				scrollViewer.VerticalScrollBarVisibility = ScrollBarVisibility.Disabled;
-#elif __WASM__
-				// We disable horizontal scrolling because the inner single-line TextBoxView provides its own horizontal scrolling
-				scrollViewer.HorizontalScrollMode = ScrollMode.Disabled;
 #endif
 			}
 
@@ -750,7 +747,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (_contentElement != null)
 			{
-				_contentElement.VerticalAlignment = newVerticalContentAlignment;
+				_contentElement.VerticalContentAlignment = newVerticalContentAlignment;
 			}
 
 			if (_placeHolder != null)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -34,16 +34,12 @@ namespace Windows.UI.Xaml.Controls
 		private void OnForegroundChanged(DependencyPropertyChangedEventArgs e)
 			=> this.SetForeground(e.NewValue);
 
-		public TextBoxView(TextBox textBox, bool isMultiline) : base(isMultiline ? "textarea" : "input")
+		public TextBoxView(TextBox textBox, bool isMultiline)
+			: base(isMultiline ? "textarea" : "input")
 		{
 			IsMultiline = isMultiline;
 			_textBox = textBox;
 			SetTextNative(_textBox.Text);
-
-			SetStyle(
-				("overflow-x", "visible"),
-				("overflow-y", "visible")
-			);
 
 			if (FeatureConfiguration.TextBox.HideCaret)
 			{
@@ -93,7 +89,8 @@ namespace Windows.UI.Xaml.Controls
 			InvalidateMeasure();
 		}
 
-		internal void SetTextNative(string text) => SetProperty("value", text);
+		internal void SetTextNative(string text)
+			=> SetProperty("value", text);
 
 		protected override Size MeasureOverride(Size availableSize) => MeasureView(availableSize);
 

--- a/src/Uno.UI/UI/Xaml/ElementStub.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml
 				&& newValue == Visibility.Visible
 			)
 			{
-				Materialize();
+				Materialize(isVisibilityChanged: true);
 			}
 		}
 
@@ -52,12 +52,15 @@ namespace Windows.UI.Xaml
 		}
 
 		public void Materialize()
+			=> Materialize(isVisibilityChanged: false);
+
+		private void Materialize(bool isVisibilityChanged)
 		{
 			var newContent = MaterializeContent();
 
 			var targetDependencyObject = newContent as DependencyObject;
 
-			if (targetDependencyObject != null)
+			if (isVisibilityChanged && targetDependencyObject != null)
 			{
 				var visibilityProperty = GetVisibilityProperty(newContent);
 

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -200,4 +200,5 @@ embed.uno-frameworkelement.uno-unarranged {
 
 textarea {
   resize: none;
+  overflow: hidden; /* Scrolling is handled by the parent ScrollViewer */
 }

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -471,6 +471,7 @@ declare namespace Uno.UI {
         private static MAX_HEIGHT;
         private measureElement;
         private measureViewInternal;
+        private createUnconstrainedStyle;
         scrollTo(pParams: number): boolean;
         rawPixelsToBase64EncodeImage(dataPtr: number, width: number, height: number): string;
         /**


### PR DESCRIPTION
GitHub Issue: fixes https://github.com/unoplatform/uno/issues/4354

## Bugfix
Fix a regression introduced by managed scroll bars where 2 vertical scrollbars appears in `TextBox` when configured to allow returns.

## What is the current behavior?
Previously the scrolling was handled by the native `textarea`.

## What is the new behavior?
The `textarea` is stretched to match its content size and the scrolling is delegated to its parent managed `ScrollViewer`.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
