### PR TITLE
feat: Support for Clipboard on WPF and Gtk

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/ApplicationModel/DataTransfer/ClipboardExtensions.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/ApplicationModel/DataTransfer/ClipboardExtensions.cs
@@ -224,7 +224,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.ApplicationModel.DataTransfer
 					foreach (var item in items)
 					{
 						var path = item.Path;
-						builder.AppendLine(UrlEncode(path));
+						builder.AppendLine(FileUriHelper.UrlEncode(path));
 					}
 
 					nativeData.Set(GnomeCopiedFilesContent, 8, Encoding.UTF8.GetBytes(builder.ToString().Trim()));
@@ -298,39 +298,6 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.ApplicationModel.DataTransfer
 		private void Clipboard_OwnerChange(object o, OwnerChangeArgs args)
 		{
 			ContentChanged?.Invoke(this, args);
-		}
-
-		/// <summary>
-		/// Encodes a file path to a file:// Url.
-		/// While the built-in Uri class can handle this, it does not process files
-		/// such as '/home/user/%51.txt' correctly.
-		/// </summary>
-		/// <param name="path">Path to the file</param>
-		/// <returns>file:// url to the file</returns>
-		private string UrlEncode(string path)
-		{
-			var uri = new StringBuilder();
-			foreach (var ch in path)
-			{
-				if (('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || ('0' <= ch && ch <= '9') ||
-					"-._~".Contains(ch))
-				{
-					uri.Append(ch);
-				}
-				else if (ch == Path.DirectorySeparatorChar || ch == Path.AltDirectorySeparatorChar)
-				{
-					uri.Append('/');
-				}
-				else
-				{
-					var bytes = Encoding.UTF8.GetBytes(new[] { ch });
-					foreach (var b in bytes)
-					{
-						uri.Append($"%{b:X2}");
-					}
-				}
-			}
-			return "file://" + uri;
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/ApplicationModel/DataTransfer/ClipboardExtensions.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/ApplicationModel/DataTransfer/ClipboardExtensions.cs
@@ -1,0 +1,266 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Gdk;
+using Gtk;
+using Uno.ApplicationModel.DataTransfer;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Streams;
+using Windows.UI.Core;
+using Clipboard = Gtk.Clipboard;
+
+namespace Uno.UI.Runtime.Skia.GTK.Extensions.ApplicationModel.DataTransfer
+{
+	internal class ClipboardExtensions : IClipboardExtension
+	{
+		public event EventHandler<object> ContentChanged;
+
+		static readonly Atom HtmlContent = Atom.Intern("text/html", false);
+		static readonly Atom RtfContent = Atom.Intern("text/rtf", false);
+		static readonly Atom GnomeCopiedFilesContent = Atom.Intern("x-special/gnome-copied-files", false);
+
+		private Clipboard _clipboard;
+
+		public ClipboardExtensions(object owner)
+		{
+			_clipboard = Clipboard.GetDefault(GtkHost.Window.Display);
+		}
+
+		public void Clear() => _clipboard.Clear();
+		public void Flush()
+		{
+			_clipboard.CanStore = null;
+			_clipboard.Store();
+		}
+
+		public DataPackageView GetContent()
+		{
+			var dataPackage = new DataPackage();
+
+			if (_clipboard.WaitIsImageAvailable())
+			{
+				dataPackage.SetDataProvider(StandardDataFormats.Bitmap, async ct =>
+				{
+					var image = _clipboard.WaitForImage();
+					var data = image.SaveToBuffer("bmp");
+					var stream = new MemoryStream(data);
+					return RandomAccessStreamReference.CreateFromStream(stream.AsRandomAccessStream());
+				});
+			}
+			if (_clipboard.WaitIsTargetAvailable(HtmlContent))
+			{
+				dataPackage.SetDataProvider(StandardDataFormats.Html, async ct =>
+				{
+					var selectionData = _clipboard.WaitForContents(HtmlContent);
+					return Encoding.UTF8.GetString(selectionData.Data);
+				});
+			}
+			if (_clipboard.WaitIsTargetAvailable(RtfContent))
+			{
+				dataPackage.SetDataProvider(StandardDataFormats.Rtf, async ct =>
+				{
+					var selectionData = _clipboard.WaitForContents(RtfContent);
+					return Encoding.UTF8.GetString(selectionData.Data);
+				});
+			}
+			if (_clipboard.WaitIsTextAvailable())
+			{
+				dataPackage.SetDataProvider(StandardDataFormats.Text, async ct =>
+				{
+					return _clipboard.WaitForText();
+				});
+			}
+			if (_clipboard.WaitIsUrisAvailable())
+			{
+				// We have to get the actual Uris before determining
+				// the Uri types. Therefore, we will not use SetDataProvider here.
+
+				// Gtk documentation https://developer.gnome.org/gtk3/stable/gtk3-Clipboards.html#gtk-clipboard-wait-for-uris
+				// says that the function returns an **array** of strings,
+				// while GTK# just exposes 1 string?
+				var uris = _clipboard.WaitForUris();
+
+				global::System.Diagnostics.Debug.WriteLine(uris);
+
+				if (uris != null)
+				{
+					DataPackage.SeparateUri(
+						uris,
+						out string webLink,
+						out string applicationLink);
+
+					var clipWebLink = webLink != null ? new Uri(webLink) : null;
+					var clipApplicationLink = applicationLink != null ? new Uri(applicationLink) : null;
+					var clipUri = new Uri(uris);
+
+					if (clipWebLink != null)
+					{
+						dataPackage.SetWebLink(clipWebLink);
+					}
+					if (clipApplicationLink != null)
+					{
+						dataPackage.SetApplicationLink(clipApplicationLink);
+					}
+					if (clipUri != null)
+					{
+						dataPackage.SetUri(clipUri);
+					}
+				}
+			}
+			if (_clipboard.WaitIsTargetAvailable(GnomeCopiedFilesContent))
+			{
+				dataPackage.SetDataProvider(StandardDataFormats.StorageItems, async ct =>
+				{
+					// Got some hint here: https://stackoverflow.com/a/7356732
+					// This function does NOT work on distros using Nautilus (the popular Ubuntu), 
+					// as the copied files are visible as **plain text** to all other
+					// programs, and registers no special data type for files on clipboard.
+					var data = _clipboard.WaitForContents(GnomeCopiedFilesContent);
+					// The first element is the command (cut, copy,...)
+					var dataList = Encoding.UTF8.GetString(data.Data).Split('\n').Skip(1);
+
+					var storageItemList = new List<IStorageItem>();
+
+					foreach (var fileUriString in dataList)
+					{
+						var fileUri = new Uri(fileUriString);
+						var path = fileUri.LocalPath;
+
+						var attr = File.GetAttributes(path);
+						if (attr.HasFlag(global::System.IO.FileAttributes.Directory))
+						{
+							storageItemList.Add(await StorageFolder.GetFolderFromPathAsync(path));
+						}
+						else
+						{
+							storageItemList.Add(await StorageFile.GetFileFromPathAsync(path));
+						}
+					}
+
+					return storageItemList;
+				});
+			}
+
+			return dataPackage.GetView();
+		}
+
+		public void SetContent(DataPackage content)
+		{
+			if (content is null)
+			{
+				throw new ArgumentNullException(nameof(content));
+			}
+
+			CoreDispatcher.Main.RunAsync(
+				CoreDispatcherPriority.High,
+				() => SetContentAsync(content));
+		}
+
+		private async Task SetContentAsync(DataPackage content)
+		{
+			var data = content?.GetView();
+
+			if (data?.Contains(StandardDataFormats.Text) ?? false)
+			{
+				_clipboard.Text = await data.GetTextAsync();
+			}
+			if (data?.Contains(StandardDataFormats.Bitmap) ?? false)
+			{
+				var streamRef = await data.GetBitmapAsync();
+				var runtimeStream = await streamRef.OpenReadAsync();
+				var stream = runtimeStream.AsStreamForRead();
+				_clipboard.Image = new Pixbuf(stream);
+			}
+			if (data?.Contains(StandardDataFormats.Html) ?? false)
+			{
+				var htmlString = await data.GetHtmlFormatAsync();
+				_clipboard.SetWithData(new[] { new TargetEntry("text/html", 0, 0) },
+					(clipboard, selection, info) =>
+					{
+						selection.Set(HtmlContent, 8, Encoding.UTF8.GetBytes(htmlString));
+					},
+					(clipboard) => { });
+			}
+			if (data?.Contains(StandardDataFormats.Rtf) ?? false)
+			{
+				var rtfString = await data.GetRtfAsync();
+				_clipboard.SetWithData(new[] { new TargetEntry("text/rtf", 0, 0) },
+					(clipboard, selection, info) =>
+					{
+						selection.Set(RtfContent, 8, Encoding.UTF8.GetBytes(rtfString));
+					},
+					(clipboard) => { });
+			}
+			if (data?.Contains(StandardDataFormats.StorageItems) ?? false)
+			{
+				var items = await data?.GetStorageItemsAsync();
+				var builder = new StringBuilder();
+
+				builder.AppendLine("copy");
+				foreach (var item in items)
+				{
+					var path = item.Path;
+					builder.AppendLine(UrlEncode(path));
+				}
+
+				var target0 = new TargetEntry("x-special/gnome-copied-files", 0, 0);
+				var target1 = new TargetEntry("text/uri-list", 0, 0);
+
+				_clipboard.SetWithData(new[] { target0, target1 },
+				(clipboard, selection, info) =>
+				{
+					selection.Set(selection.Target, 8, Encoding.UTF8.GetBytes(builder.ToString()));
+				},
+				(clipboard) => { });
+			}
+		}
+
+		public void StartContentChanged()
+		{
+			_clipboard.OwnerChange += Clipboard_OwnerChange;
+		}
+
+		public void StopContentChanged()
+		{
+			_clipboard.OwnerChange -= Clipboard_OwnerChange;
+		}
+
+		private void Clipboard_OwnerChange(object o, OwnerChangeArgs args)
+		{
+			ContentChanged?.Invoke(this, args);
+		}
+
+		/// <summary>
+		/// Encodes a file path to a file:// Url.
+		/// While the built-in Uri class can handle this, it does not process files
+		/// such as '/home/user/%51.txt' correctly.
+		/// </summary>
+		/// <param name="path">Path to the file</param>
+		/// <returns>file:// url to the file</returns>
+		private string UrlEncode(string path)
+		{
+			var uri = new StringBuilder();
+			foreach (var ch in path)
+			{
+				if (('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || ('0' <= ch && ch <= '9') ||
+					"-._~".Contains(ch))
+				{
+					uri.Append(ch);
+				}
+				else if (ch == Path.DirectorySeparatorChar || ch == Path.AltDirectorySeparatorChar)
+				{
+					uri.Append('/');
+				}
+				else
+				{
+					uri.Append($"%{(int)ch:X2}");
+				}
+			}
+			return "file://" + uri.ToString();
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/ApplicationModel/DataTransfer/ClipboardExtensions.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/ApplicationModel/DataTransfer/ClipboardExtensions.cs
@@ -25,7 +25,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.ApplicationModel.DataTransfer
 		static readonly Atom RtfContent = Atom.Intern("text/rtf", false);
 		static readonly Atom GnomeCopiedFilesContent = Atom.Intern("x-special/gnome-copied-files", false);
 
-		private Clipboard _clipboard;
+		private readonly Clipboard _clipboard;
 
 		public ClipboardExtensions(object owner)
 		{
@@ -273,7 +273,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.ApplicationModel.DataTransfer
 					}
 				}
 			}
-			return "file://" + uri.ToString();
+			return "file://" + uri;
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -18,6 +18,8 @@ using Uno.UI.Runtime.Skia.GTK.Extensions.System;
 using Uno.UI.Runtime.Skia.GTK.UI.Core;
 using Uno.Extensions.Storage.Pickers;
 using Windows.Storage.Pickers;
+using Uno.ApplicationModel.DataTransfer;
+using Uno.UI.Runtime.Skia.GTK.Extensions.ApplicationModel.DataTransfer;
 
 namespace Uno.UI.Runtime.Skia
 {
@@ -59,6 +61,7 @@ namespace Uno.UI.Runtime.Skia
 			ApiExtensibility.Register(typeof(ILauncherExtension), o => new LauncherExtension(o));
 			ApiExtensibility.Register<FileOpenPicker>(typeof(IFileOpenPickerExtension), o => new FileOpenPickerExtension(o));
 			ApiExtensibility.Register<FolderPicker>(typeof(IFolderPickerExtension), o => new FolderPickerExtension(o));
+			ApiExtensibility.Register(typeof(IClipboardExtension), o => new ClipboardExtensions(o));
 
 			_isDispatcherThread = true;
 			_window = new Gtk.Window("Uno Host");

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/ApplicationModel/DataTransfer/ClipboardExtensions.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/ApplicationModel/DataTransfer/ClipboardExtensions.cs
@@ -172,10 +172,11 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 		private async Task SetContentAsync(DataPackage content)
 		{
 			var data = content?.GetView();
+			var wpfData = new DataObject();
 
 			if (data?.Contains(StandardDataFormats.Text) ?? false)
 			{
-				Clipboard.SetText(await data.GetTextAsync());
+				wpfData.SetText(await data.GetTextAsync());
 			}
 			if (data?.Contains(StandardDataFormats.Bitmap) ?? false)
 			{
@@ -186,15 +187,15 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 				image.BeginInit();
 				image.StreamSource = stream;
 				image.EndInit();
-				Clipboard.SetImage(image);
+				wpfData.SetImage(image);
 			}
 			if (data?.Contains(StandardDataFormats.Html) ?? false)
 			{
-				Clipboard.SetData(DataFormats.Html, await data.GetHtmlFormatAsync());
+				wpfData.SetData(DataFormats.Html, await data.GetHtmlFormatAsync());
 			}
 			if (data?.Contains(StandardDataFormats.Rtf) ?? false)
 			{
-				Clipboard.SetData(DataFormats.Rtf, await data.GetRtfAsync());
+				wpfData.SetData(DataFormats.Rtf, await data.GetRtfAsync());
 			}
 			if (data?.Contains(StandardDataFormats.StorageItems) ?? false)
 			{
@@ -206,8 +207,10 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 					list.Add(item.Path);
 				}
 
-				Clipboard.SetFileDropList(list);
+				wpfData.SetFileDropList(list);
 			}
+
+			Clipboard.SetDataObject(wpfData);
 		}
 
 		private IntPtr OnWmMessage(IntPtr hwnd, int msg, IntPtr wparamOriginal, IntPtr lparamOriginal, ref bool handled)

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/ApplicationModel/DataTransfer/ClipboardExtensions.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/ApplicationModel/DataTransfer/ClipboardExtensions.cs
@@ -52,9 +52,9 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 				_hwndSource = fromDependencyObject as HwndSource;
 
 				if (_pendingStartContentChanged)
-                {
+				{
 					StartContentChanged();
-                }
+				}
 			}
 		}
 
@@ -66,10 +66,10 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 				ClipboardNativeFunctions.AddClipboardFormatListener(_hwndSource.Handle);
 			}
 			else
-            {
+			{
 				// Signals the app to hook when it's ready
 				_pendingStartContentChanged = true;
-            }
+			}
 		}
 
 		public void StopContentChanged()
