### PR TITLE
ManipulationCompleted might not be raised for each ManipulationStarted

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/ManipulationEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/ManipulationEvents.xaml.cs
@@ -9,7 +9,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
 {
-	[SampleControlInfo("Gesture recognizer", "Manipulation Events")]
+	[Sample("Gesture recognizer", "Manipulation Events", IgnoreInSnapshotTests = true)]
 	public sealed partial class ManipulationEvents : Page
 	{
 		public ManipulationEvents()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_WhenInScrollViewer.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_WhenInScrollViewer.xaml
@@ -9,6 +9,32 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<ScrollViewer Width="300" Height="300" VerticalAlignment="Center"  HorizontalAlignment="Center" x:Name="TheScroller">
+			<Border Width="300" Height="1024" Background="DeepPink">
+				<Border
+					x:Name="TouchTarget"
+					Width="50"
+					Height="50"
+					HorizontalAlignment="Left"
+					VerticalAlignment="Top"
+					Margin="10,240,0,0"
+					Background="DeepSkyBlue"
+					ManipulationMode="TranslateX, TranslateY"
+					ManipulationStarting="OnManipStarting"
+					ManipulationStarted="OnManipStarted"
+					ManipulationDelta="OnManipDelta"
+					ManipulationCompleted="OnManipCompleted"/>
+			</Border>
+		</ScrollViewer>
+		<ScrollViewer Grid.Column="1">
+			<TextBlock
+				x:Name="Output"
+				FontSize="10"
+				TextWrapping="Wrap"/>
+		</ScrollViewer>
     </Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_WhenInScrollViewer.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_WhenInScrollViewer.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.UI.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -12,19 +13,41 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
-
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
 {
-	/// <summary>
-	/// An empty page that can be used on its own or navigated to within a Frame.
-	/// </summary>
+	[Sample("Gesture recognizer", IgnoreInSnapshotTests = true)]
 	public sealed partial class Manipulation_WhenInScrollViewer : Page
 	{
 		public Manipulation_WhenInScrollViewer()
 		{
 			this.InitializeComponent();
 		}
+
+		private void OnManipStarting(object sender, ManipulationStartingRoutedEventArgs e)
+			=> Write("[Starting]");
+
+		private void OnManipStarted(object sender, ManipulationStartedRoutedEventArgs e)
+			=> Write($"[Started] {F(e.Position, new ManipulationDelta { Scale = 1f }, e.Cumulative)}");
+
+		private void OnManipDelta(object sender, ManipulationDeltaRoutedEventArgs e)
+			=> Write($"[Delta] {F(e.Position, e.Delta, e.Cumulative)}");
+
+		private void OnManipCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
+			=> Write($"[Completed] {F(e.Position, new ManipulationDelta { Scale = 1f }, e.Cumulative)}");
+
+		private void Write(string text)
+		{
+			Output.Text += "\r\n" + text;
+		}
+
+		private static string F(Point position, ManipulationDelta delta, ManipulationDelta cumulative)
+			=> $"@=[{position.X:000.00},{position.Y:000.00}] "
+				+ $"| X=(Σ:{cumulative.Translation.X:' '000.00;'-'000.00} / Δ:{delta.Translation.X:' '00.00;'-'00.00}) "
+				+ $"| Y=(Σ:{cumulative.Translation.Y:' '000.00;'-'000.00} / Δ:{delta.Translation.Y:' '00.00;'-'00.00}) "
+				+ $"| θ=(Σ:{cumulative.Rotation:' '000.00;'-'000.00} / Δ:{delta.Rotation:' '00.00;'-'00.00}) "
+				+ $"| s=(Σ:{cumulative.Scale:000.00} / Δ:{delta.Scale:00.00}) "
+				+ $"| e=(Σ:{cumulative.Expansion:' '000.00;'-'000.00} / Δ:{delta.Expansion:' '00.00;'-'00.00})";
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -884,11 +884,6 @@ namespace Windows.UI.Xaml
 			SetPressed(args, false, muteEvent: true);
 			SetOver(args, false, muteEvent: true);
 
-			if (!isOverOrCaptured)
-			{
-				return false;
-			}
-		
 			if (_gestures.IsValueCreated)
 			{
 				_gestures.Value.CompleteGesture();
@@ -896,6 +891,11 @@ namespace Windows.UI.Xaml
 				{
 					global::Windows.UI.Xaml.Window.Current.DragDrop.ProcessAborted(args);
 				}
+			}
+
+			if (!isOverOrCaptured)
+			{
+				return false;
 			}
 
 			var handledInManaged = false;


### PR DESCRIPTION
GitHub Issue: #5929 

## Bugfix
`ManipulationCompleted` might not be raised for each `ManipulationStarted`.

## What is the current behavior?
When a `ScrollViewer` kicks-in (and stole the pointer) the `PointerCancelled` event is not propagated to elements which are not under the pointer, preventing the `GestureRecognizer` to complete.

## What is the new behavior?
Pointer cancelled events are sent to `GestureRecognizer` in any cases.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.