### PR TITLE
Sync ItemCollection with ItemsSource

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ItemCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemCollection.cs
@@ -9,32 +9,86 @@ namespace Windows.UI.Xaml.Controls
 {
 	public sealed partial class ItemCollection : IList<object>, IEnumerable<object>, IObservableVector<object>
 	{
-		public event VectorChangedEventHandler<object> VectorChanged;
-
 		private readonly IList<object> _inner = new List<object>();
 
-		public IEnumerator<object> GetEnumerator() => _inner.GetEnumerator();
+		private object _syncedItemsSource = null;
 
-		IEnumerator IEnumerable.GetEnumerator() => _inner.GetEnumerator();
+		public event VectorChangedEventHandler<object> VectorChanged;
+
+		public IEnumerator<object> GetEnumerator()
+		{
+			if (_syncedItemsSource == null)
+			{
+				return _inner.GetEnumerator();
+			}
+			else
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			if (_syncedItemsSource == null)
+			{
+				return _inner.GetEnumerator();
+			}
+			else
+			{
+				throw new NotImplementedException();
+			}
+		}
 
 		public void Add(object item)
 		{
+			if (_syncedItemsSource != null)
+			{
+				throw new InvalidOperationException("Items cannot be modified when ItemsSource is set.");
+			}
 			_inner.Add(item);
 			VectorChanged.TryRaiseInserted(this, _inner.Count - 1);
 		}
 
 		public void Clear()
 		{
+			if (_syncedItemsSource != null)
+			{
+				throw new InvalidOperationException("Items cannot be modified when ItemsSource is set.");
+			}
 			_inner.Clear();
 			VectorChanged.TryRaiseReseted(this);
 		}
 
-		public bool Contains(object item) => _inner.Contains(item);
+		public bool Contains(object item)
+		{
+			if (_syncedItemsSource != null)
+			{
+				return _inner.Contains(item);
+			}
+			else
+			{
+				throw new NotImplementedException();
+			}
+		}
 
-		public void CopyTo(object[] array, int arrayIndex) => _inner.CopyTo(array, arrayIndex);
+		public void CopyTo(object[] array, int arrayIndex)
+		{
+			if (_syncedItemsSource != null)
+			{
+				_inner.CopyTo(array, arrayIndex);
+			}
+			else
+			{
+				throw new NotImplementedException();
+			}
+		}
 
 		public bool Remove(object item)
 		{
+			if (_syncedItemsSource != null)
+			{
+				throw new InvalidOperationException("Items cannot be modified when ItemsSource is set.");
+			}
 			var vectorChanged = VectorChanged;
 			if (vectorChanged == null)
 			{
@@ -56,30 +110,50 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		public int Count => _inner.Count;
+		public int Count => _syncedItemsSource == null ? _inner.Count : throw new NotImplementedException();
 
 		public uint Size => (uint)Count;
 
-		public bool IsReadOnly => _inner.IsReadOnly;
+		public bool IsReadOnly => _inner.IsReadOnly; // This actually matches UWP - Items do not reflect read-only attribute of ItemsSource
 
-		public int IndexOf(object item) =>  _inner.IndexOf(item);
+		public int IndexOf(object item) => _syncedItemsSource == null ? _inner.IndexOf(item) : throw new NotImplementedException();
 
 		public void Insert(int index, object item)
 		{
+			if (_syncedItemsSource != null)
+			{
+				throw new InvalidOperationException("Items cannot be modified when ItemsSource is set.");
+			}
 			_inner.Insert(index, item);
 			VectorChanged.TryRaiseInserted(this, index);
 		}
 
 		public void RemoveAt(int index)
 		{
+			if (_syncedItemsSource != null)
+			{
+				throw new InvalidOperationException("Items cannot be modified when ItemsSource is set.");
+			}
 			_inner.RemoveAt(index);
 			VectorChanged.TryRaiseRemoved(this, index);
 		}
 
 		public object this[int index]
 		{
-			get { return _inner[index]; }
-			set { _inner[index] = value; }
+			get => _syncedItemsSource == null ? _inner[index] : throw new NotImplementedException();
+			set
+			{
+				if (_syncedItemsSource != null)
+				{
+					throw new InvalidOperationException("Items cannot be modified when ItemsSource is set.");
+				}
+				_inner[index] = value;
+			}
+		}
+
+		internal void SetItemsSource(object itemsSource)
+		{
+			_syncedItemsSource = itemsSource;
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #1045

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`ItemCollection` is a standalone collection.

## What is the new behavior?

`ItemCollection` can be set to be in sync with an `ItemsSource`. However, the method is **not called anywhere**, which means the changes do not affect any behavior of `ItemsControl` or `ListView` yet.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.