### PR TITLE
fix: Defer NavViewItem pressed and over states only for Android

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.Uno.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.Uno.cs
@@ -8,8 +8,9 @@ namespace Microsoft.UI.Xaml.Controls
 	partial class NavigationViewItem
 	{
 		// For perf considerations, we defer the pressed and over visual state on Uno.
-		// This high improve scrolling experience by avoiding freeze of UI thread (due to measure/arrange)
+		// This highly improves scrolling experience by avoiding freeze of UI thread (due to measure/arrange)
 		// at the begging of the scroll, or when flicking during scroll.
+		// Note: This is enabled only if flag UNO_USE_DEFERRED_VISUAL_STATES is set in NavigationViewItem.cs
 
 		private bool _uno_isDefferingOverState = false;
 		private bool _uno_isDefferingPressedState = false;

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.cs
@@ -1,5 +1,12 @@
 ﻿// MUX reference NavigationViewItem.cpp, commit 4fe1fd5
 
+#if __ANDROID__
+// For performance considerations, we prefer to delay pressed and over state in order to avoid
+// visual state updates when starting scroll start or while scrolling, especially with touch.
+// This has a great impact on Android where ScrollViewer does not capture pointer while scrolling.
+#define UNO_USE_DEFERRED_VISUAL_STATES
+#endif
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -828,8 +835,10 @@ namespace Microsoft.UI.Xaml.Controls
 				m_capturedPointer = pointer;
 			}
 
+#if UNO_USE_DEFERRED_VISUAL_STATES
 			_uno_isDefferingPressedState = true;
 			DeferUpdateVisualStateForPointer();
+#endif
 
 			UpdateVisualState(true);
 		}
@@ -860,8 +869,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private void OnPresenterPointerEntered(object sender, PointerRoutedEventArgs args)
 		{
+#if UNO_USE_DEFERRED_VISUAL_STATES
 			_uno_isDefferingOverState = args.Pointer.PointerDeviceType != PointerDeviceType.Mouse;
 			DeferUpdateVisualStateForPointer();
+#endif
 
 			ProcessPointerOver(args);
 		}


### PR DESCRIPTION
## Fine tuning
Use deferred over and pressed for `NavigationViewItem` only for Android where the lag is really noticeable and where the `ScrollViewer` does not capture the pointer.

## What is the current behavior?
Pressed and over state are deferred for all platforms.

## What is the new behavior?
🙃

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
