### PR TITLE
fix(scrollviewer): [WASM] Fix reloaded ScrollViewer has scroll reset

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
@@ -87,5 +87,36 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 				actualRect: new Rectangle((int)updateButtonRect.X, (int)updateButtonRect.Y, (int)updateButtonRect.Width, (int)updateButtonRect.Height)
 			);
 		}
+
+		[Test]
+		[AutoRetry]
+		public void ScrollViewer_Removed_And_Added()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ScrollViewerTests.ScrollViewer_Add_Remove");
+			_app.WaitForElement("ViewfinderRectangle");
+			var rect = _app.GetPhysicalRect("ViewfinderRectangle");
+			AssertCurrentColor("Initial", Color.Red);
+
+			AdvanceToStep(buttonName: "ScrollToBottomButton", stepName: "Scrolled");
+			AssertCurrentColor("Initial-Scrolled", Color.Indigo);
+
+			AdvanceToStep(buttonName: "YoinkButton", stepName: "Gone");
+			AssertCurrentColor("Gone", Color.Beige);
+
+			AdvanceToStep(buttonName: "YoinkButton", stepName: "Present");
+			AssertCurrentColor("Restored", Color.Indigo);
+
+			void AdvanceToStep(string buttonName, string stepName)
+			{
+				_app.FastTap(buttonName);
+				_app.WaitForText("ChildStatusTextBlock", stepName);
+			}
+
+			void AssertCurrentColor(string description, Color color)
+			{
+				var scrn = TakeScreenshot(description);
+				ImageAssert.HasColorAt(scrn, rect.CenterX, rect.CenterY, color);
+			}
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1309,6 +1309,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Add_Remove.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Clipping.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4635,6 +4639,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollBar\ScrollBar_Simple.xaml.cs">
       <DependentUpon>ScrollBar_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Add_Remove.xaml.cs">
+      <DependentUpon>ScrollViewer_Add_Remove.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Clipping.xaml.cs">
       <DependentUpon>ScrollViewer_Clipping.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Add_Remove.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Add_Remove.xaml
@@ -1,0 +1,56 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.ScrollViewerTests.ScrollViewer_Add_Remove"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ScrollViewerTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<StackPanel>
+		<Button x:Name="YoinkButton"
+				Content="Toggle Border Child attached"
+				Click="YoinkButton_Click" />
+		<Button x:Name="ScrollToBottomButton"
+				Content="Scroll to bottom"
+				Click="ScrollToBottomButton_Click" />
+		<Grid Height="200"
+			  Width="300"
+			  Background="Beige">
+			<Border Height="200"
+					Name="YoinkBorder">
+				<ScrollViewer x:Name="YoinkableScrollViewer">
+					<StackPanel>
+						<Border Width="300"
+								Height="190"
+								Background="Red" />
+						<Border Width="300"
+								Height="190"
+								Background="Orange" />
+						<Border Width="300"
+								Height="190"
+								Background="Yellow" />
+						<Border Width="300"
+								Height="190"
+								Background="Green" />
+						<Border Width="300"
+								Height="190"
+								Background="Blue" />
+						<Border Width="300"
+								Height="190"
+								Background="Indigo" />
+					</StackPanel>
+				</ScrollViewer>
+			</Border>
+			<Rectangle x:Name="ViewfinderRectangle"
+					   IsHitTestVisible="False"
+					   Fill="Transparent"
+					   HorizontalAlignment="Stretch"
+					   Height="100"
+					   VerticalAlignment="Bottom" />
+		</Grid>
+		<TextBlock x:Name="ChildStatusTextBlock"
+				   Text="Present" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Add_Remove.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Add_Remove.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
+{
+	[Sample("ScrollViewer")]
+	public sealed partial class ScrollViewer_Add_Remove : UserControl
+	{
+		public ScrollViewer_Add_Remove()
+		{
+			this.InitializeComponent();
+		}
+
+		private UIElement _unloadedChild;
+		private void YoinkButton_Click(object sender, object args)
+		{
+			if (YoinkBorder.Child != null)
+			{
+				_unloadedChild = YoinkBorder.Child;
+				YoinkBorder.Child = null;
+				ChildStatusTextBlock.Text = "Gone";
+			}
+			else
+			{
+				YoinkBorder.Child = _unloadedChild;
+				ChildStatusTextBlock.Text = "Present";
+			}
+		}
+
+		private void ScrollToBottomButton_Click(object sender, object args)
+		{
+			YoinkableScrollViewer.ChangeView(null, 10000, null, disableAnimation: true);
+			ChildStatusTextBlock.Text = "Scrolled";
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -129,7 +129,19 @@ namespace Windows.UI.Xaml.Controls
 		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
+			RestoreScroll();
 			RegisterEventHandler("scroll", (EventHandler)OnScroll, GenericEventHandlers.RaiseEventHandler);
+		}
+
+		private void RestoreScroll()
+		{
+			if (TemplatedParent is ScrollViewer sv)
+			{
+				if (sv.HorizontalOffset > 0 || sv.VerticalOffset > 0)
+				{
+					ScrollTo(sv.HorizontalOffset, sv.VerticalOffset, disableAnimation: true);
+				}
+			}
 		}
 
 		private protected override void OnUnloaded()


### PR DESCRIPTION
This was most obvious for ComboBox, which would appear blank the second time it was opened, if an item deep in the list was selected.

GitHub Issue (If applicable): fixes #4852

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
