### PR TITLE
fix(generation): Fixes invalid Tuples expansion using Roslyn 3.5 and later

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/Given_SymbolExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/Given_SymbolExtension.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.Build.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Uno.UI.SourceGenerators.XamlGenerator.Utils;
+
+namespace Uno.UI.SourceGenerators.Tests
+{
+	[TestClass]
+	public class Given_SymbolExtension
+	{
+		[TestMethod]
+		[DataRow("int", "int")]
+		[DataRow("double", "double")]
+		[DataRow("System.Collections.Generic.IList<int>", "global::System.Collections.Generic.IList<int>")]
+		[DataRow("System.Collections.Generic.IList<System.Disposable>", "global::System.Collections.Generic.IList<global::System.Disposable>")]
+		[DataRow("System.Collections.Generic.IDictionary<int, System.Disposable>", "global::System.Collections.Generic.IDictionary<int, global::System.Disposable>")]
+		[DataRow("(int, int)", "(int, int)")]
+		[DataRow("(int, System.Disposable)", "(int, global::System.Disposable)")]
+		[DataRow("System.Collections.Generic.IList<(int, System.Disposable)>", "global::System.Collections.Generic.IList<(int, global::System.Disposable)>")]
+		[DataRow("System.Collections.Generic.IList<(string, string, double)>", "global::System.Collections.Generic.IList<(string, string, double)>")]
+		public void When_GetFullyQualifiedString(string input, string expected)
+		{
+			var compilation = CreateTestCompilation(input);
+
+			if (compilation.GetTypeByMetadataName("Test") is INamedTypeSymbol testSymbol)
+			{
+				if (testSymbol.GetAllMembersWithName("_myField").FirstOrDefault() is IPropertySymbol myField)
+				{
+					var actual = myField.Type.GetFullyQualifiedType();
+					Assert.AreEqual<string>(expected, actual);
+				}
+				else
+				{
+					Assert.Fail();
+				}
+			}
+			else
+			{
+				Assert.Fail();
+			}
+		}
+
+		private static Compilation CreateTestCompilation(string type)
+		{
+			var programPath = @"Program.cs";
+			var programText = $"public class Test {{ public static {type} _myField {{ get; set; }} }}";
+			var programTree = CSharpSyntaxTree
+				.ParseText(programText)
+				.WithFilePath(programPath);
+
+			SyntaxTree[] sourceTrees = { programTree };
+
+			MetadataReference mscorlib = MetadataReference.CreateFromFile(typeof(object).GetTypeInfo().Assembly.Location);
+			MetadataReference codeAnalysis = MetadataReference.CreateFromFile(typeof(SyntaxTree).GetTypeInfo().Assembly.Location);
+			MetadataReference csharpCodeAnalysis = MetadataReference.CreateFromFile(typeof(CSharpSyntaxTree).GetTypeInfo().Assembly.Location);
+			MetadataReference[] references = { mscorlib, codeAnalysis, csharpCodeAnalysis };
+
+			return CSharpCompilation.Create("ConsoleApplication",
+							 sourceTrees,
+							 references,
+							 new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+		}
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/Uno.UI.SourceGenerators.Tests.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/Uno.UI.SourceGenerators.Tests.csproj
@@ -11,11 +11,11 @@
 		<PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
 		<PackageReference Include="coverlet.collector" Version="1.3.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.csproj" />
 	</ItemGroup>
-
+	
 </Project>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -410,7 +410,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 
 					foreach (var property in properties)
 					{
-						var propertyTypeName = GetFullyQualifiedType(property.Type);
+						var propertyTypeName = property.Type.GetFullyQualifiedType();
 						var propertyName = property.Name;
 
 						if (IsStringIndexer(property))
@@ -505,23 +505,6 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 			writer.AppendLine();
 		}
 
-		private object GetFullyQualifiedType(ITypeSymbol type)
-		{
-			if(type is INamedTypeSymbol namedTypeSymbol)
-			{
-				if (namedTypeSymbol.IsGenericType && !namedTypeSymbol.IsNullable())
-				{
-					return SymbolDisplay.ToDisplayString(type, format: new SymbolDisplayFormat(
-						globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
-						typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
-						genericsOptions: SymbolDisplayGenericsOptions.None,
-						miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers))
-						+ "<" + string.Join(", ", namedTypeSymbol.TypeArguments.Select(GetFullyQualifiedType)) + ">";
-				}
-			}
-
-			return type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-		}
 
 		private static string ExpandType(INamedTypeSymbol ownerType)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Using a public property that uses tuples fails at compile time when Roslyn is 3.5 or later.

## What is the new behavior?

The build does not fail.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
