### PR TITLE
fix: x:Bind to fields with non-OneTime mode

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xBindTests/xBind.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xBindTests/xBind.xaml.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml.xBind
 {
-	[SampleControlInfo("XAML", "xBind")]
+	[SampleControlInfo("XBind", "xBind")]
 	public sealed partial class xBind : UserControl
 	{
 		public XbindViewModel ViewModel { get; set; }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xBindTests/xBind_Field.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xBindTests/xBind_Field.xaml.cs
@@ -18,7 +18,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace UITests.Shared.Windows_UI_Xaml.xBindTests
 {
-	[SampleControlInfo("XAML", "xBind_Field")]
+	[SampleControlInfo("XBind", "XBind_Field")]
 	public sealed partial class xBind_Field : UserControl
 	{
 		public xBind_Field()

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
@@ -675,6 +675,34 @@ namespace Uno.UI.Tests.BinderTests
 		}
 
 		[TestMethod]
+		public void When_Private_Field_And_xBind_Not_OneTime()
+		{
+			var source = new PrivateField(42);
+			var SUT = new Windows.UI.Xaml.Controls.Grid();
+
+			var binding = new Binding()
+			{
+				Path = "MyField",
+				Mode = BindingMode.OneWay,
+				CompiledSource = source
+			};
+			binding.SetBindingXBindProvider(
+					source,
+					(a) => "Test",
+					null,
+					new[] { "MyField" });
+
+			SUT.SetBinding(
+				Windows.UI.Xaml.Controls.Grid.TagProperty,
+				binding
+			);
+
+			SUT.ApplyXBind();
+
+			Assert.AreEqual("Test", SUT.Tag);
+		}
+
+		[TestMethod]
 		public void When_Public_Field_And_Binding()
 		{
 			var source = new PublicField(42);

--- a/src/Uno.UI/DataBinding/BindingPath.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.cs
@@ -504,7 +504,7 @@ namespace Uno.UI.DataBinding
 				{
 					if (DataContext != null)
 					{
-						return BindingPropertyHelper.GetPropertyType(_dataContextType, PropertyName);
+						return BindingPropertyHelper.GetPropertyType(_dataContextType, PropertyName, _allowPrivateMembers);
 					}
 					else
 					{

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -374,7 +374,7 @@ namespace Windows.UI.Xaml
 			if (fullBinding != null)
 			{
 				var boundProperty = DependencyProperty.GetProperty(_originalObjectType, dependencyProperty) 
-					?? FindStandardProperty(_originalObjectType, dependencyProperty);
+					?? FindStandardProperty(_originalObjectType, dependencyProperty, fullBinding.CompiledSource != null);
 
 				if (boundProperty != null)
 				{
@@ -390,9 +390,9 @@ namespace Windows.UI.Xaml
 		/// <summary>
 		/// Finds a DependencyProperty for the specified C# property
 		/// </summary>
-		private DependencyProperty? FindStandardProperty(Type originalObjectType, string dependencyProperty)
+		private DependencyProperty? FindStandardProperty(Type originalObjectType, string dependencyProperty, bool allowPrivateMembers)
 		{
-			var propertyType = BindingPropertyHelper.GetPropertyType(originalObjectType, dependencyProperty);
+			var propertyType = BindingPropertyHelper.GetPropertyType(originalObjectType, dependencyProperty, allowPrivateMembers);
 
 			if (propertyType != null)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #4883

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Does not work.

## What is the new behavior?

Does work 🚀


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.