### PR TITLE
docs: fixed broken link

### DIFF
--- a/doc/.howto-template.md
+++ b/doc/.howto-template.md
@@ -79,5 +79,5 @@ See the completed sample on GitHub: [YourSample](https://github.com/unoplatform/
 > [!TIP]
 > If you ran into difficulties with any part of this guide, you can:
 > 
-> * Ask for help on our [Discord channel](https://wwww.platform.uno/discord) - #uno-platform
+> * Ask for help on our [Discord channel](https://www.platform.uno/discord) - #uno-platform
 > * Ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/uno-platform) with the 'uno-platform' tag


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type
What kind of change does this PR introduce?
- Bugfix
- Documentation content changes

## What is the new behavior?
fix broken discord link in howto-template.md