### PR TITLE
fix: Selection state not visible in NavigationView

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Control.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Control.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_Control
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_SetChildTemplateUsingVisualState()
+		{
+			var parent = (Button)XamlReader.Load(_when_SetChildTemplateUsingVisualState);
+			TestServices.WindowHelper.WindowContent = parent;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var tb = parent.FindFirstChild<TextBlock>();
+
+			Assert.IsNotNull(tb);
+			Assert.AreEqual("Template loaded!", tb.Text);
+		}
+
+		private const string _when_SetChildTemplateUsingVisualState = @"
+	<Button xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+		<Button.Template>
+			<ControlTemplate TargetType=""ContentControl"">
+				<Grid>
+					<VisualStateManager.VisualStateGroups>
+						<VisualStateGroup x:Name=""CommonStates"">
+							<VisualState x:Name=""Normal"">
+								<VisualState.Setters>
+									<Setter  Target=""_sut.Template"">
+										<Setter.Value>
+											<ControlTemplate TargetType=""ContentControl"">
+												<TextBlock Text=""Template loaded!"" />
+											</ControlTemplate>
+										</Setter.Value>
+									</Setter>
+								</VisualState.Setters>
+							</VisualState>
+						</VisualStateGroup>
+					</VisualStateManager.VisualStateGroups>
+
+					<ContentControl x:Name=""_sut"" />
+				</Grid>
+			</ControlTemplate>
+		</Button.Template>
+	</Button>";
+
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Control.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Control.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Uno.UI.Extensions;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -157,9 +157,21 @@ namespace Windows.UI.Xaml.Controls
 					{
 						RegisterContentTemplateRoot();
 
-						if (!IsLoaded && FeatureConfiguration.Control.UseDeferredOnApplyTemplate)
+						if (!IsLoading && !IsLoaded && FeatureConfiguration.Control.UseDeferredOnApplyTemplate)
 						{
 							// It's too soon the call the ".OnApplyTemplate" method: it should be invoked after the "Loading" event.
+
+							// Note: we however still allow if already 'IsLoading':
+							//
+							// If this child is added to its parent while this parent is 'IsLoading' itself (eg. loading its template),
+							// the parent will invoke the Loading on this child element (and the PostLoading which will "dequeue" the _applyTemplateShouldBeInvoked),
+							// which will set the 'IsLoading' flag.
+							//
+							// The parent will then apply its own style, which might set/change the template of this element (if data-bound or set using VisualState),
+							// which would end here and set this _applyTemplateShouldBeInvoked flag (if IsLoaded were not allowed!).
+							//
+							// The parent will then invoke the Loading on all its children, but as this child has already been flagged as 'IsLoading',
+							// it will be ignored and the 'PostLoading' won't be invokes a second time, driving the control to never "dequeue" the _applyTemplateShouldBeInvoked.
 							_applyTemplateShouldBeInvoked = true;
 						}
 						else

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -157,7 +157,11 @@ namespace Windows.UI.Xaml.Controls
 					{
 						RegisterContentTemplateRoot();
 
-						if (!IsLoading && !IsLoaded && FeatureConfiguration.Control.UseDeferredOnApplyTemplate)
+						if (
+#if NETSTANDARD
+							!IsLoading &&
+#endif
+							!IsLoaded && FeatureConfiguration.Control.UseDeferredOnApplyTemplate)
 						{
 							// It's too soon the call the ".OnApplyTemplate" method: it should be invoked after the "Loading" event.
 


### PR DESCRIPTION
GitHub Issues:
fixes https://github.com/unoplatform/uno/issues/4786
fixes https://github.com/unoplatform/uno/issues/4739

## Bugfix
The selected item is not visible.

## What is the current behavior?
As the template of the `NavigationViewItemPresenter` is dynamically set by a `VisualState` of its parent `NavigationView`, it's  set while the presenter is already flagged as `IsLoading` driving the template to never be applied (i.e. `OnApplyTemplate`).

## What is the new behavior?
When the `Template` is set on a `Control` flagged as `IsLoading`, it's applied synchronously.


## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
