### PR TITLE
[WIP] Make VisualState Setter precedence Local

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/VisualStateManagerTests/VisualStateManagerTest.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/VisualStateManagerTests/VisualStateManagerTest.cs
@@ -32,5 +32,24 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.VisualStateManagerTests
 			_app.WaitForDependencyPropertyValue(border02, "Background", "[SolidColorBrush [Color: 000000FF;00000080;00000000;00000080]]");
 			_app.WaitForDependencyPropertyValue(border03, "Background", "[SolidColorBrush [Color: 000000FF;000000FF;000000A5;00000000]]");
 		}
+
+		[Test]
+		[AutoRetry]
+		public void When_Value_Overriden_Locally()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml.VisualStateTests.VisualState_LocalOverride");
+			
+			var rootGrid = _app.Marked("RootGrid");
+			_app.WaitForElement(rootGrid);
+
+			// Initially, the background should be red.
+			_app.WaitForDependencyPropertyValue(rootGrid, "Background", "[SolidColorBrush [Color: 000000FF;000000FF;00000000;00000000]]");
+
+			var setColorButton = _app.Marked("SetColorButton");
+			_app.FastTap(setColorButton);
+
+			// The button should override the value set by VisualState's Setter.
+			_app.WaitForDependencyPropertyValue(rootGrid, "Background", "[SolidColorBrush [Color: 000000FF;00000000;00000000;000000FF]]");
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/VisualStateManagerTests/VisualStateManagerTest.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/VisualStateManagerTests/VisualStateManagerTest.cs
@@ -51,5 +51,62 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.VisualStateManagerTests
 			// The button should override the value set by VisualState's Setter.
 			_app.WaitForDependencyPropertyValue(rootGrid, "Background", "[SolidColorBrush [Color: 000000FF;00000000;00000000;000000FF]]");
 		}
+
+		[Test]
+		[AutoRetry]
+		public void When_Returns_To_Default_State()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml.VisualStateTests.VisualState_ReturnPreviousValue");
+
+			var rootGrid = _app.Marked("RootGrid");
+			_app.WaitForElement(rootGrid);
+
+			// Initially, the background should be green.
+			_app.WaitForDependencyPropertyValue(rootGrid, "Background", "[SolidColorBrush [Color: 000000FF;00000000;000000FF;00000000]]");
+
+			var changeBackgroundButton = _app.Marked("ChangeBackgroundButton");
+			var defaultStateButton = _app.Marked("DefaultStateButton");
+			var secondStateButton = _app.Marked("SecondStateButton");
+			var thirdStateButton = _app.Marked("ThirdStateButton");
+
+			// Switch to second state.
+			_app.FastTap(secondStateButton);
+
+			// The background should be red.
+			_app.WaitForDependencyPropertyValue(rootGrid, "Background", "[SolidColorBrush [Color: 000000FF;000000FF;00000000;00000000]]");
+
+			// Switch to third state.
+			_app.FastTap(thirdStateButton);
+
+			// The background should be blue.
+			_app.WaitForDependencyPropertyValue(rootGrid, "Background", "[SolidColorBrush [Color: 000000FF;00000000;00000000;000000FF]]");
+
+			// Switch to default state.
+			_app.FastTap(defaultStateButton);
+
+			// The background should be green.
+			_app.WaitForDependencyPropertyValue(rootGrid, "Background", "[SolidColorBrush [Color: 000000FF;00000000;000000FF;00000000]]");
+
+			// Go back to second state.
+			_app.FastTap(secondStateButton);
+
+			// And override the background locally.
+			_app.FastTap(changeBackgroundButton);
+
+			// The background should be white.
+			_app.WaitForDependencyPropertyValue(rootGrid, "Background", "[SolidColorBrush [Color: 000000FF;000000FF;000000FF;000000FF]]");
+
+			// Switch to third state.
+			_app.FastTap(thirdStateButton);
+
+			// The background should be blue.
+			_app.WaitForDependencyPropertyValue(rootGrid, "Background", "[SolidColorBrush [Color: 000000FF;00000000;00000000;000000FF]]");
+
+			// Finally, go back to default state.
+			_app.FastTap(defaultStateButton);
+
+			// The background should have the previously set white color.
+			_app.WaitForDependencyPropertyValue(rootGrid, "Background", "[SolidColorBrush [Color: 000000FF;000000FF;000000FF;000000FF]]");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -829,6 +829,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_ReturnPreviousValue.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_Setters.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4448,6 +4452,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_LocalOverride.xaml.cs">
       <DependentUpon>VisualState_LocalOverride.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_ReturnPreviousValue.xaml.cs">
+      <DependentUpon>VisualState_ReturnPreviousValue.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_Setters.xaml.cs">
       <DependentUpon>VisualState_Setters.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -150,7 +150,7 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RatingControlTests\RatingControlPage.xaml">
-	  <SubType>Designer</SubType>
+      <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NumberBoxTests\NumberBox_Header.xaml">
@@ -822,6 +822,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_DoubleAnimationUsingKeyFrames_RotateTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_LocalOverride.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -4018,7 +4022,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RatingControlTests\RatingControlPage.xaml.cs">
       <DependentUpon>RatingControlPage.xaml</DependentUpon>
-   	</Compile>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\ProgressRing\WinUIProgressRing_CustomSources.xaml.cs">
       <DependentUpon>WinUIProgressRing_CustomSources.xaml</DependentUpon>
     </Compile>
