### PR TITLE
Misc DependencyObject performance improvements

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
@@ -1644,6 +1644,13 @@ namespace Uno.UI.Tests.BinderTests
 #endif
 		}
 
+		[TestMethod]
+		public void When_DefaultValueOverride()
+		{
+			var SUT = new MyDependencyObjectWithDefaultValueOverride();
+			Assert.AreEqual(42, SUT.GetValue(MyDependencyObjectWithDefaultValueOverride.MyPropertyProperty));
+		}
+
 		private class MyDependencyObject : FrameworkElement
 		{
 			internal static readonly DependencyProperty PropAProperty = DependencyProperty.Register(
@@ -1789,6 +1796,39 @@ namespace Uno.UI.Tests.BinderTests
 		#endregion
 
 	}
+
+	partial class MyDependencyObjectWithDefaultValueOverride : DependencyObject
+	{
+		public MyDependencyObjectWithDefaultValueOverride()
+		{
+			this.RegisterDefaultValueProvider(OnProvideDefaultValue);
+		}
+
+		private bool OnProvideDefaultValue(DependencyProperty property, out object defaultValue)
+		{
+			if(property == MyPropertyProperty)
+			{
+				defaultValue = 42;
+
+				return true;
+			}
+
+			defaultValue = null;
+			return false;
+		}
+
+		public int MyProperty
+		{
+			get { return (int)GetValue(MyPropertyProperty); }
+			set { SetValue(MyPropertyProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for MyProperty.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyPropertyProperty =
+			DependencyProperty.Register("MyProperty", typeof(int), typeof(MyDependencyObjectWithDefaultValueOverride), new PropertyMetadata(0));
+
+	}
+
 
 	#endregion
 }

--- a/src/Uno.UI/DataBinding/WeakReferencePool.cs
+++ b/src/Uno.UI/DataBinding/WeakReferencePool.cs
@@ -148,13 +148,6 @@ namespace Uno.UI.DataBinding
 					var handle = _weakReferencePool.Pop();
 					handle.Target = target;
 
-					if(handle.Target != target)
-					{
-						handle.Target = target;
-
-						throw new InvalidOperationException();
-					}
-
 					return handle;
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
@@ -279,9 +279,9 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		/// <param name="instance">The instance on which the property is attached</param>
 		/// <param name="property">The dependency property to get</param>
-		internal static void CoerceValue(this object instance, DependencyProperty property)
+		internal static void CoerceValue(this IDependencyObjectStoreProvider storeProvider, DependencyProperty property)
 		{
-			GetStore(instance).CoerceValue(property);
+			storeProvider.Store.CoerceValue(property);
 		}
 
 		/// <summary>
@@ -414,9 +414,13 @@ namespace Windows.UI.Xaml
 			uielement?.InvalidateRender();
 		}
 
-		internal static void RegisterDefaultValueProvider(this DependencyObject dependencyObject, DependencyObjectStore.DefaultValueProvider provider)
-		{
-			GetStore(dependencyObject).RegisterDefaultValueProvider(provider);
-		}
+		internal static void RegisterDefaultValueProvider(this IDependencyObjectStoreProvider storeProvider, DependencyObjectStore.DefaultValueProvider provider)
+			=> storeProvider.Store.RegisterDefaultValueProvider(provider);
+
+		/// <summary>
+		/// See <see cref="DependencyObjectStore.RegisterPropertyChangedCallbackStrong(ExplicitPropertyChangedCallback)"/> for more details
+		/// </summary>
+		internal static void RegisterPropertyChangedCallbackStrong(this IDependencyObjectStoreProvider storeProvider, ExplicitPropertyChangedCallback handler)
+			=> storeProvider.Store.RegisterPropertyChangedCallbackStrong(handler);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
@@ -359,17 +359,6 @@ namespace Windows.UI.Xaml
 		}
 
 		/// <summary>
-		/// Register for changes all dependency properties changes notifications for the specified instance.
-		/// </summary>
-		/// <param name="instance">The instance for which to observe properties changes</param>
-		/// <param name="handler">The callback</param>
-		/// <returns>A disposable that will unregister the callback when disposed.</returns>
-		internal static IDisposable RegisterInheritedPropertyChangedCallback(this object instance, ExplicitPropertyChangedCallback handler)
-		{
-			return GetStore(instance).RegisterInheritedPropertyChangedCallback(handler);
-		}
-
-		/// <summary>
 		/// Registers to parent changes.
 		/// </summary>
 		/// <param name="instance">The target dependency object</param>

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml
 
 		private readonly object _gate = new object();
 
-		private readonly HashtableEx _childrenBindableMap = new HashtableEx();
+		private readonly HashtableEx _childrenBindableMap = new HashtableEx(DependencyPropertyComparer.Default);
 		private readonly List<object?> _childrenBindable = new List<object?>();
 
 		private bool _isApplyingTemplateBindings;

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -167,10 +167,10 @@ namespace Windows.UI.Xaml
 		}
 
 		private void SetInheritedTemplatedParent(object? templatedParent)
