### PR TITLE
fix(wasm): Fix initialization issue in PlatformHelper for netstandard2.0

### DIFF
--- a/src/Uno.Foundation.Runtime.WebAssembly/Interop/PlatformHelper.cs
+++ b/src/Uno.Foundation.Runtime.WebAssembly/Interop/PlatformHelper.cs
@@ -7,12 +7,51 @@ namespace Uno.Foundation.Runtime.WebAssembly.Interop
 {
 	internal class PlatformHelper
 	{
-		internal static bool IsWebAssembly { get; }
-			// Origin of the value : https://github.com/mono/mono/blob/a65055dbdf280004c56036a5d6dde6bec9e42436/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs#L115
-			= RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY")) // Legacy Value (Bootstrapper 1.2.0-dev.29 or earlier).
-			|| RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+		private static bool _isNetCore;
+		private static bool _initialized;
+		private static bool _isWebAssembly;
 
-		internal static bool IsNetCore { get; } = Type.GetType("System.Runtime.Loader.AssemblyLoadContext") != null;
+		/// <summary>
+		/// Determines if the platform is runnnig WebAssembly
+		/// </summary>
+		internal static bool IsWebAssembly
+		{
+			get
+			{
+				EnsureInitialized();
+				return _isWebAssembly;
+			}
+		}
 
+		/// <summary>
+		/// Determines if the current runtime is running on .NET Core or 5 and later
+		/// </summary>
+		internal static bool IsNetCore
+		{
+			get
+			{
+				EnsureInitialized();
+				return _isNetCore;
+			}
+		}
+
+		/// <summary>
+		/// Initialization is performed explicitly to avoid a mono/mono issue regarding .cctor and FullAOT
+		/// see https://github.com/unoplatform/uno/issues/5395
+		/// </summary>
+		private static void EnsureInitialized()
+		{
+			if (!_initialized)
+			{
+				_initialized = true;
+
+				_isNetCore = Type.GetType("System.Runtime.Loader.AssemblyLoadContext") != null;
+
+				// Origin of the value : https://github.com/mono/mono/blob/a65055dbdf280004c56036a5d6dde6bec9e42436/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs#L115
+				_isWebAssembly =
+					RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY")) // Legacy Value (Bootstrapper 1.2.0-dev.29 or earlier).
+					|| RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+			}
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5395

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`Uno.Foundation.Runtime.WebAssembly.Interop.PlatformHelper` does not fail when running under FullAOT and Wasm netstandard2.0.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
