### PR TITLE
Add support for "Auto" for control size

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -143,7 +143,8 @@ namespace Uno.UI.Samples.Tests
 
 				if (error != null)
 				{
-					testResultBlock.Inlines.Add(new Run { Text = "\n==>" + error.Message, Foreground = new SolidColorBrush(Colors.Red) });
+					var foreground = testResult != TestResult.Sucesss ? new SolidColorBrush(Colors.Red) : new SolidColorBrush(Colors.Yellow);
+					testResultBlock.Inlines.Add(new Run { Text = "\n==>" + error.Message, Foreground = foreground });
 
 					if (testResult == TestResult.Failed || testResult == TestResult.Error)
 					{

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -517,6 +517,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_Sizes.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_UnloadedMeasure.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3931,6 +3935,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_NativeLayout.xaml.cs">
       <DependentUpon>FrameworkElement_NativeLayout.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_Sizes.xaml.cs">
+      <DependentUpon>FrameworkElement_Sizes.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_UnloadedMeasure.xaml.cs">
       <DependentUpon>FrameworkElement_UnloadedMeasure.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_Sizes.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_Sizes.xaml
@@ -1,0 +1,73 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml.FrameworkElementTests.FrameworkElement_Sizes"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml.FrameworkElementTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<Style TargetType="FrameworkElement" x:Name="autoStyle">
+			<Setter Property="Width" Value="Auto" />
+		</Style>
+		<Style TargetType="FrameworkElement" x:Name="nanStyle">
+			<Setter Property="Width" Value="NaN" />
+		</Style>
+		<Style TargetType="FrameworkElement" x:Name="fixedStyle">
+			<Setter Property="Width" Value="200" />
+		</Style>
+	</Page.Resources>
+
+	<StackPanel Spacing="8">
+		<Border Background="DarkSeaGreen" x:Name="text1" Style="{StaticResource autoStyle}">
+			<TextBlock>Auto (style setter): <Run Text="{Binding Width, ElementName=text1}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text2" Style="{StaticResource nanStyle}">
+			<TextBlock>Nan (style setter): <Run Text="{Binding Width, ElementName=text2}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text3" Style="{StaticResource fixedStyle}">
+			<TextBlock>Fixed (style setter): <Run Text="{Binding Width, ElementName=text3}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text4" Width="Auto">
+			<TextBlock>Auto (direct): <Run Text="{Binding Width, ElementName=text4}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text5" Width="auto">
+			<TextBlock>auto (direct): <Run Text="{Binding Width, ElementName=text5}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text6" Width="{Binding Tag, ElementName=text6}" Tag="Auto">
+			<TextBlock>Auto (string bound): <Run Text="{Binding Width, ElementName=text6}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text7" Width="{Binding Tag, ElementName=text7}" Tag="auto">
+			<TextBlock>auto (string bound): <Run Text="{Binding Width, ElementName=text7}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text8" Width="NaN">
+			<TextBlock>Nan (direct): <Run Text="{Binding Width, ElementName=text8}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text9" Width="nan">
+			<TextBlock>nan (direct): <Run Text="{Binding Width, ElementName=text9}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text10" Width="{Binding Tag, ElementName=text10}" Tag="nan">
+			<TextBlock>nan (string bound): <Run Text="{Binding Width, ElementName=text10}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text11" Width="{Binding Tag, ElementName=text11}" Tag="Nan">
+			<TextBlock>nan (string bound): <Run Text="{Binding Width, ElementName=text11}" /></TextBlock>
+		</Border>
+
+		<Border Background="DarkSeaGreen" x:Name="text12" Width="200">
+			<TextBlock>Fixed (direct): <Run Text="{Binding Width, ElementName=text12}" /></TextBlock>
+		</Border>
+
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_Sizes.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_Sizes.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml.FrameworkElementTests
+{
+	[Sample("FrameworkElement")]
+	public sealed partial class FrameworkElement_Sizes : Page
+	{
+		public FrameworkElement_Sizes()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
@@ -3,6 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -12,7 +13,10 @@ using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Private.Infrastructure;
 using MUXControlsTestApp.Utilities;
 #if __IOS__
@@ -50,6 +54,94 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.AreEqual(1, SUT.MeasureOverrides.Count);
 			});
 #endif
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[DataRow("Auto", "Auto", double.NaN, double.NaN)]
+		[DataRow("auto", "auto", double.NaN, double.NaN)]
+		[DataRow("   AUTO", "AUTO   ", double.NaN, double.NaN)]
+		[DataRow("auTo", "auTo", double.NaN, double.NaN)]
+		[DataRow("NaN", "	NaN			", double.NaN, double.NaN)]
+		[DataRow("NAN", "nAn", double.NaN, double.NaN)]
+		[DataRow("0", "-0", 0d, 0d)]
+		[DataRow("21", "42", 21d, 42d)]
+		[DataRow("+21", "+42", 21d, 42d)]
+#if NETFX_CORE // Those values only works on UWP, not on Uno
+		[DataRow("", "\n", double.NaN, double.NaN)]
+		[DataRow("abc", "0\n", double.NaN, 0d)]
+		[DataRow("∞", "-∞", double.NaN, double.NaN)]
+		[DataRow("21-----covfefe", "42 you're \"smart\"", 21d, 42d)]
+		[DataRow("		21\n", "\n42-", 21d, 42d)]
+#endif
+		public void When_Using_Nan_And_Auto_Sizes(string w, string h, double expectedW, double expectedH)
+		{
+			using var _ = new AssertionScope();
+
+			var sut1 = new ContentControl {Tag = w};
+
+			// Bind sut1.Width to sut1.Tag
+			sut1.SetBinding(
+				FrameworkElement.WidthProperty,
+				new Binding {Source = sut1, Path = new PropertyPath("Tag")});
+
+			sut1.Width.Should().Be(expectedW, "sut1: Width bound after setting value");
+
+			var sut2 = new ContentControl();
+
+			// Bind sut2.Width to sut2.Tag
+			sut2.SetBinding(
+				FrameworkElement.WidthProperty,
+				new Binding {Source = sut2, Path = new PropertyPath("Tag")});
+
+			// Set sut2.Tag AFTER the binding
+			sut2.Tag = w;
+
+			sut2.Width.Should().Be(expectedW, "sut2: Width bound before setting value");
+
+			var sut3 = new ContentControl {Tag = h};
+
+			// Bind sut3.Height to sut3.Tag
+			sut3.SetBinding(
+				FrameworkElement.HeightProperty,
+				new Binding {Source = sut3, Path = new PropertyPath("Tag")});
+
+			sut3.Height.Should().Be(expectedH, "sut3: Height bound after setting value");
+
+			var sut4 = new ContentControl();
+
+			// Bind sut4.Height to sut4.Tag
+			sut4.SetBinding(
+				FrameworkElement.HeightProperty,
+				new Binding {Source = sut4, Path = new PropertyPath("Tag")});
+
+			// Set sut4.Tag AFTER the binding
+			sut4.Tag = h;
+
+			sut4.Height.Should().Be(expectedH, "sut4: Height bound before setting value");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[DataRow("-42")]
+		[DataRow("Infinity")]
+		[DataRow("+Infinity")]
+		[DataRow("	Infinity")]
+		[DataRow("-Infinity ")]
+		[DataRow("	Infinity")]
+		[ExpectedException(typeof(ArgumentException))]
+#if !NETFX_CORE
+		[Ignore]
+#endif
+		public void When_Setting_Sizes_To_Invalid_Values_Then_Should_Throw(string variant)
+		{
+			using var _ = new AssertionScope();
+
+			var sut = new ContentControl { Tag = variant };
+
+			sut.SetBinding(
+				FrameworkElement.WidthProperty,
+				new Binding { Source = sut, Path = new PropertyPath("Tag") });
+		}
 
 		[TestMethod]
 		public Task When_Measure_And_Invalidate() =>

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -184,6 +184,11 @@ namespace Uno.UI.DataBinding
 
 		private static bool FastStringConvert(Type outputType, string input, ref object output)
 		{
+			if (FastStringToNumericConvert(outputType, input, ref output))
+			{
+				return true;
+			}
+
 			if (FastStringToVisibilityConvert(outputType, input, ref output))
 			{
 				return true;
@@ -329,6 +334,240 @@ namespace Uno.UI.DataBinding
 			{
 				output = Enum.Parse(outputType, input, true);
 				return true;
+			}
+
+			return false;
+		}
+
+		private static bool FastStringToNumericConvert(Type outputType, string input, ref object output)
+		{
+			const NumberStyles numberStyles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign | NumberStyles.Float | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite;
+
+			if (outputType == typeof(double))
+			{
+				if (input == "") // empty string is NaN when bound in XAML
+				{
+					output = double.NaN;
+					return true;
+				}
+
+				if (input.Length == 1)
+				{
+					// Fast path for one digit string-to-double.
+					// Often use in VisualStateManager to set double values (like opacity) to zero or one...
+					switch (input[0])
+					{
+						case '0':
+							output = 0d;
+							return true;
+						case '1':
+							output = 1d;
+							return true;
+						case '2':
+							output = 2d;
+							return true;
+						case '3':
+							output = 3d;
+							return true;
+						case '4':
+							output = 4d;
+							return true;
+						case '5':
+							output = 5d;
+							return true;
+						case '6':
+							output = 6d;
+							return true;
+						case '7':
+							output = 7d;
+							return true;
+						case '8':
+							output = 8d;
+							return true;
+						case '9':
+							output = 9d;
+							return true;
+					}
+				}
+
+				var trimmed = input.Trim();
+
+				if (trimmed.Equals("nan", StringComparison.InvariantCultureIgnoreCase)
+				    || trimmed.Equals("auto", StringComparison.OrdinalIgnoreCase))
+				{
+					output = double.NaN;
+					return true;
+				}
+
+				if (trimmed.Equals("-infinity", StringComparison.InvariantCultureIgnoreCase))
+				{
+					output = double.NegativeInfinity;
+					return true;
+				}
+
+				if (trimmed.Equals("infinity", StringComparison.InvariantCultureIgnoreCase))
+				{
+					output = double.PositiveInfinity;
+					return true;
+				}
+
+				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
+				{
+					output = 0;
+					return true;
+				}
+
+				if (double.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var d))
+				{
+					output = d;
+					return true;
+				}
+
+				return false;
+			}
+
+			if (outputType == typeof(float))
+			{
+				if (input == "") // empty string is NaN when bound in XAML
+				{
+					output = float.NaN;
+					return true;
+				}
+
+				if (input.Length == 1)
+				{
+					// Fast path for one digit string-to-float
+					switch (input[0])
+					{
+						case '0':
+							output = 0f;
+							return true;
+						case '1':
+							output = 1f;
+							return true;
+						case '2':
+							output = 2f;
+							return true;
+						case '3':
+							output = 3f;
+							return true;
+						case '4':
+							output = 4f;
+							return true;
+						case '5':
+							output = 5f;
+							return true;
+						case '6':
+							output = 6f;
+							return true;
+						case '7':
+							output = 7f;
+							return true;
+						case '8':
+							output = 8f;
+							return true;
+						case '9':
+							output = 9f;
+							return true;
+					}
+				}
+
+				var trimmed = input.Trim();
+
+				if (trimmed.Equals("nan", StringComparison.InvariantCultureIgnoreCase)) // "Auto" is for sizes, which are only of type double
+				{
+					output = float.NaN;
+					return true;
+				}
+
+				if (trimmed.Equals("-infinity", StringComparison.InvariantCultureIgnoreCase))
+				{
+					output = float.NegativeInfinity;
+					return true;
+				}
+
+				if (trimmed.Equals("infinity", StringComparison.InvariantCultureIgnoreCase))
+				{
+					output = float.PositiveInfinity;
+					return true;
+				}
+
+				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
+				{
+					output = 0f;
+					return true;
+				}
+
+				if (float.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var f))
+				{
+					output = f;
+					return true;
+				}
+
+				return false;
+			}
+
+			if (outputType == typeof(int))
+			{
+				if (input.Length == 1)
+				{
+					// Fast path for one digit string-to-float
+					switch (input[0])
+					{
+						case '0':
+							output = 0;
+							return true;
+						case '1':
+							output = 1;
+							return true;
+						case '2':
+							output = 2;
+							return true;
+						case '3':
+							output = 3;
+							return true;
+						case '4':
+							output = 4;
+							return true;
+						case '5':
+							output = 5;
+							return true;
+						case '6':
+							output = 6;
+							return true;
+						case '7':
+							output = 7;
+							return true;
+						case '8':
+							output = 8;
+							return true;
+						case '9':
+							output = 9;
+							return true;
+					}
+				}
+
+				var trimmed = input.Trim();
+
+				if (trimmed.Equals("nan", StringComparison.InvariantCultureIgnoreCase)) // "Auto" is for sizes, which are only of type double
+				{
+					output = float.NaN;
+					return true;
+				}
+
+				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
+				{
+					output = 0;
+					return true;
+				}
+
+				if (int.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var i))
+				{
+					output = i;
+					return true;
+				}
+
+				return false;
 			}
 
 			return false;

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -650,35 +650,36 @@ namespace Uno.UI.DataBinding
 					var c = input[0];
 					if (c >= '0' && c <= '9')
 					{
-						output= (double)(c - '0');
-							return true;
+						output = (double)(c - '0');
+						return true;
 					}
 				}
 
 				var trimmed = input.Trim();
 
-				if (trimmed.Equals("nan", StringComparison.InvariantCultureIgnoreCase)
-					|| trimmed.Equals("auto", StringComparison.OrdinalIgnoreCase))
+				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
+				{
+					output = 0d;
+					return true;
+				}
+
+				trimmed = trimmed.ToLowerInvariant();
+
+				if (trimmed == "nan" || trimmed == "auto")
 				{
 					output = double.NaN;
 					return true;
 				}
 
-				if (trimmed.Equals("-infinity", StringComparison.InvariantCultureIgnoreCase))
+				if (trimmed == "-infinity")
 				{
 					output = double.NegativeInfinity;
 					return true;
 				}
 
-				if (trimmed.Equals("infinity", StringComparison.InvariantCultureIgnoreCase))
+				if (trimmed == "infinity")
 				{
 					output = double.PositiveInfinity;
-					return true;
-				}
-
-				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
-				{
-					output = 0;
 					return true;
 				}
 
@@ -694,59 +695,61 @@ namespace Uno.UI.DataBinding
 
 		private static bool FastStringToSingleConvert(Type outputType, string input, ref object output)
 		{
-            const NumberStyles numberStyles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite;
+			const NumberStyles numberStyles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite;
 
-            if (outputType == typeof(float))
-            {
-                if (input == "") // empty string is NaN when bound in XAML
-                {
-                    output = float.NaN;
-                    return true;
-                }
+			if (outputType == typeof(float))
+			{
+				if (input == "") // empty string is NaN when bound in XAML
+				{
+					output = float.NaN;
+					return true;
+				}
 
-                if (input.Length == 1)
-                {
-                    // Fast path for one digit string-to-float
+				if (input.Length == 1)
+				{
+					// Fast path for one digit string-to-float
 					var c = input[0];
 					if (c >= '0' && c <= '9')
-                    {
+					{
 						output = (float)(c - '0');
-                            return true;
-                    }
-                }
+						return true;
+					}
+				}
 
-                var trimmed = input.Trim();
+				var trimmed = input.Trim();
 
-                if (trimmed.Equals("nan", StringComparison.InvariantCultureIgnoreCase)) // "Auto" is for sizes, which are only of type double
-                {
-                    output = float.NaN;
-                    return true;
-                }
+				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
+				{
+					output = 0f;
+					return true;
+				}
 
-                if (trimmed.Equals("-infinity", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    output = float.NegativeInfinity;
-                    return true;
-                }
+				trimmed = trimmed.ToLowerInvariant();
 
-                if (trimmed.Equals("infinity", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    output = float.PositiveInfinity;
-                    return true;
-                }
+				if (trimmed == "nan") // "Auto" is for sizes, which are only of type double
+				{
+					output = float.NaN;
+					return true;
+				}
 
-                if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
-                {
-                    output = 0f;
-                    return true;
-                }
+				if (trimmed == "-infinity")
+				{
+					output = float.NegativeInfinity;
+					return true;
+				}
 
-                if (float.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var f))
-                {
-                    output = f;
-                    return true;
-                }
-            }
+				if (trimmed == "infinity")
+				{
+					output = float.PositiveInfinity;
+					return true;
+				}
+
+				if (float.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var f))
+				{
+					output = f;
+					return true;
+				}
+			}
 
 			return false;
 		}
@@ -764,7 +767,7 @@ namespace Uno.UI.DataBinding
 					if (c >= '0' && c <= '9')
 					{
 						output = (int)(c - '0');
-							return true;
+						return true;
 					}
 				}
 

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -647,37 +647,10 @@ namespace Uno.UI.DataBinding
 				{
 					// Fast path for one digit string-to-double.
 					// Often use in VisualStateManager to set double values (like opacity) to zero or one...
-					switch (input[0])
+					var c = input[0];
+					if (c >= '0' && c <= '9')
 					{
-						case '0':
-							output = 0d;
-							return true;
-						case '1':
-							output = 1d;
-							return true;
-						case '2':
-							output = 2d;
-							return true;
-						case '3':
-							output = 3d;
-							return true;
-						case '4':
-							output = 4d;
-							return true;
-						case '5':
-							output = 5d;
-							return true;
-						case '6':
-							output = 6d;
-							return true;
-						case '7':
-							output = 7d;
-							return true;
-						case '8':
-							output = 8d;
-							return true;
-						case '9':
-							output = 9d;
+						output= (double)(c - '0');
 							return true;
 					}
 				}
