### PR TITLE
fix(wasm): Pivot content when using bindings

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Pivot.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Pivot.cs
@@ -10,36 +10,33 @@ using Windows.UI.Xaml.Data;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using static Private.Infrastructure.TestServices;
+using Uno.UI.Extensions;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
 	[TestClass]
 	public class Given_Pivot
 	{
+		private TestsResources _testsResources;
+
+		private DataTemplate PivotHeaderTemplate => _testsResources["PivotHeaderTemplate"] as DataTemplate;
+
+		private DataTemplate PivotItemTemplate => _testsResources["PivotItemTemplate"] as DataTemplate;
+
+		[TestInitialize]
+		public void Init()
+		{
+			_testsResources = new TestsResources();
+		}
+
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task Check_Binding()
 		{
-			var headerTemplate = new DataTemplate(() => {
-				var tb = new TextBlock();				
-				tb.SetBinding(TextBlock.TextProperty, new Binding { Path = new PropertyPath("Title") });
-				return tb;
-			});
-
-			var contentTemplate = new DataTemplate(() => {
-				var tb = new TextBlock();
-				tb.SetBinding(TextBlock.TextProperty, new Binding { Path = new PropertyPath("Content") });
-
-				var sp = new StackPanel();
-				sp.Children.Add(tb);
-
-				return sp;
-			});
-
 			var SUT = new Pivot()
 			{
-				HeaderTemplate = headerTemplate,
-				ItemTemplate = contentTemplate
+				HeaderTemplate = PivotHeaderTemplate,
+				ItemTemplate = PivotItemTemplate
 			};
 
 			var root = new Grid
@@ -56,11 +53,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.SetBinding(Pivot.ItemsSourceProperty, new Binding { Path = new PropertyPath("Items") });
 
-
 			PivotItem pi = null;
 			await WindowHelper.WaitFor(() => (pi = SUT.ContainerFromItem(items[0]) as PivotItem) != null);
 
-			var tbs = pi.EnumerateAllChildren(a => a is TextBlock).Cast<TextBlock>();
+			var tbs = pi.GetAllChildren(null, false).OfType<TextBlock>().Cast<TextBlock>();
 
 			tbs.Should().NotBeNull();
 			tbs.Should().HaveCount(1);
@@ -68,7 +64,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WindowHelper.WaitFor(() => (pi = SUT.ContainerFromItem(items[1]) as PivotItem) != null);
 
-			var tbs2 = pi.EnumerateAllChildren(a => a is TextBlock).Cast<TextBlock>();
+			var tbs2 = pi.GetAllChildren(null, false).OfType<TextBlock>().Cast<TextBlock>();
 
 			tbs2.Should().NotBeNull();
 			tbs2.Should().HaveCount(1);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Pivot.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Pivot.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	public class Given_Pivot
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task Check_Binding()
+		{
+			var headerTemplate = new DataTemplate(() => {
+				var tb = new TextBlock();				
+				tb.SetBinding(TextBlock.TextProperty, new Binding { Path = new PropertyPath("Title") });
+				return tb;
+			});
+
+			var contentTemplate = new DataTemplate(() => {
+				var tb = new TextBlock();
+				tb.SetBinding(TextBlock.TextProperty, new Binding { Path = new PropertyPath("Content") });
+
+				var sp = new StackPanel();
+				sp.Children.Add(tb);
+
+				return sp;
+			});
+
+			var SUT = new Pivot()
+			{
+				HeaderTemplate = headerTemplate,
+				ItemTemplate = contentTemplate
+			};
+
+			var root = new Grid
+			{
+				DataContext = new MyContext()
+			};
+
+			root.Children.Add(SUT);
+			WindowHelper.WindowContent = root;
+
+			await WindowHelper.WaitForIdle();
+
+			var items = (root.DataContext as MyContext)?.Items;
+
+			SUT.SetBinding(Pivot.ItemsSourceProperty, new Binding { Path = new PropertyPath("Items") });
+
+
+			PivotItem pi = null;
+			await WindowHelper.WaitFor(() => (pi = SUT.ContainerFromItem(items[0]) as PivotItem) != null);
+
+			var tbs = pi.EnumerateAllChildren(a => a is TextBlock).Cast<TextBlock>();
+
+			tbs.Should().NotBeNull();
+			tbs.Should().HaveCount(1);
+			items[0].Content.Should().Be(tbs.ElementAt(0).Text);
+
+			await WindowHelper.WaitFor(() => (pi = SUT.ContainerFromItem(items[1]) as PivotItem) != null);
+
+			var tbs2 = pi.EnumerateAllChildren(a => a is TextBlock).Cast<TextBlock>();
+
+			tbs2.Should().NotBeNull();
+			tbs2.Should().HaveCount(1);
+			items[1].Content.Should().Be(tbs2.ElementAt(0).Text);
+		}
+
+		private class MyContext
+		{
+			public MyContext()
+			{
+				Items = new List<Item>
+				{
+					new Item { Title ="Pivot1", Content="ContentPivot1" },
+					new Item { Title ="Pivot2", Content="ContentPivot2" },
+					new Item { Title ="Pivot3", Content="ContentPivot3" },
+				};
+			}
+
+			public IList<Item> Items { get; private set; }
+		}
+	}
+
+	public class Item
+	{
+		public string Title { get; set; }
+		public string Content { get; set; }
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TestsResources.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TestsResources.xaml
@@ -148,4 +148,11 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+	<DataTemplate x:Key="PivotHeaderTemplate">
+		<TextBlock Text="{Binding Title}" />
+	</DataTemplate>
+
+	<DataTemplate x:Key="PivotItemTemplate">
+		<TextBlock Text="{Binding Content}" />
+	</DataTemplate>
 </ResourceDictionary>

--- a/src/Uno.UI/UI/Xaml/Controls/Pivot/Pivot.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Pivot/Pivot.cs
@@ -57,6 +57,13 @@ namespace Windows.UI.Xaml.Controls
 			_isTemplateApplied = true;
 
 			UpdateProperties();
+
+#if __WASM__ || __SKIA__
+			//TODO: Workaround for https://github.com/unoplatform/uno/issues/5144
+			//OnApplyTemplate() is comming too late when using bindings
+			SetNeedsUpdateItems();
+#endif
+
 			SynchronizeItems();
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #
closes #5144 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Content of different PivotITems are being squashed together when using BIndings

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Content is  rendered correctly

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
