### PR TITLE
perf: Generate `Brush.Opacity` and `RelativeTransform` DPs

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Brush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.cs
@@ -25,21 +25,12 @@ namespace Windows.UI.Xaml.Media
 
 		public double Opacity
 		{
-			get => (double)GetValue(OpacityProperty);
-			set => SetValue(OpacityProperty, value);
+			get => GetOpacityValue();
+			set => SetOpacityValue(value);
 		}
 
-		// Using a DependencyProperty as the backing store for Opacity.  This enables animation, styling, binding, etc...
-		public static DependencyProperty OpacityProperty { get ; } =
-			DependencyProperty.Register(
-				"Opacity", 
-				typeof(double), 
-				typeof(Brush),
-				new FrameworkPropertyMetadata(
-					defaultValue: 1d,
-					propertyChangedCallback: (s, e) => ((Brush)s).OnOpacityChanged((double)e.OldValue, (double)e.NewValue)
-				)
-			);
+		[GeneratedDependencyProperty(DefaultValue = 1d, ChangedCallback = true)]
+		public static DependencyProperty OpacityProperty { get ; } = CreateOpacityProperty();
 
 		protected virtual void OnOpacityChanged(double oldValue, double newValue)
 		{
@@ -60,20 +51,12 @@ namespace Windows.UI.Xaml.Media
 
 		public Transform RelativeTransform
 		{
-			get => (Transform)GetValue(RelativeTransformProperty);
-			set => SetValue(RelativeTransformProperty, value);
+			get => GetRelativeTransformValue();
+			set => SetRelativeTransformValue(value);
 		}
 
-		public static DependencyProperty RelativeTransformProperty { get ; } =
-			DependencyProperty.Register(
-				"RelativeTransform",
-				typeof(Transform),
-				typeof(Brush),
-				new FrameworkPropertyMetadata(
-					null,
-
-					propertyChangedCallback: (s, e) =>
-						((Brush)s).OnRelativeTransformChanged((Transform)e.OldValue, (Transform)e.NewValue)));
+		[GeneratedDependencyProperty(DefaultValue = null, ChangedCallback = true)]
+		public static DependencyProperty RelativeTransformProperty { get ; } = CreateRelativeTransformProperty();
 
 		protected virtual void OnRelativeTransformChanged(Transform oldValue, Transform newValue)
 		{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

Improve `Brush.Opacity` and `RelativeTransform` DPs read performance

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
