### PR TITLE
fix: [WASM] Avoid flicker in SV when an hidden element is taller than viewport

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -155,9 +155,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			_app.TapCoordinates(deleteButton1.Rect.CenterX, deleteButton1.Rect.CenterY);
 
-			// Second tap is required on Wasm https://github.com/unoplatform/uno/issues/2138
-			_app.TapCoordinates(deleteButton1.Rect.CenterX, deleteButton1.Rect.CenterY);
-
 			_app.WaitForText(textBox1, "");
 
 			// Focus the first textbox
@@ -165,9 +162,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			var deleteButton2 = FindDeleteButton(textBox2Result);
 
-			_app.TapCoordinates(deleteButton2.Rect.CenterX, deleteButton2.Rect.CenterY);
-
-			// Second tap is required on Wasm https://github.com/unoplatform/uno/issues/2138
 			_app.TapCoordinates(deleteButton2.Rect.CenterX, deleteButton2.Rect.CenterY);
 
 			_app.WaitForText(textBox2, "");

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.wasm.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.wasm.cs
@@ -58,6 +58,38 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 			Assert.AreEqual("p", SUT.HtmlTag);
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_VisibilityCollapsed_Then_ScrollViewerIgnoresElement()
+		{
+			var item1 = new Border { Height = 128};
+			var item2 = new Border { Height = 4096, Visibility = Visibility.Collapsed };
+			var sv = new ScrollViewer {Content = new Grid {Children = {item1, item2}}};
+
+			TestServices.WindowHelper.WindowContent = sv;
+			await Render();
+			var sut = sv.FindFirstChild<ScrollContentPresenter>();
+
+			Assert.AreEqual(128.0, double.Parse(sut.GetProperty("scrollHeight")));
+
+			item2.Visibility = Visibility.Visible;
+			await Render();
+
+			Assert.AreEqual(4096.0, double.Parse(sut.GetProperty("scrollHeight")));
+
+			item2.Visibility = Visibility.Collapsed;
+			await Render();
+
+			Assert.AreEqual(128.0, double.Parse(sut.GetProperty("scrollHeight")));
+
+			async Task Render()
+			{
+				await TestServices.WindowHelper.WaitForIdle();
+				sv.InvalidateArrange();
+				await TestServices.WindowHelper.WaitForIdle();
+			}
+		}
 	}
 
 	public class MyLine : Line

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -255,6 +255,12 @@ namespace Windows.UI.Xaml
 				UpdateDOMXamlProperty(nameof(LayoutSlotWithMarginsAndAlignments), LayoutSlotWithMarginsAndAlignments);
 			}
 
+			if (Visibility == Visibility.Collapsed)
+			{
+				// cf. OnVisibilityChanged
+				rect.X = rect.Y = -100000;
+			}
+
 			Uno.UI.Xaml.WindowManagerInterop.ArrangeElement(HtmlId, rect, clipRect);
 			OnViewportUpdated(clipRect ?? Rect.Empty);
 
@@ -415,7 +421,10 @@ namespace Windows.UI.Xaml
 			}
 			else
 			{
-				SetStyle("visibility", "hidden");
+				// Note: On wasm when we have an 'hidden' (or 'collapsed') element, its height is used to compute the native 'scrollHeight',
+				// driving the SV to flicker when we scroll while at the bottom of the viewport (if those hidden element would have increase the viewport if visible).
+				// To avoid that, we move the element way out of the visible bounds of the view.
+				SetStyle(("visibility", "hidden"), ("top", "-100000px"), ("left", "-100000px"));
 			}
 
 			if (FeatureConfiguration.UIElement.AssignDOMXamlProperties)


### PR DESCRIPTION
## Bugfix
Avoid flicker in SV when an hidden element is taller than viewport on WASM

## What is the current behavior?
If a child of a `ScrollViewer` is taller than the managed viewport and is `Visibility=Collapsed` (`hidden` in DOM), the native computed viewport will include it.

## What is the new behavior?
We moved those elements out of the bounds of the `ScrollViewer`

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
