### PR TITLE
fix(dragdrop): Fix possible null ref in Drag and Drop

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -80,6 +80,11 @@ namespace Windows.UI.Xaml.Controls
 
 		private static void PrepareContainerForDragDropCore(UIElement itemContainer)
 		{
+			if (itemContainer is null) // Even if flagged as impossible by nullable check, https://github.com/unoplatform/uno/issues/4725
+			{
+				return;
+			}
+
 			// Known issue: the ContainerClearedForItem might not be invoked properly for all items on some platforms.
 			// This patch is acceptable as event handlers are static (so they won't leak).
 			itemContainer.DragStarting -= OnItemContainerDragStarting;
@@ -92,6 +97,11 @@ namespace Windows.UI.Xaml.Controls
 
 		private static void ClearContainerForDragDrop(UIElement itemContainer)
 		{
+			if (itemContainer is null) // Even if flagged as impossible by nullable check, https://github.com/unoplatform/uno/issues/4725
+			{
+				return;
+			}
+
 			itemContainer.DragStarting -= OnItemContainerDragStarting;
 			itemContainer.DropCompleted -= OnItemContainerDragCompleted;
 


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/4725

## Bugfix
Fix possible null ref

## What is the current behavior?
Even if flagged as not possible by the nullable check we can get a `null` `itemContainer` 

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

