### PR TITLE
fix(xLoad): Ensure re-evaluation of StaticResource markup

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -5312,10 +5312,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 										{
 											using (writer.BlockInvariant($"if ({componentName}_update_That.Target is {_className.className} that)"))
 											{
-												// Refresh the bindings when the ElementStub is unloaded. This assumes that
-												// ElementStub will be unloaded **after** the stubbed control has been created
-												// in order for the _component_XXX to be filled, and Bindings.Update() to do its work.
-												writer.AppendLineInvariant($"that.Bindings.Update();");
 
 												using (writer.BlockInvariant($"if (sender.IsMaterialized)"))
 												{
@@ -5333,6 +5329,16 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 										}
 
 										writer.AppendLineInvariant($"{closureName}.MaterializationChanged += {componentName}_update;");
+
+										using (writer.BlockInvariant($"void {componentName}_unloaded(object sender, RoutedEventArgs e)"))
+										{
+											// Refresh the bindings when the ElementStub is unloaded. This assumes that
+											// ElementStub will be unloaded **after** the stubbed control has been created
+											// in order for the _component_XXX to be filled, and Bindings.Update() to do its work.
+											writer.AppendLineInvariant($"({componentName}_update_That.Target as {_className.className})?.Bindings.Update();");
+										}
+
+										writer.AppendLineInvariant($"{closureName}.Unloaded += {componentName}_unloaded;");
 
 										var xamlObjectDef = new XamlObjectDefinition(elementStubType, 0, 0, definition);
 										xamlObjectDef.Members.AddRange(members);

--- a/src/Uno.UI.Tests/Global.cs
+++ b/src/Uno.UI.Tests/Global.cs
@@ -23,6 +23,7 @@ namespace Uno.UI.Tests
 #else
 				var logLevel = LogLevel.Information;
 #endif
+				builder.SetMinimumLevel(logLevel);
 				builder.AddConsole(o => o.LogToStandardErrorThreshold = logLevel);
 			});
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_Setter.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_Setter.xaml
@@ -1,0 +1,50 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.Binding_xLoad_Setter"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+
+    <Grid>
+
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="FormStates">
+                <VisualState x:Name="EllipseState">
+                    <VisualState.Setters>
+                        <Setter Target="ellipse.StrokeThickness"
+                                Value="4" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="SquareState">
+                    <VisualState.Setters>
+                        <Setter Target="square.StrokeThickness"
+                                Value="4" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
+        <Ellipse x:Name="ellipse"
+                 x:FieldModifier="public"
+                 Grid.Row="2"
+                 Width="200"
+                 Height="200"
+                 Fill="Red"
+                 HorizontalAlignment="Center"
+                 x:Load="{x:Bind IsEllipseLoaded, Mode=OneWay}"
+				 Loading="{x:Bind OnEllipseLoading}"
+                 Margin="20" />
+
+        <Rectangle x:Name="square"
+                   x:FieldModifier="public"
+                   Grid.Row="2"
+                   Width="200"
+                   Height="200"
+                   Fill="Blue"
+                   HorizontalAlignment="Center"
+                   x:Load="{x:Bind IsSquareLoaded, Mode=OneWay}"
+				   Loading="{x:Bind OnSquareLoading}"
+                   Margin="20" />
+    </Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_Setter.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_Setter.xaml.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_xLoad_Setter : Page
+	{
+		public Binding_xLoad_Setter()
+		{
+			this.InitializeComponent();
+
+			Loaded += OnLoaded;
+		}
+
+		public bool IsEllipseLoaded
+		{
+			get => (bool)GetValue(IsEllipseLoadedProperty);
+			set => SetValue(IsEllipseLoadedProperty, value);
+		}
+
+		public static readonly DependencyProperty IsEllipseLoadedProperty = DependencyProperty.Register(
+			nameof(IsEllipseLoaded),
+			typeof(bool),
+			typeof(Binding_xLoad_Setter),
+			new PropertyMetadata(false, OnIsEllipseLoadedChanged));
+
+		private static void OnIsEllipseLoadedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is Binding_xLoad_Setter self)
+			{
+				self.OnIsEllipseLoadedChanged((bool)e.NewValue);
+			}
+		}
+
+		private void OnIsEllipseLoadedChanged(bool newValue)
+		{
+			IsSquareLoaded = !newValue;
+		}
+
+		private void OnEllipseLoading()
+			=> UpdateStates(true);
+
+		private void OnSquareLoading()
+			=> UpdateStates(true);
+
+		public bool IsSquareLoaded
+		{
+			get => (bool)GetValue(IsSquareLoadedProperty);
+			set => SetValue(IsSquareLoadedProperty, value);
+		}
+
+		public static readonly DependencyProperty IsSquareLoadedProperty = DependencyProperty.Register(
+			nameof(IsSquareLoaded),
+			typeof(bool),
+			typeof(Binding_xLoad_Setter),
+			new PropertyMetadata(true));
+
+		private void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			UpdateStates(false);
+		}
+
+		private void UpdateStates(bool useTransitions)
+		{
+			if (this.IsEllipseLoaded)
+			{
+				VisualStateManager.GoToState(this, this.EllipseState.Name, useTransitions);
+			}
+			else
+			{
+				VisualStateManager.GoToState(this, this.SquareState.Name, useTransitions);
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_Setter_Order.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_Setter_Order.xaml
@@ -1,0 +1,48 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.Binding_xLoad_Setter_Order"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+
+    <Grid>
+
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="FormStates">
+                <VisualState x:Name="EllipseState">
+                    <VisualState.Setters>
+                        <Setter Target="ellipse.StrokeThickness"
+                                Value="4" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="SquareState">
+                    <VisualState.Setters>
+                        <Setter Target="square.StrokeThickness"
+                                Value="4" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
+        <Ellipse x:Name="ellipse"
+                 x:FieldModifier="public"
+                 Grid.Row="2"
+                 Width="200"
+                 Height="200"
+                 Fill="Red"
+                 HorizontalAlignment="Center"
+                 x:Load="{x:Bind IsEllipseLoaded, Mode=OneWay}"
+                 Margin="20" />
+
+        <Rectangle x:Name="square"
+                   x:FieldModifier="public"
+                   Grid.Row="2"
+                   Width="200"
+                   Height="200"
+                   Fill="Blue"
+                   HorizontalAlignment="Center"
+                   x:Load="{x:Bind IsSquareLoaded, Mode=OneWay}"
+                   Margin="20" />
+    </Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_Setter_Order.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_Setter_Order.xaml.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_xLoad_Setter_Order : Page
+	{
+		public Binding_xLoad_Setter_Order()
+		{
+			this.InitializeComponent();
+
+			Loaded += OnLoaded;
+		}
+
+		public bool IsEllipseLoaded
+		{
+			get => (bool)GetValue(IsEllipseLoadedProperty);
+			set => SetValue(IsEllipseLoadedProperty, value);
+		}
+
+		public static readonly DependencyProperty IsEllipseLoadedProperty = DependencyProperty.Register(
+			nameof(IsEllipseLoaded),
+			typeof(bool),
+			typeof(Binding_xLoad_Setter_Order),
+			new PropertyMetadata(false, OnIsEllipseLoadedChanged));
+
+		private static void OnIsEllipseLoadedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is Binding_xLoad_Setter_Order self)
+			{
+				self.OnIsEllipseLoadedChanged((bool)e.NewValue);
+			}
+		}
+
+		private void OnIsEllipseLoadedChanged(bool newValue)
+		{
+			IsSquareLoaded = !newValue;
+			UpdateStates(true);
+		}
+
+		public bool IsSquareLoaded
+		{
+			get => (bool)GetValue(IsSquareLoadedProperty);
+			set => SetValue(IsSquareLoadedProperty, value);
+		}
+
+		public static readonly DependencyProperty IsSquareLoadedProperty = DependencyProperty.Register(
+			nameof(IsSquareLoaded),
+			typeof(bool),
+			typeof(Binding_xLoad_Setter_Order),
+			new PropertyMetadata(true));
+
+		private void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			UpdateStates(false);
+		}
+
+		private void UpdateStates(bool useTransitions)
+		{
+			if (this.IsEllipseLoaded)
+			{
+				VisualStateManager.GoToState(this, this.EllipseState.Name, useTransitions);
+			}
+			else
+			{
+				VisualStateManager.GoToState(this, this.SquareState.Name, useTransitions);
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_StaticResources.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_StaticResources.xaml
@@ -1,0 +1,26 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.Binding_xLoad_StaticResources"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="TestTemplate">
+			<TextBox
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Center"
+                Text="{Binding}" />
+		</DataTemplate>
+	</Page.Resources>
+	<Grid
+        x:Name="TestGrid"
+		x:FieldModifier="public"
+        x:Load="{x:Bind IsTestGridLoaded, Mode=OneWay}">
+		<ContentControl x:Name="contentControl"
+					  x:FieldModifier="public"
+					  ContentTemplate="{StaticResource TestTemplate}">
+		</ContentControl>
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_StaticResources.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_xLoad_StaticResources.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_xLoad_StaticResources : Page
+	{
+		public Binding_xLoad_StaticResources()
+		{
+			this.InitializeComponent();
+		}
+
+		public string[] Items = { "1", "2", "3" };
+
+		public bool IsTestGridLoaded
+		{
+			get { return (bool)GetValue(IsTestGridLoadedProperty); }
+			set { SetValue(IsTestGridLoadedProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for IsTestGridLoaded.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty IsTestGridLoadedProperty =
+			DependencyProperty.Register("IsTestGridLoaded", typeof(bool), typeof(Binding_xLoad_StaticResources), new PropertyMetadata(false));
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -935,6 +936,45 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 
 			Assert.AreEqual(SUT.Model.Value.ToString(), SUT.ValueView.Text);
 			Assert.AreEqual(SUT.Model.Text, SUT.TextView.Text);
+		}
+
+		[TestMethod]
+		public async Task When_xLoad_StaticResource()
+		{
+			var SUT = new Binding_xLoad_StaticResources();
+
+			SUT.ForceLoaded();
+
+			Assert.IsNull(SUT.TestGrid);
+			SUT.IsTestGridLoaded = true;
+
+			Assert.IsNotNull(SUT.TestGrid);
+			Assert.IsNotNull(SUT.contentControl);
+			Assert.IsNotNull(SUT.contentControl.ContentTemplate);
+
+			SUT.IsTestGridLoaded = false;
+
+			var sw = Stopwatch.StartNew();
+			while (sw.Elapsed < TimeSpan.FromSeconds(1)
+				&& ( SUT.TestGrid != null || SUT.contentControl != null))
+			{
+				await Task.Delay(100);
+
+				// Wait for the ElementNameSubject and ComponentHolder
+				// instances to release their references.
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+			}
+
+			Assert.IsNull(SUT.TestGrid);
+
+			Assert.IsNull(SUT.contentControl);
+
+			SUT.IsTestGridLoaded = true;
+
+			Assert.IsNotNull(SUT.TestGrid);
+			Assert.IsNotNull(SUT.contentControl);
+			Assert.IsNotNull(SUT.contentControl.ContentTemplate);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/ElementStub.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.cs
@@ -30,6 +30,17 @@ namespace Windows.UI.Xaml
 #endif
 		private View _content;
 
+		/// <summary>
+		/// A delegate used to raise materialization changes in <see cref="ElementStub.MaterializationChanged"/>
+		/// </summary>
+		/// <param name="sender">The instance being changed</param>
+		public delegate void MaterializationChangedHandler(ElementStub sender);
+
+		/// <summary>
+		/// An event raised when the materialized object of the <see cref="ElementStub"/> has changed.
+		/// </summary>
+		public event MaterializationChangedHandler MaterializationChanged;
+
 		public bool Load
 		{
 			get => (bool)GetValue(LoadProperty);
@@ -40,6 +51,11 @@ namespace Windows.UI.Xaml
 		public static readonly DependencyProperty LoadProperty =
 			DependencyProperty.Register("Load", typeof(bool), typeof(ElementStub), new PropertyMetadata(
 				false, OnLoadChanged));
+
+		/// <summary>
+		/// Determines if the current ElementStub has been materialized to its target View.
+		/// </summary>
+		public bool IsMaterialized => _content != null;
 
 		public ElementStub(Func<View> contentBuilder) : this()
 		{
@@ -125,6 +141,8 @@ namespace Windows.UI.Xaml
 
 				targetDependencyObject.SetValue(visibilityProperty, Visibility.Visible, precedence);
 			}
+
+			MaterializationChanged?.Invoke(this);
 		}
 
 		private void Dematerialize()
@@ -134,6 +152,8 @@ namespace Windows.UI.Xaml
 			{
 				_content = null;
 			}
+
+			MaterializationChanged?.Invoke(this);
 		}
 
 		private static DependencyProperty GetVisibilityProperty(View view)

--- a/src/Uno.UI/UI/Xaml/ElementStub.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.cs
@@ -129,31 +129,37 @@ namespace Windows.UI.Xaml
 
 		private void Materialize(bool isVisibilityChanged)
 		{
-			_content = SwapViews(oldView: (FrameworkElement)this, newViewProvider: ContentBuilder);
-			var targetDependencyObject = _content as DependencyObject;
-
-			if (isVisibilityChanged && targetDependencyObject != null)
+			if (_content == null)
 			{
-				var visibilityProperty = GetVisibilityProperty(_content);
+				_content = SwapViews(oldView: (FrameworkElement)this, newViewProvider: ContentBuilder);
+				var targetDependencyObject = _content as DependencyObject;
 
-				// Set the visibility at the same precedence it was currently set with on the stub.
-				var precedence = this.GetCurrentHighestValuePrecedence(visibilityProperty);
+				if (isVisibilityChanged && targetDependencyObject != null)
+				{
+					var visibilityProperty = GetVisibilityProperty(_content);
 
-				targetDependencyObject.SetValue(visibilityProperty, Visibility.Visible, precedence);
+					// Set the visibility at the same precedence it was currently set with on the stub.
+					var precedence = this.GetCurrentHighestValuePrecedence(visibilityProperty);
+
+					targetDependencyObject.SetValue(visibilityProperty, Visibility.Visible, precedence);
+				}
+
+				MaterializationChanged?.Invoke(this);
 			}
-
-			MaterializationChanged?.Invoke(this);
 		}
 
 		private void Dematerialize()
 		{
-			var newView = SwapViews(oldView: (FrameworkElement)_content, newViewProvider: () => this as View);
-			if (newView != null)
+			if (_content != null)
 			{
-				_content = null;
-			}
+				var newView = SwapViews(oldView: (FrameworkElement)_content, newViewProvider: () => this as View);
+				if (newView != null)
+				{
+					_content = null;
+				}
 
-			MaterializationChanged?.Invoke(this);
+				MaterializationChanged?.Invoke(this);
+			}
 		}
 
 		private static DependencyProperty GetVisibilityProperty(View view)

--- a/src/Uno.UI/UI/Xaml/Markup/ComponentHolder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/ComponentHolder.cs
@@ -1,0 +1,32 @@
+﻿#nullable enable
+
+using Uno.UI.DataBinding;
+
+namespace Windows.UI.Xaml.Markup
+{
+	/// <summary>
+	/// Reference holder for XAML generated x:Name and other markup elements.
+	/// </summary>
+	/// <remarks>
+	/// Storing an instance in a holder is weak as it assumes that the
+	/// visual tree holds strong references to the target.
+	/// </remarks>
+	public class ComponentHolder
+	{
+		private ManagedWeakReference? _instanceRef;
+
+		/// <summary>
+		/// Creates an instance of ComponentHolder
+		/// </summary>
+		public ComponentHolder() { }
+
+		/// <summary>
+		/// The component instance
+		/// </summary>
+		public object? Instance
+		{
+			get => _instanceRef?.Target;
+			set => _instanceRef = WeakReferencePool.RentWeakReference(this, value);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Setter.cs
+++ b/src/Uno.UI/UI/Xaml/Setter.cs
@@ -173,6 +173,11 @@ namespace Windows.UI.Xaml
 					stub.Materialize();
 				}
 
+				subject.ElementInstanceChanged += (s, value) =>
+				{
+					_bindingPath.DataContext = value;
+				};
+
 				_bindingPath.DataContext = subject.ElementInstance;
 			}
 			else


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5801, fixes https://github.com/unoplatform/uno/issues/5801, fixes https://github.com/unoplatform/uno/issues/5248, fixes https://github.com/unoplatform/uno/issues/5392.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Ensure re-evaluation of StaticResource markup
- Ensure `Setter` is being refreshed on ElementNameSubject … …
- Don't set bindings on x:Load on the actual element

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
