### PR TITLE
fix(elevatedview): UpdateElevation timing issue

### DIFF
--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -73,6 +73,13 @@ namespace Uno.UI.Toolkit
 			_border = GetTemplateChild("PART_Border") as Border;
 			_shadowHost = GetTemplateChild("PART_ShadowHost") as Panel;
 
+#if __IOS__ || __MACOS__
+			if (_border != null)
+			{
+				_border.BoundsPathUpdated += (s, e) => UpdateElevation();
+			}
+#endif
+
 			UpdateElevation();
 		}
 
@@ -109,7 +116,15 @@ namespace Uno.UI.Toolkit
 
 #if !NETFX_CORE
 		public new static DependencyProperty BackgroundProperty { get ; } = DependencyProperty.Register(
-			"Background", typeof(Brush), typeof(ElevatedView), new FrameworkPropertyMetadata(default(Brush), OnChanged));
+			"Background",
+			typeof(Brush),
+			typeof(ElevatedView),
+#if __IOS__ || __MACOS__
+			new FrameworkPropertyMetadata(default(Brush))
+#else
+			new FrameworkPropertyMetadata(default(Brush), OnChanged)
+#endif
+		);
 
 		public new Brush Background
 		{
@@ -118,7 +133,15 @@ namespace Uno.UI.Toolkit
 		}
 
 		public static DependencyProperty CornerRadiusProperty { get ; } = DependencyProperty.Register(
-			"CornerRadius", typeof(CornerRadius), typeof(ElevatedView), new FrameworkPropertyMetadata(default(CornerRadius), OnChanged));
+			"CornerRadius",
+			typeof(CornerRadius),
+			typeof(ElevatedView),
+#if __IOS__ || __MACOS__
+			new FrameworkPropertyMetadata(default(CornerRadius))
+#else
+			new FrameworkPropertyMetadata(default(CornerRadius), OnChanged)
+#endif
+		);
 
 		public CornerRadius CornerRadius
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.iOSmacOS.cs
@@ -46,14 +46,12 @@ namespace Windows.UI.Xaml.Controls
 					(Background as ImageBrush)?.ImageSource?.TryOpenSync(out backgroundImage);
 				}
 
-				BoundsPath = _borderRenderer.UpdateLayer(
-					this,
-					Background,
-					BorderThickness,
-					BorderBrush,
-					CornerRadius,
-					backgroundImage
-				);
+				if (_borderRenderer.UpdateLayer(this, Background, BorderThickness, BorderBrush, CornerRadius, backgroundImage)
+					is CGPath updated) // UpdateLayer may return null if there is no update
+				{
+					BoundsPath = updated;
+					BoundsPathUpdated?.Invoke(this, default);
+				}
 			}
 
 			this.SetNeedsDisplay();
@@ -114,6 +112,7 @@ namespace Windows.UI.Xaml.Controls
         bool ICustomClippingElement.AllowClippingToLayoutSlot => CornerRadius == CornerRadius.None && (!(Child is UIElement ue) || ue.RenderTransform == null);
         bool ICustomClippingElement.ForceClippingToLayoutSlot => false;
 
+		internal event EventHandler BoundsPathUpdated;
 		internal CGPath BoundsPath { get; private set; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
@@ -40,13 +40,14 @@ namespace Windows.UI.Xaml.Shapes
 		/// <param name="borderBrush">The border brush</param>
 		/// <param name="cornerRadius">The corner radius</param>
 		/// <param name="backgroundImage">The background image in case of a ImageBrush background</param>
+		/// <returns>An updated BoundsPath if the layer has been created or updated; null if there is no change.</returns>
 		public CGPath UpdateLayer(
 			_View owner,
 			Brush background,
 			Thickness borderThickness,
 			Brush borderBrush,
 			CornerRadius cornerRadius,
-			_Image backgroundImage)		
+			_Image backgroundImage)
 		{
 			// Bounds is captured to avoid calling twice calls below.
 			var bounds = owner.Bounds;


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type
What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
On iOS, there are some timing issues between when the ElevatedView draw itself and when its nested Border has its BoundsPath calculated. In rare situations, ElevatedView could end up painting the elevation before the BoundsPath is re-calculated causing nothing to be painted.

## What is the new behavior?
Ensure the ElevatedView is repainted after its Border.BoundsPath is updated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
Due to complexity of the situation, I have not been able to produce a ui-test.

Internal Issue (If applicable):
https://github.com/unoplatform/nventive-private/issues/60