### PR TITLE
Fix NavigationView not appearing properly on iOS

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3363,13 +3363,13 @@
 		<Methods>
 			<Member
 				fullName="System.String UIKit.UIViewExtensions.GetDebugIdentifier(UIKit.UIView element)"
-				reason="Internal helper that should be public" />
+				reason="Internal helper that should not be public" />
 			<Member
 				fullName="System.String AppKit.UIViewExtensions.GetDebugIdentifier(AppKit.NSView element)"
-				reason="Internal helper that should be public" />
+				reason="Internal helper that should not be public" />
 			<Member
 				fullName="System.String Uno.UI.ViewExtensions.GetDebugIdentifier(Android.Views.View element)"
-				reason="Internal helper that should be public" />
+				reason="Internal helper that should not be public" />
 		</Methods>
 	</IgnoreSet>
 

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3358,6 +3358,20 @@
 				reason="Renamed in WinUI" />
 		</Methods>
 	</IgnoreSet>
+	
+	<IgnoreSet baseVersion="3.4.0">
+		<Methods>
+			<Member
+				fullName="System.String UIKit.UIViewExtensions.GetDebugIdentifier(UIKit.UIView element)"
+				reason="Internal helper that should be public" />
+			<Member
+				fullName="System.String AppKit.UIViewExtensions.GetDebugIdentifier(AppKit.NSView element)"
+				reason="Internal helper that should be public" />
+			<Member
+				fullName="System.String Uno.UI.ViewExtensions.GetDebugIdentifier(Android.Views.View element)"
+				reason="Internal helper that should be public" />
+		</Methods>
+	</IgnoreSet>
 
 	<!--
 	Supported nodes (please keep at the bottom of this file):

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -135,7 +135,7 @@ namespace Windows.Foundation
 		public override string ToString() => (string)this;
 
 		internal string ToDebugString()
-			=> IsEmpty ? "--empty--" : FormattableString.Invariant($"{Width:F2},{Height:F2}@{Location.ToDebugString()}");
+			=> IsEmpty ? "--empty--" : FormattableString.Invariant($"{Size.ToDebugString()}@{Location.ToDebugString()}");
 
 		/// <summary>
 		/// Provides the size of this rectangle.

--- a/src/Uno.Foundation/Size.cs
+++ b/src/Uno.Foundation/Size.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
@@ -58,6 +59,9 @@ namespace Windows.Foundation
 			sb.Append(Height.ToString(format, CultureInfo.InvariantCulture));
 			return sb.ToString();
 		}
+
+		internal string ToDebugString()
+			=> FormattableString.Invariant($"{Width:F2}x{Height:F2}");
 
 		public static bool operator ==(Size size1, Size size2) => size1.Equals(size2);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
@@ -7,6 +7,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Shapes;
 using System;
