### PR TITLE
ci: Add max startup time for android simulator

### DIFF
--- a/build/android-uitest-wait-systemui.sh
+++ b/build/android-uitest-wait-systemui.sh
@@ -18,6 +18,8 @@ fi
 echo ""
 echo "[Waiting for launcher to start]"
 LAUNCHER_READY=
+START_TIME=$SECONDS
+MAX_START_TIME=300
 while [[ -z ${LAUNCHER_READY} ]]; do
 
     if [ $ANDROID_SIMULATOR_APILEVEL -ge 29 ];
@@ -25,6 +27,13 @@ while [[ -z ${LAUNCHER_READY} ]]; do
     UI_FOCUS=`$ANDROID_HOME/platform-tools/adb shell dumpsys window 2>/dev/null | grep -E 'mCurrentFocus|mFocusedApp'`
     else
     UI_FOCUS=`$ANDROID_HOME/platform-tools/adb shell dumpsys window windows 2>/dev/null | grep -i mCurrentFocus`
+    fi
+
+    ELAPSED_TIME=$(( SECONDS - START_TIME ))
+    if [ ${ELAPSED_TIME} -gt ${MAX_START_TIME} ];
+    then
+        echo "(FAIL) Emulator failed to start properly after $MAX_START_TIME"
+        exit 1
     fi
 
     echo "(DEBUG) Current focus: ${UI_FOCUS}"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Adds a max start time for the android simulator.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
