### PR TITLE
fix(revealbrush): Use RevealBrush FallbackColor for background

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/RevealBrushTests/RevealBrush_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/RevealBrushTests/RevealBrush_Tests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Media.RevealBrushTests
+{
+	[TestFixture]
+	class RevealBrush_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void When_FallbackColor_Set()
+		{
+			Run("UITests.Windows_UI_Xaml_Media.BrushesTests.RevealBrush_Fallback");
+
+			_app.WaitForElement("StatusTextBlock");
+
+			var views = new[]
+			{
+				"RevealGrid",
+				"RevealGridCR",
+				"RevealBorder",
+				"RevealBorderCR",
+			};
+
+			using var initial = TakeScreenshot("Initial");
+			foreach (var view in views)
+			{
+				AssertHasColor(view, initial, Color.Orange);
+			}
+
+			_app.FastTap("ChangeColorButton");
+			_app.WaitForText("StatusTextBlock", "Color changed");
+
+			using var after = TakeScreenshot("After");
+			foreach (var view in views)
+			{
+				AssertHasColor(view, after, Color.ForestGreen);
+			}
+
+			void AssertHasColor(string view, ScreenshotInfo screenshot, Color expectedColor)
+			{
+				var rect = _app.GetPhysicalRect(view);
+				ImageAssert.HasColorAt(screenshot, rect.CenterX, rect.CenterY, expectedColor);
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3413,6 +3413,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\RevealBrush_Fallback.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\SolidColorBrush_Color_Changed.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6074,6 +6078,9 @@
       <DependentUpon>Brushes_ImplicitConvert.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\ColorPresenter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\RevealBrush_Fallback.xaml.cs">
+      <DependentUpon>RevealBrush_Fallback.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\SolidColorBrush_Color_Changed.xaml.cs">
       <DependentUpon>SolidColorBrush_Color_Changed.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/RevealBrush_Fallback.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/RevealBrush_Fallback.xaml
@@ -1,0 +1,52 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Media.BrushesTests.RevealBrush_Fallback"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Media.BrushesTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+	<UserControl.Resources>
+		<RevealBackgroundBrush x:Name="OrangeCrush"
+							   Color="Orange"
+							   FallbackColor="Orange" />
+	</UserControl.Resources>
+
+	<StackPanel>
+		<Button x:Name="ChangeColorButton"
+				Content="Change color"
+				Click="ChangeColor" />
+		<TextBlock x:Name="StatusTextBlock"
+				   Text="Initial" />
+
+		<Grid Background="{StaticResource OrangeCrush}"
+			  x:Name="RevealGrid"
+			  Margin="10"
+			  Width="120"
+			  Height="55">
+		</Grid>
+		<Grid CornerRadius="10"
+			  Background="{StaticResource OrangeCrush}"
+			  x:Name="RevealGridCR"
+			  Margin="10"
+			  Width="120"
+			  Height="55">
+		</Grid>
+
+		<Border Background="{StaticResource OrangeCrush}"
+				x:Name="RevealBorder"
+				Margin="10"
+				Width="120"
+				Height="55">
+		</Border>
+		<Border CornerRadius="10"
+				Background="{StaticResource OrangeCrush}"
+				x:Name="RevealBorderCR"
+				Margin="10"
+				Width="120"
+				Height="55">
+		</Border>
+
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/RevealBrush_Fallback.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/RevealBrush_Fallback.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Media.BrushesTests
+{
+	[Sample]
+	public sealed partial class RevealBrush_Fallback : UserControl
+	{
+		public RevealBrush_Fallback()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ChangeColor(object sender, object args)
+		{
+			OrangeCrush.Color = Colors.ForestGreen;
+			OrangeCrush.FallbackColor = Colors.ForestGreen;
+			StatusTextBlock.Text = "Color changed";
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Android.cs
@@ -459,6 +459,7 @@ namespace Windows.UI.Xaml.Controls
 			public readonly Thickness BorderThickness;
 			public readonly CornerRadius CornerRadius;
 			public readonly Thickness Padding;
+			public readonly Color? BackgroundFallbackColor;
 
 			public LayoutState(Windows.Foundation.Rect area, Brush background, Thickness borderThickness, Brush borderBrush, CornerRadius cornerRadius, Thickness padding)
 			{
@@ -474,6 +475,8 @@ namespace Windows.UI.Xaml.Controls
 
 				BackgroundColor = (Background as SolidColorBrush)?.Color;
 				BorderBrushColor = (BorderBrush as SolidColorBrush)?.Color;
+
+				BackgroundFallbackColor = (Background as XamlCompositionBrushBase)?.FallbackColor;
 			}
 
 			public bool Equals(LayoutState other)
@@ -487,7 +490,8 @@ namespace Windows.UI.Xaml.Controls
 					&& other.BorderBrushColor == BorderBrushColor
 					&& other.BorderThickness == BorderThickness
 					&& other.CornerRadius == CornerRadius
-					&& other.Padding == Padding;
+					&& other.Padding == Padding
+					&& other.BackgroundFallbackColor == BackgroundFallbackColor;
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
@@ -185,6 +185,11 @@ namespace Windows.UI.Xaml.Shapes
 					acrylicBrush.Subscribe(owner, area, adjustedArea, parent, sublayers, ref insertionIndex, fillMask)
 						.DisposeWith(disposables);
 				}
+				else if (background is XamlCompositionBrushBase unsupportedCompositionBrush)
+				{
+					Brush.AssignAndObserveBrush(unsupportedCompositionBrush, color => innerLayer.FillColor = color)
+						.DisposeWith(disposables);
+				}
 				else
 				{
 					innerLayer.FillColor = Colors.Transparent;
@@ -267,6 +272,16 @@ namespace Windows.UI.Xaml.Shapes
 					var insertionIndex = 0;
 
 					acrylicBrush.Subscribe(owner, fullArea, insideArea, parent, sublayers, ref insertionIndex, fillMask: null);
+				}
+				else if (background is XamlCompositionBrushBase unsupportedCompositionBrush)
+				{
+					Brush.AssignAndObserveBrush(unsupportedCompositionBrush, color => parent.BackgroundColor = color)
+						.DisposeWith(disposables);
+
+					// This is required because changing the CornerRadius changes the background drawing 
+					// implementation and we don't want a rectangular background behind a rounded background.
+					Disposable.Create(() => parent.BackgroundColor = null)
+						.DisposeWith(disposables);
 				}
 				else
 				{

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
@@ -148,6 +148,11 @@ namespace Windows.UI.Xaml.Shapes
 					Brush.AssignAndObserveBrush(acrylicBrush, color => backgroundShape.FillBrush = compositor.CreateColorBrush(color))
 						.DisposeWith(disposables);
 				}
+				else if (background is XamlCompositionBrushBase unsupportedCompositionBrush)
+				{
+					Brush.AssignAndObserveBrush(unsupportedCompositionBrush, color => backgroundShape.FillBrush = compositor.CreateColorBrush(color))
+						.DisposeWith(disposables);
+				}
 				else
 				{
 					backgroundShape.FillBrush = null;
@@ -217,6 +222,16 @@ namespace Windows.UI.Xaml.Shapes
 					Brush.AssignAndObserveBrush(acrylicBrush, c => backgroundShape.FillBrush = compositor.CreateColorBrush(c))
 						.DisposeWith(disposables);
 
+					Disposable.Create(() => backgroundShape.FillBrush = null)
+						.DisposeWith(disposables);
+				}
+				else if (background is XamlCompositionBrushBase unsupportedCompositionBrush)
+				{
+					Brush.AssignAndObserveBrush(unsupportedCompositionBrush, c => backgroundShape.FillBrush = compositor.CreateColorBrush(c))
+						.DisposeWith(disposables);
+
+					// This is required because changing the CornerRadius changes the background drawing 
+					// implementation and we don't want a rectangular background behind a rounded background.
 					Disposable.Create(() => backgroundShape.FillBrush = null)
 						.DisposeWith(disposables);
 				}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
@@ -166,6 +166,11 @@ namespace Windows.UI.Xaml
 					WindowManagerInterop.SetElementBackgroundGradient(HtmlId, gradientBrush.ToCssString(RenderSize));
 					RecalculateBrushOnSizeChanged(true);
 					break;
+				case XamlCompositionBrushBase unsupportedCompositionBrush:
+					var fallbackColor = unsupportedCompositionBrush.FallbackColorWithOpacity;
+					WindowManagerInterop.SetElementBackgroundColor(HtmlId, fallbackColor);
+					RecalculateBrushOnSizeChanged(false);
+					break;
 				default:
 					WindowManagerInterop.ResetElementBackground(HtmlId);
 					RecalculateBrushOnSizeChanged(false);

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
@@ -129,6 +129,24 @@ namespace Windows.UI.Xaml.Media
 
 				return disposables;
 			}
+			else if (b is XamlCompositionBrushBase unsupportedCompositionBrush)
+			{
+				var disposables = new CompositeDisposable(2);
+
+				colorSetter(unsupportedCompositionBrush.FallbackColorWithOpacity);
+
+				unsupportedCompositionBrush.RegisterDisposablePropertyChangedCallback(
+					XamlCompositionBrushBase.FallbackColorProperty,
+					(s, args) => colorSetter((s as XamlCompositionBrushBase).FallbackColorWithOpacity))
+					.DisposeWith(disposables);
+
+				unsupportedCompositionBrush.RegisterDisposablePropertyChangedCallback(
+					OpacityProperty,
+					(s, args) => colorSetter((s as XamlCompositionBrushBase).FallbackColorWithOpacity))
+					.DisposeWith(disposables);
+
+				return disposables;
+			}
 			else
 			{
 				colorSetter(SolidColorBrushHelper.Transparent.Color);

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Skia.cs
@@ -57,6 +57,22 @@ namespace Windows.UI.Xaml.Media
 
 					return disposables;
 				}
+				else if (b is XamlCompositionBrushBase unsupportedCompositionBrush)
+				{
+					colorSetter(unsupportedCompositionBrush.FallbackColorWithOpacity);
+
+					unsupportedCompositionBrush.RegisterDisposablePropertyChangedCallback(
+						XamlCompositionBrushBase.FallbackColorProperty,
+						(s, colorArg) => colorSetter((s as XamlCompositionBrushBase).FallbackColorWithOpacity)
+					)
+					.DisposeWith(disposables);
+
+					unsupportedCompositionBrush.RegisterDisposablePropertyChangedCallback(
+						OpacityProperty,
+						(s, colorArg) => colorSetter((s as XamlCompositionBrushBase).FallbackColorWithOpacity)
+					)
+					.DisposeWith(disposables);
+				}
 				else
 				{
 					colorSetter(SolidColorBrushHelper.Transparent.Color);

--- a/src/Uno.UI/UI/Xaml/Media/Brush.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.iOSmacOS.cs
@@ -109,6 +109,25 @@ namespace Windows.UI.Xaml.Media
 
 				return disposables;
 			}
+			else if (b is XamlCompositionBrushBase unsupportedCompositionBrush)
+			{
+				var disposables = new CompositeDisposable(2);
+				colorSetter(unsupportedCompositionBrush.FallbackColorWithOpacity);
+
+				unsupportedCompositionBrush.RegisterDisposablePropertyChangedCallback(
+						XamlCompositionBrushBase.FallbackColorProperty,
+						(s, colorArg) => colorSetter((s as XamlCompositionBrushBase).FallbackColorWithOpacity)
+					)
+					.DisposeWith(disposables);
+
+				unsupportedCompositionBrush.RegisterDisposablePropertyChangedCallback(
+						OpacityProperty,
+						(s, colorArg) => colorSetter((s as XamlCompositionBrushBase).FallbackColorWithOpacity)
+					)
+					.DisposeWith(disposables);
+
+				return disposables;
+			}
 			else
 			{
 				colorSetter(SolidColorBrushHelper.Transparent.Color);

--- a/src/Uno.UI/UI/Xaml/Media/Brush.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.wasm.cs
@@ -76,6 +76,27 @@ namespace Windows.UI.Xaml.Media
 				return Disposable.Empty;
 			}
 
+			if (b is XamlCompositionBrushBase unsupportedCompositionBrush)
+			{
+				// 
+				var disposables = new CompositeDisposable(2);
+				colorSetter(unsupportedCompositionBrush.FallbackColorWithOpacity);
+
+				unsupportedCompositionBrush.RegisterDisposablePropertyChangedCallback(
+						XamlCompositionBrushBase.FallbackColorProperty,
+						(s, colorArg) => colorSetter((s as XamlCompositionBrushBase).FallbackColorWithOpacity)
+					)
+					.DisposeWith(disposables);
+
+				unsupportedCompositionBrush.RegisterDisposablePropertyChangedCallback(
+						OpacityProperty,
+						(s, colorArg) => colorSetter((s as XamlCompositionBrushBase).FallbackColorWithOpacity)
+					)
+					.DisposeWith(disposables);
+
+				return disposables;
+			}
+
 			colorSetter(SolidColorBrushHelper.Transparent.Color);
 			return Disposable.Empty;
 		}


### PR DESCRIPTION
When a RevealBrush is set, use its FallbackColor for Panel.Background and Border.Background, since the actual reveal effect is not yet implemented.

This fixes TreeView selection background not being displayed (because, surprise, it's using RevealBrush).

GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/6000

Also related:
https://github.com/unoplatform/uno/issues/5724
https://github.com/unoplatform/uno/issues/408

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
