### PR TITLE
fix: Native-registered DPs lazy initialization

### DIFF
--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.PocoBinding.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.PocoBinding.cs
@@ -1,0 +1,73 @@
+﻿using CommonServiceLocator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Uno.Logging;
+using Uno.Extensions;
+using Uno.Presentation.Resources;
+using Uno.UI.DataBinding;
+using Windows.UI.Xaml.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using Uno.Disposables;
+using System.ComponentModel;
+using Uno.UI;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Tests.BinderTests.DependencyPropertyPath
+{
+	[TestClass]
+	public partial class Given_Binder_PocoBinding
+	{
+		[TestMethod]
+		public void When_PropertyChanged_And_SetBinding()
+		{
+			var SUT = new MyObject();
+
+			SUT.MyProperty = "41";
+
+			SUT.SetBinding("MyProperty", new Binding { Path = "Value", Mode = BindingMode.TwoWay });
+
+			SUT.DataContext = new { Value = "42" };
+
+			Assert.AreEqual("42", SUT.MyProperty);
+		}
+
+		[TestMethod]
+		public void When_SetBinding_And_PropertyChanged()
+		{
+			var SUT = new MyObject();
+
+			SUT.SetBinding("MyProperty", new Binding { Path = "Value", Mode = BindingMode.TwoWay });
+
+			SUT.MyProperty = "41";
+
+			SUT.DataContext = new { Value = "42" };
+
+			Assert.AreEqual("42", SUT.MyProperty);
+		}
+
+		public partial class MyObject : DependencyObject
+		{
+			public MyObject()
+			{
+			}
+
+			private string _myProperty;
+
+			public string MyProperty
+			{
+				get { return _myProperty; }
+				set {
+					_myProperty = value;
+
+					SetBindingValue(value);
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -427,7 +427,12 @@ namespace Windows.UI.Xaml
 		{
 			var property = DependencyProperty.GetProperty(_originalObjectType, propertyName);
 
-			if(property != null)
+			if(property == null && propertyName != null)
+			{
+				property = FindStandardProperty(_originalObjectType, propertyName, false);
+			}
+
+			if (property != null)
 			{
 				SetBindingValue(value, property);
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5022

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This fix addresses native-registered lazy initialization issue causing SetBindingValue to fail dependending on whether SetBinding was not called previously.

This issue can impact native controls for (BindableSwitchCompat) which gets its `Text` property updated before any binding has been created, failing a call to SetBindingValue.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
