### PR TITLE
docs: Add more info to Fluent symbol font usage

### DIFF
--- a/doc/articles/uno-fluent-assets.md
+++ b/doc/articles/uno-fluent-assets.md
@@ -39,6 +39,13 @@ Simply replace the contents of Font.css in your app with those of the `Font.css`
 ## Known issues
 On iOS and macOS the indeterminate state for a CheckBox is not the right color.
 
+## Usage
+
+The symbol font is automatically used by built-in styles and templates. You can reference it in XAML using the `SymbolThemeFontFamily` resource. For example:
+
+```
+<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE117;"/>
+```
 
 ## Related Topics
 - [3011](https://github.com/unoplatform/uno/issues/3011)

--- a/doc/articles/uno-fluent-assets.md
+++ b/doc/articles/uno-fluent-assets.md
@@ -43,7 +43,7 @@ On iOS and macOS the indeterminate state for a CheckBox is not the right color.
 
 The symbol font is automatically used by built-in styles and templates. You can reference it in XAML using the `SymbolThemeFontFamily` resource. For example:
 
-```
+```xaml
 <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE117;"/>
 ```
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

Fluent symbol docs missing info on usage (see https://stackoverflow.com/questions/65456676/how-to-use-font-icon-on-uno-platform)

## What is the new behavior?

Added samples

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
