### PR TITLE
perf(NativeFramePresenter): [Android] Don't detach pages in the backstack

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NativeFrame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NativeFrame.cs
@@ -1,0 +1,78 @@
+﻿#if __ANDROID__
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	public class Given_NativeFrame
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_NavigateForward()
+		{
+			var style = Windows.UI.Xaml.Application.Current.Resources["NativeDefaultFrame"] as Style;
+			Assert.IsNotNull(style);
+
+			var SUT = new Frame() {
+				Style = style
+			};
+
+			TestServices.WindowHelper.WindowContent = SUT;
+
+			int GetAllMyPages()
+				=> SUT.EnumerateAllChildren(v => v is MyPage).Count();
+
+			/// Actively waiting for pages to be stacked is
+			/// required as NativeFramePresenter.UpdateStack awaits
+			/// for animations to finish, and there's no way to determine
+			/// from the Frame PoV that the animation is finished.
+			async Task WaitForPages(int count)
+			{
+				var sw = Stopwatch.StartNew();
+
+				while(sw.Elapsed < TimeSpan.FromSeconds(5))
+				{
+					await TestServices.WindowHelper.WaitForIdle();
+
+					if (GetAllMyPages() == count)
+					{
+						break;
+					}
+				}
+
+				Assert.AreEqual(count, GetAllMyPages());
+			}
+
+			await WaitForPages(0);
+
+			SUT.Navigate(typeof(MyPage));
+
+			await WaitForPages(1);
+
+			SUT.Navigate(typeof(MyPage));
+
+			await WaitForPages(2);
+
+			SUT.GoBack();
+
+			await WaitForPages(1);
+		}
+	}
+
+	partial class MyPage : Page
+	{
+	}
+}
+#endif

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -371,6 +371,17 @@ namespace Uno.UI
 			public static int ShowDuration { get; set; } = 7000;
 		}
 
+		public static class NativeFramePresenter
+		{
+#if __ANDROID__
+			/// <summary>
+			/// Determines if pages in the backstack are kept in the visual tree.
+			/// Defaults to false for performance considerations.
+			/// </summary>
+			public static bool AndroidUnloadInactivePages { get; set; } = false;
+#endif
+		}
+
 		public static class UIElement
 		{
 			/// <summary>

--- a/src/Uno.UI/NativeFramePresenter.Android.cs
+++ b/src/Uno.UI/NativeFramePresenter.Android.cs
@@ -130,13 +130,16 @@ namespace Uno.UI.Controls
 						await newPage.AnimateAsync(GetEnterAnimation());
 						newPage.ClearAnimation();
 					}
-					if (oldPage != null)
+					if (FeatureConfiguration.NativeFramePresenter.AndroidUnloadInactivePages && oldPage != null)
 					{
 						_pageStack.Children.Remove(oldPage);
 					}
 					break;
 				case NavigationMode.Back:
-					_pageStack.Children.Insert(0, newPage);
+					if (FeatureConfiguration.NativeFramePresenter.AndroidUnloadInactivePages)
+					{
+						_pageStack.Children.Insert(0, newPage);
+					}
 					if (GetIsAnimated(oldEntry))
 					{
 						await oldPage.AnimateAsync(GetExitAnimation());


### PR DESCRIPTION
The behavior is now similar to the one from the iOS NativeFramePresenter, which keeps all pages loaded and stacked on top of each other.

GitHub Issue (If applicable): https://github.com/unoplatform/nventive-private/issues/102

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The android native frame presenter detaches pages that are in the backstack. This causes the pages to be unloaded, then reloaded on back navigation, causing implicit styles to be reevaluated.

## What is the new behavior?

The pages are now kept attached and stacked on top of each other. The behavior can be altered by using `FeatureConfiguration.NativeFramePresenter.AndroidUnloadInactivePages`, which is set to false by default.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
