### PR TITLE
fix(dragdrop): Add missing file for ListView drag and drop support

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -1,5 +1,4 @@
-﻿#if false
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -18,46 +17,46 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		private static readonly string[] _items = new[] {"#FF0018", "#FFA52C", "#FFFF41", "#008018", "#0000F9", "#86007D"};
 		private const int _itemHeight = 100;
 
-		private static float Item(IAppRect sut, int index) => sut.Y + (index * _itemHeight) - 25;
+		private static float Item(IAppRect sut, int index) => sut.Y + (index * _itemHeight) + 25;
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android | Platform.iOS)]
+		[ActivePlatforms(Platform.Browser)]
 		public void When_Reorder_Down() => Test_Reorder(1, 3);
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android | Platform.iOS)]
+		[ActivePlatforms(Platform.Browser)]
 		public void When_Reorder_Up() => Test_Reorder(3, 1);
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android | Platform.iOS)]
+		[ActivePlatforms(Platform.Browser)]
 		public void When_Reorder_First() => Test_Reorder(0, 2);
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android | Platform.iOS)]
+		[ActivePlatforms(Platform.Browser)]
 		public void When_Reorder_Last() => Test_Reorder(5, 2);
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android | Platform.iOS)]
+		[ActivePlatforms(Platform.Browser)]
 		public void When_Reorder_To_First() => Test_Reorder(1, 0);
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android | Platform.iOS)]
+		[ActivePlatforms(Platform.Browser)]
 		public void When_Reorder_To_Last() => Test_Reorder(3, 5);
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android | Platform.iOS)]
+		[ActivePlatforms(Platform.Browser)]
 		public void When_Reorder_First_To_Last() => Test_Reorder(0, 5);
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android | Platform.iOS)]
+		[ActivePlatforms(Platform.Browser)]
 		public void When_Reorder_Last_To_First() => Test_Reorder(0, 5);
 
 		public void Test_Reorder(int from, int to)
@@ -81,4 +80,3 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		}
 	}
 }
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.managed.cs
@@ -21,6 +21,11 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override Line CreateLine(GeneratorDirection fillDirection, double extentOffset, double availableBreadth, Uno.UI.IndexPath nextVisibleItem)
 		{
+			if (ShouldInsertReorderingView(extentOffset))
+			{
+				nextVisibleItem = GetReorderingIndex().Value;
+			}
+
 			var item = GetFlatItemIndex(nextVisibleItem);
 			var view = Generator.DequeueViewForItem(item);
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -105,7 +105,9 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (ItemsControlFromItemContainer(sender) is ListViewBase that && that.CanDragItems)
 			{
-				var items = that.SelectedItems.ToList();
+				var items = that.SelectionMode == ListViewSelectionMode.Multiple || that.SelectionMode == ListViewSelectionMode.Extended
+					? that.SelectedItems.ToList()
+					: new List<object>();
 				var draggedItem = that.ItemFromContainer(sender);
 				if (draggedItem is { } && !items.Contains(draggedItem))
 				{
@@ -267,7 +269,17 @@ namespace Windows.UI.Xaml.Controls
 						continue; // Item removed or already at the right place, nothing to do.
 					}
 
+					var restoreSelection = that.SelectedIndex == oldIndex;
+
 					mv(oldIndex, newIndex);
+
+					if (restoreSelection)
+					{
+						// This is a workaround for https://github.com/unoplatform/uno/issues/4741
+						container.SetValue(IndexForItemContainerProperty, newIndex);
+
+						that.SelectedIndex = newIndex;
+					}
 
 					if (oldIndex > newIndex)
 					{


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/4274

## Bugfix
Tabs reorder is not working properly on WASM + tests are disabled

## What is the current behavior?
When dragging a tab in WASM (or skia) it will always be placed at the end of the list

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

