### PR TITLE
fix(calendar): Avoid flicker when changing DisplayMode

### DIFF
--- a/src/Uno.UI.FluentTheme/Resources/PriorityDefault/CalendarView_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/Resources/PriorityDefault/CalendarView_themeresources.xaml
@@ -520,12 +520,14 @@
                                         <CalendarPanel x:Name="MonthViewPanel" />
                                     </ScrollViewer>
                                 </Grid>
+								<!-- Uno only: Opacity set to 0 to avoir flicker when changing display mode -->
 								<ScrollViewer x:Name="YearViewScrollViewer" UseLayoutRounding="False" Opacity="0" Visibility="Collapsed" IsFocusEngagementEnabled="True" Style="{StaticResource ScrollViewerStyle}">
                                     <ScrollViewer.RenderTransform>
                                         <ScaleTransform x:Name="YearViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
                                     </ScrollViewer.RenderTransform>
                                     <CalendarPanel x:Name="YearViewPanel" />
                                 </ScrollViewer>
+								<!-- Uno only: Opacity set to 0 to avoir flicker when changing display mode -->
 								<ScrollViewer x:Name="DecadeViewScrollViewer" UseLayoutRounding="False" IsFocusEngagementEnabled="True" Opacity="0" Visibility="Collapsed" Style="{StaticResource ScrollViewerStyle}">
                                     <ScrollViewer.RenderTransform>
                                         <ScaleTransform x:Name="DecadeViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />

--- a/src/Uno.UI.FluentTheme/Resources/PriorityDefault/CalendarView_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/Resources/PriorityDefault/CalendarView_themeresources.xaml
@@ -260,7 +260,12 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
                                         </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
+										<!--Begin: Uno only - We changed the default value to avoid flicker, make sure to set it to 1 even if transitions are disabled -->
+										<DoubleAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Opacity">
+											<DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
+										</DoubleAnimationUsingKeyFrames>
+										<!--End: Uno only-->
+									</Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Decade">
 									<!--Begin: Uno only-->
@@ -278,14 +283,16 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Visibility">
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
                                         </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
+										<!--Begin: Uno only - We changed the default value to avoid flicker, make sure to set it to 1 even if transitions are disabled -->
+										<DoubleAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Opacity">
+											<DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
+										</DoubleAnimationUsingKeyFrames>
+										<!--End: Uno only-->
+									</Storyboard>
                                 </VisualState>
                                 <VisualStateGroup.Transitions>
                                     <VisualTransition From="Month" To="Year">
                                         <Storyboard>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
-                                                <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
-                                            </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MonthView" Storyboard.TargetProperty="Opacity">
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
@@ -294,6 +301,10 @@
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0.233" Value="0" />
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.733" Value="1" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
+											<!--Uno only: Make sure to set visibility only AFTER opacity -->
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
+												<DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
+											</ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MonthViewTransform" Storyboard.TargetProperty="ScaleX">
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0.84" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
@@ -368,9 +379,6 @@
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
                                             </ObjectAnimationUsingKeyFrames>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Visibility">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
-                                            </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Opacity">
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
@@ -379,6 +387,10 @@
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0.233" Value="0" />
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.733" Value="1" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
+											<!--Uno only: Make sure to set visibility only AFTER opacity -->
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Visibility">
+												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
+											</ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="YearViewTransform" Storyboard.TargetProperty="ScaleX">
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0.84" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
@@ -508,13 +520,13 @@
                                         <CalendarPanel x:Name="MonthViewPanel" />
                                     </ScrollViewer>
                                 </Grid>
-                                <ScrollViewer x:Name="YearViewScrollViewer" UseLayoutRounding="False" Visibility="Collapsed" IsFocusEngagementEnabled="True" Style="{StaticResource ScrollViewerStyle}">
+								<ScrollViewer x:Name="YearViewScrollViewer" UseLayoutRounding="False" Opacity="0" Visibility="Collapsed" IsFocusEngagementEnabled="True" Style="{StaticResource ScrollViewerStyle}">
                                     <ScrollViewer.RenderTransform>
                                         <ScaleTransform x:Name="YearViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
                                     </ScrollViewer.RenderTransform>
                                     <CalendarPanel x:Name="YearViewPanel" />
                                 </ScrollViewer>
