### PR TITLE
fix: Large file write in WASM 

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_FileIO.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_FileIO.cs
@@ -470,6 +470,27 @@ namespace Uno.UI.RuntimeTests.Tests
 			}
 		}
 
+		[TestMethod]
+		public async Task When_Large_WriteBytesAsync()
+		{
+			IStorageFile targetFile = null;
+			try
+			{
+				var contents = new string('a', 200000) + new string('b', 200000);
+				var bytes = Encoding.UTF8.GetBytes(contents);
+				var fileName = GenerateRandomFileName();
+				targetFile = await ApplicationData.Current.LocalFolder.CreateFileAsync(fileName);
+				await FileIO.WriteBytesAsync(targetFile, bytes);
+
+				var realContents = File.ReadAllBytes(targetFile.Path);
+				CollectionAssert.AreEqual(bytes, realContents);
+			}
+			finally
+			{
+				DeleteFile(targetFile);
+			}
+		}
+
 		private string GenerateRandomFileName() => $"{Guid.NewGuid()}.txt";
 
 		private void DeleteFile(IStorageFile file)

--- a/src/Uno.UWP/Storage/Streams/Internal/NativeWriteStreamAdapter.wasm.cs
+++ b/src/Uno.UWP/Storage/Streams/Internal/NativeWriteStreamAdapter.wasm.cs
@@ -104,6 +104,7 @@ namespace Uno.Storage.Streams.Internal
 				var pinnedData = handle.AddrOfPinnedObject();
 				await WebAssemblyRuntime.InvokeAsync($"{JsType}.writeAsync('{_streamId}', {pinnedData}, {offset}, {count}, {Position})");
 				_length += Math.Max(Position + count, Length);
+				Position += count;
 			}
 			finally
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5911

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The write `Position` did not update properly, so for writes beyond the default buffer size of 128 KB the stream just kept overwriting from the start.

## What is the new behavior?

File writing now properly updates the position.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.