### PR TITLE
[Android] Fix text layout problem

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -433,6 +433,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Browser | Platform.Android)] // Test timed-out on iOS
 		public void When_TextAlignment_Then_Layout_Is_Correct()
 		{
 			Run("UITests.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_LayoutAlignment");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -430,5 +430,57 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 			w1.Should().BeGreaterThan(w2);
 			w3.Should().Be(w1);
 		}
+
+		[Test]
+		[AutoRetry]
+		public void When_TextAlignment_Then_Layout_Is_Correct()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_LayoutAlignment");
+
+			using var snapshot = this.TakeScreenshot("normal", ignoreInSnapshotCompare: true);
+
+			for (var i = 1; i <= 10; i++)
+			{
+				for (var j = 1; j <= 4; j++)
+				{
+					_app.Marked($"txt{i}_{j}").SetDependencyPropertyValue("Visibility", "Collapsed");
+				}
+			}
+
+			using var snapshotTextHidden = this.TakeScreenshot("text_hidden", ignoreInSnapshotCompare: true);
+
+			// This test will ensure the text "stays" in their designated zone.
+			// Any overflow would indicate a problem in the text layout engine.
+
+			for (var i = 1; i <= 10; i++)
+			{
+				for (var j = 1; j <= 4; j++)
+				{
+					using var _ = new AssertionScope($"Text {i}_{j}");
+
+					var gridRect = _app.GetPhysicalRect($"grid{i}_{j}");
+					var textRect = _app.GetPhysicalRect($"rect{i}_{j}");
+
+					// Top
+					CheckRect(gridRect.X, gridRect.Y, gridRect.Width, textRect.Y - gridRect.Y);
+
+					// Bottom
+					CheckRect(gridRect.X, textRect.Bottom, gridRect.Width, gridRect.Bottom - textRect.Bottom);
+
+					// Left
+					CheckRect(gridRect.X, gridRect.Y, textRect.X - gridRect.X, gridRect.Height);
+
+					// Right
+					CheckRect(textRect.Right, gridRect.Y, gridRect.Right - textRect.Right, gridRect.Height);
+				}
+			}
+
+			void CheckRect(float x, float y, float w, float h)
+			{
+				var r = new AppRect(x, y, w, h);
+
+				ImageAssert.AreEqual(snapshotTextHidden, r, snapshot, r);
+			}
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1389,6 +1389,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LayoutAlignment.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_MultipleControls.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4731,6 +4735,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Layout.xaml.cs">
       <DependentUpon>TextBlock_Layout.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LayoutAlignment.xaml.cs">
+      <DependentUpon>TextBlock_LayoutAlignment.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_MultipleControls.xaml.cs">
       <DependentUpon>TextBlock_LineHeight_MultipleControls.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LayoutAlignment.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LayoutAlignment.xaml
