### PR TITLE
[MacOS] Multiline TextBox were displayed as single line when not focused.

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Input_Multiline.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Input_Multiline.xaml
@@ -1,4 +1,4 @@
-<UserControl
+<Page
 	x:Class="Uno.UI.Samples.Content.UITests.TextBoxControl.Input_Multiline"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -12,15 +12,37 @@
 	d:DesignHeight="300"
 	d:DesignWidth="400">
 
-	<StackPanel>
-		<TextBox Header="Enter data:"
-		         Height="120"
+	<StackPanel Spacing="6">
+		<TextBlock>TextWrapping="Wrap" / AcceptsReturn="True"</TextBlock>
+		<TextBox Header="Header Text:"
+		         MinHeight="120"
 		         MaxWidth="300"
-		         Text="{Binding [MyInput], Mode=TwoWay}"
+		         Text="{Binding MyInput, Mode=TwoWay}"
 		         TextWrapping="Wrap"
 		         AcceptsReturn="True" />
+		<TextBlock>TextWrapping="WrapWholeWords" / AcceptsReturn="True"</TextBlock>
+		<TextBox Header="Header Text:"
+		         MinHeight="120"
+		         MaxWidth="300"
+		         Text="{Binding MyInput, Mode=TwoWay}"
+		         TextWrapping="WrapWholeWords"
+		         AcceptsReturn="True" />
+		<TextBlock>TextWrapping="Wrap" / AcceptsReturn="False"</TextBlock>
+		<TextBox Header="Header Text:"
+		         MinHeight="120"
+		         MaxWidth="300"
+		         Text="{Binding MyInput, Mode=TwoWay}"
+		         TextWrapping="Wrap"
+		         AcceptsReturn="False" />
+		<TextBlock>TextWrapping="WrapWholeWords" / AcceptsReturn="False"</TextBlock>
+		<TextBox Header="Header Text:"
+		         MinHeight="120"
+		         MaxWidth="300"
+		         Text="{Binding MyInput, Mode=TwoWay}"
+		         TextWrapping="WrapWholeWords"
+		         AcceptsReturn="False" />
 		<TextBlock Text="Result :" />
-		<TextBlock Text="{Binding [Result]}" />
+		<TextBlock Text="{Binding Result}" />
 	</StackPanel>
 
