### PR TITLE
fix(Border): [Skia] Ensure only the outer border shape is inserted as the first child

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
@@ -146,12 +146,15 @@ namespace Windows.UI.Xaml.Shapes
 				borderShape.Geometry = compositor.CreatePathGeometry(borderPath);
 				outerShape.Geometry = compositor.CreatePathGeometry(outerPath);
 
-				var shapeVisual = compositor.CreateShapeVisual();
-				shapeVisual.Shapes.Add(backgroundShape);
-				shapeVisual.Shapes.Add(borderShape);
+				var borderVisual = compositor.CreateShapeVisual();
+				var backgroundVisual = compositor.CreateShapeVisual();
+				backgroundVisual.Shapes.Add(backgroundShape);
+				borderVisual.Shapes.Add(borderShape);
 
-				sublayers.Add(shapeVisual);
-				parent.Children.InsertAtTop(shapeVisual);
+				sublayers.Add(backgroundVisual);
+				sublayers.Add(borderVisual);
+				parent.Children.InsertAtBottom(backgroundVisual);
+				parent.Children.InsertAtTop(borderVisual);
 
 				owner.ClippingIsSetByCornerRadius = cornerRadius != CornerRadius.None;
 				if (owner.ClippingIsSetByCornerRadius)


### PR DESCRIPTION
closes #5092

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/4793020/106912361-ef5cd000-66d0-11eb-9951-cb1bfad132f9.png)


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
![image](https://user-images.githubusercontent.com/4793020/106912487-10252580-66d1-11eb-84ff-a4a8982697b3.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
