### PR TITLE
fix(listview): [iOS] Fix outer ElementName bindings not available on reload

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -436,5 +436,36 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.AreEqual(list.SelectedIndex, -1);
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Outer_ElementName_Binding()
+		{
+			var page = new ListViewPages.ListViewTemplateOuterBindingPage();
+
+			for (int _ = 0; _ < 5; _++)
+			{
+				WindowHelper.WindowContent = page;
+				await WindowHelper.WaitForIdle();
+
+				var list = page.FindFirstChild<ListView>();
+				Assert.IsNotNull(list);
+
+				for (int i = 0; i < 3; i++)
+				{
+					ListViewItem lvi = null;
+					await WindowHelper.WaitFor(() => (lvi = list.ContainerFromItem(i) as ListViewItem) != null);
+					var sp = lvi.FindFirstChild<StackPanel>();
+					var tb = sp?.FindFirstChild<TextBlock>();
+					Assert.IsNotNull(tb);
+					Assert.AreEqual("OuterContextText", tb.Text);
+				}
+
+				WindowHelper.WindowContent = null; // Unload page+list
+				await WindowHelper.WaitForIdle();
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ListViewPages/ListViewTemplateOuterBindingPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ListViewPages/ListViewTemplateOuterBindingPage.xaml
@@ -1,0 +1,30 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ListViewPages.ListViewTemplateOuterBindingPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ListViewPages"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  x:Name="OuterPage"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<ListView x:Name="TargetListView"
+				  Grid.Row="1"
+				  Background="Beige"
+				  Width="200"
+				  Height="300"
+				  ItemsSource="{Binding Items}">
+
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<StackPanel>
+						<TextBlock x:Name="OuterBoundTextBlock"
+								   Text="{Binding DataContext.TextFromOuterContext, ElementName=OuterPage}" />
+						<TextBlock Text="{Binding }" />
+					</StackPanel>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+	</Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ListViewPages/ListViewTemplateOuterBindingPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ListViewPages/ListViewTemplateOuterBindingPage.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ListViewPages
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class ListViewTemplateOuterBindingPage : Page
+	{
+		public ListViewTemplateOuterBindingPage()
+		{
+			this.InitializeComponent();
+
+			DataContext = new MyViewModel();
+		}
+
+		private class MyViewModel
+		{
+			public int[] Items { get; } = Enumerable.Range(0, 3).ToArray();
+
+			public string TextFromOuterContext => "OuterContextText";
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -231,7 +231,7 @@ namespace Windows.UI.Xaml.Controls
 
 						// Ensure the item has a parent, since it's added to the native collection view
 						// which does not automatically sets the parent DependencyObject.
-						selectorItem.SetParent(Owner?.XamlParent?.InternalItemsPanelRoot);
+						selectorItem.SetParentOverride(Owner?.XamlParent?.InternalItemsPanelRoot);
 					}
 					else if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 					{

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.iOS.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using Uno.Disposables;
+using System.Text;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Core;
+using System.Threading.Tasks;
+using Uno.UI;
+using Uno.Extensions;
+using UIKit;
+
+namespace Windows.UI.Xaml.Controls.Primitives
+{
+	public partial class SelectorItem
+	{
+		private WeakReference<UIView> _parentOverride;
+
+		/// <summary>
+		/// Set a view which should be used as the DP parent for this container. Used from <see cref="NativeListViewBase"/>, because <see cref="UICollectionView"/>
+		/// wraps items in native UIViews which interrupts binding propagation.
+		/// </summary>
+		/// <param name="parentOverride">The logical parent of this container.</param>
+		internal void SetParentOverride(UIView parentOverride)
+		{
+			_parentOverride = new WeakReference<UIView>(parentOverride);
+			this.SetParent(parentOverride);
+		}
+
+		internal override void OnLoading()
+		{
+			if (_parentOverride?.GetTarget() is { } parentOverride && !(this.GetParent() is DependencyObject))
+			{
+				this.SetParent(parentOverride);
+			}
+			base.OnLoading();
+		}
+	}
+}


### PR DESCRIPTION
Bindings by ElementName to an element outside of a ListViewItem template were getting detached in some cases after the list was unloaded from the window and reloaded, because the ListViewItem's logical Parent was incorrectly getting set to the visual-tree parent (which is a native UIView imposed by UICollectionView). Ensure the logical Parent is correctly restored.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
fixes https://github.com/unoplatform/nventive-private/issues/82