### PR TITLE
feat(TransformToVisual): Add TransformToVisual logic for macOS

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -291,7 +291,7 @@ namespace Windows.UI.Xaml
 			return matrix;
 		}
 
-#if !__IOS__ && !__ANDROID__ // This is the default implementation, but it can be customized per platform
+#if !__IOS__ && !__ANDROID__ && !__MACOS__ // This is the default implementation, but it can be customized per platform
 		/// <summary>
 		/// Note: Offsets are only an approximation which does not take in consideration possible transformations
 		///	applied by a 'UIView' between this element and its parent UIElement.

--- a/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
@@ -4,6 +4,8 @@ using Windows.UI.Xaml.Input;
 using Windows.System;
 using System;
 using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Uno.UI.Extensions;
 using AppKit;
 using CoreAnimation;
@@ -48,7 +50,7 @@ namespace Windows.UI.Xaml
 			if (base.Hidden != newVisibility.IsHidden())
 			{
 				base.Hidden = newVisibility.IsHidden();
-				base.NeedsLayout = true;			
+				base.NeedsLayout = true;
 
 				if (newVisibility == Visibility.Visible)
 				{
@@ -65,8 +67,8 @@ namespace Windows.UI.Xaml
 			get => base.Hidden;
 			set
 			{
-				// Only set the Visility property, the Hidden property is updated 
-				// in the property changed handler as there are actions associated with 
+				// Only set the Visility property, the Hidden property is updated
+				// in the property changed handler as there are actions associated with
 				// the change.
 				Visibility = value ? Visibility.Collapsed : Visibility.Visible;
 			}
@@ -108,7 +110,7 @@ namespace Windows.UI.Xaml
 #endif
 
 		/// <inheritdoc />
-		public override bool AcceptsFirstResponder() 
+		public override bool AcceptsFirstResponder()
 			=> true; // This is required to receive the KeyDown / KeyUp. Note: Key events are then bubble in managed.
 
 		private protected override void OnNativeKeyDown(NSEvent evt)
@@ -121,6 +123,79 @@ namespace Windows.UI.Xaml
 			RaiseEvent(KeyDownEvent, args);
 
 			base.OnNativeKeyDown(evt);
+		}
+
+		private bool TryGetParentUIElementForTransformToVisual(out UIElement parentElement, ref double offsetX, ref double offsetY)
+		{
+			var parent = this.GetParent();
+			switch (parent)
+			{
+				// First we try the direct parent, if it's from the known type we won't even have to adjust offsets
+
+				case UIElement elt:
+					parentElement = elt;
+					return true;
+
+				case null:
+					parentElement = null;
+					return false;
+
+				case NSView view:
+					do
+					{
+						//If we found an NSClipView, we are assuming that we are inside of an NSScrollView.
+						//So "skip" past the NSClipView and allow the logic to flow through to the check for NativeScrollContentPresenter
+						if (view is NSClipView && view.Superview is NativeScrollContentPresenter)
+						{
+							parent = view.Superview?.GetParent();
+							view = view.Superview;
+						}
+						else
+						{
+							parent = parent?.GetParent();
+						}
+
+						switch (parent)
+						{
+							case UIElement eltParent:
+								// We found a UIElement in the parent hierarchy, we compute the X/Y offset between the
+								// first parent 'view' and this 'elt', and return it.
+
+								if (view is NativeScrollContentPresenter)
+								{
+									// The NativeScrollContentPresenter will include the scroll offset when converting point to coordinates
+									// space of the parent, but the same scroll offset will be applied by the parent ScrollViewer.
+									// So as it's not expected to have any transform/margins/etc., we compute offset directly from its parent.
+
+									view = view.Superview;
+								}
+
+								var offset = view?.ConvertPointToView(default, eltParent) ?? default;
+
+								parentElement = eltParent;
+								offsetX += offset.X;
+								offsetY += offset.Y;
+								return true;
+
+							case null:
+								// We reached the top of the window without any UIElement in the hierarchy,
+								// so we adjust offsets using the X/Y position of the original 'view' in the window.
+
+								offset = view.ConvertRectToView(default, null).Location;
+
+								parentElement = null;
+								offsetX += offset.X;
+								offsetY += offset.Y;
+								return false;
+						}
+					} while (true);
+
+				default:
+					Application.Current.RaiseRecoverableUnhandledException(new InvalidOperationException("Found a parent which is NOT a NSView."));
+
+					parentElement = null;
+					return false;
+			}
 		}
 
 		private protected override void OnNativeKeyUp(NSEvent evt)
@@ -156,7 +231,7 @@ namespace Windows.UI.Xaml
 
 			WantsLayer = true;
 			if (Layer != null)
-			{ 
+			{
 				this.Layer.Mask = new CAShapeLayer
 				{
 					Path = CGPath.FromRect(rect.ToCGRect())


### PR DESCRIPTION
closes #123
closes #119

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Feature


## What is the current behavior?

TransformToVisual on macOS does not take CollectionView or ScrollViews into account when calculating the offset

## What is the new behavior?

TransformToVisual on macOS **does** take CollectionView or ScrollViews into account when calculating the offset

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