@@ -1,0 +1,273 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_LayoutAlignment"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBlockControl"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="8">
+		<TextBlock FontSize="12" FontWeight="Bold">TextAlignment=Left (default)</TextBlock>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid1_1">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Top" x:Name="rect1_1" />
+				<TextBlock HorizontalAlignment="Left" VerticalAlignment="Top" FontSize="8.5" x:Name="txt1_1">
+					Left/Top
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid1_2">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Top" x:Name="rect1_2" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Top" FontSize="8.5" x:Name="txt1_2">
+					Stretch/Top
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid1_3">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Top" x:Name="rect1_3" />
+				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Top" FontSize="8.5" x:Name="txt1_3">
+					Center/Top
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid1_4">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Top" x:Name="rect1_4" />
+				<TextBlock HorizontalAlignment="Right" VerticalAlignment="Top" FontSize="8.5" x:Name="txt1_4">
+					Right/Top
+				</TextBlock>
+			</Grid>
+		</StackPanel>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid2_1">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Top" x:Name="rect2_1" />
+				<TextBlock HorizontalAlignment="Left" VerticalAlignment="Stretch" FontSize="8.5" x:Name="txt2_1">
+					Left/Stretch
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid2_2">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Top" x:Name="rect2_2" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="8.5" x:Name="txt2_2">
+					Stretch/Stretch
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid2_3">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Top" x:Name="rect2_3" />
+				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Stretch" FontSize="8.5" x:Name="txt2_3">
+					Center/Stretch
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid2_4">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Top" x:Name="rect2_4" />
+				<TextBlock HorizontalAlignment="Right" VerticalAlignment="Stretch" FontSize="8.5" x:Name="txt2_4">
+					Right/Stretch
+				</TextBlock>
+			</Grid>
+		</StackPanel>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid3_1">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Center" x:Name="rect3_1" />
+				<TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="8.5" x:Name="txt3_1">
+					Left/Center
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid3_2">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Center" x:Name="rect3_2" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Center" FontSize="8.5" x:Name="txt3_2">
+					Stretch/Center
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid3_3">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="rect3_3" />
+				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="8.5" x:Name="txt3_3">
+					Center/Center
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid3_4">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Center" x:Name="rect3_4" />
+				<TextBlock HorizontalAlignment="Right" VerticalAlignment="Center" FontSize="8.5" x:Name="txt3_4">
+					Right/Center
+				</TextBlock>
+			</Grid>
+		</StackPanel>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid4_1">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Bottom" x:Name="rect4_1" />
+				<TextBlock HorizontalAlignment="Left" VerticalAlignment="Bottom" FontSize="8.5" x:Name="txt4_1">
+					Left/Bottom
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid4_2">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Bottom" x:Name="rect4_2" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Bottom" FontSize="8.5" x:Name="txt4_2">
+					Stretch/Bottom
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid4_3">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Bottom" x:Name="rect4_3" />
+				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Bottom" FontSize="8.5" x:Name="txt4_3">
+					Center/Bottom
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid4_4">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Bottom" x:Name="rect4_4" />
+				<TextBlock HorizontalAlignment="Right" VerticalAlignment="Bottom" FontSize="8.5" x:Name="txt4_4">
+					Right/Bottom
+				</TextBlock>
+			</Grid>
+		</StackPanel>
+
+		<TextBlock FontSize="12" FontWeight="Bold">TextAlignment=Center</TextBlock>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid5_1">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Top" x:Name="rect5_1" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Top" FontSize="8.5" TextAlignment="Center" x:Name="txt5_1">
+					Stretch/Top
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid5_2">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Top" x:Name="rect5_2" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="8.5" TextAlignment="Center" x:Name="txt5_2">
+					Stretch/Stretch
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid5_3">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="rect5_3" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Center" FontSize="8.5" TextAlignment="Center" x:Name="txt5_3">
+					Stretch/Center
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid5_4">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Bottom" x:Name="rect5_4" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Bottom" FontSize="8.5" TextAlignment="Center" x:Name="txt5_4">
+					Stretch/Bottom
+				</TextBlock>
+			</Grid>
+		</StackPanel>
+
+		<TextBlock FontSize="12" FontWeight="Bold">TextAlignment=Center (text late-set)</TextBlock>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid6_1">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Top" x:Name="rect6_1" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Top" FontSize="8.5" TextAlignment="Center" x:Name="txt6_1" MaxLines="0" TextTrimming="CharacterEllipsis" LineStackingStrategy="BlockLineHeight" />
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid6_2">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Top" x:Name="rect6_2" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="8.5" TextAlignment="Center" x:Name="txt6_2" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxLines="0" LineStackingStrategy="BlockLineHeight" />
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid6_3">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="rect6_3" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Center" FontSize="8.5" TextAlignment="Center" x:Name="txt6_3" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxLines="0" LineStackingStrategy="BlockLineHeight" />
+
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid6_4">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Bottom" x:Name="rect6_4" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Bottom" FontSize="8.5" TextAlignment="Center" x:Name="txt6_4" TextWrapping="Wrap" MaxLines="0" LineStackingStrategy="BlockLineHeight" />
+			</Grid>
+		</StackPanel>
+
+		<TextBlock FontSize="12" FontWeight="Bold">TextAlignment=Right</TextBlock>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid7_1">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Top" x:Name="rect7_1" />
+				<TextBlock HorizontalAlignment="Left" VerticalAlignment="Top" FontSize="8.5" TextAlignment="Right" x:Name="txt7_1">
+					Left/Top
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid7_2">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Top" x:Name="rect7_2" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Top" FontSize="8.5" TextAlignment="Right" x:Name="txt7_2">
+					Stretch/Top
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid7_3">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Top" x:Name="rect7_3" />
+				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Top" FontSize="8.5" TextAlignment="Right" x:Name="txt7_3">
+					Center/Top
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid7_4">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Top" x:Name="rect7_4" />
+				<TextBlock HorizontalAlignment="Right" VerticalAlignment="Top" FontSize="8.5" TextAlignment="Right" x:Name="txt7_4">
+					Right/Top
+				</TextBlock>
+			</Grid>
+		</StackPanel>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid8_1">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Top" x:Name="rect8_1" />
+				<TextBlock HorizontalAlignment="Left" VerticalAlignment="Stretch" FontSize="8.5" TextAlignment="Right" x:Name="txt8_1">
+					Left/Stretch
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid8_2">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Top" x:Name="rect8_2" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontSize="8.5" TextAlignment="Right" x:Name="txt8_2">
+					Stretch/Stretch
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid8_3">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Top" x:Name="rect8_3" />
+				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Stretch" FontSize="8.5" TextAlignment="Right" x:Name="txt8_3">
+					Center/Stretch
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid8_4">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Top" x:Name="rect8_4" />
+				<TextBlock HorizontalAlignment="Right" VerticalAlignment="Stretch" FontSize="8.5" TextAlignment="Right" x:Name="txt8_4">
+					Right/Stretch
+				</TextBlock>
+			</Grid>
+		</StackPanel>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid9_1">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Center" x:Name="rect9_1" />
+				<TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" FontSize="8.5" TextAlignment="Right" x:Name="txt9_1">
+					Left/Center
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid9_2">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Center" x:Name="rect9_2" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Center" FontSize="8.5" TextAlignment="Right" x:Name="txt9_2">
+					Stretch/Center
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid9_3">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="rect9_3" />
+				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="8.5" TextAlignment="Right" x:Name="txt9_3">
+					Center/Center
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid9_4">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Center" x:Name="rect9_4" />
+				<TextBlock HorizontalAlignment="Right" VerticalAlignment="Center" FontSize="8.5" TextAlignment="Right" x:Name="txt9_4">
+					Right/Center
+				</TextBlock>
+			</Grid>
+		</StackPanel>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid10_1">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Left" VerticalAlignment="Bottom" x:Name="rect10_1" />
+				<TextBlock HorizontalAlignment="Left" VerticalAlignment="Bottom" FontSize="8.5" TextAlignment="Right" x:Name="txt10_1">
+					Left/Bottom
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid10_2">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Bottom" x:Name="rect10_2" />
+				<TextBlock HorizontalAlignment="Stretch" VerticalAlignment="Bottom" FontSize="8.5" TextAlignment="Right" x:Name="txt10_2">
+					Stretch/Bottom
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid10_3">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Center" VerticalAlignment="Bottom" x:Name="rect10_3" />
+				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Bottom" FontSize="8.5" TextAlignment="Right" x:Name="txt10_3">
+					Center/Bottom
+				</TextBlock>
+			</Grid>
+			<Grid Width="120" Height="30" BorderBrush="Blue" BorderThickness="3" x:Name="grid10_4">
+				<Rectangle Fill="LightGray" Width="65" Height="15" HorizontalAlignment="Right" VerticalAlignment="Bottom" x:Name="rect10_4" />
+				<TextBlock HorizontalAlignment="Right" VerticalAlignment="Bottom" FontSize="8.5" TextAlignment="Right" x:Name="txt10_4">
+					Right/Bottom
+				</TextBlock>
+			</Grid>
+		</StackPanel>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LayoutAlignment.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LayoutAlignment.xaml.cs
@@ -1,0 +1,27 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+using System.Threading.Tasks;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[Sample]
+	public sealed partial class TextBlock_LayoutAlignment : Page
+	{
+		public TextBlock_LayoutAlignment()
+		{
+			this.InitializeComponent();
+
+			this.Loaded += WhenLoaded;
+
+			void WhenLoaded(object sender, RoutedEventArgs e)
+			{
+				//await Task.Delay(10);
+				txt6_1.Text = "Stretch/Top";
+				txt6_2.Text = "Stretch/Stretch";
+				txt6_3.Text = "Stretch/Center";
+				txt6_4.Text = "Stretch/Bottom";
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -582,7 +582,6 @@ namespace Windows.UI.Xaml.Controls
 
 				var shouldRemoveUnfitLines = _ellipsize != null;
 
-				//if (shouldRemoveUnfitLines && maxHeight != null && measuredHeight > maxHeight)
 				if (shouldRemoveUnfitLines && maxHeight != null && measuredHeight > maxHeight)
 				{
 					var lineAtHeight = Layout.GetLineForOffset(maxHeight.Value) + 1;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -336,7 +336,7 @@ namespace Windows.UI.Xaml.Controls
 				var isSameWidth = _measureLayout.AvailableSize.Width == arrangeSize.Width;
 
 				// If the requested height is the same
-				var isSameHeight = _measureLayout.AvailableSize.Height == arrangeSize.Width;
+				var isSameHeight = _measureLayout.AvailableSize.Height == arrangeSize.Height;
 
 				// If the measured height is exactly the same
 				var isSameMeasuredHeight = _measureLayout.MeasuredSize.Height == arrangeSize.Height;
@@ -582,7 +582,8 @@ namespace Windows.UI.Xaml.Controls
 
 				var shouldRemoveUnfitLines = _ellipsize != null;
 
-				if (shouldRemoveUnfitLines && maxHeight != null && measuredHeight >= maxHeight)
+				//if (shouldRemoveUnfitLines && maxHeight != null && measuredHeight > maxHeight)
+				if (shouldRemoveUnfitLines && maxHeight != null && measuredHeight > maxHeight)
 				{
 					var lineAtHeight = Layout.GetLineForOffset(maxHeight.Value) + 1;
 					measuredHeight = Layout.GetLineTop(lineAtHeight);


### PR DESCRIPTION
Affected issues:
* fixes https://github.com/unoplatform/nventive-private/issues/149
* fixes https://github.com/unoplatform/nventive-private/issues/151
* fixes https://github.com/unoplatform/nventive-private/issues/150
* fixes https://github.com/unoplatform/nventive-private/issues/154
* fixes https://github.com/unoplatform/nventive-private/issues/155
* fixes https://github.com/unoplatform/nventive-private/issues/159

# Bugfix
Text on Android were wrongly layouted when the content were set after the loading of the `<TextBlock>` (usually by using a binding), the layout alignment is `Stretch` (which is the default) and text-alignment were not to left.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
