### PR TITLE
fix(memory): [iOS] Propagate GPU animation failures up to Storyboard to fix memory leak

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -45,9 +45,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(typeof(ListView), 15)]
 		[DataRow(typeof(ProgressRing), 15)]
 		[DataRow(typeof(Pivot), 15)]
-#if !__IOS__ // https://github.com/unoplatform/uno/issues/4953
 		[DataRow(typeof(ScrollBar), 15)]
-#endif
 		[DataRow(typeof(Slider), 15)]
 		[DataRow(typeof(SymbolIcon), 15)]
 		[DataRow(typeof(Viewbox), 15)]

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/CPUBoundAnimator.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/CPUBoundAnimator.cs
@@ -36,6 +36,11 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// <inheritdoc />
 		public event EventHandler AnimationCancel;
 
+#pragma warning disable 67
+		/// <inheritdoc />
+		public event EventHandler AnimationFailed;
+#pragma warning restore 67
+
 
 		/// <inheritdoc />
 		public object AnimatedValue => _currentValue;

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DiscreteFloatValueAnimator.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DiscreteFloatValueAnimator.cs
@@ -29,6 +29,9 @@ namespace Windows.UI.Xaml.Media.Animation
 		public event EventHandler AnimationCancel;
 		public event EventHandler AnimationEnd;
 		public event EventHandler AnimationPause;
+#pragma warning disable 67
+		public event EventHandler AnimationFailed;
+#pragma warning restore 67
 		public event EventHandler Update;
 
 		public DiscreteFloatValueAnimator(float from, float to)

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DisplayLinkValueAnimator.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DisplayLinkValueAnimator.iOSmacOS.cs
@@ -220,6 +220,10 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		public event EventHandler AnimationCancel;
 
+#pragma warning disable 67
+		public event EventHandler AnimationFailed;
+#pragma warning restore 67
+
 		public event EventHandler Update;
 
 		public long StartDelay { get; set; }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/GPUFloatValueAnimator.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/GPUFloatValueAnimator.iOSmacOS.cs
@@ -229,6 +229,8 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		public event EventHandler AnimationCancel;
 
+		public event EventHandler AnimationFailed;
+
 		public void SetDuration(long duration)
 		{
 			_duration = duration;
@@ -420,7 +422,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			switch(completedInfo)
 			{
 				case UnoCoreAnimation.CompletedInfo.Sucesss: AnimationEnd?.Invoke(this, EventArgs.Empty); break;
-				case UnoCoreAnimation.CompletedInfo.Error: AnimationCancel?.Invoke(this, EventArgs.Empty); break;
+				case UnoCoreAnimation.CompletedInfo.Error: AnimationFailed?.Invoke(this, EventArgs.Empty); break;
 				default: throw new NotSupportedException($"{completedInfo} is not supported");
 			};
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/IValueAnimator.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/IValueAnimator.cs
@@ -30,6 +30,11 @@ namespace Windows.UI.Xaml.Media.Animation
 		event EventHandler AnimationCancel;
 
 		/// <summary>
+		/// Occurs when the animation failed.
+		/// </summary>
+		event EventHandler AnimationFailed;
+
+		/// <summary>
 		/// Gets or sets the animated value. The setter is public because the Java version is public 
 		/// </summary>
 		/// <value>The animated value.</value>

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/ImmediateAnimator.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/ImmediateAnimator.cs
@@ -68,6 +68,10 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		public event EventHandler AnimationCancel;
 
+#pragma warning disable 67
+		public event EventHandler AnimationFailed;
+#pragma warning restore 67
+
 		public event EventHandler Update;
 
 		public long StartDelay { get; set; }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/NativeValueAnimatorAdapter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/NativeValueAnimatorAdapter.Android.cs
@@ -166,6 +166,10 @@ namespace Windows.UI.Xaml.Media.Animation
 			}
 		}
 
+#pragma warning disable 67
+		public event EventHandler AnimationFailed;
+#pragma warning restore 67
+
 		/// <inheritdoc />
 		public object AnimatedValue => _adaptee.AnimatedValue;
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/NotSupportedAnimator.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/NotSupportedAnimator.cs
@@ -71,6 +71,8 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		public event EventHandler AnimationCancel;
 
+		public event EventHandler AnimationFailed;
+
 		public event EventHandler Update;
 
 		public long StartDelay { get; set; }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ITimeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ITimeline.cs
@@ -20,5 +20,6 @@ namespace Windows.UI.Xaml.Media.Animation
 		void SkipToFill();
 		void Deactivate();
 		event EventHandler<object> Completed;
+		event EventHandler<object> Failed;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
@@ -249,6 +249,7 @@ namespace Windows.UI.Xaml.Media.Animation
 				_animator.AnimationEnd += OnAnimatorAnimationEnd;
 
 				_animator.AnimationCancel += OnAnimatorCancelled;
+				_animator.AnimationFailed += OnAnimatorFailed;
 			}
 
 			private void OnAnimatorAnimationEnd(object sender, EventArgs e)
@@ -337,7 +338,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 				if (FillBehavior == FillBehavior.HoldEnd)//Two types of fill behaviors : HoldEnd - Keep displaying the last frame
 				{
-	#if __IOS__ || __MACOS__
+#if __IOS__ || __MACOS__
 					// iOS && macOS: Here we make sure that the final frame is applied properly (it may have been skipped by animator)
 					// Note: The value is applied using the "Animations" precedence, which means that the user won't be able to alter
 					//		 it from application code. Instead we should set the value using a lower precedence
@@ -359,6 +360,19 @@ namespace Windows.UI.Xaml.Media.Animation
 				}
 
 				_owner.OnCompleted();
+			}
+
+			/// <summary>
+			/// Stops the timeline when an animator failed
+			/// </summary>
+			private void OnAnimatorFailed(object sender, EventArgs e)
+			{
+				// Failed - Put back the initial state, and don't try to replay.
+				State = TimelineState.Stopped;
+
+				ClearValue();
+
+				_owner.OnFailed();
 			}
 
 			/// <summary>

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -86,8 +86,16 @@ namespace Windows.UI.Xaml.Media.Animation
 
 
 		public event EventHandler<object> Completed;
+		internal event EventHandler<object> Failed;
+
+		event EventHandler<object> ITimeline.Failed
+		{
+			add => Failed += value;
+			remove => Failed += value;
+		}
 
 		protected void OnCompleted() => Completed?.Invoke(this, null);
+		protected void OnFailed() => Failed?.Invoke(this, null);
 
 		/// <summary>
 		/// Compute duration of the Timeline. Sometimes it's define by components.


### PR DESCRIPTION
GitHub Issue (If applicable): fix #4953 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

iOS GPU failed animations are now releasing resources properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
