### PR TITLE
feat: Add support for x:Bind type cast syntax

### DIFF
--- a/doc/articles/features/windows-ui-xaml-xbind.md
+++ b/doc/articles/features/windows-ui-xaml-xbind.md
@@ -82,5 +82,7 @@ Uno supports the [`x:Bind`](https://docs.microsoft.com/en-us/windows/uwp/xaml-pl
   public void OnUncheckedRaised(object sender, RoutedEventArgs args) { }
   ```
 
-# Not supported
 - Type casts
+  ```xaml
+  <TextBox FontFamily="{x:Bind (FontFamily)MyComboBox.SelectedValue}" />
+  ```

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/Given_XBindRewriter.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/Given_XBindRewriter.cs
@@ -27,6 +27,11 @@ namespace Uno.UI.SourceGenerators.Tests
 		[DataRow("ctx", "MyNameSpace.Static2.MyFunction(MyProperty)", "MyNameSpace.Static2.MyFunction(ctx.MyProperty)")]
 		[DataRow("ctx", "MyFunction(MyProperty)", "ctx.MyFunction(ctx.MyProperty)")]
 		[DataRow("ctx", "", "ctx")]
+		[DataRow("ctx", "(FontFamily)a.Value", "(FontFamily)ctx.a.Value")]
+		[DataRow("ctx", "(global::System.Int32)a.Value", "(global::System.Int32)ctx.a.Value")]
+
+		// Not supported https://github.com/unoplatform/uno/issues/5061
+		// [DataRow("ctx", "MyFunction((global::System.Int32)MyProperty)", "ctx.MyFunction((global::System.Int32)ctx.MyProperty)")]
 
 		// Main class (without context)
 		[DataRow("", "MyProperty.A", "MyProperty.A")]
@@ -38,6 +43,8 @@ namespace Uno.UI.SourceGenerators.Tests
 		[DataRow("", "Static.MyFunction(MyProperty)", "Static.MyFunction(MyProperty)")]
 		[DataRow("", "MyNameSpace.Static2.MyFunction(MyProperty)", "MyNameSpace.Static2.MyFunction(MyProperty)")]
 		[DataRow("", "MyFunction(MyProperty)", "MyFunction(MyProperty)")]
+		[DataRow("", "(FontFamily)MyProperty", "(FontFamily)MyProperty")]
+		[DataRow("", "(FontFamily)MyProperty.A", "(FontFamily)MyProperty.A")]
 		public void When_PathRewrite(string contextName, string inputExpression, string expectedOutput)
 		{
 			bool IsStaticMethod(string name)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Utils/XBindExpressionParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Utils/XBindExpressionParser.cs
@@ -120,7 +120,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 
 			public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
 			{
-				var isValidParent = !Helpers.IsInsideMethod(node).result && !Helpers.IsInsideMemberAccessExpression(node).result;
+				var isInsideCast = Helpers.IsInsideCast(node);
+				var isValidParent = !Helpers.IsInsideMethod(node).result
+					&& !Helpers.IsInsideMemberAccessExpression(node).result
+					&& !isInsideCast.result;
 
 				if (isValidParent && !_isStaticMember(node.ToFullString()))
 				{
@@ -230,6 +233,24 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 					}
 
 					child = currentNode;
+					currentNode = currentNode.Parent;
+				}
+				while (currentNode != null);
+
+				return (false, null);
+			}
+
+			internal static (bool result, CastExpressionSyntax expression) IsInsideCast(SyntaxNode node)
+			{
+				var currentNode = node.Parent;
+
+				do
+				{
+					if (currentNode is CastExpressionSyntax cast)
+					{
+						return (true, cast);
+					}
+
 					currentNode = currentNode.Parent;
 				}
 				while (currentNode != null);


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #4855

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Support for the x:Bind type casting feature:
```
FontSize="{x:Bind (x:Double)Combo3.SelectedValue, Mode=OneWay}"
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
