### PR TITLE
fix(Animations): Fix issue with multiple animators holding the same handle to their JS counterparts

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/RenderingLoopAnimator.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/RenderingLoopAnimator.wasm.cs
@@ -29,14 +29,13 @@ namespace Windows.UI.Xaml.Media.Animation
 		private class Metadata : IJSObjectMetadata
 		{
 			public static Metadata Instance {get;} = new Metadata();
-			private Metadata() { }
 
-			private static long _handles = 0L;
+			private Metadata() { }
 
 			/// <inheritdoc />
 			public long CreateNativeInstance(IntPtr managedHandle)
 			{
-				var id = Interlocked.Increment(ref _handles);
+				var id = RenderingLoopAnimatorMetadataIdProvider.Next();
 				WebAssemblyRuntime.InvokeJS($"Windows.UI.Xaml.Media.Animation.RenderingLoopFloatAnimator.createInstance(\"{managedHandle}\", \"{id}\")");
 
 				return id;

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/RenderingLoopAnimatorMetadataIdProvider.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/RenderingLoopAnimatorMetadataIdProvider.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Windows.UI.Xaml.Media.Animation
+{
+	internal static class RenderingLoopAnimatorMetadataIdProvider
+	{
+		private static long _next = 0L;
+
+		public static long Next() => Interlocked.Increment(ref _next);
+	}
+}


### PR DESCRIPTION

closes #3736
closes #5038

## PR Type

What kind of change does this PR introduce?

- Bugfix


## What is the current behavior?

`Error #1 "TypeError: Cannot read property 'DisableFrameReporting' of undefined`

Sometimes animations on WASM are not stopped properly

We used to get some annoying messages in the log, now we have to put a breakpoint in the onFrame

## What is the new behavior?

No error. Animations fully stop on the JS side

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
