### PR TITLE
perf: Skip ClearPointersStateIfNeeded during ctor

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadata.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadata.cs
@@ -117,14 +117,24 @@ namespace Windows.UI.Xaml
 		) : base(defaultValue, propertyChangedCallback, coerceValueCallback, null)
 		{
 		}
-		
+
 		internal FrameworkPropertyMetadata(
 			PropertyChangedCallback propertyChangedCallback,
 			CoerceValueCallback coerceValueCallback
 		) : base(propertyChangedCallback, coerceValueCallback)
 		{
 		}
-		
+
+		internal FrameworkPropertyMetadata(
+			object defaultValue,
+			FrameworkPropertyMetadataOptions options,
+			BackingFieldUpdateCallback backingFieldUpdateCallback,
+			CoerceValueCallback coerceValueCallback
+		) : base(defaultValue: defaultValue, propertyChangedCallback: null, coerceValueCallback: coerceValueCallback, backingFieldUpdateCallback: backingFieldUpdateCallback)
+		{
+			Options = options.WithDefault();
+		}
+
 		internal FrameworkPropertyMetadata(
 			object defaultValue,
 			FrameworkPropertyMetadataOptions options,

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -218,7 +218,7 @@ namespace Windows.UI.Xaml
 		internal HitTestability GetHitTestVisibility()
 		{
 #if __WASM__ || __SKIA__
-			return (HitTestability)this.GetValue(HitTestVisibilityProperty);
+			return HitTestVisibility;
 #else
 			// This is a coalesced HitTestVisible and should be unified with it
 			// We should follow the WASM way and unify it on all platforms!

--- a/src/Uno.UI/UI/Xaml/UIElement.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.netstd.cs
@@ -56,10 +56,16 @@ namespace Windows.UI.Xaml
 			=> visualTreeRoot.OnElementLoading(1);
 
 		internal static void RootElementLoaded(UIElement visualTreeRoot)
-			=> visualTreeRoot.OnElementLoaded();
+		{
+			visualTreeRoot.SetHitTestVisibilityForRoot();
+			visualTreeRoot.OnElementLoaded();
+		}
 
 		internal static void RootElementUnloaded(UIElement visualTreeRoot)
-			=> visualTreeRoot.OnElementUnloaded();
+		{
+			visualTreeRoot.ClearHitTestVisibilityForRoot();
+			visualTreeRoot.OnElementUnloaded();
+		}
 
 		// Overloads for the FrameworkElement to raise the events
 		// (Load/Unload is actually a concept of the FwElement, but it's easier to handle it directly from the UIElement)

--- a/src/Uno.UI/UI/Xaml/UIElement.netstdref.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.netstdref.cs
@@ -43,5 +43,10 @@ namespace Windows.UI.Xaml
 		protected virtual void OnVisibilityChanged(Visibility oldValue, Visibility newVisibility)
 		{
 		}
+
+
+		internal void SetHitTestVisibilityForRoot() => throw new NotSupportedException("Reference assembly");
+
+		internal void ClearHitTestVisibilityForRoot() => throw new NotSupportedException("Reference assembly");
 	}
 }

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -20,14 +20,17 @@ body {
   position: absolute;
   display: inline;
   outline: none;
-  pointer-events: auto;
+  /*
+      Disable pointer events by default to match HitTestVisibilityProperty
+      default value
+  */
+  pointer-events: none;
   /*
     Padding & margin are required for measure/arrange to behave well:
     margin & padding are calculated through Xaml elements.
   */
   margin: 0 !important;
   padding: 0;
-
   line-height: normal;
   -webkit-box-sizing: border-box !important;
   -moz-box-sizing: border-box !important;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

Skip the processing of pointers if the control has not yet been initialized as it cannot have received pointers yet.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
