### PR TITLE
fix(iOS): CommandBar.Title overlapping AppBarButtons

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
@@ -323,5 +323,30 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 			_app.WaitForDependencyPropertyValue(_app.Marked("Result"), "Text", "PASSED");
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)]
+		public void When_CustomContentAndLongTitleAndDoubleNavigation_TitleShouldNotOverlapBarButtons_OnNavigateBack_NativeFrame()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle.CommandBar_Frame");
+
+			_app.WaitForElement("NavigateInitialButton");
+			_app.FastTap("NavigateInitialButton");
+
+			_app.WaitForElement("NavigateToPage2Button");
+			_app.FastTap("NavigateToPage2Button");
+
+			_app.WaitForElement("NavigateToPage3Button");
+			_app.FastTap("NavigateToPage3Button");
+
+			_app.WaitForElement("GoBackButton");
+			_app.FastTap("GoBackButton");
+
+			_app.WaitForElement("CalculateSize");
+			_app.FastTap("CalculateSize");
+
+			_app.WaitForDependencyPropertyValue(_app.Marked("Result"), "Text", "PASSED");
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
 using System;
 using System.Collections.Generic;
@@ -282,6 +282,44 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 			_app.FastTap("NavigateInitialButton");
 
 			_app.WaitForElement("Result");
+
+			_app.WaitForDependencyPropertyValue(_app.Marked("Result"), "Text", "PASSED");
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)]
+		public void When_CustomContentAndLongTitle_TitleShouldNotOverlapBarButtons_OnLoad_NativeFrame()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle.CommandBar_Frame");
+
+			_app.WaitForElement("NavigateInitialButton");
+			_app.FastTap("NavigateInitialButton");
+
+			_app.WaitForElement("CalculateSize");
+			_app.FastTap("CalculateSize");
+
+			_app.WaitForDependencyPropertyValue(_app.Marked("Result"), "Text", "PASSED");
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)]
+		public void When_CustomContentAndLongTitle_TitleShouldNotOverlapBarButtons_OnNavigateBack_NativeFrame()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle.CommandBar_Frame");
+
+			_app.WaitForElement("NavigateInitialButton");
+			_app.FastTap("NavigateInitialButton");
+
+			_app.WaitForElement("NavigateToPage2Button");
+			_app.FastTap("NavigateToPage2Button");
+
+			_app.WaitForElement("GoBackButton");
+			_app.FastTap("GoBackButton");
+
+			_app.WaitForElement("CalculateSize");
+			_app.FastTap("CalculateSize");
 
 			_app.WaitForDependencyPropertyValue(_app.Marked("Result"), "Text", "PASSED");
 		}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3931,20 +3931,24 @@
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Page1.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>      
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Frame.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>      
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page1.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>      
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page2.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>      
-    </Page>            
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page3.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BindableBase.cs" />
@@ -4617,15 +4621,18 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Page1.xaml.cs">
       <DependentUpon>CommandBar_Page1.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Frame.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Frame.xaml.cs">
       <DependentUpon>CommandBar_Frame.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page1.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page1.xaml.cs">
       <DependentUpon>CommandBar_Page1.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page2.xaml.cs" >
-         <DependentUpon>CommandBar_Page2.xaml</DependentUpon>
-    </Compile> 
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page2.xaml.cs">
+      <DependentUpon>CommandBar_Page2.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page3.xaml.cs">
+      <DependentUpon>CommandBar_Page3.xaml</DependentUpon>
+    </Compile>    
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\Native_Frame\Page_Detail.xaml.cs">
       <DependentUpon>Page_Detail.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3925,14 +3925,26 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Frame.xaml" >
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Frame.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Page1.xaml" >
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Page1.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>    
+      <Generator>MSBuild:Compile</Generator>      
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Frame.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>      
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page1.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>      
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page2.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>      
+    </Page>            
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BindableBase.cs" />
@@ -4599,12 +4611,21 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Generic.xaml.cs">
       <DependentUpon>BitmapIcon_Generic.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Frame.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Frame.xaml.cs">
       <DependentUpon>CommandBar_Frame.xaml</DependentUpon>
