### PR TITLE
fix(calendarpicker): Make sure to clear the over visual state when closing and re-opening the picker

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewBaseItemChrome.uno.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewBaseItemChrome.uno.cs
@@ -20,6 +20,14 @@ namespace Windows.UI.Xaml.Controls
 
 		private void Uno_MeasureChrome(Size availableSize)
 		{
+			// Uno Patch:
+			// When CalendarDatePicker is closing we won't get a PointerExited, so we will stay flag as hovered.
+			// If we re-open the picker, the flag is never cleared and we will still drawing the over state.
+			// Here we patch this by syncing the local over state with the uno's internal over state.
+			if (IsHovered() && !IsPointerOver)
+			{
+				SetIsHovered(false);
+			}
 		}
 
 		private void Uno_ArrangeChrome(Rect finalBounds)


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/6154

## Bugfix
Clear the over state when control is hidden / unloaded

## What is the current behavior?
cf. linked bug

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
