### PR TITLE
fix(datepicker): Default date were not set when the control were created.

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePicker_DatePartVisibility.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePicker_DatePartVisibility.xaml
@@ -9,17 +9,26 @@
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<ScrollViewer>
-		<StackPanel Spacing="6">
-			<DatePicker Header="All parts shown" xamarin:UseNativePicker="False" />
-			<DatePicker Header="Month and year shown" DayVisible="False" xamarin:UseNativePicker="False"  />
-			<DatePicker Header="Month and day shown" YearVisible="False" xamarin:UseNativePicker="False" />
-			<DatePicker Header="Day and year shown" MonthVisible="False" xamarin:UseNativePicker="False" />
-			<DatePicker Header="Only year shown" MonthVisible="False" DayVisible="False" xamarin:UseNativePicker="False" />
-			<DatePicker Header="All parts shown (native)" xamarin:UseNativePicker="True" />
-			<DatePicker Header="Month and year shown (native)" DayVisible="False" xamarin:UseNativePicker="True" />
-			<DatePicker Header="Month and day shown (native)" YearVisible="False" xamarin:UseNativePicker="True" />
-			<DatePicker Header="Day and year shown (native)" MonthVisible="False" xamarin:UseNativePicker="True" />
-			<DatePicker Header="Only year shown (native)" MonthVisible="False" DayVisible="False" xamarin:UseNativePicker="True" />
-		</StackPanel>
+		<Grid ColumnSpacing="10">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+			</Grid.ColumnDefinitions>
+
+			<StackPanel Spacing="6">
+				<DatePicker Header="All parts shown" xamarin:UseNativeStyle="False" />
+				<DatePicker Header="Month and year shown" DayVisible="False" xamarin:UseNativeStyle="False"  />
+				<DatePicker Header="Month and day shown" YearVisible="False" xamarin:UseNativeStyle="False" />
+				<DatePicker Header="Day and year shown" MonthVisible="False" xamarin:UseNativeStyle="False" />
+				<DatePicker Header="Only year shown" MonthVisible="False" DayVisible="False" xamarin:UseNativeStyle="False" />
+			</StackPanel>
+			<StackPanel Spacing="6" Grid.Column="1">
+				<DatePicker Header="All parts shown (native)" xamarin:UseNativeStyle="True" />
+				<DatePicker Header="Month and year shown (native)" DayVisible="False" xamarin:UseNativeStyle="True" />
+				<DatePicker Header="Month and day shown (native)" YearVisible="False" xamarin:UseNativeStyle="True" />
+				<DatePicker Header="Day and year shown (native)" MonthVisible="False" xamarin:UseNativeStyle="True" />
+				<DatePicker Header="Only year shown (native)" MonthVisible="False" DayVisible="False" xamarin:UseNativeStyle="True" />
+			</StackPanel>
+		</Grid>
 	</ScrollViewer>
 </Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/DatePickerIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/DatePickerIntegrationTests.cs
