### PR TITLE
fix(xLoad): Fix invalid generated code when x:Load, StaticResources and Visibility are used

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -760,7 +760,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var hasXBindExpressions = CurrentScope.XBindExpressions.Count != 0;
 			var hasResourceExtensions = CurrentScope.Components.Any(HasMarkupExtensionNeedingComponent);
 
-			if (hasXBindExpressions)
+			if (hasXBindExpressions || hasResourceExtensions)
 			{
 				writer.AppendLineInvariant($"Bindings = new {GetBindingsTypeNames(className).bindingsClassName}(this);");
 			}
@@ -824,7 +824,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private void BuildCompiledBindings(IndentedStringBuilder writer, string className)
 		{
-			if (CurrentScope.XBindExpressions.Count != 0)
+			var hasXBindExpressions = CurrentScope.XBindExpressions.Count != 0;
+			var hasResourceExtensions = CurrentScope.Components.Any(HasMarkupExtensionNeedingComponent);
+
+			if (hasXBindExpressions || hasResourceExtensions)
 			{
 				var (bindingsInterfaceName, bindingsClassName) = GetBindingsTypeNames(className);
 
@@ -1645,7 +1648,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						// Bindings with ElementName properties needs to be resolved during Loading.
 						|| (o.Type.Name == "Binding" && o.Members.Any(m => m.Member.Name == "ElementName"))
 					)
-				);
+				)
+			|| (
+				objectDefinition.Type.Name == "ElementStub"
+			);
 
 		/// <summary>
 		/// Does this node or any nested nodes have markup extensions?

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_DataTemplate.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_DataTemplate.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid>
+		<Border x:Name="border1" x:FieldModifier="public" x:Load="false" />
+		<Border x:Name="border2" x:FieldModifier="public" x:Load="false" />
+		<Border x:Name="border3" x:FieldModifier="public" x:Load="false" />
+		<Border x:Name="border4" x:FieldModifier="public" x:Load="false" />
+		<Border x:Name="border5" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" />
+		<Border x:Name="border6" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="Collapsed" />
+		<Border x:Name="border7" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="{Binding ., FallbackValue=Collapsed,TargetNullValue=Collapsed}" />
+		<Border x:Name="border8" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="{x:Bind MyVisibility, Mode=OneWay}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_DataTemplate.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_DataTemplate.xaml.cs
@@ -17,11 +17,21 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
 {
-	public sealed partial class When_xLoad_Multiple : UserControl
+	public sealed partial class When_xLoad : UserControl
 	{
-		public When_xLoad_Multiple()
+		public When_xLoad()
 		{
 			this.InitializeComponent();
 		}
+
+		public bool MyVisibility
+		{
+			get { return (bool)GetValue(MyVisibilityProperty); }
+			set { SetValue(MyVisibilityProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for MyVisibility.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyVisibilityProperty =
+			DependencyProperty.Register("MyVisibility", typeof(bool), typeof(When_xLoad), new PropertyMetadata(false));
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Multiple.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_Multiple.xaml
@@ -1,5 +1,5 @@
 ﻿<UserControl
-    x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad"
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad_Multiple"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
@@ -8,13 +8,10 @@
     mc:Ignorable="d">
 
     <Grid>
-		<Border x:Name="border1" x:FieldModifier="public" x:Load="false" />
-		<Border x:Name="border2" x:FieldModifier="public" x:Load="false" />
-		<Border x:Name="border3" x:FieldModifier="public" x:Load="false" />
-		<Border x:Name="border4" x:FieldModifier="public" x:Load="false" />
-		<Border x:Name="border5" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" />
-		<Border x:Name="border6" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="Collapsed" />
-		<Border x:Name="border7" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="{Binding ., FallbackValue=Collapsed,TargetNullValue=Collapsed}" />
-		<Border x:Name="border8" x:FieldModifier="public" x:DeferLoadStrategy="Lazy" Visibility="{x:Bind MyVisibility, Mode=OneWay}" />
+		<Border x:Name="border1"
+				x:FieldModifier="public"
+				x:DeferLoadStrategy="Lazy"
+				Visibility="{Binding FallbackValue=Collapsed}"
+				Height="{StaticResource LargeComboBoxHeight}" />
 	</Grid>
 </UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -104,5 +104,25 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			var border1 = SUT.FindName("border8");
 			Assert.AreEqual(SUT.border8, border1);
 		}
+
+		[TestMethod]
+		public void When_Deferred_Visibility_and_StaticResource()
+		{
+			var SUT = new When_xLoad_Multiple();
+			SUT.ForceLoaded();
+			SUT.Measure(new Size(42, 42));
+			SUT.DataContext = Visibility.Collapsed;
+
+			var stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+			Assert.AreEqual(1, stubs.Count());
+
+			Assert.IsNull(SUT.border1);
+
+			var border1 = SUT.FindName("border1");
+			SUT.Measure(new Size(42, 42));
+
+			Assert.IsNotNull(SUT.border1);
+			Assert.AreEqual(SUT.border1, border1);
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #4557

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fix invalid generated code when x:Load, StaticResource and Visibility are used simultaneously.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
