### PR TITLE
fix(reg): Fix possible null ref in SwipeControl

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/SwipeControl/SwipeControl.Uno.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SwipeControl/SwipeControl.Uno.cs
@@ -250,17 +250,17 @@ namespace Windows.UI.Xaml.Controls
 
 		private async void OnSwipeManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
 		{
-#if !DEBUG
-			// On UWP, SwipeControl works only with touch.
-			// We do allow other pointers in DEBUG ... well, because it easier to debug on a PC :)
-			if (e.PointerDeviceType != PointerDeviceType.Touch)
-			{
-				return;
-			}
-#endif
-
 			try
 			{
+#if !DEBUG
+				// On UWP, SwipeControl works only with touch.
+				// We do allow other pointers in DEBUG ... well, because it easier to debug on a PC :)
+				// Note: The OnSwipeManipulationCompleted is invoked with null args in the Close()
+				if (e != null && e.PointerDeviceType != PointerDeviceType.Touch)
+				{
+					return;
+				}
+#endif
 				_grabbedTimer.Stop();
 
 				await SimulateInertia();


### PR DESCRIPTION
## Bugfix
Accept null args in `OnManipulationCompleted` + move check in the `try/catch`

## What is the current behavior?
Crashes the app in release

## What is the new behavior?
Does not crash

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
We need to refactor the `SwipeControl` to remove `async void` (https://github.com/unoplatform/uno/issues/5813).
