### PR TITLE
fix(reg): Don't make lazy visual states with descendants containing x:Name

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -761,7 +761,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									}
 								}
 
-							BuildComponentFields(writer);
+								BuildComponentFields(writer);
 
 								TryBuildElementStubHolders(writer);
 
@@ -1717,6 +1717,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		}
 
 		/// <summary>
+		/// Determines if the member definition as x:Name property
+		/// </summary>
+		/// <param name="m"></param>
+		/// <returns></returns>
+		private static bool HasXNameProperty(XamlMemberDefinition m)
+			=> m.Member.Name == "Name" && m.Member.PreferredXamlNamespace == XamlConstants.XamlXmlNamespace;
+
+		/// <summary>
 		/// Is <paramref name="valueNode"/> a {StaticResource ...} or {ThemeResource ...} reference?
 		/// </summary>
 		private bool HasResourceMarkupExtension(XamlMemberDefinition valueNode)
@@ -1782,6 +1790,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private bool HasDescendantsWithMarkupExtension(XamlObjectDefinition xamlObjectDefinition)
 			=> HasDescendantsWith(xamlObjectDefinition, HasMarkupExtension);
 
+		private bool HasDescendantsWithXName(XamlMemberDefinition memberDefinition)
+			=> memberDefinition.Objects.Any(o => HasDescendantsWith(o, HasXNameProperty));
+
 		private bool HasDescendantsWith(XamlObjectDefinition xamlObjectDefinition, Func<XamlMemberDefinition, bool> predicate)
 		{
 			foreach (var member in xamlObjectDefinition.Members)
@@ -1793,7 +1804,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				foreach (var obj in member.Objects)
 				{
-					if (HasDescendantsWithMarkupExtension(obj))
+					if (HasDescendantsWith(obj, predicate))
 					{
 						return true;
 					}
@@ -1802,7 +1813,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			foreach (var obj in xamlObjectDefinition.Objects)
 			{
-				if (HasDescendantsWithMarkupExtension(obj))
+				if (HasDescendantsWith(obj, predicate))
 				{
 					return true;
 				}
@@ -1845,7 +1856,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var attributeData = symbol.FindAttribute(XamlConstants.Types.CreateFromStringAttribute);
 			var targetMethod = attributeData?.NamedArguments.FirstOrDefault(kvp => kvp.Key == "MethodName").Value.Value?.ToString();
 
-			if(targetMethod == null)
+			if (targetMethod == null)
 			{
 				throw new NotSupportedException($"Unable to find MethodNameproperty on {symbol}");
 			}
@@ -2193,7 +2204,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 												.InvariantCultureFormat(contentProperty.Name));
 										}
 									}
-									else if (IsLazyVisualStateManagerProperty(contentProperty))
+									else if (IsLazyVisualStateManagerProperty(contentProperty) && !HasDescendantsWithXName(implicitContentChild))
 									{
 										writer.AppendLineInvariant($"/* Lazy VisualStateManager property {contentProperty}*/");
 									}
@@ -3187,7 +3198,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					var contentProperty = FindContentProperty(elementType);
 
-					if (contentProperty != null && IsLazyVisualStateManagerProperty(contentProperty))
+					if (contentProperty != null && IsLazyVisualStateManagerProperty(contentProperty) && !HasDescendantsWithXName(implicitContentChild))
 					{
 						return contentProperty;
 					}
@@ -4835,21 +4846,21 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				&& member.Owner != null
 				&& member.Owner.Type.Name switch
 				{
-					"VisualState" => member.Member.Name == "Storyboard"
-									|| member.Member.Name == "Setters",
-					"VisualTransition" => member.Member.Name == "Storyboard",
+					"VisualState" => (member.Member.Name == "Storyboard"
+									|| member.Member.Name == "Setters") && !HasDescendantsWithXName(member),
+					"VisualTransition" => member.Member.Name == "Storyboard" && !HasDescendantsWithXName(member),
 					_ => false,
 				};
 
 		private bool IsLazyVisualStateManagerProperty(IPropertySymbol property)
 			=> _isLazyVisualStateManagerEnabled
 				&& property.ContainingSymbol.Name switch
