### PR TITLE
feat: Contact and ContactAddress, warning when setting to longer than…

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Contacts/Contact.cs
+++ b/src/Uno.UWP/ApplicationModel/Contacts/Contact.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using Uno;
 using Windows.Foundation.Collections;
 using Windows.Storage.Streams;
+using Uno.Logging;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
 
 namespace Windows.ApplicationModel.Contacts
 {
@@ -66,50 +69,122 @@ namespace Windows.ApplicationModel.Contacts
 		/// </summary>
 		public IList<ContactPhone> Phones { get; internal set; } = new NonNullList<ContactPhone>();
 
+		private string _firstName = "";
 		/// <summary>
 		/// Gets and sets the first name for a contact.
 		/// </summary>
-		public string FirstName { get; set; } = "";
+		public string FirstName
+		{
+			get => _firstName;
+			set
+			{
+				_firstName = value;
+				LogWarningIfLenExceedsUWPLimit(value, 64, "FirstName");
+			}
+		}
 
+		private string _middleName = "";
 		/// <summary>
 		/// Gets and sets the middle name for a contact.
 		/// </summary>
-		public string MiddleName { get; set; } = "";
+		public string MiddleName
+		{
+			get => _middleName;
+			set
+			{
+				_middleName = value;
+				LogWarningIfLenExceedsUWPLimit(value, 64, "MiddleName");
+			}
+		}
 
+		private string _lastName = "";
 		/// <summary>
 		/// Gets and sets the last name for a contact.
 		/// </summary>
-		public string LastName { get; set; } = "";
+		public string LastName
+		{
+			get => _lastName;
+			set
+			{
+				_lastName = value;
+				LogWarningIfLenExceedsUWPLimit(value, 64, "LastName");
+			}
+		}
 
+		private string _honorificNamePrefix = "";
 		/// <summary>
 		/// Gets and sets the honorific prefix for the name for a contact.
 		/// </summary>
-		public string HonorificNamePrefix { get; set; } = "";
+		public string HonorificNamePrefix
+		{
+			get => _honorificNamePrefix;
+			set
+			{
+				_honorificNamePrefix = value;
+				LogWarningIfLenExceedsUWPLimit(value, 64, "HonorificNamePrefix");
+			}
+		}
 
+		private string _honorificNameSuffix = "";
 		/// <summary>
 		/// Gets and sets the honorific suffix for the name for a contact.
 		/// </summary>
-		public string HonorificNameSuffix { get; set; } = "";
+		public string HonorificNameSuffix
+		{
+			get => _honorificNameSuffix;
+			set
+			{
+				_honorificNameSuffix = value;
+				LogWarningIfLenExceedsUWPLimit(value, 64, "HonorificNameSuffix");
+			}
+		}
 
 		/// <summary>
 		/// Gets or sets the nickname for the Contact.
 		/// </summary>
 		public string Nickname { get; set; } = "";
 
+		private string _notes = "";
 		/// <summary>
 		/// Gets and sets notes for a contact.
 		/// </summary>
-		public string Notes { get; set; } = "";
+		public string Notes
+		{
+			get => _notes;
+			set
+			{
+				_notes = value;
+				LogWarningIfLenExceedsUWPLimit(value, 4096, "Notes");
+			}
+		}
 
+		private string _yomiGivenName = "";
 		/// <summary>
 		/// Gets the Yomi (phonetic Japanese equivalent) given name for a contact.
 		/// </summary>
-		public string YomiGivenName { get; set; } = "";
+		public string YomiGivenName
+		{
+			get => _yomiGivenName;
+			set
+			{
+				_yomiGivenName = value;
+				LogWarningIfLenExceedsUWPLimit(value, 120, "YomiGivenName");
+			}
+		}
 
+		private string _yomiFamilyName = "";
 		/// <summary>
 		/// Gets the Yomi (phonetic Japanese equivalent) family name for a contact.
 		/// </summary>
-		public string YomiFamilyName { get; set; } = "";
+		public string YomiFamilyName
+		{
+			get => _yomiFamilyName;
+			set
+			{
+				_yomiFamilyName = value;
+				LogWarningIfLenExceedsUWPLimit(value, 120, "YomiFamilyName");
+			}
+		}
 
 		[NotImplemented]
 		public IRandomAccessStreamReference? Thumbnail { get; set; }
@@ -122,5 +197,20 @@ namespace Windows.ApplicationModel.Contacts
 
 		[NotImplemented]
 		public IRandomAccessStreamReference? SourceDisplayPicture { get; set; }
+
+		private void LogWarningIfLenExceedsUWPLimit(string value, int lenLimit, string variableName)
+		{
+			if (value.Length > lenLimit)
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().LogWarning($"Windows.ApplicationModel.Contacts.Contact.{variableName} is set to string longer than UWP limit ({lenLimit} chars)");
+				}
+			}
+		}
+
+
+
+
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/Contacts/ContactAddress.cs
+++ b/src/Uno.UWP/ApplicationModel/Contacts/ContactAddress.cs
@@ -1,45 +1,120 @@
 ﻿#nullable enable
 
