### PR TITLE
fix: Misc issues with items repeater

### DIFF
--- a/src/Uno.CrossTargetting.props
+++ b/src/Uno.CrossTargetting.props
@@ -35,11 +35,11 @@
 		This target is the equivalent to this property group, until this
 		is fixed: https://github.com/NuGet/Home/issues/6662
 		<PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
-			<NoWarn>$(NoWarn);67</NoWarn>
+			<NoWarn>$(NoWarn);67;0649</NoWarn>
 		</PropertyGroup>
 		-->
 
-	<CreateProperty Value="$(NoWarn);67">
+	<CreateProperty Value="$(NoWarn);67;0649">
 	  <Output
 			  TaskParameter="Value"
 			  PropertyName="NoWarn" />

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/PagerControl/PagerControlTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/PagerControl/PagerControlTests.cs
@@ -49,6 +49,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 			});
 		}
 
+#if !__WASM__ // IdleSynchronizer.Wait(); is not supported on WASM
 		[TestMethod]
 		public void VerifyNumberPanelButtonUIABehavior()
 		{
@@ -75,6 +76,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 				}
 			});
 		}
+#endif
 
 		[TestMethod]
 		[Ignore("ComboBox version of the control is slow on Android/iOS (issue #3144)")]

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/PagerControl/PagerControlTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/PagerControl/PagerControlTests.cs
@@ -50,7 +50,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 		}
 
 		[TestMethod]
-		[Ignore("ItemsRepeater-based version of the control is not working yet (issue #5030)")]
 		public void VerifyNumberPanelButtonUIABehavior()
 		{
 			RunOnUIThread.Execute(() => {

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -9,6 +9,11 @@ using Windows.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
+using Uno.UI.Extensions;
+
+#if WINDOWS_UWP
+using Windows.UI.Xaml.Controls.Primitives;
+#endif
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 {
@@ -25,7 +30,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 			};
 			var popup = new Popup
 			{
-				Background = new SolidColorBrush(Colors.Red),
 				Child = new Grid
 				{
 					Width = 100,
@@ -43,11 +47,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 			sut.UpdateLayout();
 
 			var second = sut
-				.EnumerateAllChildren()
+				.GetAllChildren()
 				.OfType<TextBlock>()
 				.FirstOrDefault(t => t.Text == "Item_2");
 
 			popup.IsOpen = false;
+			TestServices.WindowHelper.WindowContent = null;
 
 			Assert.IsNotNull(second);
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
+{
+	[TestClass]
+	public class Given_ItemsRepeater
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_NoScrollViewer_Then_ShowMoreThanFirstItem()
+		{
+			var sut = new ItemsRepeater
+			{
+				ItemsSource = new[] {"Item_1", "Item_2"}
+			};
+			var popup = new Popup
+			{
+				Background = new SolidColorBrush(Colors.Red),
+				Child = new Grid
+				{
+					Width = 100,
+					Height = 200,
+					Children = {sut}
+				}
+			};
+
+			TestServices.WindowHelper.WindowContent = popup;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			popup.IsOpen = true;
+
+			await TestServices.WindowHelper.WaitForIdle();
+			sut.UpdateLayout();
+
+			var second = sut
+				.EnumerateAllChildren()
+				.OfType<TextBlock>()
+				.FirstOrDefault(t => t.Text == "Item_2");
+
+			popup.IsOpen = false;
+
+			Assert.IsNotNull(second);
+		}
+	}
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ViewportManagerWithPlatformFeatures.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ViewportManagerWithPlatformFeatures.cs
@@ -605,7 +605,18 @@ namespace Microsoft.UI.Xaml.Controls
 				// we don't invalidate measure in UpdateViewport if the view is changing to
 				// avoid layout cycles.
 				REPEATER_TRACE_INFO("%ls: \tInvalidating measure due to viewport change. \n", GetLayoutId());
+#if __ANDROID__
+				// Uno workaround:
+				// This method is mainly used by the UpdateViewport but also the OnLayoutUpdated.
+				// Both are usually being invoked while in the Arrange phase, but on Android we cannot invalidate the layout while arranging it,
+				// we have to defer the invalidate.
+				// Note: We use RunAnimation to get it as soon as possible.
+				// Note: UpdateViewport might also be invoked on Load, but in that case we expect either the viewport to not change,
+				//		 either the layout is pending anyway, so we should not have an extra useless layout pass.
+				m_owner.Dispatcher.RunAnimation(() => m_owner.InvalidateMeasure());
+#else
 				m_owner.InvalidateMeasure();
+#endif
 			}
 		}
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ViewportManagerWithPlatformFeatures.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ViewportManagerWithPlatformFeatures.cs
@@ -501,13 +501,20 @@ namespace Microsoft.UI.Xaml.Controls
 					parent = CachedVisualTreeHelpers.GetParent(parent);
 				}
 
+				/*
+				Uno workaround:
+					This a workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/2349.
+					While this bugs occurs only for `Popup` on WinUI, it might occurs even in the "main" visual tree on uno.
+					The reason is that they do have a `ScrollViewer` at the root of the app on WinUI (to support the SIP), but we don't in Uno.
+
 				if (m_scroller == null)
 				{
 					// We usually update the viewport in the post arrange handler. But, since we don't have
 					// a scroller, let's do it now.
 					UpdateViewport(new Rect( ));
 				}
-				else if (!m_managingViewportDisabled)
+				else*/
+				if (!m_managingViewportDisabled)
 				{
 					m_effectiveViewportChangedRevoker = Disposable.Create(() =>
 					{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -589,8 +589,11 @@ namespace Windows.UI.Xaml.Controls
 				{
 					container.Style = style;
 				}
-
-				container.ContentTemplate = dataTemplate;
+				
+				if (!container.IsContainerFromTemplateRoot)
+				{
+					container.ContentTemplate = dataTemplate;
+				}
 				try
 				{
 					// Attach templated container to visual tree while measuring. This works around the bug that default Style is not 


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/4742
fixes https://github.com/unoplatform/uno/issues/4935
fixes https://github.com/unoplatform/uno/issues/5030

## Bugfix
* `ItemsRepeater` does not render its items properly
* First tab of `TabView` is not rendered properly on iOS

## What is the current behavior?
* If there is no `ScrollViewer` in the parent visual tree of an `ItemsRepeater` then it "viewport" will remain to 0,0,0,0 usually leading the repeater to render only it first item. This issues has already been reported on the WinUI repo (https://github.com/microsoft/microsoft-ui-xaml/issues/2349), and the commit only workarounds it.
* If the root element of the `ItemTemplate` of the `TabView` is the "container" (i.e. `TabViewItem`)  then on iOS, the `ContentTemplate` of this container is replaced by that `ItemTemplate` (the one which has actually been used to create it) during the estimation of the elements size.

## What is the new behavior?
* Even if there is no `ScrollViewer` in the visual tree, the `ItemRepeater` does subscribe to the `EffectiveViewportChanged` event to get a valid viewport.
* The `ListView` is now validating that the container was not created by the template itself before assigning it data template.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
