### PR TITLE
fix(FileSavePicker.wasm): FileSavePicker dialog now shows all file type extensions.

### DIFF
--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
@@ -69,16 +69,9 @@ namespace Windows.Storage.Pickers
 				var acceptType = new NativeFilePickerAcceptType();
 				acceptType.Description = choice.Key;
 
-				var acceptItems = new List<NativeFilePickerAcceptTypeItem>();
-				foreach (var extension in choice.Value)
-				{
-					var acceptItem = new NativeFilePickerAcceptTypeItem()
-					{
-						MimeType = MimeTypeService.GetFromExtension(extension),
-						Extensions = new[] { extension }
-					};
-					acceptItems.Add(acceptItem);
-				}
+				var acceptItems = choice.Value
+					.GroupBy(ext => MimeTypeService.GetFromExtension(ext))
+					.Select(group => new NativeFilePickerAcceptTypeItem() { MimeType = group.Key, Extensions = group.ToArray() });
 
 				acceptType.Accept = acceptItems.ToArray();
 				acceptTypes.Add(acceptType);

--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
@@ -69,11 +69,9 @@ namespace Windows.Storage.Pickers
 				var acceptType = new NativeFilePickerAcceptType();
 				acceptType.Description = choice.Key;
 
-				var acceptItems = choice.Value
-					.GroupBy(ext => MimeTypeService.GetFromExtension(ext))
-					.Select(group => new NativeFilePickerAcceptTypeItem() { MimeType = group.Key, Extensions = group.ToArray() });
+				var acceptItem = new NativeFilePickerAcceptTypeItem() { MimeType = "*/*", Extensions = choice.Value.ToArray() };
 
-				acceptType.Accept = acceptItems.ToArray();
+				acceptType.Accept = new NativeFilePickerAcceptTypeItem[] { acceptItem };
 				acceptTypes.Add(acceptType);
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5685

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
- Bugfix

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Some file type extensions, added by `FileTypeChoices.Add` are missing.

Code: 
```
picker.FileTypeChoices.Add("C/C++ source files", new List<string>() { ".cpp", ".c", ".cc", ".cxx", ".c++", ".cp" });
```

Result:
Only shows `.cp` extension, and also some other irrelevant `.com`, `.exe`, and `.bin`.
![image](https://user-images.githubusercontent.com/57174311/113727061-fb8bfa80-971e-11eb-9ecd-0818f296c749.png)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Shows all included extensions, as well as the irrelevant extensions `.com`, `.exe`, and `.bin`.
![image](https://user-images.githubusercontent.com/57174311/113727226-22e2c780-971f-11eb-90d4-239976582c5f.png)

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
