### PR TITLE
Add support for inertia in manipulation events

### DIFF
--- a/doc/articles/features/pointers-keyboard-and-other-user-inputs.md
+++ b/doc/articles/features/pointers-keyboard-and-other-user-inputs.md
@@ -25,7 +25,7 @@ User inputs are usually propagated using `RoutedEvents`. See Uno's [routed event
 | `ManipulationStarting`        | Yes     | Yes     | Yes     | Yes   | Yes      | Yes      | Yes   | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationstarting) |
 | `ManipulationStarted`         | Yes     | Yes     | Yes     | Yes   | Yes      | Yes      | Yes   | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationstarted) |
 | `ManipulationDelta`           | Yes     | Yes     | Yes     | Yes   | Yes      | Yes      | Yes   | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationedelta) |
-| `ManipulationInertiaStarting` | No      | No      | No      | No    | No       | No       | No    | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationinertiastarting) |
+| `ManipulationInertiaStarting` | Yes     | Yes     | Yes     | Yes   | Yes      | Yes      | Yes   | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationinertiastarting) |
 | `ManipulationCompleted`       | Yes     | Yes     | Yes     | Yes   | Yes      | Yes      | Yes   | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.manipulationcompleted) |
 | **_gesture events_**
 | `Tapped`                      | Yes     | Yes     | Yes     | Yes   | Yes      | Yes      | Yes   | [Documentation](https://docs.microsoft.com/uwp/api/windows.ui.xaml.uielement.tapped) |
@@ -140,9 +140,6 @@ Without this key the current version of iPadOS reports mouse interaction as norm
 ## Manipulation Events
 
 They are generated from the PointerXXX events (using the `Windows.UI.Input.GestureRecognizer`) and are bubbling in managed only.
-
-Currently there is no inertia support, so the `IsInertial` will always be `false` and the `UIElement.ManipulationInertiaStarting` event 
-will never be fired. The `Velocities` properties of event args are not implemented either.
 
 ## Gesture Events
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -537,6 +537,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\Manipulation_Inertia.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\Manipulation_WhenInScrollViewer.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4576,6 +4580,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\Manipulation_Basics.xaml.cs">
       <DependentUpon>Manipulation_Basics.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\Manipulation_Inertia.xaml.cs">
+      <DependentUpon>Manipulation_Inertia.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\Manipulation_WhenInScrollViewer.xaml.cs">
       <DependentUpon>Manipulation_WhenInScrollViewer.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Basics.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Basics.xaml
@@ -54,6 +54,7 @@
 			ManipulationStarting="OnManipStarting"
 			ManipulationStarted="OnManipStarted"
 			ManipulationDelta="OnManipDelta"
+			ManipulationInertiaStarting="OnManipInertiaStarting"
 			ManipulationCompleted="OnManipCompleted"/>
 
 		<TextBlock

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Basics.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Basics.xaml.cs
@@ -84,6 +84,9 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
 		private void OnManipDelta(object sender, ManipulationDeltaRoutedEventArgs e)
 			=> Write($"[Delta] {F(e.Position, e.Delta, e.Cumulative)}");
 
+		private void OnManipInertiaStarting(object sender, ManipulationInertiaStartingRoutedEventArgs e)
+			=> Write($"[Inertia] {F(new Point(-1, -1), e.Delta, e.Cumulative)}");
+
 		private void OnManipCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
 			=> Write($"[Completed] {F(e.Position, new ManipulationDelta { Scale = 1f }, e.Cumulative)}");
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Inertia.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Inertia.xaml
@@ -1,0 +1,26 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Input.GestureRecognizerTests.Manipulation_Inertia"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Input.GestureRecognizerTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid
+		Background="Orange"
+		ManipulationMode="All"
+		ManipulationInertiaStarting="InertiaStarting"
+		ManipulationDelta="ManipDelta">
+
+		<Rectangle
+			x:Name="_element" 
+			Width="200"
+			Height="200"
+			Fill="DeepPink"
+			RenderTransformOrigin=".5,.5" />
+
+		<Button VerticalAlignment="Top" HorizontalAlignment="Right" Content="Reset" Click="Reset" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Inertia.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Inertia.xaml.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Linq;
+using Windows.Foundation;
+using Windows.UI.Input;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Input.GestureRecognizerTests
+{
+	[Sample("Gesture recognizer")]
+	public sealed partial class Manipulation_Inertia : Page
+	{
+		public Manipulation_Inertia()
+		{
+			this.InitializeComponent();
+		}
+
+		private long _inertiaStart = 0;
+
+		private void InertiaStarting(object sender, ManipulationInertiaStartingRoutedEventArgs e)
+		{
+			_inertiaStart = DateTimeOffset.UtcNow.Ticks;
+
+			//e.TranslationBehavior.DesiredDisplacement = 5;
+			//e.TranslationBehavior.DesiredDeceleration = .00001;
+
+			Log(@$"[INERTIA] Inertia starting: {F(default, e.Delta, e.Cumulative, e.Velocities)}
+tr: ↘={e.TranslationBehavior.DesiredDeceleration} | ⌖={e.TranslationBehavior.DesiredDisplacement}
+θ: ↘={e.RotationBehavior.DesiredDeceleration} | ⌖={e.RotationBehavior.DesiredRotation}
+s: ↘={e.ExpansionBehavior.DesiredDeceleration} | ⌖={e.ExpansionBehavior.DesiredExpansion}");
+		}
+
+		private void ManipDelta(object sender, ManipulationDeltaRoutedEventArgs e)
+		{
+			if (!(_element.RenderTransform is CompositeTransform tr))
+			{
+				_element.RenderTransform = tr = new CompositeTransform();
+			}
+
+			tr.TranslateX = e.Cumulative.Translation.X;
+			tr.TranslateY = e.Cumulative.Translation.Y;
+			tr.Rotation = e.Cumulative.Rotation;
+			tr.ScaleX = e.Cumulative.Scale;
+			tr.ScaleY = e.Cumulative.Scale;
+
+			Log(
+				$"[DELTA] {F(e.Position, e.Delta, e.Cumulative, e.Velocities)} "
+				+ (e.IsInertial ? $"{TimeSpan.FromTicks(DateTimeOffset.UtcNow.Ticks - _inertiaStart).TotalMilliseconds} ms" : ""));
+		}
+
+		private void Reset(object sender, RoutedEventArgs e)
+		{
+			_element.RenderTransform = new CompositeTransform();
+		}
+
+		private static string F(Point position, ManipulationDelta delta, ManipulationDelta cumulative, ManipulationVelocities velocities)
+			=> $"@=[{position.X:000.00},{position.Y:000.00}] "
+				+ $"| X=(Σ:{cumulative.Translation.X:' '000.00;'-'000.00} / Δ:{delta.Translation.X:' '00.00;'-'00.00} / c:{velocities.Linear.X:F2}) "
+				+ $"| Y=(Σ:{cumulative.Translation.Y:' '000.00;'-'000.00} / Δ:{delta.Translation.Y:' '00.00;'-'00.00} / c:{velocities.Linear.Y:F2}) "
+				+ $"| θ=(Σ:{cumulative.Rotation:' '000.00;'-'000.00} / Δ:{delta.Rotation:' '00.00;'-'00.00} / c:{velocities.Angular:F2}) "
+				+ $"| s=(Σ:{cumulative.Scale:000.00} / Δ:{delta.Scale:00.00} / c:{velocities.Expansion:F2}) "
+				+ $"| e=(Σ:{cumulative.Expansion:' '000.00;'-'000.00} / Δ:{delta.Expansion:' '00.00;'-'00.00} / c:{velocities.Expansion:F2})";
+
+		private static void Log(string text)
+			=> global::System.Diagnostics.Debug.WriteLine(text);
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml
@@ -319,6 +319,17 @@
 					Margin="20, 0"
 					Visibility="{Binding ElementName=_manipDelta, Path=IsOn}"/>
 				<ToggleSwitch
+					x:Name="_manipInertia"
+					Header="Manipulation inertia"
+					OnContent="Subscribed to manip inertia started"
+					OffContent="Manip delta muted"
+					Toggled="OnConfigChanged" />
+				<CheckBox
+					x:Name="_manipInertiaHandle" 
+					Content="Handle event"
+					Margin="20, 0"
+					Visibility="{Binding ElementName=_manipDelta, Path=IsOn}"/>
+				<ToggleSwitch
 					x:Name="_manipCompleted" 
 					Header="Manipulation completed"
 					OnContent="Subscribed to manip completed"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/PointersEvents.xaml.cs
@@ -47,6 +47,7 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizer
 		private readonly ManipulationStartingEventHandler _logManipulationStarting;
 		private readonly ManipulationStartedEventHandler _logManipulationStarted;
 		private readonly ManipulationDeltaEventHandler _logManipulationDelta;
+		private readonly ManipulationInertiaStartingEventHandler _logManipulationInertia;
 		private readonly ManipulationCompletedEventHandler _logManipulationCompleted;
 		private readonly TappedEventHandler _logTapped;
 		private readonly DoubleTappedEventHandler _logDoubleTapped;
@@ -77,6 +78,7 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizer
 			_logManipulationStarting = new ManipulationStartingEventHandler(CreateHandler(ManipulationStartingEvent, "Manip starting", _manipStartingHandle));
 			_logManipulationStarted = new ManipulationStartedEventHandler(CreateHandler(ManipulationStartedEvent, "Manip started", _manipStartedHandle));
 			_logManipulationDelta = new ManipulationDeltaEventHandler(CreateHandler(ManipulationDeltaEvent, "Manip delta", _manipDeltaHandle));
+			_logManipulationInertia = new ManipulationInertiaStartingEventHandler(CreateHandler(ManipulationInertiaStartingEvent, "Manip inertia", _manipInertiaHandle));
 			_logManipulationCompleted = new ManipulationCompletedEventHandler(CreateHandler(ManipulationCompletedEvent, "Manip completed", _manipCompletedHandle));
 			_logTapped = new TappedEventHandler(CreateHandler(TappedEvent, "Tapped", _gestureTappedHandle));
 			_logDoubleTapped = new DoubleTappedEventHandler(CreateHandler(DoubleTappedEvent, "DoubleTapped", _gestureDoubleTappedHandle));
@@ -164,6 +166,7 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizer
 			target.RemoveHandler(ManipulationStartingEvent, _logManipulationStarting);
 			target.RemoveHandler(ManipulationStartedEvent, _logManipulationStarted);
 			target.RemoveHandler(ManipulationDeltaEvent, _logManipulationDelta);
+			target.RemoveHandler(ManipulationInertiaStartingEvent, _logManipulationInertia);
 			target.RemoveHandler(ManipulationCompletedEvent, _logManipulationCompleted);
 			target.RemoveHandler(TappedEvent, _logTapped);
 			target.RemoveHandler(DoubleTappedEvent, _logDoubleTapped);
@@ -192,6 +195,8 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizer
 				target.AddHandler(ManipulationStartedEvent, _logManipulationStarted, handledToo);
 			if (allEvents || _manipDelta.IsOn)
 				target.AddHandler(ManipulationDeltaEvent, _logManipulationDelta, handledToo);
+			if (allEvents || _manipInertia.IsOn)
+				target.AddHandler(ManipulationInertiaStartingEvent, _logManipulationInertia, handledToo);
 			if (allEvents || _manipCompleted.IsOn)
 				target.AddHandler(ManipulationCompletedEvent, _logManipulationCompleted, handledToo);
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
@@ -158,7 +158,9 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
 						// && args.One(TappedEvent) // No tap as we moved too far
 						&& args.One(PointerReleasedEvent)
-						&& args.Some(ManipulationCompletedEvent)
+						&& args.MaybeOne(ManipulationInertiaStartingEvent)
+						&& args.MaybeSome(PointerMovedEvent, ManipulationDeltaEvent)
+						&& args.One(ManipulationCompletedEvent)
 						&& args.MaybeSome(PointerMovedEvent)
 						&& args.One(PointerExitedEvent)
 						&& args.End();
@@ -174,8 +176,11 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
 						// && args.One(TappedEvent) // No tap as we moved too far
 						&& args.One(PointerReleasedEvent)
-						&& args.Some(ManipulationCompletedEvent)
-						&& args.One(PointerExitedEvent)
+						&& args.MaybeOne(ManipulationInertiaStartingEvent)
+						&& args.MaybeOne(PointerExitedEvent)
+						&& args.MaybeSome(ManipulationDeltaEvent)
+						&& args.One(ManipulationCompletedEvent)
+						&& args.MaybeOne(PointerExitedEvent) // If no inertia
 						&& args.End();
 					break;
 			}
@@ -203,7 +208,9 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 						&& args.Click()
 						&& args.One(PointerCaptureLostEvent)
 						// && args.One(TappedEvent) // No tap as we moved too far
-						&& args.Some(ManipulationCompletedEvent)
+						&& args.MaybeOne(ManipulationInertiaStartingEvent)
+						&& args.MaybeSome(PointerMovedEvent, ManipulationDeltaEvent)
+						&& args.One(ManipulationCompletedEvent)
 						&& args.MaybeSome(PointerMovedEvent)
 						&& args.One(PointerExitedEvent)
 						&& args.End();
@@ -219,8 +226,11 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 						&& args.Click()
 						&& args.One(PointerCaptureLostEvent)
 						// && args.One(TappedEvent) // No tap as we moved too far
-						&& args.Some(ManipulationCompletedEvent)
-						&& args.One(PointerExitedEvent)
+						&& args.MaybeOne(ManipulationInertiaStartingEvent)
+						&& args.MaybeOne(PointerExitedEvent)
+						&& args.MaybeSome(ManipulationDeltaEvent)
+						&& args.One(ManipulationCompletedEvent)
+						&& args.MaybeOne(PointerExitedEvent) // If no inertia
 						&& args.End();
 					break;
 			}

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfCoreWindowExtension.cs
@@ -129,7 +129,7 @@ namespace Uno.UI.Skia.Platform
 					new PointerEventArgs(
 						new Windows.UI.Input.PointerPoint(
 							frameId: GetNextFrameId(),
-							timestamp: (uint)args.Timestamp,
+							timestamp: (ulong)(args.Timestamp * TimeSpan.TicksPerMillisecond),
 							device: GetPointerDevice(args),
 							pointerId: 1,
 							rawPosition: new Windows.Foundation.Point(position.X, position.Y),
@@ -159,7 +159,7 @@ namespace Uno.UI.Skia.Platform
 					new PointerEventArgs(
 						new Windows.UI.Input.PointerPoint(
 							frameId: GetNextFrameId(),
-							timestamp: (uint)args.Timestamp,
+							timestamp: (ulong)(args.Timestamp * TimeSpan.TicksPerMillisecond),
 							device: GetPointerDevice(args),
 							pointerId: 1,
 							rawPosition: new Windows.Foundation.Point(position.X, position.Y),
@@ -189,7 +189,7 @@ namespace Uno.UI.Skia.Platform
 					new PointerEventArgs(
 						new Windows.UI.Input.PointerPoint(
 							frameId: GetNextFrameId(),
-							timestamp: (uint)args.Timestamp,
+							timestamp: (ulong)(args.Timestamp * TimeSpan.TicksPerMillisecond),
 							device: GetPointerDevice(args),
 							pointerId: 1,
 							rawPosition: new Windows.Foundation.Point(position.X, position.Y),
@@ -219,7 +219,7 @@ namespace Uno.UI.Skia.Platform
 					new PointerEventArgs(
 						new Windows.UI.Input.PointerPoint(
 							frameId: GetNextFrameId(),
-							timestamp: (uint)args.Timestamp,
+							timestamp: (ulong)(args.Timestamp * TimeSpan.TicksPerMillisecond),
 							device: GetPointerDevice(args),
 							pointerId: 1,
 							rawPosition: new Windows.Foundation.Point(position.X, position.Y),
@@ -249,7 +249,7 @@ namespace Uno.UI.Skia.Platform
 					new PointerEventArgs(
 						new Windows.UI.Input.PointerPoint(
 							frameId: GetNextFrameId(),
-							timestamp: (uint)args.Timestamp,
+							timestamp: (ulong)(args.Timestamp * TimeSpan.TicksPerMillisecond),
 							device: GetPointerDevice(args),
 							pointerId: 1,
 							rawPosition: new Windows.Foundation.Point(position.X, position.Y),
@@ -318,7 +318,7 @@ namespace Uno.UI.Skia.Platform
 						new PointerEventArgs(
 							new Windows.UI.Input.PointerPoint(
 								frameId: GetNextFrameId(),
-								timestamp: (uint)Environment.TickCount,
+								timestamp: (ulong)Environment.TickCount,
 								device: PointerDevice.For(PointerDeviceType.Mouse),
 								pointerId: 1,
 								rawPosition: position,

--- a/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
@@ -20,6 +20,14 @@ namespace Uno.UI.Tests.Windows_UI_Input
 	[TestClass]
 	public class Given_GestureRecognizer
 	{
+		private const GestureSettings ManipulationsWithoutInertia = GestureSettings.ManipulationTranslateX
+			| GestureSettings.ManipulationTranslateY
+			| GestureSettings.ManipulationTranslateRailsX
+			| GestureSettings.ManipulationTranslateRailsY
+			| GestureSettings.ManipulationRotate
+			| GestureSettings.ManipulationScale
+			| GestureSettings.ManipulationMultipleFingerPanning; // Not supported by ManipulationMode
+
 		[TestMethod]
 		public void Tapped()
 		{
@@ -294,7 +302,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		[TestMethod]
 		public void Manipulation_Begin()
 		{
-			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var sut = new GestureRecognizer { GestureSettings = ManipulationsWithoutInertia };
 			var result = new ManipulationRecorder(sut);
 			var step = GestureRecognizer.Manipulation.StartTouch.TranslateX;
 
@@ -312,7 +320,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		[TestMethod]
 		public void Manipulation_Begin_MultiPointer()
 		{
-			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var sut = new GestureRecognizer { GestureSettings = ManipulationsWithoutInertia };
 			var result = new ManipulationRecorder(sut);
 
 			sut.ProcessDownEvent(25, 25, id: 1);
@@ -327,7 +335,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		[TestMethod]
 		public void Manipulation_Begin_WithAnotherDevice()
 		{
-			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var sut = new GestureRecognizer { GestureSettings = ManipulationsWithoutInertia };
 			var result = new ManipulationRecorder(sut);
 
 			sut.ProcessDownEvent(25, 25, id: 1);
@@ -341,7 +349,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		[TestMethod]
 		public void Manipulation_Delta()
 		{
-			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var sut = new GestureRecognizer { GestureSettings = ManipulationsWithoutInertia };
 			var result = new ManipulationRecorder(sut);
 			var step = GestureRecognizer.Manipulation.StartTouch.TranslateX + 1;
 
@@ -362,7 +370,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		[TestMethod]
 		public void Manipulation_End()
 		{
-			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var sut = new GestureRecognizer { GestureSettings = ManipulationsWithoutInertia };
 			var result = new ManipulationRecorder(sut);
 			var step = GestureRecognizer.Manipulation.StartTouch.TranslateX + 1;
 
@@ -381,7 +389,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		[TestMethod]
 		public void Manipulation_End_2()
 		{
-			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var sut = new GestureRecognizer { GestureSettings = ManipulationsWithoutInertia };
 			var result = new ManipulationRecorder(sut);
 			var step = GestureRecognizer.Manipulation.StartTouch.TranslateX + 1;
 
@@ -736,7 +744,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		[TestMethod]
 		public void Manipulation_Mixed()
 		{
-			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var sut = new GestureRecognizer { GestureSettings = ManipulationsWithoutInertia };
 			var result = new ManipulationRecorder(sut);
 
 			sut.ProcessDownEvent(50, 50, id: 1); // 1.
@@ -976,6 +984,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			recognizer.ManipulationStarted += (snd, e) => _result.Add((snd, e));
 			recognizer.ManipulationUpdated += (snd, e) => _result.Add((snd, e));
 			recognizer.ManipulationCompleted += (snd, e) => _result.Add((snd, e));
+			//recognizer.ManipulationInertiaStarting += (snd, e) => _result.Add((snd, e));
 		}
 
 		public void ShouldBe(params Func<EmptyValidator, Validator>[] expected)
@@ -1329,7 +1338,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			=> new HoldingEventArgs(ptId ?? 1, device ?? _currentPointer.Value.device?.PointerDeviceType ?? PointerDeviceType.Touch, new Point(x, y), state);
 
 		public static DraggingEventArgs Drag(PointerPoint point, DraggingState state)
-			=> new DraggingEventArgs(point, state);
+			=> new DraggingEventArgs(point, state, 1);
 
 		public static PointerPoint ProcessDownEvent(
 			this GestureRecognizer sut,

--- a/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
@@ -555,8 +555,8 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			result.ShouldBe(
 				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
-				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
-				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 270)
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -45),
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -90)
 			);
 		}
 
@@ -575,8 +575,8 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			result.ShouldBe(
 				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
-				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
-				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 270)
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -45),
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -90)
 			);
 		}
 
@@ -595,8 +595,8 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			result.ShouldBe(
 				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
-				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
-				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 270)
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -45),
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -90)
 			);
 		}
 
@@ -615,8 +615,8 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			result.ShouldBe(
 				v => v.Starting(),
 				v => v.Started().WithCumulative(angle: 0),
-				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 315),
-				v => v.Delta().WithDelta(angle: 315).WithCumulative(angle: 270)
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -45),
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -90)
 			);
 		}
 
@@ -702,6 +702,166 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		}
 
 		[TestMethod]
+		public void Manipulation_RotateOnly_Trigonometric_MultipleTurns()
+		{
+			var sut = new GestureRecognizer { GestureSettings = ManipulationsWithoutInertia };
+			var result = new ManipulationRecorder(sut);
+
+			// Performs 3 trigonometric 360°
+
+			sut.ProcessDownEvent(50, 50, id: 1);
+			sut.ProcessDownEvent(50, 200, id: 2);
+
+			// Turn 1
+			sut.ProcessMoveEvent(200, 200, id: 2);
+			sut.ProcessMoveEvent(50, 200, id: 1);
+			sut.ProcessMoveEvent(200, 50, id: 2);
+			sut.ProcessMoveEvent(200, 200, id: 1);
+			sut.ProcessMoveEvent(50, 50, id: 2);
+			sut.ProcessMoveEvent(200, 50, id: 1);
+			sut.ProcessMoveEvent(50, 200, id: 2);
+			sut.ProcessMoveEvent(50, 50, id: 1);
+
+			// Turn 2
+			sut.ProcessMoveEvent(200, 200, id: 2);
+			sut.ProcessMoveEvent(50, 200, id: 1);
+			sut.ProcessMoveEvent(200, 50, id: 2);
+			sut.ProcessMoveEvent(200, 200, id: 1);
+			sut.ProcessMoveEvent(50, 50, id: 2);
+			sut.ProcessMoveEvent(200, 50, id: 1);
+			sut.ProcessMoveEvent(50, 200, id: 2);
+			sut.ProcessMoveEvent(50, 50, id: 1);
+
+			// Turn 3
+			sut.ProcessMoveEvent(200, 200, id: 2);
+			sut.ProcessMoveEvent(50, 200, id: 1);
+			sut.ProcessMoveEvent(200, 50, id: 2);
+			sut.ProcessMoveEvent(200, 200, id: 1);
+			sut.ProcessMoveEvent(50, 50, id: 2);
+			sut.ProcessMoveEvent(200, 50, id: 1);
+			sut.ProcessMoveEvent(50, 200, id: 2);
+			sut.ProcessMoveEvent(50, 50, id: 1);
+
+			var s = (float)Math.Sqrt(2);
+			var e = (float)((Math.Sqrt(2) - 1) * 150);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(),
+
+				// Turn 1
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -45, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: 75, angle: -90, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -135, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 150, tY: 0, angle: -180, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -225, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: -75, angle: -270, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -315, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 0, tY: 0, angle: -360, scale: 1, exp: 0),
+
+				// Turn 2
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -360 - 45, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: 75, angle: -360 - 90, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -360 - 135, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 150, tY: 0, angle: -360 - 180, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -360 - 225, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: -75, angle: -360 - 270, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -360 - 315, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 0, tY: 0, angle: -360 - 360, scale: 1, exp: 0),
+
+				// Turn 3
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -720 - 45, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: 75, angle: -720 - 90, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -720 - 135, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 150, tY: 0, angle: -720 - 180, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -720 - 225, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: -75, angle: -720 - 270, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: -45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: -720 - 315, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: -45, scale: 1 / s, exp: -e).WithCumulative(tX: 0, tY: 0, angle: -720 - 360, scale: 1, exp: 0)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_RotateOnly_AntiTrigonometric_MultipleTurns()
+		{
+			var sut = new GestureRecognizer { GestureSettings = ManipulationsWithoutInertia };
+			var result = new ManipulationRecorder(sut);
+
+			// Performs 3 trigonometric 360°
+
+			sut.ProcessDownEvent(50, 50, id: 1);
+			sut.ProcessDownEvent(50, 200, id: 2);
+
+			// Turn 1
+			sut.ProcessMoveEvent(200, 50, id: 1);
+			sut.ProcessMoveEvent(50, 50, id: 2);
+			sut.ProcessMoveEvent(200, 200, id: 1);
+			sut.ProcessMoveEvent(200, 50, id: 2);
+			sut.ProcessMoveEvent(50, 200, id: 1);
+			sut.ProcessMoveEvent(200, 200, id: 2);
+			sut.ProcessMoveEvent(50, 50, id: 1);
+			sut.ProcessMoveEvent(50, 200, id: 2);
+
+			// Turn 2
+			sut.ProcessMoveEvent(200, 50, id: 1);
+			sut.ProcessMoveEvent(50, 50, id: 2);
+			sut.ProcessMoveEvent(200, 200, id: 1);
+			sut.ProcessMoveEvent(200, 50, id: 2);
+			sut.ProcessMoveEvent(50, 200, id: 1);
+			sut.ProcessMoveEvent(200, 200, id: 2);
+			sut.ProcessMoveEvent(50, 50, id: 1);
+			sut.ProcessMoveEvent(50, 200, id: 2);
+
+			// Turn 3
+			sut.ProcessMoveEvent(200, 50, id: 1);
+			sut.ProcessMoveEvent(50, 50, id: 2);
+			sut.ProcessMoveEvent(200, 200, id: 1);
+			sut.ProcessMoveEvent(200, 50, id: 2);
+			sut.ProcessMoveEvent(50, 200, id: 1);
+			sut.ProcessMoveEvent(200, 200, id: 2);
+			sut.ProcessMoveEvent(50, 50, id: 1);
+			sut.ProcessMoveEvent(50, 200, id: 2);
+
+			var s = (float)Math.Sqrt(2);
+			var e = (float)((Math.Sqrt(2) - 1) * 150);
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(),
+
+				// Turn 1
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 45, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: -75, angle: 90, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 135, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 150, tY: 0, angle: 180, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 225, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: 75, angle: 270, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 315, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 0, tY: 0, angle: 360, scale: 1, exp: 0),
+
+				// Turn 2
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 360 + 45, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: -75, angle: 360 + 90, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 360 + 135, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 150, tY: 0, angle: 360 + 180, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 360 + 225, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: 75, angle: 360 + 270, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 360 + 315, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 0, tY: 0, angle: 360 + 360, scale: 1, exp: 0),
+
+				// Turn 3
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 720 + 45, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: -75, angle: 720 + 90, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 720 + 135, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 75, tY: 0, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 150, tY: 0, angle: 720 + 180, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 720 + 225, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: 0, tY: 75, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 75, tY: 75, angle: 720 + 270, scale: 1, exp: 0),
+				v => v.Delta().WithDelta(tX: 0, tY: -75, angle: 45, scale: s, exp: e).WithCumulative(tX: 75, tY: 0, angle: 720 + 315, scale: s, exp: e),
+				v => v.Delta().WithDelta(tX: -75, tY: 0, angle: 45, scale: 1 / s, exp: -e).WithCumulative(tX: 0, tY: 0, angle: 720 + 360, scale: 1, exp: 0)
+			);
+		}
+
+		[TestMethod]
 		public void Manipulation_ScaleOnly()
 		{
 			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationScale };
