### PR TITLE
fix: Disable anoying log for pointer capture not supported on GTK and Tizen

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GTK/GtkCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GTK/GtkCoreWindowExtension.cs
@@ -35,11 +35,11 @@ namespace Uno.UI.Runtime.Skia
 
 		/// <inheritdoc />
 		public void ReleasePointerCapture()
-			=> this.Log().Error("Pointer capture release is not supported on GTK");
+			=> this.Log().Warn("Pointer capture release is not supported on GTK");
 
 		/// <inheritdoc />
 		public void SetPointerCapture()
-			=> this.Log().Error("Pointer capture is not supported on GTK");
+			=> this.Log().Warn("Pointer capture is not supported on GTK");
 
 		public GtkCoreWindowExtension(object owner)
 		{

--- a/src/Uno.UI.Runtime.Skia.Tizen/Tizen/TizenCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Tizen/Tizen/TizenCoreWindowExtension.cs
@@ -63,11 +63,11 @@ namespace Uno.UI.Runtime.Skia
 
 		/// <inheritdoc />
 		public void ReleasePointerCapture()
-			=> this.Log().Error("Pointer capture release is not supported on Tizen");
+			=> this.Log().Warn("Pointer capture release is not supported on Tizen");
 
 		/// <inheritdoc />
 		public void SetPointerCapture()
-			=> this.Log().Error("Pointer capture is not supported on Tizen");
+			=> this.Log().Warn("Pointer capture is not supported on Tizen");
 
 
 		private void SetupTapGesture()


### PR DESCRIPTION
## Log polution
Reduce log level about the fact that capture is not supported on GTK and Skia

## What is the current behavior?
Polluating log on each button click

## What is the new behavior?
Muted by default

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).~~
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
