### PR TITLE
fix: Double query of ApiInformation.IsPropertyPresent returns different results

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TabViewTests/TabViewBasicPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TabViewTests/TabViewBasicPage.xaml
@@ -18,7 +18,7 @@
 			</controls:TabViewItem>
 			<controls:TabViewItem Header="Document 1">
 				<controls:TabViewItem.IconSource>
-					<controls:SymbolIconSource Symbol="Document" />
+					<controls:BitmapIconSource ShowAsMonochrome="False" UriSource="/Assets/ingredient1.png" />
 				</controls:TabViewItem.IconSource>
 			</controls:TabViewItem>
 			<controls:TabViewItem Header="Document 2">

--- a/src/Uno.Foundation/Metadata/ApiInformation.cs
+++ b/src/Uno.Foundation/Metadata/ApiInformation.cs
@@ -110,23 +110,25 @@ namespace Windows.Foundation.Metadata
 		{
 			lock (_assemblies)
 			{
-				if (!_typeCache.TryGetValue(typeName, out var type))
+				if (_typeCache.TryGetValue(typeName, out var type))
 				{
-					foreach (var assembly in _assemblies)
+					return type;
+				}
+
+				foreach (var assembly in _assemblies)
+				{
+					type = assembly.GetType(typeName);
+
+					if (type != null)
 					{
-						type = assembly.GetType(typeName);
+						_typeCache[typeName] = type;
 
-						if (type != null)
-						{
-							_typeCache[typeName] = type;
-
-							return type;
-						}
+						return type;
 					}
 				}
-			}
 
-			return null;
+				return null;
+			}
 		}
 
 		internal static void TryRaiseNotImplemented(string type, string memberName)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Foundation/Metadata/Given_ApiInformation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Foundation/Metadata/Given_ApiInformation.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Windows.Foundation.Metadata;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Foundation.Metadata
+{
+	[TestClass]
+	public class Given_ApiInformation
+    {
+		[TestMethod]
+		public async Task When_IsPropertyPresent_Called_Twice()
+		{
+			// Verifies fix for issue #4803
+			// SharedHelpers called IsPropertyPresent twice for an implemented property
+			// but the second call resulted in false
+
+			// Application.Current is implemented on all targets
+			var isPresent = ApiInformation.IsPropertyPresent("Windows.UI.Xaml.Application", "Current");
+			Assert.IsTrue(isPresent);
+			var secondIsPresent = ApiInformation.IsPropertyPresent("Windows.UI.Xaml.Application", "Current");
+			Assert.IsTrue(secondIsPresent);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/BitmapIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/BitmapIcon.cs
@@ -15,7 +15,6 @@ namespace Windows.UI.Xaml.Controls
 		public BitmapIcon()
 		{
 			this.SetValue(ForegroundProperty, SolidColorBrushHelper.Black, DependencyPropertyValuePrecedences.Inheritance);
-
 		}
 
 		protected override Size MeasureOverride(Size availableSize)


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #4803

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Querying `ApiInformation.IsPropertyPresent` twice for the same existing property returns `true` and `false`.

## What is the new behavior?

API returns the same result each time.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
