### PR TITLE
Grid: Fixed Definitioncollectionbase breaking change

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Grid/ColumnDefinitionCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/ColumnDefinitionCollection.cs
@@ -30,21 +30,13 @@ namespace Windows.UI.Xaml.Controls
 			(item as DefinitionBase).Changed += OnDefinitionChanged;
 		}
 
-		int IList<DefinitionBase>.IndexOf(DefinitionBase item) => _inner.IndexOf(item as ColumnDefinition);
-
-		void IList<DefinitionBase>.Insert(int index, DefinitionBase item) => throw new NotSupportedException();
-
 		public void RemoveAt(int index)
 		{
 			(_inner[index] as DefinitionBase).Changed -= OnDefinitionChanged;
 			_inner.RemoveAt(index);
 		}
 
-		DefinitionBase IList<DefinitionBase>.this[int index]
-		{
-			get => _inner[index];
-			set => throw new NotSupportedException();
-		}
+		IEnumerable<DefinitionBase> DefinitionCollectionBase.GetItems() => _inner;
 
 		DefinitionBase DefinitionCollectionBase.GetItem(int index) => _inner[index];
 
@@ -68,19 +60,11 @@ namespace Windows.UI.Xaml.Controls
 			(item as DefinitionBase).Changed += OnDefinitionChanged;
 		}
 
-		void ICollection<DefinitionBase>.Add(DefinitionBase item) => throw new NotSupportedException();
-
 		public void Clear()
 		{
 			_inner.ForEach(item => (item as DefinitionBase).Changed -= OnDefinitionChanged);
 			_inner.Clear();
 		}
-
-		bool ICollection<DefinitionBase>.Contains(DefinitionBase item) => throw new NotSupportedException();
-
-		void ICollection<DefinitionBase>.CopyTo(DefinitionBase[] array, int arrayIndex) => throw new NotSupportedException();
-
-		bool ICollection<DefinitionBase>.Remove(DefinitionBase item) => throw new NotSupportedException();
 
 		public bool Contains(ColumnDefinition item) => _inner.Contains(item);
 
@@ -102,8 +86,6 @@ namespace Windows.UI.Xaml.Controls
 		/// The inner list is exposed in order to get the struct enumerable exposed by List<T> to avoid allocations.
 		/// </summary>
 		internal List<ColumnDefinition> InnerList => _inner.Items;
