### PR TITLE
fix(grid): Removed the possibility of a NullRefException when .Arrange() is called before calling .Measure() first.

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
@@ -1315,6 +1315,12 @@ namespace Windows.UI.Xaml.Controls
 		//------------------------------------------------------------------------
 		protected override XSIZEF ArrangeOverride(XSIZEF finalSize)
 		{
+			if (m_pRows == null || m_pColumns == null)
+			{
+				// Should call .Measure() first!
+				return default;
+			}
+
 			// Locking the row and columns definitions to prevent changes by user code
 			// during the arrange pass.
 			LockDefinitions();

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
@@ -1315,10 +1315,12 @@ namespace Windows.UI.Xaml.Controls
 		//------------------------------------------------------------------------
 		protected override XSIZEF ArrangeOverride(XSIZEF finalSize)
 		{
-			if (m_pRows == null || m_pColumns == null)
+			// UNO NRE FIX
+			if (HasGridFlags(GridFlags.DefinitionsChanged))
 			{
-				// Should call .Measure() first!
-				return default;
+				// A call to .Measure() is required before arranging children
+				// When the DefinitionsChanged is set, the measure is already invalidated
+				return default;  // Returning (0, 0)
 			}
 
 			// Locking the row and columns definitions to prevent changes by user code


### PR DESCRIPTION
# Bugfix
Removed a potential `NullReferenceException` while calling `.Arrange()` on `<Grid>` before calling first `.Measure()` on it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
