### PR TITLE
perf: [Wasm] Improve DOM routed events dispatch performance

### DIFF
--- a/src/Uno.UI.Runtime.WebAssembly/Xaml/UIElementWasmExtensions.cs
+++ b/src/Uno.UI.Runtime.WebAssembly/Xaml/UIElementWasmExtensions.cs
@@ -160,7 +160,7 @@ return __f(element);
 		/// </summary>
 		public static void RegisterHtmlEventHandler(this UIElement element, string eventName, EventHandler handler)
 		{
-			element.RegisterEventHandler(eventName, handler);
+			element.RegisterEventHandler(eventName, handler, UIElement.GenericEventHandlers.RaiseEventHandler);
 		}
 
 		/// <summary>
@@ -168,7 +168,7 @@ return __f(element);
 		/// </summary>
 		public static void UnregisterHtmlEventHandler(this UIElement element, string eventName, EventHandler handler)
 		{
-			element.UnregisterEventHandler(eventName, handler);
+			element.UnregisterEventHandler(eventName, handler, UIElement.GenericEventHandlers.RaiseEventHandler);
 		}
 
 		/// <summary>
@@ -189,6 +189,7 @@ return __f(element);
 			element.RegisterEventHandler(
 				eventName,
 				handler,
+				RaiseCustomEventHandler,
 				eventExtractor: extractor,
 				payloadConverter: (_, s) => new HtmlCustomEventArgs(s));
 		}
@@ -198,7 +199,18 @@ return __f(element);
 		/// </summary>
 		public static void UnregisterHtmlCustomEventHandler(this UIElement element, string eventName, EventHandler<HtmlCustomEventArgs> handler)
 		{
-			element.UnregisterEventHandler(eventName, handler);
+			element.UnregisterEventHandler(eventName, handler, RaiseCustomEventHandler);
+		}
+
+		private static object RaiseCustomEventHandler(Delegate d, object sender, object args)
+		{
+			if (d is RoutedEventHandler handler && args is RoutedEventArgs routedEventArgs)
+			{
+				handler(sender, routedEventArgs);
+				return null;
+			}
+
+			throw new InvalidOperationException($"The parameters for invoking GenericEventHandlers.RaiseEventHandler with {d} are incorrect");
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
@@ -71,8 +71,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public event RoutedEventHandler ImageOpened
 		{
-			add => _htmlImage.RegisterEventHandler("load", value);
-			remove => _htmlImage.UnregisterEventHandler("load", value);
+			add => _htmlImage.RegisterEventHandler("load", value, GenericEventHandlers.RaiseRoutedEventHandler);
+			remove => _htmlImage.UnregisterEventHandler("load", value, GenericEventHandlers.RaiseRoutedEventHandler);
 		}
 
 		private ExceptionRoutedEventArgs ImageFailedConverter(object sender, string e)
@@ -80,8 +80,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public event ExceptionRoutedEventHandler ImageFailed
 		{
-			add => _htmlImage.RegisterEventHandler("error", value, payloadConverter: ImageFailedConverter);
-			remove => _htmlImage.UnregisterEventHandler("error", value);
+			add => _htmlImage.RegisterEventHandler("error", value, GenericEventHandlers.RaiseExceptionRoutedEventHandler, payloadConverter: ImageFailedConverter);
+			remove => _htmlImage.UnregisterEventHandler("error", value, GenericEventHandlers.RaiseExceptionRoutedEventHandler);
 		}
 
 		partial void OnSourceChanged(DependencyPropertyChangedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -129,13 +129,13 @@ namespace Windows.UI.Xaml.Controls
 		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
-			RegisterEventHandler("scroll", (EventHandler)OnScroll);
+			RegisterEventHandler("scroll", (EventHandler)OnScroll, GenericEventHandlers.RaiseEventHandler);
 		}
 
 		private protected override void OnUnloaded()
 		{
 			base.OnUnloaded();
-			UnregisterEventHandler("scroll", (EventHandler)OnScroll);
+			UnregisterEventHandler("scroll", (EventHandler)OnScroll, GenericEventHandlers.RaiseEventHandler);
 		}
 
 		public void ScrollTo(double? horizontalOffset, double? verticalOffset, bool disableAnimation)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -53,8 +53,8 @@ namespace Windows.UI.Xaml.Controls
 
 		private event EventHandler HtmlInput
 		{
-			add => RegisterEventHandler("input", value);
-			remove => UnregisterEventHandler("input", value);
+			add => RegisterEventHandler("input", value, GenericEventHandlers.RaiseEventHandler);
+			remove => UnregisterEventHandler("input", value, GenericEventHandlers.RaiseEventHandler);
 		}
 
 		internal bool IsMultiline { get; }

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
@@ -124,7 +124,7 @@ namespace Windows.UI.Xaml
 				}
 				else
 				{
-					RegisterEventHandler("loading", value);
+					RegisterEventHandler("loading", value, GenericEventHandlers.RaiseRoutedEventHandler);
 				}
 			}
 			remove
