### PR TITLE
fix(ApplicationLanguages): Prevent NullReferenceException for ManifestLanguages

### DIFF
--- a/src/Uno.UWP/Globalization/ApplicationLanguages.cs
+++ b/src/Uno.UWP/Globalization/ApplicationLanguages.cs
@@ -44,13 +44,11 @@ namespace Windows.Globalization
 			var languages = new[]
 			{
 #if __ANDROID__
-#pragma warning disable CS0618 // Type or member is obsolete
-				ContextHelper.Current.Resources.Configuration.Locale.ToLanguageTag(),
-#pragma warning restore CS0618 // Type or member is obsolete
+				ContextHelper.Current?.Resources?.Configuration?.Locales?.Get(0)?.ToLanguageTag(),
 #endif
-				CultureInfo.InstalledUICulture.Name,
-				CultureInfo.CurrentUICulture.Name,
-				CultureInfo.CurrentCulture.Name
+				CultureInfo.InstalledUICulture?.Name,
+				CultureInfo.CurrentUICulture?.Name,
+				CultureInfo.CurrentCulture?.Name
 			};
 
 			return languages


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6156 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On Android, GetManifestLanguages raises a NullReferenceException, preventing the languages override to work properly

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
No exception raised

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
