### PR TITLE
[Wasm] Incorrect TextBox measurement when Wrap mode were used

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -631,5 +631,145 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			Assert.AreEqual(text.ToUpperInvariant(), upperCasingTextBox.GetDependencyPropertyValue("Text")?.ToString());
 		}
 
+		[Test]
+		[AutoRetry]
+		public void TextBox_AutoGrow_Vertically_Test()
+		{
+			Run("Uno.UI.Samples.Content.UITests.TextBoxControl.Input_Multiline_AutoHeight");
+
+			_app.FastTap("btnSingle");
+			_app.WaitForElement("Test");
+			var height1 = _app.GetLogicalRect("Test").Height;
+
+			_app.FastTap("btnDouble");
+			_app.WaitForElement("Test");
+			var height2 = _app.GetLogicalRect("Test").Height;
+
+			using var _ = new AssertionScope();
+			height2.Should().BeGreaterThan(height1);
+
+
+			_app.FastTap("btnSingle");
+			_app.WaitForElement("Test");
+			var height3 = _app.GetLogicalRect("Test").Height;
+
+			height3.Should().Be(height1);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void TextBox_AutoGrow_Vertically_Wrapping_Test()
+		{
+			Run("Uno.UI.Samples.Content.UITests.TextBoxControl.Input_Multiline_AutoHeight");
+
+			_app.Marked("Test").SetDependencyPropertyValue("MaxWidth", "200");
+			_app.Marked("Test").SetDependencyPropertyValue("TextWrapping", "Wrap");
+			_app.Marked("Test").SetDependencyPropertyValue("Text", "Short");
+			_app.WaitForElement("Test");
+			var height1 = _app.GetLogicalRect("Test").Height;
+
+			_app.EnterText("Test", "This is a significantly longer text. It should wraps.");
+			_app.WaitForElement("Test");
+			var height2 = _app.GetLogicalRect("Test").Height;
+
+			using var _ = new AssertionScope();
+			height2.Should().BeGreaterThan(height1);
+
+
+			_app.Marked("Test").SetDependencyPropertyValue("Text", "Short");
+			var height3 = _app.GetLogicalRect("Test").Height;
+
+			height3.Should().Be(height1);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void TextBox_AutoGrow_Vertically_NoWrapping_Test()
+		{
+			Run("Uno.UI.Samples.Content.UITests.TextBoxControl.Input_Multiline_AutoHeight");
+
+			_app.Marked("Test").SetDependencyPropertyValue("MaxWidth", "200");
+			_app.Marked("Test").SetDependencyPropertyValue("Text", "Short");
+			_app.WaitForElement("Test");
+			var height1 = _app.GetLogicalRect("Test").Height;
+
+			_app.EnterText("Test", "This is a significantly longer text. Since there's no wrapping, it should remains on a single line.");
+			_app.WaitForElement("Test");
+			var height2 = _app.GetLogicalRect("Test").Height;
+
+			height2.Should().Be(height1);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void TextBox_AutoGrow_Horizontally_Test()
+		{
+			using var _ = new AssertionScope();
+
+			Run("Uno.UI.Samples.Content.UITests.TextBoxControl.Input_Multiline_AutoHeight");
+
+			_app.Marked("Test").SetDependencyPropertyValue("MinWidth", "120");
+			_app.Marked("Test").SetDependencyPropertyValue("HorizontalAlignment", "Left");
+			_app.Marked("Test").SetDependencyPropertyValue("Text", "Short");
+
+			_app.WaitForElement("Test");
+			var width1 = _app.GetLogicalRect("Test").Width;
+			var height1 = _app.GetLogicalRect("Test").Height;
+
+			width1.Should().Be(120f);
+
+
+			_app.EnterText("Test", "This is a significantly larger text. Since there's no wrapping, it should remains on a single line.");
+			_app.WaitForElement("Test");
+			var width2 = _app.GetLogicalRect("Test").Width;
+			var height2 = _app.GetLogicalRect("Test").Height;
+
+			width2.Should().BeGreaterThan(width1);
+			height2.Should().Be(height1);
+
+			_app.Marked("Test").SetDependencyPropertyValue("Text", "Short");
+			_app.WaitForElement("Test");
+			var width3 = _app.GetLogicalRect("Test").Width;
+			var height3 = _app.GetLogicalRect("Test").Height;
+
+			width1.Should().Be(width1);
+			height3.Should().Be(height1);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void PasswordBox_AutoGrow_Horizontally_Test()
+		{
+			using var _ = new AssertionScope();
+
+			Run("Uno.UI.Samples.Content.UITests.TextBoxControl.PasswordBox_Simple");
+
+			_app.Marked("autoGrow").SetDependencyPropertyValue("MinWidth", "120");
+			_app.Marked("autoGrow").SetDependencyPropertyValue("HorizontalAlignment", "Left");
+			_app.Marked("autoGrow").SetDependencyPropertyValue("Password", "");
+
+			_app.WaitForElement("autoGrow");
+			var width1 = _app.GetLogicalRect("autoGrow").Width;
+			var height1 = _app.GetLogicalRect("autoGrow").Height;
+
+			width1.Should().Be(120f);
+
+
+			_app.EnterText("autoGrow", "This is a long password.");
+			_app.WaitForElement("autoGrow");
+			var width2 = _app.GetLogicalRect("autoGrow").Width;
+			var height2 = _app.GetLogicalRect("autoGrow").Height;
+
+			width2.Should().BeGreaterThan(width1);
+			height2.Should().Be(height1);
+
+			_app.Marked("autoGrow").SetDependencyPropertyValue("Password", "short");
+			_app.WaitForElement("autoGrow");
+			var width3 = _app.GetLogicalRect("autoGrow").Width;
+			var height3 = _app.GetLogicalRect("autoGrow").Height;
+
+			width3.Should().Be(width1);
+			height3.Should().Be(height1);
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -684,6 +684,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]
 		public void TextBox_AutoGrow_Vertically_NoWrapping_Test()
 		{
 			Run("Uno.UI.Samples.Content.UITests.TextBoxControl.Input_Multiline_AutoHeight");

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1545,6 +1545,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Wrapping.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\WASM_Multiline.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4938,6 +4942,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_TextChanging.xaml.cs">
       <DependentUpon>TextBox_TextChanging.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Wrapping.xaml.cs">
+      <DependentUpon>TextBox_Wrapping.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\WASM_Multiline.xaml.cs">
       <DependentUpon>WASM_Multiline.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Input_Multiline_AutoHeight.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Input_Multiline_AutoHeight.xaml
@@ -27,6 +27,10 @@
 						         xamarin:EnterCommand="{Binding [MyInputEnterCommand]}"
 						         AcceptsReturn="True" />
 					</Grid>
+					<StackPanel Orientation="Horizontal" Spacing="8">
+						<Button x:Name="btnSingle" Click="BtnSingle_OnClick">Set Single Line</Button>
+						<Button x:Name="btnDouble" Click="BtnDouble_OnClick">Set Double Line</Button>
+					</StackPanel>
 					<TextBlock Text="Result :" />
 					<TextBlock Text="{Binding [Result]}" />
 					<TextBlock Text="Command Result :" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Input_Multiline_AutoHeight.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Input_Multiline_AutoHeight.xaml.cs
@@ -1,3 +1,4 @@
+using Windows.UI.Xaml;
 using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml.Controls;
 using Uno.UI.Samples.Presentation.SamplePages;
@@ -11,5 +12,16 @@ namespace Uno.UI.Samples.Content.UITests.TextBoxControl
 		{
 			InitializeComponent();
 		}
+
+		private void BtnSingle_OnClick(object sender, RoutedEventArgs e)
+		{
+			(DataContext as TextBoxViewModel).MyInput = "Single Line";
+		}
+
+		private void BtnDouble_OnClick(object sender, RoutedEventArgs e)
+		{
+			(DataContext as TextBoxViewModel).MyInput = "Double\nLine";
+		}
+
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Simple.xaml
@@ -25,7 +25,7 @@
 	  <PasswordBox Width="150"/>
 
 	  <TextBlock Text="Simple PasswordBox without defined width (should grow with the content)"/>
-	  <PasswordBox HorizontalAlignment="Center" />
+	  <PasswordBox x:Name="autoGrow" HorizontalAlignment="Center" />
 
 	  <TextBlock Text="Simple PasswordBox with Hidden RevealMode"/>
 	  <PasswordBox Width="150" PasswordRevealMode="Hidden"/>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Wrapping.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Wrapping.xaml
@@ -1,0 +1,53 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_Wrapping"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid ColumnSpacing="8">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" MaxWidth="200" />
+			<ColumnDefinition Width="*" MaxWidth="200" />
+			<ColumnDefinition Width="*" MaxWidth="200" />
+			<ColumnDefinition Width="*" MaxWidth="200" />
+		</Grid.ColumnDefinitions>
+
+		<StackPanel Spacing="6" Grid.Column="0">
+			<TextBlock FontSize="15">TextWrapping="Wrap"<LineBreak />AcceptsReturn="True"</TextBlock>
+
+			<Border BorderBrush="Orange" BorderThickness="3">
+				<TextBox x:Name="wrapReturns" MaxHeight="400" TextWrapping="Wrap" AcceptsReturn="True" xml:space="preserve" Text="{x:Bind Text, Mode=TwoWay}" />
+				</Border>
+		</StackPanel>
+
+		<StackPanel Spacing="6" Grid.Column="1">
+			<TextBlock FontSize="15">TextWrapping="NoWrap"<LineBreak />AcceptsReturn="False"</TextBlock>
+
+			<Border BorderBrush="Orange" BorderThickness="3">
+				<TextBox x:Name="noWrapNoReturns" MaxHeight="400" AcceptsReturn="False" TextWrapping="NoWrap" Text="{x:Bind Text, Mode=TwoWay}" />
+			</Border>
+		</StackPanel>
+
+		<StackPanel Spacing="6" Grid.Column="2">
+			<TextBlock FontSize="15">TextWrapping="NoWrap"<LineBreak />AcceptsReturn="True"</TextBlock>
+
+			<Border BorderBrush="Orange" BorderThickness="3">
+				<TextBox x:Name="NoWrapReturns" MaxHeight="400" AcceptsReturn="True" TextWrapping="NoWrap" Text="{x:Bind Text, Mode=TwoWay}" />
+			</Border>
+		</StackPanel>
+
+		<StackPanel Spacing="6" Grid.Column="3">
+			<TextBlock FontSize="15">TextWrapping="Wrap"<LineBreak />AcceptsReturn="False"</TextBlock>
+
+			<Border BorderBrush="Orange" BorderThickness="3">
+				<TextBox x:Name="wrapNoReturns" MaxHeight="400" AcceptsReturn="False" TextWrapping="Wrap" Text="{x:Bind Text, Mode=TwoWay}" />
+			</Border>
+		</StackPanel>
+
+		<TextBlock Grid.ColumnSpan="3" VerticalAlignment="Bottom">
+			TextSource: <Hyperlink NavigateUri="https://vlad-saling.github.io/star-trek-ipsum/">https://vlad-saling.github.io/star-trek-ipsum/</Hyperlink>
+		</TextBlock>
+	</Grid></Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Wrapping.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Wrapping.xaml.cs
@@ -1,0 +1,32 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBox
+{
+	[Sample("TextBox")]
+	public sealed partial class TextBox_Wrapping : Page
+	{
+		public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
+			"Text", typeof(string), typeof(TextBox_Wrapping), new PropertyMetadata(default(string)));
+
+		public string Text
+		{
+			get { return (string)GetValue(TextProperty); }
+			set { SetValue(TextProperty, value); }
+		}
+
+		public TextBox_Wrapping()
+		{
+			Text = @"Now what are the possibilities of warp drive? Cmdr Riker's nervous system has been invaded by an unknown microorganism. The organisms fuse to the nerve, intertwining at the molecular level. That's why the transporter's biofilters couldn't extract it. The vertex waves show a K-complex corresponding to an REM state. The engineering section's critical. Destruction is imminent. Their robes contain ultritium, highly explosive, virtually undetectable by your transporter.
+
+Communication is not possible. The shuttle has no power. Using the gravitational pull of a star to slingshot back in time? We are going to Starbase Montgomery for Engineering consultations prompted by minor read-out anomalies. Probes have recorded unusual levels of geological activity in all five planetary systems. Assemble a team. Look at records of the Drema quadrant. Would these scans detect artificial transmissions as well as natural signals?
+
+Exceeding reaction chamber thermal limit. We have begun power-supply calibration. Force fields have been established on all turbo lifts and crawlways. Computer, run a level-two diagnostic on warp-drive systems. Antimatter containment positive. Warp drive within normal parameters. I read an ion trail characteristic of a freighter escape pod. The bomb had a molecular-decay detonator. Detecting some unusual fluctuations in subspace frequencies.
+
+Sensors indicate human life forms 30 meters below the planet's surface. Stellar flares are increasing in magnitude and frequency. Set course for Rhomboid Dronegar 006, warp seven. There's no evidence of an advanced communication network. Total guidance system failure, with less than 24 hours' reserve power. Shield effectiveness has been reduced 12 percent. We have covered the area in a spherical pattern which a ship without warp drive could cross in the given time.";
+
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -90,7 +90,11 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		internal void SetTextNative(string text)
-			=> SetProperty("value", text);
+		{
+			SetProperty("value", text);
+
+			InvalidateMeasure();
+		}
 
 		protected override Size MeasureOverride(Size availableSize) => MeasureView(availableSize);
 

--- a/src/Uno.UI/UI/Xaml/Documents/UIElementTextHelper.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UIElementTextHelper.wasm.cs
@@ -288,7 +288,6 @@ namespace Uno.UI.UI.Xaml.Documents
 				switch (value)
 				{
 					case TextWrapping.NoWrap:
-						element.SetAttribute("wrap", "off");
 						element.SetStyle(
 							("white-space", "pre"),
 							("word-break", ""));
@@ -300,16 +299,14 @@ namespace Uno.UI.UI.Xaml.Documents
 						SetTextTrimming(element, textTrimming);
 						break;
 					case TextWrapping.Wrap:
-						element.SetAttribute("wrap", "soft");
 						element.SetStyle(
-							("white-space", ""),
+							("white-space", "pre-wrap"),
 							("word-break", "break-word"), // This is required to still wrap words that are longer than the ViewPort
 							("text-overflow", ""));
 						break;
 					case TextWrapping.WrapWholeWords:
-						element.SetAttribute("wrap", "soft");
 						element.SetStyle(
-							("white-space", ""),
+							("white-space", "pre-wrap"),
 							("word-break", "keep-all"), // This is required to still wrap words that are longer than the ViewPort
 							("text-overflow", ""));
 						break;

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -1450,7 +1450,6 @@ namespace Uno.UI {
 					// Create a temporary element that will contain the input's content
 					var textOnlyElement = document.createElement("p") as HTMLParagraphElement;
 					textOnlyElement.style.cssText = unconstrainedStyleCssText;
-					textOnlyElement.style.whiteSpace = "pre"; // Make sure to preserve space for measure, especially the ending new line!
 
 					// If the input is null or empty, add a no-width character to force the paragraph to take up one line height
 					// The trailing new lines are going to be ignored for measure, so we also append no-width char at the end.


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/5142

# Bugfix
The measurement of `<TextBox>` on wasm were not correct when wrapping were used.

This was caused by the forced `white-space: pre;` CSS style when measuring the content.

## What is the new behavior?
Measurement is now very close to what UWP/WinUI is doing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
