### PR TITLE
feat: BackgroundTaskDeferral for Android

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Background/BackgroundTaskDeferral.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Background/BackgroundTaskDeferral.Android.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.ApplicationModel.Background
+{
+	public partial class BackgroundTaskDeferral
+	{
+		/// <summary>
+		/// On Android, BackgroundTaskDeferral has no meaning (background tasks will not be cancelled by OS, unless it takes really much time)
+		/// </summary>
+		public void Complete()
+		{
+			// on Android, there is nothing to do
+		}
+	}
+}
+

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/BackgroundTaskDeferral.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/BackgroundTaskDeferral.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel.Background
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class BackgroundTaskDeferral 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Complete()
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
No `BackgroundTaskDeferral` implementation, so in `App.OnBackgroundActivated` using `#if` is required.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
 `BackgroundTaskDeferral` is implemented.
(although for Android it is empty implementation, as Android doesn't kill background tasks)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
See also #2655.
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
