### PR TITLE
feat: Allow get TargetObject and TargetProperty in Custom MarkupExtension

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2689,7 +2689,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							}
 							else
 							{
-								BuildCustomMarkupExtensionPropertyValue(writer, member, closureName + ".");
+								BuildCustomMarkupExtensionPropertyValue(writer, member, closureName , ".");
 							}
 						}
 						else if (member.Objects.Any())
@@ -2989,16 +2989,15 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 
 			// Local function used to build a property/value for any custom MarkupExtensions
-			void BuildCustomMarkupExtensionPropertyValue(IIndentedStringBuilder writer, XamlMemberDefinition member, string prefix)
+			void BuildCustomMarkupExtensionPropertyValue(IIndentedStringBuilder writer, XamlMemberDefinition member, string prefix, string memberSeparator)
 			{
-				Func<string, string> formatLine = format => prefix + format + (prefix.HasValue() ? ";\r\n" : "");
+				Func<string, string> formatLine = format => prefix + memberSeparator + format + (prefix.HasValue() ? ";\r\n" : "");
 
-				var propertyValue = GetCustomMarkupExtensionValue(member);
+				var propertyValue = GetCustomMarkupExtensionValue(writer, member, prefix);
 
 				if (propertyValue.HasValue())
 				{
 					var formatted = formatLine($"{member.Member.Name} = {propertyValue}");
-
 					writer.AppendLine(formatted);
 				}
 			}
@@ -3202,7 +3201,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			TryAnnotateWithGeneratorSource(writer);
 			var literalValue = isCustomMarkupExtension
-					? GetCustomMarkupExtensionValue(member)
+					? GetCustomMarkupExtensionValue(writer, member, closureName)
 					: BuildLiteralValue(member, propertyType: propertyType, owner: member, objectUid: objectUid);
 
 			writer.AppendLineInvariant(
@@ -3273,7 +3272,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					return bindingNode
 						.Members
-						.Select(BuildMemberPropertyValue)
+						.Select(m => BuildMemberPropertyValue(writer, m, closureName, member))
 						.JoinBy(", ");
 
 				}
@@ -3282,7 +3281,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					return bindNode
 						.Members
 						.Where(m => m.Member.Name != "_PositionalParameters" && m.Member.Name != "Path" && m.Member.Name != "BindBack")
-						.Select(BuildMemberPropertyValue)
+						.Select(m => BuildMemberPropertyValue(writer, m, closureName, member))
 						.Concat(bindNode.Members.Any(m => m.Member.Name == "Mode") ? "" : "Mode = BindingMode." + GetDefaultBindMode())
 						.JoinBy(", ");
 
@@ -3291,7 +3290,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					return templateBindingNode
 						.Members
-						.Select(BuildMemberPropertyValue)
+						.Select(m => BuildMemberPropertyValue(writer, m, closureName, member))
    						.Concat("RelativeSource = new RelativeSource(RelativeSourceMode.TemplatedParent)")
 					 .JoinBy(", ");
 				}
@@ -3626,12 +3625,15 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private string GetDefaultBindMode() => _currentDefaultBindMode.Peek();
 
-		private string BuildMemberPropertyValue(XamlMemberDefinition m)
+		private string BuildMemberPropertyValue(IIndentedStringBuilder writer,
+			XamlMemberDefinition m,
+			string targetName,
+			XamlMemberDefinition targetMember)
 		{
 			if (IsCustomMarkupExtensionType(m.Objects.FirstOrDefault()?.Type))
 			{
 				// If the member contains a custom markup extension, build the inner part first
-				var propertyValue = GetCustomMarkupExtensionValue(m);
+				var propertyValue = GetCustomMarkupExtensionValue(writer, m, targetName , targetMember);
 				return "{0} = {1}".InvariantCultureFormat(m.Member.Name, propertyValue);
 			}
 			else
@@ -3640,7 +3642,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 		}
 
