### PR TITLE
fix: ToolTip change handling

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1781,6 +1781,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Binding.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Long_Text.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5363,6 +5367,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\TimePicker_Flyout_Automated.xaml.cs">
       <DependentUpon>TimePicker_Flyout_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Binding.xaml.cs">
+      <DependentUpon>ToolTip_Binding.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Long_Text.xaml.cs">
       <DependentUpon>ToolTip_Long_Text.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Binding.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Binding.xaml
@@ -1,0 +1,20 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_Binding"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <StackPanel>
+        <Button Command="{x:Bind ViewModel.ChangeTextCommand}" ToolTipService.ToolTip="{x:Bind ViewModel.Text, Mode=OneWay}">Data-bound string</Button>
+        <Button Command="{x:Bind ViewModel.ChangeToolTipCommand}" ToolTipService.ToolTip="{x:Bind ViewModel.ToolTip, Mode=OneWay}">Data-bound ToolTip instance</Button>
+        <Button Command="{x:Bind ViewModel.ChangeToolTipContentCommand}">
+            <ToolTipService.ToolTip>
+                <ToolTip Content="{x:Bind ViewModel.ToolTipContent, Mode=OneWay}" />
+            </ToolTipService.ToolTip>
+            Data-bound ToolTip.Content
+        </Button>
+    </StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Binding.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Binding.xaml.cs
@@ -1,0 +1,85 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.UITests.Helpers;
+using Windows.UI.Core;
+using System.Windows.Input;
+
+namespace UITests.Windows_UI_Xaml_Controls.ToolTip
+{
+	[Sample(ViewModelType = typeof(ToolTipBindingViewModel))]
+	public sealed partial class ToolTip_Binding : Page
+	{
+		public ToolTip_Binding()
+		{
+			InitializeComponent();
+			DataContextChanged += ToolTip_Binding_DataContextChanged;
+		}
+
+		public ToolTipBindingViewModel ViewModel { get; private set; }
+
+		private void ToolTip_Binding_DataContextChanged(DependencyObject sender, DataContextChangedEventArgs args) =>
+			ViewModel = args.NewValue as ToolTipBindingViewModel;
+	}
+
+	public class ToolTipBindingViewModel : ViewModelBase
+	{
+		private string _text = "Initial text";
+		private string _toolTipContent = "Initial content";
+		private Windows.UI.Xaml.Controls.ToolTip _toolTip = new Windows.UI.Xaml.Controls.ToolTip()
+		{
+			Content = "Initial ToolTip"
+		};
+
+		public ToolTipBindingViewModel(CoreDispatcher dispatcher) :
+			base(dispatcher)
+		{
+		}
+
+		public ICommand ChangeTextCommand => GetOrCreateCommand(ChangeText);
+
+		public ICommand ChangeToolTipContentCommand => GetOrCreateCommand(ChangeToolTipContent);
+
+		public ICommand ChangeToolTipCommand => GetOrCreateCommand(ChangeToolTip);
+
+		public string Text
+		{
+			get => _text;
+			set
+			{
+				_text = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public string ToolTipContent
+		{
+			get => _toolTipContent;
+			set
+			{
+				_toolTipContent = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public Windows.UI.Xaml.Controls.ToolTip ToolTip
+		{
+			get => _toolTip;
+			set
+			{
+				_toolTip = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		private void ChangeText() => Text = "Changed text";
+
+		private void ChangeToolTipContent() => ToolTipContent = "Chnaged content";
+
+		private void ChangeToolTip() =>
+			ToolTip = new Windows.UI.Xaml.Controls.ToolTip()
+			{
+				Content = "Changed ToolTip"
+			};
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
@@ -46,6 +46,8 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		internal long CurrentHoverId { get; set; }
+
 #pragma warning disable CS0649
 #pragma warning disable CS0169
 #pragma warning disable CS0414


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6200 


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`ToolTip` changes are not handled properly.

## What is the new behavior?

- When a non-`ToolTip` is data-bound directly to the `ToolTipService.ToolTip` property, its changes are propagated properly
- `ToolTip` instance is now directly associated with the `FrameworkElement` which allows making the event handlers static and unsubscribable
- When `ToolTip` is associated after the element is already loaded, it does show up properly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.