### PR TITLE
fix(Bindings): Avoid propagating DataContext if you are not the child's parent

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DataContext.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DataContext.cs
@@ -230,7 +230,7 @@ namespace Uno.UI.Tests.BinderTests_DataContext
 			Assert.AreEqual(null, SUT.DataContext);
 			Assert.AreEqual(0, parentCtxChanged);
 			Assert.AreEqual(1, SUTCtxChanged);
-			Assert.AreEqual(1, childCtxChanged);
+			Assert.AreEqual(0, childCtxChanged);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -105,10 +105,21 @@ namespace Windows.UI.Xaml
 					provider.Store.SetInheritedDataContext(inheritedValue);
 				}
 			}
-
 			for (int i = 0; i < _childrenBindable.Count; i++)
 			{
 				var child = _childrenBindable[i];
+				var parent = child?.GetParent();
+
+				//Do not propagate value if you are not this child's parent
+				//Covers case where a child may hold a binding to a view higher up the tree
+				//Example: Button A contains a Flyout with Button B inside of it
+				//	Button B has a binding to the Flyout itself
+				//	We should not propagate Button B's DataContext to the Flyout
+				//	since its real parent is actually Button A 
+				if (parent != null && parent != ActualInstance)
+				{
+					continue;
+				}
 
 				if (child is IDependencyObjectStoreProvider provider)
 				{


### PR DESCRIPTION

closes #4922

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Binding to Flyout from within the Flyout itself causes the wrong DataContext to be set on the Flyout

Example: 

- Button A contains a Flyout with Button B inside of it
- Button B has a binding to the Flyout itself
- We should not propagate Button B's DataContext to the Flyout since its real parent is actually Button A 

## What is the new behavior?

Binding value is not propagated to child unless you are the actual Parent of that child

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
