### PR TITLE
fix: Incorrect SymbolIcon NotImplemented attribute platform list

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SymbolIcon.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SymbolIcon.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class SymbolIcon : global::Windows.UI.Xaml.Controls.IconElement
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): fix https://github.com/unoplatform/uno/issues/5635

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Incorrect `NotImplemented` attribute platform list on `SymbolIcon`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
