### PR TITLE
fix: ViewHelper.Android not considering IgnoreTextScaleFactor at runtime

### DIFF
--- a/src/Uno.UI/Extensions/ViewHelper.Android.cs
+++ b/src/Uno.UI/Extensions/ViewHelper.Android.cs
@@ -78,16 +78,11 @@ namespace Uno.UI
 		{
 			using (Android.Util.DisplayMetrics displayMetrics = Android.App.Application.Context.Resources.DisplayMetrics)
 			{
+				AdjustScaledDensity(displayMetrics);
+
 				// WARNING: The Density value is not completely based on the DPI of the device.
 				// On two 8" devices, the Density may not be consistent.
 				_cachedDensity = displayMetrics.Density;
-				if (FeatureConfiguration.Font.IgnoreTextScaleFactor)
-				{
-					// To disable text scaling, we put the Density value in ScaledDensity so that the ratio between them is 1.
-					// This ensures it's disabled for everything using ScaledDensity (e.g. TextBlock, TextBox, AppBarButton, etc.)
-					// https://developer.xamarin.com/api/property/Android.Util.DisplayMetrics.ScaledDensity/
-					displayMetrics.ScaledDensity = displayMetrics.Density;
-				}
 				_cachedScaledDensity = displayMetrics.ScaledDensity;
 				_cachedScaledXDpi = displayMetrics.Xdpi;
 
@@ -107,6 +102,8 @@ namespace Uno.UI
 		{
 			using (Android.Util.DisplayMetrics displayMetrics = Android.App.Application.Context.Resources.DisplayMetrics)
 			{
+				AdjustScaledDensity(displayMetrics);
+
 				_cachedScaledDensity = displayMetrics.ScaledDensity;
 			}
 		}
@@ -453,6 +450,17 @@ namespace Uno.UI
 			}
 
 			return 0;
+		}
+
+		private static void AdjustScaledDensity(Android.Util.DisplayMetrics displayMetrics)
+		{
+			if (FeatureConfiguration.Font.IgnoreTextScaleFactor)
+			{
+				// To disable text scaling, we put the Density value in ScaledDensity so that the ratio between them is 1.
+				// This ensures it's disabled for everything using ScaledDensity (e.g. TextBlock, TextBox, AppBarButton, etc.)
+				// https://developer.xamarin.com/api/property/Android.Util.DisplayMetrics.ScaledDensity/
+				displayMetrics.ScaledDensity = displayMetrics.Density;
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Setting `IgnoreTextScaleFactor = true` doesn't prevent Android app from changing text scale when device's text size is changed while the app is running.


## What is the new behavior?

Setting `IgnoreTextScaleFactor = true` always prevents Android app from changing text scale.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
