### PR TITLE
fix(test): Ensure `[ActivePlatform]` in UI Tests works with NUnit's `[TestCase]`

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ActivePlatformsAttribute.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ActivePlatformsAttribute.cs
@@ -14,9 +14,18 @@ namespace SamplesApp.UITests.TestFramework
 	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
 	internal class ActivePlatformsAttribute : PropertyAttribute
 	{
+		public Platform[] Platforms
+		{
+			get
+			{
+				var property = Properties["ActivePlatforms"] as IList<object>;
+				return property?.FirstOrDefault() as Platform[];
+			}
+		}
+
 		public ActivePlatformsAttribute(params Platform[] platforms)
 		{
-			base.Properties.Add("ActivePlatforms", platforms);
+			Properties.Add("ActivePlatforms", platforms);
 		}
 	}
 }


### PR DESCRIPTION
# Fix broken CI

## What is the current behavior?
UI tests using `[TestCase]` were not properly following `[ActivePlatform]` attributes

## What is the new behavior?
Fixed this behavior.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
