### PR TITLE
chore: correcting false implementation of Geolocator.Android

### DIFF
--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -62,9 +62,6 @@ namespace Windows.Devices.Geolocation
 			}
 		}
 
-		public Task<Geoposition> GetGeopositionAsync(TimeSpan maximumAge, TimeSpan timeout)
-			=> GetGeopositionAsync();
-
 		public static async Task<GeolocationAccessStatus> RequestAccessAsync()
 		{
 			var status = GeolocationAccessStatus.Allowed;

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Geolocation/Geolocator.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Geolocation/Geolocator.cs
@@ -112,7 +112,7 @@ namespace Windows.Devices.Geolocation
 		// Forced skipping of method Windows.Devices.Geolocation.Geolocator.ReportInterval.get
 		// Forced skipping of method Windows.Devices.Geolocation.Geolocator.ReportInterval.set
 		// Forced skipping of method Windows.Devices.Geolocation.Geolocator.LocationStatus.get
-		#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if __ANDROID__ || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Devices.Geolocation.Geoposition> GetGeopositionAsync()
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #5661

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Currently, Uno falsify claims that GetGeopositionAsync(TimeSpan maximumAge, TimeSpan timeout) is implemented for Android.

## What is the new behavior?
Decision to ignore parameters (maximumAge and timeout) is left to app author.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
I think Uno have no right to make decision of ignoring parameters (as timeout) from GetGeopositionAsync call. Sometimes these two parameters are really important. E.g. app, that tests if current Geoposition is available to change user interface; hanging here for dozens of seconds is simply impossible; so app uses GetGeopositionAsync with timeout e.g. = 2 seconds. But Uno changes it to infinite timeout (by ignoring timeout parameters).
Also, sometimes it is important to have current, not cached/older Geoposition. Current implementation ignores maximumAge, and can return e.g. fix days old! And we have no ability to workaround this in app code, as next call to GetGeopositionAsync  returns same, very old, Geoposition.

Marking GetGeopositionAsync(TimeSpan maximumAge, TimeSpan timeout) as implemented is simply not true; this method is unimplemented in current Uno version.

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
