### PR TITLE
fix(NativeFramePresenter.iOS): Fix a bug where pre-populated frames would log errors when displayed

### DIFF
--- a/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
+++ b/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
@@ -122,8 +122,21 @@ namespace Uno.UI.Controls
 
 			if (_frame.Content is Page startPage)
 			{
-				var viewController = new PageViewController(startPage);
-				NavigationController.PushViewController(viewController, false);
+				// When the frame already has content, we add a NavigationRequest in the PageViewController's AssociatedRequests.
+				// Not doing this results in log errors from WillShowViewController and DidShowViewController (the ones about AssociatedRequests being empty).
+				// Then, we push the PageViewController without animations (because the page is already present in the Frame). 
+
+				var pageViewController = new PageViewController(startPage);
+				var navigationEventArgs = new NavigationEventArgs(
+					_frame.CurrentEntry.Instance,
+					NavigationMode.New,
+					_frame.CurrentEntry.NavigationTransitionInfo,
+					_frame.CurrentEntry.Parameter,
+					_frame.CurrentEntry.SourcePageType,
+					null
+				);
+				pageViewController.AssociatedRequests.Add(new NavigationRequest(_frame, navigationEventArgs));
+				NavigationController.PushViewController(pageViewController, false);
 			}
 
 			_controllerDelegate = new ControllerDelegate(this);


### PR DESCRIPTION
…ould log errors when displayed.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Displaying a pre-populated `Frame` using `NativeFramePresenter` on iOS results in errors being logged.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Displaying a pre-populated `Frame` using `NativeFramePresenter` on iOS works without logging any error.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

I discovered this bug by displaying a `Frame` inside a modal `UIViewController`.
