### PR TITLE
fix: Make ItemsRepeater.LayoutProperty logical child

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/RadioButtonsTests/Controls/When_RadioButtons_TemplateBinding.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/RadioButtonsTests/Controls/When_RadioButtons_TemplateBinding.xaml
@@ -1,0 +1,55 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_XAML_Controls.RadioButtonsTests.Controls.When_RadioButtons_TemplateBinding"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_XAML_Controls.RadioButtonsTests.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<Style x:Key="MyStyle" TargetType="muxc:RadioButtons">
+			<Setter Property="IsTabStop" Value="False" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="muxc:RadioButtons">
+						<StackPanel>
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="Disabled">
+										<VisualState.Setters>
+											<Setter Target="HeaderContentPresenter.Foreground" Value="{ThemeResource RadioButtonsHeaderForegroundDisabled}"/>
+										</VisualState.Setters>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+							<ContentPresenter x:Name="HeaderContentPresenter"
+                            Content="{TemplateBinding Header}"
+                            ContentTemplate="{TemplateBinding HeaderTemplate}"
+                            Foreground="{ThemeResource RadioButtonsHeaderForeground}"
+                            Margin="{ThemeResource RadioButtonsTopHeaderMargin}"/>
+							<muxc:ItemsRepeater x:Name="InnerRepeater">
+								<muxc:ItemsRepeater.Layout>
+									<primitives:ColumnMajorUniformToLargestGridLayout x:Name="InnerLayout"
+                                    MaxColumns="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=MaxColumns}"
+                                    ColumnSpacing="{ThemeResource RadioButtonsColumnSpacing}"
+                                    RowSpacing="{ThemeResource RadioButtonsRowSpacing}"/>
+								</muxc:ItemsRepeater.Layout>
+							</muxc:ItemsRepeater>
+						</StackPanel>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<StackPanel Grid.Row="1" Orientation="Vertical">
+		<muxc:RadioButtons x:Name="rootRB" x:FieldModifier="public" MaxColumns="2" Style="{StaticResource MyStyle}">
+		</muxc:RadioButtons>
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/RadioButtonsTests/Controls/When_RadioButtons_TemplateBinding.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/RadioButtonsTests/Controls/When_RadioButtons_TemplateBinding.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_XAML_Controls.RadioButtonsTests.Controls
+{
+	public sealed partial class When_RadioButtons_TemplateBinding : UserControl
+	{
+		public When_RadioButtons_TemplateBinding()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/RadioButtonsTests/Given_RadioButtons.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/RadioButtonsTests/Given_RadioButtons.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Tests.Windows_UI_XAML_Controls.RadioButtonsTests.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_XAML_Controls.RadioButtonsTests
+{
+	[TestClass]
+	public class Given_RadioButtons
+	{
+		[TestMethod]
+		public void When_TemplateBinding()
+		{
+			var SUT = new When_RadioButtons_TemplateBinding();
+			SUT.ForceLoaded();
+
+			var repeater = SUT.FindName("InnerRepeater") as ItemsRepeater;
+			Assert.IsNotNull(repeater);
+
+			var layout = repeater.Layout as ColumnMajorUniformToLargestGridLayout;
+
+			Assert.AreEqual(2, layout.MaxColumns);
+		}
+	}
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ItemsRepeater.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ItemsRepeater.Properties.cs
@@ -44,7 +44,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 		#region Layout (DP - With default callback)
 		public static DependencyProperty LayoutProperty { get; } = DependencyProperty.Register(
-			"Layout", typeof(Layout), typeof(ItemsRepeater), new PropertyMetadata(new StackLayout(), OnPropertyChanged));
+			"Layout", typeof(Layout), typeof(ItemsRepeater), new FrameworkPropertyMetadata(
+				defaultValue: new StackLayout(),
+				propertyChangedCallback: OnPropertyChanged
+			));
 
 #if __ANDROID__ || __MACOS__
 		public new Layout Layout


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5918

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The `ItemsRepeater.LayoutProperty` in now considered a Logical Child, which makes receive `DataContext` and `TemplatedParent` updates.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
