### PR TITLE
feat: Add Uno.WinUI compatibility for net5-windows

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -252,6 +252,9 @@
 		<Move SourceFiles=".\uno.winui.targets" DestinationFiles=".\$(PackageNamePrefix).targets" Condition="'$(UNO_UWP_BUILD)'=='true'"/>
 		<XmlUpdate XmlFileName=".\Uno.WinUI.nuspec" XPath="/x:package/x:files/x:file[@src='Uno.WinUI.targets']/@src" Value="$(PackageNamePrefix).targets" Namespace="$(NugetNamespace)" Prefix="x"  Condition="'$(UNO_UWP_BUILD)'=='true'"/>
 
+		<!-- Adjust for net5-windows -->
+		<XmlUpdate XmlFileName=".\Uno.WinUI.nuspec" XPath="/x:package/x:files/x:file[@src='..\src\Uno.UI.Toolkit\bin\Release\$winuisourcepath$\Uno.UI.Toolkit\**']/@src" Value="..\src\Uno.UI.Toolkit\bin\Release\$winuisourcepath$\Themes\**" Namespace="$(NugetNamespace)" Prefix="x"  Condition="'$(UNO_UWP_BUILD)'!='true'"/>
+
 		<!-- Adjust build targets file for UAP -->
 		<XmlUpdate XmlFileName=".\Uno.WinUI.nuspec" XPath="/x:package/x:files/x:file[@target='buildTransitive\uap10.0.16299\uno.winui.targets']/@target" Value="buildTransitive\uap10.0.16299\$(PackageNamePrefix).targets" Namespace="$(NugetNamespace)" Prefix="x"  Condition="'$(UNO_UWP_BUILD)'=='true'"/>
 		<XmlUpdate XmlFileName=".\Uno.WinUI.nuspec" XPath="/x:package/x:files/x:file[@target='buildTransitive\uap10.0.17763\uno.winui.targets']/@target" Value="buildTransitive\uap10.0.17763\$(PackageNamePrefix).targets" Namespace="$(NugetNamespace)" Prefix="x"  Condition="'$(UNO_UWP_BUILD)'=='true'"/>
@@ -304,6 +307,9 @@
 	<Target Name="BuildNuGetPackage">
 		<PropertyGroup>
 			<NuSpecProperties>NoWarn=NU5100,NU5105,NU5131;branch=$(GITVERSION_BranchName);commitid=$(GITVERSION_VersionSourceSha)</NuSpecProperties>
+
+			<NuSpecProperties Condition="'$(UNO_UWP_BUILD)'=='true'">$(NuSpecProperties);winuisourcepath=uap10.0.17763;winuitargetpath=UAP</NuSpecProperties>
+			<NuSpecProperties Condition="'$(UNO_UWP_BUILD)'!='true'">$(NuSpecProperties);winuisourcepath=net5.0-windows10.0.18362.0;winuitargetpath=net5.0-windows10.0.18362.0</NuSpecProperties>
 		</PropertyGroup>
 		
 		<!-- Create the packages -->

--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -135,10 +135,10 @@
   <files>
 
 	<!-- UAP -->
-	<file src="..\src\Uno.UI.Toolkit\bin\Release\uap10.0.17763\Uno.UI.Toolkit.dll" target="lib\UAP" />
-	<file src="..\src\Uno.UI.Toolkit\bin\Release\uap10.0.17763\Uno.UI.Toolkit.pdb" target="lib\UAP" />
-	<file src="..\src\Uno.UI.Toolkit\bin\Release\uap10.0.17763\Uno.UI.Toolkit.pri" target="lib\UAP" />
-	<file src="..\src\Uno.UI.Toolkit\bin\Release\uap10.0.17763\Uno.UI.Toolkit\**" target="lib\UAP\Uno.UI.Toolkit" />
+	<file src="..\src\Uno.UI.Toolkit\bin\Release\$winuisourcepath$\Uno.UI.Toolkit*.dll" target="lib\$winuitargetpath$" />
+	<file src="..\src\Uno.UI.Toolkit\bin\Release\$winuisourcepath$\Uno.UI.Toolkit*.pdb" target="lib\$winuitargetpath$" />
+	<file src="..\src\Uno.UI.Toolkit\bin\Release\$winuisourcepath$\Uno.UI.Toolkit*.pri" target="lib\$winuitargetpath$" />
+	<file src="..\src\Uno.UI.Toolkit\bin\Release\$winuisourcepath$\Uno.UI.Toolkit\**" target="lib\$winuitargetpath$\Uno.UI.Toolkit" />
 
 	<!-- Android 9.0 -->
 	<file src="..\src\Uno.UI\Bin\Release\MonoAndroid11.0\Uno.dll" target="lib\MonoAndroid11.0" />
