### PR TITLE
fix(macos): ManipulationDelta translateY being inverted

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
@@ -27,6 +27,43 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			TakeScreenshot("Result");
 		}
 
+		[Test] [AutoRetry] public void ManipulateDelta_DragLeft() => ManipulationDelta_Dragging(dx: 100);
+		[Test] [AutoRetry] public void ManipulateDelta_DragUp() => ManipulationDelta_Dragging(dy: 100);
+		[Test] [AutoRetry] public void ManipulateDelta_DragRight() => ManipulationDelta_Dragging(dx: -100);
+		[Test] [AutoRetry] public void ManipulateDelta_DragDown() => ManipulationDelta_Dragging(dy: -100);
+
+		public void ManipulationDelta_Dragging(int dx = 0, int dy = 0)
+		{
+			if (!(dx == 0 ^ dy == 0))
+			{
+				throw new ArgumentException($"dx and dy cannot be both 0 or both have value: {dx}, {dy}");
+			}
+
+			Run("UITests.Shared.Windows_UI_Input.GestureRecognizerTests.ManipulationEvents");
+
+			// dragging
+			var rect = _app.WaitForElement("_thumb").Single().Rect;
+			_app.DragCoordinates(rect.CenterX, rect.CenterY, rect.CenterX + dx, rect.CenterY + dy);
+
+			// assert if the square translated in the opposite direction
+			var translateX = _app.Marked("DebugThumbTranslateX").GetDependencyPropertyValue<string>("Text");
+			var translateY = _app.Marked("DebugThumbTranslateY").GetDependencyPropertyValue<string>("Text");
+			if (float.TryParse(translateX, out var tx) && float.TryParse(translateY, out var ty))
+			{
+				var context = dx != 0
+					? new { Axis = 'X', Subscript = 'x', Delta = dx, Translation = tx }
+					: new { Axis = 'Y', Subscript = 'y', Delta = dy, Translation = ty };
+				Assert.IsTrue(
+					Math.Sign(context.Delta) * -1 == Math.Sign(context.Translation),
+					$"Expect TranslateTransform.{context.Axis} (t{context.Subscript}:{context.Translation}) to be in the opposite direction of dragging direction (d{context.Subscript}:{context.Delta})."
+				);
+			}
+			else
+			{
+				throw new InvalidOperationException($"Failed to parse DebugThumbTranslate(X|Y) values: '{translateX}', '{translateY}'");
+			}
+		}
+
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Android, Platform.iOS)] // PinchToZoomInCoordinates is not supported on WASM yet

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
@@ -27,10 +27,25 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			TakeScreenshot("Result");
 		}
 
-		[Test] [AutoRetry] public void ManipulateDelta_DragLeft() => ManipulationDelta_Dragging(dx: 100);
-		[Test] [AutoRetry] public void ManipulateDelta_DragUp() => ManipulationDelta_Dragging(dy: 100);
-		[Test] [AutoRetry] public void ManipulateDelta_DragRight() => ManipulationDelta_Dragging(dx: -100);
-		[Test] [AutoRetry] public void ManipulateDelta_DragDown() => ManipulationDelta_Dragging(dy: -100);
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Android)]
+		public void ManipulateDelta_DragLeft() => ManipulationDelta_Dragging(dx: 100);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Android)]
+		public void ManipulateDelta_DragUp() => ManipulationDelta_Dragging(dy: 100);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Android)]
+		public void ManipulateDelta_DragRight() => ManipulationDelta_Dragging(dx: -100);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Android)]
+		public void ManipulateDelta_DragDown() => ManipulationDelta_Dragging(dy: -100);
 
 		public void ManipulationDelta_Dragging(int dx = 0, int dy = 0)
 		{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/ManipulationEvents.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/ManipulationEvents.xaml
@@ -12,6 +12,10 @@
 		HorizontalAlignment="Stretch"
 		VerticalAlignment="Stretch">
 
+		<!-- RenderTransform is not queryable in UITest even if marked by x:Name -->
+		<TextBlock x:Name="DebugThumbTranslateX" Text="{Binding ElementName=_thumbTranslate, Path=X}" Foreground="Transparent" />
+		<TextBlock x:Name="DebugThumbTranslateY" Text="{Binding ElementName=_thumbTranslate, Path=Y}" Foreground="Transparent" />
+
 		<TextBlock
 			VerticalAlignment="Bottom"
 			Text="This test validates the implicit capture and the sum of delta of the manipulation events. Once clicked over, the small red square should move at the opposite of your pointer."
@@ -23,7 +27,11 @@
 			VerticalAlignment="Center"
 			Width="24"
 			Height="24"
-			Background="Orange" />
+			Background="Orange">
+			<Border.RenderTransform>
+				<TranslateTransform x:Name="_thumbShadowTranslate" />
+			</Border.RenderTransform>
+		</Border>
 
 		<Border
 			x:Name="_thumb"
@@ -31,6 +39,10 @@
 			VerticalAlignment="Center"
 			Width="20"
 			Height="20"
-			Background="Red" />
+			Background="Red">
+			<Border.RenderTransform>
+				<TranslateTransform x:Name="_thumbTranslate" />
+			</Border.RenderTransform>
+		</Border>
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/ManipulationEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/ManipulationEvents.xaml.cs
@@ -38,28 +38,17 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
 
 		private void Move(ManipulationDelta delta, ManipulationDelta cumulative)
 		{
-			var deltaTransform = GetOrCreateTransform(_thumb);
+			var deltaTransform = _thumbTranslate;
 			deltaTransform.X -= delta.Translation.X;
 			deltaTransform.Y -= delta.Translation.Y;
 
-			var cumulativeTransform = GetOrCreateTransform(_thumbShadow);
+			var cumulativeTransform = _thumbShadowTranslate;
 			cumulativeTransform.X = -cumulative.Translation.X;
 			cumulativeTransform.Y = -cumulative.Translation.Y;
 
 			System.Diagnostics.Debug.WriteLine(
 				$"X: {cumulative.Translation.X:' '000.00;'-'000.00} (Δ: {delta.Translation.X:' '00.00;'-'00.00} Σ: {deltaTransform.X:' '000.00;'-'000.00}) " +
 				$"Y: {cumulative.Translation.Y:' '000.00;'-'000.00} (Δ: {delta.Translation.Y:' '00.00;'-'00.00} Σ: {deltaTransform.Y:' '000.00;'-'000.00}) ");
-		}
-
-		private static TranslateTransform GetOrCreateTransform(Border target)
-		{
-			var transform = target.RenderTransform as TranslateTransform;
-			if (transform == null)
-			{
-				target.RenderTransform = transform = new TranslateTransform();
-			}
-
-			return transform;
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
@@ -269,6 +269,10 @@ namespace Windows.UI.Input
 			{
 				var translateX = _isTranslateXEnabled ? _currents.Center.X - _origins.Center.X : 0;
 				var translateY = _isTranslateYEnabled ? _currents.Center.Y - _origins.Center.Y : 0;
+#if __MACOS__
+				// correction for translateY being inverted (#4700)
+				translateY *= -1;
+#endif
 
 				double rotate;
 				float scale, expansion;


### PR DESCRIPTION
GitHub Issue (If applicable): #4700

## PR Type

- Bugfix

## What is the current behavior?

`ManipulationDelta` event on macos has its `e.Delta.Translation.Y` inverted, as compared to other platforms.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->