### PR TITLE
perf: Make `Grid.RowDefinitions` and `ColumnDefinitions` lazy initialized

### DIFF
--- a/src/Uno.UI.Tests/Global.cs
+++ b/src/Uno.UI.Tests/Global.cs
@@ -18,7 +18,7 @@ namespace Uno.UI.Tests
 
 			var factory = LoggerFactory.Create(builder =>
 			{
-#if DEBUG
+#if false // DEBUG // debug logging is generally very verbose and slows down testing. Enable when needed.
 				var logLevel = LogLevel.Debug;
 #else
 				var logLevel = LogLevel.Information;

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Definitions.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Definitions.cs
@@ -4,18 +4,33 @@
 	{
 		public Grid()
 		{
-			var rowDefinitions = new RowDefinitionCollection(this);
-			rowDefinitions.CollectionChanged += (snd, evt) => InvalidateDefinitions();
-
-			var columnDefinitions = new ColumnDefinitionCollection(this);
-			columnDefinitions.CollectionChanged += (snd, evt) => InvalidateDefinitions();
-
-			m_pRowDefinitions = rowDefinitions;
-			m_pColumnDefinitions = columnDefinitions;
 		}
 
-		public RowDefinitionCollection RowDefinitions => m_pRowDefinitions;
+		public RowDefinitionCollection RowDefinitions
+		{
+			get
+			{
+				if(m_pRowDefinitions == null)
+				{
+					m_pRowDefinitions = new RowDefinitionCollection(this);
+					m_pRowDefinitions.CollectionChanged += (snd, evt) => InvalidateDefinitions();
+				}
+				return m_pRowDefinitions;
+			}
+		}
 
-		public ColumnDefinitionCollection ColumnDefinitions => m_pColumnDefinitions;
+		public ColumnDefinitionCollection ColumnDefinitions
+		{
+			get
+			{
+
+				if (m_pColumnDefinitions == null)
+				{
+					m_pColumnDefinitions = new ColumnDefinitionCollection(this);
+					m_pColumnDefinitions.CollectionChanged += (snd, evt) => InvalidateDefinitions();
+				}
+				return m_pColumnDefinitions;
+			}
+		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

This change moves `Grid.RowDefinitions` and `ColumnDefinitions` to improve `Grid` control creation performance, particularly column and row-less intances.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
