### PR TITLE
ci: Increase timeout for Skia UI tests

### DIFF
--- a/build/ci/.azure-devops-skia-tests.yml
+++ b/build/ci/.azure-devops-skia-tests.yml
@@ -4,7 +4,7 @@ parameters:
 jobs:
 - job: Skia_UI_Tests
   displayName: 'Skia Samples App Unit Tests'
-  timeoutInMinutes: 30
+  timeoutInMinutes: 40
 
   pool:
     vmImage: ${{ parameters.vmImage }}


### PR DESCRIPTION
GitHub Issue (If applicable): #4317 

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

Because the GTK3 runtime installation sometimes takes longer, the test may get cancelled due to timeout.

![image](https://user-images.githubusercontent.com/1075116/102693994-8dc6cc00-421e-11eb-87f6-0f98d1e9e155.png)


## What is the new behavior?

Increased timeout to 40 minutes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