@@ -747,6 +907,8 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			var sut = new GestureRecognizer { GestureSettings = ManipulationsWithoutInertia };
 			var result = new ManipulationRecorder(sut);
 
+			// Performs a trigonometric 360° .. and completes by setting pt 1 and pt 2 at same location (which is physically impossible)
+
 			sut.ProcessDownEvent(50, 50, id: 1); // 1.
 			sut.ProcessDownEvent(50, 200, id: 2); // 2.
 
@@ -779,57 +941,485 @@ namespace Uno.UI.Tests.Windows_UI_Input
 				// 3.
 				v => v.Delta()
 					.At(125, 125)
-					.WithDelta(tX: 75, tY: 0, angle: 315, scale: s, exp: e)
-					.WithCumulative(tX: 75, tY: 0, angle: 315, scale: s, exp: e),
+					.WithDelta(tX: 75, tY: 0, angle: -45, scale: s, exp: e)
+					.WithCumulative(tX: 75, tY: 0, angle: -45, scale: s, exp: e),
 
 				// 4.
 				v => v.Delta()
 					.At(125, 200)
-					.WithDelta(tX: 0, tY: 75, angle: 315, scale: 1/s, exp: -e)
-					.WithCumulative(tX: 75, tY: 75, angle: 270, scale: 1, exp: 0),
+					.WithDelta(tX: 0, tY: 75, angle: -45, scale: 1/s, exp: -e)
+					.WithCumulative(tX: 75, tY: 75, angle: -90, scale: 1, exp: 0),
 
 				// 5.
 				v => v.Delta()
 					.At(125, 125)
