### PR TITLE
docs: add uno material color override missing step

### DIFF
--- a/doc/articles/guides/uno-material-walkthrough.md
+++ b/doc/articles/guides/uno-material-walkthrough.md
@@ -235,6 +235,15 @@ This guide will walk you through the necessary steps to setup and to use the [`U
     <!-- ... --->
     ```
     > You may also use this for picking colors: https://material.io/design/color/the-color-system.html#tools-for-picking-colors
+1. In `App.xaml.cs`, update the line that initializes the material library to include the new palette:
+    ```cs
+    protected override void OnLaunched(LaunchActivatedEventArgs e)
+    {
+         Uno.Material.Resources.Init(this, new ResourceDictionary { Source = new Uri("ms-appx:///Styles/Application/ColorPaletteOverride.xaml") });
+
+        // [existing code...]
+    }
+    ```
 1. Run the app, you should now see the controls using your new color scheme.
 
 ## Note


### PR DESCRIPTION
GitHub Issue (If applicable): #5334

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the new behavior?

added the missing step to "uno material: color palette override" section

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

<!-- Please provide any additional information if necessary -->