-			{
-				"VisualState" => property.Name == "Storyboard"
-								|| property.Name == "Setters",
-				"VisualTransition" => property.Name == "Storyboard",
-				_ => false,
-			};
+				{
+					"VisualState" => property.Name == "Storyboard"
+									|| property.Name == "Setters",
+					"VisualTransition" => property.Name == "Storyboard",
+					_ => false,
+				};
 
 		/// <summary>
 		/// Determines if the member is inline initializable and the first item is not a new collection instance
@@ -5375,127 +5386,127 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					{
 						writer.AppendLine(")");
 					});
-					
+
 					return new DisposableAction(() =>
+					{
+						disposable?.Dispose();
+
+						string closureName;
+						using (var innerWriter = CreateApplyBlock(writer, GetType(XamlConstants.Types.ElementStub), out closureName))
 						{
-							disposable?.Dispose();
+							var elementStubType = new XamlType("", "ElementStub", new List<XamlType>(), new XamlSchemaContext());
 
-							string closureName;
-							using (var innerWriter = CreateApplyBlock(writer, GetType(XamlConstants.Types.ElementStub), out closureName))
+							if (hasDataContextMarkup)
 							{
-								var elementStubType = new XamlType("", "ElementStub", new List<XamlType>(), new XamlSchemaContext());
+								// We need to generate the datacontext binding, since the Visibility
+								// may require it to bind properly.
 
-								if (hasDataContextMarkup)
+								GenerateBinding("DataContext", dataContextMember, definition);
+							}
+
+							if (nameMember != null)
+							{
+								innerWriter.AppendLineInvariant(
+									$"{closureName}.Name = \"{nameMember.Value}\";"
+								);
+
+								// Set the element name to the stub, then when the stub will be replaced
+								// the actual target control will override it.
+								innerWriter.AppendLineInvariant(
+									$"_{nameMember.Value}Subject.ElementInstance = {closureName};"
+								);
+							}
+
+							if (hasLoadMarkup || hasVisibilityMarkup)
+							{
+								var members = new List<XamlMemberDefinition>();
+
+								if (hasLoadMarkup)
 								{
-									// We need to generate the datacontext binding, since the Visibility
-									// may require it to bind properly.
-
-									GenerateBinding("DataContext", dataContextMember, definition);
+									members.Add(GenerateBinding("Load", loadMember, definition));
 								}
 
-								if (nameMember != null)
+								if (hasVisibilityMarkup)
 								{
-									innerWriter.AppendLineInvariant(
-										$"{closureName}.Name = \"{nameMember.Value}\";"
-									);
-
-									// Set the element name to the stub, then when the stub will be replaced
-									// the actual target control will override it.
-									innerWriter.AppendLineInvariant(
-										$"_{nameMember.Value}Subject.ElementInstance = {closureName};"
-									);
+									members.Add(GenerateBinding("Visibility", visibilityMember, definition));
 								}
 
-								if (hasLoadMarkup || hasVisibilityMarkup)
+								if (!_isTopLevelDictionary
+									&& (HasXBindMarkupExtension(definition) || HasMarkupExtensionNeedingComponent(definition)))
 								{
-									var members = new List<XamlMemberDefinition>();
+									var componentName = $"_component_{ CurrentScope.ComponentCount}";
+									writer.AppendLineInvariant($"this.{componentName} = {closureName};");
 
-									if (hasLoadMarkup)
+									writer.AppendLineInvariant($"var {componentName}_update_That = ({CurrentResourceOwnerName} as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;");
+
+									if (nameMember != null)
 									{
-										members.Add(GenerateBinding("Load", loadMember, definition));
+										writer.AppendLineInvariant($"var {componentName}_update_subject_capture = _{nameMember.Value}Subject;");
 									}
 
-									if (hasVisibilityMarkup)
+									using (writer.BlockInvariant($"void {componentName}_update(global::Windows.UI.Xaml.ElementStub sender)"))
 									{
-										members.Add(GenerateBinding("Visibility", visibilityMember, definition));
-									}
-
-									if (!_isTopLevelDictionary
-										&& (HasXBindMarkupExtension(definition) || HasMarkupExtensionNeedingComponent(definition)))
-									{
-										var componentName = $"_component_{ CurrentScope.ComponentCount}";
-										writer.AppendLineInvariant($"this.{componentName} = {closureName};");
-
-										writer.AppendLineInvariant($"var {componentName}_update_That = ({CurrentResourceOwnerName} as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;");
-
-										if (nameMember != null)
+										using (writer.BlockInvariant($"if ({componentName}_update_That.Target is {_className.className} that)"))
 										{
-											writer.AppendLineInvariant($"var {componentName}_update_subject_capture = _{nameMember.Value}Subject;");
-										}
 
-										using (writer.BlockInvariant($"void {componentName}_update(global::Windows.UI.Xaml.ElementStub sender)"))
-										{
-											using (writer.BlockInvariant($"if ({componentName}_update_That.Target is {_className.className} that)"))
+											using (writer.BlockInvariant($"if (sender.IsMaterialized)"))
 											{
-
-												using (writer.BlockInvariant($"if (sender.IsMaterialized)"))
-												{
-													writer.AppendLineInvariant($"that.Bindings.UpdateResources();");
-												}
+												writer.AppendLineInvariant($"that.Bindings.UpdateResources();");
 											}
 										}
-
-										writer.AppendLineInvariant($"{closureName}.MaterializationChanged += {componentName}_update;");
-
-										using (writer.BlockInvariant($"void {componentName}_unloaded(object sender, RoutedEventArgs e)"))
-										{
-											// Refresh the bindings when the ElementStub is unloaded. This assumes that
-											// ElementStub will be unloaded **after** the stubbed control has been created
-											// in order for the _component_XXX to be filled, and Bindings.Update() to do its work.
-											writer.AppendLineInvariant($"({componentName}_update_That.Target as {_className.className})?.Bindings.Update();");
-										}
-
-										writer.AppendLineInvariant($"{closureName}.Unloaded += {componentName}_unloaded;");
-
-										var xamlObjectDef = new XamlObjectDefinition(elementStubType, 0, 0, definition);
-										xamlObjectDef.Members.AddRange(members);
-										CurrentScope.Components.Add(xamlObjectDef);
 									}
 
-								}
-								else
-								{
-									if (visibilityMember != null)
+									writer.AppendLineInvariant($"{closureName}.MaterializationChanged += {componentName}_update;");
+
+									using (writer.BlockInvariant($"void {componentName}_unloaded(object sender, RoutedEventArgs e)"))
 									{
-										innerWriter.AppendLineInvariant(
-											"{0}.Visibility = {1};",
-											closureName,
-											BuildLiteralValue(visibilityMember)
-										);
+										// Refresh the bindings when the ElementStub is unloaded. This assumes that
+										// ElementStub will be unloaded **after** the stubbed control has been created
+										// in order for the _component_XXX to be filled, and Bindings.Update() to do its work.
+										writer.AppendLineInvariant($"({componentName}_update_That.Target as {_className.className})?.Bindings.Update();");
 									}
+
+									writer.AppendLineInvariant($"{closureName}.Unloaded += {componentName}_unloaded;");
+
+									var xamlObjectDef = new XamlObjectDefinition(elementStubType, 0, 0, definition);
+									xamlObjectDef.Members.AddRange(members);
+									CurrentScope.Components.Add(xamlObjectDef);
 								}
 
-								XamlMemberDefinition GenerateBinding(string name, XamlMemberDefinition? memberDefinition, XamlObjectDefinition owner)
+							}
+							else
+							{
+								if (visibilityMember != null)
 								{
-									var def = new XamlMemberDefinition(
-										new XamlMember(name,
-											elementStubType,
-											false
-										), 0, 0,
-										owner
+									innerWriter.AppendLineInvariant(
+										"{0}.Visibility = {1};",
+										closureName,
+										BuildLiteralValue(visibilityMember)
 									);
-
-									if (memberDefinition != null)
-									{
-										def.Objects.AddRange(memberDefinition.Objects);
-									}
-
-									BuildComplexPropertyValue(innerWriter, def, closureName + ".", closureName);
-
-									return def;
 								}
 							}
+
+							XamlMemberDefinition GenerateBinding(string name, XamlMemberDefinition? memberDefinition, XamlObjectDefinition owner)
+							{
+								var def = new XamlMemberDefinition(
+									new XamlMember(name,
+										elementStubType,
+										false
+									), 0, 0,
+									owner
+								);
+
+								if (memberDefinition != null)
+								{
+									def.Objects.AddRange(memberDefinition.Objects);
+								}
+
+								BuildComplexPropertyValue(innerWriter, def, closureName + ".", closureName);
+
+								return def;
+							}
 						}
+					}
 					);
 				}
 			}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_Lazy.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_Lazy.xaml
