### PR TITLE
fix(iOS): CommandBar TitleView Content Display

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
@@ -269,5 +269,21 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 			// Removing the global style we added for the CommandBar preventing other UITest to fail
 			_app.FastTap("UnsetGlobalStyleButton");
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)]
+		public void When_CustomContent_CommandBarTitleShouldBeVisible_NativeFrame()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.CommandBar.CustomContent.CommandBar_Frame");
+
+			_app.WaitForElement("NavigateInitialButton");
+
+			_app.FastTap("NavigateInitialButton");
+
+			_app.WaitForElement("Result");
+
+			_app.WaitForDependencyPropertyValue(_app.Marked("Result"), "Text", "PASSED");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3921,6 +3921,14 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Frame.xaml" >
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Page1.xaml" >
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>    
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BindableBase.cs" />
@@ -4587,6 +4595,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Generic.xaml.cs">
       <DependentUpon>BitmapIcon_Generic.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Frame.xaml.cs" >
+      <DependentUpon>CommandBar_Frame.xaml</DependentUpon>
+    </Compile>    
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Page1.xaml.cs" >
+      <DependentUpon>CommandBar_Page1.xaml</DependentUpon>
+    </Compile>    
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\Native_Frame\Page_Detail.xaml.cs">
       <DependentUpon>Page_Detail.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CustomContent/CommandBar_Frame.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CustomContent/CommandBar_Frame.xaml
@@ -1,0 +1,25 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.CommandBar.CustomContent.CommandBar_Frame"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:xamarin="http://uno.ui/xamarin"
+			 mc:Ignorable="d xamarin"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<Frame x:Name="HostFrame"
+			   xamarin:Style="{StaticResource NativeDefaultFrame}" />
+
+		<Button x:Name="NavigateInitialButton"
+		        Grid.Row="1"
+		        Content="Navigate to main page"
+		        Click="Navigate_Initial" />
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CustomContent/CommandBar_Frame.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CustomContent/CommandBar_Frame.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using UITests.Windows_UI_Xaml_Controls.CommandBar.Native_Frame;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.CommandBar.CustomContent
+{
+	[SampleControlInfo("CommandBar", "CommandBar_CustomContent")]
+	public sealed partial class CommandBar_Frame : UserControl
+	{
+		public CommandBar_Frame()
+		{
+			this.InitializeComponent();
+		}
+
+		private void Navigate_Initial(object sender, RoutedEventArgs args)
+		{
+			HostFrame.Navigate(typeof(CommandBar_Page1));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CustomContent/CommandBar_Page1.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CustomContent/CommandBar_Page1.xaml
@@ -1,0 +1,52 @@
+<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.CommandBar.CustomContent.CommandBar_Page1"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:xamarin="http://uno.ui/xamarin"
+    mc:Ignorable="d xamarin"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<CommandBar x:Name="Page1CommandBar">
+			<CommandBar.Content>
+				<Border VerticalAlignment="Center"
+						Height="44"
+						HorizontalAlignment="Center">
+					<TextBlock Text="Header with custom Content"
+							   TextTrimming="CharacterEllipsis"
+							   TextWrapping="NoWrap"
+							   Foreground="Blue" />
+					</Border>
+			</CommandBar.Content>
+		</CommandBar>
+
+		<StackPanel Grid.Row="1"
+		            Spacing="10"
+		            VerticalAlignment="Center">
+
+			<TextBlock Text="Main Page"
+			           HorizontalAlignment="Center" />
+
+			<TextBlock Text="-1"
+			           x:Name="ExpectedSize"
+			           HorizontalAlignment="Center" />
+
+			<TextBlock Text="-1"
+			           x:Name="CurrentSize"
+			           HorizontalAlignment="Center" />
+
+			<TextBlock Text="-1"
+			           x:Name="Result"
+			           HorizontalAlignment="Center" />
+		</StackPanel>
+
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CustomContent/CommandBar_Page1.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CustomContent/CommandBar_Page1.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.UI;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+#if __IOS__
+using UIKit;
+using Uno.UI.Controls;
+#endif
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.CommandBar.CustomContent
+{
+    public sealed partial class CommandBar_Page1 : Page
+    {
+        public CommandBar_Page1()
+        {
+            this.InitializeComponent();
+            this.Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+#if __IOS__
+	        UIView parent = this;
+	        while (parent.HasParent())
+	        {
+		        parent = parent.Superview;
+	        }
+
+	        var titleViewChild  = parent.FindFirstChild<TitleView>()?.Child;
+
+	        var height = titleViewChild?.Frame.Height ?? 0;
+	        var width = titleViewChild?.Frame.Width ?? 0;
+
+	        var expectedHeight = titleViewChild?.DesiredSize.Height ?? 0;
+	        var expectedWidth = titleViewChild?.DesiredSize.Width ?? 0;
+
+	        ExpectedSize.Text = $"Title Content desired size: ({expectedWidth}x{expectedHeight})";
+	        CurrentSize.Text = $"Title Content current size: ({width}x{height})";
+
+	        Result.Text =
+		        (height > 0 || height <= 0 && expectedHeight <= 0) && (width > 0 || width <= 0 && expectedWidth <= 0)
+			        ? "PASSED"
+			        : "FAILED";
+#endif
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CustomContent/CommandBar_Page1.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CustomContent/CommandBar_Page1.xaml.cs
@@ -44,10 +44,7 @@ namespace UITests.Windows_UI_Xaml_Controls.CommandBar.CustomContent
 	        ExpectedSize.Text = $"Title Content desired size: ({expectedWidth}x{expectedHeight})";
 	        CurrentSize.Text = $"Title Content current size: ({width}x{height})";
 
-	        Result.Text =
-		        (height > 0 || height <= 0 && expectedHeight <= 0) && (width > 0 || width <= 0 && expectedWidth <= 0)
-			        ? "PASSED"
-			        : "FAILED";
+	        Result.Text = height > 0 && width > 0 ? "PASSED" : "FAILED";
 #endif
         }
     }

--- a/src/Uno.UI/Controls/CommandBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBarNavigationItemRenderer.iOS.cs
@@ -177,6 +177,12 @@ namespace Uno.UI.Controls
 			}
 		}
 
+		protected override void OnBeforeArrange()
+		{
+			//This is to ensure that the layouter gets the correct **finalRect**
+			LayoutSlotWithMarginsAndAlignments = RectFromUIRect(Frame);
+		}
+
 		protected override Size MeasureOverride(Size availableSize)
 		{
 			if (_blockReentrantMeasure)

--- a/src/Uno.UI/Controls/CommandBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBarNavigationItemRenderer.iOS.cs
@@ -159,7 +159,7 @@ namespace Uno.UI.Controls
 		private Size _childSize;
 		private Size? _lastAvailableSize;
 
-		public TitleView()
+		internal TitleView()
 		{
 			if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
iOS CommandBar when using custom Content this is not displayed

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
