### PR TITLE
[Wasm] Padding were not part of the key used for the measurement caching

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -396,5 +396,39 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 				$"Actual Number of lines:{actualNumberOfLines}. \n" +
 				$"Line height: {lineHeight}. \n");
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]
+		public void When_Padding_Is_Changed_Then_Cache_Is_Missed()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_MeasureCache");
+
+			_app.Marked("text").SetDependencyPropertyValue("Padding", "40");
+
+			_app.WaitForElement("text");
+
+			var w1 = _app.GetLogicalRect("textBorder").Width;
+			var misses1 = _app.Marked("misses").GetDependencyPropertyValue<int>("Text");
+
+			_app.Marked("text").SetDependencyPropertyValue("Padding", "10");
+
+			_app.WaitForElement("text");
+
+			var w2 = _app.GetLogicalRect("textBorder").Width;
+			var misses2 = _app.Marked("misses").GetDependencyPropertyValue<int>("Text");
+
+			_app.Marked("text").SetDependencyPropertyValue("Padding", "40");
+
+			_app.WaitForElement("text");
+
+			var w3 = _app.GetLogicalRect("textBorder").Width;
+			var misses3 = _app.Marked("misses").GetDependencyPropertyValue<int>("Text");
+
+			using var _ = new AssertionScope();
+
+			w1.Should().BeGreaterThan(w2);
+			w3.Should().Be(w1);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1373,6 +1373,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_MeasureCache.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextWrapping_PR1954_EdgeCase.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4672,6 +4676,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_MultipleControls.xaml.cs">
       <DependentUpon>TextBlock_LineHeight_MultipleControls.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_MeasureCache.xaml.cs">
+      <DependentUpon>TextBlock_MeasureCache.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextWrapping_PR1954_EdgeCase.xaml.cs">
       <DependentUpon>TextBlock_TextWrapping_PR1954_EdgeCase.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasureCache.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasureCache.xaml