@@ -12,7 +12,7 @@
 			<VisualStateGroup x:Name="CommonStates">
 				<VisualStateGroup.Transitions>
 
-					<VisualTransition From="Normal" To="PointerOver">
+					<VisualTransition From="Normal" To="PointerOver" x:Name="testTransition" x:FieldModifier="public">
 						<Storyboard>
 							<ObjectAnimationUsingKeyFrames Storyboard.TargetName="border1" Storyboard.TargetProperty="Background">
 								<DiscreteObjectKeyFrame KeyTime="0" Value="Transparent" />
@@ -25,13 +25,13 @@
 
 				</VisualStateGroup.Transitions>
 				
-				<VisualState x:Name="Normal">
+				<VisualState x:Name="Normal" x:FieldModifier="public">
 					<Storyboard>
 						<PointerUpThemeAnimation Storyboard.TargetName="border1" />
 					</Storyboard>
 				</VisualState>
 
-				<VisualState x:Name="PointerOver">
+				<VisualState x:Name="PointerOver" x:FieldModifier="public">
 					<Storyboard>
 						<ObjectAnimationUsingKeyFrames Storyboard.TargetName="border1" Storyboard.TargetProperty="Background">
 							<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPointerOver}" />
@@ -46,7 +46,7 @@
 					</Storyboard>
 				</VisualState>
 
