### PR TITLE
fix(WebView): Raise NavigationStarting and NavigationCompleted when doing anchor navigation on iOS.

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Constants.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Constants.cs
@@ -15,6 +15,6 @@ namespace SamplesApp.UITests
 		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";
 
 		// Default active platform when running under Visual Studio test runner
-		public const Platform CurrentPlatform = Platform.Browser;
+		public const Platform CurrentPlatform = Platform.Android;
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
 		<PackageReference Include="NUnit" />
 		<PackageReference Include="NUnit3TestAdapter" /> 
-		<PackageReference Include="Xamarin.UITest" Version="3.0.14" />
+		<PackageReference Include="Xamarin.UITest" Version="3.0.13" />
 		<PackageReference Include="Uno.UITest" />
 		<PackageReference Include="Uno.UITest.Selenium" />
 		<PackageReference Include="Uno.UITest.Xamarin" />

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WebViewTests/UnoSamples_Test_NavigateToString.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WebViewTests/UnoSamples_Test_NavigateToString.cs
@@ -41,5 +41,34 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.WebViewTests
 
 		}
 
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)]
+		public void WebView_NavigateToAnchor()
+		{
+			Run("Uno.UI.Samples.Content.UITests.WebView.WebView_AnchorNavigation");
+
+			_app.WaitForElement(_app.Marked("NavigateToAnchorButton"));
+
+			TakeScreenshot("Initial");
+
+			var navigationCompletedTextBlock = _app.Marked("NavigationCompletedTextBlock");
+			var navigateToAnchorButton = _app.Marked("NavigateToAnchorButton");
+			var clickAnchorButton = _app.Marked("ClickAnchorButton");
+
+			_app.WaitForText(navigationCompletedTextBlock, "https://tools.ietf.org/html/rfc6749");
+
+			// navigate to anchor
+			_app.FastTap(navigateToAnchorButton);
+			_app.WaitForText(navigationCompletedTextBlock, "https://tools.ietf.org/html/rfc6749#section-1");
+
+			TakeScreenshot("navigate to anchor");
+
+			// user click in the browser itself
+			_app.FastTap(clickAnchorButton);
+			_app.WaitForText(navigationCompletedTextBlock, "https://tools.ietf.org/html/rfc6749#page-4");
+
+			TakeScreenshot("click anchor");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2853,6 +2853,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_AnchorNavigation.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Animated_Opacity.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5717,6 +5721,9 @@
       <DependentUpon>UndefinedHeightListView.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebViewViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_AnchorNavigation.xaml.cs">
+      <DependentUpon>WebView_AnchorNavigation.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Animated_Opacity.xaml.cs">
       <DependentUpon>WebView_Animated_Opacity.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml
@@ -11,7 +11,7 @@
 			 d:DesignHeight="2000"
 			 d:DesignWidth="400">
 
-	<xamarin:Grid>
+	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
@@ -26,13 +26,19 @@
 			<TextBlock x:Name="NavigationCompletedTextBlock"
 					   Margin="0,0,0,12"/>
 
-			<Button Content="NavigateToAnchor"
-					Click="ButtonClicked"
+			<Button x:Name="NavigateToAnchorButton"
+					Content="Navigate To Anchor"
+					Click="{x:Bind ButtonClicked}"
+					Height="50" />
+
+			<Button x:Name="ClickAnchorButton"
+					Content="Click Anchor"
+					Click="{x:Bind OnClickAnchor}"
 					Height="50" />
 		</StackPanel>
 		
 		<WebView x:Name="webView"
 				 Grid.Row="1"
 				 Margin="32" />
-	</xamarin:Grid>
+	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml
@@ -1,0 +1,38 @@
+<UserControl x:Class="Uno.UI.Samples.Content.UITests.WebView.WebView_AnchorNavigation"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:xamarin="http://uno.ui/xamarin"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:ios="http://uno.ui/ios"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:android="http://uno.ui/android"
+			 mc:Ignorable="d ios android xamarin"
+			 d:DesignHeight="2000"
+			 d:DesignWidth="400">
+
+	<xamarin:Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<StackPanel>			
+			<TextBlock Text="Navigation Starting Uri:" />
+			<TextBlock x:Name="NavigationStartingTextBlock"
+					   Margin="0,0,0,12"/>
+
+			<TextBlock Text="Navigation Completed Uri:" />
+			<TextBlock x:Name="NavigationCompletedTextBlock"
+					   Margin="0,0,0,12"/>
+
+			<Button Content="NavigateToAnchor"
+					Click="ButtonClicked"
+					Height="50" />
+		</StackPanel>
+		
+		<WebView x:Name="webView"
+				 Grid.Row="1"
+				 Margin="32" />
+	</xamarin:Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml.cs
@@ -1,0 +1,39 @@
+using System;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.WebView
+{
+	[SampleControlInfo("WebView", "WebView_AnchorNavigation", description:"This sample tests that anchor navigation raises the proper events. The 2 uris received from the NavigationStarting and NavigationCompleted must update whether you tap the NavigateToAnchor button or tap on anchors from the web content.")]
+	public sealed partial class WebView_AnchorNavigation : UserControl
+	{
+		//Windows.UI.Xaml.Controls.WebView webView;
+
+		public WebView_AnchorNavigation()
+		{
+			InitializeComponent();
+
+#if HAS_UNO
+			webView.Navigate(new Uri("https://tools.ietf.org/html/rfc6749"));
+			webView.NavigationStarting += WebView_NavigationStarting;
+			webView.NavigationCompleted += WebView_NavigationCompleted;
+#endif
+		}
+
+		private void WebView_NavigationStarting(Windows.UI.Xaml.Controls.WebView sender, WebViewNavigationStartingEventArgs args)
+		{
+			NavigationStartingTextBlock.Text = args.Uri.AbsoluteUri;
+		}
+
+		private void WebView_NavigationCompleted(Windows.UI.Xaml.Controls.WebView sender, WebViewNavigationCompletedEventArgs args)
+		{
+			NavigationCompletedTextBlock.Text = args.Uri.AbsoluteUri;
+		}
+
+		private void ButtonClicked(object sender, RoutedEventArgs args)
+		{
+			webView.Navigate(new Uri("https://tools.ietf.org/html/rfc6749#section-1"));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -31,9 +32,14 @@ namespace Uno.UI.Samples.Content.UITests.WebView
 			NavigationCompletedTextBlock.Text = args.Uri.AbsoluteUri;
 		}
 
-		private void ButtonClicked(object sender, RoutedEventArgs args)
+		private void ButtonClicked()
 		{
 			webView.Navigate(new Uri("https://tools.ietf.org/html/rfc6749#section-1"));
+		}
+
+		private void OnClickAnchor()
+		{
+			_ = webView.InvokeScriptAsync("document.getElementById(\"page-4\").click()", null);
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes https://github.com/unoplatform/nventive-private/issues/187

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`WebView.NavigationStarting` and `WebView.NavigationCompleted` **are not** raised when clicking on anchors in a WebView.

## What is the new behavior?

`WebView.NavigationStarting` and `WebView.NavigationCompleted` **are** raised when clicking on anchors in a WebView.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