-                                <ScrollViewer x:Name="DecadeViewScrollViewer" UseLayoutRounding="False" IsFocusEngagementEnabled="True" Visibility="Collapsed" Style="{StaticResource ScrollViewerStyle}">
+								<ScrollViewer x:Name="DecadeViewScrollViewer" UseLayoutRounding="False" IsFocusEngagementEnabled="True" Opacity="0" Visibility="Collapsed" Style="{StaticResource ScrollViewerStyle}">
                                     <ScrollViewer.RenderTransform>
                                         <ScaleTransform x:Name="DecadeViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
                                     </ScrollViewer.RenderTransform>

--- a/src/Uno.UI.FluentTheme/themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/themeresources.xaml
@@ -127,7 +127,7 @@
       <SolidColorBrush x:Key="TextBoxBorderThemeBrush" Color="#FFFFFFFF" />
       <SolidColorBrush x:Key="TextBoxButtonBackgroundThemeBrush" Color="Transparent" />
       <SolidColorBrush x:Key="TextBoxButtonBorderThemeBrush" Color="Transparent" />
-      <SolidColorBrush x:Key="TextBoxButtonForegroundThemeBrush" Color="#99000000" />
+      <SolidColorBrush x:Key="TextBoxButtonForegroundThemeBrush" Color="#99FFFFFF" />
       <SolidColorBrush x:Key="TextBoxButtonPointerOverBackgroundThemeBrush" Color="#FFDEDEDE" />
       <SolidColorBrush x:Key="TextBoxButtonPointerOverBorderThemeBrush" Color="Transparent" />
       <SolidColorBrush x:Key="TextBoxButtonPointerOverForegroundThemeBrush" Color="#FF000000" />
@@ -138,8 +138,12 @@
       <SolidColorBrush x:Key="TextBoxDisabledBorderThemeBrush" Color="#66FFFFFF" />
       <SolidColorBrush x:Key="TextBoxDisabledForegroundThemeBrush" Color="#FF666666" />
       <SolidColorBrush x:Key="TextBoxForegroundThemeBrush" Color="#FF000000" />
+      <StaticResource x:Key="TextControlBackgroundFocused" ResourceKey="SystemControlBackgroundAltHighBrush" />
       <StaticResource x:Key="TextControlBorderBrush" ResourceKey="SystemControlForegroundBaseMediumBrush" />
       <StaticResource x:Key="TextControlBorderBrushPointerOver" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
+      <StaticResource x:Key="TextControlButtonForeground" ResourceKey="SystemControlForegroundBaseMediumHighBrush" />
+      <StaticResource x:Key="TextControlForegroundFocused" ResourceKey="SystemControlForegroundBaseHighBrush" />
+      <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="SystemControlForegroundBaseMediumLowBrush" />
       <Color x:Key="SystemRevealAltHighColor">#F2000000</Color>
       <Color x:Key="SystemRevealAltLowColor">#30000000</Color>
       <Color x:Key="SystemRevealAltMediumColor">#91000000</Color>
@@ -1615,8 +1619,12 @@
       <SolidColorBrush x:Key="TextBoxDisabledBorderThemeBrush" Color="#26000000" />
       <SolidColorBrush x:Key="TextBoxDisabledForegroundThemeBrush" Color="#FF666666" />
       <SolidColorBrush x:Key="TextBoxForegroundThemeBrush" Color="#FF000000" />
+      <StaticResource x:Key="TextControlBackgroundFocused" ResourceKey="SystemControlBackgroundAltHighBrush" />
       <StaticResource x:Key="TextControlBorderBrush" ResourceKey="SystemControlForegroundBaseMediumBrush" />
       <StaticResource x:Key="TextControlBorderBrushPointerOver" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
+      <StaticResource x:Key="TextControlButtonForeground" ResourceKey="SystemControlForegroundBaseMediumHighBrush" />
+      <StaticResource x:Key="TextControlForegroundFocused" ResourceKey="SystemControlForegroundBaseHighBrush" />
+      <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="SystemControlForegroundBaseMediumLowBrush" />
       <Color x:Key="SystemRevealAltHighColor">#E6FFFFFF</Color>
       <Color x:Key="SystemRevealAltLowColor">#2EFFFFFF</Color>
       <Color x:Key="SystemRevealAltMediumColor">#8AFFFFFF</Color>
@@ -3092,8 +3100,12 @@
       <SolidColorBrush x:Key="TextBoxDisabledBorderThemeBrush" Color="{ThemeResource SystemColorGrayTextColor}" />
       <SolidColorBrush x:Key="TextBoxDisabledForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
       <SolidColorBrush x:Key="TextBoxForegroundThemeBrush" Color="{ThemeResource SystemColorButtonTextColor}" />
