### PR TITLE
refactor: Remove roslyn warnings for types comparisons

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -319,13 +319,13 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 			var propertyDependencyProperties =
 				from property in ownerType.GetProperties()
 				where property.IsStatic
-					&& Equals(property.Type, _dependencyPropertySymbol)
+					&& SymbolEqualityComparer.Default.Equals(property.Type, _dependencyPropertySymbol)
 				select property.Name;
 
 			var fieldDependencyProperties =
 				from field in ownerType.GetFields()
 				where field.IsStatic
-					&& Equals(field.Type, _dependencyPropertySymbol)
+					&& SymbolEqualityComparer.Default.Equals(field.Type, _dependencyPropertySymbol)
 				select field.Name;
 
 			var dependencyProperties = fieldDependencyProperties
@@ -556,9 +556,9 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 				var ignoredByConfig = IsIgnoredType(type.BaseType);
 
 				// These types are know to not be bindable, so ignore them by default.
-				var isKnownBaseType = Equals(type.BaseType, _objectSymbol)
-					|| Equals(type.BaseType, _javaObjectSymbol)
-					|| Equals(type.BaseType, _nsObjectSymbol);
+				var isKnownBaseType = SymbolEqualityComparer.Default.Equals(type.BaseType, _objectSymbol)
+					|| SymbolEqualityComparer.Default.Equals(type.BaseType, _javaObjectSymbol)
+					|| SymbolEqualityComparer.Default.Equals(type.BaseType, _nsObjectSymbol);
 
 				if(!ignoredByConfig && !isKnownBaseType)
 				{
@@ -585,7 +585,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 			return property.IsIndexer
 				&& property.GetMethod.IsLocallyPublic(_currentModule)
 				&& property.Parameters.Length == 1
-				&& property.Parameters.Any(p => Equals(p.Type, _stringSymbol));
+				&& property.Parameters.Any(p => SymbolEqualityComparer.Default.Equals(p.Type, _stringSymbol));
 		}
 
 		private bool IsNonBindable(IPropertySymbol property) => property.FindAttributeFlattened(_nonBindableSymbol) != null;

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
@@ -101,8 +101,8 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 
 			private void ProcessType(INamedTypeSymbol typeSymbol)
 			{
-				var isDependencyObject = typeSymbol.Interfaces.Any(t => Equals(t, _dependencyObjectSymbol))
-					&& (typeSymbol.BaseType?.GetAllInterfaces().None(t => Equals(t, _dependencyObjectSymbol)) ?? true);
+				var isDependencyObject = typeSymbol.Interfaces.Any(t => SymbolEqualityComparer.Default.Equals(t, _dependencyObjectSymbol))
+					&& (typeSymbol.BaseType?.GetAllInterfaces().None(t => SymbolEqualityComparer.Default.Equals(t, _dependencyObjectSymbol)) ?? true);
 
 				if (isDependencyObject && typeSymbol.TypeKind == TypeKind.Class)
 				{
@@ -284,7 +284,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				var isAndroidActivity = typeSymbol.Is(_androidActivitySymbol);
 				var isAndroidFragment = typeSymbol.Is(_androidFragmentSymbol);
 				var isUnoViewGroup = typeSymbol.Is(_unoViewgroupSymbol);
-				var implementsIFrameworkElement = typeSymbol.Interfaces.Any(t => Equals(t, _iFrameworkElementSymbol));
+				var implementsIFrameworkElement = typeSymbol.Interfaces.Any(t => SymbolEqualityComparer.Default.Equals(t, _iFrameworkElementSymbol));
 				var hasOverridesAttachedToWindowAndroid = isAndroidView &&
 					typeSymbol
 					.GetMethods()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/RoslynMetadataHelper.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/RoslynMetadataHelper.cs
@@ -125,7 +125,7 @@ namespace Uno.Roslyn
 					.OfType<INamedTypeSymbol>()
 					.Where(r => r.Kind != SymbolKind.ErrorType && r.TypeArguments.Length == 0)
 					// Apply legacy
-					.Where(r => legacyType == null || r.OriginalDefinition.Name != name || Equals(r.OriginalDefinition, legacyType))
+					.Where(r => legacyType == null || r.OriginalDefinition.Name != name || SymbolEqualityComparer.Default.Equals(r.OriginalDefinition, legacyType))
 					.ToArray() ?? new ITypeSymbol[0];
 			}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/SymbolExtensions.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/SymbolExtensions.cs
@@ -112,7 +112,7 @@ namespace Microsoft.CodeAnalysis
 		{
 			do
 			{
-				if (Equals(symbol, other))
+				if (SymbolEqualityComparer.Default.Equals(symbol, other))
 				{
 					return true;
 				}
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis
 			symbol.DeclaredAccessibility == Accessibility.Public
 			||
 			(
-				symbol.Locations.Any(l => Equals(l.MetadataModule, currentSymbol))
+				symbol.Locations.Any(l => SymbolEqualityComparer.Default.Equals(l.MetadataModule, currentSymbol))
 				&& symbol.DeclaredAccessibility == Accessibility.Internal
 			);
 
@@ -208,12 +208,12 @@ namespace Microsoft.CodeAnalysis
 
 		public static AttributeData FindAttribute(this ISymbol property, INamedTypeSymbol attributeClassSymbol)
 		{
-			return property.GetAttributes().FirstOrDefault(a => Equals(a.AttributeClass, attributeClassSymbol));
+			return property.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeClassSymbol));
 		}
 
 		public static AttributeData FindAttributeFlattened(this ISymbol property, INamedTypeSymbol attributeClassSymbol)
 		{
-			return property.GetAllAttributes().FirstOrDefault(a => Equals(a.AttributeClass, attributeClassSymbol));
+			return property.GetAllAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeClassSymbol));
 		}
 
 		/// <summary>
