### PR TITLE
fix(DependencyObject): Fix invalid cast in generated DependencyProperty coerce

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyPropertyGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyPropertyGenerator.cs
@@ -382,7 +382,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 
 				if (coerceCallback || propertySymbol.ContainingType.GetMethods().Any(m => m.Name == "Coerce" + propertyName))
 				{
-					builder.AppendLineInvariant($"\t\t, coerceValueCallback: (instance, baseValue) => (({containingTypeName})instance).Coerce{propertyName}(({propertyTypeName})baseValue)");
+					builder.AppendLineInvariant($"\t\t, coerceValueCallback: (instance, baseValue) => (({containingTypeName})instance).Coerce{propertyName}(baseValue)");
 				}
 
 				changedCallbackName ??= $"On{propertyName}Changed";

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.LocalCache.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.LocalCache.cs
@@ -153,7 +153,7 @@ namespace Uno.UI.Tests.BinderTests
 		[GeneratedDependencyProperty(DefaultValue = true, Options = FrameworkPropertyMetadataOptions.Inherits)]
 		public static DependencyProperty IsEnabledProperty { get; } = CreateIsEnabledProperty();
 		private void OnIsEnabledChanged(bool oldValue, bool newValue) { }
-		private object CoerceIsEnabled(bool baseValue) => _suppressIsEnabled ? false : baseValue;
+		private object CoerceIsEnabled(object baseValue) => _suppressIsEnabled ? false : baseValue;
 
 		public void SuppressIsEnabled(bool suppress)
 		{

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FrameworkElement.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FrameworkElement.cs
@@ -8,6 +8,7 @@ using Windows.Foundation;
 using Windows.UI.Xaml.Controls;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Windows.UI.Xaml;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
 {
@@ -121,6 +122,14 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
 
 			SUT.PublicSuppressIsEnabled(false);
 			Assert.IsTrue(SUT.IsEnabled);
+		}
+
+		[TestMethod]
+		public void When_DP_IsEnabled_Null()
+		{
+			var grid = new UserControl();
+
+			grid.SetValue(FrameworkElement.IsEnabledProperty, null);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.net.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.net.cs
@@ -75,24 +75,14 @@ namespace Windows.UI.Xaml
 
 		#region IsEnabled DependencyProperty
 
+		[GeneratedDependencyProperty(DefaultValue = true, ChangedCallback = true, CoerceCallback = true, Options = FrameworkPropertyMetadataOptions.Inherits)]
+		public static DependencyProperty IsEnabledProperty { get; } = CreateIsEnabledProperty();
+
 		public bool IsEnabled
 		{
-			get { return (bool)GetValue(IsEnabledProperty); }
-			set { SetValue(IsEnabledProperty, value); }
+			get => GetIsEnabledValue();
+			set => SetIsEnabledValue(value);
 		}
-
-		// Using a DependencyProperty as the backing store for Enabled.  This enables animation, styling, binding, etc...
-		public static DependencyProperty IsEnabledProperty { get ; } =
-			DependencyProperty.Register(
-				"IsEnabled",
-				typeof(bool),
-				typeof(FrameworkElement),
-				new FrameworkPropertyMetadata(
-					defaultValue: true,
-					propertyChangedCallback: (s, e) => ((FrameworkElement)s)?.OnIsEnabledChanged((bool)e.OldValue, (bool)e.NewValue),
-					coerceValueCallback: (s, v) => (s as FrameworkElement)?.CoerceIsEnabled(v)
-				)
-			);
 
 		protected virtual void OnIsEnabledChanged(bool oldValue, bool newValue)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/4834

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Setting null to `FrameworkElement.IsEnabled` through SetValue does not fail.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
