### PR TITLE
fix(navigationview): Prevent crash when selecting item too early

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
@@ -12,18 +12,14 @@ using Windows.UI.Xaml.Media;
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 {
 	[TestClass]
-    public partial class Given_UIElement
+	public partial class Given_UIElement
 	{
 #if HAS_UNO // Tests use IsArrangeDirty, which is an internal property
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_Visible_InvalidateArrange()
 		{
-			var sut = new Border()
-			{
-				Width = 100,
-				Height = 10
-			};
+			var sut = new Border() {Width = 100, Height = 10};
 
 			TestServices.WindowHelper.WindowContent = sut;
 			await TestServices.WindowHelper.WaitForIdle();
@@ -74,7 +70,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 			border.UpdateLayout();
 
-			await TestServices.WindowHelper.WaitFor(()=>Math.Abs(text.ActualWidth - text.ActualSize.X) < 0.01);
+			await TestServices.WindowHelper.WaitFor(() => Math.Abs(text.ActualWidth - text.ActualSize.X) < 0.01);
 			await TestServices.WindowHelper.WaitFor(() => Math.Abs(text.ActualHeight - text.ActualSize.Y) < 0.01);
 
 			text.Text = "This is a longer text";
@@ -102,15 +98,19 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 			border.UpdateLayout();
 
-			await TestServices.WindowHelper.WaitFor(() => Math.Abs(rectangle.ActualWidth - rectangle.ActualSize.X) < 0.01);
-			await TestServices.WindowHelper.WaitFor(() => Math.Abs(rectangle.ActualHeight - rectangle.ActualSize.Y) < 0.01);
+			await TestServices.WindowHelper.WaitFor(() =>
+				Math.Abs(rectangle.ActualWidth - rectangle.ActualSize.X) < 0.01);
+			await TestServices.WindowHelper.WaitFor(() =>
+				Math.Abs(rectangle.ActualHeight - rectangle.ActualSize.Y) < 0.01);
 
 			rectangle.Width = 16;
 			rectangle.Height = 32;
 			border.UpdateLayout();
 
-			await TestServices.WindowHelper.WaitFor(() => Math.Abs(rectangle.ActualWidth - rectangle.ActualSize.X) < 0.01);
-			await TestServices.WindowHelper.WaitFor(() => Math.Abs(rectangle.ActualHeight - rectangle.ActualSize.Y) < 0.01);
+			await TestServices.WindowHelper.WaitFor(() =>
+				Math.Abs(rectangle.ActualWidth - rectangle.ActualSize.X) < 0.01);
+			await TestServices.WindowHelper.WaitFor(() =>
+				Math.Abs(rectangle.ActualHeight - rectangle.ActualSize.Y) < 0.01);
 		}
 #endif
 
@@ -121,7 +121,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		{
 			if (Window.Current.RootElement is Panel root)
 			{
-				var sut = new Grid { HorizontalAlignment = HorizontalAlignment.Stretch, VerticalAlignment = VerticalAlignment.Stretch };
+				var sut = new Grid
+				{
+					HorizontalAlignment = HorizontalAlignment.Stretch, VerticalAlignment = VerticalAlignment.Stretch
+				};
 
 				var originalRootAvailableSize = LayoutInformation.GetAvailableSize(root);
 				var originalRootDesiredSize = LayoutInformation.GetDesiredSize(root);
@@ -148,7 +151,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 					LayoutInformation.SetLayoutSlot(root, originalRootLayoutSlot);
 
 					root.Children.Remove(sut);
-					try { root.UpdateLayout(); } catch { } // Make sure to restore visual tree if test has failed!
+					try { root.UpdateLayout(); }
+					catch { } // Make sure to restore visual tree if test has failed!
 				}
 
 				Assert.AreNotEqual(default, availableSize);
@@ -174,40 +178,40 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 			Assert.IsFalse(sut.Failed);
 		}
+	}
 
-		private class When_UpdateLayout_Then_ReentrancyNotAllowed_Element : FrameworkElement
+	internal partial class When_UpdateLayout_Then_ReentrancyNotAllowed_Element : FrameworkElement
+	{
+		private bool _isMeasuring, _isArranging;
+
+		public bool Failed { get; private set; }
+
+		protected override Size MeasureOverride(Size availableSize)
 		{
-			private bool _isMeasuring, _isArranging;
+			Failed |= _isMeasuring;
 
-			public bool Failed { get; private set; }
-
-			protected override Size MeasureOverride(Size availableSize)
+			if (!Failed)
 			{
-				Failed |= _isMeasuring;
-
-				if (!Failed)
-				{
-					_isMeasuring = true;
-					UpdateLayout();
-					_isMeasuring = false;
-				}
-
-				return base.MeasureOverride(availableSize);
+				_isMeasuring = true;
+				UpdateLayout();
+				_isMeasuring = false;
 			}
 
-			protected override Size ArrangeOverride(Size finalSize)
+			return base.MeasureOverride(availableSize);
+		}
+
+		protected override Size ArrangeOverride(Size finalSize)
+		{
+			Failed |= _isArranging;
+
+			if (!Failed)
 			{
-				Failed |= _isArranging;
-
-				if (!Failed)
-				{
-					_isArranging = true;
-					UpdateLayout();
-					_isArranging = false;
-				}
-
-				return base.ArrangeOverride(finalSize);
+				_isArranging = true;
+				UpdateLayout();
+				_isArranging = false;
 			}
+
+			return base.ArrangeOverride(finalSize);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -54,11 +54,14 @@ namespace Windows.UI.Xaml.Controls
 
 		internal Size _unclippedDesiredSize;
 
+		private UIElement _elementAsUIElement;
+
 		public IFrameworkElement Panel { get; }
 
 		protected Layouter(IFrameworkElement element)
 		{
 			Panel = element;
+			_elementAsUIElement = element as UIElement;
 
 			var log = this.Log();
 			if (log.IsEnabled(LogLevel.Debug))
@@ -90,10 +93,14 @@ namespace Windows.UI.Xaml.Controls
 				return default;
 			}
 
-			using (traceActivity)
+			try
 			{
-				var (minSize, maxSize) = Panel.GetMinMax();
+				if (_elementAsUIElement?.IsVisualTreeRoot ?? false)
+				{
+					UIElement.IsLayoutingVisualTreeRoot = true;
+				}
 
+				var (minSize, maxSize) = Panel.GetMinMax();
 				var marginSize = Panel.GetMarginSize();
 
 				// NaN values are accepted as input here, particularly when coming from
@@ -141,6 +148,14 @@ namespace Windows.UI.Xaml.Controls
 				// We return "clipped" desiredSize to caller... the unclipped version stays internal
 				return clippedDesiredSize;
 			}
+			finally
+			{
+				if (_elementAsUIElement?.IsVisualTreeRoot ?? false)
+				{
+					UIElement.IsLayoutingVisualTreeRoot = false;
+				}
+				traceActivity?.Dispose();
+			}
 		}
 
 		[Pure]
@@ -163,8 +178,6 @@ namespace Windows.UI.Xaml.Controls
 		{
 			LayoutInformation.SetLayoutSlot(Panel, finalRect);
 
-			var uiElement = Panel as UIElement;
-
 			IDisposable traceActivity = null;
 			if (_trace.IsEnabled)
 			{
@@ -174,14 +187,20 @@ namespace Windows.UI.Xaml.Controls
 					new object[] { LoggingOwnerTypeName, Panel.GetDependencyObjectId() }
 				);
 			}
-			using (traceActivity)
+
+			try
 			{
+				if (_elementAsUIElement?.IsVisualTreeRoot ?? false)
+				{
+					UIElement.IsLayoutingVisualTreeRoot = true;
+				}
+
 				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 				{
 					this.Log().DebugFormat("[{0}/{1}] Arrange({2}/{3}/{4}/{5})", LoggingOwnerTypeName, Name, GetType(), Panel.Name, finalRect, Panel.Margin);
 				}
 
-				var clippedArrangeSize = uiElement?.ClippedFrame is Rect clip && !uiElement.IsArrangeDirty
+				var clippedArrangeSize = _elementAsUIElement?.ClippedFrame is Rect clip && !_elementAsUIElement.IsArrangeDirty
 					? clip.Size
 					: finalRect.Size;
 
@@ -247,11 +266,11 @@ namespace Windows.UI.Xaml.Controls
 
 				var renderSize = ArrangeOverride(arrangeSize);
 
-				if (uiElement != null)
+				if (_elementAsUIElement != null)
 				{
-					uiElement.RenderSize = renderSize.AtMost(maxSize);
-					uiElement.NeedsClipToSlot = needsClipToSlot;
-					uiElement.ApplyClip();
+					_elementAsUIElement.RenderSize = renderSize.AtMost(maxSize);
+					_elementAsUIElement.NeedsClipToSlot = needsClipToSlot;
+					_elementAsUIElement.ApplyClip();
 
 					if (Panel is FrameworkElement fe)
 					{
@@ -262,6 +281,14 @@ namespace Windows.UI.Xaml.Controls
 				{
 					evp.OnLayoutUpdated();
 				}
+			}
+			finally
+			{
+				if (_elementAsUIElement?.IsVisualTreeRoot ?? false)
+				{
+					UIElement.IsLayoutingVisualTreeRoot = true;
+				}
+				traceActivity?.Dispose();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -77,15 +77,13 @@ namespace Windows.UI.Xaml.Controls
 		/// <returns>The size of the panel, in logical pixel.</returns>
 		public Size Measure(Size availableSize)
 		{
-			IDisposable traceActivity = null;
-			if (_trace.IsEnabled)
-			{
-				traceActivity = _trace.WriteEventActivity(
+			using var traceActivity = _trace.IsEnabled
+				? _trace.WriteEventActivity(
 					FrameworkElement.TraceProvider.FrameworkElement_MeasureStart,
 					FrameworkElement.TraceProvider.FrameworkElement_MeasureStop,
-					new object[] { LoggingOwnerTypeName, Panel.GetDependencyObjectId() }
-				);
-			}
+					new object[] {LoggingOwnerTypeName, Panel.GetDependencyObjectId()}
+				)
+				: null;
 
 			if (Panel.Visibility == Visibility.Collapsed)
 			{
@@ -154,7 +152,6 @@ namespace Windows.UI.Xaml.Controls
 				{
 					UIElement.IsLayoutingVisualTreeRoot = false;
 				}
-				traceActivity?.Dispose();
 			}
 		}
 
@@ -178,15 +175,13 @@ namespace Windows.UI.Xaml.Controls
 		{
 			LayoutInformation.SetLayoutSlot(Panel, finalRect);
 
-			IDisposable traceActivity = null;
-			if (_trace.IsEnabled)
-			{
-				traceActivity = _trace.WriteEventActivity(
+			using var traceActivity = _trace.IsEnabled
+				? _trace.WriteEventActivity(
 					FrameworkElement.TraceProvider.FrameworkElement_ArrangeStart,
 					FrameworkElement.TraceProvider.FrameworkElement_ArrangeStop,
-					new object[] { LoggingOwnerTypeName, Panel.GetDependencyObjectId() }
-				);
-			}
+					new object[] {LoggingOwnerTypeName, Panel.GetDependencyObjectId()}
+				)
+				: null;
 
 			try
 			{
@@ -288,7 +283,6 @@ namespace Windows.UI.Xaml.Controls
 				{
 					UIElement.IsLayoutingVisualTreeRoot = false;
 				}
-				traceActivity?.Dispose();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -286,7 +286,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				if (_elementAsUIElement?.IsVisualTreeRoot ?? false)
 				{
-					UIElement.IsLayoutingVisualTreeRoot = true;
+					UIElement.IsLayoutingVisualTreeRoot = false;
 				}
 				traceActivity?.Dispose();
 			}

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -348,8 +348,18 @@ namespace Windows.UI.Xaml
 		[ThreadStatic]
 		private static bool _isInUpdateLayout; // Currently within the UpdateLayout() method (explicit managed layout request)
 
+#pragma warning disable CS0649 // Field not used on Desktop/Tests
 		[ThreadStatic]
-		private static bool _isLayoutingVisualTreeRoot; // Currenlty in Measure or Arrange of the element flagged with IsVisualTreeRoot (layout requested by the system)
+		private static bool _isLayoutingVisualTreeRoot; // Currently in Measure or Arrange of the element flagged with IsVisualTreeRoot (layout requested by the system)
+#pragma warning restore CS0649
+
+#if !__NETSTD__ // We need an internal accessor for the Layouter
+		internal static bool IsLayoutingVisualTreeRoot
+		{
+			get => _isLayoutingVisualTreeRoot;
+			set => _isLayoutingVisualTreeRoot = value;
+		}
+#endif
 
 		private const int MaxLayoutIterations = 250;
 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -52,6 +52,11 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		internal bool IsWindowRoot { get; set; }
 
+		/// <summary>
+		/// Is this view the top of the managed visual tree
+		/// </summary>
+		internal bool IsVisualTreeRoot { get; set; }
+
 		private void Initialize()
 		{
 			this.SetValue(KeyboardAcceleratorsProperty, new List<KeyboardAccelerator>(0), DependencyPropertyValuePrecedences.DefaultValue);
@@ -341,13 +346,16 @@ namespace Windows.UI.Xaml
 		internal bool IsRenderingSuspended { get; set; }
 
 		[ThreadStatic]
-		private static bool _isInUpdateLayout;
+		private static bool _isInUpdateLayout; // Currently within the UpdateLayout() method (explicit managed layout request)
+
+		[ThreadStatic]
+		private static bool _isLayoutingVisualTreeRoot; // Currenlty in Measure or Arrange of the element flagged with IsVisualTreeRoot (layout requested by the system)
 
 		private const int MaxLayoutIterations = 250;
 
 		public void UpdateLayout()
 		{
-			if (_isInUpdateLayout)
+			if (_isInUpdateLayout || _isLayoutingVisualTreeRoot)
 			{
 				return;
 			}

--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -56,6 +56,7 @@ namespace Windows.UI.Xaml
 
 				_main = new Grid()
 				{
+					IsVisualTreeRoot = true,
 					Children =
 					{
 						_rootBorder,

--- a/src/Uno.UI/UI/Xaml/Window.Desktop.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Desktop.cs
@@ -31,7 +31,17 @@ namespace Windows.UI.Xaml
 
 		private void InternalSetContent(UIElement value)
 		{
+			if (_content != null)
+			{
+				_content.IsWindowRoot = false;
+				_content.IsVisualTreeRoot = false;
+			}
+
 			_content = value;
+
+			_content.IsWindowRoot = true;
+			_content.IsVisualTreeRoot = true;
+
 			TryLoadContent();
 		}
 

--- a/src/Uno.UI/UI/Xaml/Window.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Skia.cs
@@ -145,6 +145,7 @@ namespace Windows.UI.Xaml
 
 				_window = new Grid
 				{
+					IsVisualTreeRoot = true,
 					Children =
 					{
 						_rootBorder,

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -75,6 +75,7 @@ namespace Windows.UI.Xaml
 		/// but also the PopupRoot, the DragRoot and all other internal UI elements.
 		/// On platforms like iOS and Android, we might still have few native controls above this.
 		/// </summary>
+		/// <remarks>This element is flagged with IsVisualTreeRoot.</remarks>
 		internal UIElement RootElement => InternalGetRootElement();
 
 		public Rect Bounds { get; private set; }

--- a/src/Uno.UI/UI/Xaml/Window.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.iOS.cs
@@ -98,6 +98,7 @@ namespace Windows.UI.Xaml
 
 				_main = new Grid()
 				{
+					IsVisualTreeRoot = true,
 					Children =
 					{
 						_rootBorder,

--- a/src/Uno.UI/UI/Xaml/Window.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.macOS.cs
@@ -85,6 +85,7 @@ namespace Windows.UI.Xaml
 
 				_main = new Grid()
 				{
+					IsVisualTreeRoot = true,
 					Children =
 					{
 						_rootBorder,

--- a/src/Uno.UI/UI/Xaml/Window.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window.wasm.cs
@@ -146,6 +146,7 @@ namespace Windows.UI.Xaml
 				_popupRoot = new PopupRoot();
 				_window = new Grid()
 				{
+					IsVisualTreeRoot = true,
 					Children =
 					{
 						_rootScrollViewer,


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/5069

## Bugfix
`NavigationView` is crashing if `SelectedItem` is set before first layouting pass.

## What is the current behavior?
When an item is realized by the `ItemsRepeater` the navigation forces a `UpdateLayout` which causes the `ItemsRepeater` to re-measure itself ... which throws an exception.

## What is the new behavior?
We are now considering the "native" layouting passes in the `UpdateLayout` and ignore the requests if layouting is already in progress.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
