### PR TITLE
fix(TimePicker): Make sure iOS flyout opens

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -39,7 +39,8 @@ namespace Windows.UI.Xaml.Controls
 			_picker.Mode = UIDatePickerMode.Time;
 
 			UpdatePickerStyle();
-
+			SetPickerTime(Time.RoundToNextMinuteInterval(MinuteIncrement));
+			SaveInitialTime();
 			_picker.ValueChanged += OnValueChanged;
 			
 			var parent = _picker.FindFirstParent<FrameworkElement>();
@@ -62,8 +63,6 @@ namespace Windows.UI.Xaml.Controls
 			UpdatePickerStyle();
 			SetPickerClockIdentifier(ClockIdentifier);
 			SetPickerMinuteIncrement(MinuteIncrement);
-			SetPickerTime(Time.RoundToNextMinuteInterval(MinuteIncrement));
-			SaveInitialTime();
 		}
 
 		private void SetPickerMinuteIncrement(int minuteIncrement)
@@ -74,7 +73,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private void SaveInitialTime() => _initialTime = _picker.Date;
+		private void SaveInitialTime() => _initialTime = _picker?.Date;
 
 		internal void SaveTime()
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

On iOS the flyout  of the TimePicker does not open


## What is the new behavior?

Make sure iOS flyout opens


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
