### PR TITLE
Dev/xygu/20201216/popup placement

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
+{
+	public class UnoSamples_Popup_HVAlign_Tests : PopupUITestBase
+	{
+		// disabled android tests due to #4761
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Browser)]
+		public void Popup_PlacementTest_1Default_HSVS() => Popup_PlacementTest("Default_HSVS", 0f, 0f);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Browser)]
+		public void Popup_PlacementTest_2Default_HTVL() => Popup_PlacementTest("Default_HLVT", 0f, 0f);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Browser)]
+		public void Popup_PlacementTest_3Default_HCVC() => Popup_PlacementTest("Default_HCVC", 0.5f, 0.5f);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Browser)] // disabled android due to all popup from the 4th column could not be located in visual tree
+		public void Popup_PlacementTest_4Default_HRVB() => Popup_PlacementTest("Default_HRVB", 1f, 1f);
+
+		public void Popup_PlacementTest(string targetName, float xMul, float yMul)
+		{
+			Run("Uno.UI.Samples.Content.UITests.Popup.Popup_HVAlignments");
+
+			// tap button open popup
+			_app.Tap(targetName);
+
+			// find the expected popup placement based on button rect
+			var buttonRect = _app.Query(targetName).Single().Rect;
+			var expectedX = buttonRect.X + (buttonRect.Width * xMul);
+			var expectedY = buttonRect.Y + (buttonRect.Height * yMul);
+
+			// compare against actual popup placement
+			var popupRect = _app.Query("PopupContent").SingleOrDefault()?.Rect ?? throw new InvalidOperationException("Failed to find 'PopupContent'");
+			if (!NearlyEqual(popupRect.X, expectedX) || !NearlyEqual(popupRect.Y, expectedY))
+			{
+				Assert.Fail(string.Join("\n",
+					$"Popup for '{targetName}' is expected to open at ({expectedX},{expectedY}), but is actually opened at ({popupRect.X},{popupRect.Y})",
+					"===== Context =====",
+					$"buttonRect: [Rect {buttonRect.Width}x{buttonRect.Height}@{buttonRect.X}{buttonRect.Y}]",
+					$"xMul: {xMul}, yMul: {yMul}"
+				));
+			}
+
+			bool NearlyEqual(float a, float b) => a.Equals(b) || Math.Abs(a - b) < float.Epsilon;
+		}
+	}
+}
+
+

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1157,6 +1157,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_HVAlignments.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Overlay_On.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4397,6 +4401,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Pivot\Pivot_CustomContent_Automated.xaml.cs">
       <DependentUpon>Pivot_CustomContent_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_HVAlignments.xaml.cs">
+      <DependentUpon>Popup_HVAlignments.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Overlay_On.xaml.cs">
       <DependentUpon>Popup_Overlay_On.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml
@@ -25,7 +25,7 @@
 								   Margin="{TemplateBinding Padding}"
 								   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 								   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-								<Border Background="Pink" Width="312">
+								<Border x:Name="PopupContent" Background="Pink" Width="312">
 									<TextBlock Margin="16">Asd</TextBlock>
 								</Border>
 							</Popup>
@@ -59,7 +59,7 @@
 								   Margin="{TemplateBinding Padding}"
 								   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
 								   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-								<Border Background="Pink" Width="312">
+								<Border x:Name="PopupContent" Background="Pink" Width="312">
 									<TextBlock Margin="16">Asd</TextBlock>
 								</Border>
 							</Popup>
@@ -88,22 +88,22 @@
 					<ColumnDefinition />
 				</Grid.ColumnDefinitions>
 
