### PR TITLE
fix(loopingselector): Fix a glitch in LoopingSelector related to way ScrollViewer events are raised.

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/LoopingSelector/LoopingSelector_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/LoopingSelector/LoopingSelector_Partial.cs
@@ -393,7 +393,17 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 					if (!_isWithinScrollChange && !_isWithinArrangeOverride)
 					{
-						Balance(true /* isOnSnapPoint */);
+						// --------------------
+						// 2021-03-17 / Uno 3.6
+						// --------------------
+						// Uno: There's a difference between Windows and Uno here.
+						// On Uno, the ViewChanging event is not raised from the ScrollViewer
+						// and the ViewChanged is called for every change in the scroll position.
+						// On Windows, the ViewChanged is called only with values on "snap point".
+						// So letting the isOnSnapPoint to true here is causing strange problems in Uno.
+
+						//Balance(true /* isOnSnapPoint */);
+						Balance(false);
 						if (_itemState == ItemState.ManipulationInProgress)
 						{
 							TransitionItemsState(ItemState.Expanded);


### PR DESCRIPTION
# Fix LoopingSelector glitching on selection

## What is the current behavior?
By clicking/tapping on an element in a LoopingSelector (in the DatePicker), sometimes the selection were _jumping_ few items and produce a selection for another item, usually the double distance from the previous selection.

## What is the new behavior?
The bug was caused by the way Uno is producing events on ScrollIViewer, which are not totally like WinUI/UWP.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
