### PR TITLE
[MacOS] Margin directly on the child element of a <ScrollViewer /> were ignored

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
@@ -7,6 +7,8 @@ using System.Runtime.Versioning;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
@@ -116,6 +118,37 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 			{
 				var scrn = TakeScreenshot(description);
 				ImageAssert.HasColorAt(scrn, rect.CenterX, rect.CenterY, color);
+			}
+		}
+
+		[Test]
+		[AutoRetry]
+		public void ScrollViewer_Margin()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ScrollViewerTests.ScrollViewer_Margin");
+
+			_app.Marked("size").SetDependencyPropertyValue("Value", "80");
+
+			_app.WaitForElement("ctl5");
+
+			using var screenshot = TakeScreenshot("test", ignoreInSnapshotCompare: true);
+
+			for(byte i=1; i<=5; i++)
+			{
+				using var _ = new AssertionScope();
+
+				var logicalRect = _app.GetLogicalRect($"ctl{i}");
+				logicalRect.Width.Should().Be(80);
+				logicalRect.Height.Should().Be(80);
+
+				var physicalRect = _app.GetPhysicalRect($"ctl{i}");
+
+				ImageAssert.HasColorAt(screenshot, physicalRect.CenterX, physicalRect.CenterY, Color.Red);
+				ImageAssert.HasColorAt(screenshot, physicalRect.X + 5, physicalRect.Y + 5, Color.Orange);
+				ImageAssert.HasColorAt(screenshot, physicalRect.Right - 5, physicalRect.Y + 5, Color.Orange);
+				ImageAssert.HasColorAt(screenshot, physicalRect.X + 5, physicalRect.Bottom - 5, Color.Orange);
+				ImageAssert.HasColorAt(screenshot, physicalRect.Right - 5, physicalRect.Bottom - 5, Color.Orange);
+
 			}
 		}
 	}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1329,6 +1329,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Margin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Padding.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4686,6 +4690,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Clipping.xaml.cs">
       <DependentUpon>ScrollViewer_Clipping.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Margin.xaml.cs">
+      <DependentUpon>ScrollViewer_Margin.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Padding.xaml.cs">
       <DependentUpon>ScrollViewer_Padding.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Margin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Margin.xaml
@@ -1,0 +1,62 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.ScrollViewerTests.ScrollViewer_Margin"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ScrollViewerTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="4" Margin="30">
+
+		<TextBlock FontSize="18">
+			All following squares should be identical
+		</TextBlock>
+
+		<Slider x:Name="size" Minimum="50" Maximum="450" Value="100" Header="size" />
+
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Border Width="{Binding Value, ElementName=size}" Height="{Binding Value, ElementName=size}" BorderBrush="Blue" BorderThickness="2" Background="Orange" x:Name="ctl1">
+				<Border Margin="20">
+					<Rectangle Fill="Red" />
+				</Border>
+			</Border>
+
+			<Border Width="{Binding Value, ElementName=size}" Height="{Binding Value, ElementName=size}" BorderBrush="Blue" BorderThickness="2" x:Name="ctl2">
+				<ScrollViewer Background="Orange">
+					<Border Margin="20">
+						<Rectangle Fill="Red" />
+					</Border>
+				</ScrollViewer>
+			</Border>
+
+			<Border Width="{Binding Value, ElementName=size}" Height="{Binding Value, ElementName=size}" BorderBrush="Blue" BorderThickness="2" x:Name="ctl3">
+				<ScrollViewer>
+					<Border Background="Orange">
+						<Border Margin="20">
+							<Rectangle Fill="Red" />
+						</Border>
+					</Border>
+				</ScrollViewer>
+			</Border>
+
+			<Border Width="{Binding Value, ElementName=size}" Height="{Binding Value, ElementName=size}" BorderBrush="Blue" BorderThickness="2" Padding="20" Background="Orange" x:Name="ctl4">
+				<ScrollViewer>
+					<Border>
+						<Rectangle Fill="Red" />
+					</Border>
+				</ScrollViewer>
+			</Border>
+
+			<Border Width="{Binding Value, ElementName=size}" Height="{Binding Value, ElementName=size}" BorderBrush="Blue" BorderThickness="2" x:Name="ctl5">
+				<ScrollViewer Padding="20" Background="Orange">
+					<Border>
+						<Rectangle Fill="Red" />
+					</Border>
+				</ScrollViewer>
+			</Border>
+		</StackPanel>
+
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Margin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Margin.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
+{
+	[Sample("ScrollViewer")]
+	public sealed partial class ScrollViewer_Margin : Page
+	{
+		public ScrollViewer_Margin()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.iOSmacOS.cs
@@ -150,7 +150,7 @@ namespace Windows.UI.Xaml.Controls
 					UpdateDelayedTouches();
 #else
 					var size = AdjustContentSize(_content.Frame.Size + new CGSize(horizontalMargin, verticalMargin));
-					ContentView.Frame = new CGRect(new CGPoint(0, 0), size);
+					ContentView.Frame = new CGRect(_content.Frame.Location, size);
 #endif
 				}
 			}
@@ -199,7 +199,6 @@ namespace Windows.UI.Xaml.Controls
 					else
 					{
 						return (nfloat)child.Margin.Left;
-
 					}
 
 				default:


### PR DESCRIPTION
Fixes https://github.com/unoplatform/private/issues/177

# Bugfix
Any `Margin` directly on the child element of a `<ScrollViewer />` on macOS were used to measure the element, but were ignored during the arrange phase, leading to a forced Top/Left alignment without the applied margin.

**STILL DRAFT: UI TESTS STILL MISSING**

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
