### PR TITLE
[refactor] Added descriptive exception for the case when a popup is created before any app Windows is created

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using CoreGraphics;
 using Uno.Extensions;
@@ -23,7 +24,9 @@ namespace Windows.UI.Xaml.Controls
 			{
 				if (_mainWindow == null)
 				{
-					_mainWindow = UIApplication.SharedApplication.KeyWindow ?? UIApplication.SharedApplication.Windows[0];
+					_mainWindow = UIApplication.SharedApplication.KeyWindow
+							   ?? UIApplication.SharedApplication.Windows.FirstOrDefault()
+							   ?? throw new InvalidOperationException("Do not create popup until any app Window is created");
 				}
 
 				return _mainWindow;


### PR DESCRIPTION
Related to https://github.com/unoplatform/uno/issues/5262
Probably it is better to subscribe to some event that will occur when an app will have at least one Window

## PR Type

- Refactoring (no functional changes, no API changes)

## What is the current behavior?

App crashes with `IndexOutOfRangeException`

## What is the new behavior?

App crashes with `InvalidOperationException`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
