### PR TITLE
fix(reg): Use internal copy of Unsafe.IsNullRef for Xamarin targets

### DIFF
--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -27,7 +27,6 @@
 		<dependency id="Uno.Core" version="2.3.0-dev.3" />
 		<dependency id="Uno.Core.Build" version="2.3.0-dev.3" />
 		<dependency id="Uno.Diagnostics.Eventing" version="1.0.4" />
-		<dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
 	  </group>
 
 	  <!-- Android 10.0 -->
@@ -40,7 +39,6 @@
 		<dependency id="Uno.Core" version="2.3.0-dev.3" />
 		<dependency id="Uno.Core.Build" version="2.3.0-dev.3" />
 		<dependency id="Uno.Diagnostics.Eventing" version="1.0.4" />
-		<dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
 	  </group>
 
 	  <!-- iOS -->
@@ -49,7 +47,6 @@
 		<dependency id="Uno.Core" version="2.3.0-dev.3" />
 		<dependency id="Uno.Core.Build" version="2.3.0-dev.3" />
 		<dependency id="Uno.Diagnostics.Eventing" version="1.0.4" />
-		<dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
 	  </group>
 
       <!-- macOS -->
@@ -58,7 +55,6 @@
         <dependency id="Uno.Core" version="2.3.0-dev.3" />
         <dependency id="Uno.Core.Build" version="2.3.0-dev.3" />
 		<dependency id="Uno.Diagnostics.Eventing" version="1.0.4" />
-		<dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
 	  </group>
 
       <!-- .NET Standard 2.0 -->
@@ -70,7 +66,6 @@
         <dependency id="System.Runtime.InteropServices.WindowsRuntime" version="4.3.0" />
         <dependency id="System.Memory" version="4.5.2" />
 		<dependency id="Uno.Diagnostics.Eventing" version="1.0.4" />
-		<dependency id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" />
 	  </group>
     </dependencies>
 

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -81,8 +81,6 @@
 		<PackageReference Include="Uno.Wasm.Bootstrap" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe"
-											Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI/Uno.UI.Skia.csproj
+++ b/src/Uno.UI/Uno.UI.Skia.csproj
@@ -36,7 +36,6 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="System.Memory" Version="4.5.2" />
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI/Uno.UI.Wasm.csproj
@@ -61,7 +61,6 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="System.Memory" Version="4.5.2" />
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -94,7 +94,6 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="System.Memory" Version="4.5.2" />
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid11.0'">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Avoid adding a dependency on `System.Runtime.CompilerServices.Unsafe` by using a simple copy of `Unsafe.NullPtr` that is compatible with current Xamarin targets.

This will avoid errors like this one:
```
System.MissingMethodException: Method not found: bool System.Runtime.CompilerServices.Unsafe.IsNullRef<!0>(!!0&)
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
