### PR TITLE
fix(Hyperlink): Use dark/light mode friendly color for WASM Hyperlink foreground

### DIFF
--- a/src/Uno.UI/UI/Xaml/Documents/Hyperlink.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/Hyperlink.wasm.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Linq;
+using Uno.UI;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Documents
 {
@@ -10,10 +12,12 @@ namespace Windows.UI.Xaml.Documents
 		public Hyperlink() : base("a")
 		{
 			UpdateNavigationProperties(null, _defaultNavigationTarget);
-
+			
 			PointerPressed += TextBlock.OnPointerPressed;
 			PointerReleased += TextBlock.OnPointerReleased;
 			PointerCaptureLost += TextBlock.OnPointerCaptureLost;
+			ResourceResolver.ApplyResource(this, Hyperlink.ForegroundProperty, "SystemControlHyperlinkTextBrush", isThemeResourceExtension: true);
+
 		}
 
 		#region NavigationTarget DependencyProperty


### PR DESCRIPTION
https://github.com/unoplatform/Uno.Gallery/issues/177

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Hyperlink text color is unreadable in dark mode for WASM

## What is the new behavior?

Hyperlink text color is readable in dark mode for WASM

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
