### PR TITLE
fix(BorderLayerRenderer): [iOS/Skia] Adjust corner radius when drawing inner path of border to account of stroke thickness offset

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
@@ -20,7 +20,7 @@ namespace SamplesApp.UITests.Runtime
 
 		[Test]
 		[AutoRetry(tryCount: 1)]
-		[Timeout(800000)] // Adjust this timeout based on average test run duration
+		[Timeout(900000)] // Adjust this timeout based on average test run duration
 		public async Task RunRuntimeTests()
 		{
 			Run("SamplesApp.Samples.UnitTests.UnitTestsPage");

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
@@ -103,12 +103,12 @@ namespace Windows.UI.Xaml.Shapes
 
 			if (cornerRadius != CornerRadius.None)
 			{
-				var maxRadius = Math.Max(0, Math.Min((float)area.Width / 2 - widthOffset, (float)area.Height / 2 - heightOffset));
-				cornerRadius = new CornerRadius(
-					Math.Min(cornerRadius.TopLeft, maxRadius),
-					Math.Min(cornerRadius.TopRight, maxRadius),
-					Math.Min(cornerRadius.BottomRight, maxRadius),
-					Math.Min(cornerRadius.BottomLeft, maxRadius));
+				var maxInnerRadius = Math.Max(0, Math.Min((float)area.Width / 2 - widthOffset, (float)area.Height / 2 - heightOffset));
+				var innerCornerRadius = new CornerRadius(
+					Math.Min(cornerRadius.TopLeft, maxInnerRadius),
+					Math.Min(cornerRadius.TopRight, maxInnerRadius),
+					Math.Min(cornerRadius.BottomRight, maxInnerRadius),
+					Math.Min(cornerRadius.BottomLeft, maxInnerRadius));
 
 				var outerLayer = new CAShapeLayer();
 				var innerLayer = new CAShapeLayer();
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml.Shapes
 					})
 					.DisposeWith(disposables);
 
-				var path = GetRoundedRect(cornerRadius, area, adjustedArea);
+				var path = GetRoundedRect(cornerRadius, innerCornerRadius, area, adjustedArea);
 				var innerPath = GetRoundedPath(cornerRadius, adjustedArea);
 
 				var insertionIndex = 0;
@@ -353,12 +353,12 @@ namespace Windows.UI.Xaml.Shapes
 		/// <summary>
 		/// Creates a rounded-rectangle path from the nominated bounds and corner radius.
 		/// </summary>
-		private static CGPath GetRoundedRect(CornerRadius cornerRadius, CGRect area, CGRect insetArea)
+		private static CGPath GetRoundedRect(CornerRadius cornerRadius, CornerRadius innerCornerRadius, CGRect area, CGRect insetArea)
 		{
 			var path = new CGPath();
 
 			GetRoundedPath(cornerRadius, area, path);
-			GetRoundedPath(cornerRadius, insetArea, path);
+			GetRoundedPath(innerCornerRadius, insetArea, path);
 
 			return path;
 		}
@@ -368,7 +368,6 @@ namespace Windows.UI.Xaml.Shapes
 			path ??= new CGPath();
 			// How AddArcToPoint works:
 			// http://www.twistedape.me.uk/blog/2013/09/23/what-arctopointdoes/
-
 			path.MoveToPoint(area.GetMidX(), area.Y);
 			path.AddArcToPoint(area.Right, area.Top, area.Right, area.GetMidY(), (float)cornerRadius.TopRight);
 			path.AddArcToPoint(area.Right, area.Bottom, area.GetMidX(), area.Bottom, (float)cornerRadius.BottomRight);

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
@@ -96,12 +96,12 @@ namespace Windows.UI.Xaml.Shapes
 
 			if (cornerRadius != CornerRadius.None)
 			{
-				var maxRadius = Math.Max(0, Math.Min((float)area.Width / 2 - heightOffset, (float)area.Height / 2 - widthOffset));
-				cornerRadius = new CornerRadius(
-					Math.Min(cornerRadius.TopLeft, maxRadius),
-					Math.Min(cornerRadius.TopRight, maxRadius),
-					Math.Min(cornerRadius.BottomRight, maxRadius),
-					Math.Min(cornerRadius.BottomLeft, maxRadius));
+				var maxInnerRadius = Math.Max(0, Math.Min((float)area.Width / 2 - widthOffset, (float)area.Height / 2 - heightOffset));
+				var innerCornerRadius = new CornerRadius(
+					Math.Min(cornerRadius.TopLeft, maxInnerRadius),
+					Math.Min(cornerRadius.TopRight, maxInnerRadius),
+					Math.Min(cornerRadius.BottomRight, maxInnerRadius),
+					Math.Min(cornerRadius.BottomLeft, maxInnerRadius));
 
 				var borderShape = compositor.CreateSpriteShape();
 				var backgroundShape = compositor.CreateSpriteShape();
@@ -143,7 +143,7 @@ namespace Windows.UI.Xaml.Shapes
 					backgroundShape.FillBrush = null;
 				}
 
-				var borderPath = GetRoundedRect(cornerRadius, area, adjustedArea);
+				var borderPath = GetRoundedRect(cornerRadius, innerCornerRadius, area, adjustedArea);
 				var backgroundPath = GetRoundedPath(cornerRadius, adjustedArea);
 				var outerPath = GetRoundedPath(cornerRadius, area);
 
@@ -372,12 +372,12 @@ namespace Windows.UI.Xaml.Shapes
 			return new CompositionPath(geometrySource);
 		}
 
-		private static CompositionPath GetRoundedRect(CornerRadius cornerRadius, Rect area, Rect insetArea)
+		private static CompositionPath GetRoundedRect(CornerRadius cornerRadius, CornerRadius innerCornerRadius, Rect area, Rect insetArea)
 		{
 			var geometrySource = new SkiaGeometrySource2D();
 
 			GetRoundedPath(cornerRadius, area, geometrySource);
-			GetRoundedPath(cornerRadius, insetArea, geometrySource);
+			GetRoundedPath(innerCornerRadius, insetArea, geometrySource);
 			geometrySource.Geometry.FillType = SKPathFillType.EvenOdd;
 			return new CompositionPath(geometrySource);
 		}


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/176

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

![image](https://user-images.githubusercontent.com/4793020/110150370-3233c580-7dad-11eb-86ff-d93e3b22512a.png)

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

![image](https://user-images.githubusercontent.com/4793020/110150389-38c23d00-7dad-11eb-95ab-166bb3917555.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
