### PR TITLE
Fix scrollbars not appearing on wasm and skia

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/BatchMergeXaml/MergedDictionary.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/BatchMergeXaml/MergedDictionary.cs
@@ -112,10 +112,10 @@ namespace Uno.UI.Tasks.BatchMerge
 
         private void AddNamespace(string xmlnsString, string namespaceString)
         {
-            if (!namespaceList.Contains(namespaceString))
+            if (!namespaceList.Contains(xmlnsString))
             {
                 xmlElement.SetAttribute("xmlns:" + xmlnsString, namespaceString);
-                namespaceList.Add(namespaceString);
+                namespaceList.Add(xmlnsString);
             }
         }
 

--- a/src/Uno.UI/Extensions/UIElementExtensions.cs
+++ b/src/Uno.UI/Extensions/UIElementExtensions.cs
@@ -18,12 +18,17 @@ namespace Uno.UI.Extensions
 			=> elt switch
 			{
 				null => "--null--",
-				FrameworkElement fwElt when fwElt.Name.HasValue() => $"{fwElt.Name} -{elt.GetHashCode():X8}",
-				_ => $"{elt.GetType().Name} -{elt.GetHashCode():X8}",
+#if __WASM__
+				FrameworkElement fwElt when fwElt.Name.HasValue() => $"{fwElt.Name}-{fwElt.HtmlId}",
+				UIElement uiElt => $"{elt.GetType().Name}-{uiElt.HtmlId}",
+#else
+				FrameworkElement fwElt when fwElt.Name.HasValue() => $"{fwElt.Name}-{elt.GetHashCode():X8}",
+#endif
+				_ => $"{elt.GetType().Name}-{elt.GetHashCode():X8}",
 			};
 
 		internal static string GetDebugIdentifier(this object? elt)
-			=> $"{new string('\t', elt.GetDebugDepth())} [{elt.GetDebugName()}]";
+			=> $"{new string('\t', Math.Max(0, elt.GetDebugDepth()))} [{elt.GetDebugName()}]";
 
 		internal static int GetDebugDepth(this object? elt) =>
 			elt switch

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -149,8 +149,8 @@ embed.uno-frameworkelement.uno-unarranged {
   }
 
   .uno-scrollcontentpresenter.scroll-x-hidden {
-    overflow-x: auto;
-    scrollbar-height: none;
+    overflow-x: auto; /* We must not use "hidden" to allow native scrolling interaction like mouse wheel */
+    scrollbar-width: none; /* scrollbar-height has no effect on FF, using scrollbar-width works on all browsers (non standard proeprty) */
   }
 
   .uno-scrollcontentpresenter.scroll-x-hidden::-webkit-scrollbar {
@@ -162,7 +162,7 @@ embed.uno-frameworkelement.uno-unarranged {
   }
 
   .uno-scrollcontentpresenter.scroll-y-hidden {
-    overflow-y: auto;
+    overflow-y: auto; /* We must not use "hidden" to allow native scrolling interaction like mouse wheel */
     scrollbar-width: none;
   }
 


### PR DESCRIPTION
GitHub Issue (If applicable): #5707 

## Bugfix
The scrollbars are missing on wasm and skia as soon as fluent style is used.

## What is the current behavior?
The resource disctionnary merge task does not includes the `win:` XML namespace (as the same URL has already be defined by another xmlns - the default in that case), but keeps the `win:` prefix where defined. 

Then the XAML generator, when reading the merged dictionary is not able to fine the namespace for node defined with the `win:`, so it tries to generate the content (even explicitly instructed to ignore the "win" prefix).

So the specific exclusion of the `ScrollBar` template of fluent styles (https://github.com/unoplatform/uno/commit/726923a0a788277c7cd039a8893c8ae35f1a2bb4) is not respected and the fluent template is used instead of the default UWP one ... causing the `ScrollBar` to not appear in the `ScrollViewer`

## What is the new behavior?
It works 🙃

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
