### PR TITLE
Fix tapped event bubbling when handled

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/TappedTapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/TappedTapped_Tests.cs
@@ -159,8 +159,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 			var result = GestureResult.Get(_app.Marked("LastTapped"));
 			result.Element.Should().Be(parentName);
-			((int)result.X).Should().BeInRange(tapX - 1, tapX + 1);
-			((int)result.Y).Should().BeInRange(tapY - 1, tapY + 1);
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/TappedTapped_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/TappedTapped_Tests.cs
@@ -142,5 +142,45 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 				: "Item_3";
 			result.Element.Should().Be(expectedItem);
 		}
+
+		[Test]
+		[AutoRetry]
+		public void When_Nested()
+		{
+			Run(_xamlTestPage);
+
+			const string parentName = "Nested_Parent";
+			const string targetName = "Nested_Target";
+			const int tapX = 10, tapY = 10;
+
+			// Tap the target
+			var target = _app.WaitForElement(targetName).Single().Rect;
+			_app.TapCoordinates(target.X + tapX, target.Y + tapY);
+
+			var result = GestureResult.Get(_app.Marked("LastTapped"));
+			result.Element.Should().Be(parentName);
+			((int)result.X).Should().BeInRange(tapX - 1, tapX + 1);
+			((int)result.Y).Should().BeInRange(tapY - 1, tapY + 1);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void When_Nested_And_Handling()
+		{
+			Run(_xamlTestPage);
+
+			const string parentName = "Nested_Handling_Parent";
+			const string targetName = "Nested_Handling_Target";
+			const int tapX = 10, tapY = 10;
+
+			// Tap the target
+			var target = _app.WaitForElement(targetName).Single().Rect;
+			_app.TapCoordinates(target.X + tapX, target.Y + tapY);
+
+			var result = GestureResult.Get(_app.Marked("LastTapped"));
+			result.Element.Should().Be(targetName);
+			((int)result.X).Should().BeInRange(tapX - 1, tapX + 1);
+			((int)result.Y).Should().BeInRange(tapY - 1, tapY + 1);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml
@@ -23,10 +23,11 @@
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition />
 			<ColumnDefinition />
+			<ColumnDefinition />
 		</Grid.ColumnDefinitions>
 
 		<TextBlock
-			Text="Double on each zones. Last double tapped:"
+			Text="Tap on each zones. Last tapped:"
 			TextWrapping="Wrap"
 			Grid.Row="0"
 			Grid.ColumnSpan="2"/>
@@ -203,5 +204,52 @@
 				</ListView.ItemTemplate>
 			</ListView>
 		</Border>
+
+		<TextBlock
+			Text="Nested"
+			Grid.Row="2"
+			Grid.Column="2"
+			HorizontalAlignment="Center"/>
+		<Border
+			x:Name="Nested_Parent"
+			Grid.Row="3"
+			Grid.Column="2"
+			Width="150"
+			Height="150"
+			Background="#FF0018"
+			Tapped="TargetTapped">
+			<Border
+				x:Name="Nested_Target"
+				Width="100"
+				Height="100"
+				HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				Background="#33000000"
+				Tapped="TargetTapped" />
+		</Border>
+
+		<TextBlock
+			Text="Nested"
+			Grid.Row="4"
+			Grid.Column="2"
+			HorizontalAlignment="Center"/>
+		<Border
+			x:Name="Nested_Handling_Parent"
+			Grid.Row="5"
+			Grid.Column="2"
+			Width="150"
+			Height="150"
+			Background="#FFA52C"
+			Tapped="TargetTapped">
+			<Border
+				x:Name="Nested_Handling_Target"
+				Width="100"
+				Height="100"
+				HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				Background="#33000000"
+				Tapped="TargetTapped" />
+		</Border>
+
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/TappedTest.xaml.cs
@@ -22,6 +22,8 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
 			var position = e.GetPosition(target).LogicalToPhysicalPixels();
 
 			LastTapped.Text = FormattableString.Invariant($"{target.Name}@{position.X:F2},{position.Y:F2}");
+
+			e.Handled = target.Name.Contains("Handling");
 		}
 
 		private void ItemTapped(object sender, TappedRoutedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/RoutedEvent.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEvent.cs
@@ -21,6 +21,8 @@ namespace Windows.UI.Xaml
 			IsManipulationEvent = flag.IsManipulationEvent();
 			IsGestureEvent = flag.IsGestureEvent();
 			IsDragAndDropEvent = flag.IsDragAndDropEvent();
+
+			IsAlwaysBubbled = IsPointerEvent || IsGestureEvent || IsManipulationEvent || IsDragAndDropEvent;
 		}
 
 		[Pure]
@@ -36,11 +38,15 @@ namespace Windows.UI.Xaml
 		/// <remarks>
 		/// For some events like PointerEvent, we always needs to get the full events sequence to maintain the
 		/// internal state, so we always needs the handled events too.
+		/// 
 		/// This flag avoids the complex update of the SubscribedToHandledEventsToo property coercing and inheritance
 		/// for those kind of well-known events.
+		/// 
+		/// Basically all routed events that are implementing the 'PrepareManaged***EventBubbling' to maintain local
+		/// state should opt-in for that.
 		/// </remarks>
 		[Pure]
-		internal bool IsAlwaysBubbled => IsPointerEvent;
+		internal bool IsAlwaysBubbled { get; }
 
 		[Pure]
 		internal bool IsPointerEvent { get; }

--- a/src/Uno.UI/UI/Xaml/RoutedEventFlag.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEventFlag.cs
@@ -99,7 +99,7 @@ namespace Uno.UI.Xaml
 			| RoutedEventFlag.ManipulationInertiaStarting
 			| RoutedEventFlag.ManipulationCompleted;
 
-		private const RoutedEventFlag _isGesture = // 0b0000_0000_0001_1111___0000_0000_0000_0000___0000_0000_0000_0000___0000_0000_0000_0000
+		private const RoutedEventFlag _isGesture = // 0b0000_0000_0000_1111___0000_0000_0000_0000___0000_0000_0000_0000___0000_0000_0000_0000
 			RoutedEventFlag.Tapped
 			| RoutedEventFlag.DoubleTapped
 			| RoutedEventFlag.RightTapped

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -725,6 +725,7 @@ namespace Windows.UI.Xaml
 			return bubblingMode;
 		}
 
+		// WARNING: When implementing one of those methods to maintain a local state, you should also opt-in for RoutedEvent.IsAlwaysBubbled
 		partial void PrepareManagedPointerEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref BubblingMode bubblingMode);
 		partial void PrepareManagedKeyEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref BubblingMode bubblingMode);
 		partial void PrepareManagedFocusEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref BubblingMode bubblingMode);


### PR DESCRIPTION
## Bugfix

`Tapped` event is bubbling even if the args are marked as `Handled = true`.

## What is the current behavior?

When a gesture and manipulation events bubbles to the parent, it will disable the local gesture recognizer of the parent in order to avoid double event. But if the event args is flagged as `Handled = true` the bubbling stops, so the parent's recognizer still detects a "tapped gesture" so it will fire the `Tapped` event again on it's own.


## What is the new behavior?

Manipulation and gesture events are flagged "always bubbling" so even if handled, they will bubble to the parent and disable the local `GestureRecognizer`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).~~
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
