### PR TITLE
fix(dotnetnew): Add `dotnet-new` classification to dotnet new templates

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/.template.config/template.json
@@ -1,7 +1,17 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Uno Platform",
-  "classifications": [ "Prism", "Xamarin", "Uno Platform", "WebAssembly", "iOS", "Android", "WinUI", "UWP" ],
+  "classifications": [
+    "Prism",
+    "Xamarin",
+    "Uno Platform",
+    "WebAssembly",
+    "iOS",
+    "Android",
+    "WinUI",
+    "UWP",
+    "dotnet-new"
+  ],
   "name": "Cross-Platform App (Prism)",
   "identity": "Uno.Platform.Prism.CSharp", // Unique name for this template
   "groupIdentity": "Uno.Platform.Prism",

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/.template.config/template.json
@@ -9,7 +9,8 @@
     "iOS",
     "Windows",
     "macOS",
-    "WinUI"
+    "WinUI",
+    "dotnet-new"
   ],
   "name": "Cross-Platform App (WinUI)",
   "identity": "Uno.Platform.UnoApp.WinUI",

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.template.config/template.json
@@ -10,7 +10,8 @@
     "Windows",
     "macOS",
     "Linux",
-    "Tizen"
+    "Tizen",
+    "dotnet-new"
   ],
   "name": "Cross-Platform App",
   "identity": "Uno.Platform.UnoApp",

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/.template.config/template.json
@@ -8,7 +8,8 @@
     "Android",
     "iOS",
     "Windows",
-    "macOS"
+    "macOS",
+    "dotnet-new"
   ],
   "name": "Cross-Runtime Library",
   "identity": "Uno.Platform.UnoCrossRuntimeLib",

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib/.template.config/template.json
@@ -8,7 +8,8 @@
     "Android",
     "iOS",
     "Windows",
-    "macOS"
+    "macOS",
+    "dotnet-new"
   ],
   "name": "Cross-Platform Library",
   "identity": "Uno.Platform.UnoLib",

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/.template.config/template.json
@@ -1,7 +1,12 @@
 ﻿{
   "$schema": "http://json.schemastore.org/template",
   "author": "Uno Platform",
-  "classifications": [ "Console" ],
+  "classifications": [
+    "Web",
+    "Uno Platform",
+    "WebAssembly",
+    "dotnet-new"
+  ],
   "name": "Uno Platform WebAssembly Head for Xamarin.Forms",
   "identity": "Uno.Platform.Wasm.XamarinForms",
   "groupIdentity": "Uno.Platform.XF",


### PR DESCRIPTION
This change disambiguates from VS 2019 vsix templates visually.

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change disambiguates from VS 2019 vsix templates from dotnet new templates visually.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
