### PR TITLE
fix(reg): Fix mousewheel support in popup

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3726,6 +3726,10 @@
 			<Member
 				fullName="System.Void Uno.UI.Controls.Legacy.HorizontalGridView.OnIsEnabledChanged(System.Boolean oldValue, System.Boolean newValue)"
 				reason="Internal method which is not part of the UWP API" />
+			
+			<Member
+				fullName="System.Boolean Windows.UI.Xaml.UIElement.DispatchEvent(System.Int32 handle, System.String eventName, System.String eventArgs)"
+				reason="Public only for marshaling purposes, need to change return value" />
 		</Methods>
 		<Fields>
 			<Member

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -111,25 +111,41 @@ namespace Windows.UI.Xaml
 		//	But the web-browser will actually behave like WinUI for pointerenter and pointerleave, so here by setting it to true,
 		//	we just ensure that the managed code won't try to bubble it by its own.
 		//	However, if the event is Handled in managed, it will then bubble while it should not! https://github.com/unoplatform/uno/issues/3007
-		private static bool DispatchNativePointerEnter(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerEnter(ToPointerArgs(target, args, isInContact: false));
+		// Note about the HtmlEventDispatchResult:
+		//	For pointer events we never want to prevent the default behavior.
+		//	Especially for wheel where preventing the default would break scrolling.
+		//	cf. remarks on HtmlEventDispatchResult.PreventDefault
+		private static HtmlEventDispatchResult DispatchNativePointerEnter(UIElement target, string eventPayload)
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerEnter(ToPointerArgs(target, args, isInContact: false))
+				? HtmlEventDispatchResult.StopPropagation
+				: HtmlEventDispatchResult.Ok;
 
-		private static bool DispatchNativePointerLeave(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerExited(ToPointerArgs(target, args, isInContact: false));
+		private static HtmlEventDispatchResult DispatchNativePointerLeave(UIElement target, string eventPayload)
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerExited(ToPointerArgs(target, args, isInContact: false))
+				? HtmlEventDispatchResult.StopPropagation
+				: HtmlEventDispatchResult.Ok;
 
-		private static bool DispatchNativePointerDown(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerDown(ToPointerArgs(target, args, isInContact: true));
+		private static HtmlEventDispatchResult DispatchNativePointerDown(UIElement target, string eventPayload)
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerDown(ToPointerArgs(target, args, isInContact: true))
+				? HtmlEventDispatchResult.StopPropagation
+				: HtmlEventDispatchResult.Ok;
 
-		private static bool DispatchNativePointerUp(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerUp(ToPointerArgs(target, args, isInContact: true));
+		private static HtmlEventDispatchResult DispatchNativePointerUp(UIElement target, string eventPayload)
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerUp(ToPointerArgs(target, args, isInContact: true))
+				? HtmlEventDispatchResult.StopPropagation
+				: HtmlEventDispatchResult.Ok;
 
-		private static bool DispatchNativePointerMove(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerMove(ToPointerArgs(target, args, isInContact: true));
+		private static HtmlEventDispatchResult DispatchNativePointerMove(UIElement target, string eventPayload)
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerMove(ToPointerArgs(target, args, isInContact: true))
+				? HtmlEventDispatchResult.StopPropagation
+				: HtmlEventDispatchResult.Ok;
 
-		private static bool DispatchNativePointerCancel(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerCancel(ToPointerArgs(target, args, isInContact: false), isSwallowedBySystem: true);
+		private static HtmlEventDispatchResult DispatchNativePointerCancel(UIElement target, string eventPayload)
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerCancel(ToPointerArgs(target, args, isInContact: false), isSwallowedBySystem: true)
+				? HtmlEventDispatchResult.StopPropagation
+				: HtmlEventDispatchResult.Ok;
 
-		private static bool DispatchNativePointerWheel(UIElement target, string eventPayload)
+		private static HtmlEventDispatchResult DispatchNativePointerWheel(UIElement target, string eventPayload)
 		{
 			if (TryParse(eventPayload, out var args))
 			{
@@ -146,11 +162,13 @@ namespace Windows.UI.Xaml
 					// Note: Web browser vertical scrolling is the opposite compared to WinUI!
 					handled |= target.OnNativePointerWheel(ToPointerArgs(target, args, wheel: (false, -args.wheelDeltaY), isInContact: null /* maybe */));
 				}
-				return handled;
+				return handled
+					? HtmlEventDispatchResult.StopPropagation
+					: HtmlEventDispatchResult.Ok;
 			}
 			else
 			{
-				return false;
+				return HtmlEventDispatchResult.Ok;
 			}
 		}
 

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -52,6 +52,14 @@ declare namespace Uno.UI {
         private static isConnectedPolyfill;
     }
 }
+declare module Uno.UI {
+    enum HtmlEventDispatchResult {
+        Ok = 0,
+        StopPropagation = 1,
+        PreventDefault = 2,
+        NotDispatched = 128
+    }
+}
 declare namespace Uno.Http {
     interface IHttpClientConfig {
         id: string;

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -158,6 +158,19 @@ var Uno;
 })(Uno || (Uno = {}));
 var Uno;
 (function (Uno) {
+    var UI;
+    (function (UI) {
+        let HtmlEventDispatchResult;
+        (function (HtmlEventDispatchResult) {
+            HtmlEventDispatchResult[HtmlEventDispatchResult["Ok"] = 0] = "Ok";
+            HtmlEventDispatchResult[HtmlEventDispatchResult["StopPropagation"] = 1] = "StopPropagation";
+            HtmlEventDispatchResult[HtmlEventDispatchResult["PreventDefault"] = 2] = "PreventDefault";
+            HtmlEventDispatchResult[HtmlEventDispatchResult["NotDispatched"] = 128] = "NotDispatched";
+        })(HtmlEventDispatchResult = UI.HtmlEventDispatchResult || (UI.HtmlEventDispatchResult = {}));
+    })(UI = Uno.UI || (Uno.UI = {}));
+})(Uno || (Uno = {}));
+var Uno;
+(function (Uno) {
     var Http;
     (function (Http) {
         class HttpClient {
@@ -990,9 +1003,12 @@ var Uno;
             }
             static dispatchPointerEvent(element, evt) {
                 const payload = WindowManager.pointerEventExtractor(evt);
-                const handled = WindowManager.current.dispatchEvent(element, evt.type, payload);
-                if (handled) {
+                const result = WindowManager.current.dispatchEvent(element, evt.type, payload);
+                if (result & UI.HtmlEventDispatchResult.StopPropagation) {
                     evt.stopPropagation();
+                }
+                if (result & UI.HtmlEventDispatchResult.PreventDefault) {
+                    evt.preventDefault();
                 }
             }
             static onPointerEnterReceived(evt) {
@@ -1097,9 +1113,11 @@ var Uno;
                     const eventPayload = eventExtractor
                         ? `${eventExtractor(event)}`
                         : "";
-                    var handled = this.dispatchEvent(element, eventName, eventPayload);
-                    if (handled) {
+                    const result = this.dispatchEvent(element, eventName, eventPayload);
+                    if (result & UI.HtmlEventDispatchResult.StopPropagation) {
                         event.stopPropagation();
+                    }
+                    if (result & UI.HtmlEventDispatchResult.PreventDefault) {
                         event.preventDefault();
                     }
                 };
@@ -1831,7 +1849,7 @@ var Uno;
                     // this way always succeed because synchronous calls are not possible
                     // between the host and the browser, unlike wasm.
                     UnoDispatch.dispatch(this.handleToString(htmlId), eventName, eventPayload);
-                    return true;
+                    return UI.HtmlEventDispatchResult.Ok;
                 }
                 else {
                     return WindowManager.dispatchEventMethod(htmlId, eventName, eventPayload || "");
@@ -1904,7 +1922,7 @@ var Uno;
         WindowManager.MAX_HEIGHT = `${Number.MAX_SAFE_INTEGER}vh`;
         UI.WindowManager = WindowManager;
         if (typeof define === "function") {
-            define([`${config.uno_app_base}/AppManifest`], () => {
+            define([`./AppManifest.js`], () => {
             });
         }
         else {

--- a/src/Uno.UI/ts/HtmlEventDispatchResult.ts
+++ b/src/Uno.UI/ts/HtmlEventDispatchResult.ts
@@ -1,0 +1,8 @@
+﻿module Uno.UI {
+	export enum HtmlEventDispatchResult {
+		Ok = 0,
+		StopPropagation = 1,
+		PreventDefault = 2,
+		NotDispatched = 128
+	}
+}

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -892,12 +892,12 @@ namespace Uno.UI {
 
 		public static dispatchPointerEvent(element: HTMLElement | SVGElement, evt: PointerEvent): void {
 			const payload = WindowManager.pointerEventExtractor(evt);
-			const handled = WindowManager.current.dispatchEvent(element, evt.type, payload);
-			if (handled) {
+			const result = WindowManager.current.dispatchEvent(element, evt.type, payload);
+			if (result & HtmlEventDispatchResult.StopPropagation) {
 				evt.stopPropagation();
-				// Not calling preventDefault() here, as that will break native focus dispatch for pointerdown
-				// If needed, we may add preventDefault() for some specific event type later, but it is not needed
-				// for any scenario yet.
+			}
+			if (result & HtmlEventDispatchResult.PreventDefault) {
+				evt.preventDefault();
 			}
 		}
 
@@ -1028,9 +1028,11 @@ namespace Uno.UI {
 					? `${eventExtractor(event)}`
 					: "";
 
-				var handled = this.dispatchEvent(element, eventName, eventPayload);
-				if (handled) {
+				const result = this.dispatchEvent(element, eventName, eventPayload);
+				if (result & HtmlEventDispatchResult.StopPropagation) {
 					event.stopPropagation();
+				}
+				if (result & HtmlEventDispatchResult.PreventDefault) {
 					event.preventDefault();
 				}
 			};
@@ -1943,7 +1945,7 @@ namespace Uno.UI {
 			}
 		}
 
-		private dispatchEvent(element: HTMLElement | SVGElement, eventName: string, eventPayload: string = null): boolean {
+		private dispatchEvent(element: HTMLElement | SVGElement, eventName: string, eventPayload: string = null): HtmlEventDispatchResult {
 			const htmlId = Number(element.getAttribute("XamlHandle"));
 
 			// console.debug(`${element.getAttribute("id")}: Raising event ${eventName}.`);
@@ -1957,7 +1959,7 @@ namespace Uno.UI {
 				// this way always succeed because synchronous calls are not possible
 				// between the host and the browser, unlike wasm.
 				UnoDispatch.dispatch(this.handleToString(htmlId), eventName, eventPayload);
-				return true;
+				return HtmlEventDispatchResult.Ok;
 			}
 			else {
 				return WindowManager.dispatchEventMethod(htmlId, eventName, eventPayload || "");


### PR DESCRIPTION
## Bugfix
Scrolling using mouse wheel does not works anymore while in popup

## What is the current behavior?
The `PopupPanel` is handling all pointer events to avoid interaction with content below, but now flagging a routed event as `Handled = true` is also doing `preventDefault` in native.

But the `preventDefault` not only impacts the element that request and its parent, but also its children (the "default behavior"is applied only once the event has bubbled up to the root element).

This means that when the `PopupPanel` is flagging the `PointerWheel` event as handled, it will also prevent native scrolling for its children.

## What is the new behavior?
Managed code can now customize if the native event should be flagged as `stopPropagation()` and/or `preventDefault()`, and pointers events never request a `preventDefault()`

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Breaking
The `UIElement.DispatchEvent` now returns an `int`