### PR TITLE
Fix for Android .Measure() bug on TextBlock

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -365,7 +365,7 @@ namespace SamplesApp
 			=> SampleControl.Presentation.SampleChooserViewModel.Instance.GetAllSamplesNames();
 
 		public static string GetDisplayScreenScaling(string displayId)
-			=> DisplayInformation.GetForCurrentView().LogicalDpi.ToString(CultureInfo.InvariantCulture);
+			=> (DisplayInformation.GetForCurrentView().LogicalDpi * 100f / 96f).ToString(CultureInfo.InvariantCulture);
 
 		public static string RunTest(string metadataName)
 		{

--- a/src/SamplesApp/SamplesApp.UITests/Extensions/AppExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Extensions/AppExtensions.cs
@@ -1,15 +1,38 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Uno.UITest;
+using Uno.UITest.Helpers;
 
 namespace SamplesApp.UITests.Extensions
 {
 	public static class AppExtensions
 	{
 		public static void DragCoordinates(this IApp app, PointF from, PointF to) => app.DragCoordinates(from.X, from.Y, to.X, to.Y);
+
+		private static float? _scaling;
+		public static float GetDisplayScreenScaling(this IApp app)
+		{
+			return _scaling ?? (float)(_scaling = GetScaling());
+
+			float GetScaling()
+			{
+				var scalingRaw = app.InvokeGeneric("browser:SampleRunner|GetDisplayScreenScaling", "0");
+
+				if (float.TryParse(scalingRaw?.ToString(), NumberStyles.Float, NumberFormatInfo.InvariantInfo, out var scaling))
+				{
+					Console.WriteLine($"Display Scaling: {scaling}");
+					return scaling / 100f;
+				}
+				else
+				{
+					return 1f;
+				}
+			}
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Extensions/AppRect.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Extensions/AppRect.cs
@@ -1,0 +1,24 @@
+using Uno.UITest;
+
+namespace SamplesApp.UITests
+{
+	public class AppRect : IAppRect
+	{
+		public AppRect(float x, float y, float width, float height)
+		{
+			X = x;
+			Y = y;
+			Width = width;
+			Height = height;
+		}
+
+		public float Width { get; }
+		public float Height { get; }
+		public float X { get; }
+		public float Y { get; }
+		public float CenterX => Width / 2f + X;
+		public float CenterY => Height / 2f + Y;
+		public float Right => X + Width;
+		public float Bottom => Y + Height;
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Extensions/AppRectExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Extensions/AppRectExtensions.cs
@@ -1,0 +1,17 @@
+using Uno.UITest;
+
+namespace SamplesApp.UITests
+{
+	public static class AppRectExtensions
+	{
+		public static IAppRect ApplyScale(this IAppRect rect, float scale) =>
+			new AppRect(
+				x: rect.X * scale,
+				y: rect.Y * scale,
+				width: rect.Width * scale,
+				height: rect.Height * scale
+			);
+
+		public static IAppRect UnapplyScale(this IAppRect rect, float scale) => rect.ApplyScale(1f / scale);
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Extensions/FluentExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Extensions/FluentExtensions.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FluentAssertions.Execution;
 
 namespace SamplesApp.UITests
 {
@@ -23,6 +25,13 @@ namespace SamplesApp.UITests
 			}
 
 			return target;
+		}
+
+		public static void FailWithText(this AssertionScope scope, string text)
+		{
+			var t = text.Replace("{", "{{").Replace("}", "}}");
+
+			scope.FailWith(t);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Extensions/QueryExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Extensions/QueryExtensions.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using SamplesApp.UITests.Extensions;
 using Uno.UITest;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
+using Uno.UITests.Helpers;
 
 namespace SamplesApp.UITests
 {
@@ -45,19 +47,84 @@ namespace SamplesApp.UITests
 		/// <summary>
 		/// Get bounds rect for an element.
 		/// </summary>
+		[Obsolete("Use _app.GetPhysicalRect() or _app.GetLogicalRect() to clarify your needs.")]
 		public static IAppRect GetRect(this IApp app, string elementName)
 		{
 			return app.WaitForElement(elementName).Single().Rect;
 		}
+		[Obsolete("Use _app.GetPhysicalRect() or _app.GetLogicalRect() to clarify your needs.")]
 		public static IAppRect GetRect(this IApp app, QueryEx query)
 		{
 			return app.WaitForElement(query).Single().Rect;
 		}
+		[Obsolete("Use _app.GetPhysicalRect() or _app.GetLogicalRect() to clarify your needs.")]
 		public static IAppRect GetRect(this IApp app, Func<IAppQuery, IAppQuery> query)
 		{
 			return app.WaitForElement(query).Single().Rect;
 		}
 
+#pragma warning disable 618 // Disable [Obsolete] warnings
+		/// <summary>
+		/// This will return a Rect in the physical coordinates space (same as screenshots)
+		/// </summary>
+		public static IAppRect GetPhysicalRect(this IApp app, string elementName) => ToPhysicalRect(app, app.GetRect(elementName));
+
+		/// <summary>
+		/// This will return a Rect in the physical coordinates space (same as screenshots)
+		/// </summary>
+		public static IAppRect GetPhysicalRect(this IApp app, QueryEx query) => ToPhysicalRect(app, app.GetRect(query));
+
+		/// <summary>
+		/// This will return a Rect in the physical coordinates space (same as screenshots)
+		/// </summary>
+		public static IAppRect GetPhysicalRect(this IApp app, Func<IAppQuery, IAppQuery> query) => ToPhysicalRect(app, app.GetRect(query));
+
+		/// <summary>
+		/// This will return a Rect in the logical coordinates space (same as XAML size units)
+		/// </summary>
+		public static IAppRect GetLogicalRect(this IApp app, string elementName) => ToLogicalRect(app, app.GetRect(elementName));
+
+		/// <summary>
+		/// This will return a Rect in the logical coordinates space (same as XAML size units)
+		/// </summary>
+		public static IAppRect GetLogicalRect(this IApp app, QueryEx query) => ToLogicalRect(app, app.GetRect(query));
+
+		/// <summary>
+		/// This will return a Rect in the logical coordinates space (same as XAML size units)
+		/// </summary>
+		public static IAppRect GetLogicalRect(this IApp app, Func<IAppQuery, IAppQuery> query) => ToLogicalRect(app, app.GetRect(query));
+
+#pragma warning restore 618
+		// ************************
+		// Physical vs Logical Rect
+		// ************************
+		//
+		// On Android. _app.GetRect() will return values in the PHYSICAL coordinate space.
+		// On iOS, _app.GetRect() will return values in the LOGICAL coordinate space.
+		// On Wasm (Browser), _app.GetRect() will be 1:1 for PHYSICAL:LOGICAL, so no need to convert.
+		//
+		// ************************
+		private static IAppRect ToPhysicalRect(IApp app, IAppRect rect)
+		{
+			return AppInitializer.GetLocalPlatform() switch
+			{
+				Platform.Android => rect,
+				Platform.iOS => rect.ApplyScale(app.GetDisplayScreenScaling()),
+				Platform.Browser => rect,
+				_ => throw new InvalidOperationException("Unknown current platform.")
+			};
+		}
+
+		private static IAppRect ToLogicalRect(IApp app, IAppRect rect)
+		{
+			return AppInitializer.GetLocalPlatform() switch
+			{
+				Platform.Android => rect.UnapplyScale(app.GetDisplayScreenScaling()),
+				Platform.iOS => rect,
+				Platform.Browser => rect,
+				_ => throw new InvalidOperationException("Unknown current platform.")
+			};
+		}
 		public static void FastTap(this IApp app, string elementName)
 		{
 			var tapPosition = app.GetRect(elementName);

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
+using SamplesApp.UITests.Extensions;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest;
 using Uno.UITest.Helpers;
@@ -16,7 +17,7 @@ namespace SamplesApp.UITests
 	{
 		protected IApp _app;
 		private static int _totalTestFixtureCount;
-		private double? _scaling;
+		private float? _scaling;
 
 		public SampleControlUITestBase()
 		{
@@ -314,25 +315,7 @@ namespace SamplesApp.UITests
 			return new PhysicalRect(logicalRect, GetDisplayScreenScaling());
 		}
 
-		internal double GetDisplayScreenScaling()
-		{
-			if (_scaling == null)
-			{
-				var scalingRaw = _app.InvokeGeneric("browser:SampleRunner|GetDisplayScreenScaling", "0");
-
-				if (double.TryParse(scalingRaw?.ToString(), out var scaling))
-				{
-					Console.WriteLine($"Display Scaling: {scaling}");
-					_scaling = scaling / 100;
-				}
-				else
-				{
-					_scaling = 1;
-				}
-			}
-
-			return _scaling.Value;
-		}
+		internal float GetDisplayScreenScaling() => _app.GetDisplayScreenScaling();
 
 		/// <summary>
 		/// Get the center of <paramref name="rect"/> adjusted for the display scale, appropriate for screenshot analysis.

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.ExpectedPixels.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.ExpectedPixels.cs
@@ -51,14 +51,21 @@ namespace SamplesApp.UITests.TestFramework
 
 		public ExpectedPixels Pixels(Bitmap source, Rectangle rect)
 		{
-			var colors = new Color[rect.Height, rect.Width];
-			for (var py = 0; py < rect.Height; py++)
-			for (var px = 0; px < rect.Width; px++)
+			try
 			{
-				colors[py, px] = source.GetPixel(rect.X + px, rect.Y + py);
+				var colors = new Color[rect.Height, rect.Width];
+				for (var py = 0; py < rect.Height; py++)
+				for (var px = 0; px < rect.Width; px++)
+				{
+					colors[py, px] = source.GetPixel(rect.X + px, rect.Y + py);
+				}
+
+				return new ExpectedPixels(Name, Location, rect.Location, colors, Tolerance);
 			}
-			
-			return new ExpectedPixels(Name, Location, rect.Location, colors, Tolerance);
+			catch (Exception ex)
+			{
+				throw new InvalidOperationException($"Unable to create a pixel array of {rect.Width}x{rect.Height} (bitmap is {source.Width}x{source.Height}).");
+			}
 		}
 
 		public ExpectedPixels Pixels(Bitmap source)

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -93,6 +95,11 @@ namespace SamplesApp.UITests.TestFramework
 			PixelTolerance tolerance,
 			[CallerLineNumber] int line = 0)
 		{
+			using var assertionScope = new AssertionScope($"{expected.StepName}<=={actual}");
+			assertionScope.AddReportable("expectedRect", expectedRect.ToString());
+			assertionScope.AddReportable("actualRect", actualRect.ToString());
+			assertionScope.AddReportable("expectedToActualScale", expectedToActualScale.ToString(NumberFormatInfo.InvariantInfo));
+
 			var (areEqual, context) = EqualityCheck(expected, expectedRect, actual, actualBitmap, actualRect, expectedToActualScale, tolerance, line);
 
 			if (areEqual)
@@ -101,7 +108,7 @@ namespace SamplesApp.UITests.TestFramework
 			}
 			else
 			{
-				Assert.Fail(context.ToString());
+				assertionScope.FailWithText(context);
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
@@ -122,12 +122,13 @@ namespace SamplesApp.UITests.TestFramework
 			PixelTolerance tolerance,
 			[CallerLineNumber] int line = 0)
 		{
+			using var expectedBitmap = new Bitmap(expected.File.FullName);
+
 			if (expectedRect != FirstQuadrant && actualRect != FirstQuadrant)
 			{
 				Assert.AreEqual(expectedRect.Size, actualRect.Size, WithContext("Compare rects don't have the same size"));
 			}
 
-			using var expectedBitmap = new Bitmap(expected.File.FullName);
 			if (expectedRect == FirstQuadrant && actualRect == FirstQuadrant)
 			{
 				var effectiveExpectedBitmapSize = new Size(
@@ -154,8 +155,8 @@ namespace SamplesApp.UITests.TestFramework
 				=> new StringBuilder()
 					.AppendLine($"ImageAssert.AreEqual @ line {line}")
 					.AppendLine("pixelTolerance: " + tolerance)
-					.AppendLine($"expected: {expected?.StepName} ({expected?.File.Name}){(expectedRect == FirstQuadrant ? null : $" in {expectedRect}")}")
-					.AppendLine($"actual  : {actual?.StepName ?? "--unknown--"} ({actual?.File.Name}){(actualRect == FirstQuadrant ? null : $" in {actualRect}")}")
+					.AppendLine($"expected: {expected?.StepName} ({expected?.File.Name} {expectedBitmap.Size}){(expectedRect == FirstQuadrant ? null : $" in {expectedRect}")}")
+					.AppendLine($"actual  : {actual?.StepName ?? "--unknown--"} ({actual?.File.Name} {actualBitmap.Size}){(actualRect == FirstQuadrant ? null : $" in {actualRect}")}")
 					.AppendLine("====================");
 
 			string WithContext(string message)
@@ -205,11 +206,11 @@ namespace SamplesApp.UITests.TestFramework
 
 			if (!result.areEqual)
 			{
-				Console.WriteLine(result.context.ToString());
+				Console.WriteLine(result.context);
 			}
 			else
 			{
-				Assert.Fail(result.context.ToString());
+				AssertionScope.Current.FailWithText(result.context);
 			}
 		}
 		#endregion
@@ -368,9 +369,20 @@ namespace SamplesApp.UITests.TestFramework
 			for (var offsetY = 0; offsetY <= expectation.Tolerance.Offset.y; offsetY++)
 			{
 				yield return (offsetX, offsetY);
-				if (offsetX > 0) yield return (-offsetX, offsetY);
-				if (offsetY > 0) yield return (offsetX, -offsetY);
-				if (offsetX > 0 && offsetY > 0) yield return (-offsetX, -offsetY);
+				if (offsetX > 0)
+				{
+					yield return (-offsetX, offsetY);
+				}
+
+				if (offsetY > 0)
+				{
+					yield return (offsetX, -offsetY);
+				}
+
+				if (offsetX > 0 && offsetY > 0)
+				{
+					yield return (-offsetX, -offsetY);
+				}
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -242,7 +242,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 				// (4)
 				var rect1 = new AppRect(
 					x: textRect.Right,
-					y:sampleRect.X,
+						y: sampleRect.Y,
 					width: sampleRect.Right - textRect.Right,
 					height:sampleRect.Height);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -219,9 +219,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			// (1)
 			var sampleScreenshot = this.TakeScreenshot("fullSample", ignoreInSnapshotCompare: true);
-			var sampleRect = _app.GetRect("sampleRootPanel");
+			var sampleRect = _app.GetPhysicalRect("sampleRootPanel");
 
 			using var _ = new AssertionScope();
+
 
 			Test("text1", "border1");
 			Test("text2", "border2");
@@ -231,7 +232,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			void Test(string textControl, string borderControl)
 			{
-				var textRect = _app.GetRect(borderControl);
+				var textRect = _app.GetPhysicalRect(borderControl);
 
 				// (2)
 				_app.Marked(textControl).SetDependencyPropertyValue("Opacity", "0");
@@ -240,24 +241,29 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 				var afterScreenshot = this.TakeScreenshot("sample-" + textControl, ignoreInSnapshotCompare: true);
 
 				// (4)
-				var rect1 = new AppRect(
-					x: textRect.Right,
+				using (var s = new AssertionScope("Right zone"))
+				{
+					var rect1 = new AppRect(
+						x: textRect.Right,
 						y: sampleRect.Y,
-					width: sampleRect.Right - textRect.Right,
-					height:sampleRect.Height);
+						width: sampleRect.Right - textRect.Right,
+						height: sampleRect.Height);
 
-				ImageAssert.AreEqual(sampleScreenshot, rect1, afterScreenshot, rect1);
+					ImageAssert.AreEqual(sampleScreenshot, rect1, afterScreenshot, rect1);
+				}
 
 				// (5)
-				var rect2 = new AppRect(
-					x: textRect.X,
-					y: textRect.Bottom,
-					width: textRect.Width,
-					height: sampleRect.Height - textRect.Bottom);
+				using (var s = new AssertionScope("Bottom zone"))
+				{
+					var rect2 = new AppRect(
+						x: textRect.X,
+						y: textRect.Bottom,
+						width: textRect.Width,
+						height: sampleRect.Height - textRect.Bottom);
 
-				ImageAssert.AreEqual(sampleScreenshot, rect2, afterScreenshot, rect2);
+					ImageAssert.AreEqual(sampleScreenshot, rect2, afterScreenshot, rect2);
+				}
 			}
-
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageUniformWithinScrollViewer.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageUniformWithinScrollViewer.xaml
@@ -1,33 +1,64 @@
-<UserControl
+<Page
 	x:Class="Uno.UI.Samples.UITests.ImageTestsControl.ImageUniformWithinScrollViewer" 
 	xmlns:controls="using:Uno.UI.Samples.Controls"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:local="Uno.UI.Samples.UITests.ImageTestsControl"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:u="using:Uno.UI.Samples.Controls"
-	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
-	xmlns:ios="http://uno.ui/ios"
-	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:android="http://uno.ui/android"
-	mc:Ignorable="d ios android"
+	mc:Ignorable="d"
 	d:DesignHeight="2000"
 	d:DesignWidth="400">
 
-	<controls:SampleControl SampleDescription="ImageUniformWithinScrollViewer - text should appear below and not be crowded out by the empty Image control.">
-		<controls:SampleControl.SampleContent>
-			<DataTemplate>
-				<ScrollViewer>
-					<u:StarStackPanel Width="200"
-								Background="Beige">
-						<Image 
-							Stretch="Uniform"/>
-						<!--http://hipsum.co/?paras=1&type=hipster-latin-->
-						<TextBlock Text="Four dollar toast tumblr offal, poutine taxidermy health goth VHS. Sapiente meh craft beer VHS, gochujang knausgaard sustainable venmo cred pug minim kale chips single-origin coffee letterpress godard. Art party street art hashtag est cornhole. Ugh listicle adipisicing swag fixie actually, aute migas retro esse distillery sriracha photo booth. Brunch ut yuccie locavore williamsburg heirloom. Yuccie kogi kale chips hella accusamus authentic, before they sold out put a bird on it organic nihil cronut single-origin coffee DIY ad. Brunch skateboard qui thundercats."/>
-					</u:StarStackPanel>
-				</ScrollViewer>
-			</DataTemplate>
-		</controls:SampleControl.SampleContent>
-	</controls:SampleControl>
-</UserControl>
+	<!--<ScrollViewer x:Name="SUT">
+		<StackPanel Width="200"
+					Background="Beige">
+			<Image Stretch="Uniform"/>
+			--><!-- http://hipsum.co/?paras=1&type=hipster-latin --><!--
+			<TextBlock Text="Four dollar toast tumblr offal, poutine taxidermy health goth VHS. Sapiente meh craft beer VHS, gochujang knausgaard sustainable venmo cred pug minim kale chips single-origin coffee letterpress godard. Art party street art hashtag est cornhole. Ugh listicle adipisicing swag fixie actually, aute migas retro esse distillery sriracha photo booth. Brunch ut yuccie locavore williamsburg heirloom. Yuccie kogi kale chips hella accusamus authentic, before they sold out put a bird on it organic nihil cronut single-origin coffee DIY ad. Brunch skateboard qui thundercats."/>
+		</StackPanel>
+	</ScrollViewer>-->
+
+	<Grid RowSpacing="10">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<TextBlock Grid.Row="0">
+			<Run FontSize="18">Following columns should be identical (first column contains an image)</Run>
+			<LineBreak />
+			+ Text should not overflow
+		</TextBlock>
+
+		<Grid Grid.Row="1">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+
+			<ScrollViewer x:Name="SUT" Grid.Column="0">
+				<Grid Width="120" Background="Beige">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
+					</Grid.RowDefinitions>
+					<Image Grid.Row="0" Stretch="Uniform"/>
+					<!-- http://hipsum.co/?paras=1&type=hipster-latin -->
+					<TextBlock Grid.Row="1" Text="Four dollar toast tumblr offal, poutine taxidermy health goth VHS. Sapiente meh craft beer VHS, gochujang knausgaard sustainable venmo cred pug minim kale chips single-origin coffee letterpress godard. Art party street art hashtag est cornhole. Ugh listicle adipisicing swag fixie actually, aute migas retro esse distillery sriracha photo booth. Brunch ut yuccie locavore williamsburg heirloom. Yuccie kogi kale chips hella accusamus authentic, before they sold out put a bird on it organic nihil cronut single-origin coffee DIY ad. Brunch skateboard qui thundercats."/>
+				</Grid>
+			</ScrollViewer>
+
+			<Border Width="120" Background="Beige" Grid.Column="1">
+				<TextBlock Text="Four dollar toast tumblr offal, poutine taxidermy health goth VHS. Sapiente meh craft beer VHS, gochujang knausgaard sustainable venmo cred pug minim kale chips single-origin coffee letterpress godard. Art party street art hashtag est cornhole. Ugh listicle adipisicing swag fixie actually, aute migas retro esse distillery sriracha photo booth. Brunch ut yuccie locavore williamsburg heirloom. Yuccie kogi kale chips hella accusamus authentic, before they sold out put a bird on it organic nihil cronut single-origin coffee DIY ad. Brunch skateboard qui thundercats."/>
+			</Border>
+
+			<Border Background="Beige" Grid.Column="2" HorizontalAlignment="Center" Width="120">
+				<TextBlock Width="120"  Text="Four dollar toast tumblr offal, poutine taxidermy health goth VHS. Sapiente meh craft beer VHS, gochujang knausgaard sustainable venmo cred pug minim kale chips single-origin coffee letterpress godard. Art party street art hashtag est cornhole. Ugh listicle adipisicing swag fixie actually, aute migas retro esse distillery sriracha photo booth. Brunch ut yuccie locavore williamsburg heirloom. Yuccie kogi kale chips hella accusamus authentic, before they sold out put a bird on it organic nihil cronut single-origin coffee DIY ad. Brunch skateboard qui thundercats."/>
+			</Border>
+		</Grid>
+	</Grid>
+
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageUniformWithinScrollViewer.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageUniformWithinScrollViewer.xaml.cs
@@ -1,23 +1,12 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
 using Uno.UI.Samples.Controls;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 
 namespace Uno.UI.Samples.UITests.ImageTestsControl
 {
-	[SampleControlInfo("Image", "ImageUniformWithinScrollViewer")]
-	public sealed partial class ImageUniformWithinScrollViewer : UserControl
+	[Sample("Image", Description = "ImageUniformWithinScrollViewer - text should appear below and not be crowded out by the empty Image control.")]
+	public sealed partial class ImageUniformWithinScrollViewer : Page
 	{
 		public ImageUniformWithinScrollViewer()
 		{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two.xaml
@@ -14,6 +14,9 @@
 	d:DesignHeight="300"
 	d:DesignWidth="400">
 
-	<TextBlock Text="This is a very very very very long text that should *not* wrap even though it goes out of the screen" FontSize="20" MaxLines="2"  />
+	<TextBlock
+		Text="This is a very very very very long text that should *not* wrap even though it goes out of the screen. We're serious, this line of text is very long and it should not wrap at all, even on a tablet"
+		FontSize="25"
+		MaxLines="2"  />
 
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml
@@ -1,4 +1,4 @@
-<UserControl
+<Page
 	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.SimpleText_MaxLines_Two_With_Wrap"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -15,53 +15,72 @@
 	d:DesignHeight="300"
 	d:DesignWidth="400">
 
-	<Grid>
-		<Grid.RowDefinitions>
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="*" />
-			<RowDefinition Height="Auto" />
-		</Grid.RowDefinitions>
-		<Slider Minimum="10" Maximum="1600" Value="350" x:Name="slider"/>
-		<Slider Minimum="5" Maximum="300" Value="70" x:Name="sliderV" Grid.Row="1"/>
+	<StackPanel>
+		<Slider Minimum="10" Maximum="1600" Value="350" x:Name="slider">
+			<Slider.Header>
+				<TextBlock>Container Width <Run Text="{Binding Value, ElementName=slider}" /></TextBlock>
+			</Slider.Header>
+		</Slider>
+		<Slider Minimum="5" Maximum="300" Value="70" x:Name="sliderV">
+			<Slider.Header>
+				<TextBlock>Container Height <Run Text="{Binding Value, ElementName=sliderV}" /></TextBlock>
+			</Slider.Header>
+		</Slider>
+		<Slider Minimum="5" Maximum="170" Value="20" x:Name="fontsize">
+			<Slider.Header>
+				<TextBlock>Font Size <Run Text="{Binding Value, ElementName=fontsize}" /></TextBlock>
+			</Slider.Header>
+		</Slider>
+		<Slider Minimum="5" Maximum="170" Value="20" x:Name="lineheight">
+			<Slider.Header>
+				<TextBlock>Line Height <Run Text="{Binding Value, ElementName=lineheight}" /></TextBlock>
+			</Slider.Header>
+		</Slider>
 
-		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Cyan" Grid.Row="2" x:Name="border1">
-			<TextBlock
-				Text="This is a very very very very long WRAPPING (Wrap) text that *should* wrap because it goes out of the screen"
-				FontSize="20"
-				TextWrapping="Wrap"
-				MaxLines="2"  />
-		</Border>
-		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Yellow" Grid.Row="3" x:Name="border2">
-			<TextBlock
-				Text="This is a very very very very long WRAPPING (WrapWholeWords) text that *should* wrap because it goes out of the screen"
-				FontSize="20"
-				TextWrapping="WrapWholeWords"
-				MaxLines="2"  />
-		</Border>
-		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Cyan" Grid.Row="4" x:Name="border3">
-			<TextBlock
-				Text="This is a very very very very long WRAPPING (WrapWholeWords/CharacterEllipsis) text that *should* wrap because it goes out of the screen"
-				FontSize="20"
-				TextWrapping="Wrap"
-				TextTrimming="CharacterEllipsis"
-				MaxLines="2"  />
-		</Border>
-		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Yellow" Grid.Row="5" x:Name="border4">
-			<TextBlock
-				Text="This is a very very very very long WRAPPING (Wrap/CharacterEllipsis) text that *should* wrap because it goes out of the screen"
-				FontSize="20"
-				TextWrapping="WrapWholeWords"
-				TextTrimming="CharacterEllipsis"
-				MaxLines="2"  />
-		</Border>
-		<wasm:TextBlock Grid.Row="7">
-			(WASM ONLY) Cache: Hits=<Run x:Name="hits">0</Run>, Misses=<Run x:Name="misses">0</Run>.
+		<wasm:TextBlock>
+			(WASM ONLY) Cache: Hits=
+			<Run x:Name="hits">0</Run> , Misses=
+			<Run x:Name="misses">0</Run> .
 		</wasm:TextBlock>
-	</Grid>
 
-</UserControl>
+		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Cyan" Name="border1">
+			<TextBlock
+				FontSize="{Binding Value, ElementName=fontsize}"
+				TextWrapping="Wrap"
+				LineHeight="{Binding Value, ElementName=lineheight}"
+				MaxLines="2">
+				<Run FontWeight="Bold">WRAPPING (Wrap)/MaxLines=2</Run> This is a very very very very long text that *should* wrap because it goes out of the screen
+			</TextBlock>
+		</Border>
+		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Yellow" x:Name="border2">
+			<TextBlock
+				FontSize="{Binding Value, ElementName=fontsize}"
+				TextWrapping="WrapWholeWords"
+				LineHeight="{Binding Value, ElementName=lineheight}"
+				MaxLines="2">
+				<Run FontWeight="Bold">WRAPPING (WrapWholeWords)/MaxLines=2</Run> This is a very very very very long text that *should* wrap because it goes out of the screen
+			</TextBlock>
+		</Border>
+		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Cyan" x:Name="border3">
+			<TextBlock
+				FontSize="{Binding Value, ElementName=fontsize}"
+				TextWrapping="Wrap"
+				TextTrimming="CharacterEllipsis"
+				LineHeight="{Binding Value, ElementName=lineheight}"
+				MaxLines="2">
+				<Run FontWeight="Bold">WRAPPING (WrapWholeWords/CharacterEllipsis)/MaxLines=2</Run> This is a very very very very long text that *should* wrap because it goes out of the screen
+			</TextBlock>
+		</Border>
+		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Yellow" x:Name="border4">
+			<TextBlock
+				FontSize="{Binding Value, ElementName=fontsize}"
+				TextWrapping="WrapWholeWords"
+				TextTrimming="CharacterEllipsis"
+				LineHeight="{Binding Value, ElementName=lineheight}"
+				MaxLines="2">
+				<Run FontWeight="Bold">WRAPPING (Wrap/CharacterEllipsis)/MaxLines=2</Run> This is a very very very very long text that *should* wrap because it goes out of the screen
+			</TextBlock>
+		</Border>
+	</StackPanel>
+
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml.cs
@@ -6,7 +6,7 @@ using Windows.UI.Xaml.Controls;
 namespace Uno.UI.Samples.Content.UITests.TextBlockControl
 {
 	[SampleControlInfo("TextBlockControl", "SimpleText_MaxLines_Two_With_Wrap", description: "This sample shows a very long line that should wrap on a maximum of two lines.")]
-	public sealed partial class SimpleText_MaxLines_Two_With_Wrap : UserControl
+	public sealed partial class SimpleText_MaxLines_Two_With_Wrap : Page
 	{
 		public SimpleText_MaxLines_Two_With_Wrap()
 		{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap.xaml
@@ -1,4 +1,4 @@
-<UserControl
+<Page
 	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Simple_Contrained_Horizontal_Center_Wrap"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -41,4 +41,4 @@
 		</Button>
 	</Grid>
 
-</UserControl>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap.xaml.cs
@@ -3,8 +3,8 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Samples.Content.UITests.TextBlockControl
 {
-	[SampleControlInfo("TextBlockControl", "Simple_Contrained_Horizontal_Center_Wrap")]
-	public sealed partial class Simple_Contrained_Horizontal_Center_Wrap : UserControl
+	[Sample]
+	public sealed partial class Simple_Contrained_Horizontal_Center_Wrap : Page
 	{
 		public Simple_Contrained_Horizontal_Center_Wrap()
 		{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_ConstrainedByContainer.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_ConstrainedByContainer.xaml
@@ -13,13 +13,35 @@
 	d:DesignHeight="2000"
 	d:DesignWidth="400">
 
-	<StackPanel>
+	<StackPanel Spacing="4" x:Name="sampleRootPanel">
 
-		<TextBlock Text="All the constrained TextBlocks have the same text :" />
+		<TextBlock FontSize="16" FontWeight="Bold">All the constrained TextBlocks have the same text</TextBlock>
 
-		<TextBlock Text=" Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur."
-				   TextWrapping="WrapWholeWords"
-				   FontSize="15" />
+		<TextBlock TextWrapping="WrapWholeWords"
+				   FontSize="15">
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur.
+		</TextBlock>
+
+		<Rectangle Height="1"
+				   Margin="0,5"
+				   Width="200" 
+				   Fill="Black" />
+
+		<TextBlock TextWrapping="WrapWholeWords">
+			The following TextBlock is inside a 200x20 Border. There is enough space for one line of text and TextWrapping is NoWrap (single line of text).
+		</TextBlock>
+
+		<Border Height="20"
+				Width="200"
+				Background="Tomato"
+				x:Name="border1"
+				Margin="0,10">
+			<TextBlock TextWrapping="NoWrap"
+					   x:Name="text1"
+					   FontSize="15">
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur.
+			</TextBlock>
+		</Border>
 
 		<Rectangle Height="1"
 				   Margin="0,5"
@@ -32,10 +54,33 @@
 		<Border Height="20"
 				Width="200"
 				Background="Tomato"
+				x:Name="border2"
 				Margin="0,10">
-			<TextBlock Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur."
-			           TextWrapping="WrapWholeWords"
-					   FontSize="15" />
+			<TextBlock TextWrapping="WrapWholeWords"
+					   x:Name="text2"
+					   FontSize="15">
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur.
+			</TextBlock>
+		</Border>
+
+		<Rectangle Height="1"
+				   Margin="0,5"
+				   Width="200" 
+				   Fill="Black" />
+
+		<TextBlock Text="The following TextBlock is inside a 200x20 Border. There is enough space for one line of text so it should trim"
+		           TextWrapping="WrapWholeWords"/>
+
+		<Border Height="20"
+				Width="200"
+				Background="Tomato"
+				x:Name="border3"
+				Margin="0,10">
+			<TextBlock TextWrapping="WrapWholeWords"
+					   x:Name="text3"
+					   FontSize="15">
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur.
+			</TextBlock>
 		</Border>
 		
 		<Rectangle Height="1"
@@ -49,10 +94,13 @@
 		<Border Height="40"
 				Width="200"
 				Background="Tomato"
+				x:Name="border4"
 				Margin="0,10">
-			<TextBlock Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur."
-			           TextWrapping="WrapWholeWords"
-					   FontSize="15" />
+			<TextBlock TextWrapping="WrapWholeWords"
+					   x:Name="text4"
+					   FontSize="15">
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur.
+			</TextBlock>
 		</Border>
 		
 		<Rectangle Height="1"
@@ -66,11 +114,14 @@
 		<Border Height="80"
 				Width="200"
 				Background="Tomato"
+				x:Name="border5"
 				Margin="0,10">
-			<TextBlock Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur." 
+			<TextBlock TextWrapping="WrapWholeWords"
 					   MaxLines="3"
-					   TextWrapping="WrapWholeWords"
-					   FontSize="15" />
+					   x:Name="text5"
+					   FontSize="15">
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur.
+			</TextBlock>
 		</Border>
 		
 	</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_TextTrimming.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_TextTrimming.xaml
@@ -8,10 +8,16 @@
 	d:DesignHeight="300"
 	d:DesignWidth="400">
 
-	<Grid>
+	<StackPanel Spacing="20">
+
+		<TextBlock FontSize="20">
+			1) You should see 2 lines of text (not a 3rd truncated line).
+			<LineBreak />2) An elipsis should appears at the end of the second line.
+		</TextBlock>
 
 		<Border Height="50"
-				Background="Tomato">
+				Background="Tomato"
+				Width="500">
 		  <TextBlock LineHeight="15"
 					 FontSize="15"
 					 TextTrimming="CharacterEllipsis"
@@ -19,5 +25,5 @@
 					 Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
 		</Border>
 
-	</Grid>
+	</StackPanel>
 </UserControl>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -607,7 +607,6 @@ namespace Windows.UI.Xaml.Controls
 					measuredHeight = Layout.GetLineTop(Layout.LineCount);
 				}
 
-
 				if(_maxLines > 0 && Layout.LineCount > _maxLines)
 				{
 					MakeLayout(


### PR DESCRIPTION
Fixes #4414 

# Bugfix
Fix measurement bug on Android.

## What is the current behavior?
Result from `.Measure()` were capped to `availableSize`, preventing the layout engine from applying clipping when required.

## What is the new behavior?
`.Measure()` now returns actual text size.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
