### PR TITLE
fix(iOS): Time and DatePicker Flyout Selector

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	public class Given_TimePicker
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_SettingNullTime_ShouldNotCrash()
+		{
+			var timePicker = new TimePicker();
+			timePicker.SetBinding(TimePicker.TimeProperty, new Binding { Path = new PropertyPath("StartTime") });
+
+			var root = new Grid
+			{
+				DataContext = new MyContext()
+			};
+
+			root.Children.Add(timePicker);
+
+			TestServices.WindowHelper.WindowContent = root;
+
+			await TestServices.WindowHelper.WaitForIdle();
+		}
+	}
+
+	class MyContext
+	{
+		public object StartTime => null;
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.iOS.cs
@@ -1,4 +1,3 @@
-#if XAMARIN_IOS
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -227,5 +226,3 @@ namespace Windows.UI.Xaml.Controls
 		}
 	}
 }
-
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout.iOS.cs
@@ -26,7 +26,6 @@ namespace Windows.UI.Xaml.Controls
 
 		public event TypedEventHandler<DatePickerFlyout, DatePickedEventArgs> DatePicked;
 
-		private readonly SerialDisposable _presenterCommandsDisposable = new SerialDisposable();
 		private readonly SerialDisposable _presenterLoadedDisposable = new SerialDisposable();
 		private readonly SerialDisposable _presenterUnloadedDisposable = new SerialDisposable();
 		private bool _isInitialized;
@@ -134,18 +133,14 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnPresenterLoaded(object sender, RoutedEventArgs e)
 		{
-			var disposables = new CompositeDisposable();
-			_presenterCommandsDisposable.Disposable = disposables;
-
-			AttachFlyoutCommand(AcceptButtonPartName, x => x.Accept()).DisposeWith(disposables);
-			AttachFlyoutCommand(DismissButtonPartName, x => x.Dismiss()).DisposeWith(disposables);
+			AttachFlyoutCommand(AcceptButtonPartName, x => x.Accept());
+			AttachFlyoutCommand(DismissButtonPartName, x => x.Dismiss());
 
 			_presenterLoadedDisposable.Disposable = null;
 		}
 
 		private void OnPresenterUnloaded(object sender, RoutedEventArgs e)
 		{
-			_presenterCommandsDisposable.Disposable = null;
 			_presenterLoadedDisposable.Disposable = null;
 			_presenterUnloadedDisposable.Disposable = null;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -169,15 +169,11 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0))
+			if (UIDevice.CurrentDevice.CheckSystemVersion(13, 14))
 			{
 				_picker.PreferredDatePickerStyle = FeatureConfiguration.DatePicker.UseLegacyStyle
 																			? UIDatePickerStyle.Wheels
 																			: UIDatePickerStyle.Inline;
-			}
-			else
-			{
-				_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
@@ -59,11 +59,7 @@ namespace Windows.UI.Xaml.Controls
 					defaultValue: DateTime.Now.TimeOfDay,
 					options: FrameworkPropertyMetadataOptions.None,
 					propertyChangedCallback: (s, e) => ((TimePicker)s)?.OnTimeChangedPartial((TimeSpan)e.OldValue, (TimeSpan)e.NewValue),
-					coerceValueCallback: (s, e) =>
-					{
-						var ts = (TimeSpan)e;
-						return new TimeSpan(ts.Days, ts.Hours, ts.Minutes, 0);
-					})
+					coerceValueCallback: (s, e) => e is TimeSpan ts ? new TimeSpan(ts.Days, ts.Hours, ts.Minutes, 0) : TimeSpan.Zero)
 				);
 
 		#endregion

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
@@ -1,7 +1,5 @@
 ﻿#nullable enable
 
-#if XAMARIN_IOS
-
 using CoreGraphics;
 using UIKit;
 using Uno.Disposables;
@@ -225,4 +223,3 @@ namespace Windows.UI.Xaml.Controls
 		}
 	}
 }
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -1,5 +1,3 @@
-#if XAMARIN_IOS
-
 using Foundation;
 using System;
 using System.Linq;
@@ -162,17 +160,12 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0))
+			if (UIDevice.CurrentDevice.CheckSystemVersion(13, 14))
 			{
 				_picker.PreferredDatePickerStyle = FeatureConfiguration.TimePicker.UseLegacyStyle
 																			? UIDatePickerStyle.Wheels
 																			: UIDatePickerStyle.Inline;
 			}
-			else
-			{
-				_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
-			}
 		}
 	}
 }
-#endif


### PR DESCRIPTION
fixes https://github.com/unoplatform/nventive-private/issues/173

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

iOS devices with OS versions lower than iOS14 crashing when opening the Picker Flyout Selector


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
