### PR TITLE
fix: Properly fallback on Skia AcrylicBrush

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
@@ -133,6 +133,11 @@ namespace Windows.UI.Xaml.Shapes
 				{
 					adjustedArea = CreateImageLayer(compositor, disposables, borderThickness, adjustedArea, backgroundShape, adjustedArea, imgBackground);
 				}
+				else if (background is AcrylicBrush acrylicBrush)
+				{
+					Brush.AssignAndObserveBrush(acrylicBrush, color => backgroundShape.FillBrush = compositor.CreateColorBrush(color))
+						.DisposeWith(disposables);
+				}
 				else
 				{
 					backgroundShape.FillBrush = null;
@@ -196,6 +201,14 @@ namespace Windows.UI.Xaml.Shapes
 				else if (background is ImageBrush imgBackground)
 				{
 					backgroundArea = CreateImageLayer(compositor, disposables, borderThickness, adjustedArea, backgroundShape, backgroundArea, imgBackground);
+				}
+				else if (background is AcrylicBrush acrylicBrush)
+				{
+					Brush.AssignAndObserveBrush(acrylicBrush, c => backgroundShape.FillBrush = compositor.CreateColorBrush(c))
+						.DisposeWith(disposables);
+
+					Disposable.Create(() => backgroundShape.FillBrush = null)
+						.DisposeWith(disposables);
 				}
 				else
 				{


### PR DESCRIPTION
GitHub Issue (If applicable): fixes part of #5186

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Fallback on `AcrylicBrush` is not working on Skia.

## What is the new behavior?

Fallback now properly uses the fallback color with opacity.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.