### PR TITLE
fix(binding): Don't try metadata lookups on internal and struct types

### DIFF
--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -240,7 +240,7 @@ namespace Uno.UI.DataBinding
 			using (Performance.Measure("InternalGetPropertyType"))
 #endif
 			{
-				if (BindableMetadataProvider != null)
+				if (IsValidMetadataProviderType(type) && BindableMetadataProvider != null)
 				{
 					var bindablePropertyDescriptor = BindablePropertyDescriptor.GetPropertByBindableMetadataProvider(type, property);
 
@@ -321,7 +321,7 @@ namespace Uno.UI.DataBinding
 						return attachedPropertyGetter.ReturnType;
 					}
 
-					if(type.IsPrimitive && property == "Value")
+					if (type.IsPrimitive && property == "Value")
 					{
 						// This case is trying assuming that Value for a primitive is used for the case
 						// of a Nullable primitive.
@@ -509,7 +509,7 @@ namespace Uno.UI.DataBinding
 				}
 
 				// Start by using the provider, to avoid reflection
-				if (BindableMetadataProvider != null)
+				if (IsValidMetadataProviderType(type) && BindableMetadataProvider != null)
 				{
 #if PROFILE
 					using (Performance.Measure("GetValueGetter.BindableMetadataProvider"))
@@ -579,7 +579,7 @@ namespace Uno.UI.DataBinding
 			}
 
 			// Start by using the provider, to avoid reflection
-			if (BindableMetadataProvider != null)
+			if (IsValidMetadataProviderType(type) && BindableMetadataProvider != null)
 			{
 #if PROFILE
 				using (Performance.Measure("GetValueGetter.BindableMetadataProvider"))
@@ -760,7 +760,7 @@ namespace Uno.UI.DataBinding
 
 
 				// Start by using the provider, to avoid reflection
-				if (BindableMetadataProvider != null)
+				if (IsValidMetadataProviderType(type) && BindableMetadataProvider != null)
 				{
 #if PROFILE
 					using (Performance.Measure("GetValueSetter.BindableMetadataProvider"))
@@ -829,7 +829,7 @@ namespace Uno.UI.DataBinding
 			}
 
 			// Start by using the provider, to avoid reflection
-			if (BindableMetadataProvider != null)
+			if (IsValidMetadataProviderType(type) && BindableMetadataProvider != null)
 			{
 #if PROFILE
 				using (Performance.Measure("GetValueSetter.BindableMetadataProvider"))
@@ -1088,6 +1088,13 @@ namespace Uno.UI.DataBinding
 			=> DependencyProperty.UnsetValue;
 
 		private static void UnsetValueSetter(object unused, object? unused2) { }
+
+		/// <summary>
+		/// Determines if the type can be provided by the MetadataProvider
+		/// </summary>
+		/// <remarks>This method needs to be aligned with the symbols query in BindableTypeProvidersSourceGenerator.</remarks>
+		private static bool IsValidMetadataProviderType(Type type)
+			=> type.IsPublic && type.IsClass;
 	}
 }
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/6267

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change reduces the number of false positives for debugging messages on bindable metadata provider types.

```
The Bindable attribute is missing and the type [XXXX] is not known by the MetadataProvider. Reflection was used instead of the binding engine and generated static metadata. Add the Bindable attribute to prevent this message and performance issues.
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
