### PR TITLE
feat(TextBox): Add keyboard command capability to macOS TextBox

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
@@ -25,7 +25,44 @@ namespace Windows.UI.Xaml.Controls
 			Initialize();
 		}
 
+		public override bool PerformKeyEquivalent(NSEvent theEvent)
+		{
+			if (theEvent.Type == NSEventType.KeyDown)
+			{
+				if ((theEvent.ModifierFlags & NSEventModifierMask.DeviceIndependentModifierFlagsMask) == NSEventModifierMask.CommandKeyMask)
+				{
+					var selectorName = theEvent.CharactersIgnoringModifiers.ToLowerInvariant() switch
+					{
+						"x" => "cut:",
+						"c" => "copy:",
+						"v" => "paste:",
+						"z" => "undo:",
+						"a" => "selectAll:",
+						_ => string.Empty,
+					};
 
+					if (!string.IsNullOrWhiteSpace(selectorName))
+					{
+						if (NSApplication.SharedApplication.SendAction(new ObjCRuntime.Selector(selectorName), null, this))
+						{
+							return true;
+						}
+					}
+				}
+				else if ((theEvent.ModifierFlags & NSEventModifierMask.DeviceIndependentModifierFlagsMask) == (NSEventModifierMask.CommandKeyMask | NSEventModifierMask.ShiftKeyMask))
+				{
+					if (theEvent.CharactersIgnoringModifiers.ToLowerInvariant() == "z")
+					{
+						if (NSApplication.SharedApplication.SendAction(new ObjCRuntime.Selector("redo:"), null, this))
+						{
+							return true;
+						}
+					}
+				}
+			}
+
+			return base.PerformKeyEquivalent(theEvent);
+		}
 		private void OnEditingChanged(object sender, EventArgs e)
 		{
 			OnTextChanged();


### PR DESCRIPTION
closes #5152

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Unable to Copy/Paste/Select All/Redo/Undo/Cut using keyboard

## What is the new behavior?

Able to Copy/Paste/Select All/Redo/Undo/Cut using keyboard

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.