@@ -462,7 +462,7 @@ namespace Microsoft.CodeAnalysis
 
 		public static IFieldSymbol FindField(this INamedTypeSymbol symbol, INamedTypeSymbol fieldType, string fieldName, StringComparison comparison = default)
 		{
-			return symbol.GetFields().FirstOrDefault(x => Equals(x.Type, fieldType) && x.Name.Equals(fieldName, comparison));
+			return symbol.GetFields().FirstOrDefault(x => SymbolEqualityComparer.Default.Equals(x.Type, fieldType) && x.Name.Equals(fieldName, comparison));
 		}
 
 		/// <summary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/NativeCtor/NativeCtorsGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/NativeCtor/NativeCtorsGenerator.cs
@@ -141,7 +141,7 @@ namespace {0}
 				{
 					var nativeCtor = typeSymbol
 						.GetMethods()
-						.Where(m => m.MethodKind == MethodKind.Constructor && Equals(m.Parameters.FirstOrDefault()?.Type, _intPtrSymbol))
+						.Where(m => m.MethodKind == MethodKind.Constructor && SymbolEqualityComparer.Default.Equals(m.Parameters.FirstOrDefault()?.Type, _intPtrSymbol))
 						.FirstOrDefault();
 					
 					if (nativeCtor == null)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/TSBindings/TSBindingsGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/TSBindings/TSBindingsGenerator.cs
@@ -15,7 +15,6 @@ using Uno.UI.SourceGenerators.Helpers;
 
 #if NETFRAMEWORK
 using Uno.SourceGeneration;
-using Uno.UI.SourceGenerators.Helpers;
 #endif
 
 namespace Uno.UI.SourceGenerators.TSBindings
@@ -222,7 +221,7 @@ namespace Uno.UI.SourceGenerators.TSBindings
 				foreach (var field in parametersType.GetFields())
 				{
 					var fieldSize = GetNativeFieldSize(field);
-					bool isStringField = Equals(field.Type, _stringSymbol);
+					bool isStringField = SymbolEqualityComparer.Default.Equals(field.Type, _stringSymbol);
 
 					if (field.Type is IArrayTypeSymbol arraySymbol)
 					{
@@ -285,7 +284,7 @@ namespace Uno.UI.SourceGenerators.TSBindings
 
 						var elementType = arraySymbol.ElementType;
 						var elementTSType = GetTSType(elementType);
-						var isElementString = Equals(elementType, _stringSymbol);
+						var isElementString = SymbolEqualityComparer.Default.Equals(elementType, _stringSymbol);
 						var elementSize = isElementString ? 4 : fieldSize;
 
 						using (sb.BlockInvariant(""))
@@ -329,7 +328,7 @@ namespace Uno.UI.SourceGenerators.TSBindings
 					{
 						using (sb.BlockInvariant(""))
 						{
-							if(Equals(field.Type, _stringSymbol))
+							if(SymbolEqualityComparer.Default.Equals(field.Type, _stringSymbol))
 							{
 								sb.AppendLineInvariant($"const ptr = Module.getValue(pData + {fieldOffset}, \"{GetEMField(field.Type)}\");");
 
@@ -366,17 +365,17 @@ namespace Uno.UI.SourceGenerators.TSBindings
 		private int GetNativeFieldSize(IFieldSymbol field)
 		{
 			if(
-				Equals(field.Type, _stringSymbol)
-				|| Equals(field.Type, _intSymbol)
-				|| Equals(field.Type, _intPtrSymbol)
-				|| Equals(field.Type, _floatSymbol)
-				|| Equals(field.Type, _boolSymbol)
+				SymbolEqualityComparer.Default.Equals(field.Type, _stringSymbol)
+				|| SymbolEqualityComparer.Default.Equals(field.Type, _intSymbol)
+				|| SymbolEqualityComparer.Default.Equals(field.Type, _intPtrSymbol)
+				|| SymbolEqualityComparer.Default.Equals(field.Type, _floatSymbol)
+				|| SymbolEqualityComparer.Default.Equals(field.Type, _boolSymbol)
 				|| field.Type is IArrayTypeSymbol
 			)
 			{
 				return 4;
 			}
-			else if(Equals(field.Type, _doubleSymbol))
+			else if(SymbolEqualityComparer.Default.Equals(field.Type, _doubleSymbol))
 			{
 				return 8;
 			}
@@ -389,37 +388,37 @@ namespace Uno.UI.SourceGenerators.TSBindings
 		private static string GetEMField(ITypeSymbol fieldType)
 		{
 			if (
-				Equals(fieldType, _stringSymbol)
-				|| Equals(fieldType, _intPtrSymbol)
+				SymbolEqualityComparer.Default.Equals(fieldType, _stringSymbol)
+				|| SymbolEqualityComparer.Default.Equals(fieldType, _intPtrSymbol)
 				|| fieldType is IArrayTypeSymbol
 			)
 			{
 				return "*";
 			}
 			else if (
-				Equals(fieldType, _intSymbol)
-				|| Equals(fieldType, _boolSymbol)
+				SymbolEqualityComparer.Default.Equals(fieldType, _intSymbol)
+				|| SymbolEqualityComparer.Default.Equals(fieldType, _boolSymbol)
 			)
 			{
 				return "i32";
 			}
-			else if (Equals(fieldType, _longSymbol))
+			else if (SymbolEqualityComparer.Default.Equals(fieldType, _longSymbol))
 			{
 				return "i64";
 			}
-			else if (Equals(fieldType, _shortSymbol))
+			else if (SymbolEqualityComparer.Default.Equals(fieldType, _shortSymbol))
 			{
 				return "i16";
 			}
-			else if (Equals(fieldType, _byteSymbol))
+			else if (SymbolEqualityComparer.Default.Equals(fieldType, _byteSymbol))
 			{
 				return "i8";
 			}
-			else if (Equals(fieldType, _floatSymbol))
+			else if (SymbolEqualityComparer.Default.Equals(fieldType, _floatSymbol))
 			{
 				return "float";
 			}
-			else if (Equals(fieldType, _doubleSymbol))
+			else if (SymbolEqualityComparer.Default.Equals(fieldType, _doubleSymbol))
 			{
 				return "double";
 			}
@@ -440,22 +439,22 @@ namespace Uno.UI.SourceGenerators.TSBindings
 			{
 				return $"Array<{GetTSType(array.ElementType)}>";
 			}
-			else if (Equals(type, _stringSymbol))
+			else if (SymbolEqualityComparer.Default.Equals(type, _stringSymbol))
 			{
 				return "String";
 			}
 			else if (
-				Equals(type, _intSymbol)
-				|| Equals(type, _floatSymbol)
-				|| Equals(type, _doubleSymbol)
-				|| Equals(type, _byteSymbol)
-				|| Equals(type, _shortSymbol)
-				|| Equals(type, _intPtrSymbol)
+				SymbolEqualityComparer.Default.Equals(type, _intSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _floatSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _doubleSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _byteSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _shortSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _intPtrSymbol)
 			)
 			{
 				return "Number";
 			}
-			else if (Equals(type, _boolSymbol))
+			else if (SymbolEqualityComparer.Default.Equals(type, _boolSymbol))
 			{
 				return "Boolean";
 			}
@@ -476,22 +475,22 @@ namespace Uno.UI.SourceGenerators.TSBindings
 			{
 				return $"Array<{GetTSFieldType(array.ElementType)}>";
 			}
-			else if (Equals(type, _stringSymbol))
+			else if (SymbolEqualityComparer.Default.Equals(type, _stringSymbol))
 			{
 				return "string";
 			}
 			else if (
-				Equals(type, _intSymbol)
-				|| Equals(type, _floatSymbol)
-				|| Equals(type, _doubleSymbol)
-				|| Equals(type, _byteSymbol)
-				|| Equals(type, _shortSymbol)
-				|| Equals(type, _intPtrSymbol)
+				SymbolEqualityComparer.Default.Equals(type, _intSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _floatSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _doubleSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _byteSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _shortSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _intPtrSymbol)
 			)
 			{
 				return "number";
 			}
-			else if (Equals(type, _boolSymbol))
+			else if (SymbolEqualityComparer.Default.Equals(type, _boolSymbol))
 			{
 				return "boolean";
 			}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Telemetry/TelemetryClient.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Telemetry/TelemetryClient.cs
@@ -114,12 +114,16 @@ namespace Uno.UI.SourceGenerators.Telemetry
 			{
 				var persistenceChannel = new PersistenceChannel.PersistenceChannel(sendersCount: _senderCount);
 				persistenceChannel.SendingInterval = TimeSpan.FromMilliseconds(1);
+#pragma warning disable CS0618 // Type or member is obsolete
 				TelemetryConfiguration.Active.TelemetryChannel = persistenceChannel;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				_commonProperties = new TelemetryCommonProperties().GetTelemetryCommonProperties();
 				_commonMeasurements = new Dictionary<string, double>();
 
+#pragma warning disable CS0618 // Type or member is obsolete
 				_client = new TelemetryClient();
+#pragma warning disable CS0618 // Type or member is obsolete
 				_client.InstrumentationKey = InstrumentationKey;
 				_client.Context.User.Id = _commonProperties[TelemetryCommonProperties.MachineId];
 				_client.Context.Session.Id = CurrentSessionId;

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
@@ -5,8 +5,9 @@
 		<AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
 		<WarningsAsErrors>true</WarningsAsErrors>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
-
+	
 	<ItemGroup Condition="'$(TargetFramework)'=='net461'">
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0" />
@@ -49,7 +50,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis">
-			<Version>3.8.0-3.final</Version>
+			<Version>3.8.0</Version>
 		</PackageReference>
 		<PackageReference Include="Mono.Cecil">
 			<Version>0.10.1</Version>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -46,10 +46,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private readonly bool _outputSourceComments = true;
 		private readonly RoslynMetadataHelper _metadataHelper;
 
-#if NETFRAMEWORK
-		private readonly ProjectInstance _projectInstance;
-#endif
-
 		/// <summary>
 		/// If set, code generated from XAML will be annotated with the source method and line # in XamlFileGenerator, for easier debugging.
 		/// </summary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -119,7 +119,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						break;
 					}
 
-				} while (!Equals(type, _objectSymbol));
+				} while (!SymbolEqualityComparer.Default.Equals(type, _objectSymbol));
 			}
 
 			return false;
@@ -138,7 +138,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				do
 				{
-					if (Equals(namedTypeSymbol, typeSymbol))
+					if (SymbolEqualityComparer.Default.Equals(namedTypeSymbol, typeSymbol))
 					{
 						return true;
 					}
@@ -150,7 +150,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						break;
 					}
 
-				} while (!Equals(namedTypeSymbol, _objectSymbol));
+				} while (!SymbolEqualityComparer.Default.Equals(namedTypeSymbol, _objectSymbol));
 			}
 
 			return false;
@@ -202,7 +202,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private bool IsImplementingInterface(INamedTypeSymbol symbol, INamedTypeSymbol interfaceName)
 		{
 			bool isSameType(INamedTypeSymbol source, INamedTypeSymbol iface) =>
-				Equals(source, iface) || Equals(source.OriginalDefinition, iface);
+				SymbolEqualityComparer.Default.Equals(source, iface) || SymbolEqualityComparer.Default.Equals(source.OriginalDefinition, iface);
 
 			if (symbol != null)
 			{
@@ -292,7 +292,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// Is the type one of the base view types in WinUI? (UIElement is most commonly used to mean 'any WinUI view type,' but
 		/// FrameworkElement is valid too)
 		/// </summary>
-		private bool IsManagedViewBaseType(INamedTypeSymbol targetType) => Equals(targetType, _uiElementSymbol) || Equals(targetType, _frameworkElementSymbol);
+		private bool IsManagedViewBaseType(INamedTypeSymbol targetType) => SymbolEqualityComparer.Default.Equals(targetType, _uiElementSymbol) || SymbolEqualityComparer.Default.Equals(targetType, _frameworkElementSymbol);
 
 		private bool IsTransform(XamlType xamlType)
 		{
@@ -679,10 +679,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// </summary>
 		private bool IsExactlyCollectionOrListType(INamedTypeSymbol type)
 		{
-			return Equals(type, _iCollectionSymbol)
-				|| Equals(type.OriginalDefinition, _iCollectionOfTSymbol)
-				|| Equals(type, _iListSymbol)
-				|| Equals(type.OriginalDefinition, _iListOfTSymbol);
+			return SymbolEqualityComparer.Default.Equals(type, _iCollectionSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, _iCollectionOfTSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, _iListSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, _iListOfTSymbol);
 		}
 
 		/// <summary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -521,7 +521,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						let sym = _metadataHelper.Compilation.GetAssemblyOrModuleSymbol(ext) as IAssemblySymbol
 						where sym != null
 						from attribute in sym.GetAllAttributes()
-						where Equals(attribute.AttributeClass, apiExtensionAttributeSymbol)
+						where SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, apiExtensionAttributeSymbol)
 						select attribute.ConstructorArguments;
 
 			foreach (var registration in query)
@@ -886,7 +886,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		}
 
 		private bool IsDependencyObject(XamlObjectDefinition component)
-			=> GetType(component.Type).GetAllInterfaces().Any(i => Equals(i, _dependencyObjectSymbol));
+			=> GetType(component.Type).GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol));
 
 		private string BuildControlInitializerDeclaration(string className, XamlObjectDefinition topLevelControl)
 		{
@@ -1189,7 +1189,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 					var targetType = GetType(targetTypeName);
 					var implicitKey = GetImplicitDictionaryResourceKey(style);
-					if (Equals(targetType.ContainingAssembly, _metadataHelper.Compilation.Assembly))
+					if (SymbolEqualityComparer.Default.Equals(targetType.ContainingAssembly, _metadataHelper.Compilation.Assembly))
 					{
 						var isNativeStyle = style.Members.FirstOrDefault(m => m.Member.Name == "IsNativeStyle")?.Value as string == "True";
 						writer.AppendLineInvariant("global::Windows.UI.Xaml.Style.RegisterDefaultStyleForType({0}, {1}, /*isNativeStyle:*/{2});",
@@ -1328,12 +1328,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				// Styles are handled differently for now, and there's no variable generated
 				// for those entries. Skip the ApplyCompiledBindings for those. See
 				// ImportResourceDictionary handling of x:Name for more details.
-				if (type.Equals(_styleSymbol))
+				if (SymbolEqualityComparer.Default.Equals(type, _styleSymbol))
 				{
 					return false;
 				}
 
-				if (type.AllInterfaces.Any(i => i.Equals(_dependencyObjectSymbol)))
+				if (type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol)))
 				{
 					return true;
 				}
@@ -1720,7 +1720,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private bool IsXamlTypeConverter(INamedTypeSymbol symbol)
 		{
-			return _xamlConversionTypes.Any(ns => ns.Equals(symbol));
+			return _xamlConversionTypes.Any(ns => SymbolEqualityComparer.Default.Equals(ns, symbol));
 		}
 
 		private string BuildXamlTypeConverterLiteralValue(INamedTypeSymbol symbol, string memberValue, bool includeQuotations)
@@ -2029,7 +2029,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 											// Explicitly instantiate the collection and set it using the content property
 											if (implicitContentChild.Objects.Count == 1
-												&& Equals(contentProperty.Type, FindType(implicitContentChild.Objects[0].Type)))
+												&& SymbolEqualityComparer.Default.Equals(contentProperty.Type, FindType(implicitContentChild.Objects[0].Type)))
 											{
 												writer.AppendFormatInvariant(contentProperty.Name + " = ");
 												BuildChild(writer, implicitContentChild, implicitContentChild.Objects[0]);
@@ -3119,7 +3119,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			TryAnnotateWithGeneratorSource(writer);
 			if (
-				Equals(FindType(objectDefinition.Type), _contentPresenterSymbol)
+				SymbolEqualityComparer.Default.Equals(FindType(objectDefinition.Type), _contentPresenterSymbol)
 				&& member.Member.Name == "Content"
 			)
 			{
@@ -3295,8 +3295,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					TryAnnotateWithGeneratorSource(writer, suffix: "HasBindingOptions");
 					var isAttachedProperty = IsDependencyProperty(member.Member);
-					var isBindingType = Equals(FindPropertyType(member.Member), _dataBindingSymbol);
-					var isOwnerDependencyObject = member.Owner != null ? GetType(member.Owner.Type).GetAllInterfaces().Any(i => Equals(i, _dependencyObjectSymbol)) : false;
+					var isBindingType = SymbolEqualityComparer.Default.Equals(FindPropertyType(member.Member), _dataBindingSymbol);
+					var isOwnerDependencyObject = member.Owner != null ? GetType(member.Owner.Type).GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol)) : false;
 
 					var bindEvalFunction = bindNode != null ? BuildXBindEvalFunction(member, bindNode) : "";
 
@@ -4000,13 +4000,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					.GetMethods()
 					.Any(m =>
 						m.Name == "op_Implicit"
-						&& m.Parameters.FirstOrDefault().SelectOrDefault(p => Equals(p.Type, _stringSymbol))
+						&& m.Parameters.FirstOrDefault().SelectOrDefault(p => SymbolEqualityComparer.Default.Equals(p.Type, _stringSymbol))
 					);
 
 				if (hasImplictToString
 
 					// Can be an object (e.g. in case of Binding.ConverterParameter).
-					|| Equals(propertyType, _objectSymbol)
+					|| SymbolEqualityComparer.Default.Equals(propertyType, _objectSymbol)
 				)
 				{
 					return "@\"" + memberValue.ToString() + "\"";
@@ -4523,7 +4523,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					var firstElementType = GetType(first.Type);
 
-					return !Equals(collectionType, firstElementType);
+					return !SymbolEqualityComparer.Default.Equals(collectionType, firstElementType);
 				}
 			}
 
@@ -4537,8 +4537,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private bool IsLocalizablePropertyType(INamedTypeSymbol propertyType)
 		{
-			return Equals(propertyType, _stringSymbol)
-				|| Equals(propertyType, _objectSymbol);
+			return SymbolEqualityComparer.Default.Equals(propertyType, _stringSymbol)
+				|| SymbolEqualityComparer.Default.Equals(propertyType, _objectSymbol);
 		}
 
 		private string GetObjectUid(XamlObjectDefinition objectDefinition)
@@ -5160,7 +5160,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					var q = from m in type.Constructors
 							where m.Parameters.Count() == 1
-							where Equals(m.Parameters.First().Type, _androidContentContextSymbol)
+							where SymbolEqualityComparer.Default.Equals(m.Parameters.First().Type, _androidContentContextSymbol)
 							select m;
 
 					var hasContextConstructor = q.Any();


### PR DESCRIPTION
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?
- Makes Uno.UI.SourceGenerators fail with warnings as errors
- Fix roslyn type comparisons
- Fix possible null references

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
