### PR TITLE
feat(skia): Enable StorageFile.GetFileFromApplicationUri

### DIFF
--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -24,11 +24,11 @@ namespace Windows.Storage
 		internal static StorageFile GetFileFromPath(string path)
 			=> new StorageFile(new Local(path));
 
-		[NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
+		[NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public static IAsyncOperation<StorageFile> GetFileFromApplicationUriAsync(Uri uri)
 			=> AsyncOperation.FromTask(ct => GetFileFromApplicationUri(ct, uri));
 
-#if NET461 || __SKIA__ || __NETSTD_REFERENCE__
+#if NET461 || __NETSTD_REFERENCE__
 		private static Task<StorageFile> GetFileFromApplicationUri(CancellationToken ct, Uri uri)
 			=> throw new NotImplementedException();
 #endif

--- a/src/Uno.UWP/Storage/StorageFile.skia.cs
+++ b/src/Uno.UWP/Storage/StorageFile.skia.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Windows.ApplicationModel;
 
 namespace Windows.Storage
 {
@@ -18,8 +19,7 @@ namespace Windows.Storage
 
 			var path = uri.PathAndQuery.TrimStart(new char[] { '/' });
 
-			var baseDir = global::System.IO.Path.GetDirectoryName(global::System.Reflection.Assembly.GetExecutingAssembly().Location);
-			var resourcePathname = global::System.IO.Path.Combine(baseDir, path);
+			var resourcePathname = global::System.IO.Path.Combine(Package.Current.InstalledLocation.Path, path);
 
 			if (resourcePathname != null)
 			{

--- a/src/Uno.UWP/Storage/StorageFile.skia.cs
+++ b/src/Uno.UWP/Storage/StorageFile.skia.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Windows.Storage
+{
+	partial class StorageFile
+	{
+		private static async Task<StorageFile> GetFileFromApplicationUri(CancellationToken ct, Uri uri)
+		{
+			if (uri.Scheme != "ms-appx")
+			{
+				throw new InvalidOperationException("Uri is not using the ms-appx scheme");
+			}
+
+			var path = uri.PathAndQuery.TrimStart(new char[] { '/' });
+
+			var baseDir = global::System.IO.Path.GetDirectoryName(global::System.Reflection.Assembly.GetExecutingAssembly().Location);
+			var resourcePathname = global::System.IO.Path.Combine(baseDir, path);
+
+			if (resourcePathname != null)
+			{
+				return await StorageFile.GetFileFromPathAsync(resourcePathname);
+			}
+			else
+			{
+				throw new FileNotFoundException($"The file [{path}] cannot be found  in the package directory");
+			}
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #
closes #4832 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Skia based apps cannot use `StorageFile.GetFileFromApplicationUri()`

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
`StorageFile.GetFileFromApplicationUri()` is available for Skia based Apps

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
