### PR TITLE
 fix(imagesource): Fix the SetSource[Async] must clone the provided stream before returning

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -57,6 +57,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 			Assert.IsTrue(success);
 		}
 
+#if !WINDOWS_UWP
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_SetSource_Stream_Then_StreamClonedSynchronously()
@@ -96,6 +97,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 
 			Assert.IsTrue(success);
 		}
+#endif
 
 		private class Given_BitmapSource_Exception : Exception
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+using Windows.UI.Xaml.Media.Imaging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
+{
+	[TestClass]
+	public class Given_BitmapSource
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_SetSource_Then_StreamClonedSynchronously()
+		{
+			var sut = new BitmapImage();
+			var stream = new Given_BitmapSource_Stream();
+			var raStream = stream.AsRandomAccessStream();
+
+			var success = false;
+			try
+			{
+				sut.SetSource(raStream);
+			}
+			catch (Given_BitmapSource_Exception ex) when (ex.Caller is nameof(Given_BitmapSource_Stream.Read))
+			{
+				success = true;
+			}
+
+			Assert.IsTrue(success);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_SetSourceAsync_Then_StreamClonedSynchronously()
+		{
+			var sut = new BitmapImage();
+			var stream = new Given_BitmapSource_Stream();
+			var raStream = stream.AsRandomAccessStream();
+
+			var success = false;
+			try
+			{
+				sut.SetSourceAsync(raStream);
+			}
+			catch (Given_BitmapSource_Exception ex) when (ex.Caller is nameof(Given_BitmapSource_Stream.Read))
+			{
+				success = true;
+			}
+
+			Assert.IsTrue(success);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_SetSource_Stream_Then_StreamClonedSynchronously()
+		{
+			var sut = new BitmapImage();
+			var stream = new Given_BitmapSource_Stream();
+
+			var success = false;
+			try
+			{
+				sut.SetSource(stream);
+			}
+			catch (Given_BitmapSource_Exception ex) when (ex.Caller is nameof(Given_BitmapSource_Stream.Read))
+			{
+				success = true;
+			}
+
+			Assert.IsTrue(success);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_SetSourceAsync_Stream_Then_StreamClonedSynchronously()
+		{
+			var sut = new BitmapImage();
+			var stream = new Given_BitmapSource_Stream();
+
+			var success = false;
+			try
+			{
+				sut.SetSourceAsync(stream); // Note: We do not await the task here. It has to fail within the method itself!
+			}
+			catch (Given_BitmapSource_Exception ex) when (ex.Caller is nameof(Given_BitmapSource_Stream.Read))
+			{
+				success = true;
+			}
+
+			Assert.IsTrue(success);
+		}
+
+		private class Given_BitmapSource_Exception : Exception
+		{
+			public string Caller { get; }
+
+			public Given_BitmapSource_Exception([CallerMemberName] string caller = null)
+			{
+				Caller = caller;
+			}
+		}
+
+		public class Given_BitmapSource_Stream : Stream
+		{
+			public override void Flush() => throw new Given_BitmapSource_Exception();
+			public override int Read(byte[] buffer, int offset, int count) => throw new Given_BitmapSource_Exception();
+			public override long Seek(long offset, SeekOrigin origin) => throw new Given_BitmapSource_Exception();
+			public override void SetLength(long value) => throw new Given_BitmapSource_Exception();
+			public override void Write(byte[] buffer, int offset, int count) => throw new Given_BitmapSource_Exception();
+
+			public override bool CanRead { get; } = true;
+			public override bool CanSeek { get; } = true;
+			public override bool CanWrite { get; } = false;
+			public override long Length { get; } = 1024;
+			public override long Position { get; set; } = 0;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.skia.cs
@@ -36,16 +36,14 @@ namespace Windows.UI.Xaml.Media.Imaging
 					{
 						var client = new HttpClient();
 						var response = await client.GetAsync(UriSource, HttpCompletionOption.ResponseContentRead, ct);
-
 						var imageStream = await response.Content.ReadAsStreamAsync();
+
 						return OpenFromStream(targetWidth, targetHeight, surface, imageStream);
 					}
 					else if (UriSource.Scheme == "ms-appx")
 					{
 						var path = UriSource.PathAndQuery;
-
 						var filePath = GetScaledPath(path);
-
 						using var fileStream = File.OpenRead(filePath);
 
 						return OpenFromStream(targetWidth, targetHeight, surface, fileStream);

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.wasm.cs
@@ -28,11 +28,6 @@ namespace Windows.UI.Xaml.Media.Imaging
 			int? targetHeight,
 			out Task<ImageData> asyncImage)
 		{
-			return OpenSourceAsyncInner(ct, out asyncImage);
-		}
-
-		internal bool OpenSourceAsyncInner(CancellationToken ct, out Task<ImageData> asyncImage)
-		{
 			if (WebUri is {} uri)
 			{
 				var hasFileScheme = uri.IsAbsoluteUri && uri.Scheme == "file";
@@ -48,7 +43,8 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 				return true;
 			}
-			if (_stream is { } stream)
+
+			if (_stream is {} stream)
 			{
 				void OnProgress(ulong position, ulong? length)
 				{
@@ -65,8 +61,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 				return true;
 			}
-
-
+			
 			asyncImage = default;
 			return false;
 		}


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/4878

## Bugfix
Make sure to always clone the source stream before completing the `BitmapSource.SetSource[Async]` method.

## What is the current behavior?
It might be clone asynchronously, especially when using the `SetSourceAsync` (clone was dispatch on next dispatcher loop).

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
