### PR TITLE
fix(applicationlanguages): Added support for _Script Subtag_ for ApplicationLanguages.PrimaryLanguageOverride

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_ApplicationLanguages.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_ApplicationLanguages.cs
@@ -21,8 +21,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Globalization
 			ApplicationLanguages.PrimaryLanguageOverride = "zh-Hans-CN";
 
 			ApplicationLanguages.Languages.First().Should().Be("zh-Hans-CN");
-			CultureInfo.CurrentCulture.Name.Should().Be("zh-CN");
-			CultureInfo.CurrentUICulture.Name.Should().Be("zh-CN");
+			CultureInfo.CurrentCulture.Name.Should().BeOneOf("zh-CN", "zh-Hans-CN");
+			CultureInfo.CurrentUICulture.Name.Should().BeOneOf("zh-CN", "zh-Hans-CN");
 		}
 
 		[TestMethod]
@@ -31,8 +31,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Globalization
 			ApplicationLanguages.PrimaryLanguageOverride = "fr-Latn-CA";
 
 			ApplicationLanguages.Languages.First().Should().Be("fr-Latn-CA");
-			CultureInfo.CurrentCulture.Name.Should().Be("fr-CA");
-			CultureInfo.CurrentUICulture.Name.Should().Be("fr-CA");
+			CultureInfo.CurrentCulture.Name.Should().BeOneOf("fr-CA", "fr-Latn-CA");
+			CultureInfo.CurrentUICulture.Name.Should().BeOneOf("fr-CA", "fr-Latn-CA");
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_ApplicationLanguages.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_ApplicationLanguages.cs
@@ -1,0 +1,38 @@
+﻿using System.Globalization;
+using System.Linq;
+using Windows.Globalization;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_Globalization
+{
+	[TestClass]
+	public class Given_ApplicationLanguages
+	{
+		[TestCleanup]
+		public void CleanUp()
+		{
+			ApplicationLanguages.PrimaryLanguageOverride = null;
+		}
+
+		[TestMethod]
+		public void Test_Chinese_With_Script_Subtag()
+		{
+			ApplicationLanguages.PrimaryLanguageOverride = "zh-Hans-CN";
+
+			ApplicationLanguages.Languages.First().Should().Be("zh-Hans-CN");
+			CultureInfo.CurrentCulture.Name.Should().Be("zh-CN");
+			CultureInfo.CurrentUICulture.Name.Should().Be("zh-CN");
+		}
+
+		[TestMethod]
+		public void Test_French_With_Script_Subtag()
+		{
+			ApplicationLanguages.PrimaryLanguageOverride = "fr-Latn-CA";
+
+			ApplicationLanguages.Languages.First().Should().Be("fr-Latn-CA");
+			CultureInfo.CurrentCulture.Name.Should().Be("fr-CA");
+			CultureInfo.CurrentUICulture.Name.Should().Be("fr-CA");
+		}
+	}
+}

--- a/src/Uno.UWP/Globalization/ApplicationLanguages.cs
+++ b/src/Uno.UWP/Globalization/ApplicationLanguages.cs
@@ -88,8 +88,7 @@ namespace Windows.Globalization
 			CultureInfo.CurrentUICulture = primaryCulture;
 		}
 
-		private static readonly Regex _cultureFormatRegex =
-			new Regex(@"(?<lang>[a-z]{2,8})(?:(?:\-(?<script>[a-zA-Z]+))?\-(?<reg>[A-Z]+))?");
+		private static Regex _cultureFormatRegex;
 
 		private static CultureInfo CreateCulture(string cultureId)
 		{
@@ -99,6 +98,10 @@ namespace Windows.Globalization
 			}
 			catch (CultureNotFoundException)
 			{
+				_cultureFormatRegex ??= new Regex(
+					@"(?<lang>[a-z]{2,8})(?:(?:\-(?<script>[a-zA-Z]+))?\-(?<reg>[A-Z]+))?",
+					RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase);
+
 				var match = _cultureFormatRegex.Match(cultureId);
 				try
 				{

--- a/src/Uno.UWP/Globalization/ApplicationLanguages.cs
+++ b/src/Uno.UWP/Globalization/ApplicationLanguages.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Uno.UI;
 
 namespace Windows.Globalization
@@ -81,10 +82,47 @@ namespace Windows.Globalization
 			}
 
 			var primaryLanguage = Languages.First();
-			var primaryCulture = new CultureInfo(primaryLanguage);
+			var primaryCulture = CreateCulture(primaryLanguage);
 
 			CultureInfo.CurrentCulture = primaryCulture;
 			CultureInfo.CurrentUICulture = primaryCulture;
+		}
+
+		private static readonly Regex _cultureFormatRegex =
+			new Regex(@"(?<lang>[a-z]{2,8})(?:(?:\-(?<script>[a-zA-Z]+))?\-(?<reg>[A-Z]+))?");
+
+		private static CultureInfo CreateCulture(string cultureId)
+		{
+			try
+			{
+				return new CultureInfo(cultureId);
+			}
+			catch (CultureNotFoundException)
+			{
+				var match = _cultureFormatRegex.Match(cultureId);
+				try
+				{
+					// If the script subtag is specified, we'll try to just remove it.
+					// Mono is not supporting it.
+					if (match.Groups["script"].Success && match.Groups["reg"].Success)
+					{
+						cultureId = $"{match.Groups["lang"].Value}-{match.Groups["reg"].Value}";
+						return new CultureInfo(cultureId);
+					}
+				}
+				catch (CultureNotFoundException)
+				{
+				}
+
+				// If the runtime is not able to match the language + region, we'll fallback to just the language.
+				if (match.Groups["lang"].Success)
+				{
+					return new CultureInfo(match.Groups["lang"].Value);
+				}
+
+				// It seems not possible to resolve this culture.
+				throw;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR will fix https://github.com/unoplatform/uno/issues/5657

# Bugfix
Setting a _Script Subtag_ on `ApplicationLanguages.PrimaryLanguage` were producing a `CultureNotFoundException` when the runtime is mono.

The bug were also happening when the application's manifest were set to `zh-Hans-CN` on iOS.

## What is the new behavior?
When the culture is not found in the runtime, another try is done after removing the _Script Subtag_.

## PR Checklist

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- ~~[ ] Validated PR `Screenshots Compare Test Run` results.~~
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
