### PR TITLE
Propagate x:DefaultBindMode to DataTemplate definitions

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Subclass.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Subclass.cs
@@ -10,15 +10,17 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 {
 	internal class Subclass
 	{
-		public Subclass(XamlMemberDefinition contentOwner, string returnType)
+		public Subclass(XamlMemberDefinition contentOwner, string returnType, string defaultBindMode)
 		{
 			ContentOwner = contentOwner;
 			ReturnType = returnType;
+			DefaultBindMode = defaultBindMode;
 		}
-
 
 		public XamlMemberDefinition ContentOwner { get;}
 
 		public string ReturnType { get; }
+
+		public string DefaultBindMode { get; }
 	}
 }

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -144,7 +144,11 @@
 			<UndefineProperties>TargetFramework</UndefineProperties>
 		</ProjectReference>
 	</ItemGroup>
-
+	
+	<ItemGroup>
+		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+	</ItemGroup>
+	
 	<ItemGroup>
 		<None Update="ResourceLoader\Strings\en\Resources.resw">
 			<Generator>ResXFileCodeGenerator</Generator>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_DefaultBindMode_DataTemplate.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_DefaultBindMode_DataTemplate.xaml
@@ -1,0 +1,76 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.Binding_DefaultBindMode_DataTemplate"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  x:DefaultBindMode="OneWay"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="myTemplate" x:DataType="local:Binding_DefaultBindMode_DataTemplate_Model">
+			<Grid>
+				<StackPanel>
+					<TextBlock x:Name="Default_undefined"
+							   x:FieldModifier="public"
+							   Text="{x:Bind Default_undefined_Property}" />
+					<TextBlock x:Name="Default_undefined_OneWay"
+							   x:FieldModifier="public"
+							   Text="{x:Bind Default_undefined_OneWay_Property, Mode=OneWay}" />
+					<TextBlock x:Name="Default_undefined_TwoWay"
+							   x:FieldModifier="public"
+							   Text="{x:Bind Default_undefined_TwoWay_Property, Mode=TwoWay}" />
+				</StackPanel>
+		
+				<StackPanel x:DefaultBindMode="OneWay">
+					<TextBlock x:Name="Default_OneWay"
+							   x:FieldModifier="public"
+							   Text="{x:Bind Default_OneWay_Property}" />
+					<TextBlock x:Name="Default_OneWay_OneWay"
+							   x:FieldModifier="public"
+							   Text="{x:Bind Default_OneWay_OneWay_Property, Mode=OneWay}" />
+					<TextBlock x:Name="Default_OneWay_TwoWay"
+							   x:FieldModifier="public"
+							   Text="{x:Bind Default_OneWay_TwoWay_Property, Mode=TwoWay}" />
+				</StackPanel>
+		
+				<StackPanel x:DefaultBindMode="TwoWay">
+					<TextBlock x:Name="Default_TwoWay"
+							   x:FieldModifier="public"
+							   Text="{x:Bind Default_TwoWay_Property}" />
+					<TextBlock x:Name="Default_TwoWay_OneWay"
+							   x:FieldModifier="public"
+							   Text="{x:Bind Default_TwoWay_OneWay_Property, Mode=OneWay}" />
+					<TextBlock x:Name="Default_TwoWay_TwoWay"
+							   x:FieldModifier="public"
+							   Text="{x:Bind Default_TwoWay_TwoWay_Property, Mode=TwoWay}" />
+				</StackPanel>
+		
+				<StackPanel x:DefaultBindMode="TwoWay">
+					<TextBlock x:Name="Nested_Default_1"
+							   x:FieldModifier="public"
+							   Text="{x:Bind Nested_Default_1_Property}" />
+					<StackPanel x:DefaultBindMode="OneWay">
+						<TextBlock x:Name="Nested_Default_2"
+								   x:FieldModifier="public"
+								   Text="{x:Bind Nested_Default_2_Property}" />
+						<TextBlock x:Name="Nested_Default_OneWay_OneTime"
+								   x:FieldModifier="public"
+								   Text="{x:Bind Nested_Default_OneWay_OneTime_Property, Mode=OneTime}" />
+						<TextBlock x:Name="Nested_Default_OneWay_OneWay"
+								   x:FieldModifier="public"
+								   Text="{x:Bind Nested_Default_OneWay_OneWay_Property, Mode=OneWay}" />
+						<TextBlock x:Name="Nested_Default_OneWay_TwoWay"
+								   x:FieldModifier="public"
+								   Text="{x:Bind Nested_Default_OneWay_TwoWay_Property, Mode=TwoWay}" />
+					</StackPanel>
+				</StackPanel>
+			</Grid>
+			
+		</DataTemplate>
+	</Page.Resources>
+
+	<ContentControl ContentTemplate="{StaticResource myTemplate}"
+					Content="{Binding}" />
+
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_DefaultBindMode_DataTemplate.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_DefaultBindMode_DataTemplate.xaml.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_DefaultBindMode_DataTemplate : Page
+	{
+		public Binding_DefaultBindMode_DataTemplate()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public partial class Binding_DefaultBindMode_DataTemplate_Model : DependencyObject
+	{ 
+		public string Default_undefined_Property
+		{
+			get { return (string)GetValue(Default_undefined_PropertyProperty); }
+			set { SetValue(Default_undefined_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Default_undefined_PropertyProperty =
+			DependencyProperty.Register("Default_undefined_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Default_undefined_OneWay_Property
+		{
+			get { return (string)GetValue(Default_undefined_OneWay_PropertyProperty); }
+			set { SetValue(Default_undefined_OneWay_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Default_undefined_OneWay_PropertyProperty =
+			DependencyProperty.Register("Default_undefined_OneWay_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Default_undefined_TwoWay_Property
+		{
+			get { return (string)GetValue(Default_undefined_TwoWay_PropertyProperty); }
+			set { SetValue(Default_undefined_TwoWay_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Default_undefined_TwoWay_PropertyProperty =
+			DependencyProperty.Register("Default_undefined_TwoWay_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+			
+		public string Default_OneWay_Property
+		{
+			get { return (string)GetValue(Default_OneWay_PropertyProperty); }
+			set { SetValue(Default_OneWay_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Default_OneWay_PropertyProperty =
+			DependencyProperty.Register("Default_OneWay_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Default_OneWay_OneWay_Property
+		{
+			get { return (string)GetValue(Default_OneWay_OneWay_PropertyProperty); }
+			set { SetValue(Default_OneWay_OneWay_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Default_OneWay_OneWay_PropertyProperty =
+			DependencyProperty.Register("Default_OneWay_OneWay_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+
+		public string Default_OneWay_TwoWay_Property
+		{
+			get { return (string)GetValue(Default_OneWay_TwoWay_PropertyProperty); }
+			set { SetValue(Default_OneWay_TwoWay_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Default_OneWay_TwoWay_PropertyProperty =
+			DependencyProperty.Register("Default_OneWay_TwoWay_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Default_TwoWay_Property
+		{
+			get { return (string)GetValue(Default_TwoWay_PropertyProperty); }
+			set { SetValue(Default_TwoWay_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Default_TwoWay_PropertyProperty =
+			DependencyProperty.Register("Default_TwoWay_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Default_TwoWay_OneWay_Property
+		{
+			get { return (string)GetValue(Default_TwoWay_OneWay_PropertyProperty); }
+			set { SetValue(Default_TwoWay_OneWay_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Default_TwoWay_OneWay_PropertyProperty =
+			DependencyProperty.Register("Default_TwoWay_OneWay_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Default_TwoWay_TwoWay_Property
+		{
+			get { return (string)GetValue(Default_TwoWay_TwoWay_PropertyProperty); }
+			set { SetValue(Default_TwoWay_TwoWay_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Default_TwoWay_TwoWay_PropertyProperty =
+			DependencyProperty.Register("Default_TwoWay_TwoWay_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Nested_Default_1_Property
+		{
+			get { return (string)GetValue(Nested_Default_1_PropertyProperty); }
+			set { SetValue(Nested_Default_1_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Nested_Default_1_PropertyProperty =
+			DependencyProperty.Register("Nested_Default_1_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Nested_Default_2_Property
+		{
+			get { return (string)GetValue(Nested_Default_2_PropertyProperty); }
+			set { SetValue(Nested_Default_2_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Nested_Default_2_PropertyProperty =
+			DependencyProperty.Register("Nested_Default_2_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Nested_Default_OneWay_OneWay_Property
+		{
+			get { return (string)GetValue(Nested_Default_OneWay_OneWay_PropertyProperty); }
+			set { SetValue(Nested_Default_OneWay_OneWay_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Nested_Default_OneWay_OneWay_PropertyProperty =
+			DependencyProperty.Register("Nested_Default_OneWay_OneWay_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Nested_Default_OneWay_TwoWay_Property
+		{
+			get { return (string)GetValue(Nested_Default_OneWay_TwoWay_PropertyProperty); }
+			set { SetValue(Nested_Default_OneWay_TwoWay_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Nested_Default_OneWay_TwoWay_PropertyProperty =
+			DependencyProperty.Register("Nested_Default_OneWay_TwoWay_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+
+		public string Nested_Default_OneWay_OneTime_Property
+		{
+			get { return (string)GetValue(Nested_Default_OneWay_OneTime_PropertyProperty); }
+			set { SetValue(Nested_Default_OneWay_OneTime_PropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty Nested_Default_OneWay_OneTime_PropertyProperty =
+			DependencyProperty.Register("Nested_Default_OneWay_OneTime_Property", typeof(string), typeof(Binding_DefaultBindMode_DataTemplate_Model), new FrameworkPropertyMetadata(null));
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -558,6 +558,49 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 		}
 
 		[TestMethod]
+		public void When_DefaultBindingMode_DataTemplate_Undefined()
+		{
+			var SUT = new Binding_DefaultBindMode_DataTemplate();
+			var model = new Binding_DefaultBindMode_DataTemplate_Model();
+
+			var default_undefined = (TextBlock)SUT.FindName("Default_undefined");
+			var default_undefined_OneWay = (TextBlock)SUT.FindName("Default_undefined_OneWay");
+			var default_undefined_TwoWay = (TextBlock)SUT.FindName("Default_undefined_TwoWay");
+
+			Assert.IsNull(model.Default_undefined_Property);
+			Assert.IsNull(model.Default_undefined_OneWay_Property);
+			Assert.IsNull(model.Default_undefined_TwoWay_Property);
+
+			model.Default_undefined_Property = "undefined updated 1";
+			model.Default_undefined_OneWay_Property = "undefined updated 2";
+			model.Default_undefined_TwoWay_Property = "undefined updated 3";
+
+			SUT.DataContext = model;
+
+			SUT.ForceLoaded();
+
+			Assert.AreEqual("undefined updated 1", default_undefined.Text);
+			Assert.AreEqual("undefined updated 2", default_undefined_OneWay.Text);
+			Assert.AreEqual("undefined updated 3", default_undefined_TwoWay.Text);
+
+			model.Default_undefined_Property = "undefined updated 4";
+			model.Default_undefined_OneWay_Property = "undefined updated 5";
+			model.Default_undefined_TwoWay_Property = "undefined updated 6";
+
+			Assert.AreEqual("undefined updated 4", default_undefined.Text);
+			Assert.AreEqual("undefined updated 5", default_undefined_OneWay.Text);
+			Assert.AreEqual("undefined updated 6", default_undefined_TwoWay.Text);
+
+			default_undefined.Text = "undefined updated 7";
+			default_undefined_OneWay.Text = "undefined updated 8";
+			default_undefined_TwoWay.Text = "undefined updated 9";
+
+			Assert.AreEqual("undefined updated 4", model.Default_undefined_Property);
+			Assert.AreEqual("undefined updated 5", model.Default_undefined_OneWay_Property);
+			Assert.AreEqual("undefined updated 9", model.Default_undefined_TwoWay_Property);
+		}
+
+		[TestMethod]
 		public void When_TwoWay_NamedElement()
 		{
 			var SUT = new Binding_TwoWay_NamedElement();


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5857

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`x:DefaultBindMode` is now flowing properly to `DataTemplate` contents

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [c] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
