### PR TITLE
fix(remotecontrol): safe fallback when directories search list is empty

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
@@ -89,7 +89,7 @@ namespace Uno.UI.SourceGenerators.RemoteControl
 
 			var distictPaths = string.Join(",\n", xamlPaths.Distinct().Select(p => $"@\"{p}\""));
 
-			sb.AppendLineInvariant("{0}", $"new[]{{{distictPaths}}}");
+			sb.AppendLineInvariant("{0}", $"new string[]{{{distictPaths}}}");
 
 			sb.AppendLineInvariant($")]");
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/5953

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

For some unknown conditions, the directory search list may be empty, and will generate invalid C#. This change works around the invalid code generation, but will not build a proper directory list for the remote control server to work properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