@@ -734,37 +707,10 @@ namespace Uno.UI.DataBinding
                 if (input.Length == 1)
                 {
                     // Fast path for one digit string-to-float
-                    switch (input[0])
+					var c = input[0];
+					if (c >= '0' && c <= '9')
                     {
-                        case '0':
-                            output = 0f;
-                            return true;
-                        case '1':
-                            output = 1f;
-                            return true;
-                        case '2':
-                            output = 2f;
-                            return true;
-                        case '3':
-                            output = 3f;
-                            return true;
-                        case '4':
-                            output = 4f;
-                            return true;
-                        case '5':
-                            output = 5f;
-                            return true;
-                        case '6':
-                            output = 6f;
-                            return true;
-                        case '7':
-                            output = 7f;
-                            return true;
-                        case '8':
-                            output = 8f;
-                            return true;
-                        case '9':
-                            output = 9f;
+						output = (float)(c - '0');
                             return true;
                     }
                 }
@@ -814,37 +760,10 @@ namespace Uno.UI.DataBinding
 				if (input.Length == 1)
 				{
 					// Fast path for one digit string-to-float
-					switch (input[0])
+					var c = input[0];
+					if (c >= '0' && c <= '9')
 					{
-						case '0':
-							output = 0;
-							return true;
-						case '1':
-							output = 1;
-							return true;
-						case '2':
-							output = 2;
-							return true;
-						case '3':
-							output = 3;
-							return true;
-						case '4':
-							output = 4;
-							return true;
-						case '5':
-							output = 5;
-							return true;
-						case '6':
-							output = 6;
-							return true;
-						case '7':
-							output = 7;
-							return true;
-						case '8':
-							output = 8;
-							return true;
-						case '9':
-							output = 9;
+						output = (int)(c - '0');
 							return true;
 					}
 				}

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -184,11 +184,6 @@ namespace Uno.UI.DataBinding
 
 		private static bool FastStringConvert(Type outputType, string input, ref object output)
 		{
-			if (FastStringToNumericConvert(outputType, input, ref output))
-			{
-				return true;
-			}
-
 			if (FastStringToVisibilityConvert(outputType, input, ref output))
 			{
 				return true;
@@ -204,22 +199,17 @@ namespace Uno.UI.DataBinding
 				return true;
 			}
 
-			if (FastStringToSingleConvert(outputType, input, ref output))
-			{
-				return true;
-			}
-
-			if (FastStringToColorConvert(outputType, input, ref output))
-			{
-				return true;
-			}
-
 			if (FastStringToBrushConvert(outputType, input, ref output))
 			{
 				return true;
 			}
 
 			if (FastStringToDoubleConvert(outputType, input, ref output))
+			{
+				return true;
+			}
+
+			if (FastStringToSingleConvert(outputType, input, ref output))
 			{
 				return true;
 			}
@@ -235,6 +225,11 @@ namespace Uno.UI.DataBinding
 			}
 
 			if (FastStringToOrientationConvert(outputType, input, ref output))
