### PR TITLE
fix: Hide `dotnet new` templates from VS 2019 new projects dialog

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/.template.config/vs-2017.3.host.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/.template.config/vs-2017.3.host.json
@@ -12,6 +12,11 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "unsupportedHosts": [
+    {
+      "id": "vs"
+    }
+  ],
   "additionalWizardParameters": {
     "$isMultiProjectTemplate$": "true"
   },

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/.template.config/vs-2017.3.host.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/.template.config/vs-2017.3.host.json
@@ -12,6 +12,11 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "unsupportedHosts": [
+    {
+      "id": "vs"
+    }
+  ],
   "additionalWizardParameters": {
     "$isMultiProjectTemplate$": "true"
   },

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/.template.config/vs-2017.3.host.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/.template.config/vs-2017.3.host.json
@@ -12,6 +12,11 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "unsupportedHosts": [
+    {
+      "id": "vs"
+    }
+  ],
   "symbolInfo": [
   ]
 }

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/.template.config/vs-2017.3.host.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/.template.config/vs-2017.3.host.json
@@ -12,6 +12,11 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "unsupportedHosts": [
+    {
+      "id": "vs"
+    }
+  ],
   "symbolInfo": [
   ]
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/6288

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

`dotnet new` templates are hiddent from VS as the creation process is significantly different from the CLI. Specifically, the IDE does not use the SLN file provided by the template and includes projects that may not be configured properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
