### PR TITLE
fix: Perf of NavView/ItemsRepeater

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ViewportManagerWithPlatformFeatures.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ViewportManagerWithPlatformFeatures.cs
@@ -255,7 +255,9 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				m_effectiveViewportChangedRevoker?.Dispose();
 			}
-			else if (m_effectiveViewportChangedRevoker == null)
+			else if (m_effectiveViewportChangedRevoker == null
+				// Uno workaround: [Perf] Do not listen for viewport update if nothing to render!
+				&& m_owner.ItemsSourceView?.Count > 0)
 			{
 				m_effectiveViewportChangedRevoker = Disposable.Create(() =>
 				{
@@ -489,6 +491,12 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				ResetScrollers();
 
+				// Uno workaround: [Perf] Do not listen for viewport update if nothing to render!
+				if (m_owner.ItemsSourceView?.Count <= 0)
+				{
+					return;
+				}
+
 				var parent = CachedVisualTreeHelpers.GetParent(m_owner);
 				while (parent != null)
 				{
@@ -599,7 +607,9 @@ namespace Microsoft.UI.Xaml.Controls
 		void TryInvalidateMeasure()
 		{
 			// Don't invalidate measure if we have an invalid window.
-			if (m_visibleWindow != new Rect())
+			if (m_visibleWindow != new Rect()
+				// Uno workaround: [Perf] Do not invalidate measure if nothing to render!
+				&& m_owner.ItemsSourceView?.Count > 0)
 			{
 				// We invalidate measure instead of just invalidating arrange because
 				// we don't invalidate measure in UpdateViewport if the view is changing to

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.cs
@@ -7,7 +7,7 @@ using Uno.Disposables;
 using Uno.UI.DataBinding;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Markup;
-
+using Uno.UI.Xaml;
 #if XAMARIN_ANDROID
 using Android.Views;
 using Android.Graphics;
@@ -95,23 +95,16 @@ namespace Windows.UI.Xaml.Controls
 		#endregion
 
 		#region CornerRadius
+		private static CornerRadius GetCornerRadiusDefaultValue() => CornerRadius.None;
+
+		[GeneratedDependencyProperty(ChangedCallback = true, Options = FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange)]
+		public static DependencyProperty CornerRadiusProperty { get; } = CreateCornerRadiusProperty();
+
 		public CornerRadius CornerRadius
 		{
-			get => (CornerRadius)this.GetValue(CornerRadiusProperty);
-			set => this.SetValue(CornerRadiusProperty, value);
+			get => GetCornerRadiusValue();
+			set => SetCornerRadiusValue(value);
 		}
-
-		public static DependencyProperty CornerRadiusProperty { get ; } =
-			DependencyProperty.Register(
-				nameof(CornerRadius),
-				typeof(CornerRadius),
-				typeof(Border),
-				new FrameworkPropertyMetadata(
-					CornerRadius.None,
-					FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange,
-					(s, e) => ((Border)s)?.OnCornerRadiusChanged((CornerRadius)e.OldValue, (CornerRadius)e.NewValue)
-				)
-			);
 
 		private void OnCornerRadiusChanged(CornerRadius oldValue, CornerRadius newValue)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -14,6 +14,7 @@ using Uno.UI;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Text;
 using Microsoft.Extensions.Logging;
+using Uno.UI.Xaml;
 #if XAMARIN_ANDROID
 using View = Android.Views.View;
 using ViewGroup = Android.Views.ViewGroup;
@@ -525,23 +526,16 @@ namespace Windows.UI.Xaml.Controls
 		#endregion
 
 		#region CornerRadius DependencyProperty
+		private static CornerRadius GetCornerRadiusDefaultValue() => CornerRadius.None;
+
+		[GeneratedDependencyProperty(ChangedCallback = true)]
+		public static DependencyProperty CornerRadiusProperty = CreateCornerRadiusProperty();
 
 		public CornerRadius CornerRadius
 		{
-			get { return (CornerRadius)GetValue(CornerRadiusProperty); }
-			set { SetValue(CornerRadiusProperty, value); }
+			get => GetCornerRadiusValue();
+			set => SetCornerRadiusValue(value);
 		}
-
-		public static DependencyProperty CornerRadiusProperty =
-			DependencyProperty.Register(
-				"CornerRadius",
-				typeof(CornerRadius),
-				typeof(ContentPresenter),
-				new FrameworkPropertyMetadata(
-					CornerRadius.None,
-					(s, e) => ((ContentPresenter)s)?.OnCornerRadiusChanged((CornerRadius)e.OldValue, (CornerRadius)e.NewValue)
-				)
-			);
 
 		private void OnCornerRadiusChanged(CornerRadius oldValue, CornerRadius newValue)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
@@ -980,9 +980,17 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		private static double GetAdjustmentForSpacing(int rowOrColumnSpan, double spacing) => spacing * (rowOrColumnSpan - 1);
 
-		private static Memory<ViewPosition> FindStarSizeChildren(Span<ViewPosition> positions, Memory<ViewPosition> pixelSizeChildren, List<ViewPosition> autoSizeChildren)
+		private ViewPosition[] _resCache;
+
+		private Memory<ViewPosition> FindStarSizeChildren(Span<ViewPosition> positions, Memory<ViewPosition> pixelSizeChildren, List<ViewPosition> autoSizeChildren)
 		{
-			var res = new Memory<ViewPosition>(new ViewPosition[positions.Length]);
+			if ((_resCache?.Length ?? -1) != positions.Length)
+			{
+				// As configuration of Grids are usually pretty stable, for perf consideration (Avoids GC) we try to re-use the same array
+				_resCache = new ViewPosition[positions.Length];
+			}
+
+			var res = new Memory<ViewPosition>(_resCache);
 			int count = 0;
 
 			// Use local function to avoid the use of Enumerable.Any. foreach on List<T> uses allocation less

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.cs
@@ -10,7 +10,7 @@ using Uno.UI.DataBinding;
 using Windows.UI.Core;
 using Windows.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Controls;
-
+using Uno.UI.Xaml;
 #if XAMARIN_ANDROID
 using View = Android.Views.View;
 #elif XAMARIN_IOS_UNIFIED
@@ -197,25 +197,16 @@ namespace Windows.UI.Xaml.Controls
 		#endregion
 
 		#region CornerRadius DependencyProperty
+		private static CornerRadius GetCornerRadiusDefaultValue() => CornerRadius.None;
+
+		[GeneratedDependencyProperty(ChangedCallback = true)]
+		public static DependencyProperty CornerRadiusProperty { get; } = CreateCornerRadiusProperty();
 
 		public CornerRadius CornerRadius
 		{
-			get { return (CornerRadius)this.GetValue(CornerRadiusProperty); }
-			set { this.SetValue(CornerRadiusProperty, value); }
+			get => GetCornerRadiusValue();
+			set => SetCornerRadiusValue(value);
 		}
-
-		// Using a DependencyProperty as the backing store for CornerRadius.  This enables animation, styling, binding, etc...
-		public static DependencyProperty CornerRadiusProperty { get ; } =
-			DependencyProperty.Register(
-				"CornerRadius",
-				typeof(CornerRadius),
-				typeof(Panel),
-				new FrameworkPropertyMetadata(
-					CornerRadius.None,
-					(s, e) => ((Panel)s)?.OnCornerRadiusChanged((CornerRadius)e.OldValue, (CornerRadius)e.NewValue)
-				)
-			);
-
 		#endregion
 
 		#region IsItemsHost DependencyProperty


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/5172
#5109 

## Perf


## What is the current behavior?
`NavigationView` is slow on Uno.Gallery

## What is the new behavior?
Slightly more performant

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
