### PR TITLE
feat: Add ControlsResourcesVersion property for WinUI 2.6 compatability

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3674,6 +3674,9 @@
 				reason="Not part of the UWP API + false positive, it's not something changed in the source" />
 		</Methods>
 		<Fields>
+			<Member
+				fullName="Windows.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.XamlControlsResources::UseCompactResourcesProperty"
+				reason="This should be a property, not a field" />
 		</Fields>
 		<Properties>
 		</Properties>

--- a/src/Uno.UI.FluentTheme/ControlsResourcesVersion.cs
+++ b/src/Uno.UI.FluentTheme/ControlsResourcesVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace Microsoft.UI.Xaml.Controls
+{
+	public enum ControlsResourcesVersion
+	{
+		Version1 = 1,
+		Version2 = 2,
+	}
+}

--- a/src/Uno.UI.FluentTheme/XamlControlsResources.cs
+++ b/src/Uno.UI.FluentTheme/XamlControlsResources.cs
@@ -30,7 +30,6 @@ namespace Microsoft.UI.Xaml.Controls
 		[NotImplemented]
 		public static void EnsureRevealLights(UIElement element) { }
 
-
 		[NotImplemented]
 		public bool UseCompactResources
 		{
@@ -39,9 +38,18 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		[NotImplemented]
-		public static readonly DependencyProperty UseCompactResourcesProperty =
-			DependencyProperty.Register("UseCompactResources", typeof(bool), typeof(XamlControlsResources), new PropertyMetadata(false));
+		public static DependencyProperty UseCompactResourcesProperty { get; } =
+			DependencyProperty.Register(nameof(UseCompactResources), typeof(bool), typeof(XamlControlsResources), new PropertyMetadata(false));
 
+		[NotImplemented]
+		public ControlsResourcesVersion ControlsResourcesVersion
+		{
+			get => (ControlsResourcesVersion)GetValue(ControlsResourcesVersionProperty);
+			set => SetValue(ControlsResourcesVersionProperty, value);
+		}
 
+		[NotImplemented]
+		public static DependencyProperty ControlsResourcesVersionProperty { get; } =
+			DependencyProperty.Register(nameof(ControlsResourcesVersion), typeof(ControlsResourcesVersion), typeof(XamlControlsResources), new PropertyMetadata(ControlsResourcesVersion.Version1));
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6059

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Not supported.


## What is the new behavior?

Supported (but has no effect yet).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.