### PR TITLE
fix: TheadPoolTimer.CreatePeriodicTimer raises events properly

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_System_Threading/Given_ThreadPoolTimer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_System_Threading/Given_ThreadPoolTimer.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.ApplicationModel.Core;
+using Windows.System;
+using Windows.System.Threading;
+using Windows.UI.Core;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_System
+{
+	[TestClass]
+	public class Given_ThreadPoolTimer
+	{
+		[TestMethod]
+		public async Task When_Timer()
+		{
+			var handlerCount = 0;
+			var timer = ThreadPoolTimer.CreateTimer(_ => handlerCount++, TimeSpan.FromMilliseconds(100));
+
+			await Task.Delay(500);
+
+			Assert.AreEqual(handlerCount, 1);
+
+			await Task.Delay(500);
+
+			Assert.AreEqual(handlerCount, 1);
+		}
+
+		[TestMethod]
+		public async Task When_PeriodicTimer()
+		{
+			var handlerCount = 0;
+			var timer = ThreadPoolTimer.CreatePeriodicTimer(_ => handlerCount++, TimeSpan.FromMilliseconds(100));
+
+			await Task.Delay(500);
+
+			Assert.IsTrue(handlerCount > 1);
+		}
+	}
+}

--- a/src/Uno.UWP/System.Threading/ThreadPoolTimer.cs
+++ b/src/Uno.UWP/System.Threading/ThreadPoolTimer.cs
@@ -34,7 +34,7 @@ namespace Windows.System.Threading
 
 			_timer.Change(
 				period: period ?? global::System.Threading.Timeout.InfiniteTimeSpan,
-				dueTime: delay ?? global::System.Threading.Timeout.InfiniteTimeSpan
+				dueTime: delay ?? TimeSpan.Zero
 			);
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5741

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`ThreadPoolTimer.CreatePeriodicTimer` is not raising events properly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
