### PR TITLE
fix: Allow multiple default value providers

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DefaultValueProvider.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DefaultValueProvider.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Tests.BinderTests;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Tests.DependencyPropertyTests
+{
+	[TestClass]
+	public partial class Given_DependencyProperty
+	{
+		[TestMethod]
+		public void When_DefaultValueProvider_Registered_Provides_Value()
+		{
+			bool GetDefaultValue(DependencyProperty property, out object value)
+			{
+				if (property == DefaultValueProviderSample.TestProperty)
+				{
+					value = 3;
+					return true;
+				}
+
+				value = null;
+				return false;
+			}
+
+			var test = new DefaultValueProviderSample();
+			test.RegisterDefaultValueProvider(GetDefaultValue);
+
+			var value = test.GetPrecedenceSpecificValue(DefaultValueProviderSample.TestProperty, DependencyPropertyValuePrecedences.DefaultValue);
+			Assert.AreEqual(3, value);
+		}
+
+		[TestMethod]
+		public void When_DefaultValueProvider_Registered_Other_Property_Not_Affected()
+		{
+			bool GetDefaultValue(DependencyProperty property, out object value)
+			{
+				if (property == DefaultValueProviderSample.TestProperty)
+				{
+					value = 3;
+					return true;
+				}
+
+				value = 42; // Set arbitrary to verify false has effect
+				return false;
+			}
+
+			var test = new DefaultValueProviderSample();
+			test.RegisterDefaultValueProvider(GetDefaultValue);
+
+			var value = test.GetPrecedenceSpecificValue(DefaultValueProviderSample.OtherProperty, DependencyPropertyValuePrecedences.DefaultValue);
+			Assert.AreEqual(0, value);
+		}
+
+		[TestMethod]
+		public void When_DefaultValueProvider_Multiple_Registered_Overwrite()
+		{
+			bool GetDefaultValue(DependencyProperty property, out object value)
+			{
+				if (property == DefaultValueProviderSample.TestProperty)
+				{
+					value = 3;
+					return true;
+				}
+
+				value = null;
+				return false;
+			}
+
+			bool GetDefaultValue2(DependencyProperty property, out object value)
+			{
+				if (property == DefaultValueProviderSample.TestProperty)
+				{
+					value = 17;
+					return true;
+				}
+
+				value = null;
+				return false;
+			}
+
+			var test = new DefaultValueProviderSample();
+			test.RegisterDefaultValueProvider(GetDefaultValue);
+			test.RegisterDefaultValueProvider(GetDefaultValue2);
+
+			var value = test.GetPrecedenceSpecificValue(DefaultValueProviderSample.TestProperty, DependencyPropertyValuePrecedences.DefaultValue);
+			Assert.AreEqual(17, value);
+		}
+
+		[TestMethod]
+		public void When_DefaultValueProvider_Multiple_Registered_Unaffected()
+		{
+			bool GetDefaultValue(DependencyProperty property, out object value)
+			{
+				if (property == DefaultValueProviderSample.TestProperty)
+				{
+					value = 3;
+					return true;
+				}
+
+				value = null;
+				return false;
+			}
+
+			bool GetDefaultValue2(DependencyProperty property, out object value)
+			{
+				if (property == DefaultValueProviderSample.OtherProperty)
+				{
+					value = 17;
+					return true;
+				}
+
+				value = 42;
+				return false;
+			}
+
+			var test = new DefaultValueProviderSample();
+			test.RegisterDefaultValueProvider(GetDefaultValue);
+			test.RegisterDefaultValueProvider(GetDefaultValue2);
+
+			var value = test.GetPrecedenceSpecificValue(DefaultValueProviderSample.TestProperty, DependencyPropertyValuePrecedences.DefaultValue);
+			Assert.AreEqual(3, value); // GetDefaultValue should apply
+		}
+	}
+
+	internal partial class DefaultValueProviderSample : MockDependencyObject
+	{
+		public DefaultValueProviderSample()
+		{
+			
+		}
+
+		public int Test
+		{
+			get => (int)GetValue(TestProperty);
+			set => SetValue(TestProperty, value);
+		}
+
+		public static DependencyProperty TestProperty { get; } =
+			DependencyProperty.Register(nameof(Test), typeof(int), typeof(DefaultValueProviderSample), new PropertyMetadata(0));
+
+		public int Other
+		{
+			get => (int)GetValue(OtherProperty);
+			set => SetValue(OtherProperty, value);
+		}
+
+		public static readonly DependencyProperty OtherProperty =
+			DependencyProperty.Register(nameof(Other), typeof(int), typeof(DefaultValueProviderSample), new PropertyMetadata(0));
+	}
+}

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
@@ -184,7 +184,7 @@ namespace Windows.UI.Xaml
 			return false;
 		}
 
