### PR TITLE
JumpListItem.Description should allow `null`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_StartScreen/Given_JumpListItem.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_StartScreen/Given_JumpListItem.cs
@@ -111,6 +111,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_StartScreen
 			item.Logo = new Uri("ms-appx:///Test.png");
 			Assert.AreEqual("ms-appx:///Test.png", item.Logo.AbsoluteUri);
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Description_Is_Empty_No_Exception()
+		{
+			try
+			{
+				var item = JumpListItem.CreateWithArguments("Hello", "Test");
+				item.Description = string.Empty;
+				var jumpList = await JumpList.LoadCurrentAsync();
+				jumpList.Items.Clear();
+				jumpList.Items.Add(item);
+				await jumpList.SaveAsync();
+				// reload from native
+				var newJumpList = await JumpList.LoadCurrentAsync();
+				Assert.AreEqual(string.Empty, newJumpList.Items.First().Description);
+			}
+			finally
+			{
+				var jumpList = await JumpList.LoadCurrentAsync();
+				jumpList.Items.Clear();
+				await jumpList.SaveAsync();
+			}
+		}
 	}
 }
 #endif

--- a/src/Uno.UWP/UI/StartScreen/Extensions/ShortcutInfoExtensions.Android.cs
+++ b/src/Uno.UWP/UI/StartScreen/Extensions/ShortcutInfoExtensions.Android.cs
@@ -26,7 +26,10 @@ namespace Uno.UI.StartScreen.Extensions
 			}
 
 			var jumpListItem = JumpListItem.CreateWithArguments(shortcut.Id, shortcut.ShortLabel);
-			jumpListItem.Description = shortcut.LongLabel;
+			if (!string.IsNullOrEmpty(shortcut.LongLabel))
+			{
+				jumpListItem.Description = shortcut.LongLabel;
+			}
 			if (shortcut.Extras.ContainsKey(JumpListItem.ImagePathKey))
 			{
 				var imagePath = shortcut.Extras.GetString(JumpListItem.ImagePathKey);


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #1418


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`null` is not allowed


## What is the new behavior?

Allowed


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.