### PR TITLE
build: Fail solution build on path with spaces

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -63,6 +63,11 @@
 	<PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.2" />
   </ItemGroup>
 
+  <Target Name="ValidateSolutionPath" BeforeTargets="Build">
+	<Error Condition="$(MSBuildThisFileDirectory.Contains(' '))"
+		 Text="The Uno.UI Solution cannot build with a space in the path. Consider changing to a path without spaces."/>
+  </Target>
+
   <!-- Import the override as the nuget tooling in VS is skipping ItemGroup conditions for legacy projects -->
   <Import Project="roslyn-override.targets" Condition="'$(MicrosoftNetCompilerVersionOverride)'!=''"/>
 </Project>


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Raise an error when building the uno.ui solution from a path containing spaces.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
