### PR TITLE
fix: ElementName binding in non-toplevel ResourceDictionary

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -59,7 +59,6 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 
 			try
 			{
-
 				if (PlatformHelper.IsValidPlatform(context)
 					&& !DesignTimeHelper.IsDesignTime(context))
 				{

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl.xaml
@@ -1,0 +1,26 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls.Binding_ElementName_In_Template_ItemsControl"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<ItemsControl x:Name="PrimaryActionsList" x:FieldModifier="public" Tag="42">
+		<ItemsControl.Template>
+			<ControlTemplate TargetType="ItemsControl">
+				<ItemsPresenter/>
+			</ControlTemplate>
+		</ItemsControl.Template>
+		<ItemsControl.ItemsPanel>
+			<ItemsPanelTemplate>
+				<StackPanel/>
+			</ItemsPanelTemplate>
+		</ItemsControl.ItemsPanel>
+		<ItemsControl.ItemTemplate>
+			<DataTemplate>
+				<Button x:Name="button" Tag="{Binding Tag, ElementName=PrimaryActionsList}" />
+			</DataTemplate>
+		</ItemsControl.ItemTemplate>
+	</ItemsControl>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_ElementName_In_Template_ItemsControl : Page
+	{
+		public Binding_ElementName_In_Template_ItemsControl()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_Resource.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_Resource.xaml
@@ -1,0 +1,18 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls.Binding_ElementName_In_Template_Resource"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="myTemplate">
+			<TextBlock x:Name="innerTextBlock" Text="{Binding Tag, ElementName=topLevel}" />
+		</DataTemplate>
+	</Page.Resources>
+	
+	<Grid>
+		<ContentControl x:Name="topLevel" x:FieldModifier="public" Tag="42" ContentTemplate="{StaticResource myTemplate}" />
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_Resource.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_Resource.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_ElementName_In_Template_Resource : Page
+	{
+		public Binding_ElementName_In_Template_Resource()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_Resource_In_Dictionary.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_Resource_In_Dictionary.xaml
@@ -1,0 +1,20 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls.Binding_ElementName_In_Template_Resource_In_Dictionary"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<ResourceDictionary>
+			<DataTemplate x:Key="myTemplate">
+				<TextBlock x:Name="innerTextBlock" Text="{Binding Tag, ElementName=topLevel}" />
+			</DataTemplate>
+		</ResourceDictionary>
+	</Page.Resources>
+	
+	<Grid>
+		<ContentControl x:Name="topLevel" x:FieldModifier="public" Tag="42" ContentTemplate="{StaticResource myTemplate}" />
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_Resource_In_Dictionary.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_Resource_In_Dictionary.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_ElementName_In_Template_Resource_In_Dictionary : Page
+	{
+		public Binding_ElementName_In_Template_Resource_In_Dictionary()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
@@ -22,5 +22,43 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests
 
 			Assert.AreEqual(SUT.topLevel.Tag, tb.Text);
 		}
+
+		[TestMethod]
+		public void When_ElementName_In_Template_Resource()
+		{
+			var SUT = new Binding_ElementName_In_Template_Resource();
+
+			SUT.ForceLoaded();
+
+			var tb = SUT.FindName("innerTextBlock") as Windows.UI.Xaml.Controls.TextBlock;
+
+			Assert.AreEqual(SUT.topLevel.Tag, tb.Text);
+		}
+
+		[TestMethod]
+		public void When_ElementName_In_Template_Resource_In_Dictionary()
+		{
+			var SUT = new Binding_ElementName_In_Template_Resource_In_Dictionary();
+
+			SUT.ForceLoaded();
+
+			var tb = SUT.FindName("innerTextBlock") as Windows.UI.Xaml.Controls.TextBlock;
+
+			Assert.AreEqual(SUT.topLevel.Tag, tb.Text);
+		}
+		      
+		[TestMethod]
+		public void When_ElementName_In_Template_ItemsControl()
+		{
+			var SUT = new Binding_ElementName_In_Template_ItemsControl();
+
+			SUT.PrimaryActionsList.ItemsSource = new[] { "test" };
+
+			SUT.ForceLoaded();
+
+			var button = SUT.FindName("button") as Windows.UI.Xaml.Controls.Button;
+
+			Assert.AreEqual(SUT.PrimaryActionsList.Tag, button.Tag);
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/4505

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`ElementName` bindings created in non-toplevel ResourceDictionary are applied properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