-
-		IEnumerator<DefinitionBase> IEnumerable<DefinitionBase>.GetEnumerator() => _inner.GetEnumerator();
 
 		public global::System.Collections.Generic.IEnumerator<ColumnDefinition> GetEnumerator() => _inner.GetEnumerator();
 

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/DefinitionCollectionBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/DefinitionCollectionBase.cs
@@ -2,8 +2,10 @@ using System.Collections.Generic;
 
 namespace Windows.UI.Xaml.Controls
 {
-	internal interface DefinitionCollectionBase : IList<DefinitionBase>
+	internal interface DefinitionCollectionBase
 	{
+		IEnumerable<DefinitionBase> GetItems();
+		int Count { get; }
 		DefinitionBase GetItem(int index);
 		internal void Lock();
 		internal void Unlock();

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
@@ -192,7 +192,7 @@ namespace Windows.UI.Xaml.Controls
 			bool treatStarAsAuto)
 		{
 			//for (auto & cdo : definitions)
-			foreach(DefinitionBase def in definitions)
+			foreach(DefinitionBase def in definitions.GetItems())
 			{
 				//var def = (DefinitionBase)(cdo);
 				bool useLayoutRounding = GetUseLayoutRounding();
@@ -585,7 +585,7 @@ namespace Windows.UI.Xaml.Controls
 			// e) Prepare indices.
 			for (int i = spanStart; i < spanEnd; i++)
 			{
-				var def = (DefinitionBase)((definitions)[i]);
+				var def = definitions.GetItem(i);
 				XFLOAT effectiveMinSize = def.GetEffectiveMinSize();
 				XFLOAT preferredSize = def.GetPreferredSize();
 				XFLOAT maxSize = Math.Max(def.GetUserMaxSize(), effectiveMinSize);
@@ -760,7 +760,7 @@ namespace Windows.UI.Xaml.Controls
 
 			do
 			{
-				var def = (DefinitionBase)((definitions)[index]);
+				var def = (DefinitionBase)(definitions.GetItem(index));
 				switch (def.GetEffectiveUnitType())
 				{
 					case GridUnitType.Auto:
@@ -792,7 +792,7 @@ namespace Windows.UI.Xaml.Controls
 
 			do
 			{
-				var def = (DefinitionBase)((definitions)[index]);
+				var def = (DefinitionBase)(definitions.GetItem(index));
 				availableSize += (def.GetEffectiveUnitType() == GridUnitType.Auto)
 					? def.GetEffectiveMinSize()
 					: def.GetMeasureArrangeSize();
@@ -817,7 +817,7 @@ namespace Windows.UI.Xaml.Controls
 
 			do
 			{
-				var def = (DefinitionBase)((definitions)[index]);
+				var def = (DefinitionBase)(definitions.GetItem(index));
 				finalSize += def.GetMeasureArrangeSize();
 			} while (index > 0 && --index >= start);
 
@@ -834,7 +834,7 @@ namespace Windows.UI.Xaml.Controls
 
 			for (Xuint i = 0; i < definitions.Count; ++i)
 			{
-				var def = (DefinitionBase)((definitions)[i]);
+				var def = (DefinitionBase)(definitions.GetItem(i));
 				desiredSize += def.GetEffectiveMinSize();
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/RowDefinitionCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/RowDefinitionCollection.cs
@@ -30,21 +30,13 @@ namespace Windows.UI.Xaml.Controls
 			(item as DefinitionBase).Changed += OnDefinitionChanged;
 		}
 
-		int IList<DefinitionBase>.IndexOf(DefinitionBase item) => _inner.IndexOf(item as RowDefinition);
-
-		void IList<DefinitionBase>.Insert(int index, DefinitionBase item) => throw new NotSupportedException();
-
 		public void RemoveAt(int index)
 		{
 			(_inner[index] as DefinitionBase).Changed -= OnDefinitionChanged;
 			_inner.RemoveAt(index);
 		}
 
-		DefinitionBase IList<DefinitionBase>.this[int index]
-		{
-			get => _inner[index];
-			set => throw new NotSupportedException();
-		}
+		IEnumerable<DefinitionBase> DefinitionCollectionBase.GetItems() => _inner;
 
 		DefinitionBase DefinitionCollectionBase.GetItem(int index) => _inner[index];
 
@@ -68,19 +60,11 @@ namespace Windows.UI.Xaml.Controls
 			(item as DefinitionBase).Changed += OnDefinitionChanged;
 		}
 
-		void ICollection<DefinitionBase>.Add(DefinitionBase item) => throw new NotSupportedException();
-
 		public void Clear()
 		{
 			_inner.ForEach(item=> (item as DefinitionBase).Changed -= OnDefinitionChanged);
 			_inner.Clear();
 		}
-
-		bool ICollection<DefinitionBase>.Contains(DefinitionBase item) => throw new NotSupportedException();
-
-		void ICollection<DefinitionBase>.CopyTo(DefinitionBase[] array, int arrayIndex) => throw new NotSupportedException();
-
-		bool ICollection<DefinitionBase>.Remove(DefinitionBase item) => throw new NotSupportedException();
 
 		public bool Contains(RowDefinition item) => _inner.Contains(item);
 
@@ -100,8 +84,6 @@ namespace Windows.UI.Xaml.Controls
 		/// The inner list is exposed in order to get the struct enumerable exposed by List<T> to avoid allocations.
 		/// </summary>
 		internal List<RowDefinition> InnerList => _inner.Items;
-
-		IEnumerator<DefinitionBase> IEnumerable<DefinitionBase>.GetEnumerator() => _inner.GetEnumerator();
 
 		public global::System.Collections.Generic.IEnumerator<RowDefinition> GetEnumerator() => _inner.GetEnumerator();
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs
@@ -29,24 +29,16 @@ namespace Windows.UI.Xaml
 
 		private readonly List<T> _list = new List<T>();
 
-		private bool _isLocked;
+		private int _isLocked;
 
-		internal void Lock()
-		{
-			Debug.Assert(!_isLocked, "collection already locked");
-			_isLocked = true;
-		}
+		internal void Lock() => _isLocked++;
 
-		internal void Unlock()
-		{
-			Debug.Assert(_isLocked, "collection already unlocked");
-			_isLocked = false;
-		}
+		internal void Unlock() => _isLocked--;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private void EnsureNotLocked()
 		{
-			if(_isLocked)
+			if(_isLocked > 0)
 			{
 				throw new InvalidOperationException("Collection is locked.");
 			}


### PR DESCRIPTION
# BugFix

## What is the current behavior?
The recent refactoring of `<Grid />` were causing problem because both `ColumnDefinitionCollection` and `RowDefinitionCollection` were implementing twice the `IEnumerable<T>` interface, causing a resolution problem for the compilator in application code.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- ~~[ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- ~~[ ] Validated PR `Screenshots Compare Test Run` results.~~
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
