### PR TITLE
fix(popup): placement issue for android

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
@@ -12,21 +12,16 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 {
 	public class UnoSamples_Popup_HVAlign_Tests : PopupUITestBase
 	{
-		// disabled android tests due to #4761
-
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.iOS, Platform.Browser)]
 		public void Popup_PlacementTest_1Default_HSVS() => Popup_PlacementTest("Default_HSVS", 0f, 0f);
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.iOS, Platform.Browser)]
 		public void Popup_PlacementTest_2Default_HTVL() => Popup_PlacementTest("Default_HLVT", 0f, 0f);
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.iOS, Platform.Browser)]
 		public void Popup_PlacementTest_3Default_HCVC() => Popup_PlacementTest("Default_HCVC", 0.5f, 0.5f);
 
 		[Test]

--- a/src/Uno.Foundation/Point.Android.cs
+++ b/src/Uno.Foundation/Point.Android.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.Foundation
+{
+	public partial struct Point
+	{
+		internal static Point From(Action<int[]> getter)
+		{
+			var result = new int[2];
+			getter(result);
+
+			return new Point(result[0], result[1]);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -118,6 +118,23 @@ namespace Windows.UI.Xaml.Controls
 				//		 (And actually it also lets the view appear out of the window ...)
 				var anchor = Popup.Anchor ?? Popup;
 				var anchorLocation = anchor.TransformToVisual(this).TransformPoint(new Point());
+
+#if __ANDROID__
+				// for android, the above line returns the absolute coordinates of anchor on the screen
+				// because the parent view of this PopupPanel is a PopupWindow and GetLocationInWindow will be (0,0)
+				// therefore, we need to make the relative adjustment
+				if (this.GetParent() is Android.Views.View view)
+				{
+					var windowLocation = Point.From(view.GetLocationInWindow);
+					var screenLocation = Point.From(view.GetLocationOnScreen);
+
+					if (windowLocation == default)
+					{
+						anchorLocation -= ViewHelper.PhysicalToLogicalPixels(screenLocation);
+					}
+				}
+#endif
+
 				var finalFrame = new Rect(
 					anchorLocation.X + (float)Popup.HorizontalOffset,
 					anchorLocation.Y + (float)Popup.VerticalOffset,


### PR DESCRIPTION
GitHub Issue (If applicable): #4761

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Popup doesnt open at the right location in android. It is offset'd by the height of status bar.

## What is the new behavior?

Should behave like UWP now.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

<!-- Please provide any additional information if necessary -->