-					.WithDelta(tX: 0, tY: -75, angle: 315, scale: s, exp: e)
-					.WithCumulative(tX: 75, tY: 0, angle: 225, scale: s, exp: e),
+					.WithDelta(tX: 0, tY: -75, angle: -45, scale: s, exp: e)
+					.WithCumulative(tX: 75, tY: 0, angle: -135, scale: s, exp: e),
 
 				// 6.
 				v => v.Delta()
 					.At(200, 125)
-					.WithDelta(tX: 75, tY: 0, angle: 315, scale: 1 / s, exp: -e)
-					.WithCumulative(tX: 150, tY: 0, angle: 180, scale: 1, exp: 0),
+					.WithDelta(tX: 75, tY: 0, angle: -45, scale: 1 / s, exp: -e)
+					.WithCumulative(tX: 150, tY: 0, angle: -180, scale: 1, exp: 0),
 
 				// 7.
 				v => v.Delta()
 					.At(125, 125)
-					.WithDelta(tX: -75, tY: 0, angle: 315, scale: s, exp: e)
-					.WithCumulative(tX: 75, tY: 0, angle: 135, scale: s, exp: e),
+					.WithDelta(tX: -75, tY: 0, angle: -45, scale: s, exp: e)
+					.WithCumulative(tX: 75, tY: 0, angle: -225, scale: s, exp: e),
 
 				// 8.
 				v => v.Delta()
 					.At(125, 50)
