### PR TITLE
fix: WriteableBitmap.Invalidate on Skia

### DIFF
--- a/src/SamplesApp/SamplesApp.Skia.Gtk/SamplesApp.Skia.Gtk.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.Gtk/SamplesApp.Skia.Gtk.csproj
@@ -3,6 +3,10 @@
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
+		<TargetFrameworks>$(UnoTargetFrameworkOverride)</TargetFrameworks>
+	</PropertyGroup>
+
 	<PropertyGroup>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/SamplesApp/SamplesApp.Skia.WPF/SamplesApp.Skia.WPF.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.WPF/SamplesApp.Skia.WPF.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 	<PropertyGroup>
-		<TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
+		<TargetFrameworks>$(UnoTargetFrameworkOverride)</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="../../netcore-build-windows.props"/>

--- a/src/SamplesApp/SamplesApp.Skia.WPF/SamplesApp.Skia.WPF.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.WPF/SamplesApp.Skia.WPF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 	<PropertyGroup>
-		<TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+		<TargetFrameworks>net472;netcoreapp3.1;net5.0-windows</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -24,10 +24,36 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			// Request to render
 			var button = _app.Marked("_update");
 			_app.WaitForElement(button);
+
+			var screenshotBefore = TakeScreenshot("WriteableBitmap_Invalidate - Before");
+
 			button.FastTap();
 
 			// Take screenshot
