### PR TITLE
docs: added uno.material docs

### DIFF
--- a/doc/articles/features/uno-material-controls-extra-setup.md
+++ b/doc/articles/features/uno-material-controls-extra-setup.md
@@ -1,0 +1,113 @@
+# Uno.Material Controls: Extra setup
+
+## Table of Contents
+- [ToggleSwitch](#ToggleSwitch):
+- [DatePicker & TimePicker](#DatePickers-and-TimePickers):
+
+## ToggleSwitch
+
+> In order to get the proper native colors on android, there is some modification needed.
+The reasoning for this is to apply the native android shadowing on the off value of the ToggleSwitch, and proper focus shadow colors when `ToggleSwitch`es are clicked.
+
+1. Open `Resources/values/Styles.xml` inside the `.Droid` project.
+    And, add two `<item>`s to under the `AppTheme`:
+    - colorControlActivated: the on color for your ToggleSwitches thumb
+    - colorSwitchThumbNormal: the off color for your ToggleSwitches thumb)
+    > you may add your colors here directly, for example #ffffff, or by files (see our example code below)
+    ```xml
+    <?xml version="1.0" encoding="utf-8" ?>
+    <resources>
+        <style name="AppTheme" parent="Theme.AppCompat.Light">
+
+            <!-- Color style for toggle switch -->
+            <item name="colorControlActivated">@color/MaterialPrimaryColor</item>
+            <item name="colorSwitchThumbNormal">@color/MaterialSurfaceVariantColor</item>
+        </style>
+    </resources>
+    ```
+
+1. (_optional_) If your application uses Light/Dark color palettes.
+    1. Inside the `Styles.xml` file change the `AppTheme`'s parent to `Theme.Compat.DayNight`:
+        ```diff
+        -<style name="AppTheme" parent="Theme.AppCompat.Light">
+        +<style name="AppTheme" parent="Theme.AppCompat.DayNight">
+        ```
+    1. Create a file named `colors.xml` under `Resources/values`.
+        And, include your "Light" theme colors:
+        ```xml
+        <?xml version="1.0" encoding="utf-8" ?>
+        <resources>
+            <color name="MaterialPrimaryColor">#5B4CF5</color>
+            <!-- SurfaceColor -->
+            <color name="MaterialSurfaceVariantColor">#FFFFFF</color>
+        </resources>
+        ```
+    1. Create a folder named `values-night` under `Resources/`
+    1. Create a file named `colors.xml` under `Resources/values-night`
+        And, include your "Dark" theme colors:
+        ```xml
+        <?xml version="1.0" encoding="utf-8" ?>
+        <resources>
+            <color name="MaterialPrimaryColor">#B6A8FB</color>
+            <!-- A variant of OnSurfaceMediumColor without alpha opacity (can't use alphas with android colors)  -->
+            <color name="MaterialSurfaceVariantColor">#808080</color>
+        </resources>
+        ```
+
+1. (_optional_) If you have changed the material color palette for your application.
+    Make sure these colors are updated as well in `ColorPaletteOverride.xaml`:
+    - `MaterialToggleSwitchButtonColor`: knob color when unchecked (IsOn=false)
+    - `MaterialSurfaceVariantLightColor`: knob color when checked (IsOn=true)
+    - `MaterialToggleSwitchBackgroundColor`: Rail fill color when checked
+    - `MaterialPrimaryVariantLowThumbColor`: Knob color when the control is disabled
+
+## DatePickers and TimePickers
+
+> If your application uses `DatePicker` and/or `TimePicker` (these are native components).
+To apply your material colors to these android components, do the following (this will affect every `DatePicker`/`TimePicker` in the application).
+
+1. Open `Resources/values/Styles.xml` inside the `.Droid` project.
+    And, add two `<item>`s to under the `AppTheme`:
+    - datePickerDialogTheme
+    - timePickerDialogTheme
+
+    And add a new `<style>` as shown below:
+    ```xml
+    <?xml version="1.0" encoding="utf-8" ?>
+    <resources>
+        <style name="AppTheme" parent="Theme.AppCompat.Light">
+
+            <!-- Color style for Time/Date Pickers -->
+            <item name="android:datePickerDialogTheme">@style/AppCompatDialogStyle</item>
+            <item name="android:timePickerDialogTheme">@style/AppCompatDialogStyle</item>
+        </style>
+
+        <style name="AppCompatDialogStyle" parent="Theme.AppCompat.Light.Dialog">
+            <item name="colorAccent">@color/MaterialPrimaryColor</item>
+        </style>
+    </resources>
+    ```
+
+2. (_optional_) If your application uses Light/Dark color palettes.
+    1. Inside the `Styles.xml` file change the `AppTheme`'s parent to `Theme.Compat.DayNight`:
+        ```diff
+        -<style name="AppTheme" parent="Theme.AppCompat.Light">
+        +<style name="AppTheme" parent="Theme.AppCompat.DayNight">
+        ```
+    1. Create a file named `colors.xml` under `Resources/values`.
+        And, include your "Light" theme colors:
+        ```xml
+        <?xml version="1.0" encoding="utf-8" ?>
+        <resources>
+            <color name="MaterialPrimaryColor">#5B4CF5</color>
+        </resources>
+        ```
+    1. Create a folder named `values-night` under `Resources/`
+    1. Create a file named `colors.xml` under `Resources/values-night`
+        And, include your "Dark" theme colors:
+        ```xml
+        <?xml version="1.0" encoding="utf-8" ?>
+        <resources>
+	        <color name="MaterialPrimaryColor">#B6A8FB</color>
+        </resources>
+        ```

--- a/doc/articles/features/uno-material.md
+++ b/doc/articles/features/uno-material.md
@@ -4,14 +4,40 @@ Uno Material is an add-on package which lets you apply [Material Design styling]
 
 - Color system for both Light and Dark themes
 - Styles for existing WinUI controls like Buttons, TextBox, etc.
-- Custom Controls for Material Components not offered out of the box by WinUI, such as Card and BottomNavigationBar.
+- Custom Controls for Material Components not offered out of the box by WinUI, such as `Card` and `BottomNavigationBar`.
 
 For complete instructions on using Uno Material in your projects, including a set of Sketch files for designers, [consult the readme](https://github.com/unoplatform/Uno.Themes/blob/master/README.md).
 
 ## Getting Started
-See: [How to use Uno.Material](../guides/uno-material-walkthrough.md)
+1. Add NuGet package `Uno.Material` to each of project heads
+1. Add the following code inside `App.xaml`:
+    ```xml
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <!-- Load WinUI resources -->
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
 
-> [!NOTE] Certain controls require [additional setup steps](uno-material-controls-extra-setup.md).
+                <!-- Application's custom styles -->
+                <!-- other ResourceDictionaries -->
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+    ```
+1. Initialize the material library in `App.xaml.cs`:
+    ```cs
+    protected override void OnLaunched(LaunchActivatedEventArgs e)
+    {
+         Uno.Material.Resources.Init(this, null);
+
+        // [existing code...]
+    }
+    ```
+
+For complete instructions on using Uno Material in your projects, check out this walkthrough: [How to use Uno.Material](../guides/uno-material-walkthrough.md).
+
+> [!NOTE]
+> Certain controls require [additional setup steps](uno-material-controls-extra-setup.md).
 
 ## Features
 

--- a/doc/articles/features/uno-material.md
+++ b/doc/articles/features/uno-material.md
@@ -7,3 +7,58 @@ Uno Material is an add-on package which lets you apply [Material Design styling]
 - Custom Controls for Material Components not offered out of the box by WinUI, such as Card and BottomNavigationBar.
 
 For complete instructions on using Uno Material in your projects, including a set of Sketch files for designers, [consult the readme](https://github.com/unoplatform/Uno.Themes/blob/master/README.md).
+
+## Getting Started
+See: [How to use Uno.Material](../guides/uno-material-walkthrough.md)
+
+> [!NOTE] Certain controls require [additional setup steps](uno-material-controls-extra-setup.md).
+
+## Features
+
+### Styles for basic controls
+Control|Resource Key
+-|-
+`AppBarButton`|MaterialAppBarButton
+`Button`|MaterialContainedButtonStyle<br>MaterialContainedSecondaryButtonStyle<br>MaterialFabStyle<br>MaterialOutlinedButtonStyle<br>MaterialOutlinedSecondaryButtonStyle<br>MaterialPaneBackArrowToggleButtonStyle<br>MaterialPaneToggleButtonStyle<br>MaterialPrimaryInvertedFabStyle<br>MaterialSecondaryFabStyle<br>MaterialSecondaryInvertedFabStyle<br>MaterialSmallFabStyle<br>MaterialTextButtonStyle<br>MaterialTextSecondaryButtonStyle
+`CheckBox`|MaterialCheckBoxStyle<br>MaterialSecondaryCheckBoxStyle
+`ComboBox`|MaterialComboBoxStyle
+`ComboBoxItem`|MaterialComboBoxItemStyle
+`CommandBar`|MaterialCommandBarStyle
+`DatePicker`|MaterialDatePickerStyle<br>MaterialSecondaryDatePickerStyle
+`FlyoutPresenter`|MaterialFlyoutPresenterStyle
+`HyperlinkButton`|MaterialHyperlinkButtonStyle<br>MaterialSecondaryHyperlinkButtonStyle
+`NavigationView`|MaterialNavigationViewStyle<br>MaterialNoCompactMenuNavigationViewStyle
+`PasswordBox`|MaterialFilledPasswordBoxStyle<br>MaterialOutlinedPasswordBoxStyle
+`RadioButton`|MaterialRadioButtonStyle<br>MaterialSecondaryRadioButtonStyle
+`Slider`|MaterialSecondarySliderStyle<br>MaterialSliderStyle
+`TextBlock`|MaterialBaseTextBlockStyle<br>MaterialBody1<br>MaterialBody2<br>MaterialButtonText<br>MaterialCaption<br>MaterialHeadline1<br>MaterialHeadline2<br>MaterialHeadline3<br>MaterialHeadline4<br>MaterialHeadline5<br>MaterialHeadline6<br>MaterialOverline<br>MaterialSubtitle1<br>MaterialSubtitle2
+`TextBox`|MaterialFilledTextBoxStyle<br>MaterialOutlinedTextBoxStyle
+`TimePicker`|MaterialTimePickerStyle
+`ToggleButton`|MaterialExpandingBottomSheetToggleButtonStyle<br>MaterialTextToggleButtonStyle
+`ToggleSwitch`|MaterialSecondaryToggleSwitchStyle<br>MaterialToggleSwitchStyle
+`winui:InfoBar`|MaterialInfoBarStyle
+`winui:ProgressBar`|MaterialProgressBarStyle<br>MaterialSecondaryProgressBarStyle
+`winui:ProgressRing`|MaterialProgressRingStyle<br>MaterialSecondaryProgressRingStyle
+
+### Styles for custom material controls
+Control|Resource Key
+-|-
+`BottomNavigationBar`|MaterialBottomNavigationBarStyle
+`BottomNavigationBarItem`|MaterialBottomNavigationBarItemStyle
+`Card`|MaterialAvatarElevatedCardStyle<br>MaterialAvatarOutlinedCardStyle<br>MaterialBaseCardStyle<br>MaterialElevatedCardStyle<br>MaterialOutlinedCardStyle<br>MaterialSmallMediaElevatedCardStyle<br>MaterialSmallMediaOutlinedCardStyle
+`Chip`|MaterialChipStyle<br>MaterialOutlinedChipStyle<br>MaterialPrimaryChipStyle<br>MaterialPrimaryOutlinedChipStyle
+`ChipGroup`|MaterialChipGroupStyle
+`Divider`|MaterialDividerStyle
+`ExpandingBottomSheet`|MaterialExpandingBottomSheetStyle
+`ModalStandardBottomSheet`|MaterialModalStandardBottomSheetStyle
+`SnackBar`|MaterialSnackBarStyle
+`StandardBottomSheet`|MaterialStandardBottomSheetStyle
+
+### Customizable Color Theme
+The colors used in the material styles are part of the color palette system, which can be customized to suit the theme of your application. Since this is decoupled from the styles, the application theme can be changed, without having to make a copy of every style and edit each of them.
+
+## Additional Resources
+- Official Material Design site: https://material.io/design
+- Uno.Material library repository: https://github.com/unoplatform/Uno.Themes
+- [Additional control-specific setup](uno-material-controls-extra-setup)
+- Tools for picking colors: https://material.io/design/color/the-color-system.html#tools-for-picking-colors

--- a/doc/articles/guides/uno-material-walkthrough.md
+++ b/doc/articles/guides/uno-material-walkthrough.md
@@ -1,0 +1,236 @@
+# How to use Uno.Material
+
+This guide will walk you through the necessary steps to setup and to use the [`Uno.Material` package](https://www.nuget.org/packages/Uno.Material) in an Uno Platform application.
+
+> [!TIP] The complete source code that goes along with this guide is available in the [unoplatform/Uno.Samples](https://github.com/unoplatform/Uno.Samples) GitHub repository - [UnoMaterialSample](https://github.com/unoplatform/Uno.Samples/tree/master/UI/UnoMaterialSample)
+
+## Prerequisites
+
+### [Visual Studio for Windows](#tab/tabid-vswin)
+
+* [Visual Studio 2019 16.3 or later](http://www.visualstudio.com/downloads/)
+  * **Universal Windows Platform** workload installed
+  * **Mobile Development with .NET (Xamarin)** workload installed
+  * **ASP**.**NET and web** workload installed
+  * [Uno Platform Extension](https://marketplace.visualstudio.com/items?itemName=nventivecorp.uno-platform-addin) installed
+
+### [VS Code](#tab/tabid-vscode)
+
+* [**Visual Studio Code**](https://code.visualstudio.com/)
+
+* [**Mono**](https://www.mono-project.com/download/stable/)
+
+* **.NET Core SDK**
+    * [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1) (**version 3.1.8 (SDK 3.1.402)** or later)
+    * [.NET Core 5.0 SDK](https://dotnet.microsoft.com/download/dotnet-core/5.0) (**version 5.0 (SDK 5.0.100)** or later)
+
+    > Use `dotnet --version` from the terminal to get the version installed.
+
+### [Visual Studio for Mac](#tab/tabid-vsmac)
+
+* [**Visual Studio for Mac 8.8**](https://visualstudio.microsoft.com/vs/mac/)
+* [**Xcode**](https://apps.apple.com/us/app/xcode/id497799835?mt=12) 10.0 or higher
+* An [**Apple ID**](https://support.apple.com/en-us/HT204316)
+* **.NET Core SDK**
+    * [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1) (**version 3.1.8 (SDK 3.1.402)** or later)
+    * [.NET Core 5.0 SDK](https://dotnet.microsoft.com/download/dotnet-core/5.0) (**version 5.0 (SDK 5.0.100)** or later)
+* [**GTK+3**](https://formulae.brew.sh/formula/gtk+3) for running the Skia/GTK projects
+
+### [JetBrains Rider](#tab/tabid-rider)
+
+* [**Rider Version 2020.2+**](https://www.jetbrains.com/rider/download/)
+* [**Rider Xamarin Android Support Plugin**](https://plugins.jetbrains.com/plugin/12056-rider-xamarin-android-support/) (you may install it directly from Rider)
+
+## Step-by-steps
+### Section 1: Setup Uno.Material
+1. Create a new Uno Platform application, following the instructions [here](..\get-started.md).
+1. Add NuGet package `Uno.Material` to each of project heads by:
+    > [!NOTE] You may have to check the `[x] Include Prerelease` to find this package, as there are currently no stable release.
+
+    > [!NOTE]  
+    > The project heads refer to the projects targeted to a specific platforms:
+    > - UnoMaterialSample.Droid
+    > - UnoMaterialSample.iOS
+    > - UnoMaterialSample.macOS
+    > - UnoMaterialSample.Skia.Gtk
+    > - UnoMaterialSample.Skia.Tizen
+    > - UnoMaterialSample.Skia.WPF
+    > - UnoMaterialSample.UWP
+    > - UnoMaterialSample.Wasm
+    >
+    > > The shared project is not part of this, and the `.Skia.WPF.Host` project is another exception.
+
+    Here are some issues that you are likely to run into after complete the above step:
+    - > NU1605: Detected package downgrade: Uno.UI from 3.6.0-dev.275 to 3.5.1. Reference the package directly from the project to select a different version.
+
+        The app may not compile, crash at runtime, or behave strangely as a result of this.
+        solution: You need to update the version of `Uno.UI` packages for all project heads that you are using to the higher version.
+        > note: By `Uno.UI` packages, it includes:
+        > - Uno.UI
+        > - Uno.UI.RemoteControl
+        > - Uno.UI.WebAssembly
+        > - Uno.UI.Skia.Gtk
+        > - Uno.UI.Skia.Tizen
+        > - Uno.UI.Skia.Wpf
+
+    - When building the `.Droid` project, the project failed to build with:
+        ```
+        error : Could not find 1 Android X assemblies, make sure to install the following NuGet packages:
+            - Xamarin.AndroidX.Lifecycle.LiveData
+        You can also copy-and-paste the following snippet into your .csproj file:
+            <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0" />
+        ```
+        solution: Simply add the specific version of `Xamarin.AndroidX.Lifecycle.LiveData` to the `.Droid` project
+1. Add the following code inside `App.xaml`:
+    ```xml
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <!-- Load WinUI resources -->
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+
+                <!-- Application's custom styles -->
+                <!-- other ResourceDictionaries -->
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+    ```
+
+1. Initialize the material library in `App.xaml.cs`:
+    ```cs
+    protected override void OnLaunched(LaunchActivatedEventArgs e)
+    {
+         Uno.Material.Resources.Init(this, null);
+
+        // [existing code...]
+    }
+    ```
+
+### Section 2: Using Uno.Material library
+1. Add a couple controls with the material style to `MainPage.xaml`:
+    ```xml
+    <Page x:Class="UnoMaterialSample.MainPage"
+          xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+          xmlns:toolkit="using:Uno.UI.Toolkit">
+
+        <Grid toolkit:VisibleBoundsPadding.PaddingMask="Top" >
+            <ScrollViewer>
+                <StackPanel Margin="16,0" Spacing="8">
+                    <!-- controls with material styles -->
+                    <TextBlock Text="Hello, Material!" Style="{StaticResource MaterialHeadline2}" />
+                    <TextBlock Text="text" Style="{StaticResource MaterialBody1}" />
+                    <Button Content="button" Style="{StaticResource MaterialContainedButtonStyle}" />
+                    <ComboBox ItemsSource="asd" Style="{StaticResource MaterialComboBoxStyle}" />
+                    <DatePicker Style="{StaticResource MaterialDatePickerStyle}" />
+                    <TextBox Text="input" Style="{StaticResource MaterialFilledTextBoxStyle}" />
+
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    <Page>
+    ```
+1. Add a couple new controls from material:
+    ```xml
+    <Page ...
+          xmlns:material="using:Uno.Material.Controls">
+
+        <Grid toolkit:VisibleBoundsPadding.PaddingMask="Top" >
+            <ScrollViewer>
+                <StackPanel Margin="16,0" Spacing="8">
+                    <!-- controls with material styles -->
+                    <!-- ... -->
+
+                    <!-- material controls -->
+                    <material:Divider SubHeader="Uno.Material Controls:" Style="{StaticResource MaterialDividerStyle}" />
+                    <material:Card HeaderContent="Material Design"
+                            SupportingContent="Material is a design system created by Google to help teams build high-quality digital experiences for Android, iOS, Flutter, and the web."
+                            Style="{StaticResource MaterialOutlinedCardStyle}">
+                        <material:Card.HeaderContentTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" Margin="16,14,16,0" Style="{ThemeResource MaterialHeadline6}" />
+                            </DataTemplate>
+                        </material:Card.HeaderContentTemplate>
+                        <material:Card.SupportingContentTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" Margin="16,0,16,14" Style="{ThemeResource MaterialBody2}" />
+                            </DataTemplate>
+                        </material:Card.SupportingContentTemplate>
+                    </material:Card>
+                    <material:ChipGroup SelectionMode="Multiple" Style="{StaticResource MaterialChipGroupStyle}">
+                        <material:Chip Content="Uno" Style="{StaticResource MaterialChipStyle}" />
+                        <material:Chip Content="Material" Style="{StaticResource MaterialChipStyle}" />
+                        <material:Chip Content="Controls" Style="{StaticResource MaterialChipStyle}" />
+                    </material:ChipGroup>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    <Page>
+    ```
+
+> [TIP!]
+> You can find the style names using these methods:
+> - "Feature" section of Uno.Themes README: https://github.com/unoplatform/Uno.Themes#features
+> - Going through the source code of control styles: https://github.com/unoplatform/Uno.Themes/tree/master/src/library/Uno.Material/Styles/Controls
+> - Check out the [Uno.Gallery web app](https://gallery.platform.uno/) (Click on the `<>` button to view xaml source)
+
+### Section 3: Overriding Color Pallette
+1. Create the nested folders `Styles\` and then `Styles\Application\` under the `.Shared` project
+1. Add a new Resource Dictionary `ColorPaletteOverride.xaml` under `Styles\Application\`
+1. Replace the content of that res-dict with the source from: https://github.com/unoplatform/Uno.Themes/blob/master/src/library/Uno.Material/Styles/Application/ColorPalette.xaml
+1. Make a few changes to the color:
+    > Here we are replacing the last 2 characters with 00, essentially dropping the blue-channel
+    ```
+    <!-- Light Theme -->
+    <ResourceDictionary x:Key="Light">
+        <Color x:Key="MaterialPrimaryColor">#5B4C00</Color>
+        <Color x:Key="MaterialPrimaryVariantDarkColor">#353F00</Color>
+        <Color x:Key="MaterialPrimaryVariantLightColor">#B6A800</Color>
+        <Color x:Key="MaterialSecondaryColor">#67E500</Color>
+        <Color x:Key="MaterialSecondaryVariantDarkColor">#2BB200</Color>
+        <Color x:Key="MaterialSecondaryVariantLightColor">#9CFF00</Color>
+        <Color x:Key="MaterialBackgroundColor">#FFFFFF</Color>
+        <Color x:Key="MaterialSurfaceColor">#FFFFFF</Color>
+        <Color x:Key="MaterialErrorColor">#F85900</Color>
+        <Color x:Key="MaterialOnPrimaryColor">#FFFF00</Color>
+        <Color x:Key="MaterialOnSecondaryColor">#000000</Color>
+        <Color x:Key="MaterialOnBackgroundColor">#000000</Color>
+        <Color x:Key="MaterialOnSurfaceColor">#000000</Color>
+        <Color x:Key="MaterialOnErrorColor">#000000</Color>
+        <Color x:Key="MaterialOverlayColor">#51000000</Color>
+
+        <!-- ... --->
+    </ResourceDictionary>
+
+    <!-- Dark Theme -->
+    <ResourceDictionary x:Key="Dark">
+        <Color x:Key="MaterialPrimaryColor">#B6A800</Color>
+        <Color x:Key="MaterialPrimaryVariantDarkColor">#353F00</Color>
+        <Color x:Key="MaterialPrimaryVariantLightColor">#D4CB00</Color>
+        <Color x:Key="MaterialSecondaryColor">#67E500</Color>
+        <Color x:Key="MaterialSecondaryVariantDarkColor">#2BB200</Color>
+        <Color x:Key="MaterialSecondaryVariantLightColor">#9CFF00</Color>
+        <Color x:Key="MaterialBackgroundColor">#121212</Color>
+        <Color x:Key="MaterialSurfaceColor">#121212</Color>
+        <Color x:Key="MaterialErrorColor">#CF6600</Color>
+        <Color x:Key="MaterialOnPrimaryColor">#0000FF</Color>
+        <Color x:Key="MaterialOnSecondaryColor">#000000</Color>
+        <Color x:Key="MaterialOnBackgroundColor">#FFFFFF</Color>
+        <Color x:Key="MaterialOnSurfaceColor">#DEFFFFFF</Color>
+        <Color x:Key="MaterialOnErrorColor">#000000</Color>
+        <Color x:Key="MaterialOverlayColor">#51FFFFFF</Color>
+
+        <!-- ... --->
+    </ResourceDictionary>
+
+    <!-- ... --->
+    ```
+    > You may also use this for picking colors: https://material.io/design/color/the-color-system.html#tools-for-picking-colors
+
+## Note
+- Certain controls may require additional setup to setup and/or overriding color pallette. For details, see: [Uno.Material controls extra setup](..\features\uno-material-controls-extra-setup.md)
+
+## Additional Resources
+- [Uno.Material](..\features\uno-material.md) overview
+- Uno.Material library repository: https://github.com/unoplatform/Uno.Themes
+- Tools for picking colors: https://material.io/design/color/the-color-system.html#tools-for-picking-colors

--- a/doc/articles/guides/uno-material-walkthrough.md
+++ b/doc/articles/guides/uno-material-walkthrough.md
@@ -2,11 +2,12 @@
 
 This guide will walk you through the necessary steps to setup and to use the [`Uno.Material` package](https://www.nuget.org/packages/Uno.Material) in an Uno Platform application.
 
-> [!TIP] The complete source code that goes along with this guide is available in the [unoplatform/Uno.Samples](https://github.com/unoplatform/Uno.Samples) GitHub repository - [UnoMaterialSample](https://github.com/unoplatform/Uno.Samples/tree/master/UI/UnoMaterialSample)
+> [!TIP]
+> The complete source code that goes along with this guide is available in the [unoplatform/Uno.Samples](https://github.com/unoplatform/Uno.Samples) GitHub repository - [UnoMaterialSample](https://github.com/unoplatform/Uno.Samples/tree/master/UI/UnoMaterialSample)
 
 ## Prerequisites
 
-### [Visual Studio for Windows](#tab/tabid-vswin)
+# [Visual Studio for Windows](#tab/tabid-vswin)
 
 * [Visual Studio 2019 16.3 or later](http://www.visualstudio.com/downloads/)
   * **Universal Windows Platform** workload installed
@@ -14,7 +15,7 @@ This guide will walk you through the necessary steps to setup and to use the [`U
   * **ASP**.**NET and web** workload installed
   * [Uno Platform Extension](https://marketplace.visualstudio.com/items?itemName=nventivecorp.uno-platform-addin) installed
 
-### [VS Code](#tab/tabid-vscode)
+# [VS Code](#tab/tabid-vscode)
 
 * [**Visual Studio Code**](https://code.visualstudio.com/)
 
@@ -26,7 +27,7 @@ This guide will walk you through the necessary steps to setup and to use the [`U
 
     > Use `dotnet --version` from the terminal to get the version installed.
 
-### [Visual Studio for Mac](#tab/tabid-vsmac)
+# [Visual Studio for Mac](#tab/tabid-vsmac)
 
 * [**Visual Studio for Mac 8.8**](https://visualstudio.microsoft.com/vs/mac/)
 * [**Xcode**](https://apps.apple.com/us/app/xcode/id497799835?mt=12) 10.0 or higher
@@ -36,18 +37,26 @@ This guide will walk you through the necessary steps to setup and to use the [`U
     * [.NET Core 5.0 SDK](https://dotnet.microsoft.com/download/dotnet-core/5.0) (**version 5.0 (SDK 5.0.100)** or later)
 * [**GTK+3**](https://formulae.brew.sh/formula/gtk+3) for running the Skia/GTK projects
 
-### [JetBrains Rider](#tab/tabid-rider)
+# [JetBrains Rider](#tab/tabid-rider)
 
 * [**Rider Version 2020.2+**](https://www.jetbrains.com/rider/download/)
 * [**Rider Xamarin Android Support Plugin**](https://plugins.jetbrains.com/plugin/12056-rider-xamarin-android-support/) (you may install it directly from Rider)
 
+***
+
+<br>
+
+> [!Tip]
+> For a step-by-step guide to installing the prerequisites for your preferred IDE and environment, consult the [Get Started guide](get-started.md).
+
 ## Step-by-steps
 ### Section 1: Setup Uno.Material
-1. Create a new Uno Platform application, following the instructions [here](..\get-started.md).
+1. Create a new Uno Platform application, following the instructions [here](../get-started.md).
 1. Add NuGet package `Uno.Material` to each of project heads by:
-    > [!NOTE] You may have to check the `[x] Include Prerelease` to find this package, as there are currently no stable release.
+    > [!NOTE]
+    > You may have to check the `[x] Include Prerelease` to find this package, as there are currently no stable release.
 
-    > [!NOTE]  
+    > [!NOTE]
     > The project heads refer to the projects targeted to a specific platforms:
     > - UnoMaterialSample.Droid
     > - UnoMaterialSample.iOS
@@ -107,7 +116,7 @@ This guide will walk you through the necessary steps to setup and to use the [`U
     ```
 
 ### Section 2: Using Uno.Material library
-1. Add a couple controls with the material style to `MainPage.xaml`:
+1. Let's add a few controls with the Material style to `MainPage.xaml`:
     ```xml
     <Page x:Class="UnoMaterialSample.MainPage"
           xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -130,7 +139,7 @@ This guide will walk you through the necessary steps to setup and to use the [`U
         </Grid>
     <Page>
     ```
-1. Add a couple new controls from material:
+1. Now we'll add a few new controls that are defined in the Material package - `Card`, `ChipGroup`, `Chip`, and `Divider`:
     ```xml
     <Page ...
           xmlns:material="using:Uno.Material.Controls">
@@ -174,7 +183,7 @@ This guide will walk you through the necessary steps to setup and to use the [`U
 > - Going through the source code of control styles: https://github.com/unoplatform/Uno.Themes/tree/master/src/library/Uno.Material/Styles/Controls
 > - Check out the [Uno.Gallery web app](https://gallery.platform.uno/) (Click on the `<>` button to view xaml source)
 
-### Section 3: Overriding Color Pallette
+### Section 3: Overriding Color Palette
 1. Create the nested folders `Styles\` and then `Styles\Application\` under the `.Shared` project
 1. Add a new Resource Dictionary `ColorPaletteOverride.xaml` under `Styles\Application\`
 1. Replace the content of that res-dict with the source from: https://github.com/unoplatform/Uno.Themes/blob/master/src/library/Uno.Material/Styles/Application/ColorPalette.xaml
@@ -226,11 +235,28 @@ This guide will walk you through the necessary steps to setup and to use the [`U
     <!-- ... --->
     ```
     > You may also use this for picking colors: https://material.io/design/color/the-color-system.html#tools-for-picking-colors
+1. Run the app, you should now see the controls using your new color scheme.
 
 ## Note
 - Certain controls may require additional setup to setup and/or overriding color pallette. For details, see: [Uno.Material controls extra setup](..\features\uno-material-controls-extra-setup.md)
+
+## Get the complete code
+
+See the completed sample on GitHub: [UnoMaterialSample](https://github.com/unoplatform/Uno.Samples/tree/master/UI/UnoMaterialSample)
 
 ## Additional Resources
 - [Uno.Material](..\features\uno-material.md) overview
 - Uno.Material library repository: https://github.com/unoplatform/Uno.Themes
 - Tools for picking colors: https://material.io/design/color/the-color-system.html#tools-for-picking-colors
+
+<br>
+
+***
+
+## Help! I'm having trouble
+
+> [!TIP]
+> If you ran into difficulties with any part of this guide, you can:
+>
+> * Ask for help on our [Discord channel](https://www.platform.uno/discord) - #uno-platform
+> * Ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/uno-platform) with the 'uno-platform' tag

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -44,6 +44,8 @@
           href: guides/localization.md
         - name: How to change app language at runtime
           href: guides/hotswap-app-language.md
+        - name: How to use Uno.Material
+          href: guides/uno-material-walkthrough.md
         - name: How to integrate SignalR
           href: signalr.md
         - name: How to update StatusBar color based on dark/light theme
@@ -55,7 +57,7 @@
     - name: Tutorials
       items:
         - name: Silverlight migration
-          topicHref: silverlight-migration-landing.md 
+          topicHref: silverlight-migration-landing.md
           items:
             - name: Overview
               href: silverlight-migration-landing.md

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -44,8 +44,6 @@
           href: guides/localization.md
         - name: How to change app language at runtime
           href: guides/hotswap-app-language.md
-        - name: How to use Uno.Material
-          href: guides/uno-material-walkthrough.md
         - name: How to integrate SignalR
           href: signalr.md
         - name: How to update StatusBar color based on dark/light theme
@@ -285,7 +283,14 @@
             - name: Other features
               href: Uno.UI.Toolkit.md
         - name: Uno Material
-          href: features/uno-material.md
+          topicHref: features/uno-material.md
+          items:
+            - name: Overview
+              href: features/uno-material.md
+            - name: Uno.Material walkthrough
+              href: guides/uno-material-walkthrough.md
+            - name: Controls extra setup
+              href: guides/uno-material-controls-extra-setup.md
         - name: Fluent icon font
           href: uno-fluent-assets.md
         - name: Lottie animations


### PR DESCRIPTION
GitHub Issue (If applicable): closing #5334

## PR Type

What kind of change does this PR introduce?
- Documentation content changes

## What is the new behavior?
- expanded the existing overview doc for Uno.Material , and
- added related how-to guide

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Related sample code is in another PR: unoplatform/Uno.Samples#52
