### PR TITLE
fix: ContentDialog bugfixes

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -23,6 +23,7 @@ namespace Windows.UI.Xaml.Controls
 		internal readonly Popup _popup;
 		private TaskCompletionSource<ContentDialogResult> _tcs;
 		private readonly SerialDisposable _subscriptions = new SerialDisposable();
+		private bool _hiding = false;
 
 		private Border m_tpBackgroundElementPart;
 		private Border m_tpButton1HostPart;
@@ -114,7 +115,16 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		public void Hide() => Hide(ContentDialogResult.None);
+		public void Hide()
+		{
+			if (_hiding)
+			{
+				return;
+			}
+			_hiding = true;
+			Hide(ContentDialogResult.None);
+		}
+
 		private bool Hide(ContentDialogResult result)
 		{
 			void Complete(ContentDialogClosingEventArgs args)
@@ -128,6 +138,7 @@ namespace Windows.UI.Xaml.Controls
 					Closed?.Invoke(this, new ContentDialogClosedEventArgs(result));
 					_tcs.SetResult(result);
 				}
+				_hiding = false;
 			}
 			var closingArgs = new ContentDialogClosingEventArgs(Complete, result);
 
@@ -302,7 +313,17 @@ namespace Windows.UI.Xaml.Controls
 
 					Hide(result);
 				}
+				else
+				{
+					_hiding = false;
+				}
 			}
+
+			if (_hiding)
+			{
+				return;
+			}
+			_hiding = true;
 
 			var args = new ContentDialogButtonClickEventArgs(Complete);
 			CloseButtonClick?.Invoke(this, args);
@@ -323,7 +344,17 @@ namespace Windows.UI.Xaml.Controls
 					SecondaryButtonCommand.ExecuteIfPossible(SecondaryButtonCommandParameter);
 					Hide(result);
 				}
+				else
+				{
+					_hiding = false;
+				}
 			}
+
+			if (_hiding)
+			{
+				return;
+			}
+			_hiding = true;
 
 			var args = new ContentDialogButtonClickEventArgs(Complete);
 			SecondaryButtonClick?.Invoke(this, args);
@@ -346,7 +377,17 @@ namespace Windows.UI.Xaml.Controls
 
 					Hide(result);
 				}
+				else
+				{
+					_hiding = false;
+				}
 			}
+
+			if (_hiding)
+			{
+				return;
+			}
+			_hiding = true;
 
 			var args = new ContentDialogButtonClickEventArgs(Complete);
 			PrimaryButtonClick?.Invoke(this, args);

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -300,10 +300,7 @@ namespace Windows.UI.Xaml.Controls
 
 					CloseButtonCommand.ExecuteIfPossible(CloseButtonCommandParameter);
 
-					if (Hide(result))
-					{
-						_tcs.SetResult(result);
-					}
+					Hide(result);
 				}
 			}
 
@@ -324,10 +321,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 					const ContentDialogResult result = ContentDialogResult.Secondary;
 					SecondaryButtonCommand.ExecuteIfPossible(SecondaryButtonCommandParameter);
-					if (Hide(result))
-					{
-						_tcs.SetResult(result);
-					}
+					Hide(result);
 				}
 			}
 
@@ -350,10 +344,7 @@ namespace Windows.UI.Xaml.Controls
 					const ContentDialogResult result = ContentDialogResult.Primary;
 					PrimaryButtonCommand.ExecuteIfPossible(PrimaryButtonCommandParameter);
 
-					if (Hide(result))
-					{
-						_tcs.SetResult(result);
-					}
+					Hide(result);
 				}
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5702

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix

## What is the current behavior?
### Dialog Closing:
```C#
        private async void Dialog_Closing(object sender, ContentDialogClosingEventArgs args)
        {
            var deferral = args.GetDeferral();
            await Task.Delay(5000);
            System.Diagnostics.Debug.WriteLine("Done handling event.");
            deferral.Complete();
        }

        private async void Button_Tapped(object sender, TappedRoutedEventArgs args)
        {
            var dialog = new SampleContentDialog();
            dialog.Closing += Dialog_Closing;
            await dialog.ShowAsync();
            System.Diagnostics.Debug.WriteLine("Dialog returned.");
        }
        
        private async void Button1_Tapped(object sender, TappedRoutedEventArgs args)
        {
            var dialog = new SampleContentDialog();
            await dialog.ShowAsync();
            System.Diagnostics.Debug.WriteLine("Dialog returned.");
        }
```

`Button_Tapped` output:
> Dialog returned.

5 seconds later:

> Done handling event.
> An unhandled exception of type 'System.InvalidOperationException' occurred in System.Private.CoreLib.dll
> An attempt was made to transition a task to a final state when it had already completed.

`Button1_Tapped`: throws `System.InvalidOperationException`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

### Buttons:
- Tap a button on the `ContentDialog` to make the dialog close.
- Tap another button, before the dialog closes.
- The `Closing` event is triggered twice, before the first event completes.

## What is the new behavior?

### Dialog Closing

`Button_Tapped` output:
> Done handling event.
> Dialog returned.

Quits quietly without an exception.

`Button1_Tapped`: Quits quietly without an exception.

<!-- Please describe the new behavior after your modifications. -->

### Buttons:
When the dialog is hiding, all button clicks and calls to `Hide()` are ignored. This is consistent with UWP.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
