### PR TITLE
Fix for Incorrect Discord Redirector Link

### DIFF
--- a/doc/articles/get-started-vs.md
+++ b/doc/articles/get-started-vs.md
@@ -67,4 +67,4 @@ You may encounter  installation and/or post-installation Visual Studio issues fo
 
 ### Getting Help
 
-If you continue experiencing issues with Visual Studio and Uno Platform, please visit our [Discord](https://wwww.platform.uno/discord) - #uno-platform channel or [StackOverflow](https://stackoverflow.com/questions/tagged/uno-platform) where our engineering team and community will be able to help you. 
+If you continue experiencing issues with Visual Studio and Uno Platform, please visit our [Discord](https://www.platform.uno/discord) - #uno-platform channel or [StackOverflow](https://stackoverflow.com/questions/tagged/uno-platform) where our engineering team and community will be able to help you. 


### PR DESCRIPTION
This is just an extremely small update to fix the incorrect Discord link that I assume nobody has noticed yet. The original link had 4 `w's` making the link "https://wwww.platform....." instead of only 3, which is the global standard abbreviation for a World Wide Web link. Love the Uno Platform, please keep up the amazing work everyone, and hopefully now more people can join the Discord to discuss this project and platform more as well as give and receive more support instantly!

Thanks for your time,
-Nathan Tuttle

P.S. Please also read the "More Information" section in this Pull Request, as it might be an even better solution that works just the same, but additionally adds an extra feature to joining the Discord server that makes the process much easier for users who have Discord installed locally on their device(s)! 😃 


GitHub Issue (If applicable): #

Just a small incorrectly-typed link containing four Ws in the URL prefix after the https:// protocol string.

## PR Type

What kind of change does this PR introduce?

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
- Refactoring (no functional changes, no api changes)
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Project automation -->
<!-- - Other... Please describe: -->

## What is the current behavior?

Prior to this Pull Request, no web-browser or program will be able to locate the link, as it does not currently exist.


## What is the new behavior?

After/if this Pull Request is accepted, the user will then be sent to the correct Discord server link, rather than a link that does not currently exist.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ✔ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ N/A ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ❌ ] Validated PR `Screenshots Compare Test Run` results.
- [ ✔ ] Contains **NO** breaking changes
- [ ❌ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ✔ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

**Hopefully this section will also get read by somebody**, but you might also want to think about redirecting the user directly to a Discord Invitation link ending with the suffix ".gg" rather than ".com" (you can just swap the suffixes with the current link if you wish, as I have tested it and it works perfectly without issues), as it is much easier to join the server if the application is already installed on a user's computer as it will come right up and automatically join them to the server. If it doesn't detect the program as being installed already, then it will also let them chat over the web through that same link as well. So the ".gg" suffix just adds an extra feature for the people who already have the program installed. Not to mention, for people who don't trust clicking on links, if it is a ".gg" link as I described, they can simply copy and paste it within the Discord application itself to join the server manually.

Internal Issue (If applicable):
N/A.
