### PR TITLE
fix(RadioButtons): Ensure RadioButton is selected on initial load

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/RadioButtonsTests/Given_RadioButtons.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/RadioButtonsTests/Given_RadioButtons.cs
@@ -43,6 +43,17 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 			}
 		}
 
+		[Test]
+		[AutoRetry]
+		public void SelectionOnLoad()
+		{
+			Run("UITests.Microsoft_UI_Xaml_Controls.RadioButtonsTests.RadioButtonsInitialLoadSelected");
+
+			var rad = QueryAll("LightThemeRadio");
+
+			Assert.IsTrue(rad.GetDependencyPropertyValue<string>("IsChecked") == "True");
+		}
+
 		private void SelectByItem(int v)
 		{
 			SetIndexToSelect(v);

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RadioButtonsTests/RadioButtonsInitialLoadSelected.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RadioButtonsTests/RadioButtonsInitialLoadSelected.xaml
@@ -1,0 +1,18 @@
+﻿<Page x:Class="UITests.Microsoft_UI_Xaml_Controls.RadioButtonsTests.RadioButtonsInitialLoadSelected"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.RadioButtonsTests"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<controls:RadioButtons x:Name="ThemeRadioButtons">
+			<RadioButton x:Name="LightThemeRadio" Content="Light Theme" />
+			<RadioButton x:Name="DarkThemeRadio" Content="Dark Theme"  />
+			<RadioButton x:Name="SystemThemeRadio" Content="System Default Theme"  />
+		</controls:RadioButtons>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RadioButtonsTests/RadioButtonsInitialLoadSelected.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RadioButtonsTests/RadioButtonsInitialLoadSelected.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Microsoft_UI_Xaml_Controls.RadioButtonsTests
+{
+	[Sample("RadioButtons", "WinUI")]
+	public sealed partial class RadioButtonsInitialLoadSelected : Page
+    {
+        public RadioButtonsInitialLoadSelected()
+        {
+            this.InitializeComponent();
+
+			ThemeRadioButtons.SelectedIndex = 0;
+		}
+    }
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -165,6 +165,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RadioButtonsTests\RadioButtonsInitialLoadSelected.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RatingControlTests\RatingControlBasic.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4231,6 +4235,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\ProgressBar\WinUIProgressBarPage.xaml.cs">
       <DependentUpon>WinUIProgressBarPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RadioButtonsTests\RadioButtonsInitialLoadSelected.xaml.cs">
+      <DependentUpon>RadioButtonsInitialLoadSelected.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RatingControlTests\RatingControlBasic.xaml.cs">
       <DependentUpon>RatingControlBasic.xaml</DependentUpon>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/RadioButtons/RadioButtons.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/RadioButtons/RadioButtons.cs
@@ -316,6 +316,13 @@ namespace Microsoft.UI.Xaml.Controls
 					{
 						Select(args.Index);
 					}
+
+					// TODO: Uno specific - remove when #4689 is fixed 
+					//If SelectedItem/SelectedIndex has already been set by the time the elements are loaded, ensure we sync the selection
+					if (args.Index == SelectedIndex)
+					{
+						toggleButton.IsChecked = true;
+					}
 				}
 				var repeater = m_repeater;
 				if (repeater != null)


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/5917
closes https://github.com/unoplatform/uno/issues/5886

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Is SelectedItem is set before the RadioButtons control is loaded, the SelectedItem/SelectedIndex properties are properly set but the ToggleButton itself is not checked

## What is the new behavior?

The actual ToggleButton within RadioButtons' ItemsRepeater is set to Checked when it is loaded and matches SelectedIndex

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.