### PR TITLE
fix: x:Bind typeof expression for nullable reference

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3615,7 +3615,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							if (propertyPaths.properties.Length == 1)
 							{
 								var targetPropertyType = GetXBindPropertyPathType(propertyPaths.properties[0], GetType(dataType));
-								return $"(___ctx, __value) => {{ if(___ctx is {dataType} ___tctx) {{ {contextFunction} = ({targetPropertyType})global::Windows.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof({targetPropertyType}), __value); }} }}";
+								return $"(___ctx, __value) => {{ if(___ctx is {dataType} ___tctx) {{ {contextFunction} = ({targetPropertyType})global::Windows.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof({targetPropertyType.ToDisplayString(NullableFlowState.None)}), __value); }} }}";
 							}
 							else
 							{
@@ -3657,7 +3657,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								var targetPropertyType = GetXBindPropertyPathType(propertyPaths.properties[0]);
 								return $"(___ctx, __value) => {{ " +
 									$"if(___ctx is global::{_className.ns + "." + _className.className} ___tctx) " +
-									$"{rawFunction} = ({targetPropertyType})global::Windows.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof({targetPropertyType}), __value);" +
+									$"{rawFunction} = ({targetPropertyType})global::Windows.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof({targetPropertyType.ToDisplayString(NullableFlowState.None)}), __value);" +
 									$" }}";
 							}
 							else

--- a/src/SourceGenerators/XamlGenerationTests/XBindNullable.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/XBindNullable.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="XamlGenerationTests.XBindNullable"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:XamlGenerationTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <ComboBox SelectedItem="{x:Bind TestProperty, Mode=TwoWay}" />
+    </Grid>
+</Page>

--- a/src/SourceGenerators/XamlGenerationTests/XBindNullable.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/XBindNullable.xaml.cs
@@ -24,6 +24,6 @@ namespace XamlGenerationTests
 			this.InitializeComponent();
 		}
 
-		public string? TestProperty { get; } = null;
+		public string? TestProperty { get; set; } = null;
 	}
 }

--- a/src/SourceGenerators/XamlGenerationTests/XBindNullable.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/XBindNullable.xaml.cs
@@ -1,0 +1,29 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace XamlGenerationTests
+{
+	public sealed partial class XBindNullable : Page
+	{
+		public XBindNullable()
+		{
+			this.InitializeComponent();
+		}
+
+		public string? TestProperty { get; } = null;
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5084

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Nullable reference type caused `typeof(XYZ?)` which is not valid.

## What is the new behavior?

Generating valid `typeof`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
