### PR TITLE
Add ability to configure scrollbar's auto-hide delay, and fully disable auto-hide

### DIFF
--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -395,6 +395,14 @@ namespace Uno.UI
 			/// </remarks>
 			public static ScrollViewerUpdatesMode DefaultUpdatesMode { get; set; } = ScrollViewerUpdatesMode.AsynchronousIdle;
 
+			/// <summary>
+			/// Defines the delay after which the scrollbars hide themselves when pointer is not over.<br/>
+			/// Default is 4 sec.<br/>
+			/// Setting this to <see cref="TimeSpan.MaxValue"/> will completely disable the auto hide feature.
+			/// </summary>
+			/// <remarks>This is effective only for managed scrollbars (WASM, macOS and Skia for now)</remarks>
+			public static TimeSpan? DefaultAutoHideDelay { get; set; }
+
 #if __ANDROID__
 			/// <summary>
 			/// This value defines an optional delay to be set for native ScrollBar thumbs to disapear. The


### PR DESCRIPTION
GitHub Issue: fixes #5844 

## Feature
Add ability to configure scrollbar's auto-hide delay, and fully disbale auto-hide

## What is the new behavior?
We now have the ability to change the auto-hide delay in Uno's `FeatureConfiguration.ScrollViewer.DefaultAutoHideDelay`.
Setting it to `TimeSpan.MaxValue` will make sure to display the scrollbars at load, and to never hide them.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
