### PR TITLE
fix: UIElementCollection adding the view twice

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
@@ -19,6 +19,16 @@ using MUXControlsTestApp.Utilities;
 using UIKit;
 #endif
 
+#if XAMARIN_ANDROID
+using _View = Android.Views.View;
+#elif XAMARIN_IOS
+using _View = UIKit.UIView;
+#elif __MACOS__
+using _View = AppKit.NSView;
+#else
+using _View = Windows.UI.Xaml.UIElement;
+#endif
+
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
 	[TestClass]
@@ -399,6 +409,17 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.AreEqual(1, loadingCount, "loading");
 			Assert.AreEqual(1, loadedCount, "loaded");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Add_Native_Child_To_ElementCollection()
+		{
+			var panel = new Grid();
+			var tbNativeTyped = (_View)new TextBlock();
+			panel.Children.Add(tbNativeTyped);
+
+			Assert.AreEqual(1, panel.Children.Count);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/UIElementCollectionExtensions.Xamarin.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementCollectionExtensions.Xamarin.cs
@@ -29,9 +29,11 @@ namespace Windows.UI.Xaml.Controls
 			{
 				uiElementCollection.Add(uiElement);
 			}
-
-			var wrapper = VisualTreeHelper.AdaptNative(view);
-			uiElementCollection.Add(wrapper);
+			else
+			{
+				var wrapper = VisualTreeHelper.AdaptNative(view);
+				uiElementCollection.Add(wrapper);
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
`UIElementCollection.Add` no longer adding view twice when the view is both an UIElement and a native view

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://github.com/unoplatform/nventive-private/issues/84
