### PR TITLE
fix(wizard): UWP project is not set as startup by default

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate.Wizard/UnoSolutionWizard.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate.Wizard/UnoSolutionWizard.cs
@@ -15,18 +15,20 @@ namespace UnoSolutionTemplate.Wizard
 {
 	public class UnoSolutionWizard : IWizard
 	{
+		private const string ProjectKinds_vsProjectKindSolutionFolder = "{66A26720-8FB5-11D2-AA7E-00C04F688DDE}";
+
 		private string? _targetPath;
 		private DTE2? _dte;
 
-		public void BeforeOpeningFile(global::EnvDTE.ProjectItem projectItem)
+		public void BeforeOpeningFile(ProjectItem projectItem)
 		{
 		}
 
-		public void ProjectFinishedGenerating(global::EnvDTE.Project project)
+		public void ProjectFinishedGenerating(Project project)
 		{
 		}
 
-		public void ProjectItemFinishedGenerating(global::EnvDTE.ProjectItem projectItem)
+		public void ProjectItemFinishedGenerating(ProjectItem projectItem)
 		{
 		}
 
@@ -41,25 +43,49 @@ namespace UnoSolutionTemplate.Wizard
 			}
 
 			OpenWelcomePage();
-			SetAsStartupProject();
+			SetStartupProject();
+			SetDefaultConfiguration();
 		}
 
 		private void OpenWelcomePage()
 			=> _dte?.ItemOperations.Navigate("https://platform.uno/docs/articles/get-started-wizard.html", vsNavigateOptions.vsNavigateOptionsNewWindow);
 
-		private void SetAsStartupProject()
+		private void SetStartupProject()
 		{
-			if (_dte != null && _dte.Solution.SolutionBuild is SolutionBuild2 val)
+			if (_dte?.Solution.SolutionBuild is SolutionBuild2 val)
 			{
 				try
 				{
-					var uwpProject = _dte.Solution.Projects.Cast<Project>().FirstOrDefault(s => s.Name.EndsWith(".UWP", StringComparison.OrdinalIgnoreCase));
+					var uwpProject = GetAllProjects().FirstOrDefault(s => s.Name.EndsWith(".UWP", StringComparison.OrdinalIgnoreCase));
 
 					if (uwpProject is { })
 					{
 						val.StartupProjects = uwpProject.UniqueName;
 					}
 
+					var x86Config = val.SolutionConfigurations
+						.Cast<SolutionConfiguration2>()
+						.FirstOrDefault(c => c.Name == "Debug" && c.PlatformName == "x86");
+
+					x86Config?.Activate();
+				}
+				catch (Exception)
+				{
+				}
+			}
+			else
+			{
+				throw new InvalidOperationException();
+			}
+		}
+
+
+		private void SetDefaultConfiguration()
+		{
+			if (_dte?.Solution.SolutionBuild is SolutionBuild2 val)
+			{
+				try
+				{
 					var x86Config = val.SolutionConfigurations
 						.Cast<SolutionConfiguration2>()
 						.FirstOrDefault(c => c.Name == "Debug" && c.PlatformName == "x86");
@@ -89,6 +115,60 @@ namespace UnoSolutionTemplate.Wizard
 		public bool ShouldAddProjectItem(string filePath)
 		{
 			return true;
+		}
+
+		public Project[] GetAllProjects()
+		{
+			var list = new List<Project>();
+			if (_dte != null)
+			{
+				var projects = _dte.Solution.Projects;
+				var item = projects.GetEnumerator();
+				while (item.MoveNext())
+				{
+					var project = item.Current as Project;
+					if (project == null)
+					{
+						continue;
+					}
+
+					if (project.Kind == ProjectKinds_vsProjectKindSolutionFolder)
+					{
+						list.AddRange(GetSolutionFolderProjects(project));
+					}
+					else
+					{
+						list.Add(project);
+					}
+				}
+			}
+
+			return list.ToArray();
+		}
+
+		private Project[] GetSolutionFolderProjects(Project solutionFolder)
+		{
+			var list = new List<Project>();
+			for (var i = 1; i <= solutionFolder.ProjectItems.Count; i++)
+			{
+				var subProject = solutionFolder.ProjectItems.Item(i).SubProject;
+				if (subProject == null)
+				{
+					continue;
+				}
+
+				// If this is another solution folder, do a recursive call, otherwise add
+				if (subProject.Kind == ProjectKinds_vsProjectKindSolutionFolder)
+				{
+					list.AddRange(GetSolutionFolderProjects(subProject));
+				}
+				else
+				{
+					list.Add(subProject);
+				}
+			}
+
+			return list.ToArray();
 		}
 	}
 }

--- a/src/Uno.UI/Uno.UI.Skia.csproj
+++ b/src/Uno.UI/Uno.UI.Skia.csproj
@@ -16,6 +16,8 @@
 
 		<UnoRuntimeIdentifier Condition="'$(TargetFramework)'=='netstandard2.0'">Skia</UnoRuntimeIdentifier>
 		<PlatformItemsBasePath>.\</PlatformItemsBasePath>
+
+		<PackageId Condition="'$(UNO_UWP_BUILD)'!='true'">Uno.WinUI</PackageId>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UWP/Helpers/Theming/SystemThemeHelper.wasm.cs
+++ b/src/Uno.UWP/Helpers/Theming/SystemThemeHelper.wasm.cs
@@ -9,9 +9,16 @@ namespace Uno.Helpers.Theming
 {
 	internal static partial class SystemThemeHelper
 	{
+		private const string BaseUIXamlNamespace =
+#if HAS_UNO_WINUI
+			"Microsoft.UI.Xaml";
+#else
+			"Windows.UI.Xaml";
+#endif
+
         private static SystemTheme GetSystemTheme()
 		{
-			var serializedTheme = WebAssemblyRuntime.InvokeJS("Windows.UI.Xaml.Application.getDefaultSystemTheme()");
+			var serializedTheme = WebAssemblyRuntime.InvokeJS(BaseUIXamlNamespace + ".Application.getDefaultSystemTheme()");
 
 			if (serializedTheme != null)
 			{


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The UWP project is set as startup by default when creating a project from the VSIX template.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