-			=> SetValue(_templatedParentProperty!, templatedParent, DependencyPropertyValuePrecedences.Inheritance, _templatedParentPropertyDetails);
+			=> SetValue(_templatedParentProperty!, templatedParent, DependencyPropertyValuePrecedences.Inheritance, _properties.TemplatedParentPropertyDetails);
 
 		private void SetInheritedDataContext(object? dataContext)
-			=> SetValue(_dataContextProperty!, dataContext, DependencyPropertyValuePrecedences.Inheritance, _dataContextPropertyDetails);
+			=> SetValue(_dataContextProperty!, dataContext, DependencyPropertyValuePrecedences.Inheritance, _properties.DataContextPropertyDetails);
 
 		/// <summary>
 		/// Apply load-time binding updates. Processes the x:Bind markup for the current FrameworkElement, applies load-time ElementName bindings, and updates ResourceBindings.

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyComparer.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyComparer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
@@ -7,7 +8,7 @@ namespace Windows.UI.Xaml
 	/// <summary>
 	/// A dependency property comparer that assumes that instances are unique and that the hash code will never change.
 	/// </summary>
-	internal class DependencyPropertyComparer : IEqualityComparer<DependencyProperty>
+	internal class DependencyPropertyComparer : IEqualityComparer<DependencyProperty>, IEqualityComparer
 	{
 		/// <summary>
 		/// Gets the default instance of DependencyPropertyComparer. This class has no state and cannot be created.
@@ -18,14 +19,11 @@ namespace Windows.UI.Xaml
 		{
 		}
 
-		public bool Equals(DependencyProperty x, DependencyProperty y)
-		{
-			return object.ReferenceEquals(x, y);
-		}
+		public bool Equals(DependencyProperty x, DependencyProperty y) => object.ReferenceEquals(x, y);
 
-		public int GetHashCode(DependencyProperty obj)
-		{
-			return obj.CachedHashCode;
-		}
+		public int GetHashCode(DependencyProperty obj) => obj.CachedHashCode;
+
+		bool IEqualityComparer.Equals(object x, object y) => object.ReferenceEquals(x, y);
+		int IEqualityComparer.GetHashCode(object obj) => obj is DependencyProperty dp ? dp.CachedHashCode : 0;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml
 		private readonly Type _dependencyObjectType;
 		private object? _fastLocalValue;
 		private BindingExpression? _lastBindings;
-		private static readonly ArrayPool<object?> _pool = ArrayPool<object?>.Create(100, 100);
+		private static readonly ArrayPool<object?> _pool = ArrayPool<object?>.Create(_stackLength, 100);
 		private object?[]? _stack;
 		private PropertyMetadata? _metadata;
 		private object? _defaultValue;

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
@@ -51,6 +51,8 @@ namespace Windows.UI.Xaml
 
 			if (_stack != null)
 			{
+				// Note that `clearArray` is required here to avoid pooled arrays to leak
+				// instances from set property values.
 				_pool.Return(_stack, clearArray: true);
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,14 +15,19 @@ namespace Windows.UI.Xaml
 	/// <summary>
 	/// Represents the stack of values used by the Dependency Property Value Precedence system
 	/// </summary>
-	internal class DependencyPropertyDetails : IEnumerable<object>, IEnumerable, IDisposable
+	internal class DependencyPropertyDetails : IEnumerable<object?>, IEnumerable, IDisposable
 	{
 		private DependencyPropertyValuePrecedences _highestPrecedence = DependencyPropertyValuePrecedences.DefaultValue;
-		private BindingExpression _lastBindings;
-		private static readonly ArrayPool<object> _pool = ArrayPool<object>.Create(100, 100);
-		private readonly object[] _stack;
-		private readonly bool _hasWeakStorage;
-		private readonly List<BindingExpression> _bindings = new List<BindingExpression>();
+		private readonly Type _dependencyObjectType;
+		private object? _fastLocalValue;
+		private BindingExpression? _lastBindings;
+		private static readonly ArrayPool<object?> _pool = ArrayPool<object?>.Create(100, 100);
+		private object?[]? _stack;
+		private PropertyMetadata? _metadata;
+		private object? _defaultValue;
+		private List<BindingExpression>? _bindings;
+		private Flags _flags;
+		private DependencyPropertyCallbackManager? _callbackManager;
 
 		private const int MaxIndex = (int)DependencyPropertyValuePrecedences.DefaultValue;
 		private const int _stackLength = MaxIndex + 1;
@@ -34,45 +41,57 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-        private DependencyPropertyDetails()
-		{
-			_stack = _pool.Rent(_stackLength);
-		}
+		private List<BindingExpression> Bindings => _bindings ??= new List<BindingExpression>();
+
+		private bool HasBindingsList => _bindings != null;
 
 		public void Dispose()
 		{
 			CallbackManager.Dispose();
-			_pool.Return(_stack, clearArray: true);
+
+			if (_stack != null)
+			{
+				_pool.Return(_stack, clearArray: true);
+			}
 		}
 
-        public DependencyPropertyCallbackManager CallbackManager { get; } = new DependencyPropertyCallbackManager();
+        public DependencyPropertyCallbackManager CallbackManager => _callbackManager ??= new DependencyPropertyCallbackManager();
 
         public DependencyProperty Property { get; }
 
-		public PropertyMetadata Metadata { get; }
+		public PropertyMetadata Metadata => _metadata ??= Property.GetMetadata(_dependencyObjectType);
 
 		/// <summary>
 		/// Constructor
 		/// </summary>
 		/// <param name="defaultValue">The default value of the Dependency Property</param>
-		internal DependencyPropertyDetails(DependencyProperty property, Type dependencyObjectType) : this()
+		internal DependencyPropertyDetails(DependencyProperty property, Type dependencyObjectType)
 		{
-            Property = property;
-			_hasWeakStorage = property.HasWeakStorage;
+			Property = property;
+			_dependencyObjectType = dependencyObjectType;
 
-			Array.Copy(_unsetStack, _stack, _stackLength);
-
-			var defaultValue = Property.GetMetadata(dependencyObjectType).DefaultValue;
-
-			// Ensures that the default value of non-nullable properties is not null
-			if (defaultValue == null && !Property.IsTypeNullable)
+			if (property.HasWeakStorage)
 			{
-				defaultValue = Property.GetFallbackDefaultValue();
+				_flags |= Flags.WeakStorage;
+			}
+		}
+
+		private object? GetDefaultValue()
+		{
+			if (!HasDefaultValueSet)
+			{
+				_defaultValue = Property.GetMetadata(_dependencyObjectType).DefaultValue;
+
+				// Ensures that the default value of non-nullable properties is not null
+				if (_defaultValue == null && !Property.IsTypeNullable)
+				{
+					_defaultValue = Property.GetFallbackDefaultValue();
+				}
+
+				_flags |= Flags.DefaultValueSet;
 			}
 
-			_stack[MaxIndex] = defaultValue;
-
-			Metadata = property.GetMetadata(dependencyObjectType);
+			return _defaultValue;
 		}
 
 		/// <summary>
@@ -80,30 +99,49 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		/// <param name="value">The value to set</param>
 		/// <param name="precedence">The precedence level to set the value at</param>
-		internal void SetValue(object value, DependencyPropertyValuePrecedences precedence)
+		internal void SetValue(object? value, DependencyPropertyValuePrecedences precedence)
 		{
-			if (_hasWeakStorage && _stack[(int)precedence] is ManagedWeakReference mwr)
+			if (!SetValueFast(value, precedence))
 			{
-				WeakReferencePool.ReturnWeakReference(this, mwr);
+				SetValueFull(value, precedence);
 			}
+		}
 
-			_stack[(int)precedence] = Validate(value);
+		private void SetValueFull(object? value, DependencyPropertyValuePrecedences precedence)
+		{
+			var valueIsUnsetValue = value is UnsetValue;
+
+			var stackAlias = Stack;
+
+			if (HasWeakStorage)
+			{
+				if (stackAlias[(int)precedence] is ManagedWeakReference mwr)
+				{
+					WeakReferencePool.ReturnWeakReference(this, mwr);
+				}
+
+				stackAlias[(int)precedence] = Validate(value);
+			}
+			else
+			{
+				stackAlias[(int)precedence] = ValidateNoWrap(value);
+			}
 
 			// After setting the value, we need to update the current highest precedence if needed
 			// If a higher value precedence was set, then this is the new highest
-			if (!(value is UnsetValue) && precedence < _highestPrecedence)
+			if (!valueIsUnsetValue && precedence < _highestPrecedence)
 			{
 				_highestPrecedence = precedence;
 				return;
 			}
 
 			// If we were unsetting the current highest precedence value, we need to find the next highest
-			if (value is UnsetValue && precedence == _highestPrecedence)
+			if (valueIsUnsetValue && precedence == _highestPrecedence)
 			{
 				// Start from current precedence and find next highest
 				for (int i = (int)precedence; i < (int)DependencyPropertyValuePrecedences.DefaultValue; i++)
 				{
-					if (_stack[i] != DependencyProperty.UnsetValue)
+					if (stackAlias[i] != DependencyProperty.UnsetValue)
 					{
 						_highestPrecedence = (DependencyPropertyValuePrecedences)i;
 						return;
@@ -114,20 +152,59 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		internal BindingExpression GetLastBinding()
+		private bool SetValueFast(object? value, DependencyPropertyValuePrecedences precedence)
+		{
+			if (_stack == null && precedence == DependencyPropertyValuePrecedences.Local)
+			{
+				var valueIsUnsetValue = value is UnsetValue;
+
+				if (HasWeakStorage)
+				{
+					if (_fastLocalValue is ManagedWeakReference mwr2)
+					{
+						WeakReferencePool.ReturnWeakReference(this, mwr2);
+					}
+
+					_fastLocalValue = Validate(value);
+				}
+				else
+				{
+					_fastLocalValue = ValidateNoWrap(value);
+				}
+
+				_highestPrecedence = valueIsUnsetValue
+					? DependencyPropertyValuePrecedences.DefaultValue
+					: DependencyPropertyValuePrecedences.Local;
+
+				return true;
+			}
+
+			return false;
+		}
+
+		internal void SetDefaultValue(object defaultValue)
+		{
+			_defaultValue = defaultValue;
+			_flags |= Flags.DefaultValueSet;
+		}
+
+		internal BindingExpression? GetLastBinding()
 			=> _lastBindings;
 
 		internal void SetBinding(BindingExpression bindingExpression)
 		{
-			_bindings.Add(bindingExpression);
+			Bindings.Add(bindingExpression);
 			_lastBindings = bindingExpression;
 		}
 
 		internal void SetSourceValue(object value)
 		{
-			for (int i = 0; i < _bindings.Count; i++)
+			if (HasBindingsList)
 			{
-				_bindings[i].SetSourceValue(value);
+				for (int i = 0; i < Bindings.Count; i++)
+				{
+					Bindings[i].SetSourceValue(value);
+				}
 			}
 		}
 
@@ -135,7 +212,7 @@ namespace Windows.UI.Xaml
 		/// Gets the value at the current highest precedence level
 		/// </summary>
 		/// <returns>The value at the current highest precedence level</returns>
-		internal object GetValue()
+		internal object? GetValue()
 			=> GetValue(_highestPrecedence);
 
 		/// <summary>
@@ -144,8 +221,22 @@ namespace Windows.UI.Xaml
 		/// <param name="precedence">The precedence level to get the value at</param>
 		/// <returns>The value at a given precedence level</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		internal object GetValue(DependencyPropertyValuePrecedences precedence)
-			=> Unwrap(_stack[(int)precedence]);
+		internal object? GetValue(DependencyPropertyValuePrecedences precedence)
+		{
+			if (_stack == null)
+			{
+				return precedence switch
+				{
+					DependencyPropertyValuePrecedences.DefaultValue => GetDefaultValue(),
+					DependencyPropertyValuePrecedences.Local when _highestPrecedence == DependencyPropertyValuePrecedences.Local => Unwrap(_fastLocalValue),
+					_ => DependencyProperty.UnsetValue
+				};
+			}
+			else
+			{
+				return Unwrap(Stack[(int)precedence]);
+			}
+		}
 
 		/// <summary>
 		/// Gets the value at the highest precedence level under the specified one
@@ -154,20 +245,36 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		/// <param name="precedence">The value precedence under which to fetch a value</param>
 		/// <returns>The value at the highest precedence level under the specified one</returns>
-		internal (object value, DependencyPropertyValuePrecedences precedence) GetValueUnderPrecedence(DependencyPropertyValuePrecedences precedence)
+		internal (object? value, DependencyPropertyValuePrecedences precedence) GetValueUnderPrecedence(DependencyPropertyValuePrecedences precedence)
 		{
-			// Start from current precedence and find next highest
-			for (int i = (int)precedence + 1; i < (int)DependencyPropertyValuePrecedences.DefaultValue; i++)
+			if (_stack == null)
 			{
-				object value = Unwrap(_stack[i]);
-
-				if (value != DependencyProperty.UnsetValue)
+				if(_highestPrecedence == DependencyPropertyValuePrecedences.Local)
 				{
-					return (value, (DependencyPropertyValuePrecedences)i);
+					return (Unwrap(_fastLocalValue), DependencyPropertyValuePrecedences.Local);
+				}
+				else
+				{
+					return (GetDefaultValue(), DependencyPropertyValuePrecedences.DefaultValue);
 				}
 			}
+			else
+			{
+				var stackAlias = Stack;
 
-			return (_stack[(int)DependencyPropertyValuePrecedences.DefaultValue], DependencyPropertyValuePrecedences.DefaultValue);
+				// Start from current precedence and find next highest
+				for (int i = (int)precedence + 1; i < (int)DependencyPropertyValuePrecedences.DefaultValue; i++)
+				{
+					object? value = Unwrap(stackAlias[i]);
+
+					if (value != DependencyProperty.UnsetValue)
+					{
+						return (value, (DependencyPropertyValuePrecedences)i);
+					}
+				}
+
+				return (stackAlias[(int)DependencyPropertyValuePrecedences.DefaultValue], DependencyPropertyValuePrecedences.DefaultValue);
+			}
 		}
 
 		/// <summary>
@@ -181,35 +288,77 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		/// <param name="value">value to validate</param>
 		/// <returns>The value if valid, otherwise the dependency property's default value.</returns>
-		private object Validate(object value)
+		private object? Validate(object? value)
 		{
 			return value == null && !Property.IsTypeNullable
-				? _stack[(int)DependencyPropertyValuePrecedences.DefaultValue]
+				? GetDefaultValue()
 				: Wrap(value);
 		}
 
+		/// <summary>
+		/// Validate the value to prevent setting null to non-nullable dependency properties.
+		/// </summary>
+		/// <param name="value">value to validate</param>
+		/// <returns>The value if valid, otherwise the dependency property's default value.</returns>
+		private object? ValidateNoWrap(object? value)
+		{
+			return value == null && !Property.IsTypeNullable
+				? GetDefaultValue()
+				: value;
+		}
+
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private object Wrap(object value)
-			=> _hasWeakStorage && value != null && value != DependencyProperty.UnsetValue
+		private object? Wrap(object? value)
+			=> HasWeakStorage && value != null && value != DependencyProperty.UnsetValue
 			? WeakReferencePool.RentWeakReference(this, value)
 			: value;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private object Unwrap(object value)
-			=> _hasWeakStorage && value is ManagedWeakReference mwr
+		private object? Unwrap(object? value)
+			=> HasWeakStorage && value is ManagedWeakReference mwr
 			? mwr.Target
 			: value;
 
+		private bool HasWeakStorage
+			=> (_flags & Flags.WeakStorage) != 0;
+
+		private bool HasDefaultValueSet
+			=> (_flags & Flags.DefaultValueSet) != 0;
+
+		private object?[] Stack
+		{
+			get
+			{
+				if (_stack == null)
+				{
+					_stack = _pool.Rent(_stackLength);
+
+					Array.Copy(_unsetStack, _stack, _stackLength);
+
+					var defaultValue = GetDefaultValue();
+
+					_stack[MaxIndex] = defaultValue;
+
+					if (_highestPrecedence == DependencyPropertyValuePrecedences.Local)
+					{
+						_stack[(int)DependencyPropertyValuePrecedences.Local] = _fastLocalValue;
+					}
+				}
+
+				return _stack;
+			}
+		}
+
 		#region IEnumerable implementation
 
-		public IEnumerator<object> GetEnumerator()
+		public IEnumerator<object?> GetEnumerator()
 		{
-			return _stack.Cast<object>().GetEnumerator();
+			return _stack.Cast<object?>().GetEnumerator();
 		}
 
 		IEnumerator IEnumerable.GetEnumerator()
 		{
-			return _stack.GetEnumerator();
+			return Stack.GetEnumerator();
 		}
 
 		#endregion
@@ -217,6 +366,20 @@ namespace Windows.UI.Xaml
 		public override string ToString()
 		{
 			return $"DependencyPropertyDetails({Property.Name})";
+		}
+
+		[Flags]
+		enum Flags
+		{
+			/// <summary>
+			/// This dependency property uses weak storage for its values
+			/// </summary>
+			WeakStorage = 1 << 0,
+
+			/// <summary>
+			/// Determines if the default value has been populated
+			/// </summary>
+			DefaultValueSet = 1 << 1,
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -140,7 +140,7 @@ namespace Windows.UI.Xaml
 
 					if(_defaultValueProvider != null && _defaultValueProvider(property, out var v))
 					{
-						propertyEntry.SetValue(v, DependencyPropertyValuePrecedences.DefaultValue);
+						propertyEntry.SetDefaultValue(v);
 					}
 				}
 

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -189,7 +189,8 @@ namespace Uno.UI
 		/// </returns>
 		internal static bool ApplyVisualStateSetter(SpecializedResourceDictionary.ResourceKey resourceKey, object context, BindingPath bindingPath, DependencyPropertyValuePrecedences precedence)
 		{
-			if (TryStaticRetrieval(resourceKey, context, out var value))
+			if (TryStaticRetrieval(resourceKey, context, out var value)
+				&& bindingPath.DataContext != null)
 			{
 				var property = DependencyProperty.GetProperty(bindingPath.DataContext.GetType(), bindingPath.LeafPropertyName);
 				if (property != null && bindingPath.DataContext is IDependencyObjectStoreProvider provider)

--- a/src/Uno.UI/UI/Xaml/UIElement.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Skia.cs
@@ -14,6 +14,7 @@ using Uno.Logging;
 using Uno.UI;
 using Uno.UI.Extensions;
 using Windows.UI.Xaml.Controls.Primitives;
+using Uno.UI.DataBinding;
 
 namespace Windows.UI.Xaml
 {
@@ -22,7 +23,6 @@ namespace Windows.UI.Xaml
 		internal Size _unclippedDesiredSize;
 		internal Point _visualOffset;
 		private ContainerVisual _visual;
-		private Visibility _visibilityCache;
 		internal double _canvasTop;
 		internal double _canvasLeft;
 		private Rect _currentFinalRect;
@@ -37,30 +37,24 @@ namespace Windows.UI.Xaml
 			InitializePointers();
 			InitializeKeyboard();
 
-			RegisterPropertyChangedCallback(VisibilityProperty, OnVisibilityPropertyChanged);
-			RegisterPropertyChangedCallback(Controls.Canvas.LeftProperty, OnCanvasLeftChanged);
-			RegisterPropertyChangedCallback(Controls.Canvas.TopProperty, OnCanvasTopChanged);
+			this.RegisterPropertyChangedCallbackStrong(OnPropertyChanged);
 
 			UpdateHitTest();
 		}
 		partial void InitializeKeyboard();
 
-		private void OnCanvasTopChanged(DependencyObject sender, DependencyProperty dp)
+		private void OnPropertyChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
 		{
-			_canvasTop = (double)this.GetValue(Controls.Canvas.TopProperty);
+			if(property == Controls.Canvas.TopProperty)
+			{
+				_canvasTop = (double)args.NewValue;
+			}
+			else if (property == Controls.Canvas.LeftProperty)
+			{
+				_canvasLeft = (double)args.NewValue;
+			}
 		}
 
-		private void OnCanvasLeftChanged(DependencyObject sender, DependencyProperty dp)
-		{
-			_canvasLeft = (double)this.GetValue(Controls.Canvas.LeftProperty);
-		}
-
-		private void OnVisibilityPropertyChanged(DependencyObject sender, DependencyProperty dp)
-		{
-			UpdateHitTest();
-
-			_visibilityCache = (Visibility)GetValue(VisibilityProperty);
-		}
 
 		partial void OnOpacityChanged(DependencyPropertyChangedEventArgs args)
 		{
@@ -193,6 +187,7 @@ namespace Windows.UI.Xaml
 
 		protected virtual void OnVisibilityChanged(Visibility oldValue, Visibility newVisibility)
 		{
+			UpdateHitTest();
 			UpdateOpacity();
 
 			if (newVisibility == Visibility.Collapsed)

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -60,7 +60,19 @@ namespace Windows.UI.Xaml
 
 		private void Initialize()
 		{
-			this.SetValue(KeyboardAcceleratorsProperty, new List<KeyboardAccelerator>(0), DependencyPropertyValuePrecedences.DefaultValue);
+			this.RegisterDefaultValueProvider(OnGetDefaultValue);
+		}
+
+		private bool OnGetDefaultValue(DependencyProperty property, out object defaultValue)
+		{
+			if (property == KeyboardAcceleratorsProperty)
+			{
+				defaultValue = new List<KeyboardAccelerator>(0);
+				return true;
+			}
+
+			defaultValue = null;
+			return false;
 		}
 
 		public Vector2 ActualSize => new Vector2((float)GetActualWidth(), (float)GetActualHeight());

--- a/src/Uno.UI/UI/Xaml/VisualState.cs
+++ b/src/Uno.UI/UI/Xaml/VisualState.cs
@@ -20,22 +20,6 @@ namespace Windows.UI.Xaml
 		{
 			InitializeBinder();
 			IsAutoPropertyInheritanceEnabled = false;
-
-			InitializeStateTriggerCollection();
-			InitializeSettersCollection();
-		}
-
-		private void InitializeSettersCollection()
-		{
-			Setters = new SetterBaseCollection(this, isAutoPropertyInheritanceEnabled: false);
-		}
-
-		private void InitializeStateTriggerCollection()
-		{
-			var stateTriggers = new DependencyObjectCollection<StateTriggerBase>(this, isAutoPropertyInheritanceEnabled: false);
-			stateTriggers.VectorChanged += OnStateTriggerCollectionChanged;
-
-			StateTriggers = stateTriggers;
 		}
 
 		public string Name { get; set; }
@@ -86,8 +70,14 @@ namespace Windows.UI.Xaml
 		{
 			get
 			{
+				if(!(GetValue(SettersProperty) is SetterBaseCollection collection))
+				{
+					collection = Setters = new SetterBaseCollection(this, isAutoPropertyInheritanceEnabled: false);
+				}
+
 				EnsureMaterialized();
-				return (SetterBaseCollection)GetValue(SettersProperty);
+
+				return collection;
 			}
 
 			internal set => SetValue(SettersProperty, value);
@@ -107,7 +97,19 @@ namespace Windows.UI.Xaml
 
 		public IList<StateTriggerBase> StateTriggers
 		{
-			get => (IList<StateTriggerBase>)GetValue(StateTriggersProperty);
+			get
+			{
+				if(!(GetValue(StateTriggersProperty) is IList<StateTriggerBase> list))
+				{
+					var stateTriggers = new DependencyObjectCollection<StateTriggerBase>(this, isAutoPropertyInheritanceEnabled: false);
+					stateTriggers.VectorChanged += OnStateTriggerCollectionChanged;
+
+					list = StateTriggers = stateTriggers;
+				}
+
+				return list;
+			}
+
 			internal set => SetValue(StateTriggersProperty, value);
 		}
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

- fix: Possible NRE when applying visual state setters on unknown targets
- perf: Remove unused WeakReference read-back on creation
- refactor: Remove unused RegisterInheritedPropertyChangedCallback
- perf(VisualState): Create VisualState.Setters and StateTriggers backing collections lazily
- perf: Improve DependencyPropertyDetails performance
  - Don't create a full stack when either `DefaultValue` or `Local`
  - Don't materialize the default value until requested
  - Make `CallbackManager` lazy
  - Make `Bindings` list lazy
  - Use flags for `WeakStorage` and `DefaultValue`
  - Precompute IsUnsetValue in `SetValue`

- perf: misc performance improvements on DependencyObjectStore
  - Don't materialize dataContextProperty and templatedParentProperty on creation
  - Don't create the entries backing until properties are requested
  - Move some extensions to use `IDependencyObjectStoreProvider` explicitly and avoid casting
  - Add `RegisterPropertyChangedCallbackStrong` to allow for fast self-observation of property changes

- perf: Initialize UIElement.KeyboardAcceleratorsProperty lazily
- perf: [Skia] Remove weak registrations in UIElement constructor


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
