### PR TITLE
[Wasm] Fixed Html custom event regression

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Wasm/Given_CustomEvents.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Wasm/Given_CustomEvents.cs
@@ -1,0 +1,49 @@
+﻿using System.Threading;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Wasm
+{
+	[TestFixture]
+	public partial class Given_CustomEvents : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]
+		public void Check_CustomEvent()
+		{
+			Run("UITests.Shared.Wasm.Wasm_CustomEvent");
+
+			_app.FastTap("genericEvent");
+
+			_app.Marked("tapResult").GetText().Should().Be("Ok");
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]
+		public void Check_CustomEvent_WithPayload()
+		{
+			Run("UITests.Shared.Wasm.Wasm_CustomEvent");
+
+			_app.FastTap("customEventString");
+
+			_app.Marked("tapResult").GetText().Should().Be("Ok");
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]
+		public void Check_CustomEvent_WithJsonPayload()
+		{
+			Run("UITests.Shared.Wasm.Wasm_CustomEvent");
+
+			_app.FastTap("customEventJson");
+
+			_app.Marked("tapResult").GetText().Should().Be("Ok");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml
+++ b/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml
@@ -6,7 +6,7 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d">
 
-	<StackPanel>
+	<StackPanel Spacing="8" Margin="10">
 		<TextBlock>This test is for the WASM target only. Don't do anything on other platforms.</TextBlock>
 		<Border Height="100" Background="BurlyWood" x:Name="genericEvent">
 			<TextBlock>Tap here to generate a generic html event</TextBlock>
@@ -17,6 +17,7 @@
 		<Border Height="100" Background="BurlyWood" x:Name="customEventJson">
 			<TextBlock>Tap here to generate a custom html event with json payload</TextBlock>
 		</Border>
+		<TextBlock x:Name="tapResult" />
 		<TextBlock x:Name="result">Result here...</TextBlock>
 
 	</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml.cs
@@ -2,6 +2,7 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
+using Newtonsoft.Json.Linq;
 #if __WASM__
 using Uno.Foundation;
 using Uno.Extensions;
@@ -61,16 +62,40 @@ namespace UITests.Shared.Wasm
 		private void OnUnoEvent1(object sender, EventArgs e)
 		{
 			result.Text += $"Received generic event from {sender}\n.";
+			tapResult.Text = "Ok";
 		}
 
 		private void OnUnoEvent2(object sender, HtmlCustomEventArgs e)
 		{
 			result.Text += $"Received string event from {sender}: \"{e.Detail}\"\n.";
+
+			tapResult.Text =
+				e.Detail == "String detail from event."
+				? "Ok"
+				: "Error: received " + e.Detail;
 		}
 
 		private void OnUnoEvent3(object sender, HtmlCustomEventArgs e)
 		{
 			result.Text += $"Received json event from {sender}: {e.Detail}\n.";
+
+			try
+			{
+				var json = JToken.Parse(e.Detail);
+				if(json["msg"].Value<string>() == "msg" && json["int"].Value<int>() == 123 && json["txt"].Value<string>() == "it works!")
+				{
+					tapResult.Text = "Ok";
+				}
+				else
+				{
+					tapResult.Text = "Error: invalid json " + json.ToString(Newtonsoft.Json.Formatting.None);
+				}
+
+			}
+			catch(Exception ex)
+			{
+				tapResult.Text = "Error: " + ex.Message;
+			}
 		}
 #endif
 	}

--- a/src/Uno.UI.Runtime.WebAssembly/Xaml/UIElementWasmExtensions.cs
+++ b/src/Uno.UI.Runtime.WebAssembly/Xaml/UIElementWasmExtensions.cs
@@ -29,17 +29,17 @@ namespace Windows.UI.Xaml
 			WindowManagerInterop.SetStyles(element.HtmlId, new[] {(name, value)});
 		}
 
-        /// <summary>
-        /// Set one or many CSS styles on a HTML element.
-        /// </summary>
-        /// <remarks>
-        /// The style is using the CSS syntax format, not the DOM syntax.
-        /// Ex: for font size, use "font-size", not "fontSize".
-        /// </remarks>
-        public static void SetCssStyle(this UIElement element, params (string name, string value)[] styles)
-        {
-            WindowManagerInterop.SetStyles(element.HtmlId, styles);
-        }
+		/// <summary>
+		/// Set one or many CSS styles on a HTML element.
+		/// </summary>
+		/// <remarks>
+		/// The style is using the CSS syntax format, not the DOM syntax.
+		/// Ex: for font size, use "font-size", not "fontSize".
+		/// </remarks>
+		public static void SetCssStyle(this UIElement element, params (string name, string value)[] styles)
+		{
+			WindowManagerInterop.SetStyles(element.HtmlId, styles);
+		}
 
 		/// <summary>
 		/// Clear one or many CSS styles from a HTML element.
@@ -189,7 +189,7 @@ return __f(element);
 			element.RegisterEventHandler(
 				eventName,
 				handler,
-				RaiseCustomEventHandler,
+				RaiseHtmlCustomEventHandler,
 				eventExtractor: extractor,
 				payloadConverter: (_, s) => new HtmlCustomEventArgs(s));
 		}
@@ -199,18 +199,17 @@ return __f(element);
 		/// </summary>
 		public static void UnregisterHtmlCustomEventHandler(this UIElement element, string eventName, EventHandler<HtmlCustomEventArgs> handler)
 		{
-			element.UnregisterEventHandler(eventName, handler, RaiseCustomEventHandler);
+			element.UnregisterEventHandler(eventName, handler, RaiseHtmlCustomEventHandler);
 		}
 
-		private static object RaiseCustomEventHandler(Delegate d, object sender, object args)
+		private static object RaiseHtmlCustomEventHandler(Delegate d, object sender, object args)
 		{
-			if (d is RoutedEventHandler handler && args is RoutedEventArgs routedEventArgs)
+			if (d is EventHandler<HtmlCustomEventArgs> handler && args is HtmlCustomEventArgs eventArgs)
 			{
-				handler(sender, routedEventArgs);
-				return null;
+				handler(sender, eventArgs);
 			}
 
-			throw new InvalidOperationException($"The parameters for invoking GenericEventHandlers.RaiseEventHandler with {d} are incorrect");
+			throw new InvalidOperationException($"The parameters {args ?? "<null>"} for invoking GenericEventHandlers.RaiseEventHandler with {d} from {sender ?? "<null>"} are incorrect");
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/4650

# Bugfix
Casting of handler + EventArgs was wrong in refactoring. There was no automated tests to prevent this.

## What is the new behavior?
Regression fixed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
