### PR TITLE
Fix(iOS) TimePicker bug selecting new Time

### DIFF
--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -494,8 +494,7 @@ namespace Uno.UI
 		public static class TimePicker
 		{
 #if __IOS__
-			//TODO: Setting the default to true because of this: https://github.com/unoplatform/uno/issues/4611
-			public static bool UseLegacyStyle { get; set; } = true;
+			public static bool UseLegacyStyle { get; set; } = false;
 #endif
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -1,4 +1,4 @@
-﻿#if XAMARIN_IOS
+#if XAMARIN_IOS
 
 using Foundation;
 using System;
@@ -42,7 +42,8 @@ namespace Windows.UI.Xaml.Controls
 			SetPickerTime(Time.RoundToNextMinuteInterval(MinuteIncrement));
 			SaveInitialTime();
 			_picker.ValueChanged += OnValueChanged;
-			
+			_picker.EditingDidBegin += OnEditingDidBegin;
+
 			var parent = _picker.FindFirstParent<FrameworkElement>();
 
 			//Removing the date picker and adding it is what enables the lines to appear. Seems to be a side effect of adding it as a view. 
@@ -52,7 +53,13 @@ namespace Windows.UI.Xaml.Controls
 				parent.AddSubview(_picker);
 			}
 		}
-		
+
+		private void OnEditingDidBegin(object sender, EventArgs e)
+		{
+			//We don't want the keyboard to be shown. https://github.com/unoplatform/uno/issues/4611
+			_picker?.ResignFirstResponder();
+		}
+
 		private void OnValueChanged(object sender, EventArgs e)
 		{
 			_newDate = _picker.Date;


### PR DESCRIPTION
GitHub Issue (If applicable): #
closes #4611 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Issues on TimePicker with iOS14+ style not allowing to select a new time because the keyboard was dismissing the Picker Dialog.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Preventing the keyboard from showing allows the users to pick the new Time "scrolling".


<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