-</UserControl>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Input_Multiline.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Input_Multiline.xaml.cs
@@ -4,8 +4,8 @@ using Uno.UI.Samples.Presentation.SamplePages;
 
 namespace Uno.UI.Samples.Content.UITests.TextBoxControl
 {
-	[SampleControlInfo("TextBox", "Input_Multiline", typeof(TextBoxViewModel))]
-	public sealed partial class Input_Multiline : UserControl
+	[Sample("TextBox", ViewModelType = typeof(TextBoxViewModel))]
+	public sealed partial class Input_Multiline : Page
 	{
 		public Input_Multiline()
 		{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Simple.xaml
@@ -11,7 +11,7 @@
 	mc:Ignorable="d ios android"
 	d:DesignHeight="2000"
 	d:DesignWidth="400">
-  
+
 	<UserControl.Resources>
 		<ResourceDictionary>
 			<ResourceDictionary.MergedDictionaries>
@@ -20,16 +20,19 @@
 		</ResourceDictionary>
 	</UserControl.Resources>
 
-	<StackPanel VerticalAlignment="Top">
+	<StackPanel VerticalAlignment="Top" HorizontalAlignment="Left">
 	  <TextBlock Text="Simple PasswordBox with a reveal button"/>
 	  <PasswordBox Width="150"/>
+
+	  <TextBlock Text="Simple PasswordBox without defined width (should grow with the content)"/>
+	  <PasswordBox HorizontalAlignment="Center" />
 
 	  <TextBlock Text="Simple PasswordBox with Hidden RevealMode"/>
 	  <PasswordBox Width="150" PasswordRevealMode="Hidden"/>
 
 	  <TextBlock Text="PasswordBox without a reveal button"/>
 	  <PasswordBox Width="150" Style="{StaticResource PasswordBoxWithoutRevealButtonStyle}"/>
-		  
+
 	  <TextBlock Text="PasswordBox with a button to toggle reveal mode"/>
 	  <PasswordBox x:Name="passBox" Width="150"/>
 	  <Button Click="ChangeRevealMode">Change Reveal Mode</Button>

--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/SecureTextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/SecureTextBoxView.macOS.cs
@@ -42,7 +42,7 @@ namespace Windows.UI.Xaml.Controls
 			set
 			{
 				// The native control will ignore a value of null and retain an empty string. We coalesce the null to prevent a spurious empty string getting bounced back via two-way binding.
-				value = value ?? string.Empty;
+				value ??= string.Empty;
 				if (base.StringValue != value)
 				{
 					base.StringValue = value;
@@ -126,17 +126,31 @@ namespace Windows.UI.Xaml.Controls
 		public void OnForegroundChanged(Brush oldValue, Brush newValue)
 		{
 			var textBox = _textBox.GetTarget();
-			if (textBox != null)
-			{
-				var scb = newValue as SolidColorBrush;
 
-				if (scb != null)
+			if (textBox != null && Brush.TryGetColorWithOpacity(newValue, out var color))
+			{
+				this.TextColor = color;
+				UpdateCaretColor(color);
+			}
+			else
+			{
+				UpdateCaretColor();
+			}
+		}
+
+		private void UpdateCaretColor(Color? color = null)
+		{
+			if (CurrentEditor is NSTextView textField)
+			{
+				if (color != null)
 				{
-					this.TextColor = scb.Color;
+					textField.InsertionPointColor = color;
+				}
+				else if (Brush.TryGetColorWithOpacity(Foreground, out var foregroundColor))
+				{
+					textField.InsertionPointColor = foregroundColor;
 				}
 			}
-
-			UpdateCaretColor();
 		}
 
 		private void UpdateCaretColor()

--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/SecureTextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/SecureTextBoxView.macOS.cs
@@ -51,6 +51,8 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		private FrameworkElement _firstManagedParent;
+
 		private void OnTextChanged()
 		{
 			var textBox = _textBox?.GetTarget();
@@ -58,6 +60,11 @@ namespace Windows.UI.Xaml.Controls
 			{
 				var text = textBox.ProcessTextInput(Text);
 				SetTextNative(text);
+
+				// Launch the invalidation of the measure + layout on the first _managed_ element
+				// Native elements will be relayouted correctly at the same time.
+				_firstManagedParent ??= this.FindFirstParent<FrameworkElement>();
+				_firstManagedParent?.InvalidateMeasure();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/SecureTextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/SecureTextBoxView.macOS.cs
@@ -153,14 +153,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private void UpdateCaretColor()
-		{
-			if (CurrentEditor is NSTextView textField && Foreground is SolidColorBrush scb)
-			{
-				textField.InsertionPointColor = scb.Color;
-			}
-		}
-
 		public void RefreshFont()
 		{
 			UpdateFont();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
@@ -43,15 +43,11 @@ namespace Windows.UI.Xaml.Controls
 				else
 				{
 					_textBoxView.BecomeFirstResponder();
-
 				}
 			}
 		}
 
-		public override bool BecomeFirstResponder()
-		{
-			return (_textBoxView?.BecomeFirstResponder()).GetValueOrDefault(false);
-		}
+		public override bool BecomeFirstResponder() => _textBoxView?.BecomeFirstResponder() ?? false;
 
 		partial void OnAcceptsReturnChangedPartial(DependencyPropertyChangedEventArgs e)
 		{
@@ -84,7 +80,13 @@ namespace Windows.UI.Xaml.Controls
 				}
 				else
 				{
-					_textBoxView = new TextBoxView(this) { UsesSingleLineMode = AcceptsReturn || TextWrapping != TextWrapping.NoWrap };
+					var textWrapping = TextWrapping;
+					var usesSingleLineMode = !(AcceptsReturn || textWrapping != TextWrapping.NoWrap);
+					_textBoxView = new TextBoxView(this)
+					{
+						UsesSingleLineMode = usesSingleLineMode,
+						LineBreakMode = textWrapping == TextWrapping.WrapWholeWords ? NSLineBreakMode.ByWordWrapping : NSLineBreakMode.CharWrapping,
+					};
 				}
 
 				_contentElement.Content = _textBoxView;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
@@ -159,7 +159,6 @@ namespace Windows.UI.Xaml.Controls
 			if (textBox != null && Brush.TryGetColorWithOpacity(newValue, out var color))
 			{
 				this.TextColor = color;
-				//this.TextColor = Colors.Red;
 				UpdateCaretColor(color);
 			}
 			else

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
@@ -83,6 +83,8 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		private FrameworkElement _firstManagedParent;
+
 		private void OnTextChanged()
 		{
 			var textBox = _textBox?.GetTarget();
@@ -90,6 +92,11 @@ namespace Windows.UI.Xaml.Controls
 			{
 				var text = textBox.ProcessTextInput(Text);
 				SetTextNative(text);
+
+				// Launch the invalidation of the measure + layout on the first _managed_ element
+				// Native elements will be relayouted correctly at the same time.
+				_firstManagedParent ??= this.FindFirstParent<FrameworkElement>();
+				_firstManagedParent?.InvalidateMeasure();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
@@ -63,15 +63,9 @@ namespace Windows.UI.Xaml.Controls
 
 			return base.PerformKeyEquivalent(theEvent);
 		}
-		private void OnEditingChanged(object sender, EventArgs e)
-		{
-			OnTextChanged();
-		}
+		private void OnEditingChanged(object sender, EventArgs e) => OnTextChanged();
 
-		internal void OnChanged()
-		{
-			OnTextChanged();
-		}
+		internal void OnChanged() => OnTextChanged();
 
 		public string Text
 		{
@@ -80,7 +74,7 @@ namespace Windows.UI.Xaml.Controls
 			set
 			{
 				// The native control will ignore a value of null and retain an empty string. We coalesce the null to prevent a spurious empty string getting bounced back via two-way binding.
-				value = value ?? string.Empty;
+				value ??= string.Empty;
 				if (base.StringValue != value)
 				{
 					base.StringValue = value;
@@ -112,10 +106,7 @@ namespace Windows.UI.Xaml.Controls
 			Bezeled = false;
 		}
 
-		public override CGSize SizeThatFits(CGSize size)
-		{
-			return IFrameworkElementHelper.SizeThatFits(this, base.SizeThatFits(size));
-		}
+		public override CGSize SizeThatFits(CGSize size) => IFrameworkElementHelper.SizeThatFits(this, base.SizeThatFits(size));
 
 		public void UpdateFont()
 		{
@@ -135,8 +126,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public Brush Foreground
 		{
-			get { return (Brush)GetValue(ForegroundProperty); }
-			set { SetValue(ForegroundProperty, value); }
+			get => (Brush)GetValue(ForegroundProperty);
+			set => SetValue(ForegroundProperty, value);
 		}
 
 		public bool HasMarkedText => throw new NotImplementedException();
@@ -165,31 +156,34 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var textBox = _textBox.GetTarget();
 
-			if (textBox != null)
+			if (textBox != null && Brush.TryGetColorWithOpacity(newValue, out var color))
 			{
-				var scb = newValue as SolidColorBrush;
+				this.TextColor = color;
+				//this.TextColor = Colors.Red;
+				UpdateCaretColor(color);
+			}
+			else
+			{
+				UpdateCaretColor();
+			}
+		}
 
-				if (scb != null)
+		private void UpdateCaretColor(Color? color = null)
+		{
+			if (CurrentEditor is NSTextView textField)
+			{
+				if (color != null)
 				{
-					this.TextColor = scb.Color;
+					textField.InsertionPointColor = color;
+				}
+				else if (Brush.TryGetColorWithOpacity(Foreground, out var foregroundColor))
+				{
+					textField.InsertionPointColor = foregroundColor;
 				}
 			}
-
-			UpdateCaretColor();
 		}
 
-		private void UpdateCaretColor()
-		{
-			if (CurrentEditor is NSTextView textField && Foreground is SolidColorBrush scb)
-			{
-				textField.InsertionPointColor = scb.Color;
-			}
-		}
-
-		public void RefreshFont()
-		{
-			UpdateFont();
-		}
+		public void RefreshFont() => UpdateFont();
 
 		public override bool BecomeFirstResponder()
 		{
@@ -197,34 +191,16 @@ namespace Windows.UI.Xaml.Controls
 			return base.BecomeFirstResponder();
 		}
 
-		public void InsertText(NSObject insertString)
-		{
-			throw new NotImplementedException();
-		}
+		public void InsertText(NSObject insertString) => throw new NotImplementedException();
 
-		public void SetMarkedText(NSObject @string, NSRange selRange)
-		{
-			throw new NotImplementedException();
-		}
+		public void SetMarkedText(NSObject @string, NSRange selRange) => throw new NotImplementedException();
 
-		public void UnmarkText()
-		{
-			throw new NotImplementedException();
-		}
+		public void UnmarkText() => throw new NotImplementedException();
 
-		public NSAttributedString GetAttributedSubstring(NSRange range)
-		{
-			throw new NotImplementedException();
-		}
+		public NSAttributedString GetAttributedSubstring(NSRange range) => throw new NotImplementedException();
 
-		public CGRect GetFirstRectForCharacterRange(NSRange range)
-		{
-			throw new NotImplementedException();
-		}
+		public CGRect GetFirstRectForCharacterRange(NSRange range) => throw new NotImplementedException();
 
-		public nuint GetCharacterIndex(CGPoint point)
-		{
-			throw new NotImplementedException();
-		}
+		public nuint GetCharacterIndex(CGPoint point) => throw new NotImplementedException();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxViewDelegate.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxViewDelegate.macOS.cs
@@ -7,6 +7,7 @@ using System.Text;
 using AppKit;
 using Windows.UI.Core;
 using System.Threading.Tasks;
+using ObjCRuntime;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -22,6 +23,23 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public bool IsKeyboardHiddenOnEnter { get; set; }
+
+		public override bool DoCommandBySelector(NSControl control, NSTextView textView, Selector commandSelector)
+		{
+			switch (commandSelector.Name)
+			{
+				case "insertNewline:":
+					if (_textBox.TryGetTarget(out var textBox) && textBox.AcceptsReturn)
+					{
+						textView.InsertText((NSString)"\n");
+						return true;
+					}
+
+					break;
+			}
+
+			return false;
+		}
 
 		public override bool TextShouldBeginEditing(NSControl control, NSText fieldEditor)
 		{


### PR DESCRIPTION
Fixes https://github.com/unoplatform/Uno.Gallery/issues/148

# Bugfix
As described in issue https://github.com/unoplatform/Uno.Gallery/issues/148, the text was behaving as _single line_ when not focused.

## What is the new behavior?
This is fixed + AcceptReturns is not working on MacOS.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