+			{
+				return true;
+			}
+
+			if (FastStringToColorConvert(outputType, input, ref output))
 			{
 				return true;
 			}
@@ -255,6 +250,11 @@ namespace Uno.UI.DataBinding
 			}
 
 			if (FastStringToFontFamilyConvert(outputType, input, ref output))
+			{
+				return true;
+			}
+
+			if (FastStringToIntegerConvert(outputType, input, ref output))
 			{
 				return true;
 			}
@@ -334,240 +334,6 @@ namespace Uno.UI.DataBinding
 			{
 				output = Enum.Parse(outputType, input, true);
 				return true;
-			}
-
-			return false;
-		}
-
-		private static bool FastStringToNumericConvert(Type outputType, string input, ref object output)
-		{
-			const NumberStyles numberStyles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign | NumberStyles.Float | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite;
-
-			if (outputType == typeof(double))
-			{
-				if (input == "") // empty string is NaN when bound in XAML
-				{
-					output = double.NaN;
-					return true;
-				}
-
-				if (input.Length == 1)
-				{
-					// Fast path for one digit string-to-double.
-					// Often use in VisualStateManager to set double values (like opacity) to zero or one...
-					switch (input[0])
-					{
-						case '0':
-							output = 0d;
-							return true;
-						case '1':
-							output = 1d;
-							return true;
-						case '2':
-							output = 2d;
-							return true;
-						case '3':
-							output = 3d;
-							return true;
-						case '4':
-							output = 4d;
-							return true;
-						case '5':
-							output = 5d;
-							return true;
-						case '6':
-							output = 6d;
-							return true;
-						case '7':
-							output = 7d;
-							return true;
-						case '8':
-							output = 8d;
-							return true;
-						case '9':
-							output = 9d;
-							return true;
-					}
-				}
-
-				var trimmed = input.Trim();
-
-				if (trimmed.Equals("nan", StringComparison.InvariantCultureIgnoreCase)
-				    || trimmed.Equals("auto", StringComparison.OrdinalIgnoreCase))
-				{
-					output = double.NaN;
-					return true;
-				}
-
-				if (trimmed.Equals("-infinity", StringComparison.InvariantCultureIgnoreCase))
-				{
-					output = double.NegativeInfinity;
-					return true;
-				}
-
-				if (trimmed.Equals("infinity", StringComparison.InvariantCultureIgnoreCase))
-				{
-					output = double.PositiveInfinity;
-					return true;
-				}
-
-				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
-				{
-					output = 0;
-					return true;
-				}
-
-				if (double.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var d))
-				{
-					output = d;
-					return true;
-				}
-
-				return false;
-			}
-
-			if (outputType == typeof(float))
-			{
-				if (input == "") // empty string is NaN when bound in XAML
-				{
-					output = float.NaN;
-					return true;
-				}
-
-				if (input.Length == 1)
-				{
-					// Fast path for one digit string-to-float
-					switch (input[0])
-					{
-						case '0':
-							output = 0f;
-							return true;
-						case '1':
-							output = 1f;
-							return true;
-						case '2':
-							output = 2f;
-							return true;
-						case '3':
-							output = 3f;
-							return true;
-						case '4':
-							output = 4f;
-							return true;
-						case '5':
-							output = 5f;
-							return true;
-						case '6':
-							output = 6f;
-							return true;
-						case '7':
-							output = 7f;
-							return true;
-						case '8':
-							output = 8f;
-							return true;
-						case '9':
-							output = 9f;
-							return true;
-					}
-				}
-
-				var trimmed = input.Trim();
-
-				if (trimmed.Equals("nan", StringComparison.InvariantCultureIgnoreCase)) // "Auto" is for sizes, which are only of type double
-				{
-					output = float.NaN;
-					return true;
-				}
-
-				if (trimmed.Equals("-infinity", StringComparison.InvariantCultureIgnoreCase))
-				{
-					output = float.NegativeInfinity;
-					return true;
-				}
-
-				if (trimmed.Equals("infinity", StringComparison.InvariantCultureIgnoreCase))
-				{
-					output = float.PositiveInfinity;
-					return true;
-				}
-
-				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
-				{
-					output = 0f;
-					return true;
-				}
-
-				if (float.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var f))
-				{
-					output = f;
-					return true;
-				}
-
-				return false;
-			}
-
-			if (outputType == typeof(int))
-			{
-				if (input.Length == 1)
-				{
-					// Fast path for one digit string-to-float
-					switch (input[0])
-					{
-						case '0':
-							output = 0;
-							return true;
-						case '1':
-							output = 1;
-							return true;
-						case '2':
-							output = 2;
-							return true;
-						case '3':
-							output = 3;
-							return true;
-						case '4':
-							output = 4;
-							return true;
-						case '5':
-							output = 5;
-							return true;
-						case '6':
-							output = 6;
-							return true;
-						case '7':
-							output = 7;
-							return true;
-						case '8':
-							output = 8;
-							return true;
-						case '9':
-							output = 9;
-							return true;
-					}
-				}
-
-				var trimmed = input.Trim();
-
-				if (trimmed.Equals("nan", StringComparison.InvariantCultureIgnoreCase)) // "Auto" is for sizes, which are only of type double
-				{
-					output = float.NaN;
-					return true;
-				}
-
-				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
-				{
-					output = 0;
-					return true;
-				}
-
-				if (int.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var i))
-				{
-					output = i;
-					return true;
-				}
-
-				return false;
 			}
 
 			return false;
