### PR TITLE
[iOS] Fixed a clipping bug with RenderTransform, mostly affecting <ViewBox>

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
@@ -161,6 +161,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Android)]
 		public void When_TextBlock_Centred_Native_Frame()
 		{
 			Run("UITests.Windows_UI_Xaml_Controls.CommandBar.CommandBar_Native_Frame");
@@ -175,7 +176,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 			_app.FastTap("NavigateBackButton");
 
 			_app.WaitForElement("CommandBarTitleText");
-			var rect = _app.GetRect("CommandBarTitleText");
+			var rect = _app.GetLogicalRect("CommandBarTitleText");
 
 			Assert.Greater(rect.Height, 1);
 		}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
@@ -23,8 +23,15 @@
 			<StackPanel Orientation="Horizontal">
 				<Button
 					x:Name="runButton"
-					Content="Run"
+					not_skia:Content="▶️ Run"
+					skia:Content="Run"
 					Click="OnRunTests" />
+				<Button
+					x:Name="stopButton"
+					IsEnabled="False"
+					not_skia:Content="⏹️ Stop"
+					skia:Content="Stop"
+					Click="OnStopTests" />
 				<TextBox x:Name="testFilter" PlaceholderText="Enter test filter here" Width="140" />
 			</StackPanel>
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1557,6 +1557,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ViewBoxTests\Viewbox_Behavior.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewControl_JavaScript_Alert_Confirm_Prompt.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4869,6 +4873,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ViewBoxTests\ViewBox_Alignment.xaml.cs">
       <DependentUpon>ViewBox_Alignment.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ViewBoxTests\Viewbox_Behavior.xaml.cs">
+      <DependentUpon>Viewbox_Behavior.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewObserverBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewSampleBehavior.cs" />

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -781,6 +781,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Transform_And_Clipping.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_AdaptiveTrigger_Storyboard.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4355,6 +4359,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Native_Child.xaml.cs">
       <DependentUpon>UIElement_Native_Child.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Transform_And_Clipping.xaml.cs">
+      <DependentUpon>UIElement_Transform_And_Clipping.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_AdaptiveTrigger_UsingOneStateOnly.xaml.cs">
       <DependentUpon>VisualState_AdaptiveTrigger_UsingOneStateOnly.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Transform_And_Clipping.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Transform_And_Clipping.xaml
@@ -1,0 +1,29 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml.UIElementTests.UIElement_Transform_And_Clipping"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml.UIElementTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Background="Gray" HorizontalAlignment="Center" VeticalAlignment="Center">
+		<Border Background="Blue" Width="200" Height="200">
+			<Border.Clip>
+				<RectangleGeometry Rect="25 25 150 150"/>
+			</Border.Clip>
+			<Border.RenderTransform>
+				<TranslateTransform X="120" />
+			</Border.RenderTransform>
+		</Border>
+		<Border Background="Red" Width="200" Height="200" Opacity="0.5">
+			<Border.Clip>
+				<RectangleGeometry Rect="25 25 150 150"/>
+			</Border.Clip>
+			<Border.RenderTransform>
+				<ScaleTransform ScaleX="2" ScaleY="2" CenterX="100" CenterY="100" />
+			</Border.RenderTransform>
+		</Border>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Transform_And_Clipping.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Transform_And_Clipping.xaml
@@ -8,7 +8,7 @@
 	mc:Ignorable="d"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<Grid Background="Gray" HorizontalAlignment="Center" VeticalAlignment="Center">
+	<Grid Background="Gray" HorizontalAlignment="Center" VerticalAlignment="Center">
 		<Border Background="Blue" Width="200" Height="200">
 			<Border.Clip>
 				<RectangleGeometry Rect="25 25 150 150"/>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Transform_And_Clipping.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Transform_And_Clipping.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml.UIElementTests
