### PR TITLE
fix(calendar): Fix year and decade view initial scrolling on Android

### DIFF
--- a/src/Uno.Foundation/Size.cs
+++ b/src/Uno.Foundation/Size.cs
@@ -19,9 +19,9 @@ namespace Windows.Foundation
 
 		public static Size Empty => new Size(double.NegativeInfinity, double.NegativeInfinity);
 
-		public double Height { get; set; }
-
 		public bool IsEmpty => double.IsNegativeInfinity(Width) && double.IsNegativeInfinity(Height);
+
+		public double Height { get; set; }
 
 		public double Width { get; set; }
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.Android.cs
@@ -222,6 +222,8 @@ namespace Windows.UI.Xaml.Controls
 						height
 					));
 
+					ScrollContentPresenter.ScrollOwner?.TryApplyPendingScrollTo();
+
 					// Give opportunity to the the content to define the viewport size itself
 					(child as ICustomScrollInfo)?.ApplyViewport(ref slotSize);
 


### PR DESCRIPTION
https://github.com/unoplatform/uno/issues/6231
fixes https://github.com/unoplatform/uno/issues/6217

## Bugfix
Initial scrolling on first navigation to year and decades views is invalid

## What is the current behavior?
- In the picker, the items was still at 1x1, so requested offset was invalid
- The `ScrollViewer` was not supporting to scroll before being being arranged with sufficient extent size

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

