### PR TITLE
fix(passwordbox): Don't fail on setting null on PasswordBox.Password

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/PasswordBoxTests/Given_PasswordBox.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/PasswordBoxTests/Given_PasswordBox.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.Tests.PasswordBoxTests
+{
+	[TestClass]
+	public class Given_PasswordBox
+	{
+		[TestMethod]
+		public void When_Binding_Set_Null()
+		{
+			var passwordBox = new PasswordBox();
+			var source = new MySource() { SourceText = "Spinach" };
+
+			passwordBox.DataContext = source;
+			passwordBox.SetBinding(PasswordBox.PasswordProperty, new Binding() { Path = new PropertyPath("SourceText") });
+
+			Assert.AreEqual("Spinach", passwordBox.Password);
+
+			source.SourceText = null;
+
+			Assert.AreEqual("", passwordBox.Password);
+		}
+
+		[TestMethod]
+		public void When_Set_DP_Null()
+		{
+			var passwordBox = new PasswordBox();
+
+			passwordBox.SetValue(PasswordBox.PasswordProperty, "Spinach");
+			Assert.AreEqual("Spinach", passwordBox.Password);
+			passwordBox.SetValue(PasswordBox.PasswordProperty, null);
+			Assert.AreEqual("", passwordBox.Password);
+		}
+
+		[TestMethod]
+		public void When_Binding_Set_Non_String()
+		{
+			var passwordBox = new PasswordBox();
+			var source = new MySource() { SourceInt = 12 };
+
+			passwordBox.DataContext = source;
+			passwordBox.SetBinding(PasswordBox.PasswordProperty, new Binding() { Path = new PropertyPath("SourceInt") });
+
+			Assert.AreEqual("12", passwordBox.Password);
+
+			source.SourceInt = 19;
+
+			Assert.AreEqual("19", passwordBox.Password);
+		}
+
+		public class MySource : System.ComponentModel.INotifyPropertyChanged
+		{
+			private string _sourceText;
+
+			public string SourceText
+			{
+				get => _sourceText;
+				set
+				{
+					if (_sourceText != value)
+					{
+						_sourceText = value;
+						OnPropertyChanged(); 
+					}
+				}
+			}
+
+			private int _sourceInt;
+
+			public int SourceInt
+			{
+				get => _sourceInt;
+				set
+				{
+					if (_sourceInt != value)
+					{
+						_sourceInt = value;
+						OnPropertyChanged();
+					}
+				}
+			}
+
+			public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+			protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+				=> PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
@@ -103,7 +103,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnPasswordChanged(DependencyPropertyChangedEventArgs e)
 		{
-			Text = (string)e.NewValue;
+			SetValue(TextProperty, (string)e.NewValue);
 
 			PasswordChanged?.Invoke(this, new RoutedEventArgs(this));
 
@@ -124,7 +124,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnTextChanged(e);
 
-			Password = (string)e.NewValue;
+			SetValue(PasswordProperty, (string)e.NewValue);
 		}
 
 		protected override AutomationPeer OnCreateAutomationPeer()


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/nventive-private/issues/142

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Databinding null to `PasswordBox.Password` won't raise an exception and rely on coercion to set an empty string.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