@@ -22,6 +22,8 @@ namespace Microsoft.UI.Tests.Controls.DatePickerTests
 	[TestClass]
 	public class DatePickerIntegrationTests
 	{
+		private const long DEFAULT_DATE_TICKS = 504910368000000000;
+
 		[TestInitialize]
 		void ClassSetup()
 		{
@@ -96,7 +98,7 @@ namespace Microsoft.UI.Tests.Controls.DatePickerTests
 				today.SetToNow();
 
 				// Default value of Date should be the null sentinel value.
-				datePicker.Date.Ticks.Should().Be(0);
+				datePicker.Date.Ticks.Should().Be(DEFAULT_DATE_TICKS); // 1600-12-31, as per MS documentation
 				datePicker.SelectedDate.Should().BeNull();
 
 				// Default value of MinYear should be 100 years ago.
@@ -979,30 +981,31 @@ namespace Microsoft.UI.Tests.Controls.DatePickerTests
 
 			await RunOnUIThread.ExecuteAsync(() =>
 			{
+				using var _ = new AssertionScope();
+
 				this.Log().Info("Setting SelectedDate to null.  Date should be the null sentinel value.");
 				datePicker.SelectedDate = null;
 
-				Assert.AreEqual(0, datePicker.Date.Ticks);
+				datePicker.Date.Ticks.Should().Be(DEFAULT_DATE_TICKS);
 
 				this.Log().Info("Setting SelectedDate to February 2, 2018. Date should change to this value.");
 				datePicker.SelectedDate = (date2);
 
 				VerifyDatesAreEqual(date2, datePicker.Date);
-				Assert.IsNotNull(datePicker.SelectedDate);
+				datePicker.SelectedDate.Should().NotBeNull();
 				VerifyDatesAreEqual(date2, datePicker.SelectedDate.Value);
 
 				this.Log().Info("Setting Date to January 1, 2018. SelectedDate should change to this value.");
 				datePicker.Date = date;
 
 				VerifyDatesAreEqual(date, datePicker.Date);
-				Assert.IsNotNull(datePicker.SelectedDate);
+				datePicker.SelectedDate.Should().NotBeNull();
 				VerifyDatesAreEqual(date, datePicker.SelectedDate.Value);
 
 				this.Log().Info("Setting Date to the null sentinel value. SelectedDate should become null.");
-				DateTimeOffset nullDate = new DateTimeOffset();
-				datePicker.Date = nullDate;
+				datePicker.Date = new DateTimeOffset(DEFAULT_DATE_TICKS, TimeSpan.Zero);
 
-				Assert.IsNull(datePicker.SelectedDate, "SelectedDate should be back to null");
+				datePicker.SelectedDate.Should().BeNull("SelectedDate should be back to null");
 			});
 		}
 
@@ -1073,20 +1076,18 @@ namespace Microsoft.UI.Tests.Controls.DatePickerTests
 			{
 				datePicker.CalendarIdentifier = "JapaneseCalendar";
 
-				Assert.AreEqual(0, datePicker.Date.Ticks);
+				datePicker.Date.Ticks.Should().Be(DEFAULT_DATE_TICKS);
 
 				this.Log().Info("Setting SelectedDate to January 9, 2019. Date should change to this value.");
 				datePicker.SelectedDate = (date);
 
 				VerifyDatesAreEqual(date, datePicker.Date);
-				Assert.IsNotNull(datePicker.SelectedDate);
+				datePicker.SelectedDate.Should().NotBeNull();
 				VerifyDatesAreEqual(date, datePicker.SelectedDate.Value);
 
 				this.Log().Info("Setting Date back to the null sentinel value. SelectedDate should become null.");
-				var nullDate = new DateTimeOffset();
-				datePicker.Date = nullDate;
-
-				Assert.IsNull(datePicker.SelectedDate);
+				datePicker.Date = new DateTimeOffset(DEFAULT_DATE_TICKS, TimeSpan.Zero);
+				datePicker.SelectedDate.Should().BeNull();
 			});
 		}
 
@@ -1097,12 +1098,14 @@ namespace Microsoft.UI.Tests.Controls.DatePickerTests
 
 		private void VerifyDatesAreEqual(Calendar expected, DateTimeOffset actual)
 		{
+			using var _ = new AssertionScope();
+
 			var actualCalendar = new Calendar();
 			actualCalendar.SetDateTime(actual);
 
-			Assert.AreEqual(expected.Year, actualCalendar.Year);
-			Assert.AreEqual(expected.Month, actualCalendar.Month);
-			Assert.AreEqual(expected.Day, actualCalendar.Day);
+			actualCalendar.Year.Should().Be(expected.Year);
+			actualCalendar.Month.Should().Be(expected.Month);
+			actualCalendar.Day.Should().Be(expected.Day);
 		}
 
 		private void VerifyDatesAreEqual(DateTimeOffset expected, DateTimeOffset actual)

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -21,6 +21,8 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class DatePicker : Control
 	{
+		internal const long DEFAULT_DATE_TICKS = 504910368000000000;
+
 		public event EventHandler<DatePickerValueChangedEventArgs> DateChanged;
 		public event TypedEventHandler<DatePicker, DatePickerSelectedValueChangedEventArgs> SelectedDateChanged;
 			   
@@ -1054,11 +1056,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else if (pDP == DatePicker.DateProperty)
 			{
-				if (m_defaultDate.Value.ToUniversalTime() == NullDateSentinelValue)
-				{
-					GetTodaysDate(out m_defaultDate);
-				}
-
 				pValue = m_defaultDate;
 				return true;
 			}
@@ -2240,11 +2237,13 @@ namespace Windows.UI.Xaml.Controls
 
 		/* static */
 
-		private static DateTimeOffset NullDateSentinel { get; } = new DateTimeOffset();
+		private static DateTimeOffset NullDateSentinel { get; } =
+			new DateTimeOffset(DEFAULT_DATE_TICKS, TimeSpan.Zero);
 
 		/* static */
 
-		private static DateTimeOffset NullDateSentinelValue { get; } = new DateTimeOffset();
+		private static DateTimeOffset NullDateSentinelValue { get; } =
+			new DateTimeOffset(DEFAULT_DATE_TICKS, TimeSpan.Zero);
 
 		void GetTodaysDate(out DateTimeOffset? todaysDate)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -342,7 +342,7 @@ namespace Windows.UI.Xaml.Controls
 					m_epYearSelectionChangedHandler.Disposable = null;
 				}
 
