### PR TITLE
fix: Use stable uri for WebView_NavigateToAnchor

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WebViewTests/UnoSamples_Test_NavigateToString.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WebViewTests/UnoSamples_Test_NavigateToString.cs
@@ -56,17 +56,17 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.WebViewTests
 			var navigateToAnchorButton = _app.Marked("NavigateToAnchorButton");
 			var clickAnchorButton = _app.Marked("ClickAnchorButton");
 
-			_app.WaitForText(navigationCompletedTextBlock, "https://tools.ietf.org/html/rfc6749");
+			_app.WaitForText(navigationCompletedTextBlock, "https://nv-assets.azurewebsites.net/tests/docs/WebView_NavigateToAnchor.html");
 
 			// navigate to anchor
 			_app.FastTap(navigateToAnchorButton);
-			_app.WaitForText(navigationCompletedTextBlock, "https://tools.ietf.org/html/rfc6749#section-1");
+			_app.WaitForText(navigationCompletedTextBlock, "https://nv-assets.azurewebsites.net/tests/docs/WebView_NavigateToAnchor.html#section-1");
 
 			TakeScreenshot("navigate to anchor");
 
 			// user click in the browser itself
 			_app.FastTap(clickAnchorButton);
-			_app.WaitForText(navigationCompletedTextBlock, "https://tools.ietf.org/html/rfc6749#page-4");
+			_app.WaitForText(navigationCompletedTextBlock, "https://nv-assets.azurewebsites.net/tests/docs/WebView_NavigateToAnchor.html#page-4");
 
 			TakeScreenshot("click anchor");
 		}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml.cs
@@ -1,22 +1,18 @@
 using System;
-using System.Threading;
 using Uno.UI.Samples.Controls;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Samples.Content.UITests.WebView
 {
-	[SampleControlInfo("WebView", "WebView_AnchorNavigation", description:"This sample tests that anchor navigation raises the proper events. The 2 uris received from the NavigationStarting and NavigationCompleted must update whether you tap the NavigateToAnchor button or tap on anchors from the web content.")]
+	[Sample(Description = "This sample tests that anchor navigation raises the proper events. The 2 uris received from the NavigationStarting and NavigationCompleted must update whether you tap the NavigateToAnchor button or tap on anchors from the web content.")]
 	public sealed partial class WebView_AnchorNavigation : UserControl
 	{
-		//Windows.UI.Xaml.Controls.WebView webView;
-
 		public WebView_AnchorNavigation()
 		{
 			InitializeComponent();
 
 #if HAS_UNO
-			webView.Navigate(new Uri("https://tools.ietf.org/html/rfc6749"));
+			webView.Navigate(new Uri("https://nv-assets.azurewebsites.net/tests/docs/WebView_NavigateToAnchor.html"));
 			webView.NavigationStarting += WebView_NavigationStarting;
 			webView.NavigationCompleted += WebView_NavigationCompleted;
 #endif
@@ -34,12 +30,12 @@ namespace Uno.UI.Samples.Content.UITests.WebView
 
 		private void ButtonClicked()
 		{
-			webView.Navigate(new Uri("https://tools.ietf.org/html/rfc6749#section-1"));
+			webView.Navigate(new Uri("https://nv-assets.azurewebsites.net/tests/docs/WebView_NavigateToAnchor.html#section-1"));
 		}
 
 		private void OnClickAnchor()
 		{
-			_ = webView.InvokeScriptAsync("document.getElementById(\"page-4\").click()", null);
+			_ = webView.InvokeScriptAsync("document.querySelector(\"a[href =\\\"#page-4\\\"]\").click()", null);
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

None, WebView_NavigateToAnchor now use a stable uri.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
