### PR TITLE
feat: SystemTrigger struct implementation

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Background/SystemTrigger.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Background/SystemTrigger.Android.cs
@@ -1,0 +1,35 @@
+#if __ANDROID__
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Windows.ApplicationModel.Background
+{
+	public partial class SystemTrigger : IBackgroundTrigger
+	{
+		public  bool OneShot { get; }
+		public SystemTriggerType TriggerType { get; }
+		public SystemTrigger( SystemTriggerType triggerType,  bool oneShot) 
+		{
+			OneShot = oneShot;
+			TriggerType = triggerType;
+			switch(triggerType)
+			{ // supported types
+				case SystemTriggerType.ServicingComplete:
+				case SystemTriggerType.SmsReceived:
+				case SystemTriggerType.TimeZoneChange:
+				case SystemTriggerType.UserAway:
+				case SystemTriggerType.UserPresent:
+					break;
+				default:	// all other types: unsupported
+					throw new NotSupportedException("Unimplemented type of SystemTrigger");
+			}
+		}
+	}
+
+}
+
+#endif

--- a/src/Uno.UWP/ApplicationModel/Background/SystemTrigger.cs
+++ b/src/Uno.UWP/ApplicationModel/Background/SystemTrigger.cs
@@ -1,5 +1,3 @@
-#if __ANDROID__
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,20 +14,7 @@ namespace Windows.ApplicationModel.Background
 		{
 			OneShot = oneShot;
 			TriggerType = triggerType;
-			switch(triggerType)
-			{ // supported types
-				case SystemTriggerType.ServicingComplete:
-				case SystemTriggerType.SmsReceived:
-				case SystemTriggerType.TimeZoneChange:
-				case SystemTriggerType.UserAway:
-				case SystemTriggerType.UserPresent:
-					break;
-				default:	// all other types: unsupported
-					throw new NotSupportedException("Unimplemented type of SystemTrigger");
-			}
 		}
 	}
 
 }
-
-#endif

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/SystemTrigger.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/SystemTrigger.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel.Background
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SystemTrigger : global::Windows.ApplicationModel.Background.IBackgroundTrigger
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool OneShot
 		{
@@ -17,7 +17,7 @@ namespace Windows.ApplicationModel.Background
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.ApplicationModel.Background.SystemTriggerType TriggerType
 		{
@@ -27,7 +27,7 @@ namespace Windows.ApplicationModel.Background
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public SystemTrigger( global::Windows.ApplicationModel.Background.SystemTriggerType triggerType,  bool oneShot) 
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/SystemTrigger.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/SystemTrigger.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel.Background
 {
-	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SystemTrigger : global::Windows.ApplicationModel.Background.IBackgroundTrigger
 	{
-		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool OneShot
 		{
@@ -17,7 +17,7 @@ namespace Windows.ApplicationModel.Background
 			}
 		}
 		#endif
-		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.ApplicationModel.Background.SystemTriggerType TriggerType
 		{
@@ -27,7 +27,7 @@ namespace Windows.ApplicationModel.Background
 			}
 		}
 		#endif
-		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public SystemTrigger( global::Windows.ApplicationModel.Background.SystemTriggerType triggerType,  bool oneShot) 
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): part #3045

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
SystemTrigger is not implemented.

## What is the new behavior?
SystemTrigger is implemented.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


## Other information
This is part of #2655, and continuation of #3965.
Android implementation of SystemTrigger struct/class (some of trigger types, because not all have analogs in Android system).
Also, part of my app SmogMeter, published in Google Play and Amazon.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
