### PR TITLE
fix(calendar): Fix few C++ translation issues

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarLayoutStrategy_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarLayoutStrategy_Partial.cs
@@ -239,7 +239,7 @@ namespace Windows.UI.Xaml.Controls
 			out bool returnValue) /*override*/
 		{
 			returnValue = false;
-			returnValue = !!_layoutStrategyImpl.HasIrregularSnapPoints(elementType);
+			returnValue = _layoutStrategyImpl.HasIrregularSnapPoints(elementType);
 		}
 
 		private void HasSnapPointOnElementImpl(

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewGeneratorHost.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewGeneratorHost.cs
@@ -151,7 +151,7 @@ namespace Windows.UI.Xaml.Controls
 
 					isTodayHighlighted = Owner.IsTodayHighlighted;
 
-					isToday = !!isTodayHighlighted;
+					isToday = isTodayHighlighted;
 				}
 
 				spContainer.SetIsToday(isToday);

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewGeneratorMonthViewHost.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewGeneratorMonthViewHost.cs
@@ -68,7 +68,7 @@ namespace Windows.UI.Xaml.Controls
 
 				isLabelVisible = Owner.IsGroupLabelVisible;
 
-				UpdateLabel(spContainer, !isLabelVisible);
+				UpdateLabel(spContainer, isLabelVisible);
 			}
 
 			// today state will be updated in CalendarViewGeneratorHost.PrepareItemContainer

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewGeneratorYearViewHost.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewGeneratorYearViewHost.cs
@@ -58,7 +58,7 @@ namespace Windows.UI.Xaml.Controls
 
 				isLabelVisible = Owner.IsGroupLabelVisible;
 
-				UpdateLabel(spContainer, !isLabelVisible);
+				UpdateLabel(spContainer, isLabelVisible);
 			}
 
 			// today state will be updated in CalendarViewGeneratorHost.PrepareItemContainer

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
@@ -2004,7 +2004,7 @@ namespace Windows.UI.Xaml.Controls
 							bool isTodayHighlighted = false;
 
 							isTodayHighlighted = IsTodayHighlighted;
-							((CalendarViewBaseItem)spChildAsI).SetIsToday(!isTodayHighlighted);
+							((CalendarViewBaseItem)spChildAsI).SetIsToday(isTodayHighlighted);
 						}
 					}
 				}
@@ -2021,7 +2021,7 @@ namespace Windows.UI.Xaml.Controls
 			// when IsOutOfScopeEnabled property is false, we don't care about scope state (all are inScope),
 			// so we don't need to hook to ScrollViewer's state change handler.
 			// when IsOutOfScopeEnabled property is true, we need to do so.
-			if (m_areDirectManipulationStateChangeHandlersHooked != !isOutOfScopeEnabled)
+			if (m_areDirectManipulationStateChangeHandlersHooked != isOutOfScopeEnabled)
 			{
 				m_areDirectManipulationStateChangeHandlersHooked = !m_areDirectManipulationStateChangeHandlersHooked;
 
@@ -2252,7 +2252,7 @@ namespace Windows.UI.Xaml.Controls
 					ForeachChildInPanel(pPanel, 
 						(CalendarViewBaseItem pItem) =>
 					{
-						pHost.UpdateLabel(pItem, !isLabelVisible);
+						pHost.UpdateLabel(pItem, isLabelVisible);
 					});
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial_Selection.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial_Selection.cs
@@ -388,7 +388,7 @@ namespace Windows.UI.Xaml.Controls
 
 			found = m_tpSelectedDates.IndexOf(date, out index);
 
-			pIsSelected = !!found;
+			pIsSelected = found;
 
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DateTimePickerFlyoutHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DateTimePickerFlyoutHelper.cs
@@ -193,7 +193,7 @@ namespace Windows.UI.Xaml.Controls
 					}
 				}
 
-				pEventArgs.Handled = !!focusChanged;
+				pEventArgs.Handled = focusChanged;
 			}
 
 			return;


### PR DESCRIPTION
## Bugfix
Some parts of the code `Calendar<View|DatePicker>` was wrongly translated from C++

## What is the current behavior?
* `IsGroupLabelVisible` is inverted
* `IsTodayHighlighted` is inverted when changed while `Calendar` is already loaded
* ...

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
