### PR TITLE
fix: Do not close JS stream reader if closed

### DIFF
--- a/src/Uno.UI/ts/Windows/Storage/Streams/NativeFileReadStream.ts
+++ b/src/Uno.UI/ts/Windows/Storage/Streams/NativeFileReadStream.ts
@@ -20,12 +20,14 @@
 
 		public static async readAsync(streamId: string, targetArrayPointer: number, offset: number, count: number, position: number): Promise<string> {
 			var streamReader: ReadableStreamDefaultReader;
+			var readerNeedsRelease = true;
 			try {
 				const instance = NativeFileReadStream._streamMap.get(streamId);
 
 				var totalRead = 0;
 				var stream = await instance._file.slice(position, position + count).stream();
 				streamReader = stream.getReader();
+
 				var chunk = await streamReader.read();
 				while (!chunk.done && chunk.value) {
 					for (var i = 0; i < chunk.value.length; i++) {
@@ -36,10 +38,26 @@
 					chunk = await streamReader.read();
 				}
 
+				// If this is the end of stream, it closed itself
+				readerNeedsRelease = !chunk.done;
+
 				return totalRead.toString();
 			}
 			finally {
-				if (streamReader) {
+				// Reader must be released only if the underlying stream has not already closed it.				
+				// Otherwise the release operation sets a new Promise.reject as reader.closed which
+				// raises silent but observable exception in Chromium-based browsers.
+				if (streamReader && readerNeedsRelease) {
+
+					// Silently handling TypeError exceptions on closed event as the releaseLock()
+					// raises one in case of a successful close.
+					streamReader.closed.catch(reason => {
+						if (!(reason instanceof TypeError)) {
+							throw reason;
+						}
+					});
+
+					streamReader.cancel();
 					streamReader.releaseLock();
 				}
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5749

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

In case the underlying stream has reached end, JS `streamReader.releaseLock()` causes `Promise.reject()` which is observed in the developer console and there is no way to prevent this. This is a weird behavior which is discussed here - https://bugs.chromium.org/p/chromium/issues/detail?id=465666.

## What is the new behavior?

`releaseLock` is no longer called if we finished reading the whole stream (in such case the release is not needed anyway).


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.