@@ -297,6 +297,7 @@
 	<!-- Force UAP to ignore netstandard 2.0 -->
 	<file src="uno.winui.uap.targets" target="buildTransitive\uap10.0.16299\uno.winui.targets" />
 	<file src="uno.winui.uap.targets" target="buildTransitive\uap10.0.17763\uno.winui.targets" />
+	<file src="uno.winui.uap.targets" target="buildTransitive\net5.0-windows\uno.winui.targets" />
 
 	<file src="..\src\SourceGenerators\Uno.UI.SourceGenerators\Content\Uno.UI.SourceGenerators.props" target="buildTransitive" />
   </files>

--- a/src/Uno.UI.Toolkit/CommandBarExtensions.cs
+++ b/src/Uno.UI.Toolkit/CommandBarExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml;

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -20,7 +20,7 @@ namespace Uno.UI.Toolkit
 	[TemplatePart(Name = "PART_Border", Type = typeof(Border))]
 	[TemplatePart(Name = "PART_ShadowHost", Type = typeof(Grid))]
 	public sealed partial class ElevatedView : Control
-#if !NETFX_CORE
+#if !NETFX_CORE && !NETCOREAPP
 		, ICustomClippingElement
 #endif
 	{
@@ -59,7 +59,7 @@ namespace Uno.UI.Toolkit
 		{
 			DefaultStyleKey = typeof(ElevatedView);
 
-#if !NETFX_CORE
+#if !NETFX_CORE && !NETCOREAPP
 			Loaded += (snd, evt) => SynchronizeContentTemplatedParent();
 
 			// Patch to deactivate the clipping by ContentControl
@@ -114,7 +114,7 @@ namespace Uno.UI.Toolkit
 			set => SetValue(ElevatedContentProperty, value);
 		}
 
-#if !NETFX_CORE
+#if !NETFX_CORE && !NETCOREAPP
 		public new static DependencyProperty BackgroundProperty { get ; } = DependencyProperty.Register(
 			"Background",
 			typeof(Brush),
@@ -178,7 +178,7 @@ namespace Uno.UI.Toolkit
 				return; // not initialized yet
 			}
 
-#if !NETFX_CORE
+#if !NETFX_CORE && !NETCOREAPP
 			SynchronizeContentTemplatedParent();
 #endif
 
@@ -197,13 +197,13 @@ namespace Uno.UI.Toolkit
 				// The elevation must be applied on the border, since
 				// it will get the right shape (with rounded corners)
 				_border.SetElevationInternal(Elevation, ShadowColor);
-#elif NETFX_CORE
+#elif NETFX_CORE || NETCOREAPP
 				(ElevatedContent as DependencyObject).SetElevationInternal(Elevation, ShadowColor, _shadowHost as DependencyObject, CornerRadius);
 #endif
 			}
 		}
 
-#if !NETFX_CORE
+#if !NETFX_CORE && !NETCOREAPP
 		bool ICustomClippingElement.AllowClippingToLayoutSlot => false; // Never clip, since it will remove the shadow
 
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => false;

--- a/src/Uno.UI.Toolkit/MapResources.cs
+++ b/src/Uno.UI.Toolkit/MapResources.cs
@@ -1,4 +1,4 @@
-﻿#if !__IOS__ && !__ANDROID__
+#if !__IOS__ && !__ANDROID__
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/Uno.UI.Toolkit/MenuFlyoutExtensions.cs
+++ b/src/Uno.UI.Toolkit/MenuFlyoutExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml;

--- a/src/Uno.UI.Toolkit/MenuFlyoutItemExtensions.cs
+++ b/src/Uno.UI.Toolkit/MenuFlyoutItemExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Uno.UI.Toolkit/SplitViewExtensions.cs
+++ b/src/Uno.UI.Toolkit/SplitViewExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Uno.UI.Toolkit/UIElementExtensions.cs
+++ b/src/Uno.UI.Toolkit/UIElementExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Reflection;
@@ -11,6 +11,10 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 using Uno.Extensions;
 using Uno.Logging;
+
+#if NETCOREAPP
+using Microsoft.UI;
+#endif
 
 #if __IOS__ || __MACOS__
 using CoreGraphics;
