### PR TITLE
fix: ElevatedView should not be tab stop

### DIFF
--- a/src/Uno.UI.Toolkit/Themes/Generic.xaml
+++ b/src/Uno.UI.Toolkit/Themes/Generic.xaml
@@ -3,6 +3,7 @@
 					xmlns:toolkit="using:Uno.UI.Toolkit">
 
 	<Style TargetType="toolkit:ElevatedView">
+		<Setter Property="IsTabStop" Value="False" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="toolkit:ElevatedView">


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5809

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

ElevatedView Is tab stop

## What is the new behavior?

ElevatedView Is not tab stop


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.