### PR TITLE
fix: VS 16.9 uap build should not run roslyn source generators

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/PlatformHelper.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/PlatformHelper.cs
@@ -23,10 +23,20 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var projectTypeGuids = context.GetMSBuildPropertyValue("ProjectTypeGuidsProperty");
 
 			var isUAP = evaluatedValue?.Equals("UAP", StringComparison.OrdinalIgnoreCase) ?? false;
-			var isNetCoreWPF = useWPF?.Equals("True", StringComparison.OrdinalIgnoreCase) ?? false;
-			var isNetCoreDesktop = projectTypeGuids == "{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";
 
-			return !isUAP && !isNetCoreWPF && !isNetCoreDesktop;
+			// Those two checks are now required since VS 16.9 which enables source generators by default
+			// and the uno targets files are not present for uap targets.
+			var isWindowsRuntimeApplicationOutput = context.Compilation.Options.OutputKind == OutputKind.WindowsRuntimeApplication;
+			var isWindowsRuntimeMetadataOutput = context.Compilation.Options.OutputKind == OutputKind.WindowsRuntimeMetadata;
+
+			var isNetCoreWPF = useWPF?.Equals("True", StringComparison.OrdinalIgnoreCase) ?? false;
+			var isNetCoreDesktop = projectTypeGuids?.Equals("{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) ?? false;
+
+			return !isUAP
+				&& !isNetCoreWPF
+				&& !isNetCoreDesktop
+				&& !isWindowsRuntimeMetadataOutput
+				&& !isWindowsRuntimeApplicationOutput;
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5468

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Uno Source generators are skipped when running on uap targets, as those are not needed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