-				if (m_tpFlyoutButton != null && !false)
+				if (m_tpFlyoutButton != null)
 				{
 					m_epFlyoutButtonClickHandler.Disposable = null;
 				}
@@ -494,12 +494,9 @@ namespace Windows.UI.Xaml.Controls
 
 				if (m_tpFlyoutButton != null)
 				{
-					if (!false)
-					{
-						m_tpFlyoutButton.Click += OnFlyoutButtonClick;
-						m_epFlyoutButtonClickHandler.Disposable =
-							Disposable.Create(() => m_tpFlyoutButton.Click -= OnFlyoutButtonClick);
-					}
+					m_tpFlyoutButton.Click += OnFlyoutButtonClick;
+					m_epFlyoutButtonClickHandler.Disposable =
+						Disposable.Create(() => m_tpFlyoutButton.Click -= OnFlyoutButtonClick);
 					RefreshFlyoutButtonAutomationName();
 				}
 
@@ -882,26 +879,23 @@ namespace Windows.UI.Xaml.Controls
 		   Task<DateTimeOffset?> getOperation,
 		   AsyncStatus status)
 		{
-			if (!false)
+			// CheckThread();
+
+			m_tpAsyncSelectionInfo = null;
+
+			if (status == AsyncStatus.Completed)
 			{
-				// CheckThread();
+				DateTimeOffset? selectedDate;
+				selectedDate = getOperation.Result;
 
-				m_tpAsyncSelectionInfo = null;
-
-				if (status == AsyncStatus.Completed)
+				// A null IReference object is returned when the user cancels out of the
+				// 
+				if (selectedDate != null)
 				{
-					DateTimeOffset? selectedDate;
-					selectedDate = getOperation.Result;
-
-					// A null IReference object is returned when the user cancels out of the
-					// 
-					if (selectedDate != null)
-					{
-						// We set SelectedDate instead of Date in order to ensure that the value
-						// propagates to both SelectedDate and Date.
-						// See the comment at the top of OnPropertyChanged2 for details.
-						SelectedDate = selectedDate;
-					}
+					// We set SelectedDate instead of Date in order to ensure that the value
+					// propagates to both SelectedDate and Date.
+					// See the comment at the top of OnPropertyChanged2 for details.
+					SelectedDate = selectedDate;
 				}
 			}
 		}
