### PR TITLE
Added support for HTML native styling.

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1405,6 +1405,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressBar.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\RadioButtonTests\RadioButton2450.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4954,6 +4958,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ProgressRing\WindowsProgressRing_GH1220.xaml.cs">
       <DependentUpon>WindowsProgressRing_GH1220.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressBar.xaml.cs">
+      <DependentUpon>ProgressBar.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\RadioButtonTests\RadioButton2450.xaml.cs">
       <DependentUpon>RadioButton2450.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Buttons_Native.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Buttons_Native.xaml
@@ -1,19 +1,18 @@
 ﻿<UserControl
-    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Buttons_Native"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:wasm="http://uno.ui/wasm"
-    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:macos="http://uno.ui/macos"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.Button"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d wasm macos"
-    d:DesignHeight="300"
-    d:DesignWidth="400">
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Buttons_Native"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:wasm="http://uno.ui/wasm"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:macos="http://uno.ui/macos"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.Button"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d wasm macos"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
 	
 	<UserControl.Resources>
-		<wasm:Style x:Key="NativeDefaultButton" BasedOn="{StaticResource DefaultXamlButton}" TargetType="Button" />
 		<wasm:Style x:Key="NativeDefaultToggleSwitch" BasedOn="{StaticResource DefaultXamlToggleSwitch}" TargetType="ToggleSwitch"  />
 		
 		<macos:Style x:Key="NativeDefaultButton" BasedOn="{StaticResource DefaultXamlButton}" TargetType="Button"  />
@@ -24,7 +23,7 @@
 	</UserControl.Resources>
 
 	<Grid>
-		<StackPanel>
+		<StackPanel Spacing="5">
 			<TextBlock Text="This sample is only valid on platforms providing native styles"/>
 			<TextBlock Text="No value" x:Name="result" />
 			<TextBlock Text="No value" x:Name="resultTapped" />
@@ -62,13 +61,22 @@
 							OnContent="On Content"
 							OffContent="Off Content"
 							Toggled="OnToggled"
-						    IsEnabled="False"
+							IsEnabled="False"
 							x:Name="toggleSwitch02"/>
 
 			<Button Style="{StaticResource NativeDefaultButton}"
 					Content="Enable ToggleSwitch 02"
 					x:Name="enableToggleSwitch02"
 					Click="OnClickEnableToggleSwitch02" />