@@ -80,9 +80,9 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 				_hwndSource.RemoveHook(OnWmMessage);
 			}
 			else
-            {
+			{
 				_pendingStartContentChanged = false;
-            }
+			}
 		}
 
 		public void Flush() => Clipboard.Flush();
@@ -218,11 +218,11 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 			switch (msg)
 			{
 				case WM_CLIPBOARDUPDATE:
-                {
+				{
 					ContentChanged?.Invoke(this, EventArgs.Empty);
 					handled = true;
 					break;
-                }
+				}
 			}
 
 			return IntPtr.Zero;

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/ApplicationModel/DataTransfer/ClipboardExtensions.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/ApplicationModel/DataTransfer/ClipboardExtensions.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media.Imaging;
+using Uno.ApplicationModel.DataTransfer;
+using Uno.UI.Skia.Platform;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Streams;
+using Windows.UI.Core;
+using Clipboard = System.Windows.Clipboard;
+
+namespace Uno.Extensions.ApplicationModel.DataTransfer
+{
+	internal class ClipboardExtensions : IClipboardExtension
+	{
+		const int WM_CLIPBOARDUPDATE = 0x031D;
+
+		private readonly WpfHost _host;
+		private HwndSource _hwndSource;
+
+		public event EventHandler<object> ContentChanged;
+
+		public ClipboardExtensions(object owner)
+		{
+			_host = WpfHost.Current;
+
+			// This class may be accessed before the Window is loaded
+			// if the Clipboard is somehow accessed really early.
+			if (_host.IsLoaded)
+			{
+				HostLoaded(null, null);
+			}
+			else
+			{
+				// Hook for native events
+				_host.Loaded += HostLoaded;
+			}
+
+			void HostLoaded(object sender, RoutedEventArgs e)
+			{
+				_host.Loaded -= HostLoaded;
+
+				var win = Window.GetWindow(_host);
+
+				var fromDependencyObject = PresentationSource.FromDependencyObject(win);
+				_hwndSource = fromDependencyObject as HwndSource;
+			}
+		}
+
+		public void StartContentChanged()
+		{
+			if (_hwndSource != null)
+			{
+				_hwndSource.AddHook(OnWmMessage);
+				ClipboardNativeFunctions.AddClipboardFormatListener(_hwndSource.Handle);
+			}
+		}
+
+		public void StopContentChanged()
+		{
+			if (_hwndSource != null)
+			{
+				ClipboardNativeFunctions.RemoveClipboardFormatListener(_hwndSource.Handle);
+				_hwndSource.RemoveHook(OnWmMessage);
+			}
+		}
+
+		public void Flush() => Clipboard.Flush();
+
+		public void Clear() => Clipboard.Clear();
+
+		public DataPackageView GetContent()
+		{
+			var dataPackage = new DataPackage();
+
+			if (Clipboard.ContainsImage())
+			{
+				dataPackage.SetDataProvider(StandardDataFormats.Bitmap, async ct =>
+				{
+					var bitmap = Clipboard.GetImage();
+					var bitmapStream = new MemoryStream();
+
+					var bitmapEncoder = new BmpBitmapEncoder();
+					bitmapEncoder.Frames.Add(BitmapFrame.Create(bitmap));
+					bitmapEncoder.Save(bitmapStream);
+
+					// Letting a MemoryStream run around does not cause problems.
+					// The GC will take care of it, just like a byte[].
+					return RandomAccessStreamReference.CreateFromStream(bitmapStream.AsRandomAccessStream());
+				});
+			}
+			if (Clipboard.ContainsText())
+			{
+				// Copying significant amounts of text still makes Clipboard.GetText() slow, so
+				// we'll still use the SetDataProvider
+				dataPackage.SetDataProvider(StandardDataFormats.Text, async ct =>
+				{
+					return Clipboard.GetText();
+				});
+			}
+			if (Clipboard.ContainsData(DataFormats.Html))
+			{
+				dataPackage.SetDataProvider(StandardDataFormats.Html, async ct =>
+				{
+					return Clipboard.GetData(DataFormats.Html);
+				});
+			}
+			if (Clipboard.ContainsData(DataFormats.Rtf))
+			{
+				dataPackage.SetDataProvider(StandardDataFormats.Rtf, async ct =>
+				{
+					return Clipboard.GetData(DataFormats.Rtf);
+				});
+			}
+			if (Clipboard.ContainsFileDropList())
+			{
+				dataPackage.SetDataProvider(StandardDataFormats.StorageItems, async ct =>
+				{
+					var list = Clipboard.GetFileDropList();
+					var storageItemList = new List<IStorageItem>(list.Count);
+					foreach (var path in list)
+					{
+						var attr = File.GetAttributes(path);
+						if (attr.HasFlag(global::System.IO.FileAttributes.Directory))
+						{
+							storageItemList.Add(await StorageFolder.GetFolderFromPathAsync(path));
+						}
+						else
+						{
+							storageItemList.Add(await StorageFile.GetFileFromPathAsync(path));
+						}
+					}
+					return storageItemList;
+				});
+			}
+
+			return dataPackage.GetView();
+		}
+
+		public void SetContent(DataPackage content)
+		{
+			if (content is null)
+			{
+				throw new ArgumentNullException(nameof(content));
+			}
+
+			CoreDispatcher.Main.RunAsync(
+				CoreDispatcherPriority.High,
+				() => SetContentAsync(content));
+		}
+
+		private async Task SetContentAsync(DataPackage content)
+		{
+			var data = content?.GetView();
+
+			if (data?.Contains(StandardDataFormats.Text) ?? false)
+			{
+				Clipboard.SetText(await data.GetTextAsync());
+			}
+			if (data?.Contains(StandardDataFormats.Bitmap) ?? false)
+			{
+				var streamRef = await data.GetBitmapAsync();
+				var runtimeStream = await streamRef.OpenReadAsync();
+				var stream = runtimeStream.AsStreamForRead();
+				var image = new BitmapImage();
+				image.BeginInit();
+				image.StreamSource = stream;
+				image.EndInit();
+				Clipboard.SetImage(image);
+			}
+			if (data?.Contains(StandardDataFormats.Html) ?? false)
+			{
+				Clipboard.SetData(DataFormats.Html, await data.GetHtmlFormatAsync());
+			}
+			if (data?.Contains(StandardDataFormats.Rtf) ?? false)
+			{
+				Clipboard.SetData(DataFormats.Rtf, await data.GetRtfAsync());
+			}
+			if (data?.Contains(StandardDataFormats.StorageItems) ?? false)
+			{
+				var items = await data?.GetStorageItemsAsync();
+				var list = new StringCollection();
+
+				foreach (var item in items)
+				{
+					list.Add(item.Path);
+				}
+
+				Clipboard.SetFileDropList(list);
+			}
+		}
+
+		private IntPtr OnWmMessage(IntPtr hwnd, int msg, IntPtr wparamOriginal, IntPtr lparamOriginal, ref bool handled)
+		{
+			switch (msg)
+			{
+				case WM_CLIPBOARDUPDATE:
+                {
+					ContentChanged?.Invoke(this, EventArgs.Empty);
+					handled = true;
+					break;
+                }
+			}
+
+			return IntPtr.Zero;
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/ApplicationModel/DataTransfer/ClipboardExtensions.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/ApplicationModel/DataTransfer/ClipboardExtensions.cs
@@ -22,6 +22,7 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 
 		private readonly WpfHost _host;
 		private HwndSource _hwndSource;
+		private bool _pendingStartContentChanged;
 
 		public event EventHandler<object> ContentChanged;
 
@@ -49,6 +50,11 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 
 				var fromDependencyObject = PresentationSource.FromDependencyObject(win);
 				_hwndSource = fromDependencyObject as HwndSource;
+
+				if (_pendingStartContentChanged)
+                {
+					StartContentChanged();
+                }
 			}
 		}
 
@@ -59,6 +65,11 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 				_hwndSource.AddHook(OnWmMessage);
 				ClipboardNativeFunctions.AddClipboardFormatListener(_hwndSource.Handle);
 			}