-					.WithDelta(tX: 0, tY: -75, angle: 315, scale: 1 / s, exp: -e)
-					.WithCumulative(tX: 75, tY: -75, angle: 90, scale: 1, exp: 0),
+					.WithDelta(tX: 0, tY: -75, angle: -45, scale: 1 / s, exp: -e)
+					.WithCumulative(tX: 75, tY: -75, angle: -270, scale: 1, exp: 0),
 
 				// 9.
 				v => v.Delta()
 					.At(125, 125)
-					.WithDelta(tX: 0, tY: 75, angle: 315, scale: s, exp: e)
-					.WithCumulative(tX: 75, tY: 0, angle: 45, scale: s, exp: e),
+					.WithDelta(tX: 0, tY: 75, angle: -45, scale: s, exp: e)
+					.WithCumulative(tX: 75, tY: 0, angle: -315, scale: s, exp: e),
 
 				// 10.
 				v => v.Delta()
 					.At(50, 125)
-					.WithDelta(tX: -75, tY: 0, angle: 315, scale: 1 / s, exp: -e)
-					.WithCumulative(tX: 0, tY: 0, angle: 0, scale: 1, exp: 0),
+					.WithDelta(tX: -75, tY: 0, angle: -45, scale: 1 / s, exp: -e)
+					.WithCumulative(tX: 0, tY: 0, angle: -360, scale: 1, exp: 0),
 
 				// 11.
 				v => v.Delta()
 					.At(50, 50)
 					.WithDelta(tX: 0, tY: -75, angle: 90 /* ??? */, scale: 0, exp: -150F)
-					.WithCumulative(tX: 0, tY: -75, angle: 90 /* ??? */, scale: 0, exp: -150F)
+					.WithCumulative(tX: 0, tY: -75, angle: -270 /* ??? */, scale: 0, exp: -150F)
 			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_Translate()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var result = new ManipulationRecorder(sut);
+
+			// flick at 2 px/ms
+			sut.ProcessDownEvent(10, 10, ts: 0);
+			sut.ProcessMoveEvent(100, 100, ts: 100 * TimeSpan.TicksPerMillisecond);
+			sut.ProcessUpEvent(102, 102, ts: 101 * TimeSpan.TicksPerMillisecond);
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(scale: 1),
+				v => v.Delta().WithDelta(tX: 90, tY: 90).WithCumulative(tX: 90, tY: 90),
+				v => v.Inertia(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial().WithCumulative(tX: 1090.40002441406, tY: 1090.40002441406),
+				v => v.End().WithCumulative(tX: 1090.40002441406, tY: 1090.40002441406)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_TranslateXOnly()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationTranslateX | GestureSettings.ManipulationTranslateInertia };
+			var result = new ManipulationRecorder(sut);
+
+			// flick at 2 px/ms
+			sut.ProcessDownEvent(10, 10, ts: 0);
+			sut.ProcessMoveEvent(100, 100, ts: 100 * TimeSpan.TicksPerMillisecond);
+			sut.ProcessUpEvent(102, 102, ts: 101 * TimeSpan.TicksPerMillisecond);
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(scale: 1),
+				v => v.Delta().WithDelta(tX: 90, tY: 0).WithCumulative(tX: 90, tY: 0),
+				v => v.Inertia(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial().WithCumulative(tX: 1090.40002441406, tY: 0),
+				v => v.End().WithCumulative(tX: 1090.40002441406, tY: 0)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_TranslateYOnly()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationTranslateY | GestureSettings.ManipulationTranslateInertia };
+			var result = new ManipulationRecorder(sut);
+
+			// flick at 2 px/ms
+			sut.ProcessDownEvent(10, 10, ts: 0);
+			sut.ProcessMoveEvent(100, 100, ts: 100 * TimeSpan.TicksPerMillisecond);
+			sut.ProcessUpEvent(102, 102, ts: 101 * TimeSpan.TicksPerMillisecond);
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(scale: 1),
+				v => v.Delta().WithDelta(tX: 0, tY: 90).WithCumulative(tX: 0, tY: 90),
+				v => v.Inertia(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial().WithCumulative(tX: 0, tY: 1090.40002441406),
+				v => v.End().WithCumulative(tX: 0, tY: 1090.40002441406)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_Translate_Negative()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettingsHelper.Manipulations };
+			var result = new ManipulationRecorder(sut);
+
+			// flick at 2 px/ms
+			sut.ProcessDownEvent(10, 10, ts: 0);
+			sut.ProcessMoveEvent(100, 100, ts: 100 * TimeSpan.TicksPerMillisecond);
+			sut.ProcessUpEvent(98, 98, ts: 101 * TimeSpan.TicksPerMillisecond);
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(scale: 1),
+				v => v.Delta().WithDelta(tX: 90, tY: 90).WithCumulative(tX: 90, tY: 90),
+				v => v.Inertia(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial().WithCumulative(tX: -910.40002441406, tY: -910.40002441406),
+				v => v.End().WithCumulative(tX: -910.40002441406, tY: -910.40002441406)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_RotateOnly_Trigonometric_InFirstQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate | GestureSettings.ManipulationRotateInertia };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, -25, id: 1, ts: 0);
+
+			// Rotate of pi/2 in a quarter of second
+			sut.ProcessDownEvent(50, -25, id: 2, ts: 1); // Angle = 0
+			sut.ProcessMoveEvent(50, -50, id: 2, ts: 100 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/4
+			sut.ProcessUpEvent(25, -50, id: 2, ts: 600 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/2
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -45),
+				v => v.Inertia().WithDelta(angle: -45).WithCumulative(angle: -90).WithSpeed(angle: -0.09f),
+
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+
+				v => v.Delta().IsInertial().WithCumulative(angle: -110.240005f),
+				v => v.End().WithCumulative(angle: -110.240005f)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_RotateOnly_Trigonometric_InSecondQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate | GestureSettings.ManipulationRotateInertia };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(-25, -25, id: 1, ts: 0);
+
+			// Rotate of Pi/4 in a quarter of second
+			sut.ProcessDownEvent(-25, -50, id: 2, ts: 1); // Angle = 0
+			sut.ProcessMoveEvent(-50, -50, id: 2, ts: 100 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/4
+			sut.ProcessUpEvent(-50, -25, id: 2, ts: 600 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/2
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -45),
+				v => v.Inertia().WithDelta(angle: -45).WithCumulative(angle: -90).WithSpeed(angle: -0.09f),
+
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+
+				v => v.Delta().IsInertial().WithCumulative(angle: -110.240005f),
+				v => v.End().WithCumulative(angle: -110.240005f)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_RotateOnly_Trigonometric_InThirdQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate | GestureSettings.ManipulationRotateInertia };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(-25, 25, id: 1, ts: 0);
+
+			// Rotate of pi/2 in a quarter of second
+			sut.ProcessDownEvent(-50, 25, id: 2, ts: 1); // Angle = 0
+			sut.ProcessMoveEvent(-50, 50, id: 2, ts: 100 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/4
+			sut.ProcessUpEvent(-25, 50, id: 2, ts: 600 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/2
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -45),
+				v => v.Inertia().WithDelta(angle: -45).WithCumulative(angle: -90).WithSpeed(angle: -0.09f),
+
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+
+				v => v.Delta().IsInertial().WithCumulative(angle: -110.240005f),
+				v => v.End().WithCumulative(angle: -110.240005f)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_RotateOnly_Trigonometric_InForthQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate | GestureSettings.ManipulationRotateInertia };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, 25, id: 1, ts: 0);
+
+			// Rotate of pi/2 in a quarter of second
+			sut.ProcessDownEvent(25, 50, id: 2, ts: 1); // Angle = 0
+			sut.ProcessMoveEvent(50, 50, id: 2, ts: 100 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/4
+			sut.ProcessUpEvent(50, 25, id: 2, ts: 600 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/2
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: -45).WithCumulative(angle: -45),
+				v => v.Inertia().WithDelta(angle: -45).WithCumulative(angle: -90).WithSpeed(angle: -0.09f),
+
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+
+				v => v.Delta().IsInertial().WithCumulative(angle: -110.240005f),
+				v => v.End().WithCumulative(angle: -110.240005f)
+			);
+		}
+
+
+		[TestMethod]
+		public void Manipulation_Inertia_RotateOnly_AntiTrigonometric_InFirstQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate | GestureSettings.ManipulationRotateInertia };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, -25, id: 1, ts: 0);
+
+			sut.ProcessDownEvent(25, -50, id: 2, ts: 1); // Angle = 0
+			sut.ProcessMoveEvent(50, -50, id: 2, ts: 100 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/4
+			sut.ProcessUpEvent(50, -25, id: 2, ts: 600 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/2
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
+				v => v.Inertia().WithDelta(angle: 45).WithCumulative(angle: 90).WithSpeed(angle: 0.09f),
+
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+
+				v => v.Delta().IsInertial().WithCumulative(angle: 110.240005f),
+				v => v.End().WithCumulative(angle: 110.240005f)
+			);
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_RotateOnly_AntiTrigonometric_InSecondQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate | GestureSettings.ManipulationRotateInertia };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(-25, -25, id: 1, ts: 0);
+
+			sut.ProcessDownEvent(-50, -25, id: 2, ts: 1); // Angle = 0
+			sut.ProcessMoveEvent(-50, -50, id: 2, ts: 100 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/4
+			sut.ProcessUpEvent(-25, -50, id: 2, ts: 600 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/2
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
+				v => v.Inertia().WithDelta(angle: 45).WithCumulative(angle: 90).WithSpeed(angle: 0.09f),
+
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+
+				v => v.Delta().IsInertial().WithCumulative(angle: 110.240005f),
+				v => v.End().WithCumulative(angle: 110.240005f)
+			);
+
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_RotateOnly_AntiTrigonometric_InThirdQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate | GestureSettings.ManipulationRotateInertia };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(-25, 25, id: 1, ts: 0);
+
+			sut.ProcessDownEvent(-25, 50, id: 2, ts: 1); // Angle = 0
+			sut.ProcessMoveEvent(-50, 50, id: 2, ts: 100 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/4
+			sut.ProcessUpEvent(-50, 25, id: 2, ts: 600 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/2
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
+				v => v.Inertia().WithDelta(angle: 45).WithCumulative(angle: 90).WithSpeed(angle: 0.09f),
+
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+
+				v => v.Delta().IsInertial().WithCumulative(angle: 110.240005f),
+				v => v.End().WithCumulative(angle: 110.240005f)
+			);
+
+		}
+
+		[TestMethod]
+		public void Manipulation_Inertia_RotateOnly_AntiTrigonometric_InForthQuadrant()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.ManipulationRotate | GestureSettings.ManipulationRotateInertia };
+			var result = new ManipulationRecorder(sut);
+
+			sut.ProcessDownEvent(25, 25, id: 1, ts: 0);
+
+			sut.ProcessDownEvent(50, 25, id: 2, ts: 1); // Angle = 0
+			sut.ProcessMoveEvent(50, 50, id: 2, ts: 100 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/4
+			sut.ProcessUpEvent(25, 50, id: 2, ts: 600 * TimeSpan.TicksPerMillisecond); // Angle = -Pi/2
+
+			sut.RunInertiaSync();
+
+			result.ShouldBe(
+				v => v.Starting(),
+				v => v.Started().WithCumulative(angle: 0),
+				v => v.Delta().WithDelta(angle: 45).WithCumulative(angle: 45),
+				v => v.Inertia().WithDelta(angle: 45).WithCumulative(angle: 90).WithSpeed(angle: 0.09f),
+
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(), v => v.Delta().IsInertial(),
+				v => v.Delta().IsInertial(),
+
+				v => v.Delta().IsInertial().WithCumulative(angle: 110.240005f),
+				v => v.End().WithCumulative(angle: 110.240005f)
+			);
+
 		}
 
 		[TestMethod]