+      <StaticResource x:Key="TextControlBackgroundFocused" ResourceKey="SystemControlBackgroundAltHighBrush" />
       <StaticResource x:Key="TextControlBorderBrush" ResourceKey="SystemControlForegroundBaseMediumBrush" />
       <StaticResource x:Key="TextControlBorderBrushPointerOver" ResourceKey="SystemControlHighlightBaseMediumHighBrush" />
+      <StaticResource x:Key="TextControlButtonForeground" ResourceKey="SystemControlForegroundBaseMediumHighBrush" />
+      <StaticResource x:Key="TextControlForegroundFocused" ResourceKey="SystemControlForegroundBaseHighBrush" />
+      <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="SystemControlForegroundBaseMediumLowBrush" />
       <Color x:Key="SystemRevealAltHighColor">#FF000000</Color>
       <Color x:Key="SystemRevealAltLowColor">#33000000</Color>
       <Color x:Key="SystemRevealAltMediumColor">#99000000</Color>
@@ -5787,9 +5799,6 @@
                     </ObjectAnimationUsingKeyFrames>
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="RequestedTheme">
-                      <DiscreteObjectKeyFrame KeyTime="0" Value="Light" />
                     </ObjectAnimationUsingKeyFrames>
                   </Storyboard>
                 </VisualState>
@@ -9941,12 +9950,14 @@
                     <CalendarPanel x:Name="MonthViewPanel" />
                   </ScrollViewer>
                 </Grid>
+                <!-- Uno only: Opacity set to 0 to avoir flicker when changing display mode -->
                 <ScrollViewer x:Name="YearViewScrollViewer" UseLayoutRounding="False" Opacity="0" Visibility="Collapsed" IsFocusEngagementEnabled="True" Style="{StaticResource ScrollViewerStyle}">
                   <ScrollViewer.RenderTransform>
                     <ScaleTransform x:Name="YearViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
                   </ScrollViewer.RenderTransform>
                   <CalendarPanel x:Name="YearViewPanel" />
                 </ScrollViewer>
+                <!-- Uno only: Opacity set to 0 to avoir flicker when changing display mode -->
                 <ScrollViewer x:Name="DecadeViewScrollViewer" UseLayoutRounding="False" IsFocusEngagementEnabled="True" Opacity="0" Visibility="Collapsed" Style="{StaticResource ScrollViewerStyle}">
                   <ScrollViewer.RenderTransform>
                     <ScaleTransform x:Name="DecadeViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />

--- a/src/Uno.UI.FluentTheme/themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/themeresources.xaml
@@ -9681,6 +9681,11 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
                       <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
                     </ObjectAnimationUsingKeyFrames>
+                    <!--Begin: Uno only - We changed the default value to avoid flicker, make sure to set it to 1 even if transitions are disabled -->
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Opacity">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
+                    </DoubleAnimationUsingKeyFrames>
+                    <!--End: Uno only-->
                   </Storyboard>
                 </VisualState>
                 <VisualState x:Name="Decade">
@@ -9699,14 +9704,16 @@
                     <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Visibility">
                       <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
                     </ObjectAnimationUsingKeyFrames>
+                    <!--Begin: Uno only - We changed the default value to avoid flicker, make sure to set it to 1 even if transitions are disabled -->
+                    <DoubleAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Opacity">
+                      <DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
+                    </DoubleAnimationUsingKeyFrames>
+                    <!--End: Uno only-->
                   </Storyboard>
                 </VisualState>
                 <VisualStateGroup.Transitions>
                   <VisualTransition From="Month" To="Year">
                     <Storyboard>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
-                      </ObjectAnimationUsingKeyFrames>
                       <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MonthView" Storyboard.TargetProperty="Opacity">
                         <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0" KeySpline="0.1,0.9,0.2,1" />
                       </DoubleAnimationUsingKeyFrames>
@@ -9715,6 +9722,10 @@
                         <DiscreteDoubleKeyFrame KeyTime="0:0:0.233" Value="0" />
                         <SplineDoubleKeyFrame KeyTime="0:0:0.733" Value="1" KeySpline="0.1,0.9,0.2,1" />
                       </DoubleAnimationUsingKeyFrames>
