### PR TITLE
fix(iOS): NavigationController resetting ViewController stack

### DIFF
--- a/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
+++ b/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
@@ -366,7 +366,15 @@ namespace Uno.UI.Controls
 				// TODO: iOS 14 introduced a bug where calling this method is getting unpleasant results (https://developer.apple.com/forums/thread/656524). (https://developer.apple.com/forums/thread/656524)
 				// A workaround for this is removing the animation as this seems to be related to the root cause.
 				// Note: This change should not affect consumer navigation since this is only used when resetting the stack.
-				NavigationController.SetViewControllers(viewControllers, animated: false);
+				if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0)) 
+				{
+					NavigationController.SetViewControllers(viewControllers, animated: false);
+				}
+				else
+				{
+					NavigationController.SetViewControllers(viewControllers, animated: true);
+				}
+				
 			}
 		}
 

--- a/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
+++ b/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
@@ -363,7 +363,10 @@ namespace Uno.UI.Controls
 					this.Log().Debug("Resetting all ViewControllers based on Frame's state.");
 				}
 
-				NavigationController.SetViewControllers(viewControllers, animated: true);
+				// TODO: iOS 14 introduced a bug where calling this method is getting unpleasant results (https://developer.apple.com/forums/thread/656524). (https://developer.apple.com/forums/thread/656524)
+				// A workaround for this is removing the animation as this seems to be related to the root cause.
+				// Note: This change should not affect consumer navigation since this is only used when resetting the stack.
+				NavigationController.SetViewControllers(viewControllers, animated: false);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #
fixes https://github.com/unoplatform/nventive-private/issues/137

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
Native Frame navigation on iOS gets wrong when clearing the Frame Stack

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
