### PR TITLE
fix:TextBox.IsReadOnly on Skia/Wpf

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -48,7 +48,7 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 
 			textBox.SizeChanged += ContentElementSizeChanged;
 			textBox.LayoutUpdated += ContentElementLayoutUpdated;
-			
+
 			_textBoxEventSubscriptions.Disposable = Disposable.Create(() =>
 			{
 				textBox.SizeChanged -= ContentElementSizeChanged;
@@ -94,12 +94,14 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 			}
 
 			EnsureWidgetForAcceptsReturn();
-			
+
 			_currentInputWidget.FontSize = textBox.FontSize;
 			_currentInputWidget.FontWeight = FontWeight.FromOpenTypeWeight(textBox.FontWeight.Weight);
 			_currentInputWidget.AcceptsReturn = textBox.AcceptsReturn;
 			_currentInputWidget.TextWrapping = textBox.AcceptsReturn ? TextWrapping.Wrap : TextWrapping.NoWrap;
 			_currentInputWidget.MaxLength = textBox.MaxLength;
+			_currentInputWidget.IsReadOnly = textBox.IsReadOnly;
+
 			if (textBox.Foreground is SolidColorBrush colorBrush)
 			{
 				var unoColor = colorBrush.Color;


### PR DESCRIPTION
GitHub Issue (If applicable): #


## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Setting `IsReadOnly` to `true` on `TextBox` on Skia/WPF doesn't have the desired effect.

## What is the new behavior?

`IsReadOnly` should work.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

