### PR TITLE
fix: Contact FullName fix

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Contacts/Contact.cs
+++ b/src/Uno.UWP/ApplicationModel/Contacts/Contact.cs
@@ -23,7 +23,11 @@ namespace Windows.ApplicationModel.Contacts
 		{
 			get
 			{
-				return string.Join(" ", new [] { HonorificNamePrefix, FirstName, MiddleName, LastName, HonorificNameSuffix }.Where(n => !string.IsNullOrEmpty(n)));
+				if (string.IsNullOrEmpty(DisplayNameOverride))
+				{
+					return string.Join(" ", new [] { HonorificNamePrefix, FirstName, MiddleName, LastName, HonorificNameSuffix }.Where(n => !string.IsNullOrEmpty(n)));
+				}
+				return DisplayNameOverride;
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #5658

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Contact.FullName returns concatenated FirstName, LastName etc. even when DisplayNameOverride is set.

## What is the new behavior?
DisplayNameOverride overrides both DisplayName and FullName (as in UWP).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

 I don't know if it is breaking change or not.

## Other information
While updating #2544 (rebase, after part of it, #5577, was merged), I encounter a problem - reading contact from Android returns DisplayName. But now it is read-only. It leads to some checking, and discovery of bug in current Uno implementation.

This code:

```
        Dim oCon = New Windows.ApplicationModel.Contacts.Contact
        oCon.HonorificNamePrefix = "dr"
        oCon.HonorificNameSuffix = "honSuf"
        oCon.FirstName = "Piotr"
        oCon.MiddleName = "Łukasz"
        oCon.LastName = "Karocki"
        Debug.WriteLine(oCon.DisplayName)
        Debug.WriteLine(oCon.FullName)
        oCon.DisplayNameOverride = "alamakota"
        Debug.WriteLine(oCon.DisplayName)
        Debug.WriteLine(oCon.FullName)
```

shows:
```
dr Piotr Karocki honSuf
dr Piotr Łukasz Karocki honSuf
alamakota
alamakota
```

 So, both DisplayName and FullName are affected by DisplayNameOverride. Hence, this PR (Win 19042, build target 19041,  min: 16299).

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
