### PR TITLE
fix(Button): Touch pressed do not update Visual State

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/VisualStatesImplementation.tt
+++ b/src/Uno.UI/UI/Xaml/Controls/VisualStatesImplementation.tt
@@ -199,7 +199,7 @@ namespace <#= mixin.NamespaceName #>
 				return __disabledState;
 			}
 #if <#= mixin.HasCommonPressedState #>
-			else if (IsPointerPressed && IsPointerOver)
+			else if (IsPointerPressed)
 			{
 				return __pressedState;
 			}


### PR DESCRIPTION
Using a touch pointer, touch screen, with Skia GTK does not set the
IsPointerOver only the IsPointerPressed when touching a button. The
check for IsPointerPressed and IsPointerOver is never true for the
touch case, so the Visual State does not change the appearance when
pressed.

I believe that the normal thing is that if we have an IsPointerPressed
true automatically IsPointerOver is also true, I cannot think of any
case where this is not true, but for touch this is getting only the
pressed not the over, please correct me if I am wrong. This commit
removes the IsPointerOver from the check to set the visual state to
"Pressed".

Signed-off-by: Matheus Castello <matheus@castello.eng.br>

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Touching a button using a touch screen does not change the visual state

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Touching a button using a touch screen changes the visual state correctly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

As I wrote in the commit description I couldn't think of any case where `IsPointerPressed` is true without `IsPointerOver` not being true, so I think that using `IsPointerOver` at check is not necessary, but I may be wrong please let me know.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