+                      <!--Uno only: Make sure to set visibility only AFTER opacity -->
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
+                        <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
+                      </ObjectAnimationUsingKeyFrames>
                       <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MonthViewTransform" Storyboard.TargetProperty="ScaleX">
                         <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0.84" KeySpline="0.1,0.9,0.2,1" />
                       </DoubleAnimationUsingKeyFrames>
@@ -9789,9 +9800,6 @@
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
                       </ObjectAnimationUsingKeyFrames>
-                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Visibility">
-                        <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
-                      </ObjectAnimationUsingKeyFrames>
                       <DoubleAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Opacity">
                         <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0" KeySpline="0.1,0.9,0.2,1" />
                       </DoubleAnimationUsingKeyFrames>
@@ -9800,6 +9808,10 @@
                         <DiscreteDoubleKeyFrame KeyTime="0:0:0.233" Value="0" />
                         <SplineDoubleKeyFrame KeyTime="0:0:0.733" Value="1" KeySpline="0.1,0.9,0.2,1" />
                       </DoubleAnimationUsingKeyFrames>
+                      <!--Uno only: Make sure to set visibility only AFTER opacity -->
+                      <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Visibility">
+                        <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
+                      </ObjectAnimationUsingKeyFrames>
                       <DoubleAnimationUsingKeyFrames Storyboard.TargetName="YearViewTransform" Storyboard.TargetProperty="ScaleX">
                         <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0.84" KeySpline="0.1,0.9,0.2,1" />
                       </DoubleAnimationUsingKeyFrames>
@@ -9929,13 +9941,13 @@
                     <CalendarPanel x:Name="MonthViewPanel" />
                   </ScrollViewer>
                 </Grid>
-                <ScrollViewer x:Name="YearViewScrollViewer" UseLayoutRounding="False" Visibility="Collapsed" IsFocusEngagementEnabled="True" Style="{StaticResource ScrollViewerStyle}">
+                <ScrollViewer x:Name="YearViewScrollViewer" UseLayoutRounding="False" Opacity="0" Visibility="Collapsed" IsFocusEngagementEnabled="True" Style="{StaticResource ScrollViewerStyle}">
                   <ScrollViewer.RenderTransform>
                     <ScaleTransform x:Name="YearViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
                   </ScrollViewer.RenderTransform>
                   <CalendarPanel x:Name="YearViewPanel" />
                 </ScrollViewer>
-                <ScrollViewer x:Name="DecadeViewScrollViewer" UseLayoutRounding="False" IsFocusEngagementEnabled="True" Visibility="Collapsed" Style="{StaticResource ScrollViewerStyle}">
+                <ScrollViewer x:Name="DecadeViewScrollViewer" UseLayoutRounding="False" IsFocusEngagementEnabled="True" Opacity="0" Visibility="Collapsed" Style="{StaticResource ScrollViewerStyle}">
                   <ScrollViewer.RenderTransform>
                     <ScaleTransform x:Name="DecadeViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
                   </ScrollViewer.RenderTransform>
