### PR TITLE
Fixes vsix issue

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate.VISX/UnoPlatformPackage.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate.VISX/UnoPlatformPackage.cs
@@ -232,7 +232,7 @@ namespace UnoSolutionTemplate
 							}
 							else
 							{
-								_infoAction("The loaded solution contains an Uno.UI Remote Control service.");
+								_infoAction($"Unable to load {unoNuGetPackage.Id} Remote Control service ({unoNuGetPackage.VersionString}) (The constructor is invalid).");
 							}
 						}
 					}

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -159,13 +159,24 @@ namespace Uno.UI.RemoteControl.VS
 			try
 			{
 				await StartServerAsync();
-
+				var portString = RemoteControlServerPort.ToString(CultureInfo.InvariantCulture);
 				foreach (var p in await GetProjectsAsync())
 				{
-					if (GetMsbuildProject(p.FileName) is Microsoft.Build.Evaluation.Project msbProject && IsApplication(msbProject))
+					var filename = string.Empty;
+					try
 					{
-						var portString = RemoteControlServerPort.ToString(CultureInfo.InvariantCulture);
-						SetGlobalProperty(p.FileName, RemoteControlServerPortProperty, portString);
+						filename = p.FileName;
+					}
+					catch (Exception ex)
+					{
+						_debugAction($"Exception on retrieving {p.UniqueName} details. Err: {ex}.");
+						_warningAction($"Cannot read {p.UniqueName} project details (It may be unloaded).");
+					}
+					if (string.IsNullOrWhiteSpace(filename) == false
+						&& GetMsbuildProject(filename) is Microsoft.Build.Evaluation.Project msbProject
+						&& IsApplication(msbProject))
+					{
+						SetGlobalProperty(filename, RemoteControlServerPortProperty, portString);
 					}
 				}
 			}

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -39,6 +39,7 @@ namespace Uno.UI.RemoteControl.VS
 		private System.Diagnostics.Process _process;
 
 		private int RemoteControlServerPort;
+		private bool _closing = false;
 
 		public EntryPoint(DTE2 dte2, string toolsPath, AsyncPackage asyncPackage, Action<Func<Task<Dictionary<string, string>>>> globalPropertiesProvider)
 		{
@@ -96,12 +97,36 @@ namespace Uno.UI.RemoteControl.VS
 				.Add(UnoPlatformOutputPane);
 			}
 
-			_debugAction = s => owPane.OutputString("[DEBUG] " + s + "\r\n");
-			_infoAction = s => owPane.OutputString("[INFO] " + s + "\r\n");
-			_infoAction = s => owPane.OutputString("[INFO] " + s + "\r\n");
-			_verboseAction = s => owPane.OutputString("[VERBOSE] " + s + "\r\n");
-			_warningAction = s => owPane.OutputString("[WARNING] " + s + "\r\n");
-			_errorAction = e => owPane.OutputString("[ERROR] " + e + "\r\n");
+			_debugAction = s => {
+				if (!_closing)
+				{
+					owPane.OutputString("[DEBUG] " + s + "\r\n");
+				}
+			};
+			_infoAction = s => {
+				if (!_closing)
+				{
+					owPane.OutputString("[INFO] " + s + "\r\n");
+				}
+			};
+			_verboseAction = s => {
+				if (!_closing)
+				{
+					owPane.OutputString("[VERBOSE] " + s + "\r\n");
+				}
+			};
+			_warningAction = s => {
+				if (!_closing)
+				{
+					owPane.OutputString("[WARNING] " + s + "\r\n");
+				}
+			};
+			_errorAction = e => {
+				if (!_closing)
+				{
+					owPane.OutputString("[ERROR] " + e + "\r\n");
+				}
+			};
 
 			_infoAction($"Uno Remote Control initialized ({GetAssemblyVersion()})");
 		}
@@ -171,6 +196,7 @@ namespace Uno.UI.RemoteControl.VS
 				}
 				finally
 				{
+					_closing = true;
 					_process = null;
 				}
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- When  Remote Control service has invalid ctor print message `The loaded solution contains an Uno.UI Remote Control service.`
- When VS closing is throwing System.Runtime.InteropServices.COMException HRESULT: 0x80004005 (E_FAIL)
- When the solution contains unloaded project is trowing System.NotImplementedException HRESULT: 0x80004001 (E_NOTIMPL) and UpdateProjectsAsync is stopped

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- When  Remote Control service has invalid ctor print message `Unable to load {unoNuGetPackage.Id} Remote Control service ({unoNuGetPackage.VersionString}) (The constructor is invalid).`
- When VS closing is not throwing System.Runtime.InteropServices.COMException HRESULT: 0x80004005 (E_FAIL)
- When the solution contains unloaded project, it is ignored and UpdateProjectAsync is not stopped

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
