### PR TITLE
fix: Handle errors from Brush callbacks for disposed views

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -414,9 +414,9 @@ namespace Windows.UI.Xaml.Controls
 #if !HAS_EXPENSIVE_TRYFINALLY
 				catch (Exception e)
 				{
-					if (this.Log().IsEnabled(LogLevel.Warning))
+					if (this.Log().IsEnabled(LogLevel.Debug))
 					{
-						this.Log().LogWarning($"Failed to invalidate for brush changed: {e}");
+						this.Log().LogDebug($"Failed to invalidate for brush changed: {e}");
 					}
 				}
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -20,6 +20,7 @@ using Windows.UI.Input;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Automation.Peers;
 using Uno;
+using Microsoft.Extensions.Logging;
 
 #if XAMARIN_IOS
 using UIKit;
@@ -108,7 +109,7 @@ namespace Windows.UI.Xaml.Controls
 			set => SetValue(FontStyleProperty, value);
 		}
 
-		public static DependencyProperty FontStyleProperty { get ; } =
+		public static DependencyProperty FontStyleProperty { get; } =
 			DependencyProperty.Register(
 				"FontStyle",
 				typeof(FontStyle),
@@ -138,7 +139,7 @@ namespace Windows.UI.Xaml.Controls
 			set => SetValue(TextWrappingProperty, value);
 		}
 
-		public static DependencyProperty TextWrappingProperty { get ; } =
+		public static DependencyProperty TextWrappingProperty { get; } =
 			DependencyProperty.Register(
 				"TextWrapping",
 				typeof(TextWrapping),
@@ -167,7 +168,7 @@ namespace Windows.UI.Xaml.Controls
 			set => SetValue(FontWeightProperty, value);
 		}
 
-		public static DependencyProperty FontWeightProperty { get ; } =
+		public static DependencyProperty FontWeightProperty { get; } =
 			DependencyProperty.Register(
 				"FontWeight",
 				typeof(FontWeight),
@@ -201,7 +202,7 @@ namespace Windows.UI.Xaml.Controls
 			set { SetValue(TextProperty, value); }
 		}
 
-		public static DependencyProperty TextProperty { get ; } =
+		public static DependencyProperty TextProperty { get; } =
 			DependencyProperty.Register(
 				"Text",
 				typeof(string),
@@ -244,7 +245,7 @@ namespace Windows.UI.Xaml.Controls
 			set => SetValue(FontFamilyProperty, value);
 		}
 
-		public static DependencyProperty FontFamilyProperty { get ; } =
+		public static DependencyProperty FontFamilyProperty { get; } =
 			DependencyProperty.Register(
 				"FontFamily",
 				typeof(FontFamily),
@@ -274,7 +275,7 @@ namespace Windows.UI.Xaml.Controls
 			set => SetValue(FontSizeProperty, value);
 		}
 
-		public static DependencyProperty FontSizeProperty { get ; } =
+		public static DependencyProperty FontSizeProperty { get; } =
 			DependencyProperty.Register(
 				"FontSize",
 				typeof(double),
@@ -304,7 +305,7 @@ namespace Windows.UI.Xaml.Controls
 			set => SetValue(MaxLinesProperty, value);
 		}
 
-		public static DependencyProperty MaxLinesProperty { get ; } =
+		public static DependencyProperty MaxLinesProperty { get; } =
 			DependencyProperty.Register(
 				"MaxLines",
 				typeof(int),
@@ -333,7 +334,7 @@ namespace Windows.UI.Xaml.Controls
 			set => SetValue(TextTrimmingProperty, value);
 		}
 
