### PR TITLE
fix(BindableNSView): Set MasksToBounds to false on init

### DIFF
--- a/src/Uno.UI/Controls/BindableNSView.macOS.cs
+++ b/src/Uno.UI/Controls/BindableNSView.macOS.cs
@@ -52,6 +52,11 @@ namespace Uno.UI.Controls
 		public BindableNSView()
 		{
 			Initialize();
+			WantsLayer = true;
+			if (Layer != null)
+			{
+				Layer.MasksToBounds = false;
+			}
 		}
 
 		public BindableNSView(IntPtr handle)


### PR DESCRIPTION
closes https://github.com/unoplatform/Uno.Gallery/issues/120

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Rectangle is clipped during rotation:

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/4793020/107281237-683c8e80-6a27-11eb-9f8c-8f1ee9838bb4.png)

## What is the new behavior?

No clipping by default

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.