@@ -20683,8 +20695,8 @@
                 </VisualState>
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
-            <Path x:Name="LeftRadiusRender" x:Load="False" Grid.Column="0" Visibility="Collapsed" VerticalAlignment="Bottom" Height="{Binding Source={ThemeResource OverlayCornerRadius}, Path=BottomLeft}" Margin="{Binding Source={ThemeResource OverlayCornerRadius},&#xA;                                Converter={StaticResource TabViewLeftInsetCornerConverter}}" Stretch="Uniform" Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}" Data="M4 0 L4 4 L0 4 A4,4 90 0 0 4 0 Z" />
-            <Path x:Name="RightRadiusRender" x:Load="False" Grid.Column="2" Visibility="Collapsed" VerticalAlignment="Bottom" Height="{Binding Source={ThemeResource OverlayCornerRadius}, Path=BottomRight}" Margin="{Binding Source={ThemeResource OverlayCornerRadius},&#xA;                                Converter={StaticResource TabViewRightInsetCornerConverter}}" Stretch="Uniform" Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}" Data="M0 0 L0 4 L4 4 A4 4 90 0 1 0 0 Z" />
+            <Path x:Name="LeftRadiusRender" x:Load="False" Grid.Column="0" Visibility="Collapsed" VerticalAlignment="Bottom" Height="{Binding Source={ThemeResource OverlayCornerRadius}, Path=BottomLeft}" Margin="{Binding Source={ThemeResource OverlayCornerRadius},&#xD;&#xA;                                Converter={StaticResource TabViewLeftInsetCornerConverter}}" Stretch="Uniform" Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}" Data="M4 0 L4 4 L0 4 A4,4 90 0 0 4 0 Z" />
+            <Path x:Name="RightRadiusRender" x:Load="False" Grid.Column="2" Visibility="Collapsed" VerticalAlignment="Bottom" Height="{Binding Source={ThemeResource OverlayCornerRadius}, Path=BottomRight}" Margin="{Binding Source={ThemeResource OverlayCornerRadius},&#xD;&#xA;                                Converter={StaticResource TabViewRightInsetCornerConverter}}" Stretch="Uniform" Fill="{ThemeResource TabViewItemHeaderBackgroundSelected}" Data="M0 0 L0 4 L4 4 A4 4 90 0 1 0 0 Z" />
             <Border x:Name="TabSeparator" HorizontalAlignment="Right" Width="1" Grid.Column="1" BorderBrush="{ThemeResource TabViewItemSeparator}" BorderThickness="1" Margin="{ThemeResource TabViewItemSeparatorMargin}" />
             <Grid x:Name="TabContainer" Grid.Column="1" Background="{ThemeResource TabViewItemHeaderBackground}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Control.IsTemplateFocusTarget="True" Padding="{ThemeResource TabViewItemHeaderPadding}" CornerRadius="{Binding Source={ThemeResource OverlayCornerRadius}, Converter={StaticResource TopCornerRadiusFilterConverter}}" FocusVisualMargin="{TemplateBinding FocusVisualMargin}">
               <Grid.ColumnDefinitions>

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_themeresources.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_themeresources.xaml
@@ -519,12 +519,14 @@
                                         <CalendarPanel x:Name="MonthViewPanel" />
                                     </ScrollViewer>
                                 </Grid>
+								<!-- Uno only: Opacity set to 0 to avoir flicker when changing display mode -->
 								<ScrollViewer x:Name="YearViewScrollViewer" UseLayoutRounding="False" Opacity="0" Visibility="Collapsed" IsFocusEngagementEnabled="True" Style="{StaticResource ScrollViewerStyle}">
                                     <ScrollViewer.RenderTransform>
                                         <ScaleTransform x:Name="YearViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
                                     </ScrollViewer.RenderTransform>
                                     <CalendarPanel x:Name="YearViewPanel" />
                                 </ScrollViewer>
+								<!-- Uno only: Opacity set to 0 to avoir flicker when changing display mode -->
 								<ScrollViewer x:Name="DecadeViewScrollViewer" UseLayoutRounding="False" IsFocusEngagementEnabled="True" Opacity="0" Visibility="Collapsed" Style="{StaticResource ScrollViewerStyle}">
                                     <ScrollViewer.RenderTransform>
                                         <ScaleTransform x:Name="DecadeViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_themeresources.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_themeresources.xaml
@@ -259,6 +259,11 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
                                         </ObjectAnimationUsingKeyFrames>
+										<!--Begin: Uno only - We changed the default value to avoid flicker, make sure to set it to 1 even if transitions are disabled -->
+										<DoubleAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Opacity">
+											<DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
+										</DoubleAnimationUsingKeyFrames>
+										<!--End: Uno only-->
 									</Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Decade">
@@ -277,14 +282,16 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Visibility">
                                             <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
                                         </ObjectAnimationUsingKeyFrames>
+										<!--Begin: Uno only - We changed the default value to avoid flicker, make sure to set it to 1 even if transitions are disabled -->
+										<DoubleAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Opacity">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
+                                        </DoubleAnimationUsingKeyFrames>
+										<!--End: Uno only-->
                                     </Storyboard>
                                 </VisualState>
                                 <VisualStateGroup.Transitions>
                                     <VisualTransition From="Month" To="Year">
                                         <Storyboard>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
-                                                <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
-                                            </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MonthView" Storyboard.TargetProperty="Opacity">
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
@@ -293,6 +300,10 @@
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0.233" Value="0" />
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.733" Value="1" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
+											<!--Uno only: Make sure to set visibility only AFTER opacity -->
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
+												<DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
+											</ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MonthViewTransform" Storyboard.TargetProperty="ScaleX">
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0.84" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
@@ -367,9 +378,6 @@
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Visibility">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
                                             </ObjectAnimationUsingKeyFrames>
