### PR TITLE
feat(xLoad): Add xLoad binding capabilities

### DIFF
--- a/doc/articles/features/windows-ui-xaml-xbind.md
+++ b/doc/articles/features/windows-ui-xaml-xbind.md
@@ -86,3 +86,9 @@ Uno supports the [`x:Bind`](https://docs.microsoft.com/en-us/windows/uwp/xaml-pl
   ```xaml
   <TextBox FontFamily="{x:Bind (FontFamily)MyComboBox.SelectedValue}" />
   ```
+
+- `x:Load` binding
+  ```xaml
+  <TextBox x:Load="{x:Bind IsMyControlVisible}" />
+  ```
+  See the [WinUI documentation](https://docs.microsoft.com/en-us/windows/uwp/xaml-platform/x-load-attribute) for more details.

--- a/doc/articles/supported-features.md
+++ b/doc/articles/supported-features.md
@@ -65,7 +65,7 @@
 ### Runtime Performance
 
 - CoreDispatcher Priority support (Large UIs performance)
-- `x:DeferLoadStrategy="Lazy"` and `x:Load="false"` support (responsive design performance)
+- `x:DeferLoadStrategy="Lazy"`, `x:Load="false"` and `x:Load="{x:Bind ...}" support (responsive design performance)
 - Image explicit size support (performance)
 - Event tracing (sub-millisecond [ETL performance profiling](Assets/diagnostics.PNG))
 - Internal logging

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -833,6 +833,22 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xLoadTests\xLoad_FindName.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xLoadTests\xLoad_Literal.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xLoadTests\xLoad_Test_For_Leak.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xLoadTests\xLoad_xBind.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Generic.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4367,6 +4383,18 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\xBind_Functions.xaml.cs">
       <DependentUpon>xBind_Functions.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xLoadTests\xLoad_FindName.xaml.cs">
+      <DependentUpon>xLoad_FindName.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xLoadTests\xLoad_Literal.xaml.cs">
+      <DependentUpon>xLoad_Literal.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xLoadTests\xLoad_Test_For_Leak.xaml.cs">
+      <DependentUpon>xLoad_Test_For_Leak.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xLoadTests\xLoad_xBind.xaml.cs">
+      <DependentUpon>xLoad_xBind.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\Border_Clipped_Change_Property.xaml.cs">
       <DependentUpon>Border_Clipped_Change_Property.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_FindName.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_FindName.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl
+    x:Class="UITests.Windows_UI_Xaml.xLoadTests.xLoad_FindName"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.xLoadTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="Clicking on the Load button should make a Green box appear in the Red border"/>
+		<Button Content="Load" x:Name="LoadButton"/>
+		<Border BorderBrush="Red" BorderThickness="1" Width="60" Height="60">
+			<Border x:Name="LoadBorder" Width="50" Height="50" Background="Green" x:Load="False"/>
+		</Border>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_FindName.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_FindName.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml.xLoadTests
+{
+	[Sample("xLoad", Name = "xLoad_FindName")]
+	public sealed partial class xLoad_FindName : UserControl
+    {
+        public xLoad_FindName()
+        {
+            this.InitializeComponent();
+			LoadButton.Click += LoadButton_Click;
+        }
+
+		private void LoadButton_Click(object sender, RoutedEventArgs e)
+		{
+			FindName("LoadBorder");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_Literal.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_Literal.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+    x:Class="UITests.Windows_UI_Xaml.xLoadTests.xLoad_Literal"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.xLoadTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="Should see two Red borders, the top one should be empty, the bottom one should contain a Green box"/>
+		<TextBlock Margin="0, 10, 0, 0" Text="Load = False" HorizontalAlignment="Center"/>
+		<Border BorderBrush="Red" BorderThickness="1" Width="60" Height="60">
+			<Border x:Name="LoadBorderFalse" Width="50" Height="50" Background="Green" x:Load="False"/>
+		</Border>
+		<TextBlock Margin="0, 10, 0, 0" Text="Load = True" HorizontalAlignment="Center"/>
+		<Border BorderBrush="Red" BorderThickness="1" Width="60" Height="60">
+			<Border x:Name="LoadBorderTrue" Width="50" Height="50" Background="Green" x:Load="True"/>
+		</Border>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_Literal.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_Literal.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml.xLoadTests
+{
+	[Sample("xLoad", Name = "xLoad_Literal")]
+	public sealed partial class xLoad_Literal : UserControl
+    {
+        public xLoad_Literal()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_Test_For_Leak.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_Test_For_Leak.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl
+    x:Class="UITests.Windows_UI_Xaml.xLoadTests.xLoad_Test_For_Leak"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.xLoadTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<Border x:Name="outerBorder" BorderBrush="Red" BorderThickness="1" Width="60" Height="60">
+			<Border x:Name="LoadBorder" Width="50" Height="50" Background="Green" x:Load="{x:Bind IsLoad, Mode=OneWay}" />
+		</Border>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_Test_For_Leak.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_Test_For_Leak.xaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml.xLoadTests
+{
+	[Sample("xLoad", Name = "xLoad_Test_For_Leak")]
+	public sealed partial class xLoad_Test_For_Leak : UserControl
+    {
+		public bool IsLoad
+		{
+			get { return (bool)GetValue(IsLoadProperty); }
+			set { SetValue(IsLoadProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for IsLoad.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty IsLoadProperty =
+			DependencyProperty.Register("IsLoad", typeof(bool), typeof(xLoad_Test_For_Leak), new PropertyMetadata(false));
+
+		public xLoad_Test_For_Leak()
+        {
+            this.InitializeComponent();
+
+			IsLoad = true;
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_xBind.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_xBind.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl
+    x:Class="UITests.Windows_UI_Xaml.xLoadTests.xLoad_xBind"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.xLoadTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+		<CheckBox Content="Is Loaded" x:Name="LoadCheckBox" Margin="30" IsChecked="{x:Bind IsLoad, Mode=TwoWay}" />
+		<Border BorderBrush="Red" BorderThickness="1" Width="60" Height="60">
+			<Border x:Name="LoadBorder" Width="50" Height="50" Background="Green" x:Load="{x:Bind IsLoad, Mode=OneWay}" />
+		</Border>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_xBind.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xLoadTests/xLoad_xBind.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml.xLoadTests
+{
+	[Sample("xLoad", Name = "xLoad_xBind")]
+	public sealed partial class xLoad_xBind : UserControl
+    {
+		public bool IsLoad
+		{
+			get { return (bool)GetValue(IsLoadProperty); }
+			set { SetValue(IsLoadProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for IsLoad.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty IsLoadProperty =
+			DependencyProperty.Register("IsLoad", typeof(bool), typeof(xLoad_xBind), new PropertyMetadata(false));
+
+		public xLoad_xBind()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/NameScope.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/NameScope.cs
@@ -8,14 +8,22 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 {
 	internal class NameScope
 	{
-		public NameScope(string name)
+		public NameScope(string @namespace, string className)
 		{
-			this.Name = name;
+			Namespace = @namespace ?? string.Empty;
+			ClassName = className;
 		}
 
-		public string Name { get; private set; }
+		public string Name => $"{Namespace.Replace(".", "")}{ClassName}";
+		public string Namespace { get; private set; }
+		public string ClassName { get; private set; }
 
 		public List<BackingFieldDefinition> BackingFields { get; } = new List<BackingFieldDefinition>();
+
+		/// <summary>
+		/// Lists the ElementStub builder holder variables used to pin references for implicit pinning platforms
+		/// </summary>
+		public List<string> ElementStubHolders { get; } = new List<string>();
 
 		public HashSet<string> ReferencedElementNames { get; } = new HashSet<string>();
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -264,22 +264,22 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private bool IsDependencyObject(XamlType xamlType)
 		{
-			return IsType(xamlType, XamlConstants.Types.DependencyObject);
+			return IsType(xamlType, _dependencyObjectSymbol);
 		}
 
 		private bool IsAndroidView(XamlType xamlType)
 		{
-			return IsType(xamlType, "Android.Views.View");
+			return IsType(xamlType, _androidViewSymbol);
 		}
 
 		private bool IsIOSUIView(XamlType xamlType)
 		{
-			return IsType(xamlType, "UIKit.UIView");
+			return IsType(xamlType, _iOSViewSymbol);
 		}
 
 		private bool IsMacOSNSView(XamlType xamlType)
 		{
-			return IsType(xamlType, "AppKit.NSView");
+			return IsType(xamlType, _appKitViewSymbol);
 		}
 
 		/// <summary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -20,7 +20,7 @@ using Uno.Logging;
 using Uno.UI.SourceGenerators.XamlGenerator.XamlRedirection;
 using System.Runtime.CompilerServices;
 using Uno.UI.Xaml;
-
+using Uno.Disposables;
 
 namespace Uno.UI.SourceGenerators.XamlGenerator
 {
@@ -109,6 +109,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private readonly INamedTypeSymbol _dependencyObjectParseSymbol;
 		private readonly INamedTypeSymbol _androidContentContextSymbol; // Android.Content.Context
 		private readonly INamedTypeSymbol _androidViewSymbol; // Android.Views.View
+		private readonly INamedTypeSymbol _iOSViewSymbol; // UIKit.UIView
+		private readonly INamedTypeSymbol _appKitViewSymbol; // AppKit.NSView
 
 		private readonly INamedTypeSymbol _iCollectionSymbol;
 		private readonly INamedTypeSymbol _iCollectionOfTSymbol;
@@ -231,6 +233,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			_colorSymbol = GetType(XamlConstants.Types.Color);
 			_androidContentContextSymbol = FindType("Android.Content.Context");
 			_androidViewSymbol = FindType("Android.Views.View");
+			_iOSViewSymbol = FindType("UIKit.UIView");
+			_appKitViewSymbol = FindType("AppKit.NSView");
 
 			_xamlConversionTypes = _metadataHelper.GetAllTypesAttributedWith(GetType(XamlConstants.Types.CreateFromStringAttribute)).ToList();
 
@@ -354,7 +358,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					{
 						var isDirectUserControlChild = _skipUserControlsInVisualTree && IsUserControl(topLevelControl.Type, checkInheritance: false);
 
-						using (Scope("{0}{1}".InvariantCultureFormat(_className.ns.Replace(".", ""), _className.className)))
+						using (Scope(_className.ns, _className.className))
 						{
 							using (writer.BlockInvariant(BuildControlInitializerDeclaration(_className.className, topLevelControl)))
 							{
@@ -394,6 +398,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									}
 								}
 							}
+
+							TryBuildElementStubHolders(writer);
 
 							BuildPartials(writer, isStatic: false);
 
@@ -691,7 +697,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			_isInChildSubclass = true;
 			TryAnnotateWithGeneratorSource(writer);
-			var disposable = isTopLevel ? writer.BlockInvariant("namespace {0}.__Resources", _defaultNamespace) : null;
+			var ns = $"{_defaultNamespace}.__Resources";
+			var disposable = isTopLevel ? writer.BlockInvariant($"namespace {ns}") : null;
 
 			using (disposable)
 			{
@@ -700,7 +707,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					var className = kvp.Key;
 					var contentOwner = kvp.Value.ContentOwner;
 
-					using (Scope(className))
+					using (Scope(ns, className))
 					{
 						var classAccessibility = isTopLevel ? "" : "private";
 
@@ -737,12 +744,27 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								writer.AppendLineInvariant($"private {GetType(current.Type).ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} _component_{i};");
 							}
 
+							TryBuildElementStubHolders(writer);
+
 							BuildBackingFields(writer);
 
 							BuildChildSubclasses(writer);
-
 						}
 					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Builds the element stub holder variables, use for platform having implicit pinning
+		/// </summary>
+		private void TryBuildElementStubHolders(IIndentedStringBuilder writer)
+		{
+			if (HasImplicitViewPinning)
+			{
+				foreach (var elementStubHolder in CurrentScope.ElementStubHolders)
+				{
+					writer.AppendLineInvariant($"private Func<_View> {elementStubHolder};");
 				}
 			}
 		}
@@ -914,7 +936,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			TryAnnotateWithGeneratorSource(writer);
 
-			using (Scope(Path.GetFileNameWithoutExtension(_fileDefinition.FilePath).Replace(".", "_") + "RD"))
+			using (Scope(null, Path.GetFileNameWithoutExtension(_fileDefinition.FilePath).Replace(".", "_") + "RD"))
 			{
 				using (writer.BlockInvariant("namespace {0}", _defaultNamespace))
 				{
@@ -1248,7 +1270,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					using (writer.BlockInvariant("public sealed partial class {0} : {1}", className.className, GetGlobalizedTypeName(controlBaseType.ToDisplayString())))
 					{
-						using (Scope("{0}{1}".InvariantCultureFormat(className.ns.Replace(".", ""), className.className)))
+						using (Scope(className.ns, className.className))
 						{
 							using (writer.BlockInvariant("public void InitializeComponent()"))
 							{
@@ -1684,10 +1706,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// Does this node or any nested nodes have markup extensions?
 		/// </summary>
 		private bool HasDescendantsWithMarkupExtension(XamlObjectDefinition xamlObjectDefinition)
+			=> HasDescendantsWith(xamlObjectDefinition, HasMarkupExtension);
+
+		private bool HasDescendantsWith(XamlObjectDefinition xamlObjectDefinition, Func<XamlMemberDefinition, bool> predicate)
 		{
 			foreach (var member in xamlObjectDefinition.Members)
 			{
-				if (HasMarkupExtension(member))
+				if (predicate(member))
 				{
 					return true;
 				}
@@ -2412,7 +2437,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// </summary>
 		private IDisposable BuildLazyResourceInitializer(IIndentedStringBuilder writer)
 		{
-			var currentScope = CurrentResourceOwner?.Name ?? "this";
+			var currentScope = CurrentResourceOwnerName;
 			var resourceOwnerScope = ResourceOwnerScope();
 			
 			writer.AppendLineInvariant($"new global::Uno.UI.Xaml.WeakResourceInitializer({currentScope}, {CurrentResourceOwner?.Name} => ");
@@ -4663,7 +4688,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 					if (contentOwner != null)
 					{
-						var resourceOwner = CurrentResourceOwner?.Name ?? "this";
+						var resourceOwner = CurrentResourceOwnerName;
 
 						writer.Append($"{resourceOwner} , __owner => ");
 						// This case is to support the layout switching for the ListViewBaseLayout, which is not
@@ -4983,10 +5008,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			TryAnnotateWithGeneratorSource(writer);
 			var strategy = FindMember(definition, "DeferLoadStrategy");
-			var loadElement = FindMember(definition, "Load");
+			var loadMember = FindMember(definition, "Load");
+			var hasLoadMarkup = HasMarkupExtension(loadMember);
 
 			if (strategy?.Value?.ToString().ToLowerInvariant() == "lazy"
-				|| loadElement?.Value?.ToString().ToLowerInvariant() == "false")
+				|| loadMember?.Value?.ToString().ToLowerInvariant() == "false"
+				|| hasLoadMarkup)
 			{
 				var visibilityMember = FindMember(definition, "Visibility");
 				var dataContextMember = FindMember(definition, "DataContext");
@@ -4998,20 +5025,38 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					return null;
 				}
 
-				if (visibilityMember != null || loadElement?.Value != null)
+				if (visibilityMember != null || loadMember?.Value != null || hasLoadMarkup)
 				{
 					var hasVisibilityMarkup = HasMarkupExtension(visibilityMember);
 					var isLiteralVisible = !hasVisibilityMarkup && (visibilityMember?.Value?.ToString() == "Visible");
 
 					var hasDataContextMarkup = dataContextMember != null && HasMarkupExtension(dataContextMember);
 
-					var disposable = writer.BlockInvariant($"new {XamlConstants.Types.ElementStub}()");
+					var currentOwnerName = CurrentResourceOwnerName;
 
-					writer.Append("ContentBuilder = () => ");
+					var elementStubHolderNameStatement = "";
 
+					if (HasImplicitViewPinning)
+					{
+						// Build the ElemenStub builder holder variable to ensute that the element stub
+						// does not keep a hard reference to "this" through the closure needed to keep
+						// the namescope and other variables. The ElementStub, in turn keeps a weak
+						// reference to the builder's target instance.
+						var elementStubHolderName = $"_elementStubHolder_{CurrentScope.ElementStubHolders.Count}";
+						elementStubHolderNameStatement = $"{elementStubHolderName} = ";
+						CurrentScope.ElementStubHolders.Add(elementStubHolderName);
+					}
+
+					writer.AppendLineInvariant($"new {XamlConstants.Types.ElementStub}({elementStubHolderNameStatement} () => ");
+
+					var disposable = new DisposableAction(() =>
+					{
+						writer.AppendLine(")");
+					});
+					
 					return new DisposableAction(() =>
 						{
-							disposable.Dispose();
+							disposable?.Dispose();
 
 							string closureName;
 							using (var innerWriter = CreateApplyBlock(writer, GetType(XamlConstants.Types.ElementStub), out closureName))
@@ -5023,16 +5068,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									// We need to generate the datacontext binding, since the Visibility
 									// may require it to bind properly.
 
-									var def = new XamlMemberDefinition(
-										new XamlMember("DataContext",
-											elementStubType,
-											false
-										), 0, 0
-									);
-
-									def.Objects.AddRange(dataContextMember.Objects);
-
-									BuildComplexPropertyValue(innerWriter, def, closureName + ".", closureName);
+									GenerateBinding("DataContext", dataContextMember, definition);
 								}
 
 								if (nameMember != null)
@@ -5048,18 +5084,19 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									);
 								}
 
-								if (hasVisibilityMarkup)
+								if (hasLoadMarkup || hasVisibilityMarkup)
 								{
-									var def = new XamlMemberDefinition(
-										new XamlMember("Visibility",
-											elementStubType,
-											false
-										), 0, 0
-									);
+									var members = new List<XamlMemberDefinition>();
 
-									def.Objects.AddRange(visibilityMember.Objects);
+									if (hasLoadMarkup)
+									{
+										members.Add(GenerateBinding("Load", loadMember, definition));
+									}
 
-									BuildComplexPropertyValue(innerWriter, def, closureName + ".", closureName);
+									if (hasVisibilityMarkup)
+									{
+										members.Add(GenerateBinding("Visibility", visibilityMember, definition));
+									}
 
 									if (!_isTopLevelDictionary
 										&& (HasXBindMarkupExtension(definition) || HasMarkupExtensionNeedingComponent(definition)))
@@ -5067,18 +5104,23 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 										var componentName = $"_component_{ CurrentScope.ComponentCount}";
 										writer.AppendLineInvariant($"this.{componentName} = {closureName};");
 
+										writer.AppendLineInvariant($"var {componentName}_update_That = ({CurrentResourceOwnerName} as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;");
+
 										using (writer.BlockInvariant($"void {componentName}_update(object sender, RoutedEventArgs e)"))
 										{
 											// Refresh the bindings when the ElementStub is unloaded. This assumes that
 											// ElementStub will be unloaded **after** the stubbed control has been created
 											// in order for the _component_XXX to be filled, and Bindings.Update() to do its work.
-											writer.AppendLineInvariant($"this.Bindings.Update();");
+											writer.AppendLineInvariant($"({componentName}_update_That.Target as {_className.className})?.Bindings.Update();");
 										}
 
 										writer.AppendLineInvariant($"{closureName}.Unloaded += {componentName}_update;");
 
-										CurrentScope.Components.Add(new XamlObjectDefinition(elementStubType, 0, 0, definition) { Members = { def } });
+										var xamlObjectDef = new XamlObjectDefinition(elementStubType, 0, 0, definition);
+										xamlObjectDef.Members.AddRange(members);
+										CurrentScope.Components.Add(xamlObjectDef);
 									}
+
 								}
 								else
 								{
@@ -5090,6 +5132,23 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 											BuildLiteralValue(visibilityMember)
 										);
 									}
+								}
+
+								XamlMemberDefinition GenerateBinding(string name, XamlMemberDefinition memberDefinition, XamlObjectDefinition owner)
+								{
+									var def = new XamlMemberDefinition(
+										new XamlMember(name,
+											elementStubType,
+											false
+										), 0, 0,
+										owner
+									);
+
+									def.Objects.AddRange(memberDefinition.Objects);
+
+									BuildComplexPropertyValue(innerWriter, def, closureName + ".", closureName);
+
+									return def;
 								}
 							}
 						}
@@ -5326,15 +5385,21 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 		}
 
-		private IDisposable Scope(string name)
+		private IDisposable Scope(string @namespace, string className)
 		{
-			_scopeStack.Push(new NameScope(name));
+			_scopeStack.Push(new NameScope(@namespace, className));
 
 			return new DisposableAction(() => _scopeStack.Pop());
 		}
 
 		private ResourceOwner CurrentResourceOwner
 			=> _resourceOwnerStack.Count != 0 ? _resourceOwnerStack.Peek() : null;
+
+		private string CurrentResourceOwnerName
+			=> CurrentResourceOwner?.Name ?? "this";
+
+		public bool HasImplicitViewPinning
+			=> _iOSViewSymbol != null || _appKitViewSymbol != null;
 
 		/// <summary>
 		/// Pushes a ResourceOwner variable name onto the stack

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_Literal.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_Literal.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.xLoad_Literal"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="Should see two Red borders, the top one should be empty, the bottom one should contain a Green box"/>
+		<TextBlock Margin="0, 10, 0, 0" Text="Load = False" HorizontalAlignment="Center"/>
+		<Border BorderBrush="Red" BorderThickness="1" Width="60" Height="60">
+			<Border x:Name="LoadBorderFalse" x:FieldModifier="public" Width="50" Height="50" Background="Green" x:Load="False"/>
+		</Border>
+		<TextBlock Margin="0, 10, 0, 0" Text="Load = True" HorizontalAlignment="Center"/>
+		<Border BorderBrush="Red" BorderThickness="1" Width="60" Height="60">
+			<Border x:Name="LoadBorderTrue" x:FieldModifier="public" Width="50" Height="50" Background="Green" x:Load="True"/>
+		</Border>
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_Literal.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_Literal.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class xLoad_Literal : UserControl
+	{
+		public xLoad_Literal()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_xBind.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_xBind.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.xLoad_xBind"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+		<CheckBox Content="Is Loaded" x:Name="LoadCheckBox" Margin="30" IsChecked="{x:Bind IsLoad, Mode=TwoWay}" />
+		<Border BorderBrush="Red" BorderThickness="1" Width="60" Height="60">
+			<Border x:Name="LoadBorder" x:FieldModifier="public" Width="50" Height="50" Background="Green" x:Load="{x:Bind IsLoad, Mode=OneWay}" />
+		</Border>
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_xBind.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/xLoad_xBind.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class xLoad_xBind : UserControl
+	{
+		public bool IsLoad
+		{
+			get { return (bool)GetValue(IsLoadProperty); }
+			set { SetValue(IsLoadProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for IsLoad.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty IsLoadProperty =
+			DependencyProperty.Register("IsLoad", typeof(bool), typeof(xLoad_xBind), new PropertyMetadata(false));
+
+		public xLoad_xBind()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -62,6 +62,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow("SamplesApp.Windows_UI_Xaml.Clipping.XamlButtonWithClipping_Scrollable", 15)]
 		[DataRow("Uno.UI.Samples.Content.UITests.ButtonTestsControl.AppBar_KeyBoard", 15)]
 		[DataRow("Uno.UI.Samples.Content.UITests.ButtonTestsControl.Buttons", 15)]
+		[DataRow("UITests.Windows_UI_Xaml.xLoadTests.xLoad_Test_For_Leak", 15)]
 		public async Task When_Add_Remove(object controlTypeRaw, int count)
 		{
 #if TRACK_REFS

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -1,0 +1,52 @@
+﻿#nullable enable
+#if !WINDOWS_UWP
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_xLoad
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_xLoad_Literal()
+		{
+			var sut = new xLoad_Literal();
+
+			TestServices.WindowHelper.WindowContent = sut;
+			var loadBorderFalse = sut.LoadBorderFalse;
+			var loadBorderTrue = sut.LoadBorderTrue;
+
+			Assert.IsNull(loadBorderFalse);
+			Assert.IsNotNull(loadBorderTrue);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_xLoad_xBind()
+		{
+			var sut = new xLoad_xBind();
+
+			TestServices.WindowHelper.WindowContent = sut;
+			TestServices.WindowHelper.WaitForLoaded(sut);
+
+			var loadBorder = sut.LoadBorder;
+			Assert.IsNull(sut.LoadBorder);
+
+			sut.IsLoad = true;
+
+			Assert.IsNotNull(sut.LoadBorder);
+			var parent = sut.LoadBorder.Parent as Border;
+
+			sut.IsLoad = false;
+
+			Assert.IsFalse((parent.Child as ElementStub).Load);
+		}
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -102,6 +102,12 @@
 	<ItemGroup>
 	  <Compile Include="Tests\Windows_UI_Xaml_Controls\HtmlElementAttributeTests\Given_HtmlElementAttribute.Wasm.cs" />
 	</ItemGroup>
+	
+	<ItemGroup>
+	  <Page Update="Tests\Windows_UI_Xaml\Controls\xLoad_xBind.xaml">
+	    <SubType>Designer</SubType>
+	  </Page>
+	</ItemGroup>
 
 	<Import Project="..\SourceGenerators\Uno.UI.SourceGenerators\Content\Uno.UI.SourceGenerators.props" />
 	<Import Project="..\SourceGenerators\Uno.UI.Tasks\Content\Uno.UI.Tasks.targets" Condition="'$(SkipUnoResourceGeneration)' == '' " />

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad_xBind"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<Grid>
+		<Border x:Name="border1" x:FieldModifier="public" x:Load="{x:Bind IsLoad, Mode=OneWay}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_xBind : UserControl
+	{
+		public bool IsLoad
+		{
+			get { return (bool)GetValue(IsLoadProperty); }
+			set { SetValue(IsLoadProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for IsLoad.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty IsLoadProperty =
+			DependencyProperty.Register("IsLoad", typeof(bool), typeof(When_xLoad_xBind), new PropertyMetadata(false));
+
+
+		public When_xLoad_xBind()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -124,5 +124,35 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			Assert.IsNotNull(SUT.border1);
 			Assert.AreEqual(SUT.border1, border1);
 		}
+
+		[TestMethod]
+		public void When_xLoad_xBind()
+		{
+			var SUT = new When_xLoad_xBind();
+			SUT.ForceLoaded();
+			SUT.Measure(new Size(42, 42));
+
+			var stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+			Assert.AreEqual(1, stubs.Count());
+
+			Assert.IsNull(SUT.border1);
+
+			SUT.IsLoad = true;
+			SUT.Measure(new Size(42, 42));
+
+			Assert.IsNotNull(SUT.border1);
+
+			var border1 = SUT.FindName("border1");
+			Assert.AreEqual(SUT.border1, border1);
+
+			SUT.IsLoad = false;
+			SUT.Measure(new Size(42, 42));
+
+			stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+			Assert.AreEqual(1, stubs.Count());
+
+			var borders = SUT.EnumerateAllChildren().OfType<Border>();
+			Assert.AreEqual(0, borders.Count());
+		}
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_DataTemplate.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_DataTemplate.xaml
@@ -1,0 +1,32 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.Binding_xLoad_DataTemplate"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="testTemplate"
+					  x:DataType="local:Binding_xLoad_DataTemplate_Data">
+			<Grid x:Name="innerRoot">
+				<ContentControl x:Name="topLevelContent"
+								x:FieldModifier="public"
+								x:Load="false"
+								Visibility="{x:Bind TopLevelVisiblity, Mode=OneWay, FallbackValue=Collapsed}">
+					<TextBlock x:Name="innerTextBlock"
+							   x:FieldModifier="public"
+							   Text="{x:Bind InnerText, Mode=OneWay}" />
+				</ContentControl>
+			</Grid>
+		</DataTemplate>
+	</Page.Resources>
+	
+	<Grid>
+		<ContentControl x:Name="root"
+						x:FieldModifier="public"
+						ContentTemplate="{StaticResource testTemplate}">
+			
+		</ContentControl>
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_DataTemplate.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_DataTemplate.xaml.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_xLoad_DataTemplate : Page
+	{
+		public Binding_xLoad_DataTemplate()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public class Binding_xLoad_DataTemplate_Data : System.ComponentModel.INotifyPropertyChanged
+	{
+		private bool topLevelVisiblity;
+
+		public bool TopLevelVisiblity
+		{
+			get => topLevelVisiblity;
+			set
+			{
+				topLevelVisiblity = value;
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(TopLevelVisiblity)));
+			}
+		}
+
+		public string InnerText { get; set; }
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -693,6 +693,39 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 		}
 
 		[TestMethod]
+		public void When_xLoad_DataTemplate()
+		{
+			var SUT = new Binding_xLoad_DataTemplate();
+
+			SUT.ForceLoaded();
+
+			var data = new Binding_xLoad_DataTemplate_Data()
+			{
+				InnerText = "Salsepareille"
+			};
+
+			SUT.root.Content = data;
+
+			var innerRoot = SUT.FindName("innerRoot") as Grid;
+			Assert.IsNotNull(innerRoot);
+
+			Assert.AreEqual(1, innerRoot.EnumerateAllChildren().OfType<ElementStub>().Count());
+
+			data.TopLevelVisiblity = true;
+
+			Assert.AreEqual(0, innerRoot.EnumerateAllChildren().OfType<ElementStub>().Count());
+
+			var innerTextBlock = SUT.FindName("innerTextBlock") as TextBlock;
+			Assert.IsNotNull(innerTextBlock);
+			Assert.AreEqual(data.InnerText, innerTextBlock.Text);
+
+			data.TopLevelVisiblity = false;
+
+			var topLevelContent = SUT.FindName("topLevelContent") as FrameworkElement;
+			Assert.AreEqual(Visibility.Collapsed, topLevelContent.Visibility);
+		}
+
+		[TestMethod]
 		public void When_PropertyChanged_Empty()
 		{
 			var SUT = new Binding_PropertyChangedAll();

--- a/src/Uno.UI/Mock/ElementStub.net.cs
+++ b/src/Uno.UI/Mock/ElementStub.net.cs
@@ -9,24 +9,20 @@ namespace Windows.UI.Xaml
 {
 	public partial class ElementStub
 	{
-		public ElementStub()
+		private FrameworkElement SwapViews(FrameworkElement oldView, Func<object> newViewProvider)
 		{
-			Visibility = Visibility.Collapsed;
-		}
-
-		private FrameworkElement MaterializeContent()
-		{
-			if (Parent is FrameworkElement parentElement)
+			if (oldView?.Parent is FrameworkElement parentElement)
 			{
-				var currentPosition = parentElement.GetChildren().IndexOf(this);
+				var currentPosition = parentElement.GetChildren().IndexOf(oldView);
 
 				if (currentPosition != -1)
 				{
-					var newContent = ContentBuilder() as UIElement;
+					var newView = (FrameworkElement)newViewProvider();
+					parentElement.RemoveChild(oldView);
 
-					parentElement.RemoveChild(this);
+					parentElement.AddChild(newView, currentPosition);
 
-					parentElement.AddChild(newContent, currentPosition);
+					return newView;
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/ElementStub.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.Android.cs
@@ -10,42 +10,33 @@ namespace Windows.UI.Xaml
 {
 	public partial class ElementStub : FrameworkElement
 	{
-		public ElementStub()
+		private View SwapViews(View oldView, Func<View> newViewProvider)
 		{
-			Visibility = Visibility.Collapsed;
-		}
-
-		private View MaterializeContent()
-		{
-			var parentViewGroup = (this as View).Parent as ViewGroup;
-			var currentPosition = parentViewGroup?.GetChildren().IndexOf(this);
+			var parentViewGroup = oldView?.Parent as ViewGroup;
+			var currentPosition = parentViewGroup?.GetChildren().IndexOf(oldView);
 
 			if (currentPosition != null && currentPosition.Value != -1)
 			{
-				// Create the instance first so that x:Bind constructs can be picked up by the
-				// Unload event of ElementStub. Not doing so does not fills up the generated variables
-				// too late and Binding.Update() does not refresh the available x:Bind instances.
-				var newContent = ContentBuilder();
-
+				var newView = newViewProvider();
 				parentViewGroup.RemoveViewAt(currentPosition.Value);
 
-				var UnoViewGroup = parentViewGroup as UnoViewGroup;
+				var unoViewGroup = parentViewGroup as UnoViewGroup;
 
-				if (UnoViewGroup != null)
+				if (unoViewGroup != null)
 				{
-					var newContentAsFrameworkElement = newContent as IFrameworkElement;
+					var newContentAsFrameworkElement = newView as IFrameworkElement;
 					if (newContentAsFrameworkElement != null)
 					{
-						newContentAsFrameworkElement.TemplatedParent = (UnoViewGroup as IFrameworkElement)?.TemplatedParent;
+						newContentAsFrameworkElement.TemplatedParent = (unoViewGroup as IFrameworkElement)?.TemplatedParent;
 					}
-					UnoViewGroup.AddView(newContent, currentPosition.Value);
+					unoViewGroup.AddView(newView, currentPosition.Value);
 				}
 				else
 				{
-					parentViewGroup.AddView(newContent, currentPosition.Value);
+					parentViewGroup.AddView(newView, currentPosition.Value);
 				}
 
-				return newContent;
+				return newView;
 			}
 
 			return null;

--- a/src/Uno.UI/UI/Xaml/ElementStub.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.cs
@@ -1,7 +1,10 @@
 ﻿#if IS_UNO
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
+using Uno.UI;
+using Uno.UI.DataBinding;
 
 #if XAMARIN_ANDROID
 using View = Android.Views.View;
@@ -15,12 +18,65 @@ using View = System.Object;
 
 namespace Windows.UI.Xaml
 {
+
 	/// <summary>
 	/// A support element for the DeferLoadStrategy Lazy Xaml directive.
 	/// </summary>
 	/// <remarks>This control is added in the visual tree, in place of the original content.</remarks>
 	public partial class ElementStub : FrameworkElement
     {
+#if UNO_HAS_UIELEMENT_IMPLICIT_PINNING
+		[Weak]
+#endif
+		private View _content;
+
+		public bool Load
+		{
+			get => (bool)GetValue(LoadProperty);
+			set => SetValue(LoadProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for Load.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty LoadProperty =
+			DependencyProperty.Register("Load", typeof(bool), typeof(ElementStub), new PropertyMetadata(
+				false, OnLoadChanged));
+
+		public ElementStub(Func<View> contentBuilder) : this()
+		{
+#if UNO_HAS_UIELEMENT_IMPLICIT_PINNING
+			// In this context, the delegate provided here closes over other UIElement instances
+			// causing memory leaks unless the Target member of the delegate is weak.
+			// Here, we deconstruct the delegate to keep the MethodInfo, and invoking it
+			// via the resolution of the weak reference. This technique only works because
+			// the provided delegate and its target (the lambda's display class) is kept
+			// alive by the "ElementStub holder" variable provided by the XAML generator.
+			var delegateTarget = WeakReferencePool.RentWeakReference(this, contentBuilder.Target);
+			var methodInfo = contentBuilder.Method;
+
+			ContentBuilder = () => (View)methodInfo.Invoke(delegateTarget.Target, null);
+#else
+			ContentBuilder = contentBuilder;
+#endif
+		}
+
+		public ElementStub()
+		{
+			Visibility = Visibility.Collapsed;
+		}
+
+		private static void OnLoadChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			if ((bool)args.NewValue)
+			{
+				((ElementStub)dependencyObject).Materialize();
+			}
+			else
+			{
+				((ElementStub)dependencyObject).Dematerialize();
+			}
+		}
+
+
 		/// <summary>
 		/// A function that will create the actual view.
 		/// </summary>
@@ -56,13 +112,12 @@ namespace Windows.UI.Xaml
 
 		private void Materialize(bool isVisibilityChanged)
 		{
-			var newContent = MaterializeContent();
-
-			var targetDependencyObject = newContent as DependencyObject;
+			_content = SwapViews(oldView: (FrameworkElement)this, newViewProvider: ContentBuilder);
+			var targetDependencyObject = _content as DependencyObject;
 
 			if (isVisibilityChanged && targetDependencyObject != null)
 			{
-				var visibilityProperty = GetVisibilityProperty(newContent);
+				var visibilityProperty = GetVisibilityProperty(_content);
 
 				// Set the visibility at the same precedence it was currently set with on the stub.
 				var precedence = this.GetCurrentHighestValuePrecedence(visibilityProperty);
@@ -71,9 +126,18 @@ namespace Windows.UI.Xaml
 			}
 		}
 
+		private void Dematerialize()
+		{
+			var newView = SwapViews(oldView: (FrameworkElement)_content, newViewProvider: () => this as View);
+			if (newView != null)
+			{
+				_content = null;
+			}
+		}
+
 		private static DependencyProperty GetVisibilityProperty(View view)
 		{
-			if(view is FrameworkElement)
+			if (view is FrameworkElement)
 			{
 				return VisibilityProperty;
 			}

--- a/src/Uno.UI/UI/Xaml/ElementStub.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.iOSmacOS.cs
@@ -14,31 +14,23 @@ namespace Windows.UI.Xaml
 {
 	public partial class ElementStub : FrameworkElement
 	{
-		public ElementStub()
+		private UIView SwapViews(UIView oldView, Func<UIView> newViewProvider)
 		{
-			Visibility = Visibility.Collapsed;
-		}
+			var currentPosition = oldView?.Superview?.Subviews.IndexOf(oldView) ?? -1;
 
-		private UIView MaterializeContent()
-		{
-			var currentPosition = Superview?.Subviews.IndexOf(this) ?? -1;
-			
 			if (currentPosition != -1)
 			{
-				// Create the instance first so that x:Bind constructs can be picked up by the
-				// Unload event of ElementStub. Not doing so does not fills up the generated variables
-				// too late and Binding.Update() does not refresh the available x:Bind instances.
-				var newContent = ContentBuilder();
+				var newContent = newViewProvider();
 
-				var currentSuperview = Superview;
-				RemoveFromSuperview();
+				var currentSuperview = oldView?.Superview;
+				oldView?.RemoveFromSuperview();
 
 #if __IOS__
 				currentSuperview?.InsertSubview(newContent, currentPosition);
-				return newContent;				
+				return newContent;
 #elif __MACOS__
-				// macOS TODO
 				currentSuperview.AddSubview(newContent, NSWindowOrderingMode.Above, currentSuperview.Subviews[Math.Max(0, currentPosition-1)]);
+				return newContent;
 #endif
 			}
 

--- a/src/Uno.UI/UI/Xaml/ElementStub.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.netstd.cs
@@ -9,33 +9,24 @@ namespace Windows.UI.Xaml
 {
 	public partial class ElementStub
 	{
-        public ElementStub()
-        {
-            Visibility = Visibility.Collapsed;
-        }
+		private FrameworkElement SwapViews(FrameworkElement oldView, Func<object> newViewProvider)
+		{
+			if (oldView?.Parent is FrameworkElement parentElement)
+			{
+				var currentPosition = parentElement.GetChildren().IndexOf(oldView);
 
-        private FrameworkElement MaterializeContent()
-        {
-            if(Parent is FrameworkElement parentElement)
-            {
-                var currentPosition = parentElement.GetChildren().IndexOf(this);
+				if (currentPosition != -1)
+				{
+					var newView = (FrameworkElement)newViewProvider();
 
-                if (currentPosition != -1)
-                {
-					// Create the instance first so that x:Bind constructs can be picked up by the
-					// Unload event of ElementStub. Not doing so does not fills up the generated variables
-					// too late and Binding.Update() does not refresh the available x:Bind instances.
-					var newContent = ContentBuilder() as UIElement;
+					parentElement.RemoveChild(oldView);
+					parentElement.AddChild(newView, currentPosition);
 
-                    parentElement.RemoveChild(this);
+					return newView;
+				}
+			}
 
-                    parentElement.AddChild(newContent, currentPosition);
-
-					return newContent as FrameworkElement;
-                }
-            }
-
-            return null;
-        }
-    }
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): Closes #925, fixes https://github.com/unoplatform/uno/issues/5068

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Currently x:Load in Uno:

- doesn't support binding
- doesn't support being toggled multiple times
- is only applied if the Visibility is also set/bound in XAML (bug)

## What is the new behavior?

The above scenarios are supported, based on the work from @kazo0.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
