### PR TITLE
fix(textblock): [WASM]Removed a useless scrollbar appearing sometimes on TextBlock

### DIFF
--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -110,7 +110,7 @@ embed.uno-frameworkelement.uno-unarranged {
   background-clip: text !important;
 
   /* overflow-x:hidden is required for text-overflow: ellipsis to work correctly */
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 .uno-buttonbase {

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -109,7 +109,7 @@ embed.uno-frameworkelement.uno-unarranged {
   -webkit-background-clip: text !important;
   background-clip: text !important;
 
-  /* overflow-x:hidden is required for text-overflow: ellipsis to work correctly */
+  /* overflow:hidden is required for text-overflow: ellipsis to work correctly */
   overflow: hidden;
 }
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5754

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

# Bugfix

## What is the current behavior?
Sometimes a Scrollbar could appear on the TextBlock, on Wasm:
![image](https://user-images.githubusercontent.com/4174207/114767409-972bf500-9d35-11eb-967f-107abafd7518.png)
(visible on the Calculator)

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- ~~[ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
