### PR TITLE
fix: Missing mime type for icudt.dat for .NET5 support

### DIFF
--- a/doc/articles/how-to-host-a-webassembly-app.md
+++ b/doc/articles/how-to-host-a-webassembly-app.md
@@ -166,6 +166,7 @@ For *Apache*, please use the [`AddType` directive](https://httpd.apache.org/docs
 ```apache
 AddType application/wasm .wasm
 AddType application/octet-stream .clr
+AddType application/octet-stream .dat
 AddType application/octet-stream .pdb
 AddType application/font-woff .woff
 AddType application/font-woff .woff2

--- a/src/SamplesApp/SamplesApp.Wasm/wwwroot/web.config
+++ b/src/SamplesApp/SamplesApp.Wasm/wwwroot/web.config
@@ -11,6 +11,7 @@
 	  <mimeMap fileExtension=".wasm" mimeType="application/wasm" />
 	  <mimeMap fileExtension=".clr" mimeType="application/octet-stream" />
 	  <mimeMap fileExtension=".woff2" mimeType="application/woff2" />
+	  <mimeMap fileExtension=".dat" mimeType="application/octet-stream" />
 	</staticContent>
 
 	<httpCompression maxDiskSpaceUsage="500"

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Wasm/wwwroot/web.config
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Wasm/wwwroot/web.config
@@ -19,8 +19,8 @@
       <mimeMap fileExtension=".pdb" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
       <mimeMap fileExtension=".woff2" mimeType="application/font-woff" />
-
-      <!-- Required for PWAs -->
+	  <mimeMap fileExtension=".dat" mimeType="application/octet-stream" />
+	  <!-- Required for PWAs -->
       <mimeMap fileExtension=".json" mimeType="application/octet-stream" />
     </staticContent>
 

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoXFQuickStart.Wasm/wwwroot/web.config
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoXFQuickStart.Wasm/wwwroot/web.config
@@ -19,8 +19,8 @@
       <mimeMap fileExtension=".pdb" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
       <mimeMap fileExtension=".woff2" mimeType="application/font-woff" />
-
-      <!-- Required for PWAs -->
+	  <mimeMap fileExtension=".dat" mimeType="application/octet-stream" />
+	  <!-- Required for PWAs -->
       <mimeMap fileExtension=".json" mimeType="application/octet-stream" />
     </staticContent>
 

--- a/src/SolutionTemplate/UnoSolutionTemplate/Wasm/wwwroot/web.config
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Wasm/wwwroot/web.config
@@ -19,7 +19,7 @@
       <mimeMap fileExtension=".pdb" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
       <mimeMap fileExtension=".woff2" mimeType="application/font-woff" />
-
+      <mimeMap fileExtension=".dat" mimeType="application/octet-stream" />
       <!-- Required for PWAs -->
       <mimeMap fileExtension=".json" mimeType="application/octet-stream" />
     </staticContent>


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adjust mime types for .NET 5 support (`icudt.dat` needs to have its extension allowed in the web.config file)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
