### PR TITLE
fix(textblock): [Android] Fix TextBlock color not updating

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ListViewPages;
+#if NETFX_CORE
+using Uno.UI.Extensions;
+#elif __IOS__
+using UIKit;
+#elif __MACOS__
+using AppKit;
+#else
+using Uno.UI;
+#endif
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using static Private.Infrastructure.TestServices;
+using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Xaml.Media;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Uno.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+using System.ComponentModel;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public partial class Given_NavigationView
+	{
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_SelectedItem_Set_Before_Load_And_Theme_Changed()
+		{
+			using (StyleHelper.UseFluentStyles())
+			{
+
+				var navView = new Microsoft.UI.Xaml.Controls.NavigationView()
+				{
+					MenuItems =
+				{
+					new Microsoft.UI.Xaml.Controls.NavigationViewItem {Content = "Item 1"},
+					new Microsoft.UI.Xaml.Controls.NavigationViewItem {Content = "Item 2"},
+					new Microsoft.UI.Xaml.Controls.NavigationViewItem {Content = "Item 3"},
+				},
+					PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal,
+					IsBackButtonVisible = Microsoft.UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed,
+				};
+				navView.SelectedItem = navView.MenuItems[1];
+				var hostGrid = new Grid() { MinWidth = 20, MinHeight = 20 };
+
+				WindowHelper.WindowContent = hostGrid;
+
+				await WindowHelper.WaitForLoaded(hostGrid);
+
+				hostGrid.Children.Add(navView);
+
+				await WindowHelper.WaitForLoaded(navView);
+
+				navView.IsPaneOpen = true;
+
+				await WindowHelper.WaitForIdle();
+
+				var togglePaneButton = navView.FindFirstChild<Button>(b => b.Name == "TogglePaneButton");
+				var iconTextBlock = togglePaneButton?.FindFirstChild<TextBlock>(t => t.Name == "Icon");
+
+				Assert.AreEqual(Colors.Black, (iconTextBlock.Foreground as SolidColorBrush)?.Color);
+				using (ThemeHelper.UseDarkTheme())
+				{
+					await WindowHelper.WaitForIdle();
+					Assert.AreEqual(Colors.White, (iconTextBlock.Foreground as SolidColorBrush)?.Color);
+#if __ANDROID__
+					// This is the meat of the test - we verify that the actual color of the TextBlock matches the managed Color, which will only be the
+					// case if it was correctly measured and arranged as requested after the theme changed.
+					Assert.AreEqual(false, iconTextBlock.IsLayoutRequested);
+					Assert.AreEqual(Android.Graphics.Color.White, iconTextBlock.NativeArrangedColor);
+#endif
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
@@ -38,8 +38,17 @@ namespace Windows.UI.Xaml.Controls
 				// Issue: https://github.com/unoplatform/uno/issues/2879
 			}
 
+			if (view.IsLayoutRequested && view.Parent is View parent && !parent.IsLayoutRequested)
+			{
+				// If a view has requested layout but its Parent hasn't, then the tree is in a broken state, because RequestLayout() calls
+				// cannot bubble up from below the view, and remeasures cannot bubble down from above the parent. This can arise, eg, when
+				// ForceLayout() is used. To fix this state, call RequestLayout() on the parent. Since MeasureChildOverride() is called
+				// from the top down, we should be able to assume that the tree above the parent is already in a good state.
+				parent.RequestLayout();
+			}
+
 			MeasureChild(view, widthSpec, heightSpec);
-			
+
 			var ret = Uno.UI.Controls.BindableView.GetNativeMeasuredDimensionsFast(view)
 				.PhysicalToLogicalPixels();
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -113,6 +113,11 @@ namespace Windows.UI.Xaml.Controls
 		private TextUtils.TruncateAt _ellipsize;
 		private Android.Text.Layout.Alignment _layoutAlignment;
 
+		/// <summary>
+		/// Used by unit tests to verify that the displayed color matches the nominal managed color.
+		/// </summary>
+		internal Android.Graphics.Color? NativeArrangedColor => _arrangeLayout?.Layout.Paint?.Color;
+
 		private void InitializePartial()
 		{
 			// This makes OnDraw to be called


### PR DESCRIPTION
Certain paths, such as a combination of infinite-width containers and calling the UpdateLayout() method, could result in parts of the visual tree falling into a bad layout state where IsLayoutRequested=true is interleaved with IsLayoutRequested=false, resulting in the bad subtrees never updating. To prevent this, check for this state and repair it by setting the layout request on the parent of the affected view.

This ensures that TextBlock will update correctly when its Foreground color changes (since it relies on a measure+arrange pass to be redrawn).

GitHub Issue (If applicable): fixes #5939

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
