### PR TITLE
perf: [Wasm] Restore conditional DependencyObject hard references

### DIFF
--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -158,11 +158,7 @@ namespace Uno.UI
 			/// See https://github.com/unoplatform/uno/issues/4730 for details.
 			/// </remarks>
 			public static bool IsStoreHardReferenceEnabled { get; set; }
-#if __WASM__
-				= false;
-#else
 				= true;
-#endif
 		}
 
 		public static class Font

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1798,6 +1798,8 @@ namespace Windows.UI.Xaml
 			{
 				_hardParentRef = Parent;
 				_hardOriginalObjectRef = ActualInstance;
+
+				_properties.TryEnableHardReferences();
 			}
 		}
 
@@ -1810,6 +1812,8 @@ namespace Windows.UI.Xaml
 			{
 				_hardParentRef = null;
 				_hardOriginalObjectRef = null;
+
+				_properties.DisableHardReferences();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.Bindings.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.Bindings.cs
@@ -165,7 +165,7 @@ namespace Windows.UI.Xaml
 			}
 			else if (Equals(binding.ParentBinding.RelativeSource, RelativeSource.Self))
 			{
-				binding.DataContext = _ownerReference.Target;
+				binding.DataContext = Owner;
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -26,6 +26,7 @@ namespace Windows.UI.Xaml
 
 		private readonly Type _ownerType;
 		private readonly ManagedWeakReference _ownerReference;
+		private object? _hardOwnerReference;
 		private readonly DependencyProperty _dataContextProperty;
 		private readonly DependencyProperty _templatedParentProperty;
 
@@ -39,6 +40,8 @@ namespace Windows.UI.Xaml
 		private int _minId;
 		private int _maxId;
 		private DependencyObjectStore.DefaultValueProvider? _defaultValueProvider;
+
+		private object? Owner => _hardOwnerReference ?? _ownerReference.Target;
 
 		/// <summary>
 		/// Creates an instance using the specified DependencyObject <see cref="Type"/>
@@ -214,6 +217,16 @@ namespace Windows.UI.Xaml
 		public void RegisterDefaultValueProvider(DependencyObjectStore.DefaultValueProvider provider)
 		{
 			_defaultValueProvider = provider;
+		}
+
+		internal void TryEnableHardReferences()
+		{
+			_hardOwnerReference = _ownerReference.Target;
+		}
+
+		internal void DisableHardReferences()
+		{
+			_hardOwnerReference = null;
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

Avoids resolving owner instance through weak references for `DependencyObjectStore` by enabling Load/Unload materialization of the reference.

This feature was disabled for Wasm on .NET 5 because of memory corruptions that have since been fixed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
