### PR TITLE
fix: BindingExpression will now apply the FallbackValue when a Converter returns DependencyProperty.UnsetValue

### DIFF
--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.Converter.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.Converter.cs
@@ -1,0 +1,70 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Dynamic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.Tests.BinderTests
+{
+	[TestClass]
+	public partial class Given_Binder_Converter
+	{
+		[TestMethod]
+		public void When_Converter_Returns_UnsetValue()
+		{
+			var SUT = new MyControl();
+
+			var myTestConverter = new MyTestConverter();
+
+			SUT.SetBinding(
+				MyControl.MyPropertyProperty,
+				new Windows.UI.Xaml.Data.Binding()
+				{
+					Path = new PropertyPath("."),
+					Converter = myTestConverter,
+					FallbackValue = "fallback value",
+					TargetNullValue = "null value"
+				}
+			);
+
+			myTestConverter.OutputValue = v => v;
+			SUT.DataContext = "hello";
+			Assert.AreEqual("hello", SUT.MyProperty);
+
+			myTestConverter.OutputValue = v => DependencyProperty.UnsetValue;
+			SUT.DataContext = "hello 3";
+			Assert.AreEqual("fallback value", SUT.MyProperty);
+		}
+
+		internal class MyTestConverter : IValueConverter
+		{
+			public Func<object, object?> OutputValue { get; set; } = o => null;
+
+			public object? Convert(object value, Type targetType, object parameter, string language) => OutputValue(value);
+
+			public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
+		}
+
+		public partial class MyControl : DependencyObject
+		{
+			public string MyProperty
+			{
+				get { return (string)GetValue(MyPropertyProperty); }
+				set { SetValue(MyPropertyProperty, value); }
+			}
+
+			public static readonly DependencyProperty MyPropertyProperty =
+				DependencyProperty.Register("MyProperty", typeof(string), typeof(MyControl), new FrameworkPropertyMetadata(null));
+		}
+	}
+
+}

--- a/src/Uno.UI/DataBinding/BindingExpression.cs
+++ b/src/Uno.UI/DataBinding/BindingExpression.cs
@@ -582,7 +582,12 @@ namespace Windows.UI.Xaml.Data
 					_IsCurrentlyPushing = true;
 					// Get the source value and place it in the target property
 					var convertedValue = ConvertValue(v);
-					if (useTargetNullValue && convertedValue == null && ParentBinding.TargetNullValue != null)
+
+					if (convertedValue == DependencyProperty.UnsetValue)
+					{
+						ApplyFallbackValue();
+					}
+					else if (useTargetNullValue && convertedValue == null && ParentBinding.TargetNullValue != null)
 					{
 						SetTargetValue(ConvertValue(ParentBinding.TargetNullValue));
 					}


### PR DESCRIPTION
GitHub Issue (If applicable): Closes #4458

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using a Converter that returns DependencyProperty.UnsetValue, the BindingExpression will currently throw an exception, output to the log, then apply the FallbackValue.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
The BindingExpression will apply the FallbackValue without throwing the exception which helps performance as well as not outputting errors to the log.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

No unit test can be written, since the outcome is the same aside from the internal exception and log output.
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