+using Windows.UI.Xaml.Media;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 {
@@ -120,13 +121,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		{
 			if (Window.Current.RootElement is Panel root)
 			{
-				var sut = new Grid();
+				var sut = new Grid { HorizontalAlignment = HorizontalAlignment.Stretch, VerticalAlignment = VerticalAlignment.Stretch };
 
 				var originalRootAvailableSize = LayoutInformation.GetAvailableSize(root);
 				var originalRootDesiredSize = LayoutInformation.GetDesiredSize(root);
 				var originalRootLayoutSlot = LayoutInformation.GetLayoutSlot(root);
 
-				Size availableSize, desiredSize;
+				Size availableSize;
 				Rect layoutSlot;
 				try
 				{
@@ -138,7 +139,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 					sut.UpdateLayout();
 
 					availableSize = LayoutInformation.GetAvailableSize(sut);
-					desiredSize = LayoutInformation.GetDesiredSize(sut);
 					layoutSlot = LayoutInformation.GetLayoutSlot(sut);
 				}
 				finally
@@ -152,8 +152,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				}
 
 				Assert.AreNotEqual(default, availableSize);
-#if !__IOS__ // Measure arrange are async on iOS!
-				Assert.AreNotEqual(default, desiredSize);
+#if !__IOS__ // Arrange is async on iOS!
 				Assert.AreNotEqual(default, layoutSlot);
 #endif
 			}

--- a/src/Uno.UI/Extensions/UIElementExtensions.cs
+++ b/src/Uno.UI/Extensions/UIElementExtensions.cs
@@ -14,10 +14,28 @@ namespace Uno.UI.Extensions
 		/// <summary>
 		/// Get a display name for the element for debug purposes
 		/// </summary>
-		internal static string GetDebugName(this UIElement? elt)
-			=> elt is null ? "--null--" : $"{(elt as FrameworkElement)?.Name ?? elt.GetType().Name}-{elt.GetHashCode():X8}";
+		internal static string GetDebugName(this object? elt)
+			=> elt switch
+			{
+				null => "--null--",
+				FrameworkElement fwElt when fwElt.Name.HasValue() => $"{fwElt.Name} -{elt.GetHashCode():X8}",
+				_ => $"{elt.GetType().Name} -{elt.GetHashCode():X8}",
+			};
 
-		internal static Thickness GetPadding(this UIElement uiElement)
+		internal static string GetDebugIdentifier(this object? elt)
+			=> $"{new string('\t', elt.GetDebugDepth())} [{elt.GetDebugName()}]";
+
+		internal static int GetDebugDepth(this object? elt) =>
+			elt switch
+			{
+				null => 0,
+#if NETSTANDARD
+				UIElement fwElt => fwElt.Depth,
+#endif
+				_ => elt.GetParent()?.GetDebugDepth() + 1?? 0,
+			};
+
+			internal static Thickness GetPadding(this UIElement uiElement)
 		{
 			if(uiElement is FrameworkElement fe && fe.TryGetPadding(out var padding))
 			{

--- a/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
@@ -533,22 +533,6 @@ namespace AppKit
 		}
 
 		/// <summary>
-		/// Gets an identifier that can be used for logging
-		/// </summary>
-		public static string GetDebugIdentifier(this _View element)
-		{
-			if (element == null)
-			{
-				return "--NULL--";
-			}
-
-			var name = (element as IFrameworkElement)?.Name;
-			return name.HasValue()
-				? element.GetType().Name + "_" + name + "_" + element.GetHashCode()
-				: element.GetType().Name + "_" + element.GetHashCode();
-		}
-
-		/// <summary>
 		/// Enumerates the children for the specified instance, either using _View.Subviews or using IShadowChildrenProvider.
 		/// </summary>
 		/// <param name="view"></param>

--- a/src/Uno.UI/Extensions/ViewExtensions.Android.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.Android.cs
@@ -552,22 +552,6 @@ namespace Uno.UI
 			return Disposable.Create(() => view.RunIfNativeInstanceAvailable(v => v.Click -= handler));
 		}
 
-		/// <summary>
-		/// Gets an identifier that can be used for logging
-		/// </summary>
-		public static string GetDebugIdentifier(this View element)
-		{
-			if (element == null)
-			{
-				return "--NULL--";
-			}
-
-			var name = (element as IFrameworkElement)?.Name;
-			return name.HasValue()
-				? element.GetType().Name + "_" + name + "_" + element.GetHashCode()
-				: element.GetType().Name + "_" + element.GetHashCode();
-		}
-
 		public static Task AnimateAsync(this View view, Animation animation)
 		{
 			var tcs = new TaskCompletionSource<object>();

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -1642,8 +1642,13 @@ namespace Microsoft.UI.Xaml.Controls
 								var menuItems = m_leftNavRepeater;
 								if (menuItems != null)
 								{
+#if __IOS__
+									var footersActualHeight = footerItemsRepeater.DesiredSize.Height;
+									var menuItemsActualHeight = menuItems.DesiredSize.Height;
+#else
 									var footersActualHeight = footerItemsRepeater.ActualHeight;
 									var menuItemsActualHeight = menuItems.ActualHeight;
+#endif
 									if (totalAvailableHeight > menuItemsActualHeight + footersActualHeight)
 									{
 										// We have enough space for two so let everyone get as much as they need.

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -1642,7 +1642,7 @@ namespace Microsoft.UI.Xaml.Controls
 								var menuItems = m_leftNavRepeater;
 								if (menuItems != null)
 								{
-#if __IOS__
+#if __IOS__ // Uno workaround: The arrange is async on iOS, ActualHeight is not set yet. This would constraints the footer to MaxHeight 0.
 									var footersActualHeight = footerItemsRepeater.DesiredSize.Height;
 									var menuItemsActualHeight = menuItems.DesiredSize.Height;
 #else

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Windows.Foundation;
 using Windows.UI.Xaml.Controls.Primitives;
 using Uno;
@@ -269,11 +270,18 @@ namespace Windows.UI.Xaml
 				: viewport;
 #endif
 
-		private void PropagateEffectiveViewportChange(bool isInitial = false)
+		private void PropagateEffectiveViewportChange(
+			bool isInitial = false
+#if TRACE_EFFECTIVE_VIEWPORT
+			, [CallerMemberName] string caller = null) {
+#else
+			)
 		{
+			const string caller = "--unavailable--";
+#endif
 			if (!IsEffectiveViewportEnabled)
 			{
-				TRACE_EFFECTIVE_VIEWPORT("Effective viewport disabled, stop propagation.");
+				TRACE_EFFECTIVE_VIEWPORT($"Effective viewport disabled, stop propagation (reason:{caller} | isInitial:{isInitial}).");
 				return;
 			}
 
@@ -294,6 +302,7 @@ namespace Windows.UI.Xaml
 #else
 				+ $"| scroll: {(IsScrollPort ? $"{ScrollOffsets.ToDebugString()}" : "--none--")} "
 #endif
+				+ $"| reason: {caller} "
 				+ $"| children: {_childrenInterestedInViewportUpdates}");
 
 			_lastEffectiveViewport = viewport;
@@ -339,7 +348,7 @@ namespace Windows.UI.Xaml
 		private void TRACE_EFFECTIVE_VIEWPORT(string text)
 		{
 #if TRACE_EFFECTIVE_VIEWPORT
-			Debug.Write($"{new string('\t', Math.Max(Depth, 0))} [{this.GetDebugName()}] {text}\r\n");
+			Debug.Write($"{this.GetDebugIdentifier()} {text}\r\n");
 #endif
 		}
 	}


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/4798

## Bugfix
1. [iOS] Children collection is out of sync while raising `child.Loaded` 
2. [iOS] `NavigationView` does not render footer elements

## What is the current behavior?
1. The `ChildrenShadow` collection is updated only after the child has been added, so we cannot walk the visual tree up and down.
2. The `NativationView` is using the `ActualHeight` of the `ItemsRepeater`s before they have been arranged

## What is the new behavior?
1. We manually pre-update the `ChildrenShadow` collection right before effective modification (we still re-clone it after).
2. The `NativationView` is using the `DesireSize` to apply constraints

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
