### PR TITLE
Read-only streams should not throw on Flush, adjust NotImplemented on Pickers

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_StorageFile_Native.base.cs
@@ -224,6 +224,72 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 			}
 		}
 
+		[TestMethod]
+		public async Task When_ReadStreamFlush()
+		{
+			var rootFolder = await GetRootFolderAsync();
+			var fileName = GetRandomTextFileName();
+			StorageFile? createdFile = null;
+			try
+			{
+				createdFile = await rootFolder.CreateFileAsync(fileName);
+				await FileIO.WriteTextAsync(createdFile, "Hello world!");
+
+				var buffer = new byte[1024];
+
+				using var stream = await createdFile.OpenStreamForReadAsync();
+
+				while (await stream.ReadAsync(buffer, 0, 1024) > 0)
+				{
+				}
+
+				try
+				{
+					stream.Flush();
+				}
+				catch (Exception ex)
+				{
+					Assert.Fail($"Read stream flush threw {ex}");
+				}
+			}
+			finally
+			{
+				await DeleteIfNotNullAsync(createdFile);
+				await CleanupRootFolderAsync();
+			}
+		}
+
+		[TestMethod]
+		public async Task When_InputStreamFlush()
+		{
+			var rootFolder = await GetRootFolderAsync();
+			var fileName = GetRandomTextFileName();
+			StorageFile? createdFile = null;
+			try
+			{
+				createdFile = await rootFolder.CreateFileAsync(fileName);
+				await FileIO.WriteTextAsync(createdFile, "Hello world!");
+
+				var buffer = new byte[1024];
+
+				using var stream = await createdFile.OpenReadAsync();
+
+				try
+				{
+					stream.FlushAsync();
+				}
+				catch (Exception ex)
+				{
+					Assert.Fail($"Input stream flush threw {ex}");
+				}
+			}
+			finally
+			{
+				await DeleteIfNotNullAsync(createdFile);
+				await CleanupRootFolderAsync();
+			}
+		}
+
 		private string GetRandomFolderName() => Guid.NewGuid().ToString();
 
 		private string GetRandomTextFileName() => Guid.NewGuid().ToString() + ".txt";

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_RandomAccessStreamReference.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Streams/Given_RandomAccessStreamReference.cs
@@ -24,6 +24,23 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage.Streams
 			Assert.AreEqual(_unoStaticTestFileContent, actual);
 		}
 
+		[TestMethod]
+		public async Task When_FlushReadOnly()
+		{
+			var sut = RandomAccessStreamReference.CreateFromUri(new Uri("https://nv-assets.azurewebsites.net/uno-unit-tests.txt"));
+			using var readStream = await sut.OpenReadAsync();
+
+			try
+			{
+				await readStream.FlushAsync();
+			}
+			catch (Exception)
+			{
+				// UWP throws NotImplementedException
+				// Uno throws InvalidOperationException with a description
+			}
+		}
+
 #if !NETFX_CORE
 		[TestMethod]
 		public async Task When_FromFile()
@@ -54,7 +71,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage.Streams
 			var tempContentBytes = Encoding.UTF8.GetBytes(tempContent);
 			temp.Write(tempContentBytes, 0, tempContentBytes.Length);
 			temp.Position = 0;
-			
+
 			var actual = await ReadToEnd(sut);
 
 			Assert.AreEqual(tempContent, actual);

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FileOpenPicker.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FileOpenPicker.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Pickers
 {
-	#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class FileOpenPicker 
@@ -94,7 +94,7 @@ namespace Windows.Storage.Pickers
 		}
 		#endif
 		#if false || false || NET461 || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public FileOpenPicker() 
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.Pickers.FileOpenPicker", "FileOpenPicker.FileOpenPicker()");
@@ -117,7 +117,7 @@ namespace Windows.Storage.Pickers
 		}
 		#endif
 		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> PickSingleFileAsync( string pickerOperationId)
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> FileOpenPicker.PickSingleFileAsync(string pickerOperationId) is not implemented in Uno.");
@@ -133,14 +133,14 @@ namespace Windows.Storage.Pickers
 		// Forced skipping of method Windows.Storage.Pickers.FileOpenPicker.CommitButtonText.set
 		// Forced skipping of method Windows.Storage.Pickers.FileOpenPicker.FileTypeFilter.get
 		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> PickSingleFileAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> FileOpenPicker.PickSingleFileAsync() is not implemented in Uno.");
 		}
 		#endif
 		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyList<global::Windows.Storage.StorageFile>> PickMultipleFilesAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IReadOnlyList<StorageFile>> FileOpenPicker.PickMultipleFilesAsync() is not implemented in Uno.");

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FileSavePicker.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FileSavePicker.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Pickers
 {
-#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+#if false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class FileSavePicker
@@ -141,7 +141,7 @@ namespace Windows.Storage.Pickers
 #endif
 
 #if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public FileSavePicker()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.Pickers.FileSavePicker", "FileSavePicker.FileSavePicker()");
@@ -174,7 +174,7 @@ namespace Windows.Storage.Pickers
 		// Forced skipping of method Windows.Storage.Pickers.FileSavePicker.SuggestedFileName.set
 
 #if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFile> PickSaveFileAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFile> FileSavePicker.PickSaveFileAsync() is not implemented in Uno.");

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FolderPicker.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FolderPicker.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Pickers
 {
-	#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class FolderPicker 
@@ -94,7 +94,7 @@ namespace Windows.Storage.Pickers
 		}
 		#endif
 		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__NETSTD_REFERENCE__")]
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public FolderPicker() 
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.Pickers.FolderPicker", "FolderPicker.FolderPicker()");
@@ -119,7 +119,7 @@ namespace Windows.Storage.Pickers
 		// Forced skipping of method Windows.Storage.Pickers.FolderPicker.CommitButtonText.set
 		// Forced skipping of method Windows.Storage.Pickers.FolderPicker.FileTypeFilter.get
 		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__NETSTD_REFERENCE__")]
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.StorageFolder> PickSingleFolderAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<StorageFolder> FolderPicker.PickSingleFolderAsync() is not implemented in Uno.");

--- a/src/Uno.UWP/Storage/Streams/Internal/NativeReadStream.wasm.cs
+++ b/src/Uno.UWP/Storage/Streams/Internal/NativeReadStream.wasm.cs
@@ -47,7 +47,7 @@ namespace Uno.Storage.Streams.Internal
 
 		public override void SetLength(long value) => throw new NotSupportedException("This stream is read-only");
 
-		public override void Flush() => throw new NotSupportedException("This stream is read-only");
+		public override void Flush() { }
 
 		public static async Task<NativeReadStream> CreateAsync(Guid fileId)
 		{

--- a/src/Uno.UWP/Storage/Streams/StreamOverInputStream.cs
+++ b/src/Uno.UWP/Storage/Streams/StreamOverInputStream.cs
@@ -65,11 +65,9 @@ namespace Windows.Storage.Streams
 			=> throw new NotSupportedException("Cannot Write an input stream.");
 
 		/// <inheritdoc />
-		public override void Flush()
-			=> FlushAsync(CancellationToken.None).Wait();
+		public override void Flush() { }
 
 		/// <inheritdoc />
-		public override Task FlushAsync(CancellationToken cancellationToken)
-			=> throw new NotSupportedException("Cannot Flush an input stream.");
+		public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5751, fixes #5766

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Some read-only streams in Storage APIs throw on Flush.
- Analyzers report file pickers as not implemented even though they are

## What is the new behavior?

- Some of the read-only streams in Storage APIs no longer throw on Flush calls to match UWP behavior.
- Adjust `NotImplemented` attributes on file pickers


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.