@@ -1060,7 +1054,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else if (pDP == DatePicker.DateProperty)
 			{
-				if (m_defaultDate.Value.ToUniversalTime() == NullDateSentinelValue && false)
+				if (m_defaultDate.Value.ToUniversalTime() == NullDateSentinelValue)
 				{
 					GetTodaysDate(out m_defaultDate);
 				}
@@ -1608,7 +1602,7 @@ namespace Windows.UI.Xaml.Controls
 			// For the Threshold template we set the Day, Month and Year strings on separate TextBlocks:
 			if (m_tpYearTextBlock != null)
 			{
-				if (selectedDate != null || false)
+				if (selectedDate != null)
 				{
 					GetYearFormatter(YearFormat, strCalendarIdentifier, out spYearFormatter);
 					strYear = spYearFormatter.Format(date.Value);
@@ -1622,7 +1616,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 			if (m_tpMonthTextBlock != null)
 			{
-				if (selectedDate != null || false)
+				if (selectedDate != null)
 				{
 					GetMonthFormatter(MonthFormat, strCalendarIdentifier, out spMonthFormatter);
 					strMonth = spMonthFormatter.Format(date.Value);
@@ -1636,7 +1630,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 			if (m_tpDayTextBlock != null)
 			{
-				if (selectedDate != null || false)
+				if (selectedDate != null)
 				{
 					strDayFormat = DayFormat;
 					GetDayFormatter(strDayFormat, strCalendarIdentifier, out spDayFormatter);

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyoutPresenter_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyoutPresenter_Partial.cs
@@ -14,6 +14,8 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class DatePickerFlyoutPresenter : Control
 	{
+		private const long DEFAULT_DATE_TICKS = 504910368000000000;
+
 		const bool PICKER_SHOULD_LOOP = true;
 
 		const int DATEPICKER_RTL_CHARACTER_CODE = 8207;
@@ -663,7 +665,7 @@ namespace Windows.UI.Xaml.Controls
 			// If we're setting the date to the null sentinel value,
 			// we'll instead set it to the current date for the purposes
 			// of where to place the user's position in the looping selectors.
-			if (newDate == DateTime.MinValue)
+			if (newDate.Ticks == DEFAULT_DATE_TICKS)
 			{
 				//DateTime dateTime = default;
 				Calendar calendar;

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.Android.cs
@@ -21,7 +21,20 @@ namespace Windows.UI.Xaml.Controls
 
 		protected internal override void Open()
 		{
-			var date = Date == DateTimeOffset.MinValue ? DateTimeOffset.Now : Date;
+			var date = Date;
+			// If we're setting the date to the null sentinel value,
+			// we'll instead set it to the current date for the purposes
+			// of where to place the user's position in the looping selectors.
+			if (date.Ticks == DatePicker.DEFAULT_DATE_TICKS)
+			{
+				var temp = new Windows.Globalization.Calendar();
+				var calendar = new Windows.Globalization.Calendar(
+					temp.Languages,
+					CalendarIdentifier,
+					temp.GetClock());
+				calendar.SetToNow();
+				date = calendar.GetDateTime();
+			}
 
 			// Note: Month needs to be -1 since on Android months go from 0-11
 			// http://developer.android.com/reference/android/app/DatePickerDialog.OnDateSetListener.html#onDateSet(android.widget.DatePicker, int, int, int)

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.iOS.cs
@@ -129,7 +129,20 @@ namespace Windows.UI.Xaml.Controls
 		private void DatePickerFlyout_Opening(object sender, EventArgs e)
 		{
 			InitializeContent();
-			var date = Date == DateTimeOffset.MinValue ? DateTimeOffset.Now : Date;
+			var date = Date;
+			// If we're setting the date to the null sentinel value,
+			// we'll instead set it to the current date for the purposes
+			// of where to place the user's position in the looping selectors.
+			if (date.Ticks == DatePicker.DEFAULT_DATE_TICKS)
+			{
+				var temp = new Windows.Globalization.Calendar();
+				var calendar = new Windows.Globalization.Calendar(
+					temp.Languages,
+					CalendarIdentifier,
+					temp.GetClock());
+				calendar.SetToNow();
+				date = calendar.GetDateTime();
+			}
 			UpdateSelectorDate(date);
 		}
 


### PR DESCRIPTION
This was due to a wrong refactoring during the conversion of DatePicker from WinUI code.

Fix https://github.com/unoplatform/uno/issues/5510

# Bugfix
Default date for `DatePicker` were not properly set.

## What is the new behavior?
Set to today by default, as Windows is doing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- ~~[ ] Validated PR `Screenshots Compare Test Run` results.~~
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
