### PR TITLE
PropertyChangedEventArgs.PropertyName null updates all bindings

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_PropertyChangedAll.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_PropertyChangedAll.xaml
@@ -1,0 +1,12 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.Binding_PropertyChangedAll"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<StackPanel>
+		<TextBlock x:FieldModifier="public" x:Name="ValueView" Text="{x:Bind Model.Value, Mode=OneWay}" />
+		<TextBlock x:FieldModifier="public" x:Name="TextView" Text="{x:Bind Model.Text, Mode=OneWay}" />
+	</StackPanel>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_PropertyChangedAll.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_PropertyChangedAll.xaml.cs
@@ -28,7 +28,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
 
 	public class PropertyChangedAllViewModel : System.ComponentModel.INotifyPropertyChanged
 	{
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
 
 		public int Value { get; set; } = 0;
 
@@ -36,7 +36,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
 
 		public void RaisePropertyChanged(string propertyName)
 		{
-			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
 		}
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_PropertyChangedAll.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_PropertyChangedAll.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	public sealed partial class Binding_PropertyChangedAll : Page
+	{
+		public Binding_PropertyChangedAll()
+		{
+			this.InitializeComponent();
+		}
+
+		public PropertyChangedAllViewModel Model { get; } = new PropertyChangedAllViewModel();
+	}
+
+	public class PropertyChangedAllViewModel : System.ComponentModel.INotifyPropertyChanged
+	{
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public int Value { get; set; } = 0;
+
+		public string Text { get; set; } = "";
+
+		public void RaisePropertyChanged(string propertyName)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -479,7 +479,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 			Assert.AreEqual("TwoWay updated 5", SUT.Default_TwoWay_OneWay_Property);
 			Assert.AreEqual("TwoWay updated 9", SUT.Default_TwoWay_TwoWay_Property);
 		}
-
+		
 		[TestMethod]
 		public void When_DefaultBindingMode_Nested()
 		{
@@ -690,6 +690,44 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 
 			SUT.TopLevelVisiblity = false;
 			Assert.AreEqual(Visibility.Collapsed, topLevelContent.Visibility);
+		}
+
+		[TestMethod]
+		public void When_PropertyChanged_Empty()
+		{
+			var SUT = new Binding_PropertyChangedAll();
+
+			SUT.ForceLoaded();
+
+			Assert.AreEqual(SUT.Model.Value.ToString(), SUT.ValueView.Text);
+			Assert.AreEqual(SUT.Model.Text, SUT.TextView.Text);
+
+			SUT.Model.Value = 42;
+			SUT.Model.Text = "World";
+
+			SUT.Model.RaisePropertyChanged(string.Empty);
+
+			Assert.AreEqual(SUT.Model.Value.ToString(), SUT.ValueView.Text);
+			Assert.AreEqual(SUT.Model.Text, SUT.TextView.Text);
+		}
+
+		[TestMethod]
+		public void When_PropertyChanged_Null()
+		{
+			var SUT = new Binding_PropertyChangedAll();
+
+			SUT.ForceLoaded();
+
+			Assert.AreEqual(SUT.Model.Value.ToString(), SUT.ValueView.Text);
+			Assert.AreEqual(SUT.Model.Text, SUT.TextView.Text);
+
+			SUT.Model.Value = 42;
+			SUT.Model.Text = "World";
+
+			SUT.Model.RaisePropertyChanged(null);
+
+			Assert.AreEqual(SUT.Model.Value.ToString(), SUT.ValueView.Text);
+			Assert.AreEqual(SUT.Model.Text, SUT.TextView.Text);
 		}
 	}
 }

--- a/src/Uno.UI/DataBinding/BindingPath.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.cs
@@ -355,7 +355,7 @@ namespace Uno.UI.DataBinding
 
 				System.ComponentModel.PropertyChangedEventHandler handler = (s, args) =>
 				{
-					if (args.PropertyName == propertyName || args.PropertyName == string.Empty)
+					if (args.PropertyName == propertyName || string.IsNullOrEmpty(args.PropertyName))
 					{
 						if (typeof(BindingPath).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 						{


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #4576


## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Not supported

## What is the new behavior?

`PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(null));` updates all bindings on that object.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.