-    </Compile>    
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Page1.xaml.cs" >
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CustomContent\CommandBar_Page1.xaml.cs">
       <DependentUpon>CommandBar_Page1.xaml</DependentUpon>
-    </Compile>    
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Frame.xaml.cs" >
+      <DependentUpon>CommandBar_Frame.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page1.xaml.cs" >
+      <DependentUpon>CommandBar_Page1.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page2.xaml.cs" >
+         <DependentUpon>CommandBar_Page2.xaml</DependentUpon>
+    </Compile> 
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\Native_Frame\Page_Detail.xaml.cs">
       <DependentUpon>Page_Detail.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Frame.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Frame.xaml
@@ -1,0 +1,32 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle.CommandBar_Frame"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:xamarin="http://uno.ui/xamarin"
+			 mc:Ignorable="d xamarin"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<Frame x:Name="HostFrame"
+			   xamarin:Style="{StaticResource NativeDefaultFrame}" />
+
+		<Grid Grid.Row="1">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+			<Button x:Name="NavigateInitialButton"
+					Content="Navigate to first page"
+					Click="Navigate_Initial" />
+		</Grid>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Frame.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Frame.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using UITests.Windows_UI_Xaml_Controls.CommandBar.Native_Frame;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle
+{
+	[SampleControlInfo("CommandBar", "CommandBar_LongTitle_Navigation")]
+	public sealed partial class CommandBar_Frame : UserControl
+	{
+		public CommandBar_Frame()
+		{
+			this.InitializeComponent();
+		}
+
+		private void Navigate_Initial(object sender, RoutedEventArgs args)
+		{
+			HostFrame.Navigate(typeof(CommandBar_Page1));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page1.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page1.xaml
@@ -1,0 +1,56 @@
+<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle.CommandBar_Page1"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:xamarin="http://uno.ui/xamarin"
+    mc:Ignorable="d xamarin"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<CommandBar x:Name="Page1CommandBar">
+			<CommandBar.Content>
+				<Border VerticalAlignment="Center"
+				        Height="44"
+				        HorizontalAlignment="Center">
+					<TextBlock Text="This is supposed to be a very long text used to overflow the CommandBar title and validate how it behaves on navigation and will try to make it very long in case this is run on an iPad"
+					           Foreground="Black"
+					           TextTrimming="CharacterEllipsis"
+					           TextWrapping="NoWrap" />
+				</Border>
+			</CommandBar.Content>
+			<CommandBar.PrimaryCommands>
+				<AppBarButton Content="Click" />
+			</CommandBar.PrimaryCommands>
+		</CommandBar>
+
+		<StackPanel Grid.Row="1"
+					Spacing="10"
+					VerticalAlignment="Center">
+
+			<TextBlock Text="Main Page"
+			           HorizontalAlignment="Center" />
+
+			<Button x:Name="NavigateToPage2Button"
+			        Content="Navigate to Page 2"
+			        Click="OnButtonClicked"
+			        HorizontalAlignment="Center"/>
+
+			<Button x:Name="CalculateSize"
+			        Content="Calculate TitleView Size"
+			        Click="OnCalculateSizeClicked"
+			        HorizontalAlignment="Center"/>
+
+			<TextBlock x:Name="Result"
+			           HorizontalAlignment="Center" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page1.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page1.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.UI;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+#if __IOS__
+using UIKit;
+using Uno.UI.Controls;
+#endif
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle
+{
+    public sealed partial class CommandBar_Page1 : Page
+    {
+        public CommandBar_Page1()
+        {
+            this.InitializeComponent();
+        }
+
+        public async void OnButtonClicked(object sender, RoutedEventArgs e)
+		{
+			Frame.Navigate(typeof(CommandBar_Page2));
+		}
+
+        public async void OnCalculateSizeClicked(object sender, RoutedEventArgs e)
+        {
+#if __IOS__
+	        UIView parent = this;
+	        while (parent.HasParent())
+	        {
+		        parent = parent.Superview;
+	        }
+
+	        var titleView  = parent.FindFirstChild<TitleView>();
+	        var titleViewParent = titleView.Superview;
+
+	        //When the error occurs the TitleView Frame.Width get bigger than its parent Frame.Width
+	        //making the TitleView overlap any AppBarButton of the CommandBar
+	        Result.Text = titleView.Frame.Width > titleViewParent.Frame.Width ? "FAILED" : "PASSED";
+#endif
+        }
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page1.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page1.xaml.cs
@@ -18,13 +18,11 @@ namespace UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle
     {
         public CommandBar_Page1()
         {
-            this.InitializeComponent();
+	        this.InitializeComponent();
         }
 
         public async void OnButtonClicked(object sender, RoutedEventArgs e)
-		{
-			Frame.Navigate(typeof(CommandBar_Page2));
-		}
+	        => Frame.Navigate(typeof(CommandBar_Page2));
 
         public async void OnCalculateSizeClicked(object sender, RoutedEventArgs e)
         {

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page2.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page2.xaml
@@ -15,15 +15,46 @@
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 
-	<CommandBar Content="Title on Page 2"
-				x:Name="Page2CommandBar" />
+	<CommandBar x:Name="Page2CommandBar">
+		<CommandBar.Content>
+			<Border VerticalAlignment="Center"
+			        Height="44"
+			        HorizontalAlignment="Center">
+				<TextBlock Text="This is supposed to be a very long text used to overflow the CommandBar title and validate how it behaves on navigation and will try to make it very long in case this is run on an iPad"
+				           Foreground="Black"
+				           TextTrimming="CharacterEllipsis"
+				           TextWrapping="NoWrap" />
+			</Border>
+		</CommandBar.Content>
+		<CommandBar.PrimaryCommands>
+			<AppBarButton Content="Save" />
+		</CommandBar.PrimaryCommands>
+	</CommandBar>
 
 	<StackPanel Grid.Row="1"
-				VerticalAlignment="Center">
-				<Button x:Name="GoBackButton"
-						Content="Go Back"
-						Click="OnButtonClicked"
-						HorizontalAlignment="Center"/>
+	            Spacing="10"
+	            VerticalAlignment="Center">
+
+		<TextBlock Text="Page 2"
+		           HorizontalAlignment="Center" />
+
+		<Button x:Name="GoBackButton"
+		        Content="Go Back"
+		        Click="OnBackButtonClicked"
+		        HorizontalAlignment="Center"/>
+
+		<Button x:Name="NavigateToPage3Button"
+		        Content="Navigate to Page 3"
+		        Click="OnButtonClicked"
+		        HorizontalAlignment="Center"/>
+
+		<Button x:Name="CalculateSize"
+		        Content="Calculate TitleView Size"
+		        Click="OnCalculateSizeClicked"
+		        HorizontalAlignment="Center"/>
+
+		<TextBlock x:Name="Result"
+		           HorizontalAlignment="Center" />
 	</StackPanel>
 
 	</Grid>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page2.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page2.xaml
@@ -1,0 +1,30 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle.CommandBar_Page2"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+	<CommandBar Content="Title on Page 2"
+				x:Name="Page2CommandBar" />
+
+	<StackPanel Grid.Row="1"
+				VerticalAlignment="Center">
+				<Button x:Name="GoBackButton"
+						Content="Go Back"
+						Click="OnButtonClicked"
+						HorizontalAlignment="Center"/>
+	</StackPanel>
+
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page2.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page2.xaml.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle
+{
+	public sealed partial class CommandBar_Page2 : Page
+    {
+        public CommandBar_Page2()
+        {
+            this.InitializeComponent();
+        }
+
+        public void OnButtonClicked(object sender, object args)
+        {
+	        Frame.GoBack();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page2.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page2.xaml.cs
@@ -14,6 +14,10 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
+#if __IOS__
+using UIKit;
+using Uno.UI.Controls;
+#endif
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
@@ -21,14 +25,33 @@ namespace UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle
 {
 	public sealed partial class CommandBar_Page2 : Page
     {
-        public CommandBar_Page2()
-        {
-            this.InitializeComponent();
-        }
+	    public CommandBar_Page2()
+	    {
+		    this.InitializeComponent();
+	    }
 
-        public void OnButtonClicked(object sender, object args)
+	    public void OnBackButtonClicked(object sender, object args)
+	        => Frame.GoBack();
+
+        public async void OnButtonClicked(object sender, RoutedEventArgs e)
+	        => Frame.Navigate(typeof(CommandBar_Page3));
+
+        public async void OnCalculateSizeClicked(object sender, RoutedEventArgs e)
         {
-	        Frame.GoBack();
+#if __IOS__
+	        UIView parent = this;
+	        while (parent.HasParent())
+	        {
+		        parent = parent.Superview;
+	        }
+
+	        var titleView  = parent.FindFirstChild<TitleView>();
+	        var titleViewParent = titleView.Superview;
+
+	        //When the error occurs the TitleView Frame.Width get bigger than its parent Frame.Width
+	        //making the TitleView overlap any AppBarButton of the CommandBar
+	        Result.Text = titleView.Frame.Width > titleViewParent.Frame.Width ? "FAILED" : "PASSED";
+#endif
         }
     }
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page3.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page3.xaml
@@ -1,5 +1,5 @@
 <Page
-    x:Class="UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle.CommandBar_Page1"
+    x:Class="UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle.CommandBar_Page3"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle"
@@ -16,7 +16,7 @@
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 
-		<CommandBar x:Name="Page1CommandBar">
+		<CommandBar x:Name="Page3CommandBar">
 			<CommandBar.Content>
 				<Border VerticalAlignment="Center"
 				        Height="44"
@@ -28,7 +28,7 @@
 				</Border>
 			</CommandBar.Content>
 			<CommandBar.PrimaryCommands>
-				<AppBarButton Content="Open" />
+				<AppBarButton Content="Close" />
 			</CommandBar.PrimaryCommands>
 		</CommandBar>
 
@@ -36,21 +36,13 @@
 					Spacing="10"
 					VerticalAlignment="Center">
 
-			<TextBlock Text="Main Page"
+			<TextBlock Text="Page 3"
 			           HorizontalAlignment="Center" />
 
-			<Button x:Name="NavigateToPage2Button"
-			        Content="Navigate to Page 2"
+			<Button x:Name="GoBackButton"
+			        Content="Go Back"
 			        Click="OnButtonClicked"
 			        HorizontalAlignment="Center"/>
-
-			<Button x:Name="CalculateSize"
-			        Content="Calculate TitleView Size"
-			        Click="OnCalculateSizeClicked"
-			        HorizontalAlignment="Center"/>
-
-			<TextBlock x:Name="Result"
-			           HorizontalAlignment="Center" />
 		</StackPanel>
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page3.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/LongTitle/CommandBar_Page3.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.UI;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.CommandBar.LongTitle
+{
+    public sealed partial class CommandBar_Page3 : Page
+    {
+	    public CommandBar_Page3()
+	    {
+		    this.InitializeComponent();
+	    }
+
+	    public async void OnButtonClicked(object sender, RoutedEventArgs e)
+	        => Frame.GoBack();
+    }
+}

--- a/src/Uno.UI/Controls/CommandBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBarNavigationItemRenderer.iOS.cs
@@ -95,7 +95,7 @@ namespace Uno.UI.Controls
 				.PrimaryCommands
 				.OfType<AppBarButton>()
 				.Where(btn => btn.Visibility == Visibility.Visible && (((btn.Content as FrameworkElement)?.Visibility ?? Visibility.Visible) == Visibility.Visible))
-				.Do(appBarButton => appBarButton.SetParent(element)) // This ensures that Behaviors expecting this button to be in the logical tree work. 
+				.Do(appBarButton => appBarButton.SetParent(element)) // This ensures that Behaviors expecting this button to be in the logical tree work.
 				.Select(appBarButton => appBarButton.GetRenderer(() => new AppBarButtonRenderer(appBarButton)).Native)
 				.Reverse()
 				.ToArray();
@@ -104,7 +104,7 @@ namespace Uno.UI.Controls
 			var navigationCommand = element.GetValue(NavigationCommandProperty) as AppBarButton;
 			if (navigationCommand?.Visibility == Visibility.Visible)
 			{
-				navigationCommand.SetParent(element); // This ensures that Behaviors expecting this button to be in the logical tree work. 
+				navigationCommand.SetParent(element); // This ensures that Behaviors expecting this button to be in the logical tree work.
 				native.LeftBarButtonItem = navigationCommand.GetRenderer(() => new AppBarButtonRenderer(navigationCommand)).Native;
 			}
 			else
@@ -112,7 +112,7 @@ namespace Uno.UI.Controls
 				native.LeftBarButtonItem = null;
 			}
 
-			// CommandBarExtensions.BackButtonText	
+			// CommandBarExtensions.BackButtonText
 			if (element.GetValue(BackButtonTitleProperty) is string backButtonText)
 			{
 				native.BackBarButtonItem = new UIBarButtonItem(backButtonText, UIBarButtonItemStyle.Plain, null);
@@ -185,14 +185,17 @@ namespace Uno.UI.Controls
 
 		protected override Size MeasureOverride(Size availableSize)
 		{
-			//for the same reason expressed below we need to check if iOS sent a wrong availableSize which can be validated
-			// by checking the availableSize.Height
-			_blockReentrantMeasure = availableSize.Height == 0 && _lastAvailableSize?.Height != 0;
-
 			if (_blockReentrantMeasure)
 			{
 				// In some cases setting the Frame below can prompt iOS to call SizeThatFits with 0 height, which would screw up the desired
 				// size of children if we're within LayoutSubviews(). In this case simply return the existing measure.
+				return _childSize;
+			}
+
+			//for the same reason expressed above we need to check if iOS sent a wrong availableSize which can be validated
+			// by checking the availableSize.Height
+			if (availableSize.Height == 0 && _lastAvailableSize?.Height != 0)
+			{
 				return _childSize;
 			}
 
@@ -221,11 +224,17 @@ namespace Uno.UI.Controls
 						&& !_childSize.Height.IsNaN()
 						&& _childSize.Height != 0
 						&& _childSize.Width != 0
-						&& (Frame.Width != _childSize.Width
-						|| Frame.Height != _childSize.Height))
+						&& ( (Frame.Width != _childSize.Width && _childSize.Width < Frame.Width)
+						|| (Frame.Height != _childSize.Height && _childSize.Height < Frame.Height)))
 					{
 						// Set the frame size to the child size so that the OS centers properly.
-						Frame = new CGRect(Frame.X, Frame.Y, _childSize.Width, _childSize.Height);
+						// but only when the Frame is bigger than the Child preventing cases where
+						// the Child Size is bigger making the Frame to overflow the Available Size.
+
+						var width = _childSize.Width < Frame.Width ? _childSize.Width : Frame.Width;
+						var height = _childSize.Height < Frame.Height ? _childSize.Height : Frame.Height;
+
+						Frame = new CGRect(Frame.X, Frame.Y, width, height);
 					}
 				}
 

--- a/src/Uno.UI/Controls/CommandBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBarNavigationItemRenderer.iOS.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -185,9 +185,13 @@ namespace Uno.UI.Controls
 
 		protected override Size MeasureOverride(Size availableSize)
 		{
+			//for the same reason expressed below we need to check if iOS sent a wrong availableSize which can be validated
+			// by checking the availableSize.Height
+			_blockReentrantMeasure = availableSize.Height == 0 && _lastAvailableSize?.Height != 0;
+
 			if (_blockReentrantMeasure)
 			{
-				// In some cases setting the Frame below can prompt iOS to call SizeThatFits with 0 height, which would screw up the desired 
+				// In some cases setting the Frame below can prompt iOS to call SizeThatFits with 0 height, which would screw up the desired
 				// size of children if we're within LayoutSubviews(). In this case simply return the existing measure.
 				return _childSize;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): #

fixes https://github.com/unoplatform/nventive-private/issues/179

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
iOS CommandBar.Title when it's too long it's overlapping any AppBarButton on the page.

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