-		internal void SetDefaultValue(object defaultValue)
+		internal void SetDefaultValue(object? defaultValue)
 		{
 			_defaultValue = defaultValue;
 			_flags |= Flags.DefaultValueSet;

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -244,11 +244,12 @@ namespace Windows.UI.Xaml
 		/// </remarks>
 		public void RegisterDefaultValueProvider(DependencyObjectStore.DefaultValueProvider provider)
 		{
-			if (_defaultValueProviders == null)
+			if (provider == null)
 			{
-				_defaultValueProviders = new List<DependencyObjectStore.DefaultValueProvider>();
+				throw new ArgumentNullException(nameof(provider));
 			}
 
+			_defaultValueProviders ??= new List<DependencyObjectStore.DefaultValueProvider>();
 			_defaultValueProviders.Add(provider);
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -249,7 +249,7 @@ namespace Windows.UI.Xaml
 				throw new ArgumentNullException(nameof(provider));
 			}
 
-			_defaultValueProviders ??= new List<DependencyObjectStore.DefaultValueProvider>();
+			_defaultValueProviders ??= new List<DependencyObjectStore.DefaultValueProvider>(2);
 			_defaultValueProviders.Add(provider);
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -237,7 +237,7 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		/// <param name="provider">Default value provider.</param>
 		/// <remarks>
-		/// Providers which are registered later have higher precedence.
+		/// Providers which are registered later have higher priority.
 		/// E.g. when both a derived and base class register their own default
 		/// value provider in the constructor for the same property, the derived
 		/// class value is used.

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml
 		private int _entriesLength;
 		private int _minId;
 		private int _maxId;
-		private DependencyObjectStore.DefaultValueProvider? _defaultValueProvider;
+		private List<DependencyObjectStore.DefaultValueProvider>? _defaultValueProviders = null;
 
 		private object? Owner => _hardOwnerReference ?? _ownerReference.Target;
 
@@ -141,9 +141,9 @@ namespace Windows.UI.Xaml
 				{
 					propertyEntry = new DependencyPropertyDetails(property, _ownerType);
 
-					if(_defaultValueProvider != null && _defaultValueProvider(property, out var v))
+					if (TryResolveDefaultValueFromProviders(property, out var value))
 					{
-						propertyEntry.SetDefaultValue(v);
+						propertyEntry.SetDefaultValue(value);
 					}
 				}
 
@@ -178,9 +178,9 @@ namespace Windows.UI.Xaml
 
 					ref var propertyEntry = ref Entries![property.UniqueId - _minId];
 					propertyEntry = new DependencyPropertyDetails(property, _ownerType);
-					if (_defaultValueProvider != null && _defaultValueProvider(property, out var v))
+					if (TryResolveDefaultValueFromProviders(property, out var value))
 					{
-						propertyEntry.SetValue(v, DependencyPropertyValuePrecedences.DefaultValue);
+						propertyEntry.SetValue(value, DependencyPropertyValuePrecedences.DefaultValue);
 					}
 
 					return propertyEntry;
@@ -190,6 +190,24 @@ namespace Windows.UI.Xaml
 					return null;
 				}
 			}
+		}
+
+		private bool TryResolveDefaultValueFromProviders(DependencyProperty property, out object? value)
+		{
+			if (_defaultValueProviders != null)
+			{
+				for (int i = _defaultValueProviders.Count - 1; i >= 0; i--)
+				{
+					var provider = _defaultValueProviders[i];
+					if (provider.Invoke(property, out var resolvedValue))
+					{
+						value = resolvedValue;
+						return true;
+					}
+				}
+			}
+			value = null;
+			return false;
 		}
 
 		private void AssignEntries(DependencyPropertyDetails[] newEntries, int newSize)
@@ -214,9 +232,24 @@ namespace Windows.UI.Xaml
 
 		internal IEnumerable<DependencyPropertyDetails> GetAllDetails() => Entries.Trim();
 
+		/// <summary>
+		/// Adds a default value provider.
+		/// </summary>
+		/// <param name="provider">Default value provider.</param>
+		/// <remarks>
+		/// Providers which are registered later have higher precedence.
+		/// E.g. when both a derived and base class register their own default
+		/// value provider in the constructor for the same property, the derived
+		/// class value is used.
+		/// </remarks>
 		public void RegisterDefaultValueProvider(DependencyObjectStore.DefaultValueProvider provider)
 		{
-			_defaultValueProvider = provider;
+			if (_defaultValueProviders == null)
+			{
+				_defaultValueProviders = new List<DependencyObjectStore.DefaultValueProvider>();
+			}
+
+			_defaultValueProviders.Add(provider);
 		}
 
 		internal void TryEnableHardReferences()


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6157

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Only a single default value provider can be registered.

## What is the new behavior?

Multiple can be registered.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