-				<VisualState x:Name="Pressed">
+				<VisualState x:Name="Pressed" x:FieldModifier="public">
 					<Storyboard>
 						<ObjectAnimationUsingKeyFrames Storyboard.TargetName="border1" Storyboard.TargetProperty="Background">
 							<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundPressed}" />
@@ -61,7 +61,7 @@
 					</Storyboard>
 				</VisualState>
 
-				<VisualState x:Name="Disabled">
+				<VisualState x:Name="Disabled" x:FieldModifier="public">
 					<Storyboard>
 						<ObjectAnimationUsingKeyFrames Storyboard.TargetName="border1" Storyboard.TargetProperty="Background">
 							<DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ButtonBackgroundDisabled}" />

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName.xaml
@@ -1,0 +1,42 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests.Controls.When_VisualStateManager_xName"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<Grid>
+		<VisualStateManager.VisualStateGroups>
+			<VisualStateGroup x:Name="MyStates">
+				<VisualState x:Name="State1" x:FieldModifier="public" />
+				<VisualState x:Name="State2" x:FieldModifier="public" >
+					<Storyboard>
+						<ObjectAnimationUsingKeyFrames x:Name="testAnimation"
+													   x:FieldModifier="public" 
+													   Storyboard.TargetName="myControl"
+													   Storyboard.TargetProperty="Tag">
+							<DiscreteObjectKeyFrame x:Name="testKeyFrame"
+													x:FieldModifier="public"
+													KeyTime="0"
+													Value="0" />
+						</ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				</VisualState>
+				<VisualState x:Name="State3" x:FieldModifier="public">
+					<Storyboard>
+						<ObjectAnimationUsingKeyFrames Storyboard.TargetName="myControl"
+													   Storyboard.TargetProperty="Tag">
+							<DiscreteObjectKeyFrame x:FieldModifier="public"
+													KeyTime="0"
+													Value="0" />
+						</ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				</VisualState>
+			</VisualStateGroup>
+		</VisualStateManager.VisualStateGroups>
+
+		<ContentControl x:Name="myControl" x:FieldModifier="public" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests.Controls
+{
+	public sealed partial class When_VisualStateManager_xName : UserControl
+	{
+		public When_VisualStateManager_xName()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/VisualStateManager_Lazy.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/VisualStateManager_Lazy.cs
@@ -23,6 +23,61 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests
 		}
 
 		[TestMethod]
+		public async Task When_VisualStateManager_Lazy()
+		{
+			var SUT = new When_VisualStateManager_Lazy();
+			var app = UnitTestsApp.App.EnsureApplication();
+			app.HostView.Children.Add(SUT);
+
+			await WaitForIdle();
+
+			Assert.IsNotNull(SUT.testTransition.LazyBuilder);
+			Assert.IsNotNull(SUT.Normal.LazyBuilder);
+			Assert.IsNotNull(SUT.PointerOver.LazyBuilder);
+			Assert.IsNotNull(SUT.Pressed.LazyBuilder);
+			Assert.IsNotNull(SUT.Disabled.LazyBuilder);
+
+			await GoTo(nameof(SUT.Normal));
+
+			Assert.IsNotNull(SUT.testTransition.LazyBuilder);
+			Assert.IsNull(SUT.Normal.LazyBuilder);
+			Assert.IsNotNull(SUT.PointerOver.LazyBuilder);
+			Assert.IsNotNull(SUT.Pressed.LazyBuilder);
+			Assert.IsNotNull(SUT.Disabled.LazyBuilder);
+
+			await GoTo(nameof(SUT.PointerOver));
+
+			Assert.IsNull(SUT.testTransition.LazyBuilder);
+			Assert.IsNull(SUT.Normal.LazyBuilder);
+			Assert.IsNull(SUT.PointerOver.LazyBuilder);
+			Assert.IsNotNull(SUT.Pressed.LazyBuilder);
+			Assert.IsNotNull(SUT.Disabled.LazyBuilder);
+
+			await GoTo(nameof(SUT.Pressed));
+
+			Assert.IsNull(SUT.testTransition.LazyBuilder);
+			Assert.IsNull(SUT.Normal.LazyBuilder);
+			Assert.IsNull(SUT.PointerOver.LazyBuilder);
+			Assert.IsNull(SUT.Pressed.LazyBuilder);
+			Assert.IsNotNull(SUT.Disabled.LazyBuilder);
+
+			await GoTo(nameof(SUT.Disabled));
+
+			Assert.IsNull(SUT.testTransition.LazyBuilder);
+			Assert.IsNull(SUT.Normal.LazyBuilder);
+			Assert.IsNull(SUT.PointerOver.LazyBuilder);
+			Assert.IsNull(SUT.Pressed.LazyBuilder);
+			Assert.IsNull(SUT.Disabled.LazyBuilder);
+
+			async Task GoTo(string stateName)
+			{
+				var goToResult = VisualStateManager.GoToState(SUT, stateName, useTransitions: false);
+				Assert.IsTrue(goToResult);
+				await WaitForIdle();
+			}
+		}
+
+		[TestMethod]
 		public async Task When_VisualStateManager_Lazy_ThemeChanges()
 		{
 			var SUT = new When_VisualStateManager_Lazy_ThemeChanges();
@@ -77,6 +132,23 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests
 			var fg = SUT.PrimaryButton.Foreground as SolidColorBrush;
 			Assert.IsNotNull(fg);
 			Assert.AreEqual(Colors.White, fg.Color);
+		}
+
+		[TestMethod]
+		public async Task When_xName()
+		{
+			var SUT = new When_VisualStateManager_xName();
+			var app = UnitTestsApp.App.EnsureApplication();
+			app.HostView.Children.Add(SUT);
+
+			await WaitForIdle();
+
+			Assert.IsNotNull(SUT.State3.LazyBuilder);
+			Assert.IsNull(SUT.State2.LazyBuilder);
+
+			Assert.IsNotNull(SUT.testAnimation);
+			Assert.IsNotNull(SUT.testKeyFrame);
+			Assert.AreEqual("0", SUT.testKeyFrame.Value);
 		}
 
 		private static async Task ShowDialog(MyContentDialog dialog)


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/nventive-private/issues/216, fixes https://github.com/unoplatform/nventive-private/issues/206

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

VisualStates containing `x:Name` in nested members are now materialized eagerly, avoiding issues where visual states are referenced from the code behind, causing NREs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
