### PR TITLE
fix(DepdendencyObject): Don't use IEnmerable when propagating the DataContext

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DataContext.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DataContext.cs
@@ -19,6 +19,7 @@ using Uno.UI;
 using Windows.UI.Xaml;
 using System.Threading;
 using Windows.UI.Xaml.Controls;
+using System.Collections;
 
 namespace Uno.UI.Tests.BinderTests_DataContext
 {
@@ -177,6 +178,22 @@ namespace Uno.UI.Tests.BinderTests_DataContext
 			var templatedParent = new Grid();
 
 			SUT.MyList = new List<MyObject>() { sub1 };
+
+			SUT.DataContext = 42;
+			SUT.TemplatedParent = templatedParent;
+
+			Assert.AreEqual(42, sub1.DataContext);
+			Assert.AreEqual(templatedParent, sub1.TemplatedParent);
+		}
+
+		[TestMethod]
+		public void When_ValueInheritDataContext_And_IList_Non_Enumerable()
+		{
+			var SUT = new MyBasicListType();
+			var sub1 = new MyObject();
+			var templatedParent = new Grid();
+
+			SUT.MyList = new NonEnumerableList<MyObject>() { sub1 };
 
 			SUT.DataContext = 42;
 			SUT.TemplatedParent = templatedParent;
@@ -349,5 +366,42 @@ namespace Uno.UI.Tests.BinderTests_DataContext
 			get { return (MyControl)GetValue(InnerFrameworkProperty); }
 			set { SetValue(InnerFrameworkProperty, value); }
 		}
+	}
+
+	class NonEnumerableList<T> : IList<T>, IList
+	{
+		private List<T> _internal = new List<T>();
+
+		public T this[int index] { get => _internal[index]; set => _internal[index] = value; }
+
+		object IList.this[int index] { get => _internal[index]; set => _internal[index] = (T)value; }
+
+		public int Count => _internal.Count;
+
+		public bool IsReadOnly => false;
+
+		public bool IsFixedSize => false;
+
+		public object SyncRoot { get; } = new object();
+
+		public bool IsSynchronized => false;
+
+		public void Add(T item) => _internal.Add(item);
+
+		public int Add(object value) => throw new NotImplementedException();
+		public void Clear() => _internal.Clear();
+		public bool Contains(T item) => _internal.Contains(item);
+		public bool Contains(object value) => throw new NotImplementedException();
+		public void CopyTo(T[] array, int arrayIndex) => _internal.CopyTo(array, arrayIndex);
+		public void CopyTo(Array array, int index) => throw new NotImplementedException();
+		public IEnumerator<T> GetEnumerator() => throw new NotSupportedException();
+		public int IndexOf(T item) => _internal.IndexOf(item);
+		public int IndexOf(object value) => throw new NotImplementedException();
+		public void Insert(int index, T item) => _internal.Insert(index, item);
+		public void Insert(int index, object value) => throw new NotImplementedException();
+		public bool Remove(T item) => _internal.Remove(item);
+		public void Remove(object value) => throw new NotImplementedException();
+		public void RemoveAt(int index) => _internal.RemoveAt(index);
+		IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -130,16 +130,28 @@ namespace Windows.UI.Xaml
 					// The property value may be an enumerable of providers
 					var isValidEnumerable = !(child is string);
 
-					if (
-						isValidEnumerable
-						&& child is IEnumerable enumerable
-					)
+					if (isValidEnumerable)
 					{
-						foreach (var item in enumerable)
+						if (child is IList list)
 						{
-							if (item is IDependencyObjectStoreProvider provider2)
+							// Special case for IList where the child may not be enumerable
+
+							for (int childIndex = 0; childIndex < list.Count; childIndex++)
 							{
-								SetInherited(provider2);
+								if (list[childIndex] is IDependencyObjectStoreProvider provider2)
+								{
+									SetInherited(provider2);
+								}
+							}
+						}
+						else if (child is IEnumerable enumerable)
+						{
+							foreach (var item in enumerable)
+							{
+								if (item is IDependencyObjectStoreProvider provider2)
+								{
+									SetInherited(provider2);
+								}
 							}
 						}
 					}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/nventive-private/issues/183

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

A dependency property propagating the DataContext will not enumerate using `GetEnumerator` if the value is an `IList`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
