### PR TITLE
fix: Update BindableTypeProvidersSourceGenerator to be stateless per generation

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -32,25 +32,6 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 	[Generator]
 	public class BindableTypeProvidersSourceGenerator : ISourceGenerator
 	{
-		private const string TypeMetadataConfigFile = "TypeMetadataConfig.xml";
-
-		private string? _defaultNamespace;
-
-		private Dictionary<INamedTypeSymbol, GeneratedTypeInfo> _typeMap = new Dictionary<INamedTypeSymbol, GeneratedTypeInfo>();
-		private INamedTypeSymbol[]? _bindableAttributeSymbol;
-		private ITypeSymbol? _dependencyPropertySymbol;
-		private INamedTypeSymbol? _objectSymbol;
-		private INamedTypeSymbol? _javaObjectSymbol;
-		private INamedTypeSymbol? _nsObjectSymbol;
-		private INamedTypeSymbol? _nonBindableSymbol;
-		private INamedTypeSymbol? _resourceDictionarySymbol;
-		private IModuleSymbol? _currentModule;
-		private IReadOnlyDictionary<string, INamedTypeSymbol[]>? _namedSymbolsLookup;
-		private INamedTypeSymbol? _stringSymbol;
-
-		public string[]? AnalyzerSuppressions { get; set; }
-
-
 		public void Initialize(GeneratorInitializationContext context)
 		{
 			DependenciesInitializer.Init();
@@ -58,143 +39,167 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 
 		public void Execute(GeneratorExecutionContext context)
 		{
-			try
+			new Generator().Generate(context);
+		}
+
+		class Generator
+		{
+			private const string TypeMetadataConfigFile = "TypeMetadataConfig.xml";
+
+			private string? _defaultNamespace;
+
+			private Dictionary<INamedTypeSymbol, GeneratedTypeInfo> _typeMap = new Dictionary<INamedTypeSymbol, GeneratedTypeInfo>();
+			private INamedTypeSymbol[]? _bindableAttributeSymbol;
+			private ITypeSymbol? _dependencyPropertySymbol;
+			private INamedTypeSymbol? _objectSymbol;
+			private INamedTypeSymbol? _javaObjectSymbol;
+			private INamedTypeSymbol? _nsObjectSymbol;
+			private INamedTypeSymbol? _nonBindableSymbol;
+			private INamedTypeSymbol? _resourceDictionarySymbol;
+			private IModuleSymbol? _currentModule;
+			private IReadOnlyDictionary<string, INamedTypeSymbol[]>? _namedSymbolsLookup;
+			private INamedTypeSymbol? _stringSymbol;
+
+			public string[]? AnalyzerSuppressions { get; set; }
+
+			internal void Generate(GeneratorExecutionContext context)
 			{
-				var validPlatform = PlatformHelper.IsValidPlatform(context);
-				var isDesignTime = DesignTimeHelper.IsDesignTime(context);
-				var isApplication = IsApplication(context);
-
-				if (validPlatform
-					&& !isDesignTime)
+				try
 				{
-					if (isApplication)
+					var validPlatform = PlatformHelper.IsValidPlatform(context);
+					var isDesignTime = DesignTimeHelper.IsDesignTime(context);
+					var isApplication = IsApplication(context);
+
+					if (validPlatform
+						&& !isDesignTime)
 					{
-						_defaultNamespace = context.GetMSBuildPropertyValue("RootNamespace");
-						_namedSymbolsLookup = context.Compilation.GetSymbolNameLookup();
+						if (isApplication)
+						{
+							_defaultNamespace = context.GetMSBuildPropertyValue("RootNamespace");
+							_namedSymbolsLookup = context.Compilation.GetSymbolNameLookup();
 
-						_bindableAttributeSymbol = FindBindableAttributes(context);
-						_dependencyPropertySymbol = context.Compilation.GetTypeByMetadataName(XamlConstants.Types.DependencyProperty);
+							_bindableAttributeSymbol = FindBindableAttributes(context);
+							_dependencyPropertySymbol = context.Compilation.GetTypeByMetadataName(XamlConstants.Types.DependencyProperty);
 
-						_objectSymbol = context.Compilation.GetTypeByMetadataName("System.Object");
-						_javaObjectSymbol = context.Compilation.GetTypeByMetadataName("Java.Lang.Object");
-						_nsObjectSymbol = context.Compilation.GetTypeByMetadataName("Foundation.NSObject");
-						_stringSymbol = context.Compilation.GetTypeByMetadataName("System.String");
-						_nonBindableSymbol = context.Compilation.GetTypeByMetadataName("Windows.UI.Xaml.Data.NonBindableAttribute");
-						_resourceDictionarySymbol = context.Compilation.GetTypeByMetadataName("Windows.UI.Xaml.ResourceDictionary");
-						_currentModule = context.Compilation.SourceModule;
+							_objectSymbol = context.Compilation.GetTypeByMetadataName("System.Object");
+							_javaObjectSymbol = context.Compilation.GetTypeByMetadataName("Java.Lang.Object");
+							_nsObjectSymbol = context.Compilation.GetTypeByMetadataName("Foundation.NSObject");
+							_stringSymbol = context.Compilation.GetTypeByMetadataName("System.String");
+							_nonBindableSymbol = context.Compilation.GetTypeByMetadataName("Windows.UI.Xaml.Data.NonBindableAttribute");
+							_resourceDictionarySymbol = context.Compilation.GetTypeByMetadataName("Windows.UI.Xaml.ResourceDictionary");
+							_currentModule = context.Compilation.SourceModule;
 
-						AnalyzerSuppressions = new string[0];
+							AnalyzerSuppressions = new string[0];
 
-						var modules = from ext in context.Compilation.ExternalReferences
-									  let sym = context.Compilation.GetAssemblyOrModuleSymbol(ext) as IAssemblySymbol
-									  where sym != null
-									  from module in sym.Modules
-									  select module;
+							var modules = from ext in context.Compilation.ExternalReferences
+										  let sym = context.Compilation.GetAssemblyOrModuleSymbol(ext) as IAssemblySymbol
+										  where sym != null
+										  from module in sym.Modules
+										  select module;
 
-						modules = modules.Concat(context.Compilation.SourceModule);
+							modules = modules.Concat(context.Compilation.SourceModule);
 
-						context.AddSource("BindableMetadata", GenerateTypeProviders(modules));
-					}
-					else
-					{
-						context.AddSource("BindableMetadata", $"// validPlatform: {validPlatform} designTime:{isDesignTime} isApplication:{isApplication}");
+							context.AddSource("BindableMetadata", GenerateTypeProviders(modules));
+						}
+						else
+						{
+							context.AddSource("BindableMetadata", $"// validPlatform: {validPlatform} designTime:{isDesignTime} isApplication:{isApplication}");
+						}
 					}
 				}
-			}
-			catch(Exception e)
-			{
-				string? message = e.Message + e.StackTrace;
-
-				if (e is AggregateException)
+				catch (Exception e)
 				{
-					message = (e as AggregateException)?.InnerExceptions.Select(ex => ex.Message + e.StackTrace).JoinBy("\r\n");
+					string? message = e.Message + e.StackTrace;
+
+					if (e is AggregateException)
+					{
+						message = (e as AggregateException)?.InnerExceptions.Select(ex => ex.Message + e.StackTrace).JoinBy("\r\n");
+					}
+
+					this.Log().Error("Failed to generate type providers.", new Exception("Failed to generate type providers." + message, e));
+				}
+			}
+			private INamedTypeSymbol[] FindBindableAttributes(GeneratorExecutionContext context) =>
+				_namedSymbolsLookup!.TryGetValue("BindableAttribute", out var types) ? types : new INamedTypeSymbol[0];
+
+			private bool IsApplication(GeneratorExecutionContext context)
+			{
+				var isAndroidApp = context.GetMSBuildPropertyValue("AndroidApplication")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+				var isiOSApp = context.GetMSBuildPropertyValue("ProjectTypeGuidsProperty")?.Equals("{FEACFBD2-3405-455C-9665-78FE426C6842},{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) ?? false;
+				var ismacOSApp = context.GetMSBuildPropertyValue("ProjectTypeGuidsProperty")?.Equals("{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1},{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) ?? false;
+				var isExe = context.GetMSBuildPropertyValue("OutputType")?.Equals("Exe", StringComparison.OrdinalIgnoreCase) ?? false;
+				var isUnoHead = context.GetMSBuildPropertyValue("IsUnoHead")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
+
+				return isAndroidApp
+					|| (isiOSApp && isExe)
+					|| (ismacOSApp && isExe)
+					|| isUnoHead;
+			}
+
+			private string GenerateTypeProviders(IEnumerable<IModuleSymbol> modules)
+			{
+				var q = from module in modules
+						from type in module.GlobalNamespace.GetNamespaceTypes()
+						where (
+							(_bindableAttributeSymbol?.Any(s => type.FindAttributeFlattened(s) != null) ?? false)
+							&& !type.IsGenericType
+							&& !type.IsAbstract
+							&& IsValidProvider(type)
+						)
+						select type;
+
+				q = q.ToArray();
+
+				var writer = new IndentedStringBuilder();
+
+				writer.AppendLineInvariant("// <auto-generated>");
+				writer.AppendLineInvariant("// *****************************************************************************");
+				writer.AppendLineInvariant("// This file has been generated by Uno.UI (BindableTypeProvidersSourceGenerator)");
+				writer.AppendLineInvariant("// *****************************************************************************");
+				writer.AppendLineInvariant("// </auto-generated>");
+				writer.AppendLine();
+				writer.AppendLineInvariant("#pragma warning disable 618  // Ignore obsolete members warnings");
+				writer.AppendLineInvariant("#pragma warning disable 1591 // Ignore missing XML comment warnings");
+				writer.AppendLineInvariant("using System;");
+				writer.AppendLineInvariant("using System.Linq;");
+				writer.AppendLineInvariant("using System.Diagnostics;");
+
+				using (writer.BlockInvariant("namespace {0}", _defaultNamespace))
+				{
+					GenerateMetadata(writer, q);
+					GenerateProviderTable(q, writer);
 				}
 
-				this.Log().Error("Failed to generate type providers.", new Exception("Failed to generate type providers." + message, e));
-			}
-		}
-
-		private INamedTypeSymbol[] FindBindableAttributes(GeneratorExecutionContext context) =>
-			_namedSymbolsLookup!.TryGetValue("BindableAttribute", out var types) ? types : new INamedTypeSymbol[0];
-
-		private bool IsApplication(GeneratorExecutionContext context)
-		{
-			var isAndroidApp = context.GetMSBuildPropertyValue("AndroidApplication")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
-			var isiOSApp = context.GetMSBuildPropertyValue("ProjectTypeGuidsProperty")?.Equals("{FEACFBD2-3405-455C-9665-78FE426C6842},{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) ?? false;
-			var ismacOSApp = context.GetMSBuildPropertyValue("ProjectTypeGuidsProperty")?.Equals("{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1},{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase) ?? false;
-			var isExe = context.GetMSBuildPropertyValue("OutputType")?.Equals("Exe", StringComparison.OrdinalIgnoreCase) ?? false;
-			var isUnoHead = context.GetMSBuildPropertyValue("IsUnoHead")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
-
-			return isAndroidApp
-				|| (isiOSApp && isExe)
-				|| (ismacOSApp && isExe)
-				|| isUnoHead;
-		}
-
-		private string GenerateTypeProviders(IEnumerable<IModuleSymbol> modules)
-		{
-			var q = from module in modules
-					from type in module.GlobalNamespace.GetNamespaceTypes()
-					where (
-						(_bindableAttributeSymbol?.Any(s => type.FindAttributeFlattened(s) != null) ?? false)
-						&& !type.IsGenericType
-						&& !type.IsAbstract
-						&& IsValidProvider(type)
-					)
-					select type;
-
-			q = q.ToArray();
-
-			var writer = new IndentedStringBuilder();
-
-			writer.AppendLineInvariant("// <auto-generated>");
-			writer.AppendLineInvariant("// *****************************************************************************");
-			writer.AppendLineInvariant("// This file has been generated by Uno.UI (BindableTypeProvidersSourceGenerator)");
-			writer.AppendLineInvariant("// *****************************************************************************");
-			writer.AppendLineInvariant("// </auto-generated>");
-			writer.AppendLine();
-			writer.AppendLineInvariant("#pragma warning disable 618  // Ignore obsolete members warnings");
-			writer.AppendLineInvariant("#pragma warning disable 1591 // Ignore missing XML comment warnings");
-			writer.AppendLineInvariant("using System;");
-			writer.AppendLineInvariant("using System.Linq;");
-			writer.AppendLineInvariant("using System.Diagnostics;");
-
-			using (writer.BlockInvariant("namespace {0}", _defaultNamespace))
-			{
-				GenerateMetadata(writer, q);
-				GenerateProviderTable(q, writer);
+				return writer.ToString();
 			}
 
-			return writer.ToString();
-		}
+			private bool IsValidProvider(INamedTypeSymbol type)
+				=> type.IsLocallyPublic(_currentModule!)
 
-		private bool IsValidProvider(INamedTypeSymbol type)
-			=> type.IsLocallyPublic(_currentModule!)
+				// Exclude resource dictionaries for linking constraints (XamlControlsResources in particular)
+				// Those are not databound, so there's no need to generate providers for them.
+				&& !type.Is(_resourceDictionarySymbol);
 
-			// Exclude resource dictionaries for linking constraints (XamlControlsResources in particular)
-			// Those are not databound, so there's no need to generate providers for them.
-			&& !type.Is(_resourceDictionarySymbol);
-
-		private void GenerateProviderTable(IEnumerable<INamedTypeSymbol> q, IndentedStringBuilder writer)
-		{
-			writer.AppendLineInvariant("[System.Runtime.CompilerServices.CompilerGeneratedAttribute]");
-			writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1502:AvoidExcessiveComplexity\", Justification=\"Must be ignored even if generated code is checked.\")]");
-			writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1506:AvoidExcessiveClassCoupling\", Justification = \"Must be ignored even if generated code is checked.\")]");
-
-			AnalyzerSuppressionsGenerator.Generate(writer, AnalyzerSuppressions);
-			using (writer.BlockInvariant("public class BindableMetadataProvider : global::Uno.UI.DataBinding.IBindableMetadataProvider"))
+			private void GenerateProviderTable(IEnumerable<INamedTypeSymbol> q, IndentedStringBuilder writer)
 			{
-				writer.AppendLineInvariant(@"static global::System.Collections.Hashtable _bindableTypeCacheByFullName = new global::System.Collections.Hashtable({0});", q.Count());
-
+				writer.AppendLineInvariant("[System.Runtime.CompilerServices.CompilerGeneratedAttribute]");
 				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1502:AvoidExcessiveComplexity\", Justification=\"Must be ignored even if generated code is checked.\")]");
 				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1506:AvoidExcessiveClassCoupling\", Justification = \"Must be ignored even if generated code is checked.\")]");
-				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1505:AvoidUnmaintainableCode\", Justification = \"Must be ignored even if generated code is checked.\")]");
 
-				writer.AppendLineInvariant("private delegate global::Uno.UI.DataBinding.IBindableType TypeBuilderDelegate();");
-
-				using (writer.BlockInvariant("private static TypeBuilderDelegate CreateMemoized(TypeBuilderDelegate builder)"))
+				AnalyzerSuppressionsGenerator.Generate(writer, AnalyzerSuppressions);
+				using (writer.BlockInvariant("public class BindableMetadataProvider : global::Uno.UI.DataBinding.IBindableMetadataProvider"))
 				{
-					writer.AppendLineInvariant(@"global::Uno.UI.DataBinding.IBindableType value = null;
+					writer.AppendLineInvariant(@"static global::System.Collections.Hashtable _bindableTypeCacheByFullName = new global::System.Collections.Hashtable({0});", q.Count());
+
+					writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1502:AvoidExcessiveComplexity\", Justification=\"Must be ignored even if generated code is checked.\")]");
+					writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1506:AvoidExcessiveClassCoupling\", Justification = \"Must be ignored even if generated code is checked.\")]");
+					writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1505:AvoidUnmaintainableCode\", Justification = \"Must be ignored even if generated code is checked.\")]");
+
+					writer.AppendLineInvariant("private delegate global::Uno.UI.DataBinding.IBindableType TypeBuilderDelegate();");
+
+					using (writer.BlockInvariant("private static TypeBuilderDelegate CreateMemoized(TypeBuilderDelegate builder)"))
+					{
+						writer.AppendLineInvariant(@"global::Uno.UI.DataBinding.IBindableType value = null;
 						return () => {{
 							if (value == null)
 							{{
@@ -203,427 +208,429 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 
 							return value;
 						}};"
-					);
-				}
-
-				using (writer.BlockInvariant("static BindableMetadataProvider()"))
-				{
-					GenerateTypeTable(writer, q);
-				}
-
-				writer.AppendLineInvariant(@"#if DEBUG");
-				writer.AppendLineInvariant(@"private global::System.Collections.Generic.List<global::System.Type> _knownMissingTypes = new global::System.Collections.Generic.List<global::System.Type>();");
-				writer.AppendLineInvariant(@"#endif");
-
-				using (writer.BlockInvariant("public void ForceInitialize()"))
-				{
-					using (writer.BlockInvariant(@"foreach(TypeBuilderDelegate item in _bindableTypeCacheByFullName.Values)"))
-					{
-						writer.AppendLineInvariant(@"item();");
+						);
 					}
-				}
 
-				using (writer.BlockInvariant("public global::Uno.UI.DataBinding.IBindableType GetBindableTypeByFullName(string fullName)"))
-				{
-					writer.AppendLineInvariant(@"var selector = _bindableTypeCacheByFullName[fullName] as TypeBuilderDelegate;");
-
-					using (writer.BlockInvariant(@"if(selector != null)"))
+					using (writer.BlockInvariant("static BindableMetadataProvider()"))
 					{
-						writer.AppendLineInvariant(@"return selector();");
-					}
-					using (writer.BlockInvariant(@"else"))
-					{
-						writer.AppendLineInvariant(@"return null;");
-					}
-				}
-
-				using (writer.BlockInvariant("public global::Uno.UI.DataBinding.IBindableType GetBindableTypeByType(Type type)"))
-				{
-					writer.AppendLineInvariant(@"var selector = _bindableTypeCacheByFullName[type.FullName] as TypeBuilderDelegate;");
-
-					using (writer.BlockInvariant(@"if(selector != null)"))
-					{
-						writer.AppendLineInvariant(@"return selector();");
+						GenerateTypeTable(writer, q);
 					}
 
 					writer.AppendLineInvariant(@"#if DEBUG");
-					using (writer.BlockInvariant(@"else"))
-					{
-						using (writer.BlockInvariant(@"lock(_knownMissingTypes)"))
-						{
-							using (writer.BlockInvariant(@"if(!_knownMissingTypes.Contains(type) && !type.IsGenericType)"))
-							{
-								writer.AppendLineInvariant(@"_knownMissingTypes.Add(type);");
-								writer.AppendLineInvariant(@"Debug.WriteLine($""The Bindable attribute is missing and the type [{{type.FullName}}] is not known by the MetadataProvider. Reflection was used instead of the binding engine and generated static metadata. Add the Bindable attribute to prevent this message and performance issues."");");
-							}
-						}
-					}
+					writer.AppendLineInvariant(@"private global::System.Collections.Generic.List<global::System.Type> _knownMissingTypes = new global::System.Collections.Generic.List<global::System.Type>();");
 					writer.AppendLineInvariant(@"#endif");
 
-					writer.AppendLineInvariant(@"return null;");
-				}
-			}
-		}
-
-		private class PropertyNameEqualityComparer : IEqualityComparer<IPropertySymbol>
-		{
-			public bool Equals(IPropertySymbol? x, IPropertySymbol? y)
-			{
-				return x?.Name == y?.Name;
-			}
-
-			public int GetHashCode(IPropertySymbol obj)
-			{
-				return obj.Name.GetHashCode();
-			}
-		}
-
-		private void GenerateMetadata(IndentedStringBuilder writer, IEnumerable<INamedTypeSymbol> types)
-		{
-			foreach (var type in types)
-			{
-				GenerateType(writer, type);
-			}
-		}
-
-		class GeneratedTypeInfo
-		{
-			public GeneratedTypeInfo(int index, bool hasProperties)
-			{
-				Index = index;
-				HasProperties = hasProperties;
-			}
-
-			public int Index { get; private set; }
-
-			public bool HasProperties { get; private set; }
-		}
-
-		private void GenerateType(IndentedStringBuilder writer, INamedTypeSymbol ownerType)
-		{
-			if (_typeMap.ContainsKey(ownerType))
-			{
-				return;
-			}
-
-			var ownerTypeName = GetGlobalQualifier(ownerType) + ownerType.ToString();
-
-			var flattenedProperties =
-				from property in ownerType.GetAllProperties()
-				where !property.IsStatic
-					&& !(property.ContainingSymbol is INamedTypeSymbol containing && IsIgnoredType(containing))
-					&& !IsNonBindable(property)
-					&& !IsOverride(property.GetMethod)
-				select property;
-
-			var properties =
-				from property in ownerType.GetProperties()
-				where !property.IsStatic
-					&& !IsNonBindable(property)
-					&& HasPublicGetter(property)
-					&& !IsOverride(property.GetMethod)
-				select property;
-
-			var propertyDependencyProperties =
-				from property in ownerType.GetProperties()
-				where property.IsStatic
-					&& SymbolEqualityComparer.Default.Equals(property.Type, _dependencyPropertySymbol)
-				select property.Name;
-
-			var fieldDependencyProperties =
-				from field in ownerType.GetFields()
-				where field.IsStatic
-					&& SymbolEqualityComparer.Default.Equals(field.Type, _dependencyPropertySymbol)
-				select field.Name;
-
-			var dependencyProperties = fieldDependencyProperties
-				.Concat(propertyDependencyProperties)
-				.ToArray();
-
-			properties = from prop in properties.Distinct(new PropertyNameEqualityComparer())
-						 where !dependencyProperties.Contains(prop.Name + "Property")
-						 select prop;
-
-			properties = properties
-				.ToArray();
-
-			var typeInfo = new GeneratedTypeInfo(
-				index: _typeMap.Count,
-				hasProperties: properties.Any() || dependencyProperties.Any()
-			);
-
-			_typeMap.Add(ownerType, typeInfo);
-
-			var baseType = GetBaseType(ownerType);
-
-			// Call the builders for the base types
-			if (baseType != null)
-			{
-				GenerateType(writer, baseType);
-			}
-
-			writer.AppendLineInvariant("/// <summary>");
-			writer.AppendLineInvariant("/// Builder for {0}", ownerType.GetFullName());
-			writer.AppendLineInvariant("/// </summary>");
-			writer.AppendLineInvariant("[System.Runtime.CompilerServices.CompilerGeneratedAttribute]");
-			writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1502:AvoidExcessiveComplexity\", Justification=\"Must be ignored even if generated code is checked.\")]");
-			writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1506:AvoidExcessiveClassCoupling\", Justification = \"Must be ignored even if generated code is checked.\")]");
-
-			AnalyzerSuppressionsGenerator.Generate(writer, AnalyzerSuppressions);
-			using (writer.BlockInvariant("static class MetadataBuilder_{0:000}", typeInfo.Index))
-			{
-				var postWriter = new IndentedStringBuilder();
-				postWriter.Indent(writer.CurrentLevel);
-
-				// Generate a parameter-less build to avoid generating a lambda during registration (avoids creating a caching backing field)
-				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1502:AvoidExcessiveComplexity\", Justification=\"Must be ignored even if generated code is checked.\")]");
-				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1506:AvoidExcessiveClassCoupling\", Justification = \"Must be ignored even if generated code is checked.\")]");
-				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1505:AvoidUnmaintainableCode\", Justification = \"Must be ignored even if generated code is checked.\")]");
-				using (writer.BlockInvariant("internal static global::Uno.UI.DataBinding.IBindableType Build()"))
-				{
-					writer.AppendLineInvariant("return Build(null);");
-				}
-
-				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1502:AvoidExcessiveComplexity\", Justification=\"Must be ignored even if generated code is checked.\")]");
-				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1506:AvoidExcessiveClassCoupling\", Justification = \"Must be ignored even if generated code is checked.\")]");
-				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1505:AvoidUnmaintainableCode\", Justification = \"Must be ignored even if generated code is checked.\")]");
-				using (writer.BlockInvariant("internal static global::Uno.UI.DataBinding.IBindableType Build(global::Uno.UI.DataBinding.BindableType parent)"))
-				{
-					writer.AppendLineInvariant(
-						@"var bindableType = parent ?? new global::Uno.UI.DataBinding.BindableType({0}, typeof({1}));",
-						flattenedProperties
-							.Where(p => !IsStringIndexer(p) && HasPublicGetter(p))
-							.Count()
-						, ExpandType(ownerType)
-					);
-
-					// Call the builders for the base types
-					if (baseType != null)
+					using (writer.BlockInvariant("public void ForceInitialize()"))
 					{
-						var baseTypeMapped = _typeMap.UnoGetValueOrDefault(baseType);
-
-						writer.AppendLineInvariant(@"MetadataBuilder_{0:000}.Build(bindableType); // {1}", baseTypeMapped.Index, ExpandType(baseType));
-					}
-
-					var ctor = ownerType.GetMethods().FirstOrDefault(m => m.MethodKind == MethodKind.Constructor && !m.Parameters.Any() && m.IsLocallyPublic(_currentModule!));
-
-					if (ctor != null && IsCreateable(ownerType))
-					{
-						using (writer.BlockInvariant("if(parent == null)"))
+						using (writer.BlockInvariant(@"foreach(TypeBuilderDelegate item in _bindableTypeCacheByFullName.Values)"))
 						{
-							writer.AppendLineInvariant(@"bindableType.AddActivator(CreateInstance);");
-							postWriter.AppendLineInvariant($@"private static object CreateInstance() => new {ownerTypeName}();");
+							writer.AppendLineInvariant(@"item();");
 						}
 					}
 
-					foreach (var property in properties)
+					using (writer.BlockInvariant("public global::Uno.UI.DataBinding.IBindableType GetBindableTypeByFullName(string fullName)"))
 					{
-						var propertyTypeName = property.Type.GetFullyQualifiedType();
-						var propertyName = property.Name;
+						writer.AppendLineInvariant(@"var selector = _bindableTypeCacheByFullName[fullName] as TypeBuilderDelegate;");
 
-						if (IsStringIndexer(property))
+						using (writer.BlockInvariant(@"if(selector != null)"))
 						{
-							writer.AppendLineInvariant("bindableType.AddIndexer(GetIndexer, SetIndexer);");
+							writer.AppendLineInvariant(@"return selector();");
+						}
+						using (writer.BlockInvariant(@"else"))
+						{
+							writer.AppendLineInvariant(@"return null;");
+						}
+					}
 
-							postWriter.AppendLineInvariant($@"private static object GetIndexer(object instance, string name) => (({ownerTypeName})instance)[name];");
+					using (writer.BlockInvariant("public global::Uno.UI.DataBinding.IBindableType GetBindableTypeByType(Type type)"))
+					{
+						writer.AppendLineInvariant(@"var selector = _bindableTypeCacheByFullName[type.FullName] as TypeBuilderDelegate;");
 
-							if (property.SetMethod != null)
-							{
-								postWriter.AppendLineInvariant($@"private static void SetIndexer(object instance, string name, object value) => (({ownerTypeName})instance)[name] = ({propertyTypeName})value;");
-							}
-							else
-							{
-								postWriter.AppendLineInvariant("private static void SetIndexer(object instance, string name, object value) {{}}");
-							}
-
-							continue;
+						using (writer.BlockInvariant(@"if(selector != null)"))
+						{
+							writer.AppendLineInvariant(@"return selector();");
 						}
 
-						if (property.IsIndexer)
+						writer.AppendLineInvariant(@"#if DEBUG");
+						using (writer.BlockInvariant(@"else"))
 						{
-							// Other types of indexers are currently not supported.
-							continue;
-						}
-
-						if (
-							property.SetMethod != null
-							&& property.SetMethod != null
-							&& property.SetMethod.IsLocallyPublic(_currentModule!)
-							)
-						{
-							if (property.Type.IsValueType)
+							using (writer.BlockInvariant(@"lock(_knownMissingTypes)"))
 							{
-								writer.AppendLineInvariant($@"bindableType.AddProperty(""{propertyName}"", typeof({propertyTypeName}), Get{propertyName}, Set{propertyName});");
-
-								postWriter.AppendLineInvariant($@"private static object Get{propertyName}(object instance, Windows.UI.Xaml.DependencyPropertyValuePrecedences? precedence) => (({ownerTypeName})instance).{propertyName};");
-
-								using (postWriter.BlockInvariant($@"private static void Set{propertyName}(object instance, object value, Windows.UI.Xaml.DependencyPropertyValuePrecedences? precedence)"))
+								using (writer.BlockInvariant(@"if(!_knownMissingTypes.Contains(type) && !type.IsGenericType)"))
 								{
-									using (postWriter.BlockInvariant($"if(value != null)"))
-									{
-										postWriter.AppendLineInvariant($"(({ownerTypeName})instance).{propertyName} = ({propertyTypeName})value;");
-									}
+									writer.AppendLineInvariant(@"_knownMissingTypes.Add(type);");
+									writer.AppendLineInvariant(@"Debug.WriteLine($""The Bindable attribute is missing and the type [{{type.FullName}}] is not known by the MetadataProvider. Reflection was used instead of the binding engine and generated static metadata. Add the Bindable attribute to prevent this message and performance issues."");");
 								}
 							}
-							else
-							{
-								writer.AppendLineInvariant($@"bindableType.AddProperty(""{propertyName}"", typeof({propertyTypeName}), Get{propertyName}, Set{propertyName});");
-
-								postWriter.AppendLineInvariant($@"private static object Get{propertyName}(object instance,  Windows.UI.Xaml.DependencyPropertyValuePrecedences? precedence) => (({ownerTypeName})instance).{propertyName};");
-								postWriter.AppendLineInvariant($@"private static void Set{propertyName}(object instance, object value, Windows.UI.Xaml.DependencyPropertyValuePrecedences? precedence) => (({ownerTypeName})instance).{propertyName} = ({propertyTypeName})value;");
-							}
 						}
-						else if (HasPublicGetter(property))
-						{
-							writer.AppendLineInvariant($@"bindableType.AddProperty(""{propertyName}"", typeof({propertyTypeName}), Get{propertyName});");
+						writer.AppendLineInvariant(@"#endif");
 
-							postWriter.AppendLineInvariant($@"private static object Get{propertyName}(object instance, Windows.UI.Xaml.DependencyPropertyValuePrecedences? precedence) => (({ownerTypeName})instance).{propertyName};");
-						}
+						writer.AppendLineInvariant(@"return null;");
 					}
+				}
+			}
 
