### PR TITLE
fix: VS restore, netstandard build of GTK, use IsTrimmable instead of LinkerSafe on iOS

### DIFF
--- a/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Wasm.csproj
+++ b/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Wasm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="../../netcore-build.props"/>

--- a/src/SamplesApp/SamplesApp.Skia.WPF/SamplesApp.Skia.WPF.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.WPF/SamplesApp.Skia.WPF.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 	<PropertyGroup>
-		<TargetFrameworks>net472;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+		<TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">

--- a/src/Uno.Foundation/AssemblyInfo.cs
+++ b/src/Uno.Foundation/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using global::System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Uno.UI.Tests")]
 
 #if __IOS__
-[assembly: Foundation.LinkerSafe]
+[assembly: AssemblyMetadata("IsTrimmable", "True")]
 #elif __ANDROID__
 [assembly: Android.LinkerSafe]
 #endif

--- a/src/Uno.Foundation/AssemblyInfo.cs
+++ b/src/Uno.Foundation/AssemblyInfo.cs
@@ -9,6 +9,9 @@ using global::System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Uno.UI.Tests")]
 
 #if __IOS__
+#pragma warning disable CS0618 // Type or member is obsolete
+[assembly: Foundation.LinkerSafe]
+#pragma warning restore CS0618 // Type or member is obsolete
 [assembly: AssemblyMetadata("IsTrimmable", "True")]
 #elif __ANDROID__
 [assembly: Android.LinkerSafe]

--- a/src/Uno.UI.Runtime.Skia.Gtk/System/LauncherHelpers/DesktopFile.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/System/LauncherHelpers/DesktopFile.cs
@@ -20,7 +20,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.System.LauncherHelpers
 			}
 			desktopFileId = desktopFileId.Replace('-', '/');
 
-			foreach (var dir in XdgDataDirs.Split(":"))
+			foreach (var dir in XdgDataDirs.Split(':'))
 			{
 				var path = Path.Combine(dir, "applications", desktopFileId);
 				if (!File.Exists(path))
@@ -50,11 +50,11 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.System.LauncherHelpers
 				{
 					continue;
 				}
-				if (line.StartsWith('#'))
+				if (line.StartsWith("#"))
 				{
 					continue;
 				}
-				if (line.StartsWith('[') && line.EndsWith(']'))
+				if (line.StartsWith("[") && line.EndsWith("]"))
 				{
 					currentHeaderName = line.Substring(1, line.Length - 2);
 					if (!_groups.ContainsKey(currentHeaderName))
@@ -68,9 +68,12 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.System.LauncherHelpers
 				var key = line.Substring(0, splitPos).Trim();
 				var value = line.Substring(splitPos + 1).Trim();
 
-				_groups[currentHeaderName].TryAdd(key, value);
+				var group = _groups[currentHeaderName];
+				if (!group.ContainsKey(key))
+				{
+					group.Add(key, value);
+				}
 			}
-
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/System/LauncherHelpers/MimeAppsList.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/System/LauncherHelpers/MimeAppsList.cs
@@ -84,16 +84,16 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.System.LauncherHelpers
 			}
 
 			locations.Add(XdgConfigHome);
-			locations.AddRange(XdgConfigDirs.Split(":"));
+			locations.AddRange(XdgConfigDirs.Split(':'));
 			locations.Add(Path.Combine(XdgDataHome, "applications"));
-			locations.AddRange(XdgDataDirs.Split(":").Select(path => Path.Combine(path, "applications")));
+			locations.AddRange(XdgDataDirs.Split(':').Select(path => Path.Combine(path, "applications")));
 
 			foreach (var location in locations)
 			{
 				ParseFile(location);
 			}
 
-			foreach (var dir in XdgDataDirs.Split(":"))
+			foreach (var dir in XdgDataDirs.Split(':'))
 			{
 				var desktopFileDir = Path.Combine(dir, "applications");
 				var directoryInfo = new DirectoryInfo(desktopFileDir);
@@ -110,7 +110,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.System.LauncherHelpers
 					{
 						continue;
 					}
-					var mimeTypes = desktopFile.DesktopEntry["MimeType"].Split(";");
+					var mimeTypes = desktopFile.DesktopEntry["MimeType"].Split(';');
 					foreach (var mimeType in mimeTypes)
 					{
 						Add(DesktopFileAssociations, mimeType, fileName);
@@ -138,7 +138,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.System.LauncherHelpers
 				}
 				else
 				{
-					target.Add(key, values.ToHashSet());
+					target.Add(key, new HashSet<string>(values));
 				}
 			}
 			// Using algorithm here: https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html#ordering
@@ -170,7 +170,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.System.LauncherHelpers
 						}
 
 						var key = line.Substring(0, line.IndexOf('=')).Trim();
-						var values = line.Substring(line.IndexOf('=') + 1).Trim().Split(";");
+						var values = line.Substring(line.IndexOf('=') + 1).Trim().Split(';');
 
 						switch (currentSection)
 						{

--- a/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net47;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
 	<Import Project="../netcore-build-windows.props" />

--- a/src/Uno.UWP/AssemblyInfo.cs
+++ b/src/Uno.UWP/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Uno.UI.Toolkit")]
 
 #if __IOS__
-[assembly: Foundation.LinkerSafe]
+[assembly: AssemblyMetadata("IsTrimmable", "True")]
 #elif __ANDROID__
 [assembly: Android.LinkerSafe]
 #endif

--- a/src/Uno.UWP/AssemblyInfo.cs
+++ b/src/Uno.UWP/AssemblyInfo.cs
@@ -9,6 +9,9 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Uno.UI.Toolkit")]
 
 #if __IOS__
+#pragma warning disable CS0618 // Type or member is obsolete
+[assembly: Foundation.LinkerSafe]
+#pragma warning restore CS0618 // Type or member is obsolete
 [assembly: AssemblyMetadata("IsTrimmable", "True")]
 #elif __ANDROID__
 [assembly: Android.LinkerSafe]


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6249

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Failures


## What is the new behavior?

- VS does not fail to restore packages for the full solution
- GTK compiles for netstandard 2.0
- Using `IsTrimmable` instead of `LinkerSafe` on iOS

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
