### PR TITLE
fix(reg): Restore original AndroidX dependencies

### DIFF
--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -32,10 +32,10 @@
 
 	  <!-- Android 10.0 -->
 	  <group targetFramework="MonoAndroid10.0">
-		<dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0.7" />
-		<dependency id="Xamarin.AndroidX.AppCompat" version="1.2.0.7" />
-		<dependency id="Xamarin.AndroidX.RecyclerView" version="1.1.0.8" />
-		<dependency id="Xamarin.AndroidX.Activity" version="1.2.0.1" />
+		<dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0" />
+		<dependency id="Xamarin.AndroidX.AppCompat" version="1.1.0" />
+		<dependency id="Xamarin.AndroidX.RecyclerView" version="1.1.0" />
+		<dependency id="Xamarin.AndroidX.Activity" version="1.1.0" />
 		<dependency id="Uno.SourceGenerationTasks" version="3.0.0" />
 		<dependency id="Uno.Core" version="2.3.0-dev.3" />
 		<dependency id="Uno.Core.Build" version="2.3.0-dev.3" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -55,12 +55,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid11.0'">
-	<PackageReference Update="Xamarin.AndroidX.Legacy.Support.v4" Version="1.0.0.7" />
-	<PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.2.0.7" />
-	<PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.1.0.8" />
+	<PackageReference Update="Xamarin.AndroidX.Legacy.Support.v4" Version="1.0.0" />
+	<PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.1.0" />
+	<PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.1.0" />
 	<PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.2" />
-	<PackageReference Update="Xamarin.AndroidX.Fragment" Version="1.3.0.1" />
-	<PackageReference Update="Xamarin.Build.Download" Version="0.10.0" />
+	<PackageReference Update="Xamarin.AndroidX.Fragment" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid10.0'">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The original changes introduces an incorrect set of dependencies, letting the head decide which version to get is more stable.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

related to https://github.com/unoplatform/Uno.WindowsCommunityToolkit/issues/132
