### PR TITLE
fix: Keep track of current view type even if content is set to null

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FramePages/FirstPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FramePages/FirstPage.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.FramePages.FirstPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.FramePages"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<TextBlock Text="Page The First" x:FieldModifier="public" x:Name="FirstTextBlock"/>
+	</Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FramePages/FirstPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FramePages/FirstPage.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.FramePages
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class FirstPage : Page
+	{
+		public FirstPage()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FramePages/SecondPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FramePages/SecondPage.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.FramePages.SecondPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.FramePages"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<TextBlock Text="Page The Second" x:FieldModifier="public" x:Name="SecondTextBlock"/>
+	</Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FramePages/SecondPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/FramePages/SecondPage.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.FramePages
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class SecondPage : Page
+	{
+		public SecondPage()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NativeFrame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NativeFrame.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__
+﻿
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,12 +12,14 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml;
 using System.Threading.Tasks;
 using System.Diagnostics;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.FramePages;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
 	[TestClass]
 	public class Given_NativeFrame
 	{
+#if __ANDROID__
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_NavigateForward()
@@ -69,10 +71,48 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WaitForPages(1);
 		}
+#endif
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_ContentIsNullAndNavigate()
+		{
+#if !NETFX_CORE
+			var style = Windows.UI.Xaml.Application.Current.Resources["NativeDefaultFrame"] as Style;
+			Assert.IsNotNull(style);
+
+			var SUT = new Frame()
+			{
+				Style = style
+			};
+#else
+			var SUT = new Frame();
+#endif
+
+			TestServices.WindowHelper.WindowContent = SUT;
+
+			SUT.Navigate(typeof(FirstPage));
+
+			var firstPage = SUT.Content as FirstPage;
+
+			Assert.IsNotNull(firstPage.FirstTextBlock);
+			Assert.AreEqual("Page The First", firstPage.FirstTextBlock.Text);
+
+			SUT.Content = null;
+			SUT.BackStack?.Clear();
+
+
+			SUT.Navigate(typeof(SecondPage));
+			var secondPage = SUT.Content as SecondPage;
+
+			Assert.IsNotNull(SUT.BackStack.FirstOrDefault());
+			Assert.AreEqual(typeof(FirstPage), SUT.BackStack.FirstOrDefault().SourcePageType);
+
+			Assert.IsNotNull(secondPage.SecondTextBlock);
+			Assert.AreEqual("Page The Second", secondPage.SecondTextBlock.Text);
+		}
 	}
 
 	partial class MyPage : Page
 	{
 	}
 }
-#endif

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -100,6 +100,16 @@
 	</ItemGroup>
 	
 	<ItemGroup>
+	  <None Remove="Tests\Windows_UI_Xaml_Controls\FramePages\FirstPage.xaml" />
+	  <None Remove="Tests\Windows_UI_Xaml_Controls\FramePages\SecondPage.xaml" />
+	</ItemGroup>
+	
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Tests\Windows_UI_Xaml_Controls\FramePages\FirstPage.xaml" />
+	  <UpToDateCheckInput Remove="Tests\Windows_UI_Xaml_Controls\FramePages\SecondPage.xaml" />
+	</ItemGroup>
+	
+	<ItemGroup>
 	  <Compile Include="Tests\Windows_UI_Xaml_Controls\HtmlElementAttributeTests\Given_HtmlElementAttribute.Wasm.cs" />
 	</ItemGroup>
 

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -43,17 +43,6 @@ namespace Windows.UI.Xaml.Controls
 
 		internal PageStackEntry CurrentEntry { get; set; }
 
-		protected override void OnContentChanged(object oldValue, object newValue)
-		{
-			base.OnContentChanged(oldValue, newValue);
-
-			// Make sure we void CurrentEntry when someone sets Frame.Content = null;
-			if (newValue == null)
-			{
-				CurrentEntry = null;
-			}
-		}
-
 		#region BackStackDepth DependencyProperty
 
 		public int BackStackDepth


### PR DESCRIPTION
Closes https://github.com/unoplatform/nventive-private/issues/137

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Setting `Frame.Content` to `null` and then navigating using `Frame.Navigate` causes the page we just navigated from to not be added to the `Frame.BackStack`. Also causes iOS to not navigate at all when using the Native Frame Presenter

## What is the new behavior?

`Frame`'s `BackStack` is intact after navigation and navigation is performed properly.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.