### PR TITLE
Fixed UWP manifest to use project executable as app automatically by setting substitution moniker

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/UWP/Package.appxmanifest
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UWP/Package.appxmanifest
@@ -29,7 +29,7 @@
 
   <Applications>
     <Application Id="App"
-      Executable="$ext_safeprojectname$.exe"
+      Executable="$targetnametoken$.exe"
       EntryPoint="$ext_safeprojectname$.App">
       <uap:VisualElements
         DisplayName="$ext_safeprojectname$"


### PR DESCRIPTION
The moniker is substituted by MSBuild on build

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

If you decide to rename UWP assembly name you will get a weird error without any clue how to fix it.
Unless you know the trick you will spend hours if ever find it.

## What is the new behavior?

The error will not occur if you rename UWP assembly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Contains **NO** breaking changes
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.