### PR TITLE
[Wasm] Removed hard-coded exception in handler for Html Custom Event

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/UIElementTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/UIElementTests.cs
@@ -43,7 +43,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml
 			_app.WaitForElement("SpacerBorder");
 			var spacerRect = _app.GetRect("SpacerBorder");
 
-			using var scrn = TakeScreenshot("Ready");
+			using var scrn = TakeScreenshot("Ready", ignoreInSnapshotCompare: true);
 
 			ImageAssert.HasColorAt(scrn, spacerRect.X, spacerRect.Y, Color.Red);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/WasmTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/WasmTests.cs
@@ -8,7 +8,7 @@ using Uno.UITest.Helpers.Queries;
 namespace SamplesApp.UITests.Windows_UI_Xaml
 {
 	[TestFixture]
-	public class WasmTests : SampleControlUITestBase
+	public partial class WasmTests : SampleControlUITestBase
 	{
 		[Test]
 		[ActivePlatforms(Platform.Browser)]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/WasmTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/UIElementTests/WasmTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Drawing;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml
+{
+	[TestFixture]
+	public class WasmTests : SampleControlUITestBase
+	{
+		[Test]
+		[ActivePlatforms(Platform.Browser)]
+		[AutoRetry]
+		public void Given_HtmlEvents_On_GenericEvents()
+		{
+			Run("UITests.Shared.Wasm.Wasm_CustomEvent");
+
+			var control = _app.Marked("genericEvent");
+			var rect = _app.GetPhysicalRect(control);
+
+			var result = _app.Marked("tapResult");
+
+			control.FastTap();
+
+			using var screenshot = TakeScreenshot("tap");
+			ImageAssert.HasColorAt(screenshot, rect.CenterX, rect.CenterY, Color.Pink, 8);
+			result.GetDependencyPropertyValue<string>("Text").Should().Be("Ok");
+		}
+		[Test]
+		[ActivePlatforms(Platform.Browser)]
+		[AutoRetry]
+		public void Given_HtmlEvents_On_CustomEvents()
+		{
+			Run("UITests.Shared.Wasm.Wasm_CustomEvent");
+
+			var control = _app.Marked("customEventString");
+			var rect = _app.GetPhysicalRect(control);
+
+			var result = _app.Marked("tapResult");
+
+			control.FastTap();
+
+			using var screenshot = TakeScreenshot("tap");
+			ImageAssert.HasColorAt(screenshot, rect.CenterX, rect.CenterY, Color.Pink, 8);
+			result.GetDependencyPropertyValue<string>("Text").Should().Be("Ok");
+		}
+		[Test]
+		[ActivePlatforms(Platform.Browser)]
+		[AutoRetry]
+		public void Given_HtmlEvents_On_CustomEventsWithJsonPayload()
+		{
+			Run("UITests.Shared.Wasm.Wasm_CustomEvent");
+
+			var control = _app.Marked("customEventJson");
+			var rect = _app.GetPhysicalRect(control);
+
+			var result = _app.Marked("tapResult");
+
+			control.FastTap();
+
+			using var screenshot = TakeScreenshot("tap");
+			ImageAssert.HasColorAt(screenshot, rect.CenterX, rect.CenterY, Color.Pink, 8);
+			result.GetDependencyPropertyValue<string>("Text").Should().Be("Ok");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml
+++ b/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml
@@ -7,7 +7,7 @@
 	mc:Ignorable="d">
 
 	<StackPanel Spacing="8" Margin="10">
-		<TextBlock>This test is for the WASM target only. Don't do anything on other platforms.</TextBlock>
+		<TextBlock TextWrapping="Wrap">This test is for the WASM target only. Don't do anything on other platforms.</TextBlock>
 		<Border Height="100" Background="BurlyWood" x:Name="genericEvent">
 			<TextBlock>Tap here to generate a generic html event</TextBlock>
 		</Border>
@@ -17,7 +17,7 @@
 		<Border Height="100" Background="BurlyWood" x:Name="customEventJson">
 			<TextBlock>Tap here to generate a custom html event with json payload</TextBlock>
 		</Border>
-		<TextBlock x:Name="tapResult" />
+		<TextBlock x:Name="tapResult" FontSize="25" FontWeight="Bold" />
 		<TextBlock x:Name="result">Result here...</TextBlock>
 
 	</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml.cs
@@ -35,14 +35,17 @@ namespace UITests.Shared.Wasm
 
 	const onDiv1 = function(){
 		div1.dispatchEvent(new Event(""unoevent1""));
+		div1.style.backgroundColor = ""pink"";
 	};
 
 	const onDiv2 = function(){
 		div2.dispatchEvent(new CustomEvent(""unoevent2"", {detail:""String detail from event.""}));
+		div2.style.backgroundColor = ""pink"";
 	};
 
 	const onDiv3 = function(){
 		div3.dispatchEvent(new CustomEvent(""unoevent3"", {detail: {msg:""msg"",int:123,txt:""it works!""}}));
+		div3.style.backgroundColor = ""pink"";
 	};
 
 	div1.addEventListener(""click"", onDiv1);
@@ -54,35 +57,50 @@ namespace UITests.Shared.Wasm
 			WebAssemblyRuntime.InvokeJS($"{script}({genericId},{stringId},{jsonId});");
 
 			genericEvent.RegisterHtmlEventHandler("unoevent1", OnUnoEvent1);
+			genericEvent.RegisterHtmlEventHandler("unoevent1", OnUnoEvent1bis);
 			customEventString.RegisterHtmlCustomEventHandler("unoevent2", OnUnoEvent2, isDetailJson: false);
+			customEventString.RegisterHtmlCustomEventHandler("unoevent2", OnUnoEvent2bis, isDetailJson: false);
 			customEventJson.RegisterHtmlCustomEventHandler("unoevent3", OnUnoEvent3, isDetailJson: true);
-
+			customEventJson.RegisterHtmlCustomEventHandler("unoevent3", OnUnoEvent3bis, isDetailJson: true);
 		}
 
 		private void OnUnoEvent1(object sender, EventArgs e)
 		{
+			tapResult.Text = "[WORKING]";
 			result.Text += $"Received generic event from {sender}\n.";
+		}
+
+		private void OnUnoEvent1bis(object sender, EventArgs e)
+		{
 			tapResult.Text = "Ok";
 		}
 
 		private void OnUnoEvent2(object sender, HtmlCustomEventArgs e)
 		{
+			tapResult.Text = "[WORKING]";
 			result.Text += $"Received string event from {sender}: \"{e.Detail}\"\n.";
+		}
 
+		private void OnUnoEvent2bis(object sender, HtmlCustomEventArgs e)
+		{
 			tapResult.Text =
 				e.Detail == "String detail from event."
-				? "Ok"
-				: "Error: received " + e.Detail;
+					? "Ok"
+					: "Error: received " + e.Detail;
 		}
 
 		private void OnUnoEvent3(object sender, HtmlCustomEventArgs e)
 		{
+			tapResult.Text = "[WORKING]";
 			result.Text += $"Received json event from {sender}: {e.Detail}\n.";
+		}
 
+		private void OnUnoEvent3bis(object sender, HtmlCustomEventArgs e)
+		{
 			try
 			{
 				var json = JToken.Parse(e.Detail);
-				if(json["msg"].Value<string>() == "msg" && json["int"].Value<int>() == 123 && json["txt"].Value<string>() == "it works!")
+				if (json["msg"].Value<string>() == "msg" && json["int"].Value<int>() == 123 && json["txt"].Value<string>() == "it works!")
 				{
 					tapResult.Text = "Ok";
 				}
@@ -92,7 +110,7 @@ namespace UITests.Shared.Wasm
 				}
 
 			}
-			catch(Exception ex)
+			catch (Exception ex)
 			{
 				tapResult.Text = "Error: " + ex.Message;
 			}

--- a/src/Uno.UI.Runtime.WebAssembly/Xaml/UIElementWasmExtensions.cs
+++ b/src/Uno.UI.Runtime.WebAssembly/Xaml/UIElementWasmExtensions.cs
@@ -207,6 +207,7 @@ return __f(element);
 			if (d is EventHandler<HtmlCustomEventArgs> handler && args is HtmlCustomEventArgs eventArgs)
 			{
 				handler(sender, eventArgs);
+				return default;
 			}
 
 			throw new InvalidOperationException($"The parameters {args ?? "<null>"} for invoking GenericEventHandlers.RaiseEventHandler with {d} from {sender ?? "<null>"} are incorrect");


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/5721

# Bugfix
When registering multiple handlers for the same custom html event (Wasm platform), the second handler were never getting called because of a hard-coded exception.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