@@ -1,0 +1,67 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_MeasureCache"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:wasm="http://uno.ui/wasm"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d wasm"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="6">
+		<TextBlock>This test only works on WASM.</TextBlock>
+		<TextBox x:Name="input" Header="Text" />
+		<ComboBox
+			x:Name="padding"
+			Header="Padding">
+			<ComboBoxItem>0</ComboBoxItem>
+			<ComboBoxItem IsSelected="True">10</ComboBoxItem>
+			<ComboBoxItem>20</ComboBoxItem>
+		</ComboBox>
+		<ComboBox
+			x:Name="fontSize"
+			Header="Font Size">
+			<ComboBoxItem>10</ComboBoxItem>
+			<ComboBoxItem IsSelected="True">20</ComboBoxItem>
+			<ComboBoxItem>30</ComboBoxItem>
+		</ComboBox>
+		<ComboBox
+			x:Name="fontWeight"
+			Header="Font Weight">
+			<ComboBoxItem>ExtraLight</ComboBoxItem>
+			<ComboBoxItem IsSelected="True">Normal</ComboBoxItem>
+			<ComboBoxItem>ExtraBold</ComboBoxItem>
+		</ComboBox>
+		<ComboBox
+			x:Name="characterSpacing"
+			Header="Character Spacing">
+			<ComboBoxItem IsSelected="True">0</ComboBoxItem>
+			<ComboBoxItem>20</ComboBoxItem>
+			<ComboBoxItem>50</ComboBoxItem>
+		</ComboBox>
+		<ComboBox
+			x:Name="style"
+			Header="Style">
+			<ComboBoxItem IsSelected="True">Normal</ComboBoxItem>
+			<ComboBoxItem>Oblique</ComboBoxItem>
+			<ComboBoxItem>Italic</ComboBoxItem>
+		</ComboBox>
+		<Border Background="LightPink" x:Name="textBorder" HorizontalAlignment="Center">
+			<TextBlock
+				x:Name="text"
+				Text="{Binding Text, ElementName=input}"
+				Padding="{Binding SelectedItem.Content, ElementName=padding}"
+				FontSize="{Binding SelectedItem.Content, ElementName=fontSize}"
+				FontWeight="Binding SelectedItem.Content, ElementName=fontWeight}"
+				CharacterSpacing="{Binding SelectedItem.Content, ElementName=characterSpacing}"
+				FontStyle="{Binding SelectedItem.Content, ElementName=style}"
+			/>
+		</Border>
+		<wasm:TextBlock>
+			<!-- Since this text is complex, it shouldn't influence the caching metrics -->
+			(WASM ONLY) Cache: Hits=<Run x:Name="hits">0</Run>, Misses=<Run x:Name="misses">0</Run>.<LineBreak />
+			Size=<Run x:Name="width" />x<Run x:Name="height" />
+		</wasm:TextBlock>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasureCache.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasureCache.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+using Uno.UI;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[Sample]
+	public sealed partial class TextBlock_MeasureCache : Page
+	{
+		public TextBlock_MeasureCache()
+		{
+			this.InitializeComponent();
+
+#if __WASM__
+			long? initialHits = default;
+			long? initialMisses = default;
+
+			textBorder.SizeChanged += (sender, e) => { UpdateCacheMetrics(); };
+			padding.SelectionChanged += (sender, e) => { UpdateCacheMetrics(); };
+			fontSize.SelectionChanged += (sender, e) => { UpdateCacheMetrics(); };
+			fontWeight.SelectionChanged += (sender, e) => { UpdateCacheMetrics(); };
+			characterSpacing.SelectionChanged += (sender, e) => { UpdateCacheMetrics(); };
+			style.SelectionChanged += (sender, e) => { UpdateCacheMetrics(); };
+
+			async void UpdateCacheMetrics()
+			{
+				if (initialHits == null)
+				{
+					initialHits = UnoMetrics.TextBlock.MeasureCacheHits;
+					initialMisses = UnoMetrics.TextBlock.MeasureCacheMisses;
+					input.Text = "Uno is awesome.";
+				}
+				await Task.Delay(10); // give time to UI to update
+				width.Text = textBorder.ActualWidth.ToString("F2");
+				height.Text = textBorder.ActualHeight.ToString("F2");
+				hits.Text = (UnoMetrics.TextBlock.MeasureCacheHits - initialHits).ToString();
+				misses.Text = (UnoMetrics.TextBlock.MeasureCacheMisses - initialMisses).ToString();
+			}
+
+			UpdateCacheMetrics();
+#endif
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
@@ -31,6 +31,7 @@ namespace Windows.UI.Xaml.Controls
 						&& x._textTrimming == y._textTrimming
 						&& x._textAlignment == y._textAlignment
 						&& Math.Abs(x._lineHeight - y._lineHeight) < 0.1e-8
+						&& x._padding == y._padding
 						&& x._lineStackingStrategy == y._lineStackingStrategy
 						&& x._textDecorations == y._textDecorations
 						&& x._characterSpacing == y._characterSpacing;
@@ -58,6 +59,7 @@ namespace Windows.UI.Xaml.Controls
 				_textTrimming = source.TextTrimming;
 				_textAlignment = source.TextAlignment;
 				_lineHeight = source.LineHeight;
+				_padding = source.Padding;
 				_lineStackingStrategy = source.LineStackingStrategy;
 				_characterSpacing = source.CharacterSpacing;
 				_textDecorations = source.TextDecorations;
@@ -82,6 +84,7 @@ namespace Windows.UI.Xaml.Controls
 			private readonly TextTrimming _textTrimming;
 			private readonly TextAlignment _textAlignment;
 			private readonly double _lineHeight;
+			private readonly Thickness _padding;
 			private readonly LineStackingStrategy _lineStackingStrategy;
 			private readonly int _characterSpacing;
 			private readonly TextDecorations _textDecorations;


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/4945
# Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