-				<ContentControl Grid.Row="0" Grid.Column="0" Content="HSVS" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="1" Grid.Column="0" Content="HSVT" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="2" Grid.Column="0" Content="HSVC" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="3" Grid.Column="0" Content="HSVB" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="0" Grid.Column="1" Content="HLVS" HorizontalContentAlignment="Left" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="1" Grid.Column="1" Content="HLVT" HorizontalContentAlignment="Left" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="2" Grid.Column="1" Content="HLVC" HorizontalContentAlignment="Left" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="3" Grid.Column="1" Content="HLVB" HorizontalContentAlignment="Left" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="0" Grid.Column="2" Content="HCVS" HorizontalContentAlignment="Center" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="1" Grid.Column="2" Content="HCVT" HorizontalContentAlignment="Center" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="2" Grid.Column="2" Content="HCVC" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="3" Grid.Column="2" Content="HCVB" HorizontalContentAlignment="Center" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="0" Grid.Column="3" Content="HRVS" HorizontalContentAlignment="Right" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="1" Grid.Column="3" Content="HRVT" HorizontalContentAlignment="Right" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="2" Grid.Column="3" Content="HRVC" HorizontalContentAlignment="Right" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Row="3" Grid.Column="3" Content="HRVB" HorizontalContentAlignment="Right" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HSVS" Grid.Row="0" Grid.Column="0" Content="HSVS" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HSVT" Grid.Row="1" Grid.Column="0" Content="HSVT" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HSVC" Grid.Row="2" Grid.Column="0" Content="HSVC" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HSVB" Grid.Row="3" Grid.Column="0" Content="HSVB" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HLVS" Grid.Row="0" Grid.Column="1" Content="HLVS" HorizontalContentAlignment="Left" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HLVT" Grid.Row="1" Grid.Column="1" Content="HLVT" HorizontalContentAlignment="Left" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HLVC" Grid.Row="2" Grid.Column="1" Content="HLVC" HorizontalContentAlignment="Left" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HLVB" Grid.Row="3" Grid.Column="1" Content="HLVB" HorizontalContentAlignment="Left" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HCVS" Grid.Row="0" Grid.Column="2" Content="HCVS" HorizontalContentAlignment="Center" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HCVT" Grid.Row="1" Grid.Column="2" Content="HCVT" HorizontalContentAlignment="Center" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HCVC" Grid.Row="2" Grid.Column="2" Content="HCVC" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HCVB" Grid.Row="3" Grid.Column="2" Content="HCVB" HorizontalContentAlignment="Center" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HRVS" Grid.Row="0" Grid.Column="3" Content="HRVS" HorizontalContentAlignment="Right" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HRVT" Grid.Row="1" Grid.Column="3" Content="HRVT" HorizontalContentAlignment="Right" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HRVC" Grid.Row="2" Grid.Column="3" Content="HRVC" HorizontalContentAlignment="Right" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Default_HRVB" Grid.Row="3" Grid.Column="3" Content="HRVB" HorizontalContentAlignment="Right" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
 			</Grid>
 
 			<TextBlock Text="with Margin=20 on Popup" />
@@ -115,10 +115,11 @@
 					<ColumnDefinition />
 				</Grid.ColumnDefinitions>
 
-				<ContentControl Grid.Column="0" Content="HSVS" Padding="20" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Column="1" Content="HLVT" Padding="20" HorizontalContentAlignment="Left" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Column="2" Content="HCVC" Padding="20" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
-				<ContentControl Grid.Column="3" Content="HRVB" Padding="20" HorizontalContentAlignment="Right" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Margin_HSVS" Grid.Column="0" Content="HSVS" Padding="20" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Margin_HLVT" Grid.Column="1" Content="HLVT" Padding="20" HorizontalContentAlignment="Left" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Margin_HCVC" Grid.Column="2" Content="HCVC" Padding="20" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl x:Name="Margin_HRVB" Grid.Column="3" Content="HRVB" Padding="20" HorizontalContentAlignment="Right" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+
 			</Grid>
 			
 			<TextBlock Text="with Height=Width=20 on Popup" />
@@ -130,10 +131,10 @@
 					<ColumnDefinition />
 				</Grid.ColumnDefinitions>
 
-				<ContentControl Grid.Column="0" Content="HSVS" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
-				<ContentControl Grid.Column="1" Content="HLVT" HorizontalContentAlignment="Left" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
-				<ContentControl Grid.Column="2" Content="HCVC" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
-				<ContentControl Grid.Column="3" Content="HRVB" HorizontalContentAlignment="Right" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
+				<ContentControl x:Name="Size_HSVS" Grid.Column="0" Content="HSVS" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
+				<ContentControl x:Name="Size_HLVT" Grid.Column="1" Content="HLVT" HorizontalContentAlignment="Left" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
+				<ContentControl x:Name="Size_HCVC" Grid.Column="2" Content="HCVC" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
+				<ContentControl x:Name="Size_HRVB" Grid.Column="3" Content="HRVB" HorizontalContentAlignment="Right" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
 			</Grid>
 
 		</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml
@@ -1,0 +1,141 @@
+﻿<UserControl x:Class="Uno.UI.Samples.Content.UITests.Popup.Popup_HVAlignments"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	<UserControl.Resources>
+		<Style x:Name="PopupPlacementTest_ContentControlStyle"
+			   TargetType="ContentControl">
+			<Setter Property="HorizontalAlignment" Value="Stretch" />
+			<Setter Property="VerticalAlignment" Value="Stretch" />
+
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ContentControl">
+						<Grid Background="SkyBlue">
+							<ToggleButton x:Name="Trigger"
+										  BorderBrush="Black"
+										  BorderThickness="1"
+										  Content="{TemplateBinding Content}"
+										  HorizontalAlignment="Stretch"
+										  VerticalAlignment="Stretch" />
+							<Rectangle Height="1" Fill="Black" HorizontalAlignment="Stretch" VerticalAlignment="Center" IsHitTestVisible="False" />
+							<Rectangle Width="1" Fill="Black" HorizontalAlignment="Center" VerticalAlignment="Stretch" IsHitTestVisible="False" />
+
+							<Popup IsOpen="{Binding ElementName=Trigger, Path=IsChecked, Mode=TwoWay}"
+								   IsLightDismissEnabled="True"
+								   Margin="{TemplateBinding Padding}"
+								   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+								<Border Background="Pink" Width="312">
+									<TextBlock Margin="16">Asd</TextBlock>
+								</Border>
+							</Popup>
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+		<Style x:Name="PopupPlacementTestWithFixedSize_ContentControlStyle"
+			   TargetType="ContentControl">
+			<Setter Property="HorizontalAlignment" Value="Stretch" />
+			<Setter Property="VerticalAlignment" Value="Stretch" />
+
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ContentControl">
+						<Grid Background="SkyBlue">
+							<ToggleButton x:Name="Trigger"
+										  BorderBrush="Black"
+										  BorderThickness="1"
+										  Content="{TemplateBinding Content}"
+										  HorizontalAlignment="Stretch"
+										  VerticalAlignment="Stretch" />
+							<Rectangle Height="1" Fill="Black" HorizontalAlignment="Stretch" VerticalAlignment="Center" IsHitTestVisible="False" />
+							<Rectangle Width="1" Fill="Black" HorizontalAlignment="Center" VerticalAlignment="Stretch" IsHitTestVisible="False" />
+
+							<Popup IsOpen="{Binding ElementName=Trigger, Path=IsChecked, Mode=TwoWay}"
+								   IsLightDismissEnabled="True"
+								   Height="20"
+								   Width="20"
+								   Margin="{TemplateBinding Padding}"
+								   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+								<Border Background="Pink" Width="312">
+									<TextBlock Margin="16">Asd</TextBlock>
+								</Border>
+							</Popup>
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<ScrollViewer>
+		<StackPanel>
+			<TextBlock Text="left2right: HStretch, HLeft, HCenter, HRight" />
+			<TextBlock Text="top2bottom: VStretch, VTop, VCenter, VBottom" />
+			<Grid Width="320" Height="320">
+				<Grid.RowDefinitions>
+					<RowDefinition />
+					<RowDefinition />
+					<RowDefinition />
+					<RowDefinition />
+				</Grid.RowDefinitions>
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition />
+					<ColumnDefinition />
+					<ColumnDefinition />
+					<ColumnDefinition />
+				</Grid.ColumnDefinitions>
+
+				<ContentControl Grid.Row="0" Grid.Column="0" Content="HSVS" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="1" Grid.Column="0" Content="HSVT" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="2" Grid.Column="0" Content="HSVC" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="3" Grid.Column="0" Content="HSVB" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="0" Grid.Column="1" Content="HLVS" HorizontalContentAlignment="Left" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="1" Grid.Column="1" Content="HLVT" HorizontalContentAlignment="Left" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="2" Grid.Column="1" Content="HLVC" HorizontalContentAlignment="Left" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="3" Grid.Column="1" Content="HLVB" HorizontalContentAlignment="Left" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="0" Grid.Column="2" Content="HCVS" HorizontalContentAlignment="Center" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="1" Grid.Column="2" Content="HCVT" HorizontalContentAlignment="Center" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="2" Grid.Column="2" Content="HCVC" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="3" Grid.Column="2" Content="HCVB" HorizontalContentAlignment="Center" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="0" Grid.Column="3" Content="HRVS" HorizontalContentAlignment="Right" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="1" Grid.Column="3" Content="HRVT" HorizontalContentAlignment="Right" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="2" Grid.Column="3" Content="HRVC" HorizontalContentAlignment="Right" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Row="3" Grid.Column="3" Content="HRVB" HorizontalContentAlignment="Right" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+			</Grid>
+
+			<TextBlock Text="with Margin=20 on Popup" />
+			<Grid Width="320" Height="80">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition />
+					<ColumnDefinition />
+					<ColumnDefinition />
+					<ColumnDefinition />
+				</Grid.ColumnDefinitions>
+
+				<ContentControl Grid.Column="0" Content="HSVS" Padding="20" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Column="1" Content="HLVT" Padding="20" HorizontalContentAlignment="Left" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Column="2" Content="HCVC" Padding="20" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+				<ContentControl Grid.Column="3" Content="HRVB" Padding="20" HorizontalContentAlignment="Right" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTest_ContentControlStyle}" />
+			</Grid>
+			
+			<TextBlock Text="with Height=Width=20 on Popup" />
+			<Grid Width="320" Height="80">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition />
+					<ColumnDefinition />
+					<ColumnDefinition />
+					<ColumnDefinition />
+				</Grid.ColumnDefinitions>
+
+				<ContentControl Grid.Column="0" Content="HSVS" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
+				<ContentControl Grid.Column="1" Content="HLVT" HorizontalContentAlignment="Left" VerticalContentAlignment="Top" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
+				<ContentControl Grid.Column="2" Content="HCVC" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
+				<ContentControl Grid.Column="3" Content="HRVB" HorizontalContentAlignment="Right" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
+			</Grid>
+
+		</StackPanel>
+	</ScrollViewer>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Samples.Content.UITests.Popup
+{
+	[SampleControlInfo("Popup", nameof(Popup_HVAlignments), description: "Popup always opens at the top-left corner of their available \"zone\".\n This zone is can be visualized by placing a Grid next to the Popup with the same H&V-Alignement, Height/Width, Margin.")]
+	public sealed partial class Popup_HVAlignments : UserControl
+	{
+		public Popup_HVAlignments()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -7,6 +7,7 @@ using Windows.UI.Xaml.Input;
 using Uno.Extensions;
 using Uno.UI.DataBinding;
 using Windows.UI.Xaml.Media;
+using Uno.UI;
 #if XAMARIN_IOS
 using CoreGraphics;
 using UIKit;
@@ -39,19 +40,15 @@ namespace Windows.UI.Xaml.Controls
 		/// <inheritdoc />
 		protected override Size MeasureOverride(Size availableSize)
 		{
-			// As the Child is NOT part of the visual tree, it does not have to be measured,
-			// and the result size of this Popup is always 0,0
-
-			return new Size();
+			// As the Child is NOT part of the visual tree, it does not have to be measured
+			return new Size(Width, Height).FiniteOrDefault(default);
 		}
 
 		/// <inheritdoc />
 		protected override Size ArrangeOverride(Size finalSize)
 		{
-			// As the Child is NOT part of the visual tree, it does not have to be arranged,
-			// and the result size of this Popup is always 0,0
-
-			return new Size();
+			// As the Child is NOT part of the visual tree, it does not have to be arranged
+			return finalSize;
 		}
 
 		partial void OnIsOpenChangedPartial(bool oldIsOpen, bool newIsOpen)


### PR DESCRIPTION
GitHub Issue (If applicable): #4683

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Popup placement behavior on wasm doesnt align with UWP

## What is the new behavior?

Popup placement behavior on wasm now mirrors UWP

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

<!-- Please provide any additional information if necessary -->