@@ -867,12 +633,85 @@ namespace Uno.UI.DataBinding
 
 		private static bool FastStringToDoubleConvert(Type outputType, string input, ref object output)
 		{
+			const NumberStyles numberStyles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite;
+
 			if (outputType == typeof(double))
 			{
-				double result;
-				if (double.TryParse((string)input, NumberStyles.Any, CultureInfo.InvariantCulture, out result))
+				if (input == "") // empty string is NaN when bound in XAML
 				{
-					output = result;
+					output = double.NaN;
+					return true;
+				}
+
+				if (input.Length == 1)
+				{
+					// Fast path for one digit string-to-double.
+					// Often use in VisualStateManager to set double values (like opacity) to zero or one...
+					switch (input[0])
+					{
+						case '0':
+							output = 0d;
+							return true;
+						case '1':
+							output = 1d;
+							return true;
+						case '2':
+							output = 2d;
+							return true;
+						case '3':
+							output = 3d;
+							return true;
+						case '4':
+							output = 4d;
+							return true;
+						case '5':
+							output = 5d;
+							return true;
+						case '6':
+							output = 6d;
+							return true;
+						case '7':
+							output = 7d;
+							return true;
+						case '8':
+							output = 8d;
+							return true;
+						case '9':
+							output = 9d;
+							return true;
+					}
+				}
+
+				var trimmed = input.Trim();
+
+				if (trimmed.Equals("nan", StringComparison.InvariantCultureIgnoreCase)
+					|| trimmed.Equals("auto", StringComparison.OrdinalIgnoreCase))
+				{
+					output = double.NaN;
+					return true;
+				}
+
+				if (trimmed.Equals("-infinity", StringComparison.InvariantCultureIgnoreCase))
+				{
+					output = double.NegativeInfinity;
+					return true;
+				}
+
+				if (trimmed.Equals("infinity", StringComparison.InvariantCultureIgnoreCase))
+				{
+					output = double.PositiveInfinity;
+					return true;
+				}
+
+				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
+				{
+					output = 0;
+					return true;
+				}
+
+				if (double.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var d))
+				{
+					output = d;
 					return true;
 				}
 			}