-			TakeScreenshot("WriteableBitmap_Invalidate - Result");
+			var screenshotAfter = TakeScreenshot("WriteableBitmap_Invalidate - Result");
+
+			ImageAssert.AreNotEqual(screenshotBefore, screenshotAfter);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void WriteableBitmap_MultiInvalidate()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.ImageTests.WriteableBitmap_MultiInvalidate");
+
+			// Request to render
+			var button = _app.Marked("_randomize");
+			_app.WaitForElement(button);
+			button.FastTap();
+
+			var screenshotBefore = TakeScreenshot("WriteableBitmap_MultiInvalidate - Before");
+
+			button.FastTap();
+
+			// Take screenshot
+			var screenshotAfter = TakeScreenshot("WriteableBitmap_MultiInvalidate - After");
+
+			ImageAssert.AreNotEqual(screenshotBefore, screenshotAfter);
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -39,7 +39,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 		[AutoRetry]
 		public void WriteableBitmap_MultiInvalidate()
 		{
-			Run("UITests.Shared.Windows_UI_Xaml_Controls.ImageTests.WriteableBitmap_MultiInvalidate");
+			Run("UITests.Windows_UI_Xaml_Controls.ImageTests.WriteableBitmap_MultiInvalidate");
 
 			// Request to render
 			var button = _app.Marked("_randomize");

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1261,6 +1261,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\WriteableBitmap_MultiInvalidate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListViewItem_IsEnabled.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4849,6 +4853,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\LoadFromBytes.xaml.cs">
       <DependentUpon>LoadFromBytes.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\WriteableBitmap_MultiInvalidate.xaml.cs">
+      <DependentUpon>WriteableBitmap_MultiInvalidate.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\CounterGrid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListViewItem_IsEnabled.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceWriteableBitmapInvalidate.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceWriteableBitmapInvalidate.xaml.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.ImageTests
 {
-	[SampleControlInfo(category: "Image", controlName: nameof(ImageSourceWriteableBitmapInvalidate))]
+	[SampleControlInfo(category: "WriteableBitmap", controlName: nameof(ImageSourceWriteableBitmapInvalidate))]
 	public sealed partial class ImageSourceWriteableBitmapInvalidate : Page
 	{
 		private WriteableBitmap _bitmap;
@@ -41,13 +41,18 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ImageTests
 			}
 #else
 			if (_bitmap.PixelBuffer is Windows.Storage.Streams.Buffer buffer
-				&& buffer.GetType().GetProperty("Data", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(buffer) is byte[] data)
+				&& buffer.GetType().GetField("_data", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(buffer) is Memory<byte> data)
 			{
+				var span = data.Span;
 				// Half of the image in green, alpha 100% (bgra buffer)
 				for (var i = 1; i < data.Length / 2; i += 2)
 				{
-					data[i] = byte.MaxValue;
+					span[i] = byte.MaxValue;
 				}
+			}
+			else
+			{
+				throw new InvalidOperationException("Could not access _data field in Buffer type.");
 			}
 #endif
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceWriteableBitmapInvalidate.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceWriteableBitmapInvalidate.xaml.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices.WindowsRuntime;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.ImageTests
 {
-	[SampleControlInfo(category: "WriteableBitmap", controlName: nameof(ImageSourceWriteableBitmapInvalidate))]
+	[Sample("WriteableBitmap")]
 	public sealed partial class ImageSourceWriteableBitmapInvalidate : Page
 	{
 		private WriteableBitmap _bitmap;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/WriteableBitmap_MultiInvalidate.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/WriteableBitmap_MultiInvalidate.xaml
@@ -1,0 +1,24 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.ImageTests.WriteableBitmap_MultiInvalidate"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ImageTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel>
+		<Button
+			x:Name="_randomize"
+			Content="Randomize writeable image source"
+			Click="UpdateSource" />
+
+		<Border BorderBrush="Orange"
+				BorderThickness="3"
+				Width="206"
+				Height="206">
+			<Image x:Name="_image" />
+		</Border>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/WriteableBitmap_MultiInvalidate.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/WriteableBitmap_MultiInvalidate.xaml.cs
@@ -10,8 +10,8 @@ namespace UITests.Windows_UI_Xaml_Controls.ImageTests
 	[Sample("WriteableBitmap")]
 	public sealed partial class WriteableBitmap_MultiInvalidate : Page
 	{
-		private readonly Random _randomizer = new Random();
-		private WriteableBitmap _bitmap;
+		private readonly WriteableBitmap _bitmap;
+		private int _seed = 42;
 
 		public WriteableBitmap_MultiInvalidate()
 		{
@@ -23,6 +23,7 @@ namespace UITests.Windows_UI_Xaml_Controls.ImageTests
 
 		private void UpdateSource(object sender, RoutedEventArgs e)
 		{
+			var randomizer = new Random(_seed++);
 			if (_bitmap.PixelBuffer is Windows.Storage.Streams.Buffer buffer
 				&& buffer.GetType().GetField("_data", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(buffer) is Memory<byte> data)
 			{
@@ -36,7 +37,7 @@ namespace UITests.Windows_UI_Xaml_Controls.ImageTests
 					}
 					else
 					{
-						span[i] = (byte)_randomizer.Next(256);
+						span[i] = (byte)randomizer.Next(256);
 					}
 				}
 			}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/WriteableBitmap_MultiInvalidate.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/WriteableBitmap_MultiInvalidate.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Reflection;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace UITests.Windows_UI_Xaml_Controls.ImageTests
+{
+	[Sample("WriteableBitmap")]
+	public sealed partial class WriteableBitmap_MultiInvalidate : Page
+	{
+		private readonly Random _randomizer = new Random();
+		private WriteableBitmap _bitmap;
+
+		public WriteableBitmap_MultiInvalidate()
+		{
+			this.InitializeComponent();
+
+			_bitmap = new WriteableBitmap(200, 200);
+			_image.Source = _bitmap;
+		}
+
+		private void UpdateSource(object sender, RoutedEventArgs e)
+		{
+			if (_bitmap.PixelBuffer is Windows.Storage.Streams.Buffer buffer
+				&& buffer.GetType().GetField("_data", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(buffer) is Memory<byte> data)
+			{
+				var span = data.Span;
+				for (var i = 0; i < data.Length; i++)
+				{
+					if (i % 4 == 3)
+					{
+						// Alpha channel
+						span[i] = 255;
+					}
+					else
+					{
+						span[i] = (byte)_randomizer.Next(256);
+					}
+				}
+			}
+			else
+			{
+				throw new InvalidOperationException("Could not access _data field in Buffer type.");
+			}
+
+			// This request to the image to redraw the buffer
+			_bitmap.Invalidate();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
@@ -238,10 +238,6 @@ namespace Windows.UI.Xaml.Shapes
 						spriteShape.Geometry = compositor.CreatePathGeometry(new CompositionPath(geometry));
 
 						shapeVisual.Shapes.Add(spriteShape);
-
-						// Must be inserted below the other subviews, which may happen when
-						// the current view has subviews.
-						sublayers.Add(shapeVisual);
 					};
 
 					if (borderThickness.Top != 0)
@@ -292,7 +288,11 @@ namespace Windows.UI.Xaml.Shapes
 						});
 					}
 				}
+				
+				sublayers.Add(shapeVisual);
 
+				// Must be inserted below the other subviews, which may happen when
+				// the current view has subviews.
 				parent.Children.InsertAtBottom(shapeVisual);
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): related to #4309, #4713

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The `BorderLayoutRenderer` accumulates visual layers when the control changes and has no border set. This means that changes are not visible, as they are hidden below previously rendered layers.

## What is the new behavior?

Fixed, added UI tests.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
