### PR TITLE
WebAuthenticationBroker: Added support for Android.

### DIFF
--- a/doc/articles/features/web-authentication-broker.md
+++ b/doc/articles/features/web-authentication-broker.md
@@ -2,7 +2,7 @@
 
 * The timeout is set by default to 5 minutes. You can change it using `WinRTFeatureConfiguration.WebAuthenticationBroker.AuthenticationTimeout`.
 
-## WebAssembly
+## Usage on WebAssembly
 
 * The _redirect URI_ **MUST** be with the origin (protocol + hostname + port) of the application. It is not possible to use a custom scheme URI.
 * When using the `<iframe>` mode (see _advanced usages_ below), the server must allow for using CSP (Content Security Policy).
@@ -10,15 +10,41 @@
 * It is not possible for applications to clear cookies for the authentication server when this one is from another origin. The only way clear cookies is to deploy the app and the authentication server on the same site (sharing the same origin).
 * You can change the size and the initial title of the open window by setting corresponding settings in `WinRTFeatureConfiguration.WebAuthenticationBroker` .
 
-## iOS & MacOS
+## Usage on iOS & MacOS
 
-* The _redirect URI_ **MUST** use a custom scheme URI and this one must be registered in the `Info.plist` of the application.
+* The *redirect URI* **MUST** use a custom scheme URI and  this one must be registered in the `Info.plist` of the  application.
+* Default *redirect URI* will be `<scheme>:/authentication-callback`. Ex:  `my-app-auth:/authentication-callback`
+* The default *redirect URI* will be automatic if there's only one custom scheme defined in the application. If there are more than one scheme, the first one will be used. You may want to set the right one using the `WinRTFeatureConfiguration.WebAuthenticationBroker.DefaultReturnUri`  property.
+
+## Usage on Android
+
+* The *redirect URI* **MUST** use a custom scheme URI. This one will launch a special *Activity* declared in your application.
+
+* You **MUST** declare an activity deriving from `WebAuthenticationBrokerActivityBase` in the Android head of your application:
+
+  ``` csharp
+  // Android: add this class near the MainActivity of your head project
+  [Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop)]
+  [IntentFilter(
+  	new[] {Android.Content.Intent.ActionView},
+  	Categories = new[] {Android.Content.Intent.CategoryDefault, Android.Content.Intent.CategoryBrowsable},
+      // Change the following DataScheme for one specific to your application...
+  	DataScheme = "myapplication")]
+  public class WebAuthenticationBrokerActivity : WebAuthenticationBrokerActivityBase
+  {
+      // You can change the name of this class if you wish, it really not something important.
+  }
+  ```
+
+* To use the automatic discovery of the _redirect URI_, it is required to set the `IntentFilter` using the attributes like in the previous point. If you put it in the manifest, you'll need to set the URI using the `WinRTFeatureConfiguration.WebAuthenticationBroker.DefaultReturnUri` property.
+
 * Default _redirect URI_ will be `<scheme>:/authentication-callback`. Ex: `my-app-auth:/authentication-callback`
-* The default _redirect URI_ will be automatic if there's only one custom scheme defined in the application.  If there are more that one scheme, the _default redirect URI_ must be set in the  `WinRTFeatureConfiguration.WebAuthenticationBroker.DefaultReturnUri` configuration.
+
+* The default implementation of the `WebAuthenticationBroker` on Android will launch the system browser and the result will come back through the custom scheme of the _Return Uri_. You may want something more elaborated, like the _AndroidX Chrome Custom Tabs_. Check in the _Advanced_ section below for instructions to use it in your application.
 
 ## Advanced Usages
 
-### Custom implementation
+### Custom Implementation
 
 For special needs, it is possible to create a custom implementation of the Web Authentication Broker by using the `[ApiExtension]` mechanism of Uno and implementing the `IWebAuthenticationBrokerProvider` interface:
 
@@ -38,7 +64,61 @@ public class MyBrokerImplementation : IWebAuthenticationBrokerProvider
 
 This implementation can also published as a NuGet package and it will be discovered automatically by the Uno tooling during compilation.
 
