### PR TITLE
fix(calendar): Fix setting Width and Height on Calendar does nothing

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/Primitives/CalendarPanel.ModernCollectionBasePanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/Primitives/CalendarPanel.ModernCollectionBasePanel.cs
@@ -517,11 +517,11 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			var viewport = new Rect(
 				_effectiveViewport.Location.FiniteOrDefault(default),
 				_effectiveViewport.Size.AtLeast(availableSize).AtLeast(_defaultHardCodedSize).FiniteOrDefault(_defaultHardCodedSize));
-			if (calendar.HorizontalAlignment != HorizontalAlignment.Stretch)
+			if (calendar.HorizontalAlignment != HorizontalAlignment.Stretch && double.IsNaN(calendar.Width) && calendar.MinWidth <= 0)
 			{
 				viewport.Width = _defaultHardCodedSize.Width;
 			}
-			if (calendar.VerticalAlignment != VerticalAlignment.Stretch)
+			if (calendar.VerticalAlignment != VerticalAlignment.Stretch && double.IsNaN(calendar.Height) && calendar.MinHeight <= 0)
 			{
 				viewport.Height = _defaultHardCodedSize.Height;
 			}


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/6228

## Bugfix
Day items aren't correctly resized while changing the calendar Height or Width

## What is the current behavior?
If not stretch, we use hard coded size

## What is the new behavior?
We make sure to also validate if Width and/or Height are set

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
