### PR TITLE
fix: Add missing slash character in namespaces declarations referring to Uno URIs

### DIFF
--- a/doc/articles/platform-specific-xaml.md
+++ b/doc/articles/platform-specific-xaml.md
@@ -99,12 +99,12 @@ The pre-defined prefixes are listed below:
 | Prefix        | Included platforms                 | Excluded platforms                 | Namespace                                                   | Put in `mc:Ignorable`? |
 |---------------|------------------------------------|------------------------------------|-------------------------------------------------------------|------------------------|
 | `win`         | Windows                            | Android, iOS, web, macOS, Skia     | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
-| `xamarin`     | Android, iOS, web, macOS, Skia     | Windows                            | `http:/uno.ui/xamarin`                                      | yes                    |
-| `not_win`     | Android, iOS, web, macOS, Skia     | Windows                            | `http:/uno.ui/not_win`                                      | yes                    |
-| `android`     | Android                            | Windows, iOS, web, macOS, Skia     | `http:/uno.ui/android`                                      | yes                    |
-| `ios`         | iOS                                | Windows, Android, web, macOS, Skia | `http:/uno.ui/ios`                                          | yes                    |
-| `wasm`        | web                                | Windows, Android, iOS, macOS, Skia | `http:/uno.ui/wasm`                                         | yes                    |
-| `macos`       | macOS                              | Windows, Android, iOS, web, Skia   | `http:/uno.ui/macos`                                        | yes                    |
+| `xamarin`     | Android, iOS, web, macOS, Skia     | Windows                            | `http://uno.ui/xamarin`                                      | yes                    |
+| `not_win`     | Android, iOS, web, macOS, Skia     | Windows                            | `http://uno.ui/not_win`                                      | yes                    |
+| `android`     | Android                            | Windows, iOS, web, macOS, Skia     | `http://uno.ui/android`                                      | yes                    |
+| `ios`         | iOS                                | Windows, Android, web, macOS, Skia | `http://uno.ui/ios`                                          | yes                    |
+| `wasm`        | web                                | Windows, Android, iOS, macOS, Skia | `http://uno.ui/wasm`                                         | yes                    |
+| `macos`       | macOS                              | Windows, Android, iOS, web, Skia   | `http://uno.ui/macos`                                        | yes                    |
 | `skia`        | Skia                               | Windows, Android, iOS, web, macOs  | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
 | `not_android` | Windows, iOS, web, macOS, Skia     | Android                            | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
 | `not_ios`     | Windows, Android, web, macOS, Skia | iOS                                | `http://schemas.microsoft.com/winfx/2006/xaml/presentation` | no                     |
@@ -143,5 +143,5 @@ In cases where it is needed (fonts are one example) then the XAML files must be 
 
 | Prefix          | Namespace                                                   | Put in `mc:Ignorable`? |
 |-----------------|-------------------------------------------------------------|------------------------|
-| `netstdref`     | `http:/uno.ui/netstdref`                                    | yes                    |
-| `not_netstdref` | `http:/uno.ui/not_netstdref`                                | yes                    |
+| `netstdref`     | `http://uno.ui/netstdref`                                   | yes                    |
+| `not_netstdref` | `http://uno.ui/not_netstdref`                               | yes                    |

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/InfoBarTests/InfoBarPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/InfoBarTests/InfoBarPage.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d not_win"
-	xmlns:not_win="http:/uno.ui/not_win"
+	xmlns:not_win="http://uno.ui/not_win"
 	xmlns:controls="using:Microsoft.UI.Xaml.Controls"
 	xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/Midi/MidiDeviceOutput.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/Midi/MidiDeviceOutput.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:UITests.Shared.Windows_Devices.Midi"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:not_win="http:/uno.ui/not_win"
+    xmlns:not_win="http://uno.ui/not_win"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     d:DesignHeight="1000"
     d:DesignWidth="1000"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
@@ -5,7 +5,7 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:media="using:Microsoft.UI.Xaml.Media"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:not_win="http:/uno.ui/not_win"
+	xmlns:not_win="http://uno.ui/not_win"
 	mc:Ignorable="d not_win"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/RadialGradientBrushPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/RadialGradientBrushPage.xaml
@@ -7,7 +7,7 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:media="using:Microsoft.UI.Xaml.Media"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:not_win="http:/uno.ui/not_win"
+	xmlns:not_win="http://uno.ui/not_win"
 	mc:Ignorable="d not_win">
 
 	<Grid x:Name="RootGrid" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix
- Documentation content changes

## What is the current behavior?

Missing slash character in namespaces declarations referring to Uno URIs


## What is the new behavior?

Added missing slash character in namespaces declarations referring to Uno URIs in the documentation and xaml files.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
