### PR TITLE
fix: Use sr instead of sr-Cyrl-BA

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
@@ -65,7 +65,7 @@
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\fr-CA\Resources.resw" />
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en\Test01.resw" />
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\fr\Resources.resw" />
-    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\sr-Cyrl-BA\Resources.resw" />
+    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\sr\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="$(MSBuildThisFileDirectory)Samples\UnitTests\HttpUnitTests.xaml.cs">

--- a/src/SamplesApp/SamplesApp.Shared/Strings/sr/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/sr/Resources.resw
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'sr-Cyrl-BA'</value>
+    <value>Text in 'sr'</value>
   </data>
 </root>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel_Resources/Given_ResourceLoader.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel_Resources/Given_ResourceLoader.cs
@@ -105,7 +105,7 @@ namespace Uno.UI.RuntimeTests.Tests
 		public void When_LocalizedResource()
 		{
 			var SUT = ResourceLoader.GetForViewIndependentUse();
-			var languages = new[] {"fr-CA", "fr", "en-US", "en", "sr-Cyrl-BA"};
+			var languages = new[] {"fr-CA", "fr", "en-US", "en", "sr"};
 
 			foreach (var language in languages)
 			{

--- a/src/Uno.UI.Tests/ResourceLoader/Strings/sr/Resources.resw
+++ b/src/Uno.UI.Tests/ResourceLoader/Strings/sr/Resources.resw
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'sr-Cyrl-BA'</value>
+    <value>Text in 'sr'</value>
   </data>
 </root>


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6297 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The test fails on WASM .NET 5 due to https://github.com/dotnet/runtime/pull/47301 - 

https://github.com/dotnet/runtime/blob/01b7e73cd378145264a7cb7a09365b41ed42b240/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs#L303


## What is the new behavior?

No longer fails.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.