### PR TITLE
Fix(CalendarView): Fix header not updating while scrolling

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
@@ -7,6 +7,7 @@ using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Globalization;
 using Windows.Globalization.DateTimeFormatting;
+using Windows.System;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
@@ -1848,7 +1849,12 @@ namespace Windows.UI.Xaml.Controls
 
 				if (isScopeChanged)
 				{
+#if __ANDROID__
+					// .InvalidateMeasure() bug
+					DispatcherQueue.GetForCurrentThread().TryEnqueue(() => UpdateHeaderText(false /*withAnimation*/));
+#else
 					UpdateHeaderText(false /*withAnimation*/);
+#endif
 				}
 
 				// everytime visible indices changed, we need to update

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
@@ -1850,8 +1850,8 @@ namespace Windows.UI.Xaml.Controls
 				if (isScopeChanged)
 				{
 #if __ANDROID__
-					// .InvalidateMeasure() bug
-					DispatcherQueue.GetForCurrentThread().TryEnqueue(() => UpdateHeaderText(false /*withAnimation*/));
+					// .InvalidateMeasure() bug https://github.com/unoplatform/uno/issues/6236
+					DispatcherQueue.TryEnqueue(() => UpdateHeaderText(false /*withAnimation*/));
 #else
 					UpdateHeaderText(false /*withAnimation*/);
 #endif

--- a/src/Uno.UI/UI/Xaml/UIElement.MuxInternal.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.MuxInternal.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Windows.System;
 using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml
@@ -19,6 +20,11 @@ namespace Windows.UI.Xaml
 		internal void RemoveChild(UIElement viewToRemove) => VisualTreeHelper.RemoveChild(this, viewToRemove);
 
 		internal void AddChild(UIElement viewToAdd) => VisualTreeHelper.AddChild(this, viewToAdd);
+#endif
+
+#if !HAS_UNO_WINUI
+		// This is to ensure forward compatibility with WinUI
+		private protected DispatcherQueue DispatcherQueue => DispatcherQueue.GetForCurrentThread();
 #endif
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/6214
fixes https://github.com/unoplatform/uno/issues/6229

# Bugfix

## What is the current behavior?
Sometimes the header of the `<CalendarView />` were not updated properly when the user what scrolling the content, on Android.

## What is the new behavior?
A patch has been done.  The issue https://github.com/unoplatform/uno/issues/6236 should fix the problem.


## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- ~~[ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ -- it's a patch.  The test will come with the correct fix.
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
