### PR TITLE
fix: Adjust incorrect generation behavior during roslyn design-time build

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -41,6 +41,7 @@
 		<CompilerVisibleProperty Include="MSBuildProjectName" />
 		<CompilerVisibleProperty Include="BuildingProject" />
 		<CompilerVisibleProperty Include="DesignTimeBuild" />
+		<CompilerVisibleProperty Include="UnoUISourceGeneratorDebuggerBreak" />
 
 		<CompilerVisibleProperty Include="UseWPF" />
 		<CompilerVisibleProperty Include="IsUnoHead" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Telemetry/TelemetryClient.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Telemetry/TelemetryClient.cs
@@ -97,7 +97,11 @@ namespace Uno.UI.SourceGenerators.Telemetry
 				return;
 			}
 
-			_trackEventTask.Wait();
+			// Skip the wait if the task has not yet been activated
+			if (_trackEventTask.Status != TaskStatus.WaitingForActivation)
+			{
+				_trackEventTask.Wait(TimeSpan.FromSeconds(1));
+			}
 		}
 
 		public void Dispose()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.Telemetry.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.Telemetry.cs
@@ -50,7 +50,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private void TrackGenerationDone(TimeSpan elapsed)
 		{
-			if (IsTelemetryEnabled)
+			if (IsTelemetryEnabled
+				&& !_isDesignTimeBuild)
 			{
 				try
 				{
@@ -74,7 +75,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private void TrackGenerationFailed(Exception exception, TimeSpan elapsed)
 		{
-			if (IsTelemetryEnabled)
+			if (IsTelemetryEnabled
+				&& !_isDesignTimeBuild)
 			{
 				try
 				{
@@ -99,7 +101,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private void TrackStartGeneration(XamlFileDefinition[] files)
 		{
-			if (IsTelemetryEnabled)
+			if (IsTelemetryEnabled
+				&& !_isDesignTimeBuild)
 			{
 				try
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -34,6 +34,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private readonly string _targetPath;
 		private readonly string _defaultLanguage;
 		private readonly bool _isWasm;
+		private readonly bool _isDesignTimeBuild;
 		private readonly string _defaultNamespace;
 		private readonly string[] _assemblySearchPaths;
 		private readonly string[] _excludeXamlNamespaces;
@@ -180,6 +181,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			_defaultNamespace = context.GetMSBuildPropertyValue("RootNamespace");
 
 			_isWasm = context.GetMSBuildPropertyValue("DefineConstantsProperty")?.Contains("__WASM__") ?? false;
+			_isDesignTimeBuild = Helpers.DesignTimeHelper.IsDesignTime(context);
 		}
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5628

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

VS may freeze under unknown conditions when generating design-time source.

## What is the new behavior?

VS does not freeze anymore.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