+{
+	[Sample("UIElement", "Clipping")]
+	public sealed partial class UIElement_Transform_And_Clipping : Page
+	{
+		public UIElement_Transform_And_Clipping()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ViewBoxTests/ViewBox_Alignment.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ViewBoxTests/ViewBox_Alignment.xaml.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Linq;
-using Windows.UI.Xaml.Controls;
+﻿using Windows.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.ViewBoxTests
 {
-	[SampleControlInfo("ViewBox")]
+	[Sample("Viewbox")]
 	public sealed partial class ViewBox_Alignment : Page
 	{
 		public ViewBox_Alignment()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ViewBoxTests/ViewBox_Dynamic.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ViewBoxTests/ViewBox_Dynamic.xaml.cs
@@ -5,10 +5,7 @@ using Windows.UI.Xaml.Media;
 
 namespace Uno.UI.Samples.Content.UITests.ViewBoxTests
 {
-	/// <summary>
-	/// An empty page that can be used on its own or navigated to within a Frame.
-	/// </summary>
-	[SampleControlInfo("ViewBox", nameof(ViewBox_Dynamic))]
+	[Sample("Viewbox")]
 	public sealed partial class ViewBox_Dynamic : UserControl
 	{
         public ViewBox_Dynamic()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ViewBoxTests/Viewbox_Behavior.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ViewBoxTests/Viewbox_Behavior.xaml
@@ -1,0 +1,46 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.ViewBoxTests.Viewbox_Behavior"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ViewBoxTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<StackPanel Grid.ColumnSpan="2" Spacing="4">
+			<Slider x:Name="outer" Minimum="50" Maximum="450" Value="100" Header="outer" />
+			<Slider x:Name="inner" Minimum="50" Maximum="450" Value="100" Header="inner" />
+		</StackPanel>
+
+		<Border Grid.Row="1" Grid.Column="0" Width="{Binding Value, ElementName=outer}" Height="{Binding Value, ElementName=outer}" BorderBrush="Blue" BorderThickness="2">
+			<Viewbox>
+				<Rectangle Width="{Binding Value, ElementName=inner}" Height="{Binding Value, ElementName=inner}" Fill="Red" Stroke="Orange" StrokeThickness="20" />
+			</Viewbox>
+		</Border>
+
+		<Border Grid.Row="1" Grid.Column="1" Width="{Binding Value, ElementName=outer}" Height="100" BorderBrush="Blue" BorderThickness="2">
+			<Viewbox>
+				<Rectangle Width="{Binding Value, ElementName=inner}" Height="100" Fill="Red" Stroke="Orange" StrokeThickness="20" />
+			</Viewbox>
+		</Border>
+
+		<Border Grid.Row="2" Grid.Column="0" Width="100" Height="{Binding Value, ElementName=outer}" BorderBrush="Blue" BorderThickness="2">
+			<Viewbox>
+				<Rectangle Width="100" Height="{Binding Value, ElementName=inner}" Fill="Red" Stroke="Orange" StrokeThickness="20" />
+			</Viewbox>
+		</Border>
+
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ViewBoxTests/Viewbox_Behavior.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ViewBoxTests/Viewbox_Behavior.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.ViewBoxTests
+{
+	[Sample("Viewbox")]
+	public sealed partial class Viewbox_Behavior : Page
+	{
+		public Viewbox_Behavior()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -107,8 +107,14 @@ namespace Windows.Foundation
 			}
 
 			var parts = text
-				.Split(new[] { ',' })
+				.Split(new[] { ',', ' ' })
 				.SelectToArray(s => double.Parse(s, NumberFormatInfo.InvariantInfo));
+
+			if(parts.Length != 4)
+			{
+				throw new ArgumentException(
+					"Cannot create a Rect from " + text + ": needs 4 parts separated by a comma or a space.");
+			}
 
 			return new Rect
 			(

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -107,7 +107,7 @@ namespace Windows.Foundation
 			}
 
 			var parts = text
-				.Split(new[] { ',', ' ' })
+				.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
 				.SelectToArray(s => double.Parse(s, NumberFormatInfo.InvariantInfo));
 
 			if(parts.Length != 4)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -21,6 +21,9 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using static Private.Infrastructure.TestServices;
 using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Xaml.Media;
+using FluentAssertions;
 using FluentAssertions.Execution;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
@@ -92,13 +95,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 #if HAS_UNO
+			SUT.MaterializedContainers.Should().HaveCount(2);
+
 			var containerIndices = SUT.MaterializedContainers
 				.Select(container => container.GetValue(ItemsControl.IndexForItemContainerProperty))
 				.OfType<int>()
 				.OrderBy(index => index)
 				.ToArray();
 
-			CollectionAssert.AreEqual(new int[] { 0, 1 }, containerIndices);
+			containerIndices.Should().Equal(0, 1);
 #endif
 
 			var container0 = SUT.ContainerFromIndex(0);
@@ -639,14 +644,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitFor(() => (lastItem = list.ContainerFromItem(19) as ListViewItem) != null);
 			var secondLastItem = list.ContainerFromItem(18) as ListViewItem;
 
-			await WindowHelper.WaitFor(() => ApproxEquals(181, GetTop(lastItem)), message: $"Expected 181 but got {GetTop(lastItem)}");
-			await WindowHelper.WaitFor(() => ApproxEquals(152, GetTop(secondLastItem)), message: $"Expected 152 but got {GetTop(secondLastItem)}");
+			await WindowHelper.WaitFor(() => GetTop(lastItem), 181, comparer: ApproxEquals);
+			await WindowHelper.WaitFor(() => GetTop(secondLastItem), 152, comparer: ApproxEquals);
 
 			source.Remove(19);
 
 			await WindowHelper.WaitFor(() => list.Items.Count == 19);
 
-			await WindowHelper.WaitFor(() => ApproxEquals(181, GetTop(secondLastItem)), message: $"Expected 181 but got {GetTop(secondLastItem)}");
+			await WindowHelper.WaitFor(() => GetTop(secondLastItem), 181, comparer: ApproxEquals);
 
 			double GetTop(FrameworkElement element)
 			{

--- a/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
@@ -15,7 +15,7 @@ using Uno.Logging;
 using Windows.UI.Core;
 using Uno.UI.Controls;
 using Windows.UI.Xaml.Controls;
-
+using Windows.UI.Xaml.Media;
 #if XAMARIN_IOS_UNIFIED
 using Foundation;
 using UIKit;
@@ -618,13 +618,26 @@ namespace AppKit
 				var uiElement = innerView as UIElement;
 				var desiredSize = uiElement?.DesiredSize.ToString() ?? "<native/unk>";
 				var fe = innerView as IFrameworkElement;
+				var transforms = GetTransforms(uiElement?.RenderTransform);
+
+				string GetTransforms(Transform transform)
+				{
+					return transform switch
+					{
+						TransformGroup group => $"Grp({@group.Children.Select(GetTransforms)})",
+						ScaleTransform scale => $"Scale({scale.ScaleX}, {scale.ScaleY} @{scale.CenterX},{scale.CenterY})",
+						MatrixTransform matrix => $"Matrix({matrix.Matrix.M11}, {matrix.Matrix.M12}, {matrix.Matrix.M21}, {matrix.Matrix.M22})",
+						TranslateTransform translate => $"Translate({translate.X}, {translate.Y})",
+						_ => ""
+					};
+				}
 
 				return sb
 						.Append(spacing)
 						.Append(innerView == viewOfInterest ? "*>" : ">")
 						.Append(innerView.ToString() + namePart)
 						.Append($"-({innerView.Frame.Width}x{innerView.Frame.Height})@({innerView.Frame.X},{innerView.Frame.Y})")
-						.Append($" d:{desiredSize}")
+						.Append($" ds:{desiredSize}")
 #if __IOS__
 						.Append($" {(innerView.Hidden ? "Hidden" : "Visible")}")
 #endif
@@ -635,9 +648,11 @@ namespace AppKit
 						.Append(fe != null && fe.TryGetPadding(out var p) && p != default ? $" Padding={p}" : "")
 						.Append(fe != null && fe.TryGetCornerRadius(out var cr) && cr != default ? $" CornerRadius={cr.ToStringCompact()}" : "")
 						.Append(uiElement?.Clip != null ? $" Clip={uiElement.Clip.Rect}" : "")
-						.Append(uiElement != null ? $" DesiredSize={uiElement.DesiredSize}, AvailableSize={uiElement.LastAvailableSize}" : "")
+						.Append(uiElement != null ? $" AvailableSize={uiElement.LastAvailableSize}" : "")
 						.Append(uiElement?.NeedsClipToSlot ?? false ? " CLIPPED_TO_SLOT" : "")
-						.Append(innerView is TextBlock textBlock ? $" Text=\"{textBlock.Text}\"" : "")
+						.Append(innerView is TextBlock textBlock ? $" Text=\"{textBlock.Text}\" - {textBlock.FontFamily}/{textBlock.FontSize}" : "")
+						.Append(innerView is Viewbox viewBox ? $" Scale={viewBox.scaleX}x{viewBox.scaleY} - Stretch={viewBox.Stretch}/{viewBox.StretchDirection}" : "")
+						.Append(" " + transforms)
 						.AppendLine();
 			}
 		}

--- a/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
@@ -651,7 +651,7 @@ namespace AppKit
 						.Append(uiElement != null ? $" AvailableSize={uiElement.LastAvailableSize}" : "")
 						.Append(uiElement?.NeedsClipToSlot ?? false ? " CLIPPED_TO_SLOT" : "")
 						.Append(innerView is TextBlock textBlock ? $" Text=\"{textBlock.Text}\" - {textBlock.FontFamily}/{textBlock.FontSize}" : "")
-						.Append(innerView is Viewbox viewBox ? $" Scale={viewBox.scaleX}x{viewBox.scaleY} - Stretch={viewBox.Stretch}/{viewBox.StretchDirection}" : "")
+						.Append(innerView is Viewbox viewBox ? $" Stretch={viewBox.Stretch}/{viewBox.StretchDirection}" : "")
 						.Append(" " + transforms)
 						.AppendLine();
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ViewBox/Viewbox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ViewBox/Viewbox.cs
@@ -18,6 +18,8 @@ namespace Windows.UI.Xaml.Controls
 	public partial class Viewbox : global::Windows.UI.Xaml.FrameworkElement
 	{
 		private readonly Border _container;
+		internal double scaleX { get; private set; }
+		internal double scaleY { get; private set; }
 
 		public Viewbox()
 		{
@@ -45,7 +47,7 @@ namespace Windows.UI.Xaml.Controls
 				)
 			);
 
-			var (scaleX, scaleY) = GetScale(availableSize, measuredSize);
+			(scaleX, scaleY) = GetScale(availableSize, measuredSize);
 
 			return new Size(
 				Math.Min(availableSize.Width, measuredSize.Width * scaleX),
@@ -55,13 +57,26 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override Size ArrangeOverride(Size finalSize)
 		{
+			if(finalSize.Width == 0 || finalSize.Height == 0)
+			{
+				return default;
+			}
+
 			var (scaleX, scaleY) = GetScale(finalSize, _container.DesiredSize);
 
-			_container.RenderTransform = new ScaleTransform()
+			if (Math.Abs(scaleX - 1d) < 0.001d && Math.Abs(scaleY - 1d) < 0.001d)
 			{
-				ScaleX = scaleX,
-				ScaleY = scaleY
-			};
+				_container.RenderTransform = null;
+			}
+			else
+			{
+				var transform = _container.RenderTransform as ScaleTransform ?? new ScaleTransform();
+				transform.ScaleX = scaleX;
+				transform.ScaleY = scaleY;
+				transform.CenterX = finalSize.Width / 2d;
+				transform.CenterY = finalSize.Height / 2d;
+				_container.RenderTransform = transform;
+			}
 
 			base.ArrangeElement(_container, new Rect(new Point(), _container.DesiredSize));
 

--- a/src/Uno.UI/UI/Xaml/Controls/ViewBox/Viewbox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ViewBox/Viewbox.cs
@@ -17,9 +17,9 @@ namespace Windows.UI.Xaml.Controls
 	[ContentProperty(Name = "Child")]
 	public partial class Viewbox : global::Windows.UI.Xaml.FrameworkElement
 	{
+		private const double SCALE_EPSILON = 0.00001d;
+
 		private readonly Border _container;
-		internal double scaleX { get; private set; }
-		internal double scaleY { get; private set; }
 
 		public Viewbox()
 		{
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Controls
 				)
 			);
 
-			(scaleX, scaleY) = GetScale(availableSize, measuredSize);
+			var (scaleX, scaleY) = GetScale(availableSize, measuredSize);
 
 			return new Size(
 				Math.Min(availableSize.Width, measuredSize.Width * scaleX),
@@ -64,7 +64,7 @@ namespace Windows.UI.Xaml.Controls
 
 			var (scaleX, scaleY) = GetScale(finalSize, _container.DesiredSize);
 
-			if (Math.Abs(scaleX - 1d) < 0.001d && Math.Abs(scaleY - 1d) < 0.001d)
+			if (Math.Abs(scaleX - 1d) < SCALE_EPSILON && Math.Abs(scaleY - 1d) < SCALE_EPSILON)
 			{
 				_container.RenderTransform = null;
 			}
@@ -73,8 +73,6 @@ namespace Windows.UI.Xaml.Controls
 				var transform = _container.RenderTransform as ScaleTransform ?? new ScaleTransform();
 				transform.ScaleX = scaleX;
 				transform.ScaleY = scaleY;
-				transform.CenterX = finalSize.Width / 2d;
-				transform.CenterY = finalSize.Height / 2d;
 				_container.RenderTransform = transform;
 			}
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml
 
 					OnBeforeArrange();
 
-					var finalRect = RectFromUIRect(Bounds);
+					var finalRect = Parent is UIElement ? LayoutSlotWithMarginsAndAlignments : RectFromUIRect(Frame);
 
 					_layouter.Arrange(finalRect);
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -49,7 +49,8 @@ namespace Windows.UI.Xaml
 
 					OnBeforeArrange();
 
-					var finalRect = RectFromUIRect(Frame);
+					var finalRect = RectFromUIRect(Bounds);
+
 					_layouter.Arrange(finalRect);
 
 					OnAfterArrange();


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/4918
Fixes https://github.com/unoplatform/uno/issues/4976

# Bugfix
On iOS, the wrong coordinates were used to provide the `availableSize` for the _arrange_ phase. The correct iOS value to use is `.Bounds`, but `.Frame` were used.

`<ViewBox>` were the most affected control because it was often triggering a clipping with wrong measurements on the content control.

Another related fix is to disable clipping on controls when transforms are used.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