-					foreach (var dependencyProperty in dependencyProperties)
-					{
-						var propertyName = dependencyProperty.TrimEnd("Property");
-
-						var getMethod = ownerType.GetMethods().FirstOrDefault(m => m.Name == "Get" + propertyName && m.Parameters.Length == 1 && m.IsLocallyPublic(_currentModule!));
-
-						if (getMethod == null)
-						{
-							getMethod = ownerType
-								.GetProperties()
-								.FirstOrDefault(p => p.Name == propertyName && (p.GetMethod?.IsLocallyPublic(_currentModule!) ?? false))
-								?.GetMethod;
-						}
-
-						if (getMethod != null)
-						{
-							writer.AppendLineInvariant($@"bindableType.AddProperty({ownerType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}.{dependencyProperty});");
-						}
-					}
-
-					writer.AppendLineInvariant(@"return bindableType;");
+			private class PropertyNameEqualityComparer : IEqualityComparer<IPropertySymbol>
+			{
+				public bool Equals(IPropertySymbol? x, IPropertySymbol? y)
+				{
+					return x?.Name == y?.Name;
 				}
 
-				writer.Append(postWriter.ToString());
-			}
-
-			writer.AppendLine();
-		}
-
-
-		private static string ExpandType(INamedTypeSymbol ownerType)
-		{
-			if(ownerType.TypeKind == TypeKind.Error)
-			{
-				return ownerType.ToString() + "/* Type is error */";
-			}
-			else
-			{
-				return GetGlobalQualifier(ownerType) + ownerType.GetFullName();
-			}
-		}
-
-		private static string GetGlobalQualifier(ITypeSymbol ownerType)
-		{
-			var arrayType = ownerType as IArrayTypeSymbol;
-			if (arrayType != null)
-			{
-				return GetGlobalQualifier(arrayType.ElementType);
-			}
-
-			ITypeSymbol? nullType;
-			if (ownerType.IsNullable(out nullType))
-			{
-				return GetGlobalQualifier(nullType!);
-			}
-
-			var needsGlobal = ownerType.SpecialType == SpecialType.None && !ownerType.IsTupleType;
-			return (needsGlobal ? "global::" : "");
-		}
-
-		private bool IsCreateable(INamedTypeSymbol type)
-		{
-			return !type.IsAbstract  
-				&& type
-					.GetMethods()
-					.Safe()
-					.Any(m => 
-						m.MethodKind == MethodKind.Constructor 
-						&& m.IsLocallyPublic(_currentModule!)
-						&& m.Parameters.Safe().None()
-					);
-		}
-
-		private INamedTypeSymbol? GetBaseType(INamedTypeSymbol type)
-		{
-			if (type.BaseType != null)
-			{
-				var ignoredByConfig = IsIgnoredType(type.BaseType);
-
-				// These types are know to not be bindable, so ignore them by default.
-				var isKnownBaseType = SymbolEqualityComparer.Default.Equals(type.BaseType, _objectSymbol)
-					|| SymbolEqualityComparer.Default.Equals(type.BaseType, _javaObjectSymbol)
-					|| SymbolEqualityComparer.Default.Equals(type.BaseType, _nsObjectSymbol);
-
-				if(!ignoredByConfig && !isKnownBaseType)
+				public int GetHashCode(IPropertySymbol obj)
 				{
-					return type.BaseType;
+					return obj.Name.GetHashCode();
+				}
+			}
+
+			private void GenerateMetadata(IndentedStringBuilder writer, IEnumerable<INamedTypeSymbol> types)
+			{
+				foreach (var type in types)
+				{
+					GenerateType(writer, type);
+				}
+			}
+
+			class GeneratedTypeInfo
+			{
+				public GeneratedTypeInfo(int index, bool hasProperties)
+				{
+					Index = index;
+					HasProperties = hasProperties;
+				}
+
+				public int Index { get; private set; }
+
+				public bool HasProperties { get; private set; }
+			}
+
+			private void GenerateType(IndentedStringBuilder writer, INamedTypeSymbol ownerType)
+			{
+				if (_typeMap.ContainsKey(ownerType))
+				{
+					return;
+				}
+
+				var ownerTypeName = GetGlobalQualifier(ownerType) + ownerType.ToString();
+
+				var flattenedProperties =
+					from property in ownerType.GetAllProperties()
+					where !property.IsStatic
+						&& !(property.ContainingSymbol is INamedTypeSymbol containing && IsIgnoredType(containing))
+						&& !IsNonBindable(property)
+						&& !IsOverride(property.GetMethod)
+					select property;
+
+				var properties =
+					from property in ownerType.GetProperties()
+					where !property.IsStatic
+						&& !IsNonBindable(property)
+						&& HasPublicGetter(property)
+						&& !IsOverride(property.GetMethod)
+					select property;
+
+				var propertyDependencyProperties =
+					from property in ownerType.GetProperties()
+					where property.IsStatic
+						&& SymbolEqualityComparer.Default.Equals(property.Type, _dependencyPropertySymbol)
+					select property.Name;
+
+				var fieldDependencyProperties =
+					from field in ownerType.GetFields()
+					where field.IsStatic
+						&& SymbolEqualityComparer.Default.Equals(field.Type, _dependencyPropertySymbol)
+					select field.Name;
+
+				var dependencyProperties = fieldDependencyProperties
+					.Concat(propertyDependencyProperties)
+					.ToArray();
+
+				properties = from prop in properties.Distinct(new PropertyNameEqualityComparer())
+							 where !dependencyProperties.Contains(prop.Name + "Property")
+							 select prop;
+
+				properties = properties
+					.ToArray();
+
+				var typeInfo = new GeneratedTypeInfo(
+					index: _typeMap.Count,
+					hasProperties: properties.Any() || dependencyProperties.Any()
+				);
+
+				_typeMap.Add(ownerType, typeInfo);
+
+				var baseType = GetBaseType(ownerType);
+
+				// Call the builders for the base types
+				if (baseType != null)
+				{
+					GenerateType(writer, baseType);
+				}
+
+				writer.AppendLineInvariant("/// <summary>");
+				writer.AppendLineInvariant("/// Builder for {0}", ownerType.GetFullName());
+				writer.AppendLineInvariant("/// </summary>");
+				writer.AppendLineInvariant("[System.Runtime.CompilerServices.CompilerGeneratedAttribute]");
+				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1502:AvoidExcessiveComplexity\", Justification=\"Must be ignored even if generated code is checked.\")]");
+				writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1506:AvoidExcessiveClassCoupling\", Justification = \"Must be ignored even if generated code is checked.\")]");
+
+				AnalyzerSuppressionsGenerator.Generate(writer, AnalyzerSuppressions);
+				using (writer.BlockInvariant("static class MetadataBuilder_{0:000}", typeInfo.Index))
+				{
+					var postWriter = new IndentedStringBuilder();
+					postWriter.Indent(writer.CurrentLevel);
+
+					// Generate a parameter-less build to avoid generating a lambda during registration (avoids creating a caching backing field)
+					writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1502:AvoidExcessiveComplexity\", Justification=\"Must be ignored even if generated code is checked.\")]");
+					writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1506:AvoidExcessiveClassCoupling\", Justification = \"Must be ignored even if generated code is checked.\")]");
+					writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1505:AvoidUnmaintainableCode\", Justification = \"Must be ignored even if generated code is checked.\")]");
+					using (writer.BlockInvariant("internal static global::Uno.UI.DataBinding.IBindableType Build()"))
+					{
+						writer.AppendLineInvariant("return Build(null);");
+					}
+
+					writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1502:AvoidExcessiveComplexity\", Justification=\"Must be ignored even if generated code is checked.\")]");
+					writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1506:AvoidExcessiveClassCoupling\", Justification = \"Must be ignored even if generated code is checked.\")]");
+					writer.AppendLineInvariant("[System.Diagnostics.CodeAnalysis.SuppressMessage(\"Microsoft.Maintainability\", \"CA1505:AvoidUnmaintainableCode\", Justification = \"Must be ignored even if generated code is checked.\")]");
+					using (writer.BlockInvariant("internal static global::Uno.UI.DataBinding.IBindableType Build(global::Uno.UI.DataBinding.BindableType parent)"))
+					{
+						writer.AppendLineInvariant(
+							@"var bindableType = parent ?? new global::Uno.UI.DataBinding.BindableType({0}, typeof({1}));",
+							flattenedProperties
+								.Where(p => !IsStringIndexer(p) && HasPublicGetter(p))
+								.Count()
+							, ExpandType(ownerType)
+						);
+
+						// Call the builders for the base types
+						if (baseType != null)
+						{
+							var baseTypeMapped = _typeMap.UnoGetValueOrDefault(baseType);
+
+							writer.AppendLineInvariant(@"MetadataBuilder_{0:000}.Build(bindableType); // {1}", baseTypeMapped.Index, ExpandType(baseType));
+						}
+
+						var ctor = ownerType.GetMethods().FirstOrDefault(m => m.MethodKind == MethodKind.Constructor && !m.Parameters.Any() && m.IsLocallyPublic(_currentModule!));
+
+						if (ctor != null && IsCreateable(ownerType))
+						{
+							using (writer.BlockInvariant("if(parent == null)"))
+							{
+								writer.AppendLineInvariant(@"bindableType.AddActivator(CreateInstance);");
+								postWriter.AppendLineInvariant($@"private static object CreateInstance() => new {ownerTypeName}();");
+							}
+						}
+
+						foreach (var property in properties)
+						{
+							var propertyTypeName = property.Type.GetFullyQualifiedType();
+							var propertyName = property.Name;
+
+							if (IsStringIndexer(property))
+							{
+								writer.AppendLineInvariant("bindableType.AddIndexer(GetIndexer, SetIndexer);");
+
+								postWriter.AppendLineInvariant($@"private static object GetIndexer(object instance, string name) => (({ownerTypeName})instance)[name];");
+
+								if (property.SetMethod != null)
+								{
+									postWriter.AppendLineInvariant($@"private static void SetIndexer(object instance, string name, object value) => (({ownerTypeName})instance)[name] = ({propertyTypeName})value;");
+								}
+								else
+								{
+									postWriter.AppendLineInvariant("private static void SetIndexer(object instance, string name, object value) {{}}");
+								}
+
+								continue;
+							}
+
+							if (property.IsIndexer)
+							{
+								// Other types of indexers are currently not supported.
+								continue;
+							}
+
+							if (
+								property.SetMethod != null
+								&& property.SetMethod != null
+								&& property.SetMethod.IsLocallyPublic(_currentModule!)
+								)
+							{
+								if (property.Type.IsValueType)
+								{
+									writer.AppendLineInvariant($@"bindableType.AddProperty(""{propertyName}"", typeof({propertyTypeName}), Get{propertyName}, Set{propertyName});");
+
+									postWriter.AppendLineInvariant($@"private static object Get{propertyName}(object instance, Windows.UI.Xaml.DependencyPropertyValuePrecedences? precedence) => (({ownerTypeName})instance).{propertyName};");
+
+									using (postWriter.BlockInvariant($@"private static void Set{propertyName}(object instance, object value, Windows.UI.Xaml.DependencyPropertyValuePrecedences? precedence)"))
+									{
+										using (postWriter.BlockInvariant($"if(value != null)"))
+										{
+											postWriter.AppendLineInvariant($"(({ownerTypeName})instance).{propertyName} = ({propertyTypeName})value;");
+										}
+									}
+								}
+								else
+								{
+									writer.AppendLineInvariant($@"bindableType.AddProperty(""{propertyName}"", typeof({propertyTypeName}), Get{propertyName}, Set{propertyName});");
+
+									postWriter.AppendLineInvariant($@"private static object Get{propertyName}(object instance,  Windows.UI.Xaml.DependencyPropertyValuePrecedences? precedence) => (({ownerTypeName})instance).{propertyName};");
+									postWriter.AppendLineInvariant($@"private static void Set{propertyName}(object instance, object value, Windows.UI.Xaml.DependencyPropertyValuePrecedences? precedence) => (({ownerTypeName})instance).{propertyName} = ({propertyTypeName})value;");
+								}
+							}
+							else if (HasPublicGetter(property))
+							{
+								writer.AppendLineInvariant($@"bindableType.AddProperty(""{propertyName}"", typeof({propertyTypeName}), Get{propertyName});");
+
+								postWriter.AppendLineInvariant($@"private static object Get{propertyName}(object instance, Windows.UI.Xaml.DependencyPropertyValuePrecedences? precedence) => (({ownerTypeName})instance).{propertyName};");
+							}
+						}
+
+						foreach (var dependencyProperty in dependencyProperties)
+						{
+							var propertyName = dependencyProperty.TrimEnd("Property");
+
+							var getMethod = ownerType.GetMethods().FirstOrDefault(m => m.Name == "Get" + propertyName && m.Parameters.Length == 1 && m.IsLocallyPublic(_currentModule!));
+
+							if (getMethod == null)
+							{
+								getMethod = ownerType
+									.GetProperties()
+									.FirstOrDefault(p => p.Name == propertyName && (p.GetMethod?.IsLocallyPublic(_currentModule!) ?? false))
+									?.GetMethod;
+							}
+
+							if (getMethod != null)
+							{
+								writer.AppendLineInvariant($@"bindableType.AddProperty({ownerType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}.{dependencyProperty});");
+							}
+						}
+
+						writer.AppendLineInvariant(@"return bindableType;");
+					}
+
+					writer.Append(postWriter.ToString());
+				}
+
+				writer.AppendLine();
+			}
+
+
+			private static string ExpandType(INamedTypeSymbol ownerType)
+			{
+				if (ownerType.TypeKind == TypeKind.Error)
+				{
+					return ownerType.ToString() + "/* Type is error */";
 				}
 				else
 				{
-					return GetBaseType(type.BaseType);
+					return GetGlobalQualifier(ownerType) + ownerType.GetFullName();
 				}
 			}
 
