### PR TITLE
Ensure a non-scrollable scroller does not matrialize its scrollbars.

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControlPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControlPage.xaml.cs
@@ -33,14 +33,14 @@ namespace MUXControlsTestApp
 	[Sample("SwipeControl")]
     public sealed partial class SwipeControlPage : Page //: TestPage
     {
-        object asyncEventReportingLock = new object();
-        List<string> lstAsyncEventMessage = new List<string>();
-        List<string> fullLogs = new List<string>();
-        FrameworkElement lastInteractedWithSwipeControlContentContainer;
-        FrameworkElement lastInteractedWithSwipeControlContentRoot;
-        SwipeItem pastSender;
-        UIElement animatedSwipe;
-        DispatcherTimer _dt;
+        //object asyncEventReportingLock = new object();
+        //List<string> lstAsyncEventMessage = new List<string>();
+        //List<string> fullLogs = new List<string>();
+        //FrameworkElement lastInteractedWithSwipeControlContentContainer;
+        //FrameworkElement lastInteractedWithSwipeControlContentRoot;
+        //SwipeItem pastSender;
+        //UIElement animatedSwipe;
+        //DispatcherTimer _dt;
         public SwipeControlPage()
         {
             // create command, and bind it to this object before initializing the components
@@ -48,7 +48,6 @@ namespace MUXControlsTestApp
             Resources.Add("command", command);
 
             this.InitializeComponent();
-
 		}
 
 		private void SwipeItemInvoked(SwipeItem sender, SwipeItemInvokedEventArgs args)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -58,6 +58,72 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsTrue(buttons > 0); // We make sure that we really loaded the right template
 			Assert.IsTrue(buttons <= 4);
 		}
+
+
+		[TestMethod]
+		public async Task When_NonScrollableScroller_Then_DoNotLoadAllTemplate()
+		{
+			var sut = new ScrollViewer
+			{
+				VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+				VerticalScrollMode = ScrollMode.Enabled,
+				HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+				HorizontalScrollMode = ScrollMode.Disabled,
+				Height = 100,
+				Width = 100,
+				Content = new Border { Height = 50, Width = 50 }
+			};
+			WindowHelper.WindowContent = sut;
+
+			await WindowHelper.WaitForIdle();
+
+			var buttons = sut
+				.EnumerateAllChildren(maxDepth: 256)
+				.OfType<RepeatButton>()
+				.Count();
+
+			Assert.IsTrue(buttons == 0);
+		}
+
+		[TestMethod]
+		public async Task When_HorizontallyScrollableTextBox_Then_DoNotLoadAllScrollerTemplate()
+		{
+			var sut = new TextBox
+			{
+				Width = 100,
+				Text = "Hello world, this a long text that would cause the TextBox to enable horizontal scroll, so we should find some RepeatButton in the children of this TextBox."
+			};
+			WindowHelper.WindowContent = sut;
+
+			await WindowHelper.WaitForIdle();
+
+			var bars = sut
+				.EnumerateAllChildren(maxDepth: 256)
+				.OfType<ScrollBar>()
+				.Count();
+
+			Assert.IsTrue(bars == 0); // TextBox is actually not using scrollbars!
+		}
+
+		[TestMethod]
+		public async Task When_NonScrollableTextBox_Then_DoNotLoadAllScrollerTemplate()
+		{
+			var sut = new TextBox
+			{
+				Width = 100,
+				Text = "42"
+			};
+			WindowHelper.WindowContent = sut;
+
+			await WindowHelper.WaitForIdle();
+
+			var bars = sut
+				.EnumerateAllChildren(maxDepth: 256)
+				.OfType<ScrollBar>()
+				.Count();
+
+			Assert.IsTrue(bars == 0); // TextBox is actually not using scrollbars!
+		}
 #endif
 
 		[TestMethod]


### PR DESCRIPTION
## Tests
Ensure a non-scrollable scroller does not matrialize its scrollbars.

## What is the current behavior?
Works

## What is the new behavior?
Still works

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] ~~Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).~~
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
