### PR TITLE
fix: Avoid StackOverflow for multiline TextBox, fail on remove

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2873,6 +2873,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_In_ContentDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_HorizontalAlignment.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5714,6 +5718,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Header.xaml.cs">
       <DependentUpon>TextBox_Header.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_In_ContentDialog.xaml.cs">
+      <DependentUpon>TextBox_In_ContentDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_HorizontalAlignment.xaml.cs">
       <DependentUpon>TextBox_HorizontalAlignment.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_In_ContentDialog.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_In_ContentDialog.xaml
@@ -1,0 +1,25 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBoxControl.TextBox_In_ContentDialog"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="TextBox in ContentDialog">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<Button Click="ShowSinglelineClick">Show singleline TextBox</Button>
+					<Button Click="ShowMultilineClick">Show multiline TextBox</Button>
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_In_ContentDialog.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_In_ContentDialog.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBoxControl
+{
+	[Sample("TextBox")]
+	public sealed partial class TextBox_In_ContentDialog : UserControl
+	{
+		public TextBox_In_ContentDialog()
+		{
+			this.InitializeComponent();
+		}
+
+		private async void ShowSinglelineClick(object sender, RoutedEventArgs e)
+		{
+			var dialog = new ContentDialog()
+			{
+				Content = new TextBox(),
+				PrimaryButtonText = "OK"
+			};
+			await dialog.ShowAsync();
+		}
+
+		private async void ShowMultilineClick(object sender, RoutedEventArgs e)
+		{
+			var dialog = new ContentDialog()
+			{
+				Content = new TextBox() { AcceptsReturn = true },
+				PrimaryButtonText = "OK"
+			};
+			await dialog.ShowAsync();
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -24,6 +24,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 		private readonly GtkWindow _window;
 		private ContentControl? _contentElement;
 		private Widget? _currentInputWidget;
+		private bool _handlingTextChanged;
 
 		private readonly SerialDisposable _textChangedDisposable = new SerialDisposable();
 		private readonly SerialDisposable _textBoxEventSubscriptions = new SerialDisposable();
@@ -83,8 +84,11 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 			_contentElement = null;
 			_textBoxEventSubscriptions.Disposable = null;
 
-			var textInputLayer = GetWindowTextInputLayer();
-			textInputLayer.Remove(_currentInputWidget);
+			if (_currentInputWidget != null)
+			{
+				var textInputLayer = GetWindowTextInputLayer();
+				textInputLayer.Remove(_currentInputWidget);
+			}
 		}
 
 		public void UpdateNativeView()
@@ -202,8 +206,27 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 			return widget;
 		}
 
-		private void WidgetTextChanged(object? sender, EventArgs e) =>
-			_owner.UpdateTextFromNative(GetInputText() ?? string.Empty);
+		private void WidgetTextChanged(object? sender, EventArgs e)
+		{
+			// Avoid stack overflow as updating text from
+			// shared code briefly sets empty string and causes
+			// infinite loop
+			if (_handlingTextChanged)
+			{
+				return;
+			}
+
+			try
+			{
+				_handlingTextChanged = true;
+				_owner.UpdateTextFromNative(GetInputText() ?? string.Empty);
+
+			}
+			finally
+			{
+				_handlingTextChanged = false;
+			}
+		}
 
 		private string? GetInputText() =>
 			_currentInputWidget switch

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Skia.cs
@@ -71,7 +71,10 @@ namespace Windows.UI.Xaml.Controls
 			if (textBox != null)
 			{
 				var text = textBox.ProcessTextInput(newText);
-				SetTextNative(text);
+				if (text != newText)
+				{
+					SetTextNative(text);
+				}
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5817

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Stack overflow exception occurs when multiline TextBox is edited in Skia, because GTK triggers an additional TextChanged event with empty string and causes infinite loop
- When TextBox is unfocused and the entry was not visible, it should not be removed

## What is the new behavior?

Fixed.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.