@@ -882,12 +721,145 @@ namespace Uno.UI.DataBinding
 
 		private static bool FastStringToSingleConvert(Type outputType, string input, ref object output)
 		{
-			if (outputType == typeof(float))
+            const NumberStyles numberStyles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite;
+
+            if (outputType == typeof(float))
+            {
+                if (input == "") // empty string is NaN when bound in XAML
+                {
+                    output = float.NaN;
+                    return true;
+                }
+
+                if (input.Length == 1)
+                {
+                    // Fast path for one digit string-to-float
+                    switch (input[0])
+                    {
+                        case '0':
+                            output = 0f;
+                            return true;
+                        case '1':
+                            output = 1f;
+                            return true;
+                        case '2':
+                            output = 2f;
+                            return true;
+                        case '3':
+                            output = 3f;
+                            return true;
+                        case '4':
+                            output = 4f;
+                            return true;
+                        case '5':
+                            output = 5f;
+                            return true;
+                        case '6':
+                            output = 6f;
+                            return true;
+                        case '7':
+                            output = 7f;
+                            return true;
+                        case '8':
+                            output = 8f;
+                            return true;
+                        case '9':
+                            output = 9f;
+                            return true;
+                    }
+                }
+
+                var trimmed = input.Trim();
+
+                if (trimmed.Equals("nan", StringComparison.InvariantCultureIgnoreCase)) // "Auto" is for sizes, which are only of type double
+                {
+                    output = float.NaN;
+                    return true;
+                }
+
+                if (trimmed.Equals("-infinity", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    output = float.NegativeInfinity;
+                    return true;
+                }
+
+                if (trimmed.Equals("infinity", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    output = float.PositiveInfinity;
+                    return true;
+                }
+
+                if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
+                {
+                    output = 0f;
+                    return true;
+                }
+
+                if (float.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var f))
+                {
+                    output = f;
+                    return true;
+                }
+            }
+
+			return false;
+		}
+
+		private static bool FastStringToIntegerConvert(Type outputType, string input, ref object output)
+		{
+			const NumberStyles numberStyles = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite;
+
+			if (outputType == typeof(int))
 			{
-				float floatResult;
-				if (float.TryParse((string)input, NumberStyles.Any, CultureInfo.InvariantCulture, out floatResult))
+				if (input.Length == 1)
 				{
-					output = floatResult;
+					// Fast path for one digit string-to-float
+					switch (input[0])
+					{
+						case '0':
+							output = 0;
+							return true;
+						case '1':
+							output = 1;
+							return true;
+						case '2':
+							output = 2;
+							return true;
+						case '3':
+							output = 3;
+							return true;
+						case '4':
+							output = 4;
+							return true;
+						case '5':
+							output = 5;
+							return true;
+						case '6':
+							output = 6;
+							return true;
+						case '7':
+							output = 7;
+							return true;
+						case '8':
+							output = 8;
+							return true;
+						case '9':
+							output = 9;
+							return true;
+					}
+				}
+
+				var trimmed = input.Trim();
+
+				if (trimmed == "0" || trimmed == "") // Fast path for zero / empty values (means zero in XAML)
+				{
+					output = 0;
+					return true;
+				}
+
+				if (int.TryParse(trimmed, numberStyles, NumberFormatInfo.InvariantInfo, out var i))
+				{
+					output = i;
 					return true;
 				}
 			}


### PR DESCRIPTION
Fixes #4403

# Feature
It is now possible to set bound values (and style setters) as 'Auto' in dependency properties.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