-			return null;
-		}
-
-		private bool IsIgnoredType(INamedTypeSymbol typeSymbol)
-		{
-			return typeSymbol.IsGenericType;
-		}
-
-		private bool HasPublicGetter(IPropertySymbol property) => property.GetMethod?.IsLocallyPublic(_currentModule!) ?? false;
-
-		private bool IsStringIndexer(IPropertySymbol property)
-		{
-			return property.IsIndexer
-				&& property.GetMethod!.IsLocallyPublic(_currentModule!)
-				&& property.Parameters.Length == 1
-				&& property.Parameters.Any(p => SymbolEqualityComparer.Default.Equals(p.Type, _stringSymbol));
-		}
-
-		private bool IsNonBindable(IPropertySymbol property) => property.FindAttributeFlattened(_nonBindableSymbol!) != null;
-
-		private bool IsOverride(IMethodSymbol? methodDefinition)
-		{
-			return methodDefinition !=null
-				&& methodDefinition.IsOverride
-				&& !methodDefinition.IsVirtual;
-		}
-
-		private string SanitizeTypeName(string name)
-		{
-			for (int i = 0; i < 10; i++)
+			private static string GetGlobalQualifier(ITypeSymbol ownerType)
 			{
-				name = name.Replace("`" + i, "");
+				var arrayType = ownerType as IArrayTypeSymbol;
+				if (arrayType != null)
+				{
+					return GetGlobalQualifier(arrayType.ElementType);
+				}
+
+				ITypeSymbol? nullType;
+				if (ownerType.IsNullable(out nullType))
+				{
+					return GetGlobalQualifier(nullType!);
+				}
+
+				var needsGlobal = ownerType.SpecialType == SpecialType.None && !ownerType.IsTupleType;
+				return (needsGlobal ? "global::" : "");
 			}
 
-			name = name.Replace("/", ".");
-
-			return name;
-		}
-
-		private void GenerateTypeTable(IndentedStringBuilder writer, IEnumerable<INamedTypeSymbol> types)
-		{
-			foreach (var type in _typeMap.Where(k => !k.Key.IsGenericType))
+			private bool IsCreateable(INamedTypeSymbol type)
 			{
-				writer.AppendLineInvariant(
-					"_bindableTypeCacheByFullName[\"{0}\"] = CreateMemoized(MetadataBuilder_{1:000}.Build);",
-					type.Key, 
-					type.Value.Index
-				);
+				return !type.IsAbstract
+					&& type
+						.GetMethods()
+						.Safe()
+						.Any(m =>
+							m.MethodKind == MethodKind.Constructor
+							&& m.IsLocallyPublic(_currentModule!)
+							&& m.Parameters.Safe().None()
+						);
 			}
+
+			private INamedTypeSymbol? GetBaseType(INamedTypeSymbol type)
+			{
+				if (type.BaseType != null)
+				{
+					var ignoredByConfig = IsIgnoredType(type.BaseType);
+
+					// These types are know to not be bindable, so ignore them by default.
+					var isKnownBaseType = SymbolEqualityComparer.Default.Equals(type.BaseType, _objectSymbol)
+						|| SymbolEqualityComparer.Default.Equals(type.BaseType, _javaObjectSymbol)
+						|| SymbolEqualityComparer.Default.Equals(type.BaseType, _nsObjectSymbol);
+
+					if (!ignoredByConfig && !isKnownBaseType)
+					{
+						return type.BaseType;
+					}
+					else
+					{
+						return GetBaseType(type.BaseType);
+					}
+				}
+
+				return null;
+			}
+
+			private bool IsIgnoredType(INamedTypeSymbol typeSymbol)
+			{
+				return typeSymbol.IsGenericType;
+			}
+
+			private bool HasPublicGetter(IPropertySymbol property) => property.GetMethod?.IsLocallyPublic(_currentModule!) ?? false;
+
+			private bool IsStringIndexer(IPropertySymbol property)
+			{
+				return property.IsIndexer
+					&& property.GetMethod!.IsLocallyPublic(_currentModule!)
+					&& property.Parameters.Length == 1
+					&& property.Parameters.Any(p => SymbolEqualityComparer.Default.Equals(p.Type, _stringSymbol));
+			}
+
+			private bool IsNonBindable(IPropertySymbol property) => property.FindAttributeFlattened(_nonBindableSymbol!) != null;
+
+			private bool IsOverride(IMethodSymbol? methodDefinition)
+			{
+				return methodDefinition != null
+					&& methodDefinition.IsOverride
+					&& !methodDefinition.IsVirtual;
+			}
+
+			private string SanitizeTypeName(string name)
+			{
+				for (int i = 0; i < 10; i++)
+				{
+					name = name.Replace("`" + i, "");
+				}
+
+				name = name.Replace("/", ".");
+
+				return name;
+			}
+
+			private void GenerateTypeTable(IndentedStringBuilder writer, IEnumerable<INamedTypeSymbol> types)
+			{
+				foreach (var type in _typeMap.Where(k => !k.Key.IsGenericType))
+				{
+					writer.AppendLineInvariant(
+						"_bindableTypeCacheByFullName[\"{0}\"] = CreateMemoized(MetadataBuilder_{1:000}.Build);",
+						type.Key,
+						type.Value.Index
+					);
+				}
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Generation does not fail when used within C# delta application

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
