### PR TITLE
fix: Adjust nuspec dependencies for Uno.Core

### DIFF
--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -24,8 +24,8 @@
 		<dependency id="Xamarin.AndroidX.Fragment" version="1.1.0" />
 		<dependency id="Xamarin.AndroidX.Activity" version="1.1.0" />
 		<dependency id="Uno.SourceGenerationTasks" version="3.0.0" />
-		<dependency id="Uno.Core" version="2.2.0" />
-		<dependency id="Uno.Core.Build" version="2.2.0" />
+		<dependency id="Uno.Core" version="2.3.0-dev.3" />
+		<dependency id="Uno.Core.Build" version="2.3.0-dev.3" />
 		<dependency id="Uno.Diagnostics.Eventing" version="1.0.4" />
 		<dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
 	  </group>
@@ -37,8 +37,8 @@
 		<dependency id="Xamarin.AndroidX.RecyclerView" version="1.1.0.8" />
 		<dependency id="Xamarin.AndroidX.Activity" version="1.2.0.1" />
 		<dependency id="Uno.SourceGenerationTasks" version="3.0.0" />
-		<dependency id="Uno.Core" version="2.2.0" />
-		<dependency id="Uno.Core.Build" version="2.2.0" />
+		<dependency id="Uno.Core" version="2.3.0-dev.3" />
+		<dependency id="Uno.Core.Build" version="2.3.0-dev.3" />
 		<dependency id="Uno.Diagnostics.Eventing" version="1.0.4" />
 		<dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
 	  </group>
@@ -46,8 +46,8 @@
 	  <!-- iOS -->
 	  <group targetFramework="xamarinios10">
 		<dependency id="Uno.SourceGenerationTasks" version="3.0.0" />
-		<dependency id="Uno.Core" version="2.2.0" />
-		<dependency id="Uno.Core.Build" version="2.2.0" />
+		<dependency id="Uno.Core" version="2.3.0-dev.3" />
+		<dependency id="Uno.Core.Build" version="2.3.0-dev.3" />
 		<dependency id="Uno.Diagnostics.Eventing" version="1.0.4" />
 		<dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
 	  </group>
@@ -55,8 +55,8 @@
       <!-- macOS -->
       <group targetFramework="xamarinmac20">
         <dependency id="Uno.SourceGenerationTasks" version="3.0.0" />
-        <dependency id="Uno.Core" version="2.2.0" />
-        <dependency id="Uno.Core.Build" version="2.2.0" />
+        <dependency id="Uno.Core" version="2.3.0-dev.3" />
+        <dependency id="Uno.Core.Build" version="2.3.0-dev.3" />
 		<dependency id="Uno.Diagnostics.Eventing" version="1.0.4" />
 		<dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
 	  </group>
@@ -64,8 +64,8 @@
       <!-- .NET Standard 2.0 -->
       <group targetFramework="netstandard2.0">
         <dependency id="Uno.SourceGenerationTasks" version="3.0.0" />
-        <dependency id="Uno.Core" version="2.2.0" />
-        <dependency id="Uno.Core.Build" version="2.2.0" />
+        <dependency id="Uno.Core" version="2.3.0-dev.3" />
+        <dependency id="Uno.Core.Build" version="2.3.0-dev.3" />
         <dependency id="System.Numerics.Vectors" version="4.5.0" />
         <dependency id="System.Runtime.InteropServices.WindowsRuntime" version="4.3.0" />
         <dependency id="System.Memory" version="4.5.2" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -21,7 +21,7 @@
 	<PackageReference Update="Uno.SourceGenerationTasks" Version="3.0.0" />
 	<PackageReference Update="Uno.SourceGeneration" Version="3.0.0" />
 	<PackageReference Update="Uno.Core" Version="2.3.0-dev.3" />
-	<PackageReference Update="Uno.Core.Build" Version="2.2.0" />
+	<PackageReference Update="Uno.Core.Build" Version="2.3.0-dev.3" />
 	<PackageReference Update="Uno.Diagnostics.Eventing" Version="1.0.4" />
 	<PackageReference Update="Uno.Wasm.Bootstrap" Version="2.0.0-dev.167" />
 	<PackageReference Update="Uno.Wasm.Bootstrap.DevServer" Version="2.0.0-dev.167" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

An app build may fail with the following error:

```
  MMP : error MM2002: Failed to resolve "Uno.Disposables.RefCountDisposable" reference from "Uno.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" [/Users/runner/work/1/s/XamlControlsGallery.macOS/XamlControlsGallery.macOS.csproj]
```

## What is the new behavior?

Uno.Core dependencies are now aligned.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
