### PR TITLE
fix(skiagtk): Remove unused incorrect dependency in `Uno.UI.Runtime.Skia.Gtk` and `FrameBuffer`

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/Uno.UI.Runtime.Skia.Gtk.csproj
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Uno.UI.Runtime.Skia.Gtk.csproj
@@ -32,7 +32,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-		<PackageReference Include="SkiaSharp.Views" />
+		<!--<PackageReference Include="SkiaSharp.Views" />-->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Uno.UI.Runtime.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Uno.UI.Runtime.Skia.Linux.FrameBuffer.csproj
@@ -36,7 +36,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-		<PackageReference Include="SkiaSharp.Views" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/mono/SkiaSharp/pull/1704

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Removes unused and invalid dependency to `SkiaSharp.Views` for Gtk and Framebuffer support.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