-		private string GetCustomMarkupExtensionValue(XamlMemberDefinition member)
+		private string GetCustomMarkupExtensionValue(IIndentedStringBuilder writer, XamlMemberDefinition member, string targetObject, XamlMemberDefinition targetMember = null)
 		{
 			// Get the type of the custom markup extension
 			var markupTypeDef = member
@@ -3668,11 +3670,58 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var markupTypeFullName = GetGlobalizedTypeName(markupType.GetFullName());
 			var xamlMarkupFullName = GetGlobalizedTypeName(XamlConstants.Types.IMarkupExtensionOverrides);
 
+
+			// Check that the Custom MarkupExtension has a public property of object type named TargetObject
+		    var	hasTargetObject = markupType.GetAllProperties()
+				.Any(p => p.Name == "TargetObject"
+					&& p.IsReadOnly == false
+					&& p.DeclaredAccessibility == Accessibility.Public
+					&& SymbolEqualityComparer.Default.Equals(p.Type, _objectSymbol));
+			// Check that the Custom MarkupExtension has a public property of object type named TargetProperty
+			var hasTargetProperty = markupType.GetAllProperties()
+				.Any(p => p.Name == "TargetProperty"
+					&& p.IsReadOnly == false
+					&& p.DeclaredAccessibility == Accessibility.Public
+					&& SymbolEqualityComparer.Default.Equals(p.Type, _objectSymbol));
+
 			// Get the attribute from the custom markup extension class then get the return type specifed with MarkupExtensionReturnTypeAttribute
 			var attributeData = markupType.FindAttribute(XamlConstants.Types.MarkupExtensionReturnTypeAttribute);
 			var returnType = attributeData?.NamedArguments.FirstOrDefault(kvp => kvp.Key == "ReturnType").Value.Value;
 			var cast = string.Empty;
-			var provideValue = $"(({xamlMarkupFullName})(new {markupTypeFullName} {{ {properties} }})).ProvideValue()";
+			string provideValue = string.Empty;
+			var initializzer = string.Empty;
+
+			// if is valid targetObject and hasTargetObject hasTargetProperty
+			if ( string.IsNullOrWhiteSpace(targetObject) == false
+				&& (hasTargetObject || hasTargetProperty))
+			{
+				writer.AppendLine($"var mex = (new { markupTypeFullName } {{ { properties} }});");
+				writer.AppendLine(); // Workaround unoplatform/Uno.Roslyn#12
+
+				// if MarkupExtension have property named TargetObject assing value
+				if (hasTargetObject)
+				{
+					writer.AppendLine($"mex.TargetObject = {targetObject};");
+					writer.AppendLine(); // Workaround unoplatform/Uno.Roslyn#12
+				}
+				// if MarkupExtension have property named TargetProperty assing value
+				if (hasTargetProperty)
+				{
+					var tm = targetMember
+						?? member;
+					var parentType = IsAttachedProperty(tm)
+						? GetType(tm.Member.DeclaringType)
+						: GetType(tm.Owner.Type);
+					writer.AppendLine($"mex.TargetProperty = {GetGlobalizedTypeName(parentType.GetFullName())}.{tm.Member.Name}Property;");
+					writer.AppendLine(); // Workaround unoplatform/Uno.Roslyn#12
+				}
+				provideValue = $"((({ xamlMarkupFullName})mex).ProvideValue())";
+			}
+			else
+			{
+				provideValue = $"(({xamlMarkupFullName})(new {markupTypeFullName} {{ {properties} }})).ProvideValue()";
+			}
+			
 
 			if (returnType != null)
 			{

--- a/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml
@@ -59,8 +59,6 @@
 		<TextBlock x:Name="Text13"
 				   beh:AttachedPropertiesBehavior.CustomText="{ex:SimpleMarkupExtExtension TextValue='String from attached property Fullname'}" />
 
-
-
 		<TextBlock x:Name="BaseShinyTextBlock"
 				   x:FieldModifier="public"
 				   Text="{ex:Shiny Wrapped=BaseNamespaceShiny}" />
@@ -71,6 +69,18 @@
 				   x:FieldModifier="public"
 				   Text="{ex:TextBlock}" />
 
+		<TextBlock x:Name="TextBlockExtensionGetTarget"
+				   x:FieldModifier="public"
+				   Text="{ex:GetTarget}" />
+		<TextBlock x:Name="TextBlockExtensionAttachedPropertiedGetTarget"
+				   x:FieldModifier="public"
+				   beh:AttachedPropertiesBehavior.CustomText="{ex:GetTarget}" />
+		<TextBlock x:Name="IsTextBlock"
+				   x:FieldModifier="public"
+				   Text="{Binding ElementName=IsTextBlock, Converter={ex:IsTextBlockExtension}}" />
+		<TextBox x:Name="NotIsTextBlock"
+				 x:FieldModifier="public"
+				 Text="{Binding ElementName=NotIsTextBlock, Converter={ex:IsTextBlockExtension}}"/>
 		<Border>
 			<Border.Child>
 				<TextBlock Text="This should compile and not be confused with TextBlockExtension" />

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
@@ -41,6 +41,10 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests
 				Assert.AreEqual("Just a simple ... fullname markup extension", control.TestText11.Text);
 				Assert.AreEqual("From a Resource String FullName markup extension", control.TestText12.Text);
 				Assert.AreEqual("String from attached property Fullname markup extension", control.TestText13.Text);
+				Assert.AreEqual("TextBlockExtensionGetTarget.Text", control.TextBlockExtensionGetTarget.Text);
+				Assert.AreEqual("TextBlockExtensionAttachedPropertiedGetTarget.(AttachedPropertiesBehavior.CustomText)", control.TextBlockExtensionAttachedPropertiedGetTarget.Text);
+				Assert.AreEqual("True", control.IsTextBlock.Text);
+				Assert.AreEqual("False", control.NotIsTextBlock.Text);
 			}
 			finally
 			{
@@ -163,6 +167,50 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests
 		public object Wrapped { get; set; }
 
 		protected override object ProvideValue() => $"**{Wrapped}**";
+	}
+	
+	public class GetTargetExtension : MarkupExtension
+	{
+		public object TargetObject { get; set; }
+		public object TargetProperty { get; set; }
+		protected override object ProvideValue()
+		{
+			var targetObject = "Unknown";
+			var targetProperty = "Unknown";
+
+			if (TargetObject is Windows.UI.Xaml.FrameworkElement fe)
+			{
+				targetObject = fe.Name ??
+					fe.GetType().Name;
+			}
+
+			if (TargetProperty is Windows.UI.Xaml.DependencyProperty dp)
+			{
+				targetProperty = dp.IsAttached
+					? $"({dp.OwnerType.Name}.{dp.Name})"
+					: dp.Name;
+			}
+			return $"{targetObject}.{targetProperty}";
+		}
+	}
+
+	[MarkupExtensionReturnType(ReturnType = typeof(IValueConverter))]
+	public class IsTextBlockExtension : MarkupExtension, IValueConverter
+	{
+		public object TargetObject { get; set; }
+		public object TargetProperty { get; set; }
+
+		protected override object ProvideValue() => this;
+
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			return TargetObject is Windows.UI.Xaml.Controls.TextBlock;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language)
+		{
+			return Windows.UI.Xaml.DependencyProperty.UnsetValue;
+		}
 	}
 
 	// This should not be mistaken for a TextBlock