@@ -25,7 +29,7 @@ namespace Uno.UI.Toolkit
 #endif
 	public static class UIElementExtensions
 	{
-		#region Elevation
+#region Elevation
 
 		public static void SetElevation(this UIElement element, double elevation)
 		{
@@ -58,7 +62,7 @@ namespace Uno.UI.Toolkit
 
 #if __IOS__ || __MACOS__
 		internal static void SetElevationInternal(this DependencyObject element, double elevation, Color shadowColor, CGPath path = null)
-#elif NETFX_CORE
+#elif NETFX_CORE || NETCOREAPP
 		internal static void SetElevationInternal(this DependencyObject element, double elevation, Color shadowColor, DependencyObject host = null, CornerRadius cornerRadius = default(CornerRadius))
 #else
 		internal static void SetElevationInternal(this DependencyObject element, double elevation, Color shadowColor)
@@ -79,7 +83,7 @@ namespace Uno.UI.Toolkit
 			if (element is AppKit.NSView view)
 #else
 			if (element is UIKit.UIView view)
-	#endif
+#endif
 			{
 				if (elevation > 0)
 				{
@@ -88,17 +92,17 @@ namespace Uno.UI.Toolkit
 					const float y = 0.92f * 0.5f; // Looks more accurate than the recommended 0.92f.
 					const float blur = 0.5f;
 
-	#if __MACOS__
+#if __MACOS__
 					view.WantsLayer = true;
 					view.Shadow ??= new AppKit.NSShadow();
-	#endif
+#endif
 					view.Layer.MasksToBounds = false;
 					view.Layer.ShadowOpacity = shadowColor.A / 255f;
-	#if __MACOS__
+#if __MACOS__
 					view.Layer.ShadowColor = AppKit.NSColor.FromRgb(shadowColor.R, shadowColor.G, shadowColor.B).CGColor;
-	#else
+#else
 					view.Layer.ShadowColor = UIKit.UIColor.FromRGB(shadowColor.R, shadowColor.G, shadowColor.B).CGColor;
-	#endif
+#endif
 					view.Layer.ShadowRadius = (nfloat)(blur * elevation);
 					view.Layer.ShadowOffset = new CoreGraphics.CGSize(x * elevation, y * elevation);
 					view.Layer.ShadowPath = path;
@@ -129,7 +133,7 @@ namespace Uno.UI.Toolkit
 					uiElement.UnsetCssClasses("noclip");
 				}
 			}
-#elif NETFX_CORE
+#elif NETFX_CORE || NETCOREAPP
 			if (element is UIElement uiElement)
 			{
 				var compositor = ElementCompositionPreview.GetElementVisual(uiElement).Compositor;
@@ -318,7 +322,7 @@ namespace Uno.UI.Toolkit
 			{
 				uiElement.Log().Warn($"The {propertyName} dependency property does not exist on {type}");
 			}
-#if !NETFX_CORE
+#if !NETFX_CORE && !NETCOREAPP
 			else if (property.Type != propertyType)
 			{
 				uiElement.Log().Warn($"The {propertyName} dependency property {type} is not of the {propertyType} Type.");

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -2,6 +2,9 @@
 	<PropertyGroup>
 		<TargetFrameworks>xamarinmac20;MonoAndroid11.0;uap10.0.17763;xamarinios10;netstandard2.0</TargetFrameworks>
 		<TargetFrameworksCI>MonoAndroid11.0;MonoAndroid10.0;uap10.0.17763;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+
+		<TargetFrameworks Condition="'$(UNO_UWP_BUILD)'!='true'">$(TargetFrameworks);net5.0-windows10.0.18362.0</TargetFrameworks>
+		<TargetFrameworksCI Condition="'$(UNO_UWP_BUILD)'!='true'">$(TargetFrameworksCI);net5.0-windows10.0.18362.0</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
@@ -82,15 +85,15 @@
 		</ProjectReference>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.17763'">
-		<PackageReference Include="Microsoft.WinUI" Condition="'$(UNO_UWP_BUILD)'!='true'">
-			<Version>3.0.0-alpha.200210.0</Version>
+	<ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362.0' or '$(TargetFramework)'=='uap10.0.17763'">
+		<PackageReference Include="Microsoft.ProjectReunion.WinUI" Condition="'$(UNO_UWP_BUILD)'!='true'">
+			<Version>0.5.0</Version>
 		</PackageReference>
 		<Compile Include="$(MSBuildThisFileDirectory)..\Uno.UI\Extensions\DependencyObjectExtensions.cs">
 			<Link>Uno.UI\Extensions\%(RecursiveDir)%(FileName)%(Extension)</Link>
 		</Compile>
 	</ItemGroup>
-
+	
 	<ItemGroup>
 		<Page Remove="Themes\Generic.xaml" />
 		<Page Include="Themes\Generic.xaml" />
@@ -130,4 +133,8 @@
 		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
 		<Copy SourceFiles="@(_OutputFilesPDB)" DestinationFiles="@(_OutputFilesPDB->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename).pdb')" />
 	</Target>
+
+	<!-- https://github.com/microsoft/microsoft-ui-xaml/issues/4503 -->
+	<Target Name="_CalculateXbfSupport" Condition="'$(TargetFramework)'=='uap10.0.17763'"/>
+
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Enable support for `net5.0-windows` for `Uno.UI.Toolkit` classes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
