### PR TITLE
fix: Fix bounce ease producing invalid final value

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3401,8 +3401,14 @@
 				reason="Constructor not public in UWP" />
 			<Member
 				fullName="System.Void Windows.ApplicationModel.DataTransfer.DataRequest..ctor()"
-				reason="Constructor not public in UWP" />
-		</Methods>
+				reason="Constructor not public in UWP" />																		
+			<Member
+				fullName="System.Double Windows.UI.Xaml.Media.Animation.BounceEase.BounceEaseIn(System.Double currentTime, System.Double startValue, System.Double finalValue, System.Double duration)"
+				reason="Constructor not public in UWP" />																		
+			<Member
+				fullName="System.Double Windows.UI.Xaml.Media.Animation.BounceEase.BounceEaseOut(System.Double currentTime, System.Double startValue, System.Double finalValue, System.Double duration)"
+				reason="Constructor not public in UWP" />																		
+		 </Methods>
 	</IgnoreSet>
 
 	<!--

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
@@ -19,8 +19,7 @@ namespace Uno.UI.Tests.ListViewBaseTests
 	[TestClass]
 	public class Given_ListViewBase
 	{
-		// Make sure to have a valid custom theme set, so it won't try to read it from the Application.Current(<<== null).RequestedTheme
-		[TestInitialize] public void Init() => global::Uno.UI.ApplicationHelper.RequestedCustomTheme = "HighContrast";
+		[TestInitialize] public void Init() => UnitTestsApp.App.EnsureApplication();
 
 		[TestMethod]
 		public void When_MultiSelectedItem()

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Media_Animation/Given_BounceEase.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Media_Animation/Given_BounceEase.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Media.Animation;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Media_Animation
+{
+	[TestClass]
+	public class Given_BounceEase
+	{
+		[TestMethod]
+		public void When_FinalValueGreaterThanInitial()
+		{
+			var sut = new BounceEase();
+
+			EaseCore(0.0).Should().BeApproximately(100, .1);
+			EaseCore(1.0).Should().BeApproximately(200, .1);
+
+			double EaseCore(double normalizedTime)
+				=> sut.Ease(
+					currentTime: normalizedTime, duration: 1.0,
+					startValue: 100, finalValue: 200);
+		}
+
+		[TestMethod]
+		public void When_FinalValueLowerThanInitial()
+		{
+			var sut = new BounceEase();
+
+			EaseCore(0.0).Should().BeApproximately(200, .1);
+			EaseCore(1.0).Should().BeApproximately(100, .1);
+
+			double EaseCore(double normalizedTime)
+				=> sut.Ease(
+					currentTime: normalizedTime, duration: 1.0,
+					startValue: 200, finalValue: 100);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/BounceEase.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/BounceEase.cs
@@ -6,44 +6,67 @@ namespace Windows.UI.Xaml.Media.Animation
 {
 	public partial class BounceEase : EasingFunctionBase
 	{
+		// Source: https://easings.net/
+
 		public override double Ease(double currentTime, double startValue, double finalValue, double duration)
 		{
-			//Depending on the mode we have different functions for the return value.
-			switch (this.EasingMode)
+			var delta = finalValue - startValue;
+			var progress = currentTime / duration;
+
+			var ratio = EaseCore(progress);
+
+			return startValue + ratio * delta;
+		}
+
+		internal double EaseCore(double progress)
+		{
+			switch (EasingMode)
 			{
 				case EasingMode.EaseIn:
-					return BounceEaseIn(currentTime, startValue,finalValue, duration);
+					return BounceEaseIn(progress);
 
 				case EasingMode.EaseOut:
-					return BounceEaseOut(currentTime, startValue, finalValue, duration);
+					return BounceEaseOut(progress);
 
 				case EasingMode.EaseInOut:
-
-					if (currentTime < duration / 2)
-						return BounceEaseIn(currentTime * 2, 0, finalValue, duration) * .5 + startValue;
-					else
-						return BounceEaseOut(currentTime * 2 - duration, 0, finalValue, duration) * .5 + finalValue * .5 + startValue;
-
 				default:
-					return finalValue * currentTime / duration + startValue;
+					return BounceEaseInOut(progress);
 			}
 		}
 
-		public static double BounceEaseIn(double currentTime, double startValue, double finalValue, double duration)
+		public static double BounceEaseIn(double progress)
 		{
-			return finalValue - BounceEaseOut(duration - currentTime, 0, finalValue, duration) + startValue;
+			return 1 - BounceEaseOut(1 - progress);
 		}
 
-		public static double BounceEaseOut(double currentTime, double startValue, double finalValue, double duration)
+		public static double BounceEaseOut(double progress)
 		{
-			if ((currentTime /= duration) < (1 / 2.75))
-				return finalValue * (7.5625 * currentTime * currentTime) + startValue;
-			else if (currentTime < (2 / 2.75))
-				return finalValue * (7.5625 * (currentTime -= (1.5 / 2.75)) * currentTime + .75) + startValue;
-			else if (currentTime < (2.5 / 2.75))
-				return finalValue * (7.5625 * (currentTime -= (2.25 / 2.75)) * currentTime + .9375) + startValue;
+			const double n1 = 7.5625;
+			const double d1 = 2.75;
+
+			if (progress < 1 / d1)
+			{
+				return n1 * progress * progress;
+			}
+			else if (progress < 2 / d1)
+			{
+				return n1 * (progress -= 1.5 / d1) * progress + 0.75;
+			}
+			else if (progress < 2.5 / d1)
+			{
+				return n1 * (progress -= 2.25 / d1) * progress + 0.9375;
+			}
 			else
-				return finalValue * (7.5625 * (currentTime -= (2.625 / 2.75)) * currentTime + .984375) + startValue;
+			{
+				return n1 * (progress -= 2.625 / d1) * progress + 0.984375;
+			}
 		}
-	}
+
+		public static double BounceEaseInOut(double progress)
+		{
+			return progress < 0.5
+				? (1 - BounceEaseOut(1 - 2 * progress)) / 2
+				: (1 + BounceEaseOut(2 * progress - 1)) / 2;
+		}
+}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/BounceEase.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/BounceEase.cs
@@ -34,12 +34,12 @@ namespace Windows.UI.Xaml.Media.Animation
 			}
 		}
 
-		public static double BounceEaseIn(double progress)
+		private static double BounceEaseIn(double progress)
 		{
 			return 1 - BounceEaseOut(1 - progress);
 		}
 
-		public static double BounceEaseOut(double progress)
+		private static double BounceEaseOut(double progress)
 		{
 			const double n1 = 7.5625;
 			const double d1 = 2.75;
@@ -62,7 +62,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			}
 		}
 
-		public static double BounceEaseInOut(double progress)
+		private static double BounceEaseInOut(double progress)
 		{
 			return progress < 0.5
 				? (1 - BounceEaseOut(1 - 2 * progress)) / 2


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/5141

## Bugfix
Animations are invalid when using `BounceEase` on netstandard platforms

## What is the current behavior?
The algorithm used for the bounce effect was producing out of range values.

## What is the new behavior?
🙃

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
