### PR TITLE
fix(WASM): SrollViewer.ChangeView to end of page

### DIFF
--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -21,6 +21,9 @@ namespace Uno.UI.Xaml
 	/// <remarks>Slow methods are present for the WPF hosting mode, for which memory sharing is not available</remarks>
 	internal partial class WindowManagerInterop
 	{
+		//When users set double.MaxValue to scroll to the end of the page Javascript doesn't scroll.
+		private const double MAX_SCROLLING_OFFSET = 1_000_000_000_000_000_000;
+
 		private static bool UseJavascriptEval =>
 			!WebAssemblyRuntime.IsWebAssembly || FeatureConfiguration.Interop.ForceJavascriptInterop;
 
@@ -1264,13 +1267,16 @@ namespace Uno.UI.Xaml
 		#region ScrollTo
 		internal static void ScrollTo(IntPtr htmlId, double? left, double? top, bool disableAnimation)
 		{
+			var sanitizedTop = top.HasValue && top == double.MaxValue ? MAX_SCROLLING_OFFSET : top;
+			var sanitizedLeft = left.HasValue && left == double.MaxValue ? MAX_SCROLLING_OFFSET : left;
+
 			var parms = new WindowManagerScrollToOptionsParams
 			{
 				HtmlId = htmlId,
-				HasLeft = left.HasValue,
-				Left = left ?? 0,
-				HasTop = top.HasValue,
-				Top = top ?? 0,
+				HasLeft = sanitizedLeft.HasValue,
+				Left = sanitizedLeft ?? 0,
+				HasTop = sanitizedTop.HasValue,
+				Top = sanitizedTop ?? 0,
 				DisableAnimation = disableAnimation
 			};
 


### PR DESCRIPTION
GitHub Issue (If applicable): # 
closes #5848 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
in WASM when using double.MaxValue in order to scroll to the end of the page the scroll does not happen.

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
