### PR TITLE
fix(iOS): NativePresenter CommandBar.Title overlapped

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -373,6 +373,10 @@ namespace SamplesApp
 		{
 #if !NETFX_CORE
 			Uno.UI.FeatureConfiguration.Style.UseUWPDefaultStylesOverride[typeof(CommandBar)] = false;
+#endif
+
+#if __IOS__
+			Uno.UI.FeatureConfiguration.CommandBar.AllowNativePresenterContent = true;
 #endif
 		}
 

--- a/src/Uno.UI/Controls/NativeCommandBarPresenter.iOS.cs
+++ b/src/Uno.UI/Controls/NativeCommandBarPresenter.iOS.cs
@@ -57,7 +57,10 @@ namespace Uno.UI.Controls
 
 			var navigationBarSuperview = _navigationBar?.Superview;
 
-			// Prevents the UINavigationController's NavigationBar instance from being moved to the Page
+			// Allows the UINavigationController's NavigationBar instance to be moved to the Page. This feature
+			// is used in the context of the sample application to test NavigationBars outside of a NativeFramePresenter for 
+			// UI Testing. In general cases, this should not happen as the bar may be moved back to to this presenter while
+			// another page is already visible, making this bar overlay on top of another.			
 			if (FeatureConfiguration.CommandBar.AllowNativePresenterContent && (navigationBarSuperview == null || navigationBarSuperview is NativeCommandBarPresenter))
 			{
 				Content = _navigationBar;

--- a/src/Uno.UI/Controls/NativeCommandBarPresenter.iOS.cs
+++ b/src/Uno.UI/Controls/NativeCommandBarPresenter.iOS.cs
@@ -56,7 +56,9 @@ namespace Uno.UI.Controls
 			_navigationBar.SetNeedsLayout();
 
 			var navigationBarSuperview = _navigationBar?.Superview;
-			if (navigationBarSuperview == null || navigationBarSuperview is NativeCommandBarPresenter) // Prevents the UINavigationController's NavigationBar instance from being moved to the Page
+
+			// Prevents the UINavigationController's NavigationBar instance from being moved to the Page
+			if (FeatureConfiguration.CommandBar.AllowNativePresenterContent && (navigationBarSuperview == null || navigationBarSuperview is NativeCommandBarPresenter))
 			{
 				Content = _navigationBar;
 			}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml;
@@ -501,6 +501,13 @@ namespace Uno.UI
 		public static class CommandBar
 		{
 #if __IOS__
+			/// <summary>
+			/// Gets or Set whether the AllowNativePresenterContent feature is on or off.
+			/// This feature is used in the context of the sample application to test NavigationBars outside of a NativeFramePresenter for
+			/// UI Testing. In general cases, this should not happen as the bar may be moved back to to this presenter while
+			/// another page is already visible, making this bar overlay on top of another.
+			/// </summary>
+			/// <returns>True if this feature is on, False otherwise</returns>
 			public static bool AllowNativePresenterContent { get; set; } = false;
 #endif
 		}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -309,13 +309,13 @@ namespace Uno.UI
 			public static IDictionary<Type, bool> UseUWPDefaultStylesOverride { get; } = new Dictionary<Type, bool>();
 
 			/// <summary>
-			/// This enables native frame navigation on Android and iOS by setting related classes (<see cref="Frame"/>, <see cref="CommandBar"/>
+			/// This enables native frame navigation on Android and iOS by setting related classes (<see cref="Frame"/>, <see cref="Windows.UI.Xaml.Controls.CommandBar"/>
 			/// and <see cref="AppBarButton"/>) to use their native styles.
 			/// </summary>
 			public static void ConfigureNativeFrameNavigation()
 			{
 				SetUWPDefaultStylesOverride<Frame>(useUWPDefaultStyle: false);
-				SetUWPDefaultStylesOverride<CommandBar>(useUWPDefaultStyle: false);
+				SetUWPDefaultStylesOverride<Windows.UI.Xaml.Controls.CommandBar>(useUWPDefaultStyle: false);
 				SetUWPDefaultStylesOverride<AppBarButton>(useUWPDefaultStyle: false);
 			}
 
@@ -495,6 +495,13 @@ namespace Uno.UI
 		{
 #if __IOS__
 			public static bool UseLegacyStyle { get; set; } = false;
+#endif
+		}
+
+		public static class CommandBar
+		{
+#if __IOS__
+			public static bool AllowNativePresenterContent { get; set; } = false;
 #endif
 		}
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): #
closes https://github.com/unoplatform/nventive-private/issues/186

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->


## What is the new behavior?
Fixes an edge case found when doing Multi Frame navigation and using NativePresenter and the CommandBar.Titles of two pages get overlapped.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
Could not find a way to UI/Runtime test this. 

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issues if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
