### PR TITLE
MenuFlyoutItem bugfixes

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutItem.cs
@@ -197,7 +197,7 @@ namespace Windows.UI.Xaml.Controls
 					m_bIsPointerLeftButtonDown = true;
 					m_bIsPressed = true;
 
-					pArgs.Handled = true;
+					pArgs.Handled = CapturePointer(pArgs.Pointer);
 					UpdateVisualState();
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutItem.cs
@@ -235,8 +235,13 @@ namespace Windows.UI.Xaml.Controls
 						PerformPointerUpAction();
 					}
 #else
-				PerformPointerUpAction();
+				// Only perform actions if the pointer is still in over.
+				// This is consistent with UWP.
+				if (m_bIsPointerOver)
+				{
+					PerformPointerUpAction();
 #endif
+				}
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5882

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
Described in #5882.
Also, on all targets, `MenuFlyoutItem`s still activates after the pointer is dragged away, making it different from UWP.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
`MenuFlyoutItem`s handle events properly, and also cancels actions if pointer is dragged away.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
I'm making the behavior a bit more like Uno platform's `Button`.
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
