### PR TITLE
fix(linux): Package base path resolution for single-file .NET 5 packaging

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Package.Other.cs
+++ b/src/Uno.UWP/ApplicationModel/Package.Other.cs
@@ -27,9 +27,9 @@ namespace Windows.ApplicationModel
 
 		private string GetInstalledLocation()
 		{
-			if (Assembly.GetEntryAssembly() is Assembly assembly)
+			if (!string.IsNullOrEmpty(AppContext.BaseDirectory))
 			{
-				return global::System.IO.Path.GetDirectoryName(new Uri(assembly.Location).LocalPath);
+				return global::System.IO.Path.GetDirectoryName(AppContext.BaseDirectory);
 			}
 			else
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/4840

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The `Package.InstalledLocation` may fail when using Single-File packaging.

## What is the new behavior?

The Package class does not rely on assembly location to determine the intallation path.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
