### PR TITLE
fix(datepicker): Fix datePicker .Date is not correctly updated.

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/LoopingSelector/LoopingSelector_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/LoopingSelector/LoopingSelector_Partial.cs
@@ -1904,9 +1904,14 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				//IFCEXPECT(enqueued);
 				enqueued = spDispatcherQueue.TryEnqueue(() =>
 				{
+#if __ANDROID__
 					// UNO-TODO: Animations are disabled because of https://github.com/unoplatform/uno/issues/5845
 					_tpScrollViewer.ChangeViewWithOptionalAnimation(null, spVerticalOffset, null,
 						true /* disableAnimation */);
+#else
+					_tpScrollViewer.ChangeViewWithOptionalAnimation(null, spVerticalOffset, null,
+						false /* disableAnimation */);
+#endif
 				});
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/LoopingSelector/LoopingSelector_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/LoopingSelector/LoopingSelector_Partial.cs
@@ -1904,8 +1904,9 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				//IFCEXPECT(enqueued);
 				enqueued = spDispatcherQueue.TryEnqueue(() =>
 				{
+					// UNO-TODO: Animations are disabled because of https://github.com/unoplatform/uno/issues/5845
 					_tpScrollViewer.ChangeViewWithOptionalAnimation(null, spVerticalOffset, null,
-						false /* disableAnimation */);
+						true /* disableAnimation */);
 				});
 			}
 		}


### PR DESCRIPTION
This PR is a workaround for the following bug: https://github.com/unoplatform/uno/issues/5845

This will fix https://github.com/unoplatform/uno/issues/5471

# Bugfix - DatePicker

## What is the current behavior?
When selecting a date using the datePicker, sometimes the internally selected date were properly updated.

This was happening when clicking **DIRECTLY** on the choosen date. Doesn't occurs when the picker is scrolled to the desired position.

## What is the new behavior?
Fixed


## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- ~~[ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
