### PR TITLE
fix(xamlreader): XamlSchemaContext leaks when hooking on AppDomain.AssemblyLoad

### DIFF
--- a/src/SourceGenerators/System.Xaml.Tests/Test/System.Xaml/XamlSchemaContextTest.cs
+++ b/src/SourceGenerators/System.Xaml.Tests/Test/System.Xaml/XamlSchemaContextTest.cs
@@ -29,6 +29,7 @@ using System.Windows.Markup;
 using Uno.Xaml;
 using Uno.Xaml.Schema;
 using NUnit.Framework;
+using System.Diagnostics;
 
 [assembly:XmlnsDefinition ("urn:mono-test", "MonoTests.Uno.Xaml.NamespaceTest")]
 [assembly:XmlnsDefinition ("urn:mono-test2", "MonoTests.Uno.Xaml.NamespaceTest2")]
@@ -60,10 +61,10 @@ namespace MonoTests.Uno.Xaml
 		}
 
 		[Test]
-		public void ConstructorNullSettings ()
+		public void ConstructorNullSettings()
 		{
 			// allowed.
-			var ctx = new XamlSchemaContext ((XamlSchemaContextSettings) null);
+			var ctx = new XamlSchemaContext((XamlSchemaContextSettings)null);
 		}
 
 		[Test]
@@ -279,6 +280,27 @@ namespace MonoTests.Uno.Xaml
 			ctx = new XamlSchemaContext ();
 			xt = ctx.GetXamlType (xn);
 			Assert.IsNotNull (xt, "#2");
+		}
+
+		[Test]
+		public void ConstructorDefaultNoLeak()
+		{
+			WeakReference Create()
+			{
+				var ctx = new XamlSchemaContext();
+				return new WeakReference(ctx);
+			}
+
+			var weakRef = Create();
+
+			var sw = Stopwatch.StartNew();
+			while (weakRef.IsAlive && sw.Elapsed < TimeSpan.FromSeconds(1))
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			Assert.IsFalse(weakRef.IsAlive);
 		}
 	}
 }

--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlSchemaContext.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlSchemaContext.cs
@@ -20,6 +20,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+// History:
+// - 2021/02/21 (jerome@platform.uno): Adjust for hard link to AppDomain.AssemblyLoad
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -56,9 +59,11 @@ namespace Uno.Xaml
 		public XamlSchemaContext (IEnumerable<Assembly> referenceAssemblies, XamlSchemaContextSettings settings)
 		{
 			if (referenceAssemblies != null)
-				reference_assemblies = new List<Assembly> (referenceAssemblies);
+				reference_assemblies = new List<Assembly>(referenceAssemblies);
 			else
-				AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoaded;
+			{
+				RegisterAssemblyLoaded();
+			}
 
 			if (settings == null)
 				return;
@@ -67,10 +72,35 @@ namespace Uno.Xaml
 			SupportMarkupExtensionsWithDuplicateArity = settings.SupportMarkupExtensionsWithDuplicateArity;
 		}
 
+		private void RegisterAssemblyLoaded()
+		{
+			var that = new WeakReference<XamlSchemaContext>(this);
+
+			void Hook(object o, AssemblyLoadEventArgs e)
+			{
+				if (that.TryGetTarget(out var target))
+				{
+					target.OnAssemblyLoaded(o, e);
+				}
+				else
+				{
+					AppDomain.CurrentDomain.AssemblyLoad -= Hook;
+				}
+			}
+
+			// Abstract away the use of the Hool method, so that it can be called
+			// from the finalizer.
+			unhookAssemblyLoad = () => AppDomain.CurrentDomain.AssemblyLoad -= Hook;
+
+			// Register the Hook method to the AssemblyLoad event, so there's no
+			// hard link between "this" and the AssemblyLoad event delegate.
+			AppDomain.CurrentDomain.AssemblyLoad += Hook;
+		}
+
 		~XamlSchemaContext ()
 		{
 			if (reference_assemblies == null)
-				AppDomain.CurrentDomain.AssemblyLoad -= OnAssemblyLoaded;
+				unhookAssemblyLoad?.Invoke();
 		}
 
 		IList<Assembly> reference_assemblies;
@@ -83,6 +113,7 @@ namespace Uno.Xaml
 		XamlType [] empty_xaml_types = new XamlType [0];
 		List<XamlType> run_time_types = new List<XamlType> ();
 		object gate = new object();
+		Action unhookAssemblyLoad;
 
 		public bool FullyQualifyAssemblyNamesInClrNamespaces { get; private set; }
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5284

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The `XamlSchemaContext` does not leak when created without an assemblies list.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
