### PR TITLE
fix(reg): Fix double path separator for lottie assets

### DIFF
--- a/src/Uno.UWP/Storage/Helpers/AssetsPathBuilder.wasm.cs
+++ b/src/Uno.UWP/Storage/Helpers/AssetsPathBuilder.wasm.cs
@@ -21,7 +21,7 @@ namespace Windows.Storage.Helpers
 			=> !string.IsNullOrEmpty(UNO_BOOTSTRAP_APP_BASE)
 				// Concatenates the app's base path (used to support deep-linking), with the generated app based content folder name.
 				// See https://github.com/unoplatform/Uno.Wasm.Bootstrap#configuration-environment-variables for more details.
-				? $"{UNO_BOOTSTRAP_WEBAPP_BASE_PATH}{UNO_BOOTSTRAP_APP_BASE}/{contentRelativePath}"
+				? $"{UNO_BOOTSTRAP_WEBAPP_BASE_PATH}{UNO_BOOTSTRAP_APP_BASE}/{contentRelativePath?.TrimStart('/')}"
 				: contentRelativePath;
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes https://github.com/unoplatform/uno/issues/6277

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Lottie assets path are containing doubled path separators, making IIS hosted resource location fail. 

This change avoids this double separator.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
