### PR TITLE
fix(ImageBrush): [iOS/Android] subscribe to ImageBrush property changes

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Shape_Fill_StretchAndAlignment.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Shape_Fill_StretchAndAlignment.cs
@@ -22,71 +22,79 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.ImageBrushTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Browser)]
-		//Only include Browser as a platform until following issue is fixed: https://github.com/unoplatform/uno/issues/5271
+		[Timeout(7 * 60 * 1000)]
 		public void When_StretchAndAlignment()
 		{
-			Run("UITests.Windows_UI_Xaml_Media.ImageBrushTests.ImageBrushShapeStretchesAlignments");
-			_app.WaitForElement("MyRectangle");
-
-
-			foreach (var expected in _expectedColors)
+			try
 			{
-				SetProperty("MyStretch", "SelectedIndex", ((int)expected.Stretch).ToString());
-				SetProperty("MyAlignmentX", "SelectedIndex", ((int)expected.AlignmentX).ToString());
-				SetProperty("MyAlignmentY", "SelectedIndex", ((int)expected.AlignmentY).ToString());
-
-				SetProperty("MyWidth", "Text", expected.Size.Width.ToString());
-				SetProperty("MyHeight", "Text", expected.Size.Height.ToString());
+				Run("UITests.Windows_UI_Xaml_Media.ImageBrushTests.ImageBrushShapeStretchesAlignments");
+				_app.SetOrientationPortrait();
 
 
-				var greenContainer = _app.GetPhysicalRect("GreenBackground");
+				_app.WaitForElement("MyRectangle");
 
-				var permutation = $"{expected.Size.Width}-{expected.Size.Height}-{Enum.GetName(typeof(Stretch), expected.Stretch)}-X{Enum.GetName(typeof(AlignmentX), expected.AlignmentX)}-Y{Enum.GetName(typeof(AlignmentY), expected.AlignmentY)}";
-				using var snapshot = TakeScreenshot($"ImageBrush-{permutation}");
 
-				ImageAssert.HasPixels(
-					snapshot,
-					ExpectedPixels
-						.At($"middle-left-{permutation}", greenContainer.X, greenContainer.CenterY)
-						.WithPixelTolerance(1, 1)
-						.Pixel(expected.Colors[0]),
-					ExpectedPixels
-						.At($"top-left-{permutation}", greenContainer.X, greenContainer.Y)
-						.WithPixelTolerance(1, 1)
-						.Pixel(expected.Colors[1]),
-					ExpectedPixels
-						.At($"middle-top-{permutation}", greenContainer.CenterX, greenContainer.Y)
-						.WithPixelTolerance(1, 1)
-						.Pixel(expected.Colors[2]),
-					ExpectedPixels
-						.At($"top-right-{permutation}", greenContainer.Right, greenContainer.Y)
-						.WithPixelTolerance(1, 1)
-						.Pixel(expected.Colors[3]),
-					ExpectedPixels
-						.At($"middle-right-{permutation}", greenContainer.Right, greenContainer.CenterY)
-						.WithPixelTolerance(1, 1)
-						.Pixel(expected.Colors[4]),
-					ExpectedPixels
-						.At($"bottom-right-{permutation}", greenContainer.Right, greenContainer.Bottom)
-						.WithPixelTolerance(1, 1)
-						.Pixel(expected.Colors[5]),
-					ExpectedPixels
-						.At($"middle-bottom-{permutation}", greenContainer.CenterX, greenContainer.Bottom)
-						.WithPixelTolerance(1, 1)
-						.Pixel(expected.Colors[6]),
-					ExpectedPixels
-						.At($"bottom-left-{permutation}", greenContainer.X, greenContainer.Bottom)
-						.WithPixelTolerance(1, 1)
-						.Pixel(expected.Colors[7]),
-					ExpectedPixels
-						.At($"middle-middle-{permutation}", greenContainer.CenterX, greenContainer.CenterY)
-						.WithPixelTolerance(1, 1)
-						.Pixel(expected.Colors[8])
-				);
+				foreach (var expected in _expectedColors)
+				{
+					SetProperty("MyStretch", "SelectedIndex", ((int)expected.Stretch).ToString());
+					SetProperty("MyAlignmentX", "SelectedIndex", ((int)expected.AlignmentX).ToString());
+					SetProperty("MyAlignmentY", "SelectedIndex", ((int)expected.AlignmentY).ToString());
+
+					SetProperty("MyWidth", "Text", expected.Size.Width.ToString());
+					SetProperty("MyHeight", "Text", expected.Size.Height.ToString());
+
+
+					var greenContainer = _app.GetPhysicalRect("GreenBackground");
+
+					var permutation = $"{expected.Size.Width}-{expected.Size.Height}-{Enum.GetName(typeof(Stretch), expected.Stretch)}-X{Enum.GetName(typeof(AlignmentX), expected.AlignmentX)}-Y{Enum.GetName(typeof(AlignmentY), expected.AlignmentY)}";
+					using var snapshot = TakeScreenshot($"ImageBrush-{permutation}");
+
+					ImageAssert.HasPixels(
+						snapshot,
+						ExpectedPixels
+							.At($"middle-left-{permutation}", greenContainer.X, greenContainer.CenterY)
+							.WithPixelTolerance(1, 1)
+							.Pixel(expected.Colors[0]),
+						ExpectedPixels
+							.At($"top-left-{permutation}", greenContainer.X, greenContainer.Y)
+							.WithPixelTolerance(1, 1)
+							.Pixel(expected.Colors[1]),
+						ExpectedPixels
+							.At($"middle-top-{permutation}", greenContainer.CenterX, greenContainer.Y)
+							.WithPixelTolerance(1, 1)
+							.Pixel(expected.Colors[2]),
+						ExpectedPixels
+							.At($"top-right-{permutation}", greenContainer.Right, greenContainer.Y)
+							.WithPixelTolerance(1, 1)
+							.Pixel(expected.Colors[3]),
+						ExpectedPixels
+							.At($"middle-right-{permutation}", greenContainer.Right, greenContainer.CenterY)
+							.WithPixelTolerance(1, 1)
+							.Pixel(expected.Colors[4]),
+						ExpectedPixels
+							.At($"bottom-right-{permutation}", greenContainer.Right, greenContainer.Bottom)
+							.WithPixelTolerance(1, 1)
+							.Pixel(expected.Colors[5]),
+						ExpectedPixels
+							.At($"middle-bottom-{permutation}", greenContainer.CenterX, greenContainer.Bottom)
+							.WithPixelTolerance(1, 1)
+							.Pixel(expected.Colors[6]),
+						ExpectedPixels
+							.At($"bottom-left-{permutation}", greenContainer.X, greenContainer.Bottom)
+							.WithPixelTolerance(1, 1)
+							.Pixel(expected.Colors[7]),
+						ExpectedPixels
+							.At($"middle-middle-{permutation}", greenContainer.CenterX, greenContainer.CenterY)
+							.WithPixelTolerance(1, 1)
+							.Pixel(expected.Colors[8])
+					);
+				}
+
 			}
-
-			
+			finally
+			{
+				_app.SetOrientationLandscape();
+			}
 		}
 
 		private void SetProperty(string name, string propertyName, string item)

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
@@ -81,7 +81,7 @@ namespace Windows.UI.Xaml.Media
 			}
 			else if (b is ImageBrush imageBrush && imageBrushCallback != null)
 			{
-				var disposables = new CompositeDisposable(3);
+				var disposables = new CompositeDisposable(5);
 				imageBrush.RegisterDisposablePropertyChangedCallback(
 					ImageBrush.ImageSourceProperty,
 					(_, __) => imageBrushCallback()
@@ -89,6 +89,16 @@ namespace Windows.UI.Xaml.Media
 
 				imageBrush.RegisterDisposablePropertyChangedCallback(
 					ImageBrush.StretchProperty,
+					(_, __) => imageBrushCallback()
+				).DisposeWith(disposables);
+
+				imageBrush.RegisterDisposablePropertyChangedCallback(
+					ImageBrush.AlignmentXProperty,
+					(_, __) => imageBrushCallback()
+				).DisposeWith(disposables);
+
+				imageBrush.RegisterDisposablePropertyChangedCallback(
+					ImageBrush.AlignmentYProperty,
 					(_, __) => imageBrushCallback()
 				).DisposeWith(disposables);
 

--- a/src/Uno.UI/UI/Xaml/Media/Brush.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.iOSmacOS.cs
@@ -60,11 +60,35 @@ namespace Windows.UI.Xaml.Media
 			}
 			else if (b is ImageBrush imageBrush)
 			{
+				var disposables = new CompositeDisposable(5);
 				void ImageChanged(_Image _) => colorSetter(SolidColorBrushHelper.Transparent.Color);
 
 				imageBrush.ImageChanged += ImageChanged;
 
-				return Disposable.Create(() => imageBrush.ImageChanged -= ImageChanged);
+				Disposable.Create(() => imageBrush.ImageChanged -= ImageChanged)
+					.DisposeWith(disposables);
+
+				imageBrush.RegisterDisposablePropertyChangedCallback(
+					ImageBrush.StretchProperty,
+					(_, __) => imageBrushCallback?.Invoke()
+				).DisposeWith(disposables);
+
+				imageBrush.RegisterDisposablePropertyChangedCallback(
+					ImageBrush.AlignmentXProperty,
+					(_, __) => imageBrushCallback?.Invoke()
+				).DisposeWith(disposables);
+
+				imageBrush.RegisterDisposablePropertyChangedCallback(
+					ImageBrush.AlignmentYProperty,
+					(_, __) => imageBrushCallback?.Invoke()
+				).DisposeWith(disposables);
+
+				imageBrush.RegisterDisposablePropertyChangedCallback(
+					ImageBrush.RelativeTransformProperty,
+					(_, __) => imageBrushCallback?.Invoke()
+				).DisposeWith(disposables);
+
+				return disposables;
 			}
 			else if (b is AcrylicBrush acrylicBrush)
 			{

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
@@ -54,7 +54,7 @@ namespace Windows.UI.Xaml.Shapes
 				propertyChangedCallback: (s, e) => ((Shape)s).OnFillChanged((Brush)e.NewValue)
 #else
 				options: FrameworkPropertyMetadataOptions.ValueInheritsDataContext | FrameworkPropertyMetadataOptions.LogicalChild | FrameworkPropertyMetadataOptions.AffectsArrange,
-				propertyChangedCallback: (s, e) => ((Shape)s)._brushChanged.Disposable = Brush.AssignAndObserveBrush((Brush)e.NewValue, _ => s.InvalidateArrange())
+				propertyChangedCallback: (s, e) => ((Shape)s)._brushChanged.Disposable = Brush.AssignAndObserveBrush((Brush)e.NewValue, _ => s.InvalidateArrange(), imageBrushCallback: () => s.InvalidateArrange())
 #endif
 			)
 		);


### PR DESCRIPTION
closes #5271

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Having an ImageBrush as the Fill for a Shape would not re-draw if Stretch/AlignmentX/AlignmentY were changed

## What is the new behavior?

Having an ImageBrush as the Fill for a Shape will re-draw if Stretch/AlignmentX/AlignmentY were changed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
