### PR TITLE
Fix layout update could be skipped sometimes on Android.

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
@@ -7,7 +7,6 @@ using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Globalization;
 using Windows.Globalization.DateTimeFormatting;
-using Windows.System;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
@@ -1849,12 +1848,7 @@ namespace Windows.UI.Xaml.Controls
 
 				if (isScopeChanged)
 				{
-#if __ANDROID__
-					// .InvalidateMeasure() bug https://github.com/unoplatform/uno/issues/6236
-					DispatcherQueue.TryEnqueue(() => UpdateHeaderText(false /*withAnimation*/));
-#else
 					UpdateHeaderText(false /*withAnimation*/);
-#endif
 				}
 
 				// everytime visible indices changed, we need to update


### PR DESCRIPTION
Fixes #6236

# Bugfix
For an unclear reason, sometimes the Android layout engine could reset the internal flag `PFLAG_FORCE_LAYOUT` (`.isLayoutRequested()`) without calling the `.onMeasure()`.

## What is the new behavior?
Code has been added to `UnoViewGroup.java` to detect when it is happening and force the Android layout engine to do another pass.

## PR Checklist

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
