### PR TITLE
feat: Use preventDefault for Handled events

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -569,6 +569,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\ScrollHandled.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\ScrollViewer_PointerMoved.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4529,6 +4533,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_Shapes.xaml.cs">
       <DependentUpon>HitTest_Shapes.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\ScrollHandled.xaml.cs">
+      <DependentUpon>ScrollHandled.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\ScrollViewer_PointerMoved.xaml.cs">
       <DependentUpon>ScrollViewer_PointerMoved.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/ScrollHandled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/ScrollHandled.xaml
@@ -1,0 +1,63 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Input.PointersTests.ScrollHandled"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Input.PointersTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<ScrollViewer>
+			<StackPanel PointerWheelChanged="OnPointerWheelChanged">
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+				<Button>Test</Button>
+			</StackPanel>
+		</ScrollViewer>
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/ScrollHandled.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/ScrollHandled.xaml.cs
@@ -1,0 +1,21 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Core;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace UITests.Windows_UI_Input.PointersTests
+{
+    [Sample("Pointers", Description = "When scroll wheel is used while hovering above the buttons, it should not scroll. When scroll wheel is used above the page's blank area, it should scroll.")]
+    public sealed partial class ScrollHandled : Page
+    {
+        public ScrollHandled()
+        {
+            InitializeComponent();
+        }
+
+		private void OnPointerWheelChanged(object sender, PointerRoutedEventArgs args)
+		{
+			args.Handled = true;
+		}
+	}
+}

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -1100,6 +1100,7 @@ var Uno;
                     var handled = this.dispatchEvent(element, eventName, eventPayload);
                     if (handled) {
                         event.stopPropagation();
+                        event.preventDefault();
                     }
                 };
                 element.addEventListener(eventName, eventHandler, onCapturePhase);

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -895,6 +895,9 @@ namespace Uno.UI {
 			const handled = WindowManager.current.dispatchEvent(element, evt.type, payload);
 			if (handled) {
 				evt.stopPropagation();
+				// Not calling preventDefault() here, as that will break native focus dispatch for pointerdown
+				// If needed, we may add preventDefault() for some specific event type later, but it is not needed
+				// for any scenario yet.
 			}
 		}
 
@@ -1028,6 +1031,7 @@ namespace Uno.UI {
 				var handled = this.dispatchEvent(element, eventName, eventPayload);
 				if (handled) {
 					event.stopPropagation();
+					event.preventDefault();
 				}
 			};
 


### PR DESCRIPTION
GitHub Issue (If applicable): #6078

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Browser processes `Handled` events.


## What is the new behavior?

Using `preventDefault()` to prevent the browser from processing `Handled` events.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.