### PR TITLE
feat(animations): Add compositor thread on Android

### DIFF
--- a/doc/articles/composition.md
+++ b/doc/articles/composition.md
@@ -1,0 +1,34 @@
+# Composition
+
+Composition Visuals make up the visual tree structure which all other features of the composition API use and build on.
+The API allows developers to define and create one or many visual objects each representing a single node in a visual tree.
+
+To get more info, you can refer to [Microsoft's documentation](https://docs.microsoft.com/en-us/windows/uwp/composition/composition-visual-tree).
+
+Uno does support few APIs of the [`Windows.UI.Composition` namespace](https://docs.microsoft.com/en-us/uwp/api/windows.ui.composition?view=winrt).
+
+** On Android, composition APIs are functionnal only for Android 10 and upper (API 29).**
+
+## Compositor Thread [Android]
+
+On Android, the composition refers to the [`Draw`](https://developer.android.com/reference/android/view/View#draw(android.graphics.Canvas)) and [`OnDraw`](https://developer.android.com/reference/android/view/View#onDraw(android.graphics.Canvas)) methods.
+To get more info about custom drawing on Android, you can refer to the [Android's documentation](https://developer.android.com/training/custom-views/custom-drawing).
+
+By default, those methods are invoked on the UI Thread.
+
+With Uno, you can request to run those methods on a dedicated thread by setting in your Android application's constructor:
+
+```csharp
+Uno.UI.FeatureConfiguration.Composition.Configuration = Uno.UI.FeatureConfiguration.Composition.Options.Enabled;
+```
+
+This thread will also be used for [independent animations](https://docs.microsoft.com/en-us/windows/uwp/design/motion/storyboarded-animations#dependent-and-independent-animations).
+
+**When overriding the `[On]Draw` methods, it's really important to not access any state that can be edited from the UI Thread, including any `DependencyProperty`.**
+**Instead, you should capture the state of your control into a `RenderNode` during the `ArrangeOverride` and render it on the provided `Canvas`.**
+
+_There is few known issues associated with the used of the compositor thread, [make sure to read them](#known_issues)._
+
+## Knwon issues
+
+* When using the compositor thread, the native ripple effect of Android (used in native buttons) will not work anymore.

--- a/doc/articles/composition.md
+++ b/doc/articles/composition.md
@@ -24,11 +24,11 @@ Uno.CompositionConfiguration.Configuration = Uno.CompositionConfiguration.Option
 
 This thread will also be used for [independent animations](https://docs.microsoft.com/en-us/windows/uwp/design/motion/storyboarded-animations#dependent-and-independent-animations).
 
-**When overriding the `[On]Draw` methods, it's really important to not access any state that can be edited from the UI Thread, including any `DependencyProperty`.**
+**When overriding the `[On]Draw` methods, it is really important not to access any state that can be edited from the UI Thread, including any `DependencyProperty`.**
 **Instead, you should capture the state of your control into a `RenderNode` during the `ArrangeOverride` and render it on the provided `Canvas`.**
 
-_There is few known issues associated with the used of the compositor thread, [make sure to read them](#known_issues)._
+_There are few known issues associated with the used of the compositor thread, [make sure to read the section below](#known_issues)._
 
 ## Knwon issues
 
-* When using the compositor thread, the native ripple effect of Android (used in native buttons) will not work anymore.
+* When using the compositor thread, the native ripple effect of Android (used in native buttons) does not work.

--- a/doc/articles/composition.md
+++ b/doc/articles/composition.md
@@ -19,7 +19,7 @@ By default, those methods are invoked on the UI Thread.
 With Uno, you can request to run those methods on a dedicated thread by setting in your Android application's constructor:
 
 ```csharp
-Uno.UI.FeatureConfiguration.Composition.Configuration = Uno.UI.FeatureConfiguration.Composition.Options.Enabled;
+Uno.CompositionConfiguration.Configuration = Uno.CompositionConfiguration.Options.Enabled;
 ```
 
 This thread will also be used for [independent animations](https://docs.microsoft.com/en-us/windows/uwp/design/motion/storyboarded-animations#dependent-and-independent-animations).

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -531,5 +531,24 @@ namespace Uno.UI
 			public static bool EnableBitmapIconTint { get; set; } = false;
 #endif
 		}
+
+		public static class Composition
+		{
+			/// <summary>
+			/// 
+			/// </summary>
+			/// <remarks>This is captured on window creation, this means that you can </remarks>
+			public static Options Configuration { get; set; } = Options.Disabled;
+
+			[Flags]
+			public enum Options
+			{
+				Disabled = 0,
+
+				UseCompositorThread = 0x1,
+
+				Enabled = UseCompositorThread,
+			}
+		}
 	}
 }

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -531,42 +531,5 @@ namespace Uno.UI
 			public static bool EnableBitmapIconTint { get; set; } = false;
 #endif
 		}
-
-		public static class Composition
-		{
-			/// <summary>
-			/// Configures the composition options for the whole application.
-			/// Refer to uno's documentation to get more info about capabilities and impacts of composition for each platform.
-			/// </summary>
-			/// <remarks>
-			/// Due to the nature of the core feature of composition, this flag must be set as soon as possible in your application startup.
-			/// Changing configuration while the application is already running will result to an undefined behavior.
-			/// </remarks>
-			public static Options Configuration { get; set; } = Options.Disabled;
-
-			[Flags]
-			public enum Options
-			{
-				/// <summary>
-				/// Disables all composition supports in the application.
-				/// </summary>
-				Disabled = 0,
-
-#if __ANDROID__
-				/// <summary>
-				/// Use a dedicated background thread to render the views.
-				/// </summary>
-				UseCompositorThread = 0x1,
-#endif
-				/// <summary>
-				/// Enables all composition capabilities for this platform.
-				/// </summary>
-#if __ANDROID__
-				Enabled = UseCompositorThread,
-#else
-				Enabled = 0,
-#endif
-			}
-		}
 	}
 }

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -535,19 +535,37 @@ namespace Uno.UI
 		public static class Composition
 		{
 			/// <summary>
-			/// 
+			/// Configures the composition options for the whole application.
+			/// Refer to uno's documentation to get more info about capabilities and impacts of composition for each platform.
 			/// </summary>
-			/// <remarks>This is captured on window creation, this means that you can </remarks>
+			/// <remarks>
+			/// Due to the nature of the core feature of composition, this flag must be set as soon as possible in your application startup.
+			/// Changing configuration while the application is already running will result to an undefined behavior.
+			/// </remarks>
 			public static Options Configuration { get; set; } = Options.Disabled;
 
 			[Flags]
 			public enum Options
 			{
+				/// <summary>
+				/// Disables all composition supports in the application.
+				/// </summary>
 				Disabled = 0,
 
+#if __ANDROID__
+				/// <summary>
+				/// Use a dedicated background thread to render the views.
+				/// </summary>
 				UseCompositorThread = 0x1,
-
+#endif
+				/// <summary>
+				/// Enables all composition capabilities for this platform.
+				/// </summary>
+#if __ANDROID__
 				Enabled = UseCompositorThread,
+#else
+				Enabled = 0,
+#endif
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
@@ -122,7 +122,7 @@ namespace Windows.UI.Xaml
 
 		protected override void OnCreate(Bundle bundle)
 		{
-			if (FeatureConfiguration.Composition.Configuration.HasFlag(FeatureConfiguration.Composition.Options.UseCompositorThread))
+			if (Uno.CompositionConfiguration.UseCompositorThread)
 			{
 				Uno.UI.Composition.CompositorThread.Start(this);
 			}

--- a/src/Uno.UWP/UI/Composition/Uno/CompositionConfiguration.cs
+++ b/src/Uno.UWP/UI/Composition/Uno/CompositionConfiguration.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+
+namespace Uno
+{
+	public static partial class CompositionConfiguration
+	{
+		/// <summary>
+		/// Configures the composition options for the whole application.
+		/// Refer to uno's documentation to get more info about capabilities and impacts of composition for each platform.
+		/// </summary>
+		/// <remarks>
+		/// Due to the nature of the core feature of composition, this flag must be set as soon as possible in your application startup.
+		/// Changing configuration while the application is already running will result to an undefined behavior.
+		/// </remarks>
+		public static Options Configuration { get; set; } = Options.Disabled;
+
+		[Flags]
+		public enum Options
+		{
+			/// <summary>
+			/// Disables all composition supports in the application.
+			/// </summary>
+			Disabled = 0,
+
+			/// <summary>
+			/// [ANDROID ONLY] Use a dedicated background thread to render the views.
+			/// </summary>
+			UseCompositorThread = 0x1,
+
+			/// <summary>
+			/// Enables all composition capabilities for the current platform.
+			/// </summary>
+			Enabled = UseCompositorThread,
+		}
+
+		internal static bool UseCompositorThread
+		{
+			get
+			{
+				var value = Configuration.HasFlag(Options.UseCompositorThread);
+#if __ANDROID__
+				value &= ((int)Android.OS.Build.VERSION.SdkInt) >= 29; // Android 10, for RenderNode which is required for all composition operations!
+#endif
+				return value;
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/Uno/CompositorThread.android.cs
+++ b/src/Uno.UWP/UI/Composition/Uno/CompositorThread.android.cs
@@ -77,8 +77,8 @@ namespace Uno.UI.Composition
 			_frameRendered.Wait();
 		}
 
-#if __ANDROID_11__
-		void ISurfaceHolderCallback2.SurfaceRedrawNeededAsync(ISurfaceHolder? holder, Java.Lang.IRunnable drawingFinished)
+		// Note: We don't make it an explicit interface implementation as it's not available yet on the Xamarin.Android version used by the CI
+		public void /*ISurfaceHolderCallback2.*/SurfaceRedrawNeededAsync(ISurfaceHolder? holder, Java.Lang.IRunnable drawingFinished)
 		{
 			_frameRendered.Reset();
 
@@ -98,7 +98,6 @@ namespace Uno.UI.Composition
 				}
 			});
 		}
-#endif
 
 		private void SetBounds(int width, int height)
 		{

--- a/src/Uno.UWP/UI/Composition/Uno/CompositorThread.android.cs
+++ b/src/Uno.UWP/UI/Composition/Uno/CompositorThread.android.cs
@@ -56,7 +56,7 @@ namespace Uno.UI.Composition
 			Start();
 		}
 
-		void ISurfaceHolderCallback.SurfaceChanged(ISurfaceHolder holder, Format format, int width, int height)
+		void ISurfaceHolderCallback.SurfaceChanged(ISurfaceHolder? holder, Format format, int width, int height)
 		{
 			SetBounds(width, height);
 		}
@@ -77,7 +77,8 @@ namespace Uno.UI.Composition
 			_frameRendered.Wait();
 		}
 
-		void ISurfaceHolderCallback2.SurfaceRedrawNeededAsync(ISurfaceHolder holder, Java.Lang.IRunnable drawingFinished)
+#if __ANDROID_11__
+		void ISurfaceHolderCallback2.SurfaceRedrawNeededAsync(ISurfaceHolder? holder, Java.Lang.IRunnable drawingFinished)
 		{
 			_frameRendered.Reset();
 
@@ -97,6 +98,7 @@ namespace Uno.UI.Composition
 				}
 			});
 		}
+#endif
 
 		private void SetBounds(int width, int height)
 		{

--- a/src/Uno.UWP/UI/Composition/Uno/CompositorThread.android.cs
+++ b/src/Uno.UWP/UI/Composition/Uno/CompositorThread.android.cs
@@ -1,0 +1,186 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Android.App;
+using Android.Graphics;
+using Android.OS;
+using Android.Views;
+using Uno.Extensions;
+using Uno.Logging;
+using Exception = System.Exception;
+using Point = Windows.Foundation.Point;
+using Rect = Windows.Foundation.Rect;
+using ThreadPriority = System.Threading.ThreadPriority;
+
+namespace Uno.UI.Composition
+{
+	internal interface ICompositionRoot
+	{
+		Window Window { get; }
+
+		View Content { get; }
+	}
+
+	internal class CompositorThread : Java.Lang.Object, ISurfaceHolderCallback2, Choreographer.IFrameCallback
+	{
+		[ThreadStatic] // Static to the related UI Thread !!!
+		private static CompositorThread? _current;
+
+		public static void Start(ICompositionRoot activity)
+			=> _current ??= new CompositorThread(activity);
+
+		//private RenderNode _animationsNode;
+		//private List<(RenderNode node, double x, double y)> _animatedNodes = new List<(RenderNode node, double x, double y)>();
+
+		private readonly HardwareRenderer _hwRender = new HardwareRenderer();
+		private readonly RenderNode _visualTree = new RenderNode("visual-tree");
+		private readonly ManualResetEventSlim _frameRendered = new ManualResetEventSlim(false);
+		private readonly ICompositionRoot _activity;
+
+		private Thread? _thread;
+
+		public CompositorThread(ICompositionRoot activity)
+		{
+			_activity = activity;
+
+			_hwRender.SetContentRoot(_visualTree);
+			_activity.Window!.TakeSurface(this);
+		}
+		
+		void ISurfaceHolderCallback.SurfaceCreated(ISurfaceHolder? holder)
+		{
+			_hwRender.SetSurface(holder!.Surface);
+
+			Start();
+		}
+
+		void ISurfaceHolderCallback.SurfaceChanged(ISurfaceHolder holder, Format format, int width, int height)
+		{
+			_visualTree.SetPosition(new Rect(new Point(), new Size(width, height)));
+		}
+
+		void ISurfaceHolderCallback.SurfaceDestroyed(ISurfaceHolder? holder)
+		{
+			Stop();
+
+			_hwRender?.Stop();
+			_hwRender?.Destroy(); // Note: This only release the surface, we can restore it by setting a new surface
+		}
+
+		void ISurfaceHolderCallback2.SurfaceRedrawNeeded(ISurfaceHolder? holder)
+		{
+			_frameRendered.Reset();
+			_frameRendered.Wait();
+		}
+
+		void ISurfaceHolderCallback2.SurfaceRedrawNeededAsync(ISurfaceHolder holder, Java.Lang.IRunnable drawingFinished)
+		{
+			_frameRendered.Reset();
+
+			Task.Run(() => // TODO: Should we invoke drawingFinished on calling / UI thread?
+			{
+				try
+				{
+					_frameRendered.Wait();
+					drawingFinished.Run();
+				}
+				catch (Exception e)
+				{
+					this.Log().Error("Async redraw failed.", e);
+				}
+			});
+		}
+
+		private void Start()
+		{
+			if (_thread is {})
+			{
+				this.Log().Warn("Try to start an already running compositor thread.");
+				return;
+			}
+
+			_thread = new Thread(() =>
+			{
+				_hwRender.Start();
+
+				Looper.Prepare(); // Required to get a Choreographer.Instance
+				Choreographer.Instance!.PostFrameCallback(this);
+
+				Looper.Loop(); // Start the looper so the Choreographer.Instance will invoke our callback
+			})
+			{
+				Name = "Compositor",
+				Priority = ThreadPriority.AboveNormal
+			};
+
+			_thread.Start();
+		}
+
+		private void Stop()
+		{
+			try
+			{
+				_thread?.Abort();
+			}
+			catch (Exception e)
+			{
+				this.Log().Warn("Failed to abort compositor thread.", e);
+			}
+			_thread = null;
+		}
+
+		void Choreographer.IFrameCallback.DoFrame(long frameTimeNanos)
+		{
+			RenderFrame(frameTimeNanos);
+
+			Choreographer.Instance!.PostFrameCallback(this);
+		}
+
+		private void RenderFrame(long frameTimeNanos)
+		{
+			RecordingCanvas canvas;
+			try
+			{
+				canvas = _visualTree.BeginRecording();
+			}
+			catch (Java.Lang.IllegalStateException)
+			{
+				// Cannot start recording (most probably recording is already running somehow).
+				return;
+			}
+
+			try
+			{
+				_activity.Content.Draw(canvas);
+			}
+			catch (Exception e)
+			{
+				this.Log().Error("Failed to render frame.", e);
+			}
+			finally
+			{
+				_visualTree.EndRecording();
+
+				var request = _hwRender.CreateRenderRequest();
+				var needsSync = !_frameRendered.IsSet;
+
+				if (needsSync)
+				{
+					request.SetWaitForPresent(true);
+				}
+
+				request.SyncAndDraw();
+
+				if (needsSync)
+				{
+					_frameRendered.Set();
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/Uno/ICompositionRoot.android.cs
+++ b/src/Uno.UWP/UI/Composition/Uno/ICompositionRoot.android.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Linq;
+using Android.Views;
+
+namespace Uno.UI.Composition
+{
+	internal interface ICompositionRoot
+	{
+		Window Window { get; }
+
+		View Content { get; }
+	}
+}


### PR DESCRIPTION
Epic: https://github.com/unoplatform/uno/issues/5586

## Feature
Add compositor thread on Android

## What is the current behavior?
Composition is done on UI thread

## What is the new behavior?
🙃

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~ ==> Part of a bigger 
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

