### PR TITLE
Make ContentDialog.ShowAsync awaitable return result on Hide() call

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
@@ -434,5 +434,28 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 				}
 			}
 		}
+
+		[Test]
+		[AutoRetry]
+		public void ContentDialog_Async()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Async");
+
+			var showDialogButton = _app.Marked("AsyncDialogButton");
+			var hideDialogButton = _app.Marked("HideButton");
+			var statusTextblock = _app.Marked("DidShowAsyncReturnTextBlock");
+
+			// open dialog
+			_app.WaitForElement(showDialogButton);
+			_app.FastTap(showDialogButton);
+
+			// hide dialog
+			_app.WaitForElement(hideDialogButton);
+			_app.WaitForDependencyPropertyValue(statusTextblock, "Text", "Not Returned"); // verify that the dialog didn't return yet
+			_app.FastTap(hideDialogButton);
+
+			// verify showAsync() returned
+			_app.WaitForDependencyPropertyValue(statusTextblock, "Text", "Returned");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -813,6 +813,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentDialogTests\ContentDialog_Async.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentDialogTests\ContentDialog_Closing.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4083,6 +4087,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentDialogTests\ComboBoxContentDialog.xaml.cs">
       <DependentUpon>ComboBoxContentDialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentDialogTests\ContentDialog_Async.xaml.cs">
+      <DependentUpon>ContentDialog_Async.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ContentDialogTests\ContentDialog_Closing.xaml.cs">
       <DependentUpon>ContentDialog_Closing.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Async.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Async.xaml
@@ -12,7 +12,7 @@
 		<StackPanel>
 			<TextBlock Text="ContentDialog Async tests"
 					   Margin="50" />
-			<Button x:Name="AsyncDialog"
+			<Button x:Name="AsyncDialogButton"
 					Content="Show Dialog"
 					Click="Button_Click" />
 			<TextBlock x:Name="DidShowAsyncReturnTextBlock"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Async.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Async.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Async"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<StackPanel>
+			<TextBlock Text="ContentDialog Async tests"
+					   Margin="50" />
+			<Button x:Name="AsyncDialog"
+					Content="Show Dialog"
+					Click="Button_Click" />
+			<TextBlock x:Name="DidShowAsyncReturnTextBlock"
+					   Text="Not returned"
+					   Margin="50" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Async.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Async.xaml.cs
@@ -34,7 +34,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests
 			dialog = new ContentDialog();
 			_Button hideButton = new _Button()
 			{
-				Content = new TextBlock() { Text = "Hide" }
+				Content = new TextBlock() { Name = "HideButton", Text = "Hide" }
 			};
 			hideButton.Click += HideButton_Click;
 			dialog.Content = hideButton;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Async.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Async.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using _Button = Windows.UI.Xaml.Controls.Button;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests
+{
+	[SampleControlInfo("ContentDialog", "ContentDialog_Async", description: "Tests for ContentDialog async mechanism")]
+    public sealed partial class ContentDialog_Async : UserControl
+    {
+		private ContentDialog dialog;
+        public ContentDialog_Async()
+        {
+            this.InitializeComponent();
+		}
+
+		private async void Button_Click(object sender, RoutedEventArgs args)
+		{
+			dialog = new ContentDialog();
+			_Button hideButton = new _Button()
+			{
+				Content = new TextBlock() { Text = "Hide" }
+			};
+			hideButton.Click += HideButton_Click;
+			dialog.Content = hideButton;
+
+			DidShowAsyncReturnTextBlock.Text = "Not Returned";
+			var dummy = await dialog.ShowAsync();
+			DidShowAsyncReturnTextBlock.Text = "Returned";
+		}
+
+		private void HideButton_Click(object sender, RoutedEventArgs e)
+		{
+			dialog.Hide();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Closing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentDialogTests/ContentDialog_Closing.xaml.cs
@@ -58,14 +58,14 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests
 			var defer1Button = new _Button { Name = "Complete1Button", Content = "Complete 1" };
 			defer1Button.Click += (o, e) =>
 			{
-				deferral1.Complete();
 				ResultTextBlock.Text = "First complete called";
+				deferral1.Complete();
 			};
 			var defer2Button = new _Button { Name = "Complete2Button", Content = "Complete 2" };
 			defer2Button.Click += (o, e) =>
 			{
-				deferral2.Complete();
 				ResultTextBlock.Text = "Second complete called";
+				deferral2.Complete();
 			};
 			var panel = new StackPanel
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -125,9 +125,8 @@ namespace Windows.UI.Xaml.Controls
 					_popup.IsOpen = false;
 					_popup.Child = null;
 					UpdateVisualState();
-					_tcs.SetResult(result);
-
 					Closed?.Invoke(this, new ContentDialogClosedEventArgs(result));
+					_tcs.SetResult(result);
 				}
 			}
 			var closingArgs = new ContentDialogClosingEventArgs(Complete, result);

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -125,6 +125,7 @@ namespace Windows.UI.Xaml.Controls
 					_popup.IsOpen = false;
 					_popup.Child = null;
 					UpdateVisualState();
+					_tcs.SetResult(result);
 
 					Closed?.Invoke(this, new ContentDialogClosedEventArgs(result));
 				}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #4428

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On Android and iOS, awaiting `ContentDialog.ShowAsync()` didn't return with `ContentDialogResult.None` if `ContentDialog.Hide()` was called to dismiss it.

## What is the new behavior?

It now does.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

I don't think this PR contains any breaking changes.