### PR TITLE
fix: Ensure protocol activation is handled

### DIFF
--- a/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
@@ -209,6 +209,9 @@ namespace Windows.UI.Xaml
 		{
 			base.OnNewIntent(intent);
 			this.Intent = intent;
+			// In case this activity is in SingleTask mode, we try to handle
+			// the intent (for protocol activation scenarios).
+			(Application as NativeApplication)?.TryHandleIntent(intent);
 		}
 
 		/// <summary>


### PR DESCRIPTION


GitHub Issue (If applicable): fixes #5076

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

For `SingleTask` activity, the protocol activation fails.


## What is the new behavior?

In case the application activity is in SingleTask mode, OnNewIntent is called to set the intent. This occurs after Activity OnStarted, so we need to check whether the intent should be handled (by OnActivated for example)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.