### PR TITLE
[WASM] Fixed a problem with TextBlock alignment when used with MaxLines

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml
@@ -16,26 +16,17 @@
 	d:DesignWidth="400">
 
 	<StackPanel>
-		<Slider Minimum="10" Maximum="1600" Value="350" x:Name="slider">
-			<Slider.Header>
-				<TextBlock>Container Width <Run Text="{Binding Value, ElementName=slider}" /></TextBlock>
-			</Slider.Header>
-		</Slider>
-		<Slider Minimum="5" Maximum="300" Value="70" x:Name="sliderV">
-			<Slider.Header>
-				<TextBlock>Container Height <Run Text="{Binding Value, ElementName=sliderV}" /></TextBlock>
-			</Slider.Header>
-		</Slider>
-		<Slider Minimum="5" Maximum="170" Value="20" x:Name="fontsize">
-			<Slider.Header>
-				<TextBlock>Font Size <Run Text="{Binding Value, ElementName=fontsize}" /></TextBlock>
-			</Slider.Header>
-		</Slider>
-		<Slider Minimum="5" Maximum="170" Value="20" x:Name="lineheight">
-			<Slider.Header>
-				<TextBlock>Line Height <Run Text="{Binding Value, ElementName=lineheight}" /></TextBlock>
-			</Slider.Header>
-		</Slider>
+		<TextBlock>Container Width <Run Text="{Binding Value, ElementName=slider}" />:</TextBlock>
+		<Slider Minimum="10" Maximum="1600" Value="350" x:Name="slider" />
+
+		<TextBlock>Container Height <Run Text="{Binding Value, ElementName=sliderV}" />:</TextBlock>
+		<Slider Minimum="5" Maximum="300" Value="70" x:Name="sliderV" />
+
+		<TextBlock>Font Size <Run Text="{Binding Value, ElementName=fontsize}" />:</TextBlock>
+		<Slider Minimum="5" Maximum="170" Value="20" x:Name="fontsize" />
+
+		<TextBlock>Line Height <Run Text="{Binding Value, ElementName=lineheight}" />:</TextBlock>
+		<Slider Minimum="5" Maximum="170" Value="20" x:Name="lineheight" />
 
 		<wasm:TextBlock>
 			(WASM ONLY) Cache: Hits=
@@ -45,6 +36,7 @@
 
 		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Cyan" Name="border1">
 			<TextBlock
+				x:Name="textwrap"
 				FontSize="{Binding Value, ElementName=fontsize}"
 				TextWrapping="Wrap"
 				LineHeight="{Binding Value, ElementName=lineheight}"
@@ -54,6 +46,7 @@
 		</Border>
 		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Yellow" x:Name="border2">
 			<TextBlock
+				x:Name="textwrapwords"
 				FontSize="{Binding Value, ElementName=fontsize}"
 				TextWrapping="WrapWholeWords"
 				LineHeight="{Binding Value, ElementName=lineheight}"
@@ -64,6 +57,7 @@
 		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Cyan" x:Name="border3">
 			<TextBlock
 				FontSize="{Binding Value, ElementName=fontsize}"
+				x:Name="textwrapellipsis"
 				TextWrapping="Wrap"
 				TextTrimming="CharacterEllipsis"
 				LineHeight="{Binding Value, ElementName=lineheight}"
@@ -74,6 +68,7 @@
 		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Yellow" x:Name="border4">
 			<TextBlock
 				FontSize="{Binding Value, ElementName=fontsize}"
+				x:Name="textwrapwordsellipsis"
 				TextWrapping="WrapWholeWords"
 				TextTrimming="CharacterEllipsis"
 				LineHeight="{Binding Value, ElementName=lineheight}"

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -55,8 +55,8 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		private void InitializeDefaultValues()
 		{
-            this.SetValue(VerticalAlignmentProperty, VerticalAlignment.Top, DependencyPropertyValuePrecedences.DefaultValue);
-        }
+			this.SetValue(VerticalAlignmentProperty, VerticalAlignment.Top, DependencyPropertyValuePrecedences.DefaultValue);
+		}
 
 		private void ConditionalUpdate(ref bool condition, Action action)
 		{
@@ -134,9 +134,21 @@ namespace Windows.UI.Xaml.Controls
 		/// <returns></returns>
 		protected override Size ArrangeOverride(Size finalSize)
 		{
-			var arrangeSize = IsLayoutConstrainedByMaxLines
-				? DesiredSize
-				: finalSize;
+			Size arrangeSize;
+			if (IsLayoutConstrainedByMaxLines)
+			{
+				arrangeSize = DesiredSize;
+
+				if (HorizontalAlignment == HorizontalAlignment.Stretch)
+				{
+					arrangeSize.Width = finalSize.Width;
+				}
+			}
+			else
+			{
+				arrangeSize = finalSize;
+			}
+
 			return base.ArrangeOverride(arrangeSize);
 		}
 


### PR DESCRIPTION
Fixes #4910 

# Bugfix

## What is the current behavior?
The size reported by the `<TextBlock />` during `Arrange()` phase were incorrect when `MaxLines` were specified. The correct size should always be the available width for a `<TextBlock />`, because the default `HorizontalAlignement` for any control (that includes `<TextBlock />`) is `Stretch`. And this mode (`Stretch`) will cause the layout to behave like `Center` when the control is not filling its parent's size.

## What is the new behavior?
The fix was to return the available width during the `Arrange()` phase when the `HorizontalAlignment` is set to `Stretch`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
