### PR TITLE
Fixes the HtmlElementAttribute inheritance for non-uno.ui types

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3793,6 +3793,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Path_Custom.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Path_Geometries.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6093,6 +6097,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Path_ClearData.xaml.cs">
       <DependentUpon>Path_ClearData.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Path_Custom.xaml.cs">
+      <DependentUpon>Path_Custom.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Path_Geometries.xaml.cs">
       <DependentUpon>Path_Geometries.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_Custom.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_Custom.xaml
@@ -1,0 +1,34 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Shapes.Path_Custom"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Shapes"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+	  <local:MyPath Stroke="Black" StrokeThickness="1" >
+		<Path.Data>
+		  <PathGeometry>
+			<PathGeometry.Figures>
+			  <PathFigure StartPoint="10,50">
+				<PathFigure.Segments>
+				  <BezierSegment
+					Point1="100,0"
+					Point2="200,200"
+					Point3="300,100"/>
+				  <LineSegment Point="400,100" />
+				  <ArcSegment
+					Size="50,50" RotationAngle="45"
+					IsLargeArc="True" SweepDirection="Clockwise"
+					Point="200,100"/>
+				</PathFigure.Segments>
+			  </PathFigure>
+			</PathGeometry.Figures>
+		  </PathGeometry>
+		</Path.Data>
+	  </local:MyPath>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_Custom.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Path_Custom.xaml.cs
@@ -1,0 +1,23 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Shapes;
+
+namespace UITests.Windows_UI_Xaml_Shapes
+{
+	[Sample("Shapes")]
+	public sealed partial class Path_Custom : Page
+	{
+		public Path_Custom()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+//#if __WASM__
+//	[Uno.UI.Runtime.WebAssembly.HtmlElement("svg")]
+//#endif
+	public partial class MyPath : Path
+	{
+		
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.wasm.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.wasm.cs
@@ -1,0 +1,80 @@
+﻿#if __WASM__
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Uno.Extensions;
+using Uno.UI.Extensions;
+using DependencyObjectExtensions = Uno.UI.Extensions.DependencyObjectExtensions;
+using Windows.UI.Xaml.Shapes;
+using Uno.UI.Runtime.WebAssembly;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	public partial class Given_UIElement
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_HTMLElement_InternalElement()
+		{
+			var SUT = new Line();
+
+			Assert.AreEqual("svg", SUT.HtmlTag);
+
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_HTMLElement_ExternalElement_NoOverride()
+		{
+			var SUT = new MyLine();
+
+			Assert.AreEqual("svg", SUT.HtmlTag);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_HTMLElement_ExternalElement_Override()
+		{
+			var SUT = new MyLineOverride();
+
+			Assert.AreEqual("p", SUT.HtmlTag);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_HTMLElement_ExternalElement_Override_Twice()
+		{
+			var SUT = new MyLine2();
+
+			Assert.AreEqual("p", SUT.HtmlTag);
+		}
+	}
+
+	public class MyLine : Line
+	{
+
+	}
+
+	[HtmlElement("p")]
+	public class MyLineOverride : Line
+	{
+
+	}
+
+
+	public class MyLine2 : MyLineOverride
+	{
+
+	}
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -128,7 +128,8 @@ namespace Windows.UI.Xaml
 
 				if (!_htmlTagCache.TryGetValue(currentType, out var htmlTagOverride))
 				{
-					htmlTagOverride = DefaultHtmlTag;
+					// Set the tag of the parent class to default.
+					htmlTagOverride = htmlTag;
 
 					if (currentType.GetCustomAttribute(_htmlElementAttribute) is Attribute attr)
 					{

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -128,10 +128,10 @@ namespace Windows.UI.Xaml
 
 				if (!_htmlTagCache.TryGetValue(currentType, out var htmlTagOverride))
 				{
-					// Set the tag of the parent class to default.
+					// Set the tag from the internal explicit UIElement parameter
 					htmlTagOverride = htmlTag;
 
-					if (currentType.GetCustomAttribute(_htmlElementAttribute) is Attribute attr)
+					if (currentType.GetCustomAttribute(_htmlElementAttribute, true) is Attribute attr)
 					{
 						_htmlTagCache[currentType] = htmlTagOverride = _htmlTagAttributeTagGetter.GetValue(attr, Array.Empty<object>()) as string;
 					}


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #3654, closes https://github.com/unoplatform/uno/pull/5100

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes the `HtmlElementAttribute` inheritance for non-uno.ui types.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
