### PR TITLE
fix(Calendar): Fix `Calendar.YearAsString()` and `Calendar.YearAsTruncatedString()`

### DIFF
--- a/src/Uno.UI.Tests/Windows_Globalization/When_Calendar.cs
+++ b/src/Uno.UI.Tests/Windows_Globalization/When_Calendar.cs
@@ -340,7 +340,6 @@ namespace Uno.UI.Tests.Windows_Globalization
 			);
 		}
 
-
 		[TestMethod]
 		public void When_Gregorian_FixedDate_AddDay()
 		{
@@ -489,14 +488,16 @@ namespace Uno.UI.Tests.Windows_Globalization
 		}
 
 		[TestMethod]
-		public void When_Gregorian_FixedDate_Format_12h()
+		[DataRow(2020, "Thursday")]
+		[DataRow(2021, "Saturday")]
+		public void When_Gregorian_FixedDate_Format_12h(int year, string dayOfWeek)
 		{
 			ValidateFormat(culture: "en-US",
 				  calendar: WG.CalendarIdentifiers.GregorianValue,
 				  clock: WG.ClockIdentifiers.TwelveHour,
-				  date: new DateTimeOffset(2020, 01, 02, 23, 04, 05, 00, TimeSpan.Zero),
-				  yearAsPaddedString: "2020",
-				  yearAsString: "2020",
+				  date: new DateTimeOffset(year, 01, 02, 23, 04, 05, 00, TimeSpan.Zero),
+				  yearAsPaddedString: year.ToString(CultureInfo.InvariantCulture),
+				  yearAsString: year.ToString(CultureInfo.InvariantCulture),
 				  monthAsPaddedNumericString: "01",
 				  monthAsSoloString: "Jan",
 				  monthAsString: "Jan",
@@ -511,19 +512,21 @@ namespace Uno.UI.Tests.Windows_Globalization
 				  secondAsString: "5",
 				  nanosecondAsPaddedString: "00",
 				  nanosecondAsString: "0",
-				  dayOfWeekAsSoloString: "Thursday",
-				  dayOfWeekAsString: "Thursday");
+				  dayOfWeekAsSoloString: dayOfWeek,
+				  dayOfWeekAsString: dayOfWeek);
 		}
 
 		[TestMethod]
-		public void When_Gregorian_FixedDate_Format_24h()
+		[DataRow(2020, "Thursday")]
+		[DataRow(2021, "Saturday")]
+		public void When_Gregorian_FixedDate_Format_24h(int year, string dayOfWeek)
 		{
 			ValidateFormat(culture: "en-US",
 				  calendar: WG.CalendarIdentifiers.GregorianValue,
 				  clock: WG.ClockIdentifiers.TwentyFourHourValue,
-				  date: new DateTimeOffset(2020, 01, 02, 23, 04, 05, 00, TimeSpan.Zero),
-				  yearAsPaddedString: "2020",
-				  yearAsString: "2020",
+				  date: new DateTimeOffset(year, 01, 02, 23, 04, 05, 00, TimeSpan.Zero),
+				  yearAsPaddedString: year.ToString(CultureInfo.InvariantCulture),
+				  yearAsString: year.ToString(CultureInfo.InvariantCulture),
 				  monthAsPaddedNumericString: "01",
 				  monthAsSoloString: "Jan",
 				  monthAsString: "Jan",
@@ -538,8 +541,8 @@ namespace Uno.UI.Tests.Windows_Globalization
 				  secondAsString: "5",
 				  nanosecondAsPaddedString: "00",
 				  nanosecondAsString: "0",
-				  dayOfWeekAsSoloString: "Thursday",
-				  dayOfWeekAsString: "Thursday");
+				  dayOfWeekAsSoloString: dayOfWeek,
+				  dayOfWeekAsString: dayOfWeek);
 		}
 
 		private void Validate(

--- a/src/Uno.UWP/Globalization/Calendar.cs
+++ b/src/Uno.UWP/Globalization/Calendar.cs
@@ -373,10 +373,10 @@ namespace Windows.Globalization
 			=> throw new global::System.NotImplementedException("The member string Calendar.EraAsString(int idealLength) is not implemented in Uno.");
 
 		public string YearAsString()
-			=> DateTimeOffset.Now.Year.ToString(_resolvedCulture);
+			=> _time.Year.ToString(_resolvedCulture);
 
 		public string YearAsTruncatedString(int remainingDigits)
-			=> DateTimeOffset.Now.ToString("yy", _resolvedCulture);
+			=> _time.ToString("yy", _resolvedCulture);
 
 		public string YearAsPaddedString(int minDigits)
 			=> _time.Year.ToString(new string('0', minDigits), _resolvedCulture);


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes invalid dependency on DateTimeOffset.Now in Calendar.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
