### PR TITLE
fix: Match ProtocolActivated property support with Launch

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Activation/ProtocolActivatedEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/Activation/ProtocolActivatedEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Uno;
 
 namespace Windows.ApplicationModel.Activation
 {
@@ -44,6 +45,18 @@ namespace Windows.ApplicationModel.Activation
 		/// Gets the Uniform Resource Identifier (URI) for which the app was activated.
 		/// </summary>
 		public Uri Uri { get; }
+
+		[NotImplemented]
+		public SplashScreen SplashScreen
+		{
+			get;
+		}
+
+		[NotImplemented]
+		public int CurrentlyShownApplicationViewId
+		{
+			get;
+		}
 #endif
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Activation/ProtocolActivatedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Activation/ProtocolActivatedEventArgs.cs
@@ -27,7 +27,7 @@ namespace Windows.ApplicationModel.Activation
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.ApplicationModel.Activation.SplashScreen SplashScreen
 		{
@@ -47,7 +47,7 @@ namespace Windows.ApplicationModel.Activation
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int CurrentlyShownApplicationViewId
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Accessing the `SplashScreen` property on `ProtocolActivatedEventArgs` causes exception.

## What is the new behavior?

Accessing the `SplashScreen` property on `ProtocolActivatedEventArgs` returns `null` to match `LaunchActivatedEventArgs`.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
