### PR TITLE
fix(iOS): [Commandbar] SetNavigationBar throwing exception when null

### DIFF
--- a/src/Uno.UI/Controls/CommandBarHelper.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBarHelper.iOS.cs
@@ -12,7 +12,7 @@ namespace Uno.UI.Controls
 	{
 		internal static void SetNavigationBar(CommandBar commandBar, UIKit.UINavigationBar? navigationBar)
 		{
-			commandBar.GetRenderer(() => new CommandBarRenderer(commandBar)).Native = navigationBar ?? throw new ArgumentNullException(nameof(navigationBar));
+			commandBar.GetRenderer(() => new CommandBarRenderer(commandBar)).Native = navigationBar;
 		}
 
 		internal static void SetNavigationItem(CommandBar commandBar, UIKit.UINavigationItem? navigationItem)


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
iOS throwing exception when setting a NavigationBar to null.

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->


## What is the new behavior?
No exception is raised when the NavigationBar is set to null since this is commonly used in the code.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