-### WebAssembly: Use `<iframe>` instead of a browser window
+### Android: Custom Implementation for AndroidX Chrome Custom Tabs
+
+1. Add reference to following NuGet packages:
+
+   * `Xamarin.Android.Support.CustomTabs`
+   * `Xamarin.AndroidX.Lifecycle.LiveData`
+   * `Xamarin.AndroidX.Browser`
+
+2. Directly in the Android head project, create a class deriving from `WebAuthenticationBrokerProvider`:
+
+   ``` csharp
+   public class ChromeCustomTabsProvider : WebAuthenticationBrokerProvider
+   {   
+   }
+   ```
+
+3. Override the `LaunchBrowserCore` virtual method:
+
+   ``` csharp
+   public class ChromeCustomTabsProvider : WebAuthenticationBrokerProvider
+   {   
+       protected override async Task LaunchBrowserCore(
+                   WebAuthenticationOptions options,
+                   Uri requestUri,
+                   Uri callbackUri,
+                   CancellationToken ct)
+       {
+           var builder = new CustomTabsIntent.Builder();
+   		var intent = builder.Build();
+   		intent.LaunchUrl(
+               ContextHelper.Current,
+               Android.Net.Uri.Parse(requestUri.OriginalString));
+       }
+   }
+   ```
+
+4. Register the override in the `Application` constructor in the `Main.cs` file:
+
+   ```csharp
+   public Application(IntPtr javaReference, JniHandleOwnership transfer)
+   	: base(() => new App(), javaReference, transfer)
+   {
+   	ConfigureUniversalImageLoader();
+           
+       // ---- Add the following lines ----
+       // Register a custom implementation of WebAuthenticationBroker
+       // by using the AndroidX Chrome Custom Tabs on Android.
+       ApiExtensibility.Register(
+   		typeof(IWebAuthenticationBrokerProvider),
+   		_ => new ChromeCustomTabsProvider());
+       // ---------------------------------
+   }
+   ```
+
+### WebAssembly: How to use `<iframe>` instead of a browser window
 
 On WebAssembly, it is possible to use an in-application `<iframe>` instead of opening a new window. Beware **the authentication server must support this mode**.
 

--- a/doc/articles/features/web-authentication-broker.md
+++ b/doc/articles/features/web-authentication-broker.md
@@ -12,7 +12,7 @@
 
 ## Usage on iOS & MacOS
 
-* The *redirect URI* **MUST** use a custom scheme URI and this one must be registered in the `Info.plist` of the application.
+* The *redirect URI* **MUST** use a custom scheme URI and this scheme must be registered in the `Info.plist` of the application.
 * Default *redirect URI* will be `<scheme>:/authentication-callback`. Ex: `my-app-auth:/authentication-callback`
 * The default *redirect URI* will be automatic if there's only one custom scheme defined in the application. If there are more than one scheme, the first one will be used. You may want to set the right one using the `WinRTFeatureConfiguration.WebAuthenticationBroker.DefaultReturnUri` property.
 
@@ -32,7 +32,7 @@
   	DataScheme = "myapplication")]
   public class WebAuthenticationBrokerActivity : WebAuthenticationBrokerActivityBase
   {
-      // Note: the name of this class it not important
+      // Note: the name of this class is not important
   }
   ```
 

--- a/doc/articles/features/web-authentication-broker.md
+++ b/doc/articles/features/web-authentication-broker.md
@@ -12,27 +12,27 @@
 
 ## Usage on iOS & MacOS
 
-* The *redirect URI* **MUST** use a custom scheme URI and  this one must be registered in the `Info.plist` of the  application.
-* Default *redirect URI* will be `<scheme>:/authentication-callback`. Ex:  `my-app-auth:/authentication-callback`
-* The default *redirect URI* will be automatic if there's only one custom scheme defined in the application. If there are more than one scheme, the first one will be used. You may want to set the right one using the `WinRTFeatureConfiguration.WebAuthenticationBroker.DefaultReturnUri`  property.
+* The *redirect URI* **MUST** use a custom scheme URI and this one must be registered in the `Info.plist` of the application.
+* Default *redirect URI* will be `<scheme>:/authentication-callback`. Ex: `my-app-auth:/authentication-callback`
+* The default *redirect URI* will be automatic if there's only one custom scheme defined in the application. If there are more than one scheme, the first one will be used. You may want to set the right one using the `WinRTFeatureConfiguration.WebAuthenticationBroker.DefaultReturnUri` property.
 
 ## Usage on Android
 
-* The *redirect URI* **MUST** use a custom scheme URI. This one will launch a special *Activity* declared in your application.
+* The *redirect URI* **MUST** use a custom scheme URI. This one will launch a special *Activity* declared in the application.
 
-* You **MUST** declare an activity deriving from `WebAuthenticationBrokerActivityBase` in the Android head of your application:
+* You **MUST** declare an activity inheriting from `WebAuthenticationBrokerActivityBase` in the Android head:
 
   ``` csharp
