### PR TITLE
fix(GTK): pointer events in wrong locations using Wayland

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkCoreWindowExtension.cs
@@ -51,17 +51,21 @@ namespace Uno.UI.Runtime.Skia
 			_owner = (CoreWindow)owner;
 			_ownerEvents = (ICoreWindowEvents)owner;
 
+			// even though we are not going to use events directly in the window here maintain the masks
 			GtkHost.Window.AddEvents((int)RequestedEvents);
+			// add masks for the GtkEventBox
+			GtkHost.EventBox.AddEvents((int)RequestedEvents);
 
-			GtkHost.Window.EnterNotifyEvent += OnWindowEnterEvent;
-			GtkHost.Window.LeaveNotifyEvent += OnWindowLeaveEvent;
-			GtkHost.Window.ButtonPressEvent += OnWindowButtonPressEvent;
-			GtkHost.Window.ButtonReleaseEvent += OnWindowButtonReleaseEvent;
-			GtkHost.Window.MotionNotifyEvent += OnWindowMotionEvent;
-			GtkHost.Window.ScrollEvent += OnWindowScrollEvent;
-			GtkHost.Window.TouchEvent += OnWindowTouchEvent;
-			GtkHost.Window.ProximityInEvent += OnWindowProximityInEvent;
-			GtkHost.Window.ProximityOutEvent += OnWindowProximityOutEvent;
+			// Use GtkEventBox to fix Wayland titlebar events
+			GtkHost.EventBox.EnterNotifyEvent += OnWindowEnterEvent;
+			GtkHost.EventBox.LeaveNotifyEvent += OnWindowLeaveEvent;
+			GtkHost.EventBox.ButtonPressEvent += OnWindowButtonPressEvent;
+			GtkHost.EventBox.ButtonReleaseEvent += OnWindowButtonReleaseEvent;
+			GtkHost.EventBox.MotionNotifyEvent += OnWindowMotionEvent;
+			GtkHost.EventBox.ScrollEvent += OnWindowScrollEvent;
+			GtkHost.EventBox.TouchEvent += OnWindowTouchEvent;
+			GtkHost.EventBox.ProximityInEvent += OnWindowProximityInEvent;
+			GtkHost.EventBox.ProximityOutEvent += OnWindowProximityOutEvent;
 
 			InitializeKeyboard();
 		}

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -26,11 +26,13 @@ namespace Uno.UI.Runtime.Skia
 		private readonly string[] _args;
 		private readonly Func<WUX.Application> _appBuilder;
 		private static Gtk.Window _window;
+		private static Gtk.EventBox _eventBox;
 		private UnoDrawingArea _area;
 		private Fixed _fix;
 		private GtkDisplayInformationExtension _displayInformationExtension;
 
 		public static Gtk.Window Window => _window;
+		public static Gtk.EventBox EventBox => _eventBox;
 
 		public GtkHost(Func<WUX.Application> appBuilder, string[] args)
 		{
@@ -108,13 +110,15 @@ namespace Uno.UI.Runtime.Skia
 				WUX.Window.Current.OnNativeSizeChanged(new Windows.Foundation.Size(e.Allocation.Width, e.Allocation.Height));
 			};
 
-			var overlay = new Overlay();			
+			var overlay = new Overlay();
 
+			_eventBox = new EventBox();
 			_area = new UnoDrawingArea();
 			_fix = new Fixed();
 			overlay.Add(_area);
 			overlay.AddOverlay(_fix);
-			_window.Add(overlay);
+			_eventBox.Add(overlay);
+			_window.Add(_eventBox);
 
 			/* avoids double invokes at window level */
 			_area.AddEvents((int)GtkCoreWindowExtension.RequestedEvents);

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -36,7 +36,8 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 
 		private Fixed GetWindowTextInputLayer()
 		{
-			var overlay = (Overlay)_window.Child;
+			// now we have the GtkEventBox
+			var overlay = (Overlay)((EventBox) _window.Child).Child;
 			return overlay.Children.OfType<Fixed>().First();
 		}
 


### PR DESCRIPTION
For GTK applications using Wayland the title bar is rendered by the
window itself and not by the composer. And it seems to me that GTK
counts the title bar as part of the window and uses it to trigger the
window events, leading to erroneous considerations about the size and
location of pointers in the area where it is used to draw the
components.

The fix adds a GtkEventBox in the window, instead of use the window
events we will be based on the events of the GtkEventBox which we can
assure that the GTK will take into account the title bar.

Related-to: #5706
Signed-off-by: Matheus Castello <matheus@castello.eng.br>

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![SQAVXSEqbL](https://user-images.githubusercontent.com/2633321/115815843-20929580-a3ce-11eb-9d83-ce2c433c255b.gif)


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
![a43lV9ZcgK](https://user-images.githubusercontent.com/2633321/115816745-c85c9300-a3cf-11eb-895d-71e4ee8f2203.gif)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
