### PR TITLE
fix(xBind): Invalid xBind initialization on controls without code-behind base class

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -366,7 +366,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									BuildNamedResources(writer, _namedResources);
 								}
 
-								BuildCompiledBindingsInitializer(writer, _className.className);
+								BuildCompiledBindingsInitializer(writer, _className.className, controlBaseType);
 
 								if (isDirectUserControlChild)
 								{
@@ -384,7 +384,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								{
 									writer.AppendLineInvariant("Content = (_View)GetContent();");
 
-									BuildCompiledBindingsInitializer(writer, _className.className);
+									BuildCompiledBindingsInitializer(writer, _className.className, controlBaseType);
 
 									if (_isDebug)
 									{
@@ -758,11 +758,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private (string bindingsInterfaceName, string bindingsClassName) GetBindingsTypeNames(string className)
 			=> ($"I{className}_Bindings", $"{className}_Bindings");
 
-		private void BuildCompiledBindingsInitializer(IndentedStringBuilder writer, string className)
+		private void BuildCompiledBindingsInitializer(IndentedStringBuilder writer, string className, INamedTypeSymbol controlBaseType)
 		{
 			var hasXBindExpressions = CurrentScope.XBindExpressions.Count != 0;
 			var hasResourceExtensions = CurrentScope.Components.Any(HasMarkupExtensionNeedingComponent);
-			var isFrameworkElement = IsType(className, _frameworkElementSymbol);
+			var isFrameworkElement =
+				IsType(className, _frameworkElementSymbol)				// The current type may not have a base type as it is defined in XAML,
+				|| IsType(controlBaseType, _frameworkElementSymbol);    // so look at the control base type extracted from the XAML.
 
 			if (hasXBindExpressions || hasResourceExtensions)
 			{

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_UserControl.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_UserControl.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.xBind_UserControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<TextBlock x:Name="tb1" x:FieldModifier="public" Text="{x:Bind MyProperty}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_UserControl.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_UserControl.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	public sealed partial class xBind_UserControl /* : UserControl: Don't specify the base type so x:Bind generator lookups uses the XAML control type */
+	{
+		public xBind_UserControl()
+		{
+			this.InitializeComponent();
+		}
+
+		public string MyProperty
+		{
+			get { return (string)GetValue(MyPropertyProperty); }
+			set { SetValue(MyPropertyProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for MyProperty.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyPropertyProperty =
+			DependencyProperty.Register("MyProperty", typeof(string), typeof(xBind_UserControl), new PropertyMetadata("Default string"));
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_UserControl.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_UserControl.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
+{
+	[TestClass]
+	public class Given_xBind_UserControl
+	{
+		[TestMethod]
+		public void When_Initial_Value()
+		{
+			var SUT = new xBind_UserControl();
+			var _MyProperty = SUT.FindName("tb1") as TextBlock;
+			Assert.AreEqual("", _MyProperty.Text);
+
+			SUT.ForceLoaded();
+
+			Assert.AreEqual("Default string", _MyProperty.Text);
+		}
+	}
+}


### PR DESCRIPTION

GitHub Issue (If applicable): fixes #4680 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`x:Bind` is now working properly for controls that omit the specification of the base class in code-behind.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