-                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Visibility">
-                                                <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
-                                            </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="YearViewScrollViewer" Storyboard.TargetProperty="Opacity">
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
@@ -378,6 +386,10 @@
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0.233" Value="0" />
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.733" Value="1" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
+											<!--Uno only: Make sure to set visibility only AFTER opacity -->
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="DecadeViewScrollViewer" Storyboard.TargetProperty="Visibility">
+												<DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible" />
+											</ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="YearViewTransform" Storyboard.TargetProperty="ScaleX">
                                                 <SplineDoubleKeyFrame KeyTime="0:0:0.233" Value="0.84" KeySpline="0.1,0.9,0.2,1" />
                                             </DoubleAnimationUsingKeyFrames>
@@ -507,13 +519,13 @@
                                         <CalendarPanel x:Name="MonthViewPanel" />
                                     </ScrollViewer>
                                 </Grid>
-                                <ScrollViewer x:Name="YearViewScrollViewer" UseLayoutRounding="False" Visibility="Collapsed" IsFocusEngagementEnabled="True" Style="{StaticResource ScrollViewerStyle}">
+								<ScrollViewer x:Name="YearViewScrollViewer" UseLayoutRounding="False" Opacity="0" Visibility="Collapsed" IsFocusEngagementEnabled="True" Style="{StaticResource ScrollViewerStyle}">
                                     <ScrollViewer.RenderTransform>
                                         <ScaleTransform x:Name="YearViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
                                     </ScrollViewer.RenderTransform>
                                     <CalendarPanel x:Name="YearViewPanel" />
                                 </ScrollViewer>
-                                <ScrollViewer x:Name="DecadeViewScrollViewer" UseLayoutRounding="False" IsFocusEngagementEnabled="True" Visibility="Collapsed" Style="{StaticResource ScrollViewerStyle}">
+								<ScrollViewer x:Name="DecadeViewScrollViewer" UseLayoutRounding="False" IsFocusEngagementEnabled="True" Opacity="0" Visibility="Collapsed" Style="{StaticResource ScrollViewerStyle}">
                                     <ScrollViewer.RenderTransform>
                                         <ScaleTransform x:Name="DecadeViewTransform" CenterX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterX}" CenterY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.CenterY}" />
                                     </ScrollViewer.RenderTransform>

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/Primitives/CalendarPanel.ModernCollectionBasePanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/Primitives/CalendarPanel.ModernCollectionBasePanel.cs
@@ -509,7 +509,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 #else
 			ShouldInterceptInvalidate = true;
 #endif
-			var index = -1;
+			int index = -1, startIndex = 0, firstVisibleIndex = -1, lastVisibleIndex = -1;
 			var bottom = 0.0;
 			try
 			{
@@ -524,7 +524,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				}
 
 				// Gets the index of the first element to render and the actual viewport to use
-				_layoutStrategy.EstimateElementIndex(ElementType.ItemContainer, default, default, viewport, out var renderWindow, out var startIndex);
+				_layoutStrategy.EstimateElementIndex(ElementType.ItemContainer, default, default, viewport, out var renderWindow, out startIndex);
 				renderWindow.Size = requestedRenderingWindow.Size; // The renderWindow contains only position information
 				startIndex = Math.Max(0, startIndex - StartIndex);
 
@@ -533,7 +533,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				_cache.BeginGeneration(startIndex, startIndex + expectedItemsCount);
 
 				index = startIndex;
-				int firstVisibleIndex = -1, lastVisibleIndex = -1;
 				var count = _host.Count;
 				var layout = new LayoutReference { RelativeLocation = ReferenceIdentity.Myself };
 				var currentLine = (y: double.MinValue, col: 0);
@@ -605,12 +604,12 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 					index++;
 				}
-				
-				FirstVisibleIndexBase = Math.Max(firstVisibleIndex, startIndex);
-				LastVisibleIndexBase = Math.Max(FirstVisibleIndexBase, lastVisibleIndex);
 			}
 			finally
 			{
+				FirstVisibleIndexBase = Math.Max(firstVisibleIndex, startIndex);
+				LastVisibleIndexBase = Math.Max(FirstVisibleIndexBase, lastVisibleIndex);
+
 				foreach (var unusedEntry in _cache.CompleteGeneration(index - 1))
 				{
 					Children.Remove(unusedEntry.Container);


### PR DESCRIPTION
## Bugfix
Avoid flicker when changing `DisplayMode` of `CalendarView` 

## What is the current behavior?
We briefly see the "year view" before transitioning from "month view" to "year view"

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
