### PR TITLE
fix: TargetPropertyPath is not releasing its WeakReference properly

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -726,6 +726,13 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.AreEqual(2, tabView1.TabItems.Count);
 		}
 
+		[TestMethod]
+		public void When_StateTrigger_PropertyPath()
+		{
+			var s = GetContent(nameof(When_StateTrigger_PropertyPath));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+		}
+
 		private string GetContent(string testName)
 		{
 			var assembly = this.GetType().Assembly;

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_StateTrigger_PropertyPath.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_StateTrigger_PropertyPath.xamltest
@@ -1,0 +1,28 @@
+﻿<UserControl
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+>
+  <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<VisualStateManager.VisualStateGroups>
+	  <VisualStateGroup>
+		<VisualState>
+		  <VisualState.StateTriggers>
+			<!--VisualState to be triggered when window width is >=720 effective pixels.-->
+			<StateTrigger IsActive="True"/>
+		  </VisualState.StateTriggers>
+		  <VisualState.Setters>
+			<Setter Target="myPanel.Orientation" Value="Horizontal"/>
+		  </VisualState.Setters>
+		</VisualState>
+	  </VisualStateGroup>
+	</VisualStateManager.VisualStateGroups>
+	<StackPanel x:Name="myPanel" Orientation="Vertical">
+	  <TextBlock Text="This is a block of text. It is text block 1. "
+						   Style="{ThemeResource BodyTextBlockStyle}"/>
+	  <TextBlock Text="This is a block of text. It is text block 2. "
+						   Style="{ThemeResource BodyTextBlockStyle}"/>
+	  <TextBlock Text="This is a block of text. It is text block 3. "
+						   Style="{ThemeResource BodyTextBlockStyle}"/>
+	</StackPanel>
+  </Grid>
+</UserControl>

--- a/src/Uno.UI/UI/Xaml/TargetPropertyPath.cs
+++ b/src/Uno.UI/UI/Xaml/TargetPropertyPath.cs
@@ -10,22 +10,31 @@ namespace Windows.UI.Xaml
 {
 	public sealed partial class TargetPropertyPath
 	{
+#if UNO_HAS_UIELEMENT_IMPLICIT_PINNING
 		private ManagedWeakReference? _targetRef;
+#endif
 
 		public object? Target
 		{
+#if UNO_HAS_UIELEMENT_IMPLICIT_PINNING
 			get => _targetRef?.Target;
 			set
 			{
 				if (_targetRef != null)
 				{
 					WeakReferencePool.ReturnWeakReference(this, _targetRef);
+					_targetRef = null;
 				}
-				else
+
+				if (!(value is null))
 				{
 					_targetRef = WeakReferencePool.RentWeakReference(this, value);
 				}
 			}
+#else
+			get;
+			set;
+#endif
 		}
 
 		public PropertyPath? Path


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/4917

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

No exception when a `TargetPropertyPath.Target` gets assigned multiple times.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