+			else
+            {
+				// Signals the app to hook when it's ready
+				_pendingStartContentChanged = true;
+            }
 		}
 
 		public void StopContentChanged()
@@ -68,6 +79,10 @@ namespace Uno.Extensions.ApplicationModel.DataTransfer
 				ClipboardNativeFunctions.RemoveClipboardFormatListener(_hwndSource.Handle);
 				_hwndSource.RemoveHook(OnWmMessage);
 			}
+			else
+            {
+				_pendingStartContentChanged = false;
+            }
 		}
 
 		public void Flush() => Clipboard.Flush();

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/ApplicationModel/DataTransfer/ClipboardNativeFunctions.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/ApplicationModel/DataTransfer/ClipboardNativeFunctions.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Uno.Extensions.ApplicationModel.DataTransfer
+{
+	internal static class ClipboardNativeFunctions
+	{
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool AddClipboardFormatListener(IntPtr hwnd);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool RemoveClipboardFormatListener(IntPtr hwnd);
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -31,6 +31,10 @@ using WpfApplication = System.Windows.Application;
 using WpfCanvas = System.Windows.Controls.Canvas;
 using WpfControl = System.Windows.Controls.Control;
 using WpfFrameworkPropertyMetadata = System.Windows.FrameworkPropertyMetadata;
+using Uno.UI.Xaml;
+using Uno.UI.Runtime.Skia.Wpf;
+using Uno.ApplicationModel.DataTransfer;
+using Uno.Extensions.ApplicationModel.DataTransfer;
 
 namespace Uno.UI.Skia.Platform
 {
@@ -63,6 +67,7 @@ namespace Uno.UI.Skia.Platform
 			ApiExtensibility.Register(typeof(IConnectionProfileExtension), o => new WindowsConnectionProfileExtension(o));
 			ApiExtensibility.Register<TextBoxView>(typeof(ITextBoxViewExtension), o => new TextBoxViewExtension(o));
 			ApiExtensibility.Register(typeof(ILauncherExtension), o => new LauncherExtension(o));
+			ApiExtensibility.Register(typeof(IClipboardExtension), o => new ClipboardExtensions(o));
 		}
 
 		public static WpfHost Current => _current;

--- a/src/Uno.UI.Tests/Windows_ApplicationModel_DataTransfer/Given_FileUriHelper.cs
+++ b/src/Uno.UI.Tests/Windows_ApplicationModel_DataTransfer/Given_FileUriHelper.cs
@@ -1,0 +1,21 @@
+using Windows.ApplicationModel.DataTransfer;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.Tests.Windows_ApplicationModel_DataTransfer
+{
+	[TestClass]
+	public class Given_FileUriHelper
+	{
+		[TestMethod]
+		[DataRow("/home/user/C#/foo/bar.txt", "file:///home/user/C%23/foo/bar.txt")]
+		[DataRow("/home/user/C#/foo/%79.txt", "file:///home/user/C%23/foo/%2579.txt")]
+		[DataRow("/home/user/%51.txt/", "file:///home/user/%2551.txt/")]
+		public void When_Encode_Linux_File_Path(string input, string expectedOutput)
+		{
+			var sut = FileUriHelper.UrlEncode(input);
+
+			sut.Should().Be(expectedOutput);
+		}
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.cs
@@ -9,10 +9,13 @@ namespace Windows.ApplicationModel.DataTransfer
 		private static object _syncLock = new object();
 		private static EventHandler<object> _contentChanged;
 
+#if !__SKIA__
 		public static void Flush()
 		{
 			// Do nothing, data available automatically even after application closes.
+			// Except for Skia.WPF where you do have to Flush().
 		}
+#endif
 
 		public static event EventHandler<object> ContentChanged
 		{

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.skia.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.skia.cs
@@ -1,18 +1,74 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Uno.ApplicationModel.DataTransfer;
+using Uno.Extensions;
 using Uno.Foundation;
+using Uno.Foundation.Extensibility;
 
 namespace Windows.ApplicationModel.DataTransfer
 {
 	public static partial class Clipboard
 	{
+		private static readonly Lazy<IClipboardExtension?> _clipboardExtension = new Lazy<IClipboardExtension?>(() =>
+		{
+			if (ApiExtensibility.CreateInstance<IClipboardExtension>(typeof(Clipboard), out var clipboardExtension))
+			{
+				return clipboardExtension;
+			}
+			if (typeof(Clipboard).Log().IsEnabled(LogLevel.Error))
+			{
+				typeof(Clipboard).Log().LogError("Clipboard is not implemented on this platform.");
+			}
+			return null;
+		});
+
+		public static void Flush()
+		{
+			_clipboardExtension.Value?.Flush();
+		}
+
+		public static void Clear()
+		{
+			_clipboardExtension.Value?.Clear();
+		}
+
+		public static DataPackageView? GetContent()
+		{
+			return _clipboardExtension.Value?.GetContent();
+		}
+
+		public static void SetContent(DataPackage content)
+		{
+			_clipboardExtension.Value?.SetContent(content);
+		}
+
 		private static void StartContentChanged()
 		{
+			if (_clipboardExtension.Value == null)
+			{
+				return;
+			}
+			_clipboardExtension.Value.ContentChanged += ClipboardExtension_ContentChanged;
+			_clipboardExtension.Value.StartContentChanged();
 		}
 
 		private static void StopContentChanged()
 		{
+			if (_clipboardExtension.Value == null)
+			{
+				return;
+			}
+			_clipboardExtension.Value.StopContentChanged();
+			_clipboardExtension.Value.ContentChanged -= ClipboardExtension_ContentChanged;
+		}
+
+		private static void ClipboardExtension_ContentChanged(object? sender, object? args)
+		{
+			OnContentChanged();
 		}
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/FileUriHelper.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/FileUriHelper.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Windows.ApplicationModel.DataTransfer
+{
+	internal static class FileUriHelper
+	{
+		private static readonly char[] urlAllowedChars = "-._~".ToCharArray();
+
+		/// <summary>
+		/// Encodes a file path to a file:// Url.
+		/// While the built-in Uri class can handle this, it does not process files
+		/// such as '/home/user/%51.txt' correctly.
+		/// </summary>
+		/// <param name="path">Path to the file</param>
+		/// <returns>file:// url to the file</returns>
+		public static string UrlEncode(string path)
+		{
+			var uri = new StringBuilder();
+			foreach (var ch in path)
+			{
+				if (('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || ('0' <= ch && ch <= '9') ||
+					urlAllowedChars.Contains(ch))
+				{
+					uri.Append(ch);
+				}
+				else if (ch == Path.DirectorySeparatorChar || ch == Path.AltDirectorySeparatorChar)
+				{
+					uri.Append('/');
+				}
+				else
+				{
+					var bytes = Encoding.UTF8.GetBytes(new[] { ch });
+					foreach (var b in bytes)
+					{
+						uri.Append($"%{b:X2}");
+					}
+				}
+			}
+			return "file://" + uri;
+		}
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/IClipboardExtension.skia.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/IClipboardExtension.skia.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.DataTransfer;
+
+namespace Uno.ApplicationModel.DataTransfer
+{
+	internal interface IClipboardExtension
+    {
+		event EventHandler<object> ContentChanged;
+		void StartContentChanged();
+		void StopContentChanged();
+		void Clear();
+		void Flush();
+		DataPackageView GetContent();
+		void SetContent(DataPackage content);
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.DataTransfer/Clipboard.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.DataTransfer/Clipboard.cs
@@ -62,15 +62,15 @@ namespace Windows.ApplicationModel.DataTransfer
 		// Forced skipping of method Windows.ApplicationModel.DataTransfer.Clipboard.RoamingEnabledChanged.remove
 		// Forced skipping of method Windows.ApplicationModel.DataTransfer.Clipboard.HistoryEnabledChanged.add
 		// Forced skipping of method Windows.ApplicationModel.DataTransfer.Clipboard.HistoryEnabledChanged.remove
-		#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
+		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public static global::Windows.ApplicationModel.DataTransfer.DataPackageView GetContent()
 		{
 			throw new global::System.NotImplementedException("The member DataPackageView Clipboard.GetContent() is not implemented in Uno.");
 		}
 		#endif
-		#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
+		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public static void SetContent( global::Windows.ApplicationModel.DataTransfer.DataPackage content)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.DataTransfer.Clipboard", "void Clipboard.SetContent(DataPackage content)");
@@ -83,8 +83,8 @@ namespace Windows.ApplicationModel.DataTransfer
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.DataTransfer.Clipboard", "void Clipboard.Flush()");
 		}
 		#endif
-		#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
+		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public static void Clear()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.DataTransfer.Clipboard", "void Clipboard.Clear()");


### PR DESCRIPTION
GitHub Issue (If applicable): a part of #6179

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature

<!-- Please uncomment one or more that apply to this PR

- Bugfix

- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
Clipboard does nothing on Skia.Wpf and Skia.Gtk targets.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Clipboard should copy data.
<!-- Please describe the new behavior after your modifications. -->

Some more details:
- `ContentChanged` event: Invokes properly, however, on both platforms, the functions may be invoke multiple times as many data targets are set.
- Text, Bitmap, and Html data: Works properly on both platforms.
- Rtf data: Works properly on WPF, can be detected on Linux if somehow Rtf data is set (for example when sharing clipboard using VMWare), although Rtf data is not natively found on Linux.
- Files: Works properly on WPF, should (theoretically) work on Gtk, however does ~~**not** work on popular distros using Nautilus (which stores copied files as _text_)~~. GNOME 40 [fixed the bug](https://gitlab.gnome.org/GNOME/nautilus/-/issues/634), I've tested it on Ubuntu and files are now working fine.
- Uri: 
   + There seems to be no Uri content on WPF, so Uri is not supported at all.
   + On Gtk, there are methods to obtain Uris, however, there is no official way to set an Uri to clipboard.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
