### PR TITLE
fix(keyboard): [Gtk] Add missing operators mapping

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GTK/GtkCoreWindowExtension.Keyboard.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GTK/GtkCoreWindowExtension.Keyboard.cs
@@ -227,7 +227,13 @@ namespace Uno.UI.Runtime.Skia
 				Gdk.Key.KP_7 => VirtualKey.NumberPad7,
 				Gdk.Key.KP_8 => VirtualKey.NumberPad8,
 				Gdk.Key.KP_9 => VirtualKey.NumberPad9,
+
+				Gdk.Key.plus => VirtualKey.Add,
+				Gdk.Key.minus => VirtualKey.Subtract,
 				Gdk.Key.multiply => VirtualKey.Multiply,
+				Gdk.Key.slash => VirtualKey.Divide,
+
+				Gdk.Key.KP_Multiply => VirtualKey.Multiply,
 				Gdk.Key.KP_Add => VirtualKey.Add,
 				Gdk.Key.KP_Separator => VirtualKey.Separator,
 				Gdk.Key.KP_Subtract => VirtualKey.Subtract,


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adjust for missing operator keys for GTK.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
