### PR TITLE
fix(animations): [iOS] Cancel animators on detached layers

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/GPUFloatValueAnimator.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/GPUFloatValueAnimator.iOSmacOS.cs
@@ -405,7 +405,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			return NSValue.FromCATransform3D(CATransform3D.MakeFromAffine(matrix));
 		}
 
-		private void FinalizeAnimation()
+		private void FinalizeAnimation(UnoCoreAnimation.CompletedInfo completedInfo)
 		{
 			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 			{
@@ -417,7 +417,13 @@ namespace Windows.UI.Xaml.Media.Animation
 				_valueAnimator.Cancel();
 			}
 
-			AnimationEnd?.Invoke(this, EventArgs.Empty);
+			switch(completedInfo)
+			{
+				case UnoCoreAnimation.CompletedInfo.Sucesss: AnimationEnd?.Invoke(this, EventArgs.Empty); break;
+				case UnoCoreAnimation.CompletedInfo.Error: AnimationCancel?.Invoke(this, EventArgs.Empty); break;
+				default: throw new NotSupportedException($"{completedInfo} is not supported");
+			};
+
 			ReleaseCoreAnimation();
 		}
 

--- a/src/Uno.UWP/UI/Composition/SpriteVisual.iOS.cs
+++ b/src/Uno.UWP/UI/Composition/SpriteVisual.iOS.cs
@@ -80,7 +80,7 @@ namespace Windows.UI.Composition
 			);
 		}
 
-		private void FinalizeAnimation() { }
+		private void FinalizeAnimation(UnoCoreAnimation.CompletedInfo info) { }
 	}
 }
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes https://github.com/unoplatform/nventive-private/issues/139, Fixes https://github.com/unoplatform/nventive-private/issues/123.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change cancels repeatable animations to avoid being stuck in a very tight loop when trying to animate a detached layer. This can happen when Storyboards are running, and animating an unloaded control.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
