### PR TITLE
fix(DisplayInformation): [Android] DisplayInformation cannot be used too early

### DIFF
--- a/src/Uno.UWP/ContextHelper.cs
+++ b/src/Uno.UWP/ContextHelper.cs
@@ -39,6 +39,17 @@ namespace Uno.UI
 			}
 			set => _current = value;
 		}
+
+		/// <summary>
+		/// Tries getting the current context.
+		/// </summary>
+		/// <param name="context">The context if available</param>
+		/// <returns>true if the current context is available, otherwise false.</returns>
+		internal static bool TryGetCurrent(out Android.Content.Context context)
+		{
+			context = _current;
+			return _current != null;
+		}
 	}
 }
 #endif

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
@@ -11,6 +11,25 @@ namespace Windows.Graphics.Display
 {
 	public sealed partial class DisplayInformation
 	{
+		private static DisplayInformation _instance;
+
+		private static DisplayInformation InternalGetForCurrentView()
+		{
+			if (_instance == null)
+			{
+				if (ContextHelper.TryGetCurrent(out _))
+				{
+					_instance = new DisplayInformation();
+				}
+				else
+				{
+					throw new Exception($"Failed to get current activity, DisplayInformation is not available. On Android, DisplayInformation is available as early as Application.OnLaunched.");
+				}
+			}
+
+			return _instance;
+		}
+
 		static partial void SetOrientationPartial(DisplayOrientations orientations)
 		{
 			var currentActivity = ContextHelper.Current as Activity;

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.cs
@@ -17,7 +17,6 @@ namespace Windows.Graphics.Display
 
 		private const float BaseDpi = 96.0f;
 
-		private static readonly Lazy<DisplayInformation> _lazyInstance = new Lazy<DisplayInformation>(() => new DisplayInformation());
 		private static readonly object _syncLock = new object();
 
 		private static DisplayOrientations _autoRotationPreferences;
@@ -42,7 +41,7 @@ namespace Windows.Graphics.Display
 
 		public bool StereoEnabled { get; private set; } = false;
 
-		public static DisplayInformation GetForCurrentView() => _lazyInstance.Value;
+		public static DisplayInformation GetForCurrentView() => InternalGetForCurrentView();
 
 		static partial void SetOrientationPartial(DisplayOrientations orientations);
 

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.iOS.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.iOS.cs
@@ -11,6 +11,10 @@ namespace Windows.Graphics.Display
 {
 	public sealed partial class DisplayInformation
 	{
+		private static readonly Lazy<DisplayInformation> _lazyInstance = new Lazy<DisplayInformation>(() => new DisplayInformation());
+
+		private static DisplayInformation InternalGetForCurrentView() => _lazyInstance.Value;
+
 		private NSObject _didChangeStatusBarOrientationObserver;
 
 		public static UIInterfaceOrientationMask[] PreferredOrientations =

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.macOS.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.macOS.cs
@@ -1,10 +1,15 @@
 ﻿using AppKit;
 using Foundation;
+using System;
 
 namespace Windows.Graphics.Display
 {
 	public sealed partial class DisplayInformation
 	{
+		private static readonly Lazy<DisplayInformation> _lazyInstance = new Lazy<DisplayInformation>(() => new DisplayInformation());
+
+		private static DisplayInformation InternalGetForCurrentView() => _lazyInstance.Value;
+
 		private NSObject _didChangeScreenParametersObserver = null;
 
 		public DisplayOrientations CurrentOrientation

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.skia.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.skia.cs
@@ -7,6 +7,10 @@ namespace Windows.Graphics.Display
 {
 	public sealed partial class DisplayInformation
 	{
+		private static readonly Lazy<DisplayInformation> _lazyInstance = new Lazy<DisplayInformation>(() => new DisplayInformation());
+
+		private static DisplayInformation InternalGetForCurrentView() => _lazyInstance.Value;
+
 		private IDisplayInformationExtension _displayInformationExtension;
 
 		partial void Initialize()

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.unsupported.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.unsupported.cs
@@ -1,9 +1,10 @@
 ﻿using Uno;
+using System;
 
 namespace Windows.Graphics.Display
 {
 	public partial class DisplayInformation
-    {
+	{
 #if __WASM__ || NET461 || __SKIA__ || __NETSTD_REFERENCE__
 		/// <summary>
 		//// Gets the native orientation of the display monitor, 
@@ -49,6 +50,10 @@ namespace Windows.Graphics.Display
 #endif
 
 #if NET461 || __NETSTD_REFERENCE__
+		private static readonly Lazy<DisplayInformation> _lazyInstance = new Lazy<DisplayInformation>(() => new DisplayInformation());
+
+		private static DisplayInformation InternalGetForCurrentView() => _lazyInstance.Value;
+
 		[NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public DisplayOrientations CurrentOrientation => DisplayOrientations.None;
 

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
@@ -1,11 +1,16 @@
 ﻿#if __WASM__
 using Uno;
 using Uno.Foundation;
+using System;
 
 namespace Windows.Graphics.Display
 {
 	public sealed partial class DisplayInformation
 	{
+		private static readonly Lazy<DisplayInformation> _lazyInstance = new Lazy<DisplayInformation>(() => new DisplayInformation());
+
+		private static DisplayInformation InternalGetForCurrentView() => _lazyInstance.Value;
+
 		private const string JsType = "Windows.Graphics.Display.DisplayInformation";
 
 		[Preserve]


### PR DESCRIPTION
On Android, `DisplayInformation` relies on `ContextHelper.Current` which may not be available when called to early during the app's lifecycle. This change will make the exception more explicit.

GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/6019

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fail with a more explicit error message when using `DisplayInformation` too early in the app.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