### PR DESCRIPTION
GitHub Issue: #5026



## PR Type

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
in a markupextension it is not possible to obtain TargetObject and TargetProperty.

## What is the new behavior?

When  in a custom markup extension, you define a r/w public property  TargetObject and/or TargeProperty of type object, SourceGenerators automatically assigns the value based on the object to which markupextesnion is applied.

if markupextesnion is within a binding  , SourceGenerators assigns the object to which the binding is applied.

### Examples:

##### Xaml
```xaml
<TextBlock Text="{ex:GetTarget}"/>
```
##### SourceGenerators
```csharp
mex.TargetObject = c18;
mex.TargetProperty = global::Windows.UI.Xaml.Controls.TextBlock.TextProperty;
c18.Text = (string)Convert.ChangeType(((((global::Windows.UI.Xaml.Markup.IMarkupExtensionOverrides)mex).ProvideValue())).ToString(), typeof(string));

```

##### Xaml
```xaml
<TextBlock AttachedPropertiesBehavior.CustomTextText="{ex:GetTarget}"/>
```
##### SourceGenerators
```csharp
var mex = (new global::Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests.GetTargetExtension {  });
mex.TargetObject = c19;
mex.TargetProperty = global::Uno.UI.Tests.App.Behaviors.AttachedPropertiesBehavior.CustomTextProperty;
global::Uno.UI.Tests.App.Behaviors.AttachedPropertiesBehavior.SetCustomText(c19, (string)Convert.ChangeType(((((global::Windows.UI.Xaml.Markup.IMarkupExtensionOverrides)mex).ProvideValue())).ToString(), typeof(string)));

```

##### Xaml
```xaml
<TextBlock AttachedPropertiesBehavior.CustomTextText="{ex:GetTarget}"/>
```
##### SourceGenerators
```csharp
var mex = (new global::Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests.GetTargetExtension {  });
mex.TargetObject = c19;
mex.TargetProperty = global::Uno.UI.Tests.App.Behaviors.AttachedPropertiesBehavior.CustomTextProperty;
global::Uno.UI.Tests.App.Behaviors.AttachedPropertiesBehavior.SetCustomText(c19, (string)Convert.ChangeType(((((global::Windows.UI.Xaml.Markup.IMarkupExtensionOverrides)mex).ProvideValue())).ToString(), typeof(string)));

```

##### Xaml
```xaml
<TextBlock Text="Text="{Binding ., Converter={ex:IsTextBlockExtension}}""/>
```
##### SourceGenerators
```csharp
var mex = (new global::Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests.IsTextBlockExtension {  });
mex.TargetObject = c20;
mex.TargetProperty = global::Windows.UI.Xaml.Controls.TextBlock.TextProperty;
c20.SetBinding(global::Windows.UI.Xaml.Controls.TextBlock.TextProperty,
       new Windows.UI.Xaml.Data.Binding{ Path = @"."/* Windows.UI.Xaml.PropertyPath/Windows.UI.Xaml.PropertyPath,
       ., /_PositionalParameters */, 
       Converter = (Windows.UI.Xaml.Data.IValueConverter)(((global::Windows.UI.Xaml.Markup.IMarkupExtensionOverrides)mex).ProvideValue()) });
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->