@@ -4441,6 +4445,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_DoubleAnimationUsingKeyFrames_RotateTransform.xaml.cs">
       <DependentUpon>VisualState_DoubleAnimationUsingKeyFrames_RotateTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_LocalOverride.xaml.cs">
+      <DependentUpon>VisualState_LocalOverride.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_Setters.xaml.cs">
       <DependentUpon>VisualState_Setters.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_LocalOverride.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_LocalOverride.xaml
@@ -1,0 +1,33 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml.VisualStateTests.VisualState_LocalOverride"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.VisualStateTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<VisualStateManager.VisualStateGroups>
+			<VisualStateGroup>
+				<VisualState x:Name="Large">
+					<VisualState.StateTriggers>
+						<AdaptiveTrigger MinWindowWidth="10" />
+					</VisualState.StateTriggers>
+					<VisualState.Setters>
+						<Setter Target="RootGrid.Background" Value="#FF0000" />
+					</VisualState.Setters>
+				</VisualState>
+			</VisualStateGroup>
+		</VisualStateManager.VisualStateGroups>
+		<Grid x:Name="RootGrid" Background="#00FF00">
+			<Button
+				HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				x:Name="SetColorButton"
+				Click="SetColorButton_Click"
+				Content="Set color" />
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_LocalOverride.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_LocalOverride.xaml.cs
@@ -1,0 +1,23 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace UITests.Windows_UI_Xaml.VisualStateTests
+{
+	[Sample("Visual states", Description = "Background should start off as red, but turn blue after the button is clicked.")]
+
+	public sealed partial class VisualState_LocalOverride : Page
+    {
+        public VisualState_LocalOverride()
+        {
+            this.InitializeComponent();
+        }
+
+		private void SetColorButton_Click(object sender, RoutedEventArgs e)
+		{
+			RootGrid.Background = new SolidColorBrush(Color.FromArgb(255, 0, 0, 255));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_ReturnPreviousValue.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_ReturnPreviousValue.xaml
@@ -1,0 +1,36 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml.VisualStateTests.VisualState_ReturnPreviousValue"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.VisualStateTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<VisualStateManager.VisualStateGroups>
+			<VisualStateGroup>
+				<VisualState x:Name="DefaultState" />
+				<VisualState x:Name="SecondState">
+					<VisualState.Setters>
+						<Setter Target="RootGrid.Background" Value="Red" />
+					</VisualState.Setters>
+				</VisualState>
+				<VisualState x:Name="ThirdState">
+					<VisualState.Setters>
+						<Setter Target="RootGrid.Background" Value="Blue" />
+					</VisualState.Setters>
+				</VisualState>
+			</VisualStateGroup>
+		</VisualStateManager.VisualStateGroups>
+		<Grid x:Name="RootGrid" Background="Green">
+			<StackPanel Orientation="Vertical">
+				<Button x:Name="ChangeBackgroundButton" Click="ChangeBackground_Click">Change background</Button>
+				<Button x:Name="DefaultStateButton" Tag="DefaultState" Click="SetState_Click">Set default state</Button>
+				<Button x:Name="SecondStateButton" Tag="SecondState" Click="SetState_Click">Set second state</Button>
+				<Button x:Name="ThirdStateButton" Tag="ThirdState" Click="SetState_Click">Set third state</Button>
+			</StackPanel>
+		</Grid>
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_ReturnPreviousValue.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_ReturnPreviousValue.xaml.cs
@@ -1,0 +1,28 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace UITests.Windows_UI_Xaml.VisualStateTests
+{
+	[Sample("Visual states")]
+	public sealed partial class VisualState_ReturnPreviousValue : Page
+    {
+        public VisualState_ReturnPreviousValue()
+        {
+            this.InitializeComponent();
+        }
+
+		private void SetState_Click(object sender, RoutedEventArgs e)
+		{
+			var button = (Button)sender;
+			VisualStateManager.GoToState(this, button.Tag.ToString(), true);
+		}
+
+		private void ChangeBackground_Click(object sender, RoutedEventArgs e)
+		{
+			RootGrid.Background = new SolidColorBrush(Color.FromArgb(255, 255, 255, 255));
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
@@ -245,7 +245,7 @@ namespace Windows.UI.Xaml
 
 				foreach (var setter in this.CurrentState.Setters.OfType<Setter>())
 				{
-					if (element != null && (state?.Setters.OfType<Setter>().Any(o => o.HasSameTarget(setter, DependencyPropertyValuePrecedences.Animations, element)) ?? false))
+					if (element != null && (state?.Setters.OfType<Setter>().Any(o => o.HasSameTarget(setter, DependencyPropertyValuePrecedences.Local, element)) ?? false))
 					{
 						// PERF: We clear the value of the current setter only if there isn't any setter in the target state
 						// which changes the same target property.
@@ -273,7 +273,7 @@ namespace Windows.UI.Xaml
 				{
 					foreach (var setter in this.CurrentState.Setters.OfType<Setter>())
 					{
-						setter.ApplyValue(DependencyPropertyValuePrecedences.Animations, element);
+						setter.ApplyValue(DependencyPropertyValuePrecedences.Local, element);
 					}
 				}
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5168

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On UWP, values set by `VisualState.Setters` can be overriden by a `Local` value. In Uno, their precedence is higher, so they cannot be overriden.

## What is the new behavior?

`Setter` uses `Local` precedence.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.