-  // Android: add this class near the MainActivity of your head project
+  // Android: add this class near the MainActivity, in the head project
   [Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop)]
   [IntentFilter(
   	new[] {Android.Content.Intent.ActionView},
   	Categories = new[] {Android.Content.Intent.CategoryDefault, Android.Content.Intent.CategoryBrowsable},
-      // Change the following DataScheme for one specific to your application...
+      // To be changed for a scheme specific to the application
   	DataScheme = "myapplication")]
   public class WebAuthenticationBrokerActivity : WebAuthenticationBrokerActivityBase
   {
-      // You can change the name of this class if you wish, it really not something important.
+      // Note: the name of this class it not important
   }
   ```
 
@@ -40,7 +40,7 @@
 
 * Default _redirect URI_ will be `<scheme>:/authentication-callback`. Ex: `my-app-auth:/authentication-callback`
 
-* The default implementation of the `WebAuthenticationBroker` on Android will launch the system browser and the result will come back through the custom scheme of the _Return Uri_. You may want something more elaborated, like the _AndroidX Chrome Custom Tabs_. Check in the _Advanced_ section below for instructions to use it in your application.
+* The default implementation of the `WebAuthenticationBroker` on Android will launch the system browser and the result will come back through the custom scheme of the _Return Uri_. The _AndroidX Chrome Custom Tabs_ may also be used. _Advanced_ section below contains instructions about this.
 
 ## Advanced Usages
 
@@ -51,7 +51,7 @@ For special needs, it is possible to create a custom implementation of the Web A
 ``` csharp
 [assembly: ApiExtension(typeof(MyNameSpace.MyBrokerImplementation), typeof(Uno.AuthenticationBroker.IWebAuthenticationBrokerProvider))]
 
-public class MyBrokerImplementation : IWebAuthenticationBrokerProvider
+public class MyBrokerImplementation : Uno.AuthenticationBroker.IWebAuthenticationBrokerProvider
 {
 	Uri GetCurrentApplicationCallbackUri() => [TODO]
 
@@ -66,16 +66,16 @@ This implementation can also published as a NuGet package and it will be discove
 
 ### Android: Custom Implementation for AndroidX Chrome Custom Tabs
 
-1. Add reference to following NuGet packages:
+1. Add references to following NuGet packages:
 
    * `Xamarin.Android.Support.CustomTabs`
    * `Xamarin.AndroidX.Lifecycle.LiveData`
    * `Xamarin.AndroidX.Browser`
 
-2. Directly in the Android head project, create a class deriving from `WebAuthenticationBrokerProvider`:
+2. Directly in the Android head project, create a class inheriting from `WebAuthenticationBrokerProvider`:
 
    ``` csharp
-   public class ChromeCustomTabsProvider : WebAuthenticationBrokerProvider
+   public class ChromeCustomTabsProvider : Uno.AuthenticationBroker.WebAuthenticationBrokerProvider
    {   
    }
    ```
@@ -83,7 +83,7 @@ This implementation can also published as a NuGet package and it will be discove
 3. Override the `LaunchBrowserCore` virtual method:
 
    ``` csharp
-   public class ChromeCustomTabsProvider : WebAuthenticationBrokerProvider
+   public class ChromeCustomTabsProvider : Uno.AuthenticationBroker.WebAuthenticationBrokerProvider
    {   
        protected override async Task LaunchBrowserCore(
                    WebAuthenticationOptions options,
@@ -111,7 +111,7 @@ This implementation can also published as a NuGet package and it will be discove
        // ---- Add the following lines ----
        // Register a custom implementation of WebAuthenticationBroker
        // by using the AndroidX Chrome Custom Tabs on Android.
-       ApiExtensibility.Register(
+       Uno.Foundation.Extensibility.ApiExtensibility.Register(
    		typeof(IWebAuthenticationBrokerProvider),
    		_ => new ChromeCustomTabsProvider());
        // ---------------------------------

--- a/doc/articles/guides/open-id-connect.md
+++ b/doc/articles/guides/open-id-connect.md
@@ -8,7 +8,7 @@ This article will document the usage of  `IdentityModel.OidcClient` into a Uno a
 
 ## Limitations
 
-- **Not all platforms  yet**: The `WebAuthenticationBroker` is not yet  supported on all platforms yet. For Uno 3.6 it is implemented only on  WebAssembly, iOS and MacOS.
+- **Not all platforms  yet**: The `WebAuthenticationBroker` is not yet  supported on all platforms yet. For Uno 3.6 it is implemented only on  WebAssembly, Android, iOS and MacOS.
 - **Return URI on  WebAssembly**: Because of browser security  restrictions, on WebAssembly, the return URL must be on the same origin as the  application. On other platforms the best approach is to use a custom protocol  scheme (like `my-application:`). For most applications, you  may simply use the automatic discovery of return URLs, which will use the  [`WebAuthenticationBroker.GetCurrentApplicationCallbackUri()`  method](https://docs.microsoft.com/en-us/uwp/api/windows.security.authentication.web.webauthenticationbroker.getcurrentapplicationcallbackuri).
 - **Browser Anti-Popup  Protection**: On WebAssembly, a  foreign/public web site is usually used to authenticate the user. Doing this  without losing the application context requires the opening of a new browser  window. To ensure the window will open on all browsers without being denied,  this one **must be opened using the  handling of a user interaction**. For this reason the  IdentityModel.OidcClient's *automatic  mode* can't be used because it's doing async processing (fetching  the discovery endpoint) before opening the authentication browser.
 
@@ -36,6 +36,25 @@ For platforms supporting it, the custom protocol "oidc-auth:" will be used.
 Add the package [`IdentityModel.OidcClient`](https://www.nuget.org/packages/IdentityModel.OidcClient) to all relevant _head_ projects of the solution.
 
 ## Step 2 - Prepare for Return Uri
+
+**Android**
+
+Add the following class in the project of the Android Head:
+
+``` csharp
+[Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop)]
+[IntentFilter(
+	new[] {Android.Content.Intent.ActionView},
+	Categories = new[] {Android.Content.Intent.CategoryDefault, Android.Content.Intent.CategoryBrowsable},
+	DataScheme = "oidc-auth")]
+public class WebAuthenticationBrokerActivity : WebAuthenticationBrokerActivityBase
+{
+}
+```
+
+This activity will intercept the return URI and forward it to any waiting `WebAuthenticationBroker`.
+
+Note: it's using the system browser. Check the [WebAuthenticationBroker documentation](web-authentication-broker.md) to use another mechanism.
 
 **iOS & MacOS**
 

--- a/doc/articles/guides/open-id-connect.md
+++ b/doc/articles/guides/open-id-connect.md
@@ -1,16 +1,16 @@
 # Authentication using OpenID Connect
 
-OpenID Connect is a layer over OAuth 2.0,  allowing a simpler integration into applications, especially when the OpenID  Connect Discovery is used.
+OpenID Connect is a layer over OAuth 2.0, allowing a simpler integration into applications, especially when the OpenID  Connect Discovery is used.
 
-This article will document the usage of  `IdentityModel.OidcClient` into a Uno application using the [`WebAuthenticationBroker`](about:web-authentication-broker.md). You can find [the  IdentityModel.OidcClient documentation here](https://identitymodel.readthedocs.io/en/latest/native/overview.html).
+This article will document the usage of `IdentityModel.OidcClient` into a Uno application using the [`WebAuthenticationBroker`](about:web-authentication-broker.md). You can find [the IdentityModel.OidcClient documentation here](https://identitymodel.readthedocs.io/en/latest/native/overview.html).
 
-> The code of this article can be found in the Uno Samples at  the following address: https://github.com/unoplatform/Uno.Samples/tree/master/UI/Authentication.OidcDemo
+> The code of this article can be found in the Uno Samples at the following address: https://github.com/unoplatform/Uno.Samples/tree/master/UI/Authentication.OidcDemo
 
 ## Limitations
 
-- **Not all platforms  yet**: The `WebAuthenticationBroker` is not yet  supported on all platforms yet. For Uno 3.6 it is implemented only on  WebAssembly, Android, iOS and MacOS.
-- **Return URI on  WebAssembly**: Because of browser security  restrictions, on WebAssembly, the return URL must be on the same origin as the  application. On other platforms the best approach is to use a custom protocol  scheme (like `my-application:`). For most applications, you  may simply use the automatic discovery of return URLs, which will use the  [`WebAuthenticationBroker.GetCurrentApplicationCallbackUri()`  method](https://docs.microsoft.com/en-us/uwp/api/windows.security.authentication.web.webauthenticationbroker.getcurrentapplicationcallbackuri).
-- **Browser Anti-Popup  Protection**: On WebAssembly, a  foreign/public web site is usually used to authenticate the user. Doing this  without losing the application context requires the opening of a new browser  window. To ensure the window will open on all browsers without being denied,  this one **must be opened using the  handling of a user interaction**. For this reason the  IdentityModel.OidcClient's *automatic  mode* can't be used because it's doing async processing (fetching  the discovery endpoint) before opening the authentication browser.
+- **Platforms**: The `WebAuthenticationBroker` is not yet supported on all platforms yet. For Uno 3.6 it is implemented only on WebAssembly, Android, iOS and MacOS.
+- **Return URI on WebAssembly**: Because of browser security restrictions, on WebAssembly, the return URL must be on the same origin as the application. On other platforms the best approach is to use a custom protocol scheme (like `my-application:`). For most applications, you may simply use the automatic discovery of return URLs, which will use the [`WebAuthenticationBroker.GetCurrentApplicationCallbackUri()` method](https://docs.microsoft.com/en-us/uwp/api/windows.security.authentication.web.webauthenticationbroker.getcurrentapplicationcallbackuri).
+- **Browser Anti-Popup Protection**: On WebAssembly, a foreign/public web site is usually used to authenticate the user. Doing this without losing the application context requires the opening of a new browser window. To ensure the window will open on all browsers without being denied, this one **must be opened using the handling of a user interaction**. For this reason the IdentityModel.OidcClient's *automatic mode* can't be used because it's doing async processing (fetching the discovery endpoint) before opening the authentication browser.
 
 ## Demo Endpoint
 
@@ -54,7 +54,7 @@ public class WebAuthenticationBrokerActivity : WebAuthenticationBrokerActivityBa
 
 This activity will intercept the return URI and forward it to any waiting `WebAuthenticationBroker`.
 
-Note: it's using the system browser. Check the [WebAuthenticationBroker documentation](web-authentication-broker.md) to use another mechanism.
+Note: it's using the system browser. Check the [WebAuthenticationBroker documentation](../features/web-authentication-broker.md) to use another mechanism.
 
 **iOS & MacOS**
 

--- a/doc/articles/guides/open-id-connect.md
+++ b/doc/articles/guides/open-id-connect.md
@@ -8,9 +8,9 @@ This article will document the usage of `IdentityModel.OidcClient` into a Uno ap
 
 ## Limitations
 
-- **Platforms**: The `WebAuthenticationBroker` is not yet supported on all platforms yet. For Uno 3.6 it is implemented only on WebAssembly, Android, iOS and MacOS.
+- **Platforms**: The `WebAuthenticationBroker` is not supported on all platforms yet. For Uno 3.6 it is implemented only on WebAssembly, Android, iOS and MacOS.
 - **Return URI on WebAssembly**: Because of browser security restrictions, on WebAssembly, the return URL must be on the same origin as the application. On other platforms the best approach is to use a custom protocol scheme (like `my-application:`). For most applications, you may simply use the automatic discovery of return URLs, which will use the [`WebAuthenticationBroker.GetCurrentApplicationCallbackUri()` method](https://docs.microsoft.com/en-us/uwp/api/windows.security.authentication.web.webauthenticationbroker.getcurrentapplicationcallbackuri).
-- **Browser Anti-Popup Protection**: On WebAssembly, a foreign/public web site is usually used to authenticate the user. Doing this without losing the application context requires the opening of a new browser window. To ensure the window will open on all browsers without being denied, this one **must be opened using the handling of a user interaction**. For this reason the IdentityModel.OidcClient's *automatic mode* can't be used because it's doing async processing (fetching the discovery endpoint) before opening the authentication browser.
+- **Browser Anti-Popup Protection**: On WebAssembly, a foreign/public web site is usually used to authenticate the user. Doing this without losing the application context requires the opening of a new browser window. To ensure the window will open on all browsers without being denied, this new window **must be opened using the handling of a user interaction**. For this reason the IdentityModel.OidcClient's *automatic mode* can't be used because it's doing async processing (fetching the discovery endpoint) before opening the authentication browser.
 
 ## Demo Endpoint
 

--- a/src/SamplesApp/SamplesApp.Droid/WebAuthBrokerActivity.cs
+++ b/src/SamplesApp/SamplesApp.Droid/WebAuthBrokerActivity.cs
@@ -1,0 +1,15 @@
+﻿using Android.App;
+using Android.Content.PM;
+using Uno.AuthenticationBroker;
+
+namespace SamplesApp.Droid
+{
+	[Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop)]
+	[IntentFilter(
+		new[] {Android.Content.Intent.ActionView},
+		Categories = new[] {Android.Content.Intent.CategoryDefault, Android.Content.Intent.CategoryBrowsable},
+		DataScheme = "uno-samples-auth")]
+	public class WebAuthenticationBrokerActivity : WebAuthenticationBrokerActivityBase
+	{
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_Security_Authentication_Web/AuthenticationBroker_Demo.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Security_Authentication_Web/AuthenticationBroker_Demo.xaml.cs
@@ -22,41 +22,49 @@ namespace SamplesApp.UITests.Windows_Security_Authentication_Web
 
 		private async void PrepareClient()
 		{
-			var redirectUri = WebAuthenticationBroker.GetCurrentApplicationCallbackUri().OriginalString;
-
-			// Create options for endpoint discovery
-			var options = new OidcClientOptions()
+			try
 			{
-				Authority = "https://demo.identityserver.io",
-				ClientId = "interactive.confidential",
-				ClientSecret = "secret",
-				Scope = "openid profile email api offline_access",
-				RedirectUri = redirectUri,
-				PostLogoutRedirectUri = redirectUri,
-				ResponseMode = OidcClientOptions.AuthorizeResponseMode.Redirect,
-				Flow = OidcClientOptions.AuthenticationFlow.AuthorizationCode
-			};
+				var redirectUri = WebAuthenticationBroker.GetCurrentApplicationCallbackUri().OriginalString;
 
-			// Create the client. In production application, this is often created and stored
-			// directly in the Application class.
-			_oidcClient = new OidcClient(options);
+				// Create options for endpoint discovery
+				var options = new OidcClientOptions()
+				{
+					Authority = "https://demo.identityserver.io",
+					ClientId = "interactive.confidential",
+					ClientSecret = "secret",
+					Scope = "openid profile email api offline_access",
+					RedirectUri = redirectUri,
+					PostLogoutRedirectUri = redirectUri,
+					ResponseMode = OidcClientOptions.AuthorizeResponseMode.Redirect,
+					Flow = OidcClientOptions.AuthenticationFlow.AuthorizationCode
+				};
 
-			// Invoke Discovery and prepare a request state, containing the nonce.
-			// This is done here to ensure the discovery mecanism is done before
-			// the user clicks on the SignIn button. Since the opening of a web window
-			// should be done during the handling of a user interaction (here it's the button click),
-			// it will be too late to reach the discovery endpoint.
-			// Not doing this could trigger popup blockers mechanisms in browsers.
-			_loginState = await _oidcClient.PrepareLoginAsync();
-			btnSignin.IsEnabled = true;
+				// Create the client. In production application, this is often created and stored
+				// directly in the Application class.
+				_oidcClient = new OidcClient(options);
 
-			resultTxt.Text = "Login URI correct";
+				// Invoke Discovery and prepare a request state, containing the nonce.
+				// This is done here to ensure the discovery mecanism is done before
+				// the user clicks on the SignIn button. Since the opening of a web window
+				// should be done during the handling of a user interaction (here it's the button click),
+				// it will be too late to reach the discovery endpoint.
+				// Not doing this could trigger popup blockers mechanisms in browsers.
+				_loginState = await _oidcClient.PrepareLoginAsync();
+				btnSignin.IsEnabled = true;
 
-			// Same for logout url.
-			_logoutUrl = new Uri(await _oidcClient.PrepareLogoutAsync(new LogoutRequest()));
-			btnSignout.IsEnabled = true;
+				resultTxt.Text = "Login URI correct";
 
-			resultTxt.Text = $"Initialization completed.\nStart={_loginState.StartUrl}\nCallback={_loginState.RedirectUri}\nLogout={_logoutUrl}";
+				// Same for logout url.
+				_logoutUrl = new Uri(await _oidcClient.PrepareLogoutAsync(new LogoutRequest()));
+				btnSignout.IsEnabled = true;
+
+				resultTxt.Text = $"Initialization completed.\nStart={_loginState.StartUrl}\nCallback={_loginState.RedirectUri}\nLogout={_logoutUrl}";
+			}
+			catch(Exception ex)
+			{
+				resultTxt.Text = $"Error {ex}";
+
+			}
 		}
 
 		private async void SignIn_Clicked(object sender, RoutedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
@@ -14,6 +14,7 @@ using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Media;
 using Windows.Devices.Sensors;
 using Windows.Storage.Pickers;
+using Uno.AuthenticationBroker;
 
 namespace Windows.UI.Xaml
 {
@@ -164,6 +165,8 @@ namespace Windows.UI.Xaml
 			base.OnResume();
 
 			RaiseConfigurationChanges();
+
+			WebAuthenticationBrokerProvider.OnMainActivityResumed();
 		}
 
 		protected override void OnPause()

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerActivityBase.Android.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerActivityBase.Android.cs
@@ -1,0 +1,22 @@
+﻿#nullable enable
+using System;
+using Android.App;
+using Android.OS;
+
+namespace Uno.AuthenticationBroker
+{
+	public abstract class WebAuthenticationBrokerActivityBase : Activity
+	{
+		protected override void OnCreate(Bundle? savedInstanceState)
+		{
+			base.OnCreate(savedInstanceState);
+
+			var data = Intent?.Data?.ToString();
+			if (data != null)
+			{
+				WebAuthenticationBrokerProvider.SetReturnData(new Uri(data));
+				Finish();
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.Android.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.Android.cs
@@ -1,25 +1,121 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Security.Authentication.Web;
+using Windows.System;
+using Android.App;
+using Android.OS;
+using Uno.UI;
 
 namespace Uno.AuthenticationBroker
 {
 	partial class WebAuthenticationBrokerProvider
 	{
-		private static IEnumerable<string> GetCustomSchemes()
+		private static string[]? _schemes;
+
+		protected virtual IEnumerable<string> GetApplicationCustomSchemes()
 		{
-			throw new NotImplementedException();
+			if (_schemes == null)
+			{
+				var appType = ContextHelper.Current.GetType();
+				var applicationTypes = appType.Assembly.GetTypes();
+
+				static IEnumerable<string> ExtractSchemes(IntentFilterAttribute a)
+				{
+					if (a.DataSchemes != null)
+					{
+						// If DataSchemes is defined, it will be used
+						// instead of DataScheme (the singular version)
+						foreach (var ds in a.DataSchemes)
+						{
+							yield return ds;
+						}
+					}
+					else if (!string.IsNullOrWhiteSpace(a.DataScheme))
+					{
+						// When DataScheme (singular version) is used.
+						yield return a.DataScheme!;
+					}
+				}
+
+				_schemes = applicationTypes
+					// Check all types deriving from Activity
+					.Where(t => t.BaseType != null && (t.BaseType == typeof(WebAuthenticationBrokerActivityBase) || t.BaseType.IsSubclassOf(typeof(WebAuthenticationBrokerActivityBase))))
+					// Extract "IntentFilter" attributes
+					.SelectMany(t => t.GetCustomAttributes(typeof(IntentFilterAttribute), true))
+					.OfType<IntentFilterAttribute>()
+					// Extract Data Schemes
+					.SelectMany(ExtractSchemes)
+					// Add ":" to create a scheme prefix
+					.Select(s => s + ":")
+					// Remove duplicates
+					.Distinct()
+					// Materialize the results
+					.ToArray();
+			}
+
+			return _schemes;
 		}
 
-		public async Task<WebAuthenticationResult> AuthenticateAsync(
+		internal static void SetReturnData(Uri data)
+		{
+			if (_waitingForCallbackUri == null || _completionSource == null)
+			{
+				return; // Not waiting for this
+			}
+
+			if (data.OriginalString.StartsWith(_waitingForCallbackUri))
+			{
+				_completionSource?.TrySetResult(
+					new WebAuthenticationResult(data.OriginalString, 0, WebAuthenticationStatus.Success));
+			}
+		}
+
+		internal static void OnMainActivityResumed()
+		{
+			// This is called when the application activity is resumed.
+			// If it occurs before the TCS is competed, it means the user canceled the operation.
+
+			Interlocked.Exchange(ref _completionSource, null)
+				?.TrySetResult(new WebAuthenticationResult(null, 0, WebAuthenticationStatus.UserCancel));
+		}
+
+		private static string? _waitingForCallbackUri;
+
+		private static TaskCompletionSource<WebAuthenticationResult>? _completionSource;
+
+		protected virtual async Task<WebAuthenticationResult> AuthenticateAsyncCore(
 			WebAuthenticationOptions options,
 			Uri requestUri,
 			Uri callbackUri,
 			CancellationToken ct)
 		{
-			throw new NotImplementedException();
+			var tcs = new TaskCompletionSource<WebAuthenticationResult>();
+			Interlocked.Exchange(ref _completionSource, tcs)?.TrySetCanceled();
+
+			_waitingForCallbackUri = callbackUri.OriginalString;
+
+			await LaunchBrowserCore(options, requestUri, callbackUri, ct);
+
+			var result = await tcs!.Task;
+
+			if(Interlocked.CompareExchange(ref _completionSource, null, tcs) == tcs)
+			{
+				_waitingForCallbackUri = null;
+			}
+
+			return result;
+		}
+
+		protected virtual async Task LaunchBrowserCore(WebAuthenticationOptions options,
+			Uri requestUri,
+			Uri callbackUri,
+			CancellationToken ct)
+		{
+			await Launcher.LaunchUriAsync(requestUri);
 		}
 	}
 }

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.Skia.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.Skia.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,12 +9,12 @@ namespace Uno.AuthenticationBroker
 {
 	partial class WebAuthenticationBrokerProvider
 	{
-		private static IEnumerable<string> GetCustomSchemes()
+		protected virtual IEnumerable<string> GetApplicationCustomSchemes()
 		{
 			throw new NotImplementedException();
 		}
 
-		public async Task<WebAuthenticationResult> AuthenticateAsync(
+		protected virtual async Task<WebAuthenticationResult> AuthenticateAsyncCore(
 			WebAuthenticationOptions options,
 			Uri requestUri,
 			Uri callbackUri,

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOSmacOS.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOSmacOS.cs
@@ -90,7 +90,7 @@ namespace Uno.AuthenticationBroker
 			var startUrl = new NSUrl(requestUri.OriginalString);
 			var callbackUrl = callbackUri.OriginalString;
 
-			var schemes = GetCustomSchemes().ToArray();
+			var schemes = GetApplicationCustomSchemes().ToArray();
 			if (!schemes.Any(s => callbackUrl.StartsWith(s)))
 			{
 				var message = schemes.Length == 0

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOSmacOS.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOSmacOS.cs
@@ -26,7 +26,7 @@ namespace Uno.AuthenticationBroker
 		private const string sfAuthenticationErrorDomain = "com.apple.SafariServices.Authentication";
 		private const int sfAuthenticationErrorCanceledLogin = 1;
 #endif
-		public async Task<WebAuthenticationResult> AuthenticateAsync(
+		protected virtual async Task<WebAuthenticationResult> AuthenticateAsyncCore(
 			WebAuthenticationOptions options,
 			Uri requestUri,
 			Uri callbackUri,
@@ -177,7 +177,7 @@ namespace Uno.AuthenticationBroker
 #endif
 		}
 
-		private static IEnumerable<string> GetCustomSchemes()
+		protected virtual IEnumerable<string> GetApplicationCustomSchemes()
 		{
 			if (NSBundle.MainBundle.InfoDictionary.TryGetValue((NSString)"CFBundleURLTypes", out var o))
 			{

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.net.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.net.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,12 +9,12 @@ namespace Uno.AuthenticationBroker
 {
 	partial class WebAuthenticationBrokerProvider
 	{
-		private static IEnumerable<string> GetCustomSchemes()
+		protected virtual IEnumerable<string> GetApplicationCustomSchemes()
 		{
 			throw new NotImplementedException();
 		}
 
-		public async Task<WebAuthenticationResult> AuthenticateAsync(
+		protected virtual async Task<WebAuthenticationResult> AuthenticateAsyncCore(
 			WebAuthenticationOptions options,
 			Uri requestUri,
 			Uri callbackUri,

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.netstdref.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.netstdref.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -8,12 +9,12 @@ namespace Uno.AuthenticationBroker
 {
 	partial class WebAuthenticationBrokerProvider
 	{
-		private static IEnumerable<string> GetCustomSchemes()
+		protected virtual IEnumerable<string> GetApplicationCustomSchemes()
 		{
 			throw new NotImplementedException();
 		}
 
-		public async Task<WebAuthenticationResult> AuthenticateAsync(
+		public virtual async Task<WebAuthenticationResult> AuthenticateAsyncCore(
 			WebAuthenticationOptions options,
 			Uri requestUri,
 			Uri callbackUri,


### PR DESCRIPTION
# WebAuthenticationBroker on Android
This PR is adding support for WebAuthenticationBroker on Android. It's using the system browser with a callback using a custom scheme. In the documentation there's instructions to replace it by the _Chrome Custom Tabs_ instead, but since it's requiring dependencies on AndroidX, it was decided to not put that dependency in Uno.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- ~[ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