@@ -984,7 +1574,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			recognizer.ManipulationStarted += (snd, e) => _result.Add((snd, e));
 			recognizer.ManipulationUpdated += (snd, e) => _result.Add((snd, e));
 			recognizer.ManipulationCompleted += (snd, e) => _result.Add((snd, e));
-			//recognizer.ManipulationInertiaStarting += (snd, e) => _result.Add((snd, e));
+			recognizer.ManipulationInertiaStarting += (snd, e) => _result.Add((snd, e));
 		}
 
 		public void ShouldBe(params Func<EmptyValidator, Validator>[] expected)
@@ -1070,6 +1660,18 @@ namespace Uno.UI.Tests.Windows_UI_Input
 					_pendingAssertResult.Add((name, expected.Value, actual));
 			}
 
+			protected void AreEquals(string name, PointerDeviceType? expected, PointerDeviceType actual)
+			{
+				if (expected.HasValue && expected.Value != actual)
+					_pendingAssertResult.Add((name, expected.Value, actual));
+			}
+
+			protected void AreEquals(string name, uint? expected, uint actual)
+			{
+				if (expected.HasValue && expected.Value != actual)
+					_pendingAssertResult.Add((name, expected.Value, actual));
+			}
+
 			protected void AreEquals(string name, ManipulationDelta? expected, ManipulationDelta actual)
 			{
 				if (!expected.HasValue)
@@ -1079,10 +1681,10 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 				var e = expected.Value;
 
-				if (e.Translation.X != actual.Translation.X)
+				if (Math.Abs(e.Translation.X - actual.Translation.X) > .00001)
 					_pendingAssertResult.Add((name + ".Translation.X", expected.Value.Translation.X, actual.Translation.X));
 
-				if (e.Translation.Y != actual.Translation.Y)
+				if (Math.Abs(e.Translation.Y - actual.Translation.Y) > .00001)
 					_pendingAssertResult.Add((name + ".Translation.Y", expected.Value.Translation.Y, actual.Translation.Y));
 
 				if (Math.Abs(e.Rotation - actual.Rotation) > .00001)
@@ -1090,6 +1692,28 @@ namespace Uno.UI.Tests.Windows_UI_Input
 
 				if (Math.Abs(e.Scale - actual.Scale) > .00001)
 					_pendingAssertResult.Add((name + ".Scale", expected.Value.Scale, actual.Scale));
+
+				if (Math.Abs(e.Expansion - actual.Expansion) > .00001)
+					_pendingAssertResult.Add((name + ".Expansion", expected.Value.Expansion, actual.Expansion));
+			}
+
+			protected void AreEquals(string name, ManipulationVelocities? expected, ManipulationVelocities actual)
+			{
+				if (!expected.HasValue)
+				{
+					return;
+				}
+
+				var e = expected.Value;
+
+				if (e.Linear.X != actual.Linear.X)
+					_pendingAssertResult.Add((name + ".Linear.X", expected.Value.Linear.X, actual.Linear.X));
+
+				if (e.Linear.Y != actual.Linear.Y)
+					_pendingAssertResult.Add((name + ".Linear.Y", expected.Value.Linear.Y, actual.Linear.Y));
+
+				if (Math.Abs(e.Angular - actual.Angular) > .00001)
+					_pendingAssertResult.Add((name + ".Angular", expected.Value.Angular, actual.Angular));
 
 				if (Math.Abs(e.Expansion - actual.Expansion) > .00001)
 					_pendingAssertResult.Add((name + ".Expansion", expected.Value.Expansion, actual.Expansion));
@@ -1106,6 +1730,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			public StartedValidator Started() => new StartedValidator();
 			public DeltaValidator Delta() => new DeltaValidator();
 			public EndValidator End() => new EndValidator();
+			public InertiaValidator Inertia() => new InertiaValidator();
 
 			internal override void Assert(object args, string identifier)
 				=> throw new AssertionFailedException($"Expected of {identifier} is not configured");
@@ -1247,6 +1872,79 @@ namespace Uno.UI.Tests.Windows_UI_Input
 				AreEquals(nameof(args.Position), _position, args.Position);
 				AreEquals(nameof(args.Cumulative), _cumulative, args.Cumulative);
 				AreEquals(nameof(args.IsInertial), _isInertial, args.IsInertial);
+			}
+		}
+
+		public class InertiaValidator : Validator<ManipulationInertiaStartingEventArgs>
+		{
+			private Point? _position;
+			private ManipulationDelta? _delta;
+			private ManipulationDelta? _cumulative;
+			private ManipulationVelocities? _velocities;
+			private PointerDeviceType? _pointer;
+			private uint? _contactCount;
+
+			public InertiaValidator At(double x, double y)
+			{
+				_position = new Point(x, y);
+				return this;
+			}
+
+			public InertiaValidator WithDelta(double tX = 0, double tY = 0, float angle = 0, float scale = 1, float exp = 0)
+			{
+				_delta = new ManipulationDelta
+				{
+					Translation = new Point(tX, tY),
+					Rotation = angle,
+					Scale = scale,
+					Expansion = exp,
+				};
+				return this;
+			}
+
+			public InertiaValidator WithCumulative(double tX = 0, double tY = 0, float angle = 0, float scale = 1, float exp = 0)
+			{
+				_cumulative = new ManipulationDelta
+				{
+					Translation = new Point(tX, tY),
+					Rotation = angle,
+					Scale = scale,
+					Expansion = exp,
+				};
+				return this;
+			}
+
+			public InertiaValidator WithSpeed(double tX = 0, double tY = 0, float angle = 0, float exp = 0)
+			{
+				_velocities = new ManipulationVelocities
+				{
+					Linear = new Point(tX, tY),
+					Angular = angle,
+					Expansion = exp
+				};
+				return this;
+			}
+
+			public InertiaValidator WithPointer(PointerDeviceType pointer)
+			{
+				_pointer = pointer;
+				return this;
+			}
+
+			public InertiaValidator WithContacts(uint contactCount)
+			{
+				_contactCount = contactCount;
+				return this;
+			}
+
+			protected override void Assert(ManipulationInertiaStartingEventArgs args)
+			{
+				AreEquals(nameof(args.Position), _position, args.Position);
+				AreEquals(nameof(args.Delta), _delta, args.Delta);
+				AreEquals(nameof(args.Cumulative), _cumulative, args.Cumulative);
+				AreEquals(nameof(args.Velocities), _velocities, args.Velocities);
+				AreEquals(nameof(args.PointerDeviceType), _pointer, args.PointerDeviceType);
+				AreEquals(nameof(args.ContactCount), _contactCount, args.ContactCount);
 			}
 		}
 	}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/InertiaExpansionBehavior.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/InertiaExpansionBehavior.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class InertiaExpansionBehavior 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  double DesiredExpansion
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  double DesiredDeceleration
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/InertiaRotationBehavior.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/InertiaRotationBehavior.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class InertiaRotationBehavior 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  double DesiredRotation
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  double DesiredDeceleration
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/InertiaTranslationBehavior.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/InertiaTranslationBehavior.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class InertiaTranslationBehavior 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  double DesiredDisplacement
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  double DesiredDeceleration
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationCompletedRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationCompletedRoutedEventArgs.cs
@@ -13,7 +13,7 @@ namespace Windows.UI.Xaml.Input
 		// Skipping already declared property IsInertial
 		// Skipping already declared property PointerDeviceType
 		// Skipping already declared property Position
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Input.ManipulationVelocities Velocities
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationDeltaRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationDeltaRoutedEventArgs.cs
@@ -14,7 +14,7 @@ namespace Windows.UI.Xaml.Input
 		// Skipping already declared property IsInertial
 		// Skipping already declared property PointerDeviceType
 		// Skipping already declared property Position
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Input.ManipulationVelocities Velocities
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationInertiaStartingRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/ManipulationInertiaStartingRoutedEventArgs.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Xaml.Input
 	#endif
 	public  partial class ManipulationInertiaStartingRoutedEventArgs : global::Windows.UI.Xaml.RoutedEventArgs
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.Input.InertiaTranslationBehavior TranslationBehavior
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.Input.InertiaRotationBehavior RotationBehavior
 		{
@@ -36,7 +36,7 @@ namespace Windows.UI.Xaml.Input
 		}
 		#endif
 		// Skipping already declared property Handled
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.Input.InertiaExpansionBehavior ExpansionBehavior
 		{
@@ -54,7 +54,7 @@ namespace Windows.UI.Xaml.Input
 		// Skipping already declared property Cumulative
 		// Skipping already declared property Delta
 		// Skipping already declared property PointerDeviceType
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Input.ManipulationVelocities Velocities
 		{

--- a/src/Uno.UI/UI/Xaml/Input/InertiaExpansionBehavior.cs
+++ b/src/Uno.UI/UI/Xaml/Input/InertiaExpansionBehavior.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+using Windows.UI.Input;
+
+namespace Windows.UI.Xaml.Input
+{
+	public partial class InertiaExpansionBehavior 
+	{
+		private readonly GestureRecognizer.Manipulation.InertiaProcessor _processor;
+
+		internal InertiaExpansionBehavior(GestureRecognizer.Manipulation.InertiaProcessor processor)
+		{
+			_processor = processor;
+		}
+
+		public double DesiredExpansion
+		{
+			get => _processor.DesiredExpansion;
+			set => _processor.DesiredExpansion = value;
+		}
+
+		public double DesiredDeceleration
+		{
+			get => _processor.DesiredExpansionDeceleration;
+			set => _processor.DesiredExpansionDeceleration = value;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Input/InertiaRotationBehavior.cs
+++ b/src/Uno.UI/UI/Xaml/Input/InertiaRotationBehavior.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+using Windows.UI.Input;
+
+namespace Windows.UI.Xaml.Input
+{
+	public partial class InertiaRotationBehavior 
+	{
+		private readonly GestureRecognizer.Manipulation.InertiaProcessor _processor;
+
+		internal InertiaRotationBehavior(GestureRecognizer.Manipulation.InertiaProcessor processor)
+		{
+			_processor = processor;
+		}
+
+		public double DesiredRotation
+		{
+			get => _processor.DesiredRotation;
+			set => _processor.DesiredRotation = value;
+		}
+
+		public double DesiredDeceleration
+		{
+			get => _processor.DesiredRotationDeceleration;
+			set => _processor.DesiredRotationDeceleration = value;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Input/InertiaTranslationBehavior.cs
+++ b/src/Uno.UI/UI/Xaml/Input/InertiaTranslationBehavior.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+using Windows.UI.Input;
+
+namespace Windows.UI.Xaml.Input
+{
+	public partial class InertiaTranslationBehavior 
+	{
+		private readonly GestureRecognizer.Manipulation.InertiaProcessor _processor;
+
+		internal InertiaTranslationBehavior(GestureRecognizer.Manipulation.InertiaProcessor processor)
+		{
+			_processor = processor;
+		}
+
+		public double DesiredDisplacement
+		{
+			get => _processor.DesiredDisplacement;
+			set => _processor.DesiredDisplacement = value;
+		}
+
+		public double DesiredDeceleration
+		{
+			get => _processor.DesiredDisplacementDeceleration;
+			set => _processor.DesiredDisplacementDeceleration = value;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedRoutedEventArgs.cs
@@ -16,6 +16,7 @@ namespace Windows.UI.Xaml.Input
 			PointerDeviceType = args.PointerDeviceType;
 			Position = args.Position;
 			Cumulative = args.Cumulative;
+			Velocities = args.Velocities;
 			IsInertial = args.IsInertial;
 		}
 
@@ -26,6 +27,7 @@ namespace Windows.UI.Xaml.Input
 		public PointerDeviceType PointerDeviceType { get; }
 		public Point Position { get; }
 		public ManipulationDelta Cumulative { get; }
+		public ManipulationVelocities Velocities { get; }
 		public bool IsInertial { get; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
@@ -22,6 +22,7 @@ namespace Windows.UI.Xaml.Input
 			Position = args.Position;
 			Delta = args.Delta;
 			Cumulative = args.Cumulative;
+			Velocities = args.Velocities;
 			IsInertial = args.IsInertial;
 		}
 
@@ -32,6 +33,7 @@ namespace Windows.UI.Xaml.Input
 		public Point Position { get; }
 		public ManipulationDelta Delta { get; }
 		public ManipulationDelta Cumulative { get; }
+		public ManipulationVelocities Velocities { get; }
 		public bool IsInertial { get; }
 
 		public void Complete()

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationInertiaStartingRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationInertiaStartingRoutedEventArgs.cs
@@ -16,6 +16,11 @@ namespace Windows.UI.Xaml.Input
 			PointerDeviceType = args.PointerDeviceType;
 			Delta = args.Delta;
 			Cumulative = args.Cumulative;
+			Velocities = args.Velocities;
+
+			TranslationBehavior = new InertiaTranslationBehavior(args.Processor);
+			RotationBehavior = new InertiaRotationBehavior(args.Processor);
+			ExpansionBehavior = new InertiaExpansionBehavior(args.Processor);
 		}
 
 		public bool Handled { get; set; }
@@ -25,5 +30,10 @@ namespace Windows.UI.Xaml.Input
 		public PointerDeviceType PointerDeviceType { get; }
 		public ManipulationDelta Delta { get; }
 		public ManipulationDelta Cumulative { get; }
+		public ManipulationVelocities Velocities { get; }
+
+		public InertiaTranslationBehavior TranslationBehavior { get; set; } // Ctor is internal, so we don't support external set!
+		public InertiaRotationBehavior RotationBehavior { get; set; } // Ctor is internal, so we don't support external set!
+		public InertiaExpansionBehavior ExpansionBehavior { get; set; } // Ctor is internal, so we don't support external set!
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationModes.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationModes.cs
@@ -29,13 +29,10 @@ namespace Windows.UI.Xaml.Input
 		/// <summary>Permit manipulation actions that scale the target.</summary>
 		Scale = 32U,
 		/// <summary>Apply inertia to translate actions.</summary>
-		[global::Uno.NotImplemented]
 		TranslateInertia = 64U,
 		/// <summary>Apply inertia to rotate actions.</summary>
-		[global::Uno.NotImplemented]
 		RotateInertia = 128U,
 		/// <summary>Apply inertia to scale actions.</summary>
-		[global::Uno.NotImplemented]
 		ScaleInertia = 256U,
 		/// <summary>Enable all manipulation interaction modes except those supported through Direct Manipulation</summary>
 		All = 65535U,

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationCompletedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationCompletedEventArgs.cs
@@ -10,7 +10,7 @@ namespace Windows.UI.Input
 		// Skipping already declared property Cumulative
 		// Skipping already declared property PointerDeviceType
 		// Skipping already declared property Position
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Input.ManipulationVelocities Velocities
 		{
@@ -20,7 +20,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  uint ContactCount
 		{
@@ -30,7 +30,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  uint CurrentContactCount
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationInertiaStartingEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationInertiaStartingEventArgs.cs
@@ -11,7 +11,7 @@ namespace Windows.UI.Input
 		// Skipping already declared property Delta
 		// Skipping already declared property PointerDeviceType
 		// Skipping already declared property Position
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Input.ManipulationVelocities Velocities
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  uint ContactCount
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationStartedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationStartedEventArgs.cs
@@ -10,7 +10,7 @@ namespace Windows.UI.Input
 		// Skipping already declared property Cumulative
 		// Skipping already declared property PointerDeviceType
 		// Skipping already declared property Position
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  uint ContactCount
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationUpdatedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationUpdatedEventArgs.cs
@@ -11,7 +11,7 @@ namespace Windows.UI.Input
 		// Skipping already declared property Delta
 		// Skipping already declared property PointerDeviceType
 		// Skipping already declared property Position
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Input.ManipulationVelocities Velocities
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  uint ContactCount
 		{
@@ -31,7 +31,7 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  uint CurrentContactCount
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationVelocities.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/ManipulationVelocities.cs
@@ -2,19 +2,19 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial struct ManipulationVelocities 
 	{
 		// Forced skipping of method Windows.UI.Input.ManipulationVelocities.ManipulationVelocities()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		public  global::Windows.Foundation.Point Linear;
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		public  float Angular;
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		public  float Expansion;
 		#endif
 	}

--- a/src/Uno.UWP/System/DispatcherQueueTimer.net.cs
+++ b/src/Uno.UWP/System/DispatcherQueueTimer.net.cs
@@ -11,17 +11,14 @@ namespace Windows.System
 	{
 		private void StartNative(TimeSpan interval)
 		{
-			throw new NotImplementedException("DispatcherQueueTimer not supported on .net");
 		}
 
 		private void StartNative(TimeSpan dueTime, TimeSpan interval)
 		{
-			throw new NotImplementedException("DispatcherQueueTimer not supported on .net");
 		}
 
 		private void StopNative()
 		{
-			throw new NotImplementedException("DispatcherQueueTimer not supported on .net");
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Input/DraggingEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/DraggingEventArgs.cs
@@ -3,12 +3,13 @@ using Windows.Foundation;
 
 namespace Windows.UI.Input
 {
-	public  partial class DraggingEventArgs 
+	public partial class DraggingEventArgs 
 	{
-		internal DraggingEventArgs(PointerPoint point, DraggingState state)
+		internal DraggingEventArgs(PointerPoint point, DraggingState state, uint contactCount)
 		{
 			Pointer = point;
 			DraggingState = state;
+			ContactCount = contactCount;
 		}
 
 		internal PointerPoint Pointer { get; }
@@ -19,14 +20,6 @@ namespace Windows.UI.Input
 
 		public Point Position => Pointer.Position;
 
-		[global::Uno.NotImplemented]
-		public uint ContactCount
-		{
-			get
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.DraggingEventArgs", "uint DraggingEventArgs.ContactCount");
-				return 0;
-			}
-		}
+		public uint ContactCount { get; }
 	}
 }

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.InertiaProcessor.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.InertiaProcessor.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Linq;
+using Windows.Foundation;
+using Windows.System;
+using Uno.Extensions;
+
+namespace Windows.UI.Input
+{
+	public partial class GestureRecognizer
+	{
+		internal partial class Manipulation
+		{
+			internal class InertiaProcessor : IDisposable
+			{
+				// TODO: We should somehow sync tick with frame rendering
+				const double framePerSecond = 25;
+				const double durationTicks = 1.5 * TimeSpan.TicksPerSecond;
+
+				private readonly DispatcherQueueTimer _timer;
+				private readonly Manipulation _owner;
+				private readonly ManipulationDelta _initial;
+
+				private readonly bool _isTranslateInertiaXEnabled;
+				private readonly bool _isTranslateInertiaYEnabled;
+				private readonly bool _isRotateInertiaEnabled;
+				private readonly bool _isScaleInertiaEnabled;
+
+				// Those values can be customized by the application through the ManipInertiaStartingArgs.Inertia<Tr|Rot|Exp>Behavior
+				public double DesiredDisplacement;
+				public double DesiredDisplacementDeceleration;
+				public double DesiredRotation;
+				public double DesiredRotationDeceleration;
+				public double DesiredExpansion;
+				public double DesiredExpansionDeceleration;
+
+				public InertiaProcessor(Manipulation owner, ManipulationDelta cumulative, ManipulationVelocities velocities)
+				{
+					_owner = owner;
+					_initial = cumulative;
+
+					_isTranslateInertiaXEnabled = _owner._isTranslateXEnabled && _owner._settings.HasFlag(Input.GestureSettings.ManipulationTranslateInertia);
+					_isTranslateInertiaYEnabled = _owner._isTranslateYEnabled && _owner._settings.HasFlag(Input.GestureSettings.ManipulationTranslateInertia);
+					_isRotateInertiaEnabled = _owner._isRotateEnabled && _owner._settings.HasFlag(Input.GestureSettings.ManipulationRotateInertia);
+					_isScaleInertiaEnabled = _owner._isScaleEnabled && _owner._settings.HasFlag(Input.GestureSettings.ManipulationScaleInertia);
+
+					_timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+					_timer.Interval = TimeSpan.FromMilliseconds(1000d / framePerSecond);
+					_timer.IsRepeating = true;
+					_timer.Tick += OnTick;
+
+					// TODO
+					DesiredDisplacement = _isTranslateInertiaXEnabled || _isTranslateInertiaYEnabled ? 300 : 0;
+					DesiredRotation = _isRotateInertiaEnabled ? 60 : 0;
+					DesiredExpansion = _isScaleInertiaEnabled ? 200 : 0;
+				}
+
+				public bool IsRunning => _timer.IsRunning;
+
+				/// <summary>
+				/// Gets the elapsed time of the inertia (cf. Remarks)
+				/// </summary>
+				/// <remarks>
+				/// Depending of the platform, the timestamp provided by pointer events might not be absolute,
+				/// so it's preferable to not compare timestamp between pointers and inertia processor.
+				/// </remarks>
+				public long Elapsed => _timer.LastTickElapsed.Ticks;
+
+				public void Start()
+					=> _timer.Start();
+
+				public ManipulationDelta GetCumulative()
+				{
+					var progress = 1 - Math.Pow(1 - GetNormalizedTime(), 4); // Source: https://easings.net/#easeOutQuart
+
+					var translateX = _isTranslateInertiaXEnabled ? _initial.Translation.X + progress * DesiredDisplacement : 0;
+					var translateY = _isTranslateInertiaYEnabled ? _initial.Translation.Y + progress * DesiredDisplacement : 0;
+					var rotate = _isRotateInertiaEnabled ? _initial.Rotation + progress * DesiredRotation : 0;
+					var expansion = _isScaleInertiaEnabled ? _initial.Expansion + progress * DesiredExpansion : 0;
+
+					var scale = (_owner._origins.Distance + expansion) / _owner._origins.Distance;
+
+					return new ManipulationDelta
+					{
+						Translation = new Point(translateX, translateY),
+						Rotation = (float)MathEx.NormalizeDegree(rotate),
+						Scale = (float)scale,
+						Expansion = (float)expansion
+					};
+				}
+
+				private double GetNormalizedTime()
+				{
+					var elapsed = _timer.LastTickElapsed;
+					var normalizedTime = elapsed.Ticks / durationTicks;
+
+					return normalizedTime;
+				}
+
+				private void OnTick(DispatcherQueueTimer sender, object args)
+				{
+					_owner.NotifyUpdate();
+
+					if (GetNormalizedTime() >= 1)
+					{
+						_timer.Stop();
+						_owner.NotifyUpdate();
+					}
+				}
+
+				/// <inheritdoc />
+				public void Dispose()
+					=> _timer.Stop();
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
@@ -405,14 +405,14 @@ namespace Windows.UI.Input
 
 				var translateX = _isTranslateXEnabled ? cumulative.Translation.X - deltaSum.Translation.X : 0;
 				var translateY = _isTranslateYEnabled ? cumulative.Translation.Y - deltaSum.Translation.Y : 0;
-				var rotate = _isRotateEnabled ? cumulative.Rotation - deltaSum.Rotation : 0;
+				var rotation = _isRotateEnabled ? cumulative.Rotation - deltaSum.Rotation : 0;
 				var scale = _isScaleEnabled ? cumulative.Scale / deltaSum.Scale : 1;
 				var expansion = _isScaleEnabled ? cumulative.Expansion - deltaSum.Expansion : 0;
 
 				return new ManipulationDelta
 				{
 					Translation = new Point(translateX, translateY),
-					Rotation = rotate,
+					Rotation = rotation,
 					Scale = scale,
 					Expansion = expansion
 				};
@@ -426,7 +426,7 @@ namespace Windows.UI.Input
 				var elapsedMs = elapsedTicks / TimeSpan.TicksPerMillisecond;
 
 				// With uno a single native event might produce multiple managed pointer events.
-				// In that case we would get en empty velocities ... which is often not relevant!
+				// In that case we would get an empty velocities ... which is often not relevant!
 				// When we detect that case, we prefer to replay the last known velocities.
 				if (delta.IsEmpty || elapsedMs == 0)
 				{
@@ -615,10 +615,6 @@ namespace Windows.UI.Input
 
 						Center = new Point((p1.X + p2.X) / 2, (p1.Y + p2.Y) / 2);
 						Distance = Vector2.Distance(p1.ToVector(), p2.ToVector());
-
-						// As long as possible we try to keep the angle close to the previous value.
-						// According to the doc, if angles goes from the second to the third quadrant the computed angle 
-
 						Angle = Math.Atan2(p1.Y - p2.Y, p1.X - p2.X);
 					}
 				}

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
@@ -57,7 +57,7 @@ namespace Windows.UI.Input
 			private Points _origins;
 			private Points _currents;
 			private (ushort onStart, ushort current) _contacts;
-			private (ManipulationDelta sumOfDelta, ulong timestamp, ushort contacts) _lastPublishedState = (ManipulationDelta.Empty, 0, 0); // Note: not maintained for dragging manipulation
+			private (ManipulationDelta sumOfDelta, ulong timestamp, ushort contacts) _lastPublishedState = (ManipulationDelta.Empty, 0, 1); // Note: not maintained for dragging manipulation
 			private ManipulationVelocities _lastRelevantVelocities;
 			private InertiaProcessor? _inertia;
 

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -102,9 +102,10 @@ namespace Windows.UI.Input
 					_manipulation = new Manipulation(this, value);
 					TryStartHapticFeedbackTimer(value);
 				}
-				else
+				else if (!_manipulation.TryAdd(value))
 				{
-					_manipulation.Add(value);
+					_manipulation.Complete();
+					_manipulation = new Manipulation(this, value);
 				}
 			}
 		}
@@ -240,9 +241,7 @@ namespace Windows.UI.Input
 		#region Manipulations
 		internal event TypedEventHandler<GestureRecognizer, ManipulationStartingEventArgs> ManipulationStarting; // This is not on the public API!
 		public event TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> ManipulationCompleted;
-#pragma warning disable  // Event not raised: inertia is not supported yet
 		public event TypedEventHandler<GestureRecognizer, ManipulationInertiaStartingEventArgs> ManipulationInertiaStarting;
-#pragma warning restore 67
 		public event TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> ManipulationStarted;
 		public event TypedEventHandler<GestureRecognizer, ManipulationUpdatedEventArgs> ManipulationUpdated;
 

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -160,6 +160,14 @@ namespace Windows.UI.Input
 			_manipulation?.Remove(value);
 		}
 
+#if NET461
+		/// <summary>
+		/// For test purposes only!
+		/// </summary>
+		internal void RunInertiaSync()
+			=> _manipulation?.RunInertiaSync();
+#endif
+
 		public void CompleteGesture()
 		{
 			// Capture the list in order to avoid alteration while enumerating

--- a/src/Uno.UWP/UI/Input/GestureSettings.cs
+++ b/src/Uno.UWP/UI/Input/GestureSettings.cs
@@ -39,13 +39,10 @@ namespace Windows.UI.Input
 		/// <summary>Enable support for the pinch or stretch gesture through pointer input.These gestures can be used for optical or semantic zoom and resizing an object. The ManipulationStarted, ManipulationUpdated, and ManipulationCompleted events are all raised during the course of this interaction.</summary>
 		ManipulationScale = 2048U,
 		/// <summary>Enable support for translation inertia after the slide gesture (through pointer input) is complete. The ManipulationInertiaStarting event is raised if inertia is enabled.</summary>
-		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		ManipulationTranslateInertia = 4096U,
 		/// <summary>Enable support for rotation inertia after the rotate gesture (through pointer input) is complete. The ManipulationInertiaStarting event is raised if inertia is enabled.</summary>
-		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		ManipulationRotateInertia = 8192U,
 		/// <summary>Enable support for scaling inertia after the pinch or stretch gesture (through pointer input) is complete. The ManipulationInertiaStarting event is raised if inertia is enabled.</summary>
-		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
 		ManipulationScaleInertia = 16384U,
 		/// <summary>Enable support for the CrossSliding interaction when using the slide or swipe gesture through a single touch contact.This gesture can be used for selecting or rearranging objects.</summary>
 		[global::Uno.NotImplemented] // The GestureRecognizer won't raise this event
@@ -88,7 +85,7 @@ namespace Windows.UI.Input
 		/// A combination of all "gesture" flags that can be raised by the GestureRecognizer
 		/// </summary>
 		public const GestureSettings SupportedGestures =
-			GestureSettings.Tap
+			  GestureSettings.Tap
 			| GestureSettings.DoubleTap
 			| GestureSettings.Hold
 			| GestureSettings.HoldWithMouse
@@ -98,5 +95,13 @@ namespace Windows.UI.Input
 		/// A combination of all "drag and drop" flags
 		/// </summary>
 		public const GestureSettings DragAndDrop = GestureSettings.Drag;
+
+		/// <summary>
+		/// A combination of all "inertia" flags
+		/// </summary>
+		public const GestureSettings Inertia =
+			  GestureSettings.ManipulationTranslateInertia
+			| GestureSettings.ManipulationScaleInertia
+			| GestureSettings.ManipulationRotateInertia;
 	}
 }

--- a/src/Uno.UWP/UI/Input/ManipulationCompletedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationCompletedEventArgs.cs
@@ -11,18 +11,26 @@ namespace Windows.UI.Input
 			PointerDeviceType pointerDeviceType,
 			Point position,
 			ManipulationDelta cumulative,
-			bool isInertial)
+			ManipulationVelocities velocities,
+			bool isInertial,
+			uint contactCount,
+			uint currentContactCount)
 		{
 			PointerDeviceType = pointerDeviceType;
 			Position = position;
 			Cumulative = cumulative;
+			Velocities = velocities;
 			IsInertial = isInertial;
+			ContactCount = contactCount;
+			CurrentContactCount = currentContactCount;
 		}
 
 		public PointerDeviceType PointerDeviceType { get; }
 		public Point Position { get; }
 		public ManipulationDelta Cumulative { get; }
-
+		public ManipulationVelocities Velocities { get; }
+		public uint ContactCount { get; }
+		public uint CurrentContactCount { get; }
 		internal bool IsInertial { get; }
 	}
 }

--- a/src/Uno.UWP/UI/Input/ManipulationDelta.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationDelta.cs
@@ -22,9 +22,7 @@ namespace Windows.UI.Input
 		public float Rotation;
 		public float Expansion;
 
-		/// <inheritdoc />
-		public override string ToString()
-			=> $"x:{Translation.X:N0};y:{Translation.Y:N0};θ:{Rotation:F2};s:{Scale:F2};e:{Expansion:F2}";
+		internal bool IsEmpty => Translation == Point.Zero && Rotation == 0 && Scale == 1 && Expansion == 0;
 
 		internal ManipulationDelta Add(ManipulationDelta right) => Add(this, right);
 		internal static ManipulationDelta Add(ManipulationDelta left, ManipulationDelta right)
@@ -44,5 +42,10 @@ namespace Windows.UI.Input
 			|| Math.Abs(Translation.Y) >= thresholds.TranslateY
 			|| Rotation >= thresholds.Rotate // We used the ToDegreeNormalized, no need to check for negative angles
 			|| Math.Abs(Expansion) >= thresholds.Expansion;
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"x:{Translation.X:N0};y:{Translation.Y:N0};θ:{Rotation:F2};s:{Scale:F2};e:{Expansion:F2}";
+
 	}
 }

--- a/src/Uno.UWP/UI/Input/ManipulationDelta.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationDelta.cs
@@ -43,7 +43,7 @@ namespace Windows.UI.Input
 		internal bool IsSignificant(GestureRecognizer.Manipulation.Thresholds thresholds)
 			=> Math.Abs(Translation.X) >= thresholds.TranslateX
 			|| Math.Abs(Translation.Y) >= thresholds.TranslateY
-			|| Rotation >= thresholds.Rotate // We used the ToDegreeNormalized, no need to check for negative angles
+			|| Math.Abs(Rotation) >= thresholds.Rotate
 			|| Math.Abs(Expansion) >= thresholds.Expansion;
 
 		/// <inheritdoc />

--- a/src/Uno.UWP/UI/Input/ManipulationDelta.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationDelta.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 using Windows.Foundation;
 
 namespace Windows.UI.Input
@@ -24,6 +25,7 @@ namespace Windows.UI.Input
 
 		internal bool IsEmpty => Translation == Point.Zero && Rotation == 0 && Scale == 1 && Expansion == 0;
 
+		[Pure]
 		internal ManipulationDelta Add(ManipulationDelta right) => Add(this, right);
 		internal static ManipulationDelta Add(ManipulationDelta left, ManipulationDelta right)
 			=> new ManipulationDelta
@@ -37,6 +39,7 @@ namespace Windows.UI.Input
 			};
 
 		// Note: We should apply a velocity factor to thresholds to determine if isSignificant
+		[Pure]
 		internal bool IsSignificant(GestureRecognizer.Manipulation.Thresholds thresholds)
 			=> Math.Abs(Translation.X) >= thresholds.TranslateX
 			|| Math.Abs(Translation.Y) >= thresholds.TranslateY
@@ -44,6 +47,7 @@ namespace Windows.UI.Input
 			|| Math.Abs(Expansion) >= thresholds.Expansion;
 
 		/// <inheritdoc />
+		[Pure]
 		public override string ToString()
 			=> $"x:{Translation.X:N0};y:{Translation.Y:N0};θ:{Rotation:F2};s:{Scale:F2};e:{Expansion:F2}";
 

--- a/src/Uno.UWP/UI/Input/ManipulationInertiaStartingEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationInertiaStartingEventArgs.cs
@@ -5,17 +5,31 @@ namespace Windows.UI.Input
 {
 	public partial class ManipulationInertiaStartingEventArgs 
 	{
-		internal ManipulationInertiaStartingEventArgs(PointerDeviceType pointerDeviceType, Point position, ManipulationDelta delta, ManipulationDelta cumulative)
+		internal ManipulationInertiaStartingEventArgs(
+			PointerDeviceType pointerDeviceType,
+			Point position,
+			ManipulationDelta delta,
+			ManipulationDelta cumulative,
+			ManipulationVelocities velocities,
+			uint contactCount,
+			GestureRecognizer.Manipulation.InertiaProcessor processor)
 		{
 			PointerDeviceType = pointerDeviceType;
 			Position = position;
 			Delta = delta;
 			Cumulative = cumulative;
+			Velocities = velocities;
+			ContactCount = contactCount;
+			Processor = processor;
 		}
 
 		public PointerDeviceType PointerDeviceType { get; }
 		public Point Position { get; }
 		public ManipulationDelta Delta { get; }
 		public ManipulationDelta Cumulative { get; }
+		public ManipulationVelocities Velocities { get; }
+		public uint ContactCount { get; }
+
+		internal GestureRecognizer.Manipulation.InertiaProcessor Processor { get; }
 	}
 }

--- a/src/Uno.UWP/UI/Input/ManipulationStartedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationStartedEventArgs.cs
@@ -5,15 +5,17 @@ namespace Windows.UI.Input
 {
 	public partial class ManipulationStartedEventArgs 
 	{
-		internal ManipulationStartedEventArgs(PointerDeviceType pointerDeviceType, Point position, ManipulationDelta cumulative)
+		internal ManipulationStartedEventArgs(PointerDeviceType pointerDeviceType, Point position, ManipulationDelta cumulative, uint contactCount)
 		{
 			PointerDeviceType = pointerDeviceType;
 			Position = position;
 			Cumulative = cumulative;
+			ContactCount = contactCount;
 		}
 
 		public PointerDeviceType PointerDeviceType { get; }
 		public Point Position { get; }
 		public ManipulationDelta Cumulative { get; }
+		public uint ContactCount { get; }
 	}
 }

--- a/src/Uno.UWP/UI/Input/ManipulationUpdatedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationUpdatedEventArgs.cs
@@ -10,19 +10,28 @@ namespace Windows.UI.Input
 			Point position,
 			ManipulationDelta delta,
 			ManipulationDelta cumulative,
-			bool isInertial)
+			ManipulationVelocities velocities,
+			bool isInertial,
+			uint contactCount,
+			uint currentContactCount)
 		{
 			PointerDeviceType = pointerDeviceType;
 			Position = position;
 			Delta = delta;
 			Cumulative = cumulative;
+			Velocities = velocities;
 			IsInertial = isInertial;
+			ContactCount = contactCount;
+			CurrentContactCount = currentContactCount;
 		}
 
 		public PointerDeviceType PointerDeviceType { get; }
 		public Point Position { get; }
 		public ManipulationDelta Delta { get; }
 		public ManipulationDelta Cumulative { get; }
+		public ManipulationVelocities Velocities { get; }
+		public uint ContactCount { get; }
+		public uint CurrentContactCount { get; }
 
 		internal bool IsInertial { get; }
 	}

--- a/src/Uno.UWP/UI/Input/ManipulationVelocities.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationVelocities.cs
@@ -1,0 +1,32 @@
+using System;
+using Windows.Foundation;
+
+namespace Windows.UI.Input
+{
+	public partial struct ManipulationVelocities
+	{
+		internal static ManipulationVelocities Empty { get; } = new ManipulationVelocities();
+
+		/// <summary>
+		/// The expansion, or scaling, velocity in device-independent pixel (DIP) per millisecond.
+		/// </summary>
+		public Point Linear;
+
+		/// <summary>
+		/// The rotational velocity in degrees per millisecond.
+		/// </summary>
+		public float Angular;
+
+		/// <summary>
+		/// The expansion, or scaling, velocity in device-independent pixel (DIP) per millisecond.
+		/// </summary>
+		public float Expansion;
+
+		// Note: We should apply a velocity factor to thresholds to determine if isSignificant
+		internal bool IsAnyAbove(GestureRecognizer.Manipulation.Thresholds thresholds)
+			=> Math.Abs(Linear.X) > thresholds.TranslateX
+				|| Math.Abs(Linear.Y) > thresholds.TranslateY
+				|| Angular > thresholds.Rotate // We used the ToDegreeNormalized, no need to check for negative angles
+				|| Math.Abs(Expansion) > thresholds.Expansion;
+	}
+}

--- a/src/Uno.UWP/UI/Input/ManipulationVelocities.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationVelocities.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Input
 		internal bool IsAnyAbove(GestureRecognizer.Manipulation.Thresholds thresholds)
 			=> Math.Abs(Linear.X) > thresholds.TranslateX
 				|| Math.Abs(Linear.Y) > thresholds.TranslateY
-				|| Angular > thresholds.Rotate // We used the ToDegreeNormalized, no need to check for negative angles
+				|| Math.Abs(Angular) > thresholds.Rotate
 				|| Math.Abs(Expansion) > thresholds.Expansion;
 	}
 }

--- a/src/Uno.UWP/UI/Input/ManipulationVelocities.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationVelocities.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Diagnostics.Contracts;
 using Windows.Foundation;
 
 namespace Windows.UI.Input
@@ -28,5 +29,10 @@ namespace Windows.UI.Input
 				|| Math.Abs(Linear.Y) > thresholds.TranslateY
 				|| Math.Abs(Angular) > thresholds.Rotate
 				|| Math.Abs(Expansion) > thresholds.Expansion;
+
+		/// <inheritdoc />
+		[Pure]
+		public override string ToString()
+			=> $"x:{Linear.X:N0};y:{Linear.Y:N0};θ:{Angular};e:{Expansion:F2}";
 	}
 }


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/6186

## Feature
Add support of inertia in manipulation events

## What is the current behavior?
The `UIElement.ManipulationInertiaStarted` event was never raised, and no "delta" due to inertia was raised.

## What is the new behavior?
🙃

## PR Checklist
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~=> Some constructors that was not part of public UWP API have been converted to `internal`
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