+
+		  <Button Style="{StaticResource NativeDefaultButton}"
+				  Content="Click to increment"
+				  Click="OnIncrement" />
+
+		  <Button Style="{StaticResource NativeDefaultButton}"
+				  Content="Tap to increment"
+				  Tapped="OnIncrement" />
+
 		</StackPanel>
 	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Buttons_Native.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Buttons_Native.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -23,19 +24,19 @@ using ICommand = System.Windows.Input.ICommand;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls
 {
-    [SampleControlInfo("Button", "Buttons_Native")]
+	[SampleControlInfo("Button", "Buttons_Native")]
 
-    public sealed partial class Buttons_Native : UserControl
-    {
+	public sealed partial class Buttons_Native : UserControl
+	{
 		int clickActionsCounter = 0;
 		int commandActionsCounter = 0;
 		int tappedActionsCounter = 0;
 		int toggleActionsCounter = 0;
 
 		public Buttons_Native()
-        {
-            this.InitializeComponent();
-        }
+		{
+			this.InitializeComponent();
+		}
 
 		public ICommand ClickCommand => new DelegateCommand<object>(o => resultCommand.Text = $"Command {o} ({++commandActionsCounter})");
 
@@ -77,6 +78,18 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls
 		private void OnClickEnableToggleSwitch02(object sender, object args)
 		{
 			toggleSwitch02.IsEnabled = true;
+		}
+
+		private void OnIncrement(object sender, object args)
+		{
+			if (sender is Windows.UI.Xaml.Controls.Button btn)
+			{
+				var txt = Convert.ToString(btn.Content);
+				var current = int.TryParse(txt, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out var i)
+					? i
+					: 0;
+				btn.Content = "" + (current + 1);
+			}
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button.xaml
@@ -13,39 +13,46 @@
 	d:DesignHeight="300"
 	d:DesignWidth="400">
 
-	<controls:SampleControl SampleDescription="CheckBox_Button">
-		<controls:SampleControl.SampleContent>
-			<DataTemplate>
+	<StackPanel Spacing="4">
 
-				<StackPanel>
+		<TextBlock Text="Native Checkbox" />
+		<CheckBox Content="Native Checkbox - unchecked"
+				  Command="{Binding [SampleCommand]}"
+				  Style="{StaticResource NativeDefaultCheckBox}" />
+		<CheckBox Content="Native Checkbox - checked"
+				  Command="{Binding [SampleCommand]}"
+				  Style="{StaticResource NativeDefaultCheckBox}"
+				  IsChecked="true" />
+		<CheckBox Content="Native Checkbox - 3-states"
+		          Command="{Binding [SampleCommand]}"
+		          Style="{StaticResource NativeDefaultCheckBox}"
+				  IsThreeState="True"
+		          IsChecked="{x:Null}" />
 
-					<TextBlock Text="Native Checkbox" />
-					<CheckBox Content="Checkbox"
-							  Command="{Binding [SampleCommand]}"
-							  android:Style="{StaticResource AndroidCheckBoxStyle}" />
-					<CheckBox Content="Checkbox"
-							  Command="{Binding [SampleCommand]}"
-							  android:Style="{StaticResource AndroidCheckBoxStyle}"
-							  IsChecked="true" />
+		<TextBlock Text="Checkbox with the default style from UWA" />
+		<CheckBox Content="UWACheckbox - unchecked"
+				  Command="{Binding [SampleCommand]}" />
+		<CheckBox Content="UWACheckbox - checked"
+				  Command="{Binding [SampleCommand]}"
+				  IsChecked="true" />
+		<CheckBox Content="UWACheckbox - 3-states"
+		          Command="{Binding [SampleCommand]}"
+		          IsThreeState="True"
+		          IsChecked="{x:Null}" />
 
-					<TextBlock Text="Checkbox with the default style from UWA" />
-					<CheckBox Content="UWACheckbox"
-							  Command="{Binding [SampleCommand]}" />
-					<CheckBox Content="UWACheckbox"
-							  Command="{Binding [SampleCommand]}"
-							  IsChecked="true" />
+		<TextBlock Text="Checkbox with the default style from UWA Disabled" />
+		<CheckBox Content="UWACheckbox- unchecked"
+				  Command="{Binding [SampleCommand]}"
+				  IsEnabled="False" />
+		<CheckBox Content="UWACheckbox - checked"
+				  Command="{Binding [SampleCommand]}"
+				  IsEnabled="False"
+				  IsChecked="true" />
+		<CheckBox Content="UWACheckbox - 3-states"
+		          Command="{Binding [SampleCommand]}"
+		          IsEnabled="False"
+		          IsThreeState="True"
+		          IsChecked="{x:Null}" />
 
-					<TextBlock Text="Checkbox with the default style from UWA Disabled" />
-					<CheckBox Content="UWACheckbox"
-							  Command="{Binding [SampleCommand]}"
-							  IsEnabled="False" />
-					<CheckBox Content="UWACheckbox"
-							  Command="{Binding [SampleCommand]}"
-							  IsEnabled="False"
-							  IsChecked="true" />
-
-				</StackPanel>
-			</DataTemplate>
-		</controls:SampleControl.SampleContent>
-	</controls:SampleControl>
+	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button.xaml.cs
@@ -4,7 +4,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
 {
-	[SampleControlInfo("Button", "CheckBox_Button", typeof(ButtonTestsViewModel))]
+	[Sample("Button", ViewModelType = typeof(ButtonTestsViewModel))]
 	public sealed partial class CheckBox_Button : UserControl
 	{
 		public CheckBox_Button()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Radio_Button.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Radio_Button.xaml
@@ -1,6 +1,5 @@
 <UserControl
 	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.Radio_Button"
-	xmlns:controls="using:Uno.UI.Samples.Controls"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -10,16 +9,21 @@
 	d:DesignHeight="300"
 	d:DesignWidth="400">
 
-	<controls:SampleControl SampleDescription="Radio_Button">
-		<controls:SampleControl.SampleContent>
-			<DataTemplate>
-				<StackPanel Background="CornflowerBlue">
-					<RadioButton Content="Checkbox 01" Command="{Binding [CheckBox01_Command]}" />
-					<RadioButton Content="Checkbox 02" Command="{Binding [CheckBox02_Command]}" />
-					<RadioButton Content="Checkbox 03" Command="{Binding [CheckBox03_Command]}" />
-					<RadioButton Content="Checkbox 04 (Alternating)" Command="{Binding [AlternateEnableCommand]}" />
-				</StackPanel>
-			</DataTemplate>
-		</controls:SampleControl.SampleContent>
-	</controls:SampleControl>
+	<StackPanel Spacing="6">
+		<TextBlock FontSize="15">Standard Style</TextBlock>
+		<StackPanel Background="CornflowerBlue">
+			<RadioButton Content="Checkbox 01" Command="{Binding [CheckBox01_Command]}" />
+			<RadioButton Content="Checkbox 02" Command="{Binding [CheckBox02_Command]}" />
+			<RadioButton Content="Checkbox 03" Command="{Binding [CheckBox03_Command]}" />
+			<RadioButton Content="Checkbox 04 (Alternating)" Command="{Binding [AlternateEnableCommand]}" />
+		</StackPanel>
+		<TextBlock FontSize="15">Native Style</TextBlock>
+		<StackPanel Background="LightSeaGreen">
+			<RadioButton Content="Checkbox 01" Command="{Binding [CheckBox01_Command]}" Style="{StaticResource NativeDefaultRadioButton}" />
+			<RadioButton Content="Checkbox 02" Command="{Binding [CheckBox02_Command]}" Style="{StaticResource NativeDefaultRadioButton}" />
+			<RadioButton Content="Checkbox 03" Command="{Binding [CheckBox03_Command]}" Style="{StaticResource NativeDefaultRadioButton}" />
+			<RadioButton Content="Checkbox 04 (Alternating)" Command="{Binding [AlternateEnableCommand]}" Style="{StaticResource NativeDefaultRadioButton}" />
+		</StackPanel>
+		<TextBlock Text="{Binding [Message]}" />
+	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CheckBoxTests/CheckBox_Automated.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CheckBoxTests/CheckBox_Automated.xaml.cs
@@ -1,25 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox;
-using Uno.UI.Samples.Controls;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
+﻿using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-
-// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.CheckBoxTests
 {
-	[SampleControlInfo("CheckBox")]
+	[Sample("Button")]
 	public sealed partial class CheckBox_Automated : UserControl
 	{
 		public CheckBox_Automated()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Progress/ProgressBar.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Progress/ProgressBar.xaml
@@ -1,0 +1,16 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.Progress.ProgressBar"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<StackPanel Spacing="6">
+		<Slider x:Name="v" Value="50" Maximum="100" />
+		<TextBlock>Standard Styling</TextBlock>
+		<ProgressBar Maximum="100" Value="{Binding Value, ElementName=v}" />
+		<TextBlock>Native Styling</TextBlock>
+		<ProgressBar Maximum="100" Value="{Binding Value, ElementName=v}" Style="{StaticResource NativeDefaultProgressBar}" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Progress/ProgressBar.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Progress/ProgressBar.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.Progress
+{
+	[Sample]
+	public sealed partial class ProgressBar : Page
+	{
+		public ProgressBar()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Button/HtmlButtonPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/HtmlButtonPresenter.wasm.cs
@@ -1,0 +1,71 @@
+﻿#nullable enable
+using System;
+using Windows.Foundation;
+using Uno.UI.DataBinding;
+
+namespace Windows.UI.Xaml.Controls
+{
+	/// <summary>
+	/// This control is designed to be used in the ControlTemplate of a button for a native styling.
+	/// </summary>
+	public class HtmlButtonPresenter : ContentControl
+	{
+		public HtmlButtonPresenter() : base("button")
+		{
+			this.RegisterDisposablePropertyChangedCallback(OnPropertyChanged);
+		}
+
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			// Measure child control
+			var contentSize = base.MeasureOverride(availableSize);
+
+			Console.WriteLine($"ContentSize: {contentSize}");
+
+			MeasureView(availableSize);
+
+			// Measure the native HTML control
+			return MeasureContainerView(contentSize, availableSize);
+		}
+
+		private void OnPropertyChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
+		{
+			if (property == BackgroundProperty || property == ForegroundProperty)
+			{
+				OnRenderChanged();
+			}
+			else if (property == ContentProperty)
+			{
+				OnContentChanged(args.OldValue as UIElement, args.NewValue as UIElement);
+			}
+			else if (property == IsEnabledProperty)
+			{
+				OnEnabilityChanged((bool)args.NewValue);
+			}
+		}
+
+		private void OnRenderChanged()
+		{
+			// Set Foreground & Background here
+		}
+
+		private void OnContentChanged(UIElement? oldElement, UIElement? newElement)
+		{
+			if (oldElement is { })
+			{
+				RemoveChild(oldElement);
+			}
+
+			if (newElement is { })
+			{
+				AddChild(newElement);
+			}
+		}
+
+		private void OnEnabilityChanged(bool isEnabled)
+		{
+			var disabledTxt = isEnabled ? "false" : "true";
+			SetProperty("disabled", disabledTxt);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Button/HtmlCheckboxPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/HtmlCheckboxPresenter.wasm.cs
@@ -1,0 +1,64 @@
+﻿#nullable enable
+using Windows.Foundation;
+using Uno.UI.DataBinding;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class HtmlCheckboxPresenter : Control
+	{
+		public HtmlCheckboxPresenter() : base("input")
+		{
+			this.RegisterDisposablePropertyChangedCallback(OnPropertyChanged);
+			SetAttribute("type", "checkbox");
+		}
+
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			return MeasureView(availableSize);
+		}
+
+		public static readonly DependencyProperty IsCheckedProperty = DependencyProperty.Register(
+			"IsChecked", typeof(bool?), typeof(HtmlCheckboxPresenter), new PropertyMetadata(default(bool?)));
+
+		public bool? IsChecked
+		{
+			get => (bool?)GetValue(IsCheckedProperty);
+			set => SetValue(IsCheckedProperty, value);
+		}
+
+		private void OnPropertyChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
+		{
+			if(property == IsCheckedProperty)
+			{
+				SetCheckedState((bool?)args.NewValue);
+			}
+			else if (property == IsEnabledProperty)
+			{
+				OnEnabilityChanged((bool)args.NewValue);
+			}
+		}
+
+		private void SetCheckedState(bool? isChecked)
+		{
+			switch (isChecked)
+			{
+				case true:
+					SetProperty("checked", "true");
+					return;
+				case false:
+					SetProperty("checked", "false");
+					return;
+				case null:
+				default:
+					SetProperty("indeterminate", "true");
+					return;
+			}
+		}
+
+		private void OnEnabilityChanged(bool isEnabled)
+		{
+			var disabledTxt = isEnabled ? "false" : "true";
+			SetProperty("disabled", disabledTxt);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Button/HtmlLabelPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/HtmlLabelPresenter.wasm.cs
@@ -1,0 +1,52 @@
+﻿using Uno.UI.DataBinding;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class HtmlLabelPresenter : ContentControl
+	{
+		public HtmlLabelPresenter() : base("label")
+		{
+			this.RegisterDisposablePropertyChangedCallback(OnPropertyChanged);
+		}
+
+		public static readonly DependencyProperty RelatedElementProperty = DependencyProperty.Register(
+			"RelatedElement", typeof(UIElement), typeof(HtmlLabelPresenter), new PropertyMetadata(default(UIElement)));
+
+		public UIElement RelatedElement
+		{
+			get => (UIElement)GetValue(RelatedElementProperty);
+			set => SetValue(RelatedElementProperty, value);
+		}
+
+		private void OnPropertyChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
+		{
+			if (property == ContentProperty)
+			{
+				OnContentChanged(args.OldValue as UIElement, args.NewValue as UIElement);
+			}
+			else if(property == RelatedElementProperty)
+			{
+				if (args.NewValue is UIElement relatedElement)
+				{
+					SetAttribute("for", "" + relatedElement.HtmlId);
+				}
+				else
+				{
+					RemoveAttribute("for");
+				}
+			}
+		}
+		private void OnContentChanged(UIElement? oldElement, UIElement? newElement)
+		{
+			if (oldElement is { })
+			{
+				RemoveChild(oldElement);
+			}
+
+			if (newElement is { })
+			{
+				AddChild(newElement);
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Button/HtmlRadioButtonPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/HtmlRadioButtonPresenter.wasm.cs
@@ -1,0 +1,59 @@
+﻿using Windows.Foundation;
+using Uno.UI.DataBinding;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class HtmlRadioButtonPresenter : Control
+	{
+		public HtmlRadioButtonPresenter() : base("input")
+		{
+			this.RegisterDisposablePropertyChangedCallback(OnPropertyChanged);
+			SetAttribute("type", "radio");
+		}
+
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			return MeasureView(availableSize);
+		}
+
+		public static readonly DependencyProperty IsCheckedProperty = DependencyProperty.Register(
+			"IsChecked", typeof(bool), typeof(HtmlRadioButtonPresenter), new PropertyMetadata(default(bool)));
+
+		public bool IsChecked
+		{
+			get => (bool)GetValue(IsCheckedProperty);
+			set => SetValue(IsCheckedProperty, value);
+		}
+
+		private void OnPropertyChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
+		{
+			if (property == IsCheckedProperty)
+			{
+				SetCheckedState((bool)args.NewValue);
+			}
+			else if (property == IsEnabledProperty)
+			{
+				OnEnabilityChanged((bool)args.NewValue);
+			}
+		}
+
+		private void SetCheckedState(bool isChecked)
+		{
+			switch (isChecked)
+			{
+				case true:
+					SetProperty("checked", "true");
+					return;
+				case false:
+					SetProperty("checked", "false");
+					return;
+			}
+		}
+
+		private void OnEnabilityChanged(bool isEnabled)
+		{
+			var disabledTxt = isEnabled ? "false" : "true";
+			SetProperty("disabled", disabledTxt);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.wasm.cs
@@ -15,6 +15,13 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class ContentControl
 	{
+		public ContentControl(string htmlTag) : base(htmlTag)
+		{
+			DefaultStyleKey = typeof(ContentControl);
+
+			InitializePartial();
+		}
+
 		partial void InitializePartial()
 		{
 			IFrameworkElementHelper.Initialize(this);

--- a/src/Uno.UI/UI/Xaml/Controls/ProgressBar/HtmlProgressBarPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ProgressBar/HtmlProgressBarPresenter.wasm.cs
@@ -1,0 +1,54 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.Extensions;
+using Uno.UI.DataBinding;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class HtmlProgressBarPresenter : Control
+	{
+		public HtmlProgressBarPresenter() : base("progress")
+		{
+			this.RegisterDisposablePropertyChangedCallback(OnPropertyChanged);
+			SetAttribute("max", "1");
+		}
+
+		public static readonly DependencyProperty MaximumProperty = DependencyProperty.Register(
+			"Maximum", typeof(double), typeof(HtmlProgressBarPresenter), new PropertyMetadata(default(double)));
+
+		public double Maximum
+		{
+			get => (double)GetValue(MaximumProperty);
+			set => SetValue(MaximumProperty, value);
+		}
+
+		public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+			"Value", typeof(double), typeof(HtmlProgressBarPresenter), new PropertyMetadata(default(double)));
+
+		public double Value
+		{
+			get => (double)GetValue(ValueProperty);
+			set => SetValue(ValueProperty, value);
+		}
+
+		private void OnPropertyChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
+		{
+			if (property == ValueProperty || property == MaximumProperty)
+			{
+				SetValue();
+			}
+		}
+
+		private void SetValue()
+		{
+			var max = Maximum;
+			if (max <= 0)
+			{
+				max = 1;
+			}
+
+			var ratioValue = Value / max;
+			SetAttribute("value", ratioValue.ToStringInvariant());
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.Native.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.Native.xaml
@@ -62,8 +62,20 @@
 
 	<wasm:Style
 		x:Key="NativeDefaultButton"
-		TargetType="Button"
-				BasedOn="{StaticResource XamlDefaultButton}" />
+		TargetType="Button">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Button">
+					<HtmlButtonPresenter IsEnabled="{TemplateBinding IsEnabled}"
+					            Foreground="{TemplateBinding Foreground}"
+					            Background="{TemplateBinding Background}">
+						<ContentPresenter Margin="{TemplateBinding Padding}"
+						                  Content="{TemplateBinding Content}" />
+					</HtmlButtonPresenter>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</wasm:Style>
 
 	<skia:Style
 		x:Key="NativeDefaultButton"
@@ -118,8 +130,23 @@
 
 	<wasm:Style
 		x:Key="NativeDefaultCheckBox"
-		TargetType="CheckBox"
-				BasedOn="{StaticResource XamlDefaultCheckBox}" />
+		TargetType="CheckBox">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="CheckBox">
+					<StackPanel Orientation="Horizontal"
+					            Margin="{TemplateBinding Padding}">
+						<HtmlCheckboxPresenter
+							MinWidth="16"
+							x:Name="PART_Checkbox" IsChecked="{TemplateBinding IsChecked}" />
+						<HtmlLabelPresenter
+							RelatedElement="{Binding ElementName=PART_Checkbox}"
+							Content="{TemplateBinding Content}"/>
+					</StackPanel>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</wasm:Style>
 
 	<skia:Style
 		x:Key="NativeDefaultCheckBox"
@@ -135,10 +162,10 @@
 				TargetType="CheckBox"
 				BasedOn="{StaticResource XamlDefaultCheckBox}" />
 
-	<xamarin:Style
+	<!--<xamarin:Style
 		TargetType="CheckBox"
 		xamarin:IsNativeStyle="True"
-		BasedOn="{StaticResource NativeDefaultCheckBox}" />
+		BasedOn="{StaticResource NativeDefaultCheckBox}" />-->
 
 	<!-- Default native RadioButton styles -->
 	<android:Style x:Key="AndroidRadioButtonStyle"
@@ -153,6 +180,53 @@
 			</Setter.Value>
 		</Setter>
 	</android:Style>
+
+	<android:Style x:Key="NativeDefaultRadioButton"
+	               TargetType="RadioButton"
+	               BaseOn="{StaticResource AndroidRadioButtonStyle}" />
+
+	<ios:Style x:Key="NativeDefaultRadioButton"
+	           TargetType="RadioButton"
+	           BaseOn="{StaticResource XamlDefaultRadioButton}" />
+
+	<wasm:Style x:Key="NativeDefaultRadioButton"
+	           TargetType="RadioButton">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="RadioButton">
+					<StackPanel Orientation="Horizontal"
+					            Margin="{TemplateBinding Padding}">
+						<HtmlRadioButtonPresenter
+							MinWidth="16"
+							x:Name="PART_Checkbox" IsChecked="{TemplateBinding IsChecked}" />
+						<HtmlLabelPresenter
+							RelatedElement="{Binding ElementName=PART_Checkbox}"
+							Content="{TemplateBinding Content}"/>
+					</StackPanel>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</wasm:Style>
+
+	<skia:Style x:Key="NativeDefaultRadioButton"
+	           TargetType="RadioButton"
+	           BaseOn="{StaticResource XamlDefaultRadioButton}" />
+
+	<macos:Style x:Key="NativeDefaultRadioButton"
+	           TargetType="RadioButton"
+	           BaseOn="{StaticResource XamlDefaultRadioButton}" />
+
+	<net461:Style x:Key="NativeDefaultRadioButton"
+	              TargetType="RadioButton"
+	              BaseOn="{StaticResource XamlDefaultRadioButton}" />
+
+	<android:Style TargetType="RadioButton"
+	               xamarin:IsNativeStyle="True"
+	               BaseOn="{StaticResource NativeDefaultRadioButton}" />
+
+	<wasm:Style TargetType="RadioButton"
+	               xamarin:IsNativeStyle="True"
+	               BaseOn="{StaticResource NativeDefaultRadioButton}" />
 
 	<!-- Default native ToggleSwitch styles -->
 	<ios:Style x:Key="NativeDefaultToggleSwitch"
@@ -293,8 +367,17 @@
 
 	<wasm:Style
 		x:Key="NativeDefaultProgressBar"
-		TargetType="ProgressBar"
-		BasedOn="{StaticResource XamlDefaultProgressBar}" />
+		TargetType="ProgressBar">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="ProgressBar">
+					<HtmlProgressBarPresenter Maximum="{TemplateBinding Max}"
+					                          Value="{TemplateBinding ActualValue}"/>
+
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</wasm:Style>
 
 	<skia:Style
 		x:Key="NativeDefaultProgressBar"

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -52,6 +52,11 @@ namespace Windows.UI.Xaml
 			}
 		}
 
+		public Size MeasureContainerView(Size containerSize, Size availableSize)
+		{
+			return Uno.UI.Xaml.WindowManagerInterop.MeasureContainerView(HtmlId, containerSize, availableSize);
+		}
+
 		public Size MeasureView(Size availableSize)
 		{
 			return Uno.UI.Xaml.WindowManagerInterop.MeasureView(HtmlId, availableSize);

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -244,6 +244,22 @@ namespace Uno.UI.Xaml
 		#endregion
 
 		#region MeasureView
+
+		internal static Size MeasureContainerView(IntPtr htmlId, Size containerSize, Size availableSize)
+		{
+			var cw = containerSize.Width.ToStringInvariant();
+			var ch = containerSize.Height.ToStringInvariant();
+			var w = double.IsInfinity(availableSize.Width) ? "null" : availableSize.Width.ToStringInvariant();
+			var h = double.IsInfinity(availableSize.Height) ? "null" : availableSize.Height.ToStringInvariant();
+			var command = "Uno.UI.WindowManager.current.measureContainerView(" + htmlId + ", \"" + cw + "\", \"" + ch + "\", \"" + w + "\", \"" + h + "\");";
+			var result = WebAssemblyRuntime.InvokeJS(command);
+
+			var parts = result.Split(';');
+
+			return new Size(
+				double.Parse(parts[0], CultureInfo.InvariantCulture),
+				double.Parse(parts[1], CultureInfo.InvariantCulture));
+		}
 		internal static Size MeasureView(IntPtr htmlId, Size availableSize)
 		{
 			if (UseJavascriptEval)

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -473,6 +473,7 @@ declare namespace Uno.UI {
             * @param maxHeight string containing height in pixels. Empty string means infinite.
             */
         measureViewNative(pParams: number, pReturn: number): boolean;
+        measureContainerView(viewId: number, containerWidth: string, containerHeight: string, maxWidth: string, maxHeight: string): string;
         private static MAX_WIDTH;
         private static MAX_HEIGHT;
         private measureElement;

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -1372,6 +1372,21 @@ var Uno;
                 ret2.marshal(pReturn);
                 return true;
             }
+            measureContainerView(viewId, containerWidth, containerHeight, maxWidth, maxHeight) {
+                const cw = containerWidth ? Number(containerWidth) : NaN;
+                const ch = containerWidth ? Number(containerHeight) : NaN;
+                const mw = maxWidth ? Number(maxWidth) : NaN;
+                const mh = maxHeight ? Number(maxHeight) : NaN;
+                const element = this.getView(viewId);
+                const stubNode = document.createElement("div");
+                stubNode.style.width = `${cw}px`;
+                stubNode.style.height = `${ch}px`;
+                element.appendChild(stubNode);
+                const desiredSize = this.measureViewInternal(viewId, mw, mh);
+                console.log(`measureContainerView(${viewId}, cw:${cw}, ch:${ch}, mw:${mw}, mh:${mh}): ${desiredSize[0]}x${desiredSize[1]}`);
+                element.removeChild(stubNode);
+                return `${desiredSize[0]};${desiredSize[1]}`;
+            }
             measureElement(element) {
                 const offsetWidth = element.offsetWidth;
                 const offsetHeight = element.offsetHeight;

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -1370,6 +1370,28 @@ namespace Uno.UI {
 			return true;
 		}
 
+		public measureContainerView(viewId: number,
+			containerWidth: string,
+			containerHeight: string,
+			maxWidth: string,
+			maxHeight: string): string {
+
+			const cw = containerWidth ? Number(containerWidth) : NaN;
+			const ch = containerWidth ? Number(containerHeight) : NaN;
+			const mw = maxWidth ? Number(maxWidth) : NaN;
+			const mh = maxHeight ? Number(maxHeight) : NaN;
+			const element = this.getView(viewId);
+
+			const stubNode = document.createElement("div");
+			stubNode.style.width = `${cw}px`;
+			stubNode.style.height = `${ch}px`;
+			element.appendChild(stubNode);
+			const desiredSize = this.measureViewInternal(viewId, mw, mh);
+
+			element.removeChild(stubNode);
+			return `${desiredSize[0]};${desiredSize[1]}`;
+		}
+
 		private static MAX_WIDTH = `${Number.MAX_SAFE_INTEGER}vw`;
 		private static MAX_HEIGHT = `${Number.MAX_SAFE_INTEGER}vh`;
 


### PR DESCRIPTION
# Feature
Added support for HTML _native_ styling for following controls:
* `<Button>`
* `<CheckBox>`
* `<RadioButton>`
* `<ProgressBar>`

# Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 774cf6f</samp>

This pull request adds or updates native styles for various controls on the wasm platform, using the Html*Presenter elements to render the native HTML elements. It also adds or updates UI tests and sample pages for the controls, using the Sample attribute and the new ProgressBar page. It also adds or updates methods to measure the size of the native HTML elements, using the WindowManager class and the UIElement class. It also fixes some minor issues with namespaces, formatting, and attributes in the XAML and code-behind files.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