+using Uno.Logging;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+
 namespace Windows.ApplicationModel.Contacts
 {
+
+
 	/// <summary>
 	/// Represents the address of a contact.
 	/// </summary>
 	public partial class ContactAddress
 	{
+
 		/// <summary>
 		/// Gets and sets the kind of contact address.
 		/// </summary>
 		public ContactAddressKind Kind { get; set; } = ContactAddressKind.Home;
 
+		private string _streetAddress = string.Empty;
 		/// <summary>
 		/// Gets and sets the street address of a contact address.
 		/// </summary>
-		public string StreetAddress { get; set; } = string.Empty;
+		public string StreetAddress
+		{
+			get => _streetAddress;
+			set
+			{
+				_streetAddress = value;
+				LogWarningIfLenExceedsUWPLimit(value, 1024, "StreetAddress");
+			}
+		}
 
+		private string _region = string.Empty;
 		/// <summary>
 		/// Gets and sets the region of a contact address.
 		/// </summary>
-		public string Region { get; set; } = string.Empty;
+		public string Region
+		{
+			get => _region;
+			set
+			{
+				_region = value;
+				LogWarningIfLenExceedsUWPLimit(value, 1024, "Region");
+			}
+		}
 
+		private string _postalCode = string.Empty;
 		/// <summary>
 		/// Gets and sets the postal code of a contact address.
 		/// </summary>
-		public string PostalCode { get; set; } = string.Empty;
+		public string PostalCode
+		{
+			get => _postalCode;
+			set
+			{
+				_postalCode = value;
+				LogWarningIfLenExceedsUWPLimit(value, 1024, "PostalCode");
+			}
+		}
 
+		private string _locality = string.Empty;
 		/// <summary>
 		/// Gets and sets the locality of a contact address.
 		/// </summary>
-		public string Locality { get; set; } = string.Empty;
+		public string Locality
+		{
+			get => _locality;
+			set
+			{
+				_locality = value;
+				LogWarningIfLenExceedsUWPLimit(value, 1024, "Locality");
+			}
+		}
 
+		private string _country = string.Empty;
 		/// <summary>
 		/// Gets and sets the country of a contact address.
 		/// </summary>
-		public string Country { get; set; } = string.Empty;
+		public string Country
+		{
+			get => _country;
+			set
+			{
+				_country = value;
+				LogWarningIfLenExceedsUWPLimit(value, 1024, "Country");
+			}
+		}
+
+		private string _description = string.Empty;
 
 		/// <summary>
 		/// Gets and sets the description of a contact address.
 		/// </summary>
-		public string Description { get; set; } = string.Empty;
+		public string Description
+		{
+			get => _description;
+			set
+			{
+				_description = value;
+				LogWarningIfLenExceedsUWPLimit(value, 512, "Country");
+			}
+		}
+
+		private void LogWarningIfLenExceedsUWPLimit(string value, int lenLimit, string variableName)
+		{
+			if (value.Length > lenLimit)
+			{
+				if (!this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().LogWarning($"Windows.ApplicationModel.Contacts.ContactAddress.{variableName} is set to string longer than UWP limit ({lenLimit} chars)");
+				}
+			}
+		}
+
+
 	}
 }


### PR DESCRIPTION
… UWP

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Contact and ContactAddress fields can be set to longer than UWP.
Currently, no warning is produced.

## What is the new behavior?
Setting field to longer than UWP len limit produces warning.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
This is part of #2544, waiting for over year now. In the meantime, MartinZikmund implemented these struct/class, but I think such "length warning" is nice feature.
As I'm recompiling my apps with newer Uno, and rebasing my PRs, some of them reports conflicts to be resolved. This PR is such "change merging".

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
