### PR TITLE
feat: missing ActivationKind values

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Activation/ActivationKind.cs
+++ b/src/Uno.UWP/ApplicationModel/Activation/ActivationKind.cs
@@ -141,6 +141,51 @@ namespace Windows.ApplicationModel.Activation
 		//
 		// Summary:
 		//     This app was activated as a result of pairing a device.
-		DevicePairing = 1013
+		DevicePairing = 1013,
+
+		//
+		// Summary:
+		//     The app was launched to handle the user interface for account management. Introduced in Windows 10, version 1607 (10.0.14393).
+		UserDataAccountsProvider = 1014,
+
+		//
+		// Summary:
+		//     Reserved for system use. Introduced in Windows 10, version 1607 (10.0.14393).
+		FilePickerExperience = 1015,
+
+		//
+		// Summary:
+		//     Reserved for system use. Introduced in Windows 10, version 1703 (10.0.15063).
+		LockScreenComponent = 1016,
+
+		//
+		// Summary:
+		//     The app was launched from the My People UI. Note: introduced in Windows 10, version 1703 (10.0.15063), but not used. Now used starting with Windows 10, version 1709 (10.0.16299).
+		ContactPanel = 1017,
+
+		//
+		// Summary:
+		//     The app was activated because the user is printing to a printer that has a Print Workflow Application associated with it which has requested user input.
+		PrintWorkflowForegroundTask = 1018,
+
+		//
+		// Summary:
+		//    The app was activated because it was launched by the OS due to a game's request for Xbox-specific UI. Introduced in Windows 10, version 1703 (10.0.15063).
+		GameUIProvider = 1019,
+
+		//
+		// Summary:
+		//    The app was activated because the app is specified to launch at system startup or user log-in. Introduced in Windows 10, version 1703 (10.0.15063).
+		StartupTask = 1020,
+
+		//
+		// Summary:
+		//    The app was launched from the command line. Introduced in Windows 10, version 1709 (10.0.16299) 
+		CommandLineLaunch = 1021,
+
+		//
+		// Summary:
+		//     The app was activated as a barcode scanner provider.
+		BarcodeScannerProvider = 1022	
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Not all values of ActivationKind is defined, especially CommandLineLaunch is missing. And I'm using it in my code inside OnActivated() to differentiate between activation from Toast (#2585) and CommandLine.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
All values are defined.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