-		public static DependencyProperty TextTrimmingProperty { get ; } =
+		public static DependencyProperty TextTrimmingProperty { get; } =
 			DependencyProperty.Register(
 				"TextTrimming",
 				typeof(TextTrimming),
@@ -380,7 +381,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		public static DependencyProperty ForegroundProperty { get ; } =
+		public static DependencyProperty ForegroundProperty { get; } =
 			DependencyProperty.Register(
 				"Foreground",
 				typeof(Brush),
@@ -396,8 +397,29 @@ namespace Windows.UI.Xaml.Controls
 		{
 			void refreshForeground()
 			{
-				OnForegroundChangedPartial();
-				InvalidateTextBlock();
+				// The try-catch here is primarily for the benefit of Android. This callback is raised when (say) the brush color changes,
+				// which may happen when the system theme changes from light to dark. For app-level resources, a large number of views may
+				// be subscribed to changes on the brush, including potentially some that have been removed from the visual tree, collected
+				// on the native side, but not yet collected on the managed side (for Xamarin targets).
+
+				// On Android, in practice this could result in ObjectDisposedExceptions when calling RequestLayout(). The try/catch is to
+				// ensure that callbacks are correctly raised for remaining views referencing the brush which *are* still live in the visual tree.
+#if !HAS_EXPENSIVE_TRYFINALLY
+				try
+#endif
+				{
+					OnForegroundChangedPartial();
+					InvalidateTextBlock();
+				}
+#if !HAS_EXPENSIVE_TRYFINALLY
+				catch (Exception e)
+				{
+					if (this.Log().IsEnabled(LogLevel.Warning))
+					{
+						this.Log().LogWarning($"Failed to invalidate for brush changed: {e}");
+					}
+				}
+#endif
 			}
 
 			_foregroundChanged.Disposable =
@@ -447,7 +469,7 @@ namespace Windows.UI.Xaml.Controls
 			set => SetValue(TextAlignmentProperty, value);
 		}
 
-		public static DependencyProperty TextAlignmentProperty { get ; } =
+		public static DependencyProperty TextAlignmentProperty { get; } =
 			DependencyProperty.Register(
 				"TextAlignment",
 				typeof(TextAlignment),
@@ -503,7 +525,7 @@ namespace Windows.UI.Xaml.Controls
 			set => SetValue(LineHeightProperty, value);
 		}
 
-		public static DependencyProperty LineHeightProperty { get ; } =
+		public static DependencyProperty LineHeightProperty { get; } =
 			DependencyProperty.Register("LineHeight", typeof(double), typeof(TextBlock), new FrameworkPropertyMetadata(0d,
 				propertyChangedCallback: (s, e) => ((TextBlock)s).OnLineHeightChanged())
 			);

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
@@ -79,9 +79,9 @@ namespace Windows.UI.Xaml.Shapes
 #if !HAS_EXPENSIVE_TRYFINALLY
 			catch (Exception e)
 			{
-				if (this.Log().IsEnabled(LogLevel.Warning))
+				if (this.Log().IsEnabled(LogLevel.Debug))
 				{
-					this.Log().LogWarning($"Failed to invalidate for brush changed: {e}");
+					this.Log().LogDebug($"Failed to invalidate for brush changed: {e}");
 				}
 			}
 #endif

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
@@ -10,6 +10,7 @@ using Windows.Foundation;
 using Uno.Extensions;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Microsoft.Extensions.Logging;
 
 namespace Windows.UI.Xaml.Shapes
 {
@@ -54,11 +55,37 @@ namespace Windows.UI.Xaml.Shapes
 				propertyChangedCallback: (s, e) => ((Shape)s).OnFillChanged((Brush)e.NewValue)
 #else
 				options: FrameworkPropertyMetadataOptions.ValueInheritsDataContext | FrameworkPropertyMetadataOptions.LogicalChild | FrameworkPropertyMetadataOptions.AffectsArrange,
-				propertyChangedCallback: (s, e) => ((Shape)s)._brushChanged.Disposable = Brush.AssignAndObserveBrush((Brush)e.NewValue, _ => s.InvalidateArrange(), imageBrushCallback: () => s.InvalidateArrange())
+				propertyChangedCallback: (s, e) => ((Shape)s)._brushChanged.Disposable = Brush.AssignAndObserveBrush((Brush)e.NewValue, _ => ((Shape)s).InvalidateForFillChanged(), imageBrushCallback: () => ((Shape)s).InvalidateForFillChanged())
 #endif
 			)
 		);
 		#endregion
+
+		private void InvalidateForFillChanged()
+		{
+			// The try-catch here is primarily for the benefit of Android. This callback is raised when (say) the brush color changes,
+			// which may happen when the system theme changes from light to dark. For app-level resources, a large number of views may
+			// be subscribed to changes on the brush, including potentially some that have been removed from the visual tree, collected
+			// on the native side, but not yet collected on the managed side (for Xamarin targets).
+
+			// On Android, in practice this could result in ObjectDisposedExceptions when calling RequestLayout(). The try/catch is to
+			// ensure that callbacks are correctly raised for remaining views referencing the brush which *are* still live in the visual tree.
+#if !HAS_EXPENSIVE_TRYFINALLY
+			try
+#endif
+			{
+				InvalidateArrange();
+			}
+#if !HAS_EXPENSIVE_TRYFINALLY
+			catch (Exception e)
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().LogWarning($"Failed to invalidate for brush changed: {e}");
+				}
+			}
+#endif
+		}
 
 		#region Stroke Dependency Property
 		public Brush Stroke


### PR DESCRIPTION
Wrap the callbacks from TextBlock.Foreground and Shape.Fill Brush changes in try/catch. 

This fixes a bug on Android where system light/dark theme changes were only partially completing because they were interrupted by ObjectDisposedExceptions from calling InvalidateMeasure() on a disposed view.

GitHub Issue (If applicable): fixes https://github.com/unoplatform/Uno.Themes/issues/508

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
