### PR TITLE
fix(fluent): Exclude SplitView fluent style to fallback on UWP's version

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Constants.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Constants.cs
@@ -15,6 +15,6 @@ namespace SamplesApp.UITests
 		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";
 
 		// Default active platform when running under Visual Studio test runner
-		public const Platform CurrentPlatform = Platform.Android;
+		public const Platform CurrentPlatform = Platform.Browser;
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/NavigationViewTests/NavigationView_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/NavigationViewTests/NavigationView_Tests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NavigationViewTests
+{
+	public class NavigationView_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry()]
+		public void NavigateBackAndForthBetweenMenuItemsAndSettings_Fluent()
+		{
+			Run("SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle.FluentStyle_NavigationViewSample");
+
+			_app.WaitForElement(_app.Marked("BasicNavigation"));
+
+			var secondMenuItem = _app.Marked("SecondItem");
+			secondMenuItem.FastTap();
+
+			_app.WaitForElement("Page2NavViewContent");
+
+			var togglePaneButton = _app.Marked("TogglePaneButton");
+			togglePaneButton.FastTap();
+
+			var firstMenuItem = _app.Marked("FirstItem");
+			firstMenuItem.FastTap();
+
+			_app.WaitForElement("Page1NavViewContent");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item1Page.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item1Page.xaml
@@ -1,0 +1,17 @@
+﻿<Page
+    x:Class="SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle.Item1Page"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:SamplesApp.Shared.Samples.NavigationViewSample"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<StackPanel Margin="20" VerticalAlignment="Top" Orientation="Horizontal">
+			<SymbolIcon Symbol="Play" Margin="20" />
+			<TextBlock x:Name="Page1NavViewContent" Text="Page 1" FontSize="30" VerticalAlignment="Center" />
+		</StackPanel>
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item1Page.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item1Page.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class Item1Page : Page
+    {
+        public Item1Page()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item2Page.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item2Page.xaml
@@ -1,0 +1,17 @@
+﻿<Page
+    x:Class="SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle.Item2Page"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:SamplesApp.Shared.Samples.NavigationViewSample"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<StackPanel Margin="20" VerticalAlignment="Top" Orientation="Horizontal">
+			<SymbolIcon Symbol="Save" Margin="20" />
+			<TextBlock x:Name="Page2NavViewContent" Text="Page 2" FontSize="30" VerticalAlignment="Center" />
+		</StackPanel>
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item2Page.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item2Page.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class Item2Page : Page
+    {
+        public Item2Page()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item3Page.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item3Page.xaml
@@ -1,0 +1,17 @@
+﻿<Page
+    x:Class="SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle.Item3Page"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:SamplesApp.Shared.Samples.NavigationViewSample"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<StackPanel Margin="20" VerticalAlignment="Top" Orientation="Horizontal">
+			<SymbolIcon Symbol="Refresh" Margin="20" />
+			<TextBlock Text="Page 3" FontSize="30" VerticalAlignment="Center" />
+		</StackPanel>
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item3Page.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/Item3Page.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class Item3Page : Page
+    {
+        public Item3Page()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/NavigationViewSample.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/NavigationViewSample.xaml
@@ -1,0 +1,74 @@
+﻿<UserControl
+	x:Class="SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle.FluentStyle_NavigationViewSample"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	mc:Ignorable="d xamarin"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<UserControl.Resources>
+        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+    </UserControl.Resources>
+
+	<Grid>
+		<muxc:NavigationView Loaded="NavigationView_Loaded"
+						Margin="0,12,0,0"
+						HorizontalAlignment="Stretch" 
+						SelectionChanged="NavigationView_SelectionChanged"
+						ItemInvoked="NvSample_ItemInvoked"
+						xamarin:BackRequested="NvSample_BackRequested"
+						x:Name="BasicNavigation"
+						IsSettingsVisible="true"
+						IsTabStop="False"						
+						Header="This is header text.">
+			<muxc:NavigationView.MenuItems>
+				<muxc:NavigationViewItem AutomationProperties.AutomationId="FirstItem"
+										 Content="Menu Item1"
+										Tag="SamplePage1">
+					<muxc:NavigationViewItem.Icon>
+						<SymbolIcon Symbol="Play" />
+					</muxc:NavigationViewItem.Icon>
+				</muxc:NavigationViewItem>
+				<muxc:NavigationViewItemHeader Content="Actions" />
+				<muxc:NavigationViewItem AutomationProperties.AutomationId="SecondItem"
+										 Content="Menu Item2"
+										 Tag="SamplePage2">
+					<muxc:NavigationViewItem.Icon>
+						<SymbolIcon Symbol="Save" />
+					</muxc:NavigationViewItem.Icon>
+				</muxc:NavigationViewItem>
+				<muxc:NavigationViewItem Content="Menu Item3"
+									Tag="SamplePage3">
+					<muxc:NavigationViewItem.Icon>
+						<SymbolIcon Symbol="Refresh" />
+					</muxc:NavigationViewItem.Icon>
+				</muxc:NavigationViewItem>
+			</muxc:NavigationView.MenuItems>
+				
+			<muxc:NavigationView.AutoSuggestBox>
+				<AutoSuggestBox x:Name="controlsSearchBox"
+								VerticalAlignment="Center"
+								PlaceholderText="Search"
+								QueryIcon="Find"
+								RequestedTheme="Light">
+				</AutoSuggestBox>
+			</muxc:NavigationView.AutoSuggestBox>
+
+			<Frame x:Name="contentFrame">
+				<Frame.ContentTransitions>
+					<TransitionCollection>
+						<NavigationThemeTransition>
+							<NavigationThemeTransition.DefaultNavigationTransitionInfo>
+								<EntranceNavigationTransitionInfo />
+							</NavigationThemeTransition.DefaultNavigationTransitionInfo>
+						</NavigationThemeTransition>
+					</TransitionCollection>
+				</Frame.ContentTransitions>
+			</Frame>
+		</muxc:NavigationView>
+
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/NavigationViewSample.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/NavigationViewSample.xaml.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo("NavigationView", "FluentStyle_NavigationViewSample")]
+	public sealed partial class FluentStyle_NavigationViewSample
+	{
+		public FluentStyle_NavigationViewSample()
+		{
+			this.InitializeComponent();
+
+			contentFrame.Navigated += (s, e) =>
+			{
+				UpdateBackButton();
+				Console.WriteLine($"Navigated to {e.Content}, {contentFrame.BackStackDepth}");
+
+				if (e.NavigationMode == NavigationMode.Back)
+				{
+					NavigationViewItem getItemNamed(string name)
+					=> BasicNavigation.MenuItems.OfType<NavigationViewItem>().FirstOrDefault(i => i.Tag?.ToString() == name);
+
+					if (e.Content is Item1Page)
+					{
+						BasicNavigation.SelectedItem = getItemNamed("SamplePage1");
+					}
+					else if (e.Content is Item2Page)
+					{
+						BasicNavigation.SelectedItem = getItemNamed("SamplePage2");
+					}
+					else if (e.Content is Item3Page)
+					{
+						BasicNavigation.SelectedItem = getItemNamed("SamplePage3");
+					}
+					else if (e.Content is SettingsPage)
+					{
+						BasicNavigation.SelectedItem = BasicNavigation.SettingsItem;
+					}
+				}
+			};
+
+			UpdateBackButton();
+		}
+
+		private void UpdateBackButton()
+			=> BasicNavigation.IsBackEnabled = contentFrame.BackStackDepth != 0;
+
+		private void NavigationView_Loaded(object sender, RoutedEventArgs e)
+		{
+			Console.WriteLine("NavigationView_Loaded");
+		}
+
+		private void NavigationView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
+		{
+			Console.WriteLine("NavigationView_SelectionChanged");
+		}
+
+		private void NvSample_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
+		{
+			if (args.IsSettingsInvoked)
+			{
+				contentFrame.Navigate(typeof(SettingsPage));
+			}
+			else if(args.InvokedItemContainer is NavigationViewItem item)
+			{
+				switch (item.Tag)
+				{
+					case "SamplePage1":
+						contentFrame.Navigate(typeof(Item1Page));
+						break;
+					case "SamplePage2":
+						contentFrame.Navigate(typeof(Item2Page));
+						break;
+					case "SamplePage3":
+						contentFrame.Navigate(typeof(Item3Page));
+						break;
+				}
+			}
+		}
+
+		private void NvSample_BackRequested(NavigationView sender, NavigationViewBackRequestedEventArgs args)
+		{
+			Console.WriteLine("BasicNavigation_BackRequested");
+			contentFrame.GoBack();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/SettingsPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/SettingsPage.xaml
@@ -1,0 +1,17 @@
+﻿<Page
+    x:Class="SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle.SettingsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:SamplesApp.Shared.Samples.NavigationViewSample"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<StackPanel Margin="20" VerticalAlignment="Top" Orientation="Horizontal">
+			<SymbolIcon Symbol="Setting" Margin="20" />
+			<TextBlock x:Name="SettingsNavViewContent" Text="Settings" FontSize="30" VerticalAlignment="Center" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/SettingsPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/FluentStyle/SettingsPage.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace SamplesApp.Samples.Microsoft_UI_Xaml_Controls.NavigationViewTests.FluentStyle
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class SettingsPage : Page
+    {
+        public SettingsPage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -89,6 +89,26 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\FluentStyle\Item1Page.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\FluentStyle\Item2Page.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\FluentStyle\Item3Page.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\FluentStyle\NavigationViewSample.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\FluentStyle\SettingsPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\Footer\PaneLayoutTestPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4031,6 +4051,21 @@
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\DialogWithNavView.xaml.cs">
       <DependentUpon>DialogWithNavView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\FluentStyle\Item1Page.xaml.cs">
+      <DependentUpon>Item1Page.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\FluentStyle\Item2Page.xaml.cs">
+      <DependentUpon>Item2Page.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\FluentStyle\Item3Page.xaml.cs">
+      <DependentUpon>Item3Page.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\FluentStyle\NavigationViewSample.xaml.cs">
+      <DependentUpon>NavigationViewSample.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\FluentStyle\SettingsPage.xaml.cs">
+      <DependentUpon>SettingsPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\Footer\PaneLayoutTestPage.xaml.cs">
       <DependentUpon>PaneLayoutTestPage.xaml</DependentUpon>
     </Compile>
@@ -4652,7 +4687,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\LongTitle\CommandBar_Page3.xaml.cs">
       <DependentUpon>CommandBar_Page3.xaml</DependentUpon>
-    </Compile>    
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\Native_Frame\Page_Detail.xaml.cs">
       <DependentUpon>Page_Detail.xaml</DependentUpon>
     </Compile>

--- a/src/Uno.UI.FluentTheme/Resources/PriorityDefault/SplitView_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/Resources/PriorityDefault/SplitView_themeresources.xaml
@@ -3,7 +3,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <ResourceDictionary.ThemeDictionaries>
+
+	<!-- UNO TODO Fails to display correctly for multiple reasons, including https://github.com/unoplatform/uno/issues/325 but also undiagnosed issues -->
+
+	<win:ResourceDictionary.ThemeDictionaries>
         <ResourceDictionary x:Key="Default">
             <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
             <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>
@@ -34,18 +37,17 @@
             <x:String x:Key="SplitViewPaneAnimationOpenPreDuration">00:00:00.19999</x:String>
             <x:String x:Key="SplitViewPaneAnimationCloseDuration">00:00:00.1</x:String>
         </ResourceDictionary>
-    </ResourceDictionary.ThemeDictionaries>
+    </win:ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="SplitView" BasedOn="{StaticResource DefaultSplitViewStyle}" />
+    <win:Style TargetType="SplitView" BasedOn="{StaticResource DefaultSplitViewStyle}" />
 
-    <Style x:Key="DefaultSplitViewStyle" TargetType="SplitView">
+	<win:Style x:Key="DefaultSplitViewStyle" TargetType="SplitView">
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="OpenPaneLength" Value="{ThemeResource SplitViewOpenPaneThemeLength}" />
         <Setter Property="CompactPaneLength" Value="{ThemeResource SplitViewCompactPaneThemeLength}" />
         <Setter Property="PaneBackground" Value="{ThemeResource SystemControlPageBackgroundChromeLowBrush}" />
-		<!--UNO TODO Fails to display correctly for multiple reasons, including https://github.com/unoplatform/uno/issues/325 but also undiagnosed issues -->
-        <win:Setter Property="Template">
+		<Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="SplitView">
                     <Grid Background="{TemplateBinding Background}">
@@ -620,7 +622,7 @@
 
                 </ControlTemplate>
             </Setter.Value>
-        </win:Setter>
-    </Style>
+        </Setter>
+    </win:Style>
 
 </ResourceDictionary>

--- a/src/Uno.UI.FluentTheme/themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/themeresources.xaml
@@ -1245,14 +1245,6 @@
       <StaticResource x:Key="SplitButtonBorderBrushCheckedPressed" ResourceKey="SystemControlHighlightAltTransparentBrush" />
       <StaticResource x:Key="SplitButtonBorderBrushCheckedDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
       <Thickness x:Key="SplitButtonBorderThemeThickness">1</Thickness>
-      <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
-      <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>
-      <Thickness x:Key="SplitViewLeftBorderThemeThickness">0,0,1,0</Thickness>
-      <Thickness x:Key="SplitViewRightBorderThemeThickness">1,0,0,0</Thickness>
-      <StaticResource x:Key="SplitViewLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
-      <x:String x:Key="SplitViewPaneAnimationOpenDuration">00:00:00.2</x:String>
-      <x:String x:Key="SplitViewPaneAnimationOpenPreDuration">00:00:00.19999</x:String>
-      <x:String x:Key="SplitViewPaneAnimationCloseDuration">00:00:00.1</x:String>
       <StaticResource x:Key="SwipeItemBackground" ResourceKey="SystemControlBackgroundBaseLowBrush" />
       <StaticResource x:Key="SwipeItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
       <StaticResource x:Key="SwipeItemBackgroundPressed" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
@@ -2730,14 +2722,6 @@
       <StaticResource x:Key="SplitButtonBorderBrushCheckedPressed" ResourceKey="SystemControlHighlightAltTransparentBrush" />
       <StaticResource x:Key="SplitButtonBorderBrushCheckedDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
       <Thickness x:Key="SplitButtonBorderThemeThickness">1</Thickness>
-      <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
-      <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>
-      <Thickness x:Key="SplitViewLeftBorderThemeThickness">0,0,1,0</Thickness>
-      <Thickness x:Key="SplitViewRightBorderThemeThickness">1,0,0,0</Thickness>
-      <StaticResource x:Key="SplitViewLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
-      <x:String x:Key="SplitViewPaneAnimationOpenDuration">00:00:00.2</x:String>
-      <x:String x:Key="SplitViewPaneAnimationOpenPreDuration">00:00:00.19999</x:String>
-      <x:String x:Key="SplitViewPaneAnimationCloseDuration">00:00:00.1</x:String>
       <StaticResource x:Key="SwipeItemBackground" ResourceKey="SystemControlBackgroundBaseLowBrush" />
       <StaticResource x:Key="SwipeItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
       <StaticResource x:Key="SwipeItemBackgroundPressed" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
@@ -4214,14 +4198,6 @@
       <StaticResource x:Key="SplitButtonBorderBrushCheckedPressed" ResourceKey="SystemControlHighlightAltTransparentBrush" />
       <StaticResource x:Key="SplitButtonBorderBrushCheckedDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
       <Thickness x:Key="SplitButtonBorderThemeThickness">1</Thickness>
-      <StaticResource x:Key="SplitViewLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
-      <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
-      <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>
-      <Thickness x:Key="SplitViewLeftBorderThemeThickness">0,0,1,0</Thickness>
-      <Thickness x:Key="SplitViewRightBorderThemeThickness">1,0,0,0</Thickness>
-      <x:String x:Key="SplitViewPaneAnimationOpenDuration">00:00:00.2</x:String>
-      <x:String x:Key="SplitViewPaneAnimationOpenPreDuration">00:00:00.19999</x:String>
-      <x:String x:Key="SplitViewPaneAnimationCloseDuration">00:00:00.1</x:String>
       <StaticResource x:Key="SwipeItemBackground" ResourceKey="SystemControlBackgroundBaseLowBrush" />
       <StaticResource x:Key="SwipeItemForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
       <StaticResource x:Key="SwipeItemBackgroundPressed" ResourceKey="SystemControlBackgroundBaseMediumLowBrush" />
@@ -19409,15 +19385,46 @@
   <Style TargetType="controls:ToggleSplitButton" BasedOn="{StaticResource SplitButtonStyle}" />
   <x:Double x:Key="SplitButtonPrimaryButtonSize">32</x:Double>
   <x:Double x:Key="SplitButtonSecondaryButtonSize">32</x:Double>
-  <Style TargetType="SplitView" BasedOn="{StaticResource DefaultSplitViewStyle}" />
-  <Style x:Key="DefaultSplitViewStyle" TargetType="SplitView">
+  <win:ResourceDictionary.ThemeDictionaries xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+    <ResourceDictionary x:Key="Default">
+      <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
+      <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>
+      <Thickness x:Key="SplitViewLeftBorderThemeThickness">0,0,1,0</Thickness>
+      <Thickness x:Key="SplitViewRightBorderThemeThickness">1,0,0,0</Thickness>
+      <StaticResource x:Key="SplitViewLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+      <x:String x:Key="SplitViewPaneAnimationOpenDuration">00:00:00.2</x:String>
+      <x:String x:Key="SplitViewPaneAnimationOpenPreDuration">00:00:00.19999</x:String>
+      <x:String x:Key="SplitViewPaneAnimationCloseDuration">00:00:00.1</x:String>
+    </ResourceDictionary>
+    <ResourceDictionary x:Key="HighContrast">
+      <StaticResource x:Key="SplitViewLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+      <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
+      <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>
+      <Thickness x:Key="SplitViewLeftBorderThemeThickness">0,0,1,0</Thickness>
+      <Thickness x:Key="SplitViewRightBorderThemeThickness">1,0,0,0</Thickness>
+      <x:String x:Key="SplitViewPaneAnimationOpenDuration">00:00:00.2</x:String>
+      <x:String x:Key="SplitViewPaneAnimationOpenPreDuration">00:00:00.19999</x:String>
+      <x:String x:Key="SplitViewPaneAnimationCloseDuration">00:00:00.1</x:String>
+    </ResourceDictionary>
+    <ResourceDictionary x:Key="Light">
+      <x:Double x:Key="SplitViewOpenPaneThemeLength">320</x:Double>
+      <x:Double x:Key="SplitViewCompactPaneThemeLength">48</x:Double>
+      <Thickness x:Key="SplitViewLeftBorderThemeThickness">0,0,1,0</Thickness>
+      <Thickness x:Key="SplitViewRightBorderThemeThickness">1,0,0,0</Thickness>
+      <StaticResource x:Key="SplitViewLightDismissOverlayBackground" ResourceKey="SystemControlPageBackgroundMediumAltMediumBrush" />
+      <x:String x:Key="SplitViewPaneAnimationOpenDuration">00:00:00.2</x:String>
+      <x:String x:Key="SplitViewPaneAnimationOpenPreDuration">00:00:00.19999</x:String>
+      <x:String x:Key="SplitViewPaneAnimationCloseDuration">00:00:00.1</x:String>
+    </ResourceDictionary>
+  </win:ResourceDictionary.ThemeDictionaries>
+  <win:Style TargetType="SplitView" BasedOn="{StaticResource DefaultSplitViewStyle}" xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation" />
+  <win:Style x:Key="DefaultSplitViewStyle" TargetType="SplitView" xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Stretch" />
     <Setter Property="OpenPaneLength" Value="{ThemeResource SplitViewOpenPaneThemeLength}" />
     <Setter Property="CompactPaneLength" Value="{ThemeResource SplitViewCompactPaneThemeLength}" />
     <Setter Property="PaneBackground" Value="{ThemeResource SystemControlPageBackgroundChromeLowBrush}" />
-    <!--UNO TODO Fails to display correctly for multiple reasons, including https://github.com/unoplatform/uno/issues/325 but also undiagnosed issues -->
-    <win:Setter Property="Template" xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+    <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="SplitView">
           <Grid Background="{TemplateBinding Background}">
@@ -19964,8 +19971,8 @@
           </Grid>
         </ControlTemplate>
       </Setter.Value>
-    </win:Setter>
-  </Style>
+    </Setter>
+  </win:Style>
   <Style x:Key="DefaultSwipeControlStyle" TargetType="controls:SwipeControl">
     <Setter Property="IsTabStop" Value="False" />
     <Setter Property="Background" Value="Transparent" />


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5265

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The MUX `NavigationView` now displays properly when fluent styles are imported.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