@@ -135,7 +135,7 @@ namespace Windows.UI.Xaml
 				}
 				else
 				{
-					UnregisterEventHandler("loading", value);
+					UnregisterEventHandler("loading", value, GenericEventHandlers.RaiseRoutedEventHandler);
 				}
 			}
 		}
@@ -151,7 +151,7 @@ namespace Windows.UI.Xaml
 				}
 				else
 				{
-					RegisterEventHandler("loaded", value);
+					RegisterEventHandler("loaded", value, GenericEventHandlers.RaiseRoutedEventHandler);
 				}
 			}
 			remove
@@ -162,7 +162,7 @@ namespace Windows.UI.Xaml
 				}
 				else
 				{
-					UnregisterEventHandler("loaded", value);
+					UnregisterEventHandler("loaded", value, GenericEventHandlers.RaiseRoutedEventHandler);
 				}
 			}
 		}
@@ -178,7 +178,7 @@ namespace Windows.UI.Xaml
 				}
 				else
 				{
-					RegisterEventHandler("unloaded", value);
+					RegisterEventHandler("unloaded", value, GenericEventHandlers.RaiseRoutedEventHandler);
 				}
 			}
 			remove
@@ -189,7 +189,7 @@ namespace Windows.UI.Xaml
 				}
 				else
 				{
-					UnregisterEventHandler("unloaded", value);
+					UnregisterEventHandler("unloaded", value, GenericEventHandlers.RaiseRoutedEventHandler);
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/UIElement.GenericEventHandlers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.GenericEventHandlers.wasm.cs
@@ -1,0 +1,65 @@
+﻿using System;
+
+namespace Windows.UI.Xaml
+{
+	partial class UIElement
+	{
+		/// <summary>
+		/// Generic handlers for DOM mapped events
+		/// </summary>
+		internal static class GenericEventHandlers
+		{
+			internal static object RaiseEventHandler(Delegate d, object sender, object args)
+			{
+				if (d is EventHandler handler)
+				{
+					handler(sender, args as EventArgs);
+					return null;
+				}
+
+				throw new InvalidOperationException($"The parameters for invoking GenericEventHandlers.RaiseEventHandler with {d} are incorrect");
+			}
+
+			internal static object RaiseRawEventHandler(Delegate d, object sender, object args)
+			{
+				if (d is RawEventHandler handler)
+				{
+					return handler(sender as UIElement, args as string);
+				}
+
+				throw new InvalidOperationException($"The parameters for invoking GenericEventHandlers.RaiseEventHandler with {d} are incorrect");
+			}
+
+			internal static object RaiseRoutedEventHandler(Delegate d, object sender, object args)
+			{
+				if (d is RoutedEventHandler handler)
+				{
+					handler(sender, args as RoutedEventArgs);
+					return null;
+				}
+
+				throw new InvalidOperationException($"The parameters for invoking GenericEventHandlers.RaiseEventHandler with {d} are incorrect");
+			}
+
+			internal static object RaiseExceptionRoutedEventHandler(Delegate d, object sender, object args)
+			{
+				if (d is ExceptionRoutedEventHandler handler)
+				{
+					handler(sender, args as ExceptionRoutedEventArgs);
+					return null;
+				}
+				return null;
+			}
+
+			internal static object RaiseRoutedEventHandlerWithHandled(Delegate d, object sender, object args)
+			{
+				if (d is RoutedEventHandlerWithHandled handler)
+				{
+					handler(sender, args as RoutedEventArgs);
+					return null;
+				}
+				return null;
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -53,11 +53,11 @@ namespace Windows.UI.Xaml
 				//		 as on UWP, even if the event are RoutedEvents, PointerEntered and PointerExited
 				//		 are routed only in some particular cases (entering at once on multiple controls),
 				//		 it's easier to handle this in managed code.
-				RegisterEventHandler("pointerenter", (RawEventHandler)DispatchNativePointerEnter);
-				RegisterEventHandler("pointerleave", (RawEventHandler)DispatchNativePointerLeave);
-				RegisterEventHandler("pointerdown", (RawEventHandler)DispatchNativePointerDown);
-				RegisterEventHandler("pointerup", (RawEventHandler)DispatchNativePointerUp);
-				RegisterEventHandler("pointercancel", (RawEventHandler)DispatchNativePointerCancel); //https://www.w3.org/TR/pointerevents/#the-pointercancel-event
+				RegisterEventHandler("pointerenter", (RawEventHandler)DispatchNativePointerEnter, GenericEventHandlers.RaiseRawEventHandler);
+				RegisterEventHandler("pointerleave", (RawEventHandler)DispatchNativePointerLeave, GenericEventHandlers.RaiseRawEventHandler);
+				RegisterEventHandler("pointerdown", (RawEventHandler)DispatchNativePointerDown, GenericEventHandlers.RaiseRawEventHandler);
+				RegisterEventHandler("pointerup", (RawEventHandler)DispatchNativePointerUp, GenericEventHandlers.RaiseRawEventHandler);
+				RegisterEventHandler("pointercancel", (RawEventHandler)DispatchNativePointerCancel, GenericEventHandlers.RaiseRawEventHandler); //https://www.w3.org/TR/pointerevents/#the-pointercancel-event
 			}
 
 			switch (routedEvent.Flag)
@@ -75,6 +75,7 @@ namespace Windows.UI.Xaml
 					RegisterEventHandler(
 						"pointermove",
 						handler: (RawEventHandler)DispatchNativePointerMove,
+						invoker: GenericEventHandlers.RaiseRawEventHandler,
 						onCapturePhase: false,
 						eventExtractor: HtmlEventExtractor.PointerEventExtractor
 					);
@@ -90,6 +91,7 @@ namespace Windows.UI.Xaml
 					RegisterEventHandler(
 						"wheel",
 						handler: (RawEventHandler)DispatchNativePointerWheel,
+						invoker: GenericEventHandlers.RaiseRawEventHandler,
 						onCapturePhase: false,
 						eventExtractor: HtmlEventExtractor.PointerEventExtractor
 					);

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -625,6 +625,7 @@ namespace Windows.UI.Xaml
 			RegisterEventHandler(
 				domEventName,
 				handler: new RoutedEventHandlerWithHandled((snd, args) => RaiseEvent(routedEvent, args)),
+				invoker: GenericEventHandlers.RaiseRoutedEventHandlerWithHandled,
 				onCapturePhase: false,
 				eventExtractor: HtmlEventExtractor.KeyboardEventExtractor,
 				payloadConverter: PayloadToKeyArgs


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Workaround .NET 6 memory corruption issue https://github.com/dotnet/runtime/issues/45304, but removing the use of `Delegate.DynamicInvoke` and also improve performance as a result.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
