### PR TITLE
fix: tooltip remains opened when host control is no longer visible

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToolTipTests/ToolTip_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToolTipTests/ToolTip_Tests.cs
@@ -95,5 +95,30 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ToolTipTests
 			ImageAssert.AreNotEqual(before, upperToolTip, upperRect); // Mouse is close to top of button, ToolTip should extend above Button bounds
 			ImageAssert.AreNotEqual(before, upperToolTip, buttonRect);
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // Only WASM supports mouse-based tests for now
+		public void ToolTip_WhenHostCollapsed_Test()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_CollapsedHost");
+			var hideToggle = _app.Marked("ToggleHide"); // ToggleButton "Hide" that will hide itself
+			var tooltipText = _app.Marked("TooltipText"); // TextBlock within ToggleHide's Tooltip
+			const int TooltipShowDelay = 1000; // FeatureConfiguration.ToolTip.ShowDelay (in ms)
+
+			_app.WaitForElement(hideToggle);
+
+			hideToggle.Tap();
+
+			// normally, as the cursor enter hideToggle's hitbox to press it,
+			// the tooltip will start to appears after 1s (TooltipShowDelay)
+			// and, it will remain visible for another 1s.
+			// (moving within the hitbox will reset the remaining duration back to 1s again, but we are not)
+			_app.Wait(TimeSpan.FromMilliseconds(TooltipShowDelay + 300));
+
+			// however, since we made the host control to disappear (Visibility=Collapsed),
+			// its tooltip should disappear as well.
+			tooltipText.ShouldNotBeVisible();
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1805,7 +1805,15 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_DynamicContent.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Long_Text.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_CollapsedHost.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -5406,8 +5414,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\TimePicker_Flyout_Automated.xaml.cs">
       <DependentUpon>TimePicker_Flyout_Automated.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_DynamicContent.xaml.cs">
+      <DependentUpon>ToolTip_DynamicContent.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Long_Text.xaml.cs">
       <DependentUpon>ToolTip_Long_Text.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_CollapsedHost.xaml.cs">
+      <DependentUpon>ToolTip_CollapsedHost.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\UIElementCollectionTests\UIElementCollection_Insert.xaml.cs">
       <DependentUpon>UIElementCollection_Insert.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1809,6 +1809,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_LeakTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Long_Text.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5416,6 +5420,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_DynamicContent.xaml.cs">
       <DependentUpon>ToolTip_DynamicContent.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_LeakTest.xaml.cs">
+      <DependentUpon>ToolTip_LeakTest.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Long_Text.xaml.cs">
       <DependentUpon>ToolTip_Long_Text.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_CollapsedHost.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_CollapsedHost.xaml
@@ -1,0 +1,27 @@
+﻿<Page x:Class="UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_CollapsedHost"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ToolTip"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Margin="0,100,0,0">
+		<ToggleButton x:Name="MainToggle"
+					  IsChecked="True"
+					  Content="Toggle without Tooltip" />
+
+		<TextBlock Text="To hide the tooltip, use the toggle above to reveal the hidden 'Click Here' button and mouse over and out of the button."
+				   TextWrapping="Wrap" />
+		<ToggleButton x:Name="ToggleHide"
+					  Content="Click Here"
+					  IsChecked="{Binding ElementName=MainToggle, Path=IsChecked, Mode=TwoWay}"
+					  Visibility="{Binding ElementName=MainToggle, Path=IsChecked}">
+			<ToolTipService.ToolTip>
+				<TextBlock x:Name="TooltipText"
+						   Text="Tooltip associated with 'Hide' button" />
+			</ToolTipService.ToolTip>
+		</ToggleButton>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_CollapsedHost.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_CollapsedHost.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading;
+using Uno.UI.Samples.Controls;
+using Uno.UI;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.ToolTip
+{
+	[SampleControlInfo(nameof(ToolTip), nameof(ToolTip_CollapsedHost), description: SampleDescription)]
+	public sealed partial class ToolTip_CollapsedHost : Page
+	{
+		private const string SampleDescription =
+			"This is used to simulate tooltip linger issue when the host control is no longer visible.";
+
+		public ToolTip_CollapsedHost()
+		{
+#if HAS_UNO
+			FeatureConfiguration.ToolTip.UseToolTips = true;
+#endif
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_DynamicContent.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_DynamicContent.xaml
@@ -1,0 +1,49 @@
+﻿<Page x:Class="UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_DynamicContent"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ToolTip"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Padding="16"
+		  RowSpacing="16">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<Border Grid.Row="0" x:Name="TooltipTarget" Background="SkyBlue"
+				Padding="16"
+				ToolTipService.ToolTip="default tooltip">
+			<TextBlock Text="mouse over the blue area to reveal the tooltip"
+					   TextWrapping="Wrap" />
+		</Border>
+
+		<StackPanel Grid.Row="1"
+					Spacing="4"
+					HorizontalAlignment="Stretch">
+			<StackPanel.Resources>
+				<Style TargetType="Button">
+					<Setter Property="HorizontalAlignment" Value="Stretch" />
+				</Style>
+			</StackPanel.Resources>
+			
+			<Button x:Name="SetTooltipToNullButton" Content="SetTooltipToNull" Click="SetTooltip" Tag="{x:Null}" />
+			<Button x:Name="SetTooltipToText1Button" Content="SetTooltipToText1" Click="SetTooltip" Tag="Text 1" />
+			<Button x:Name="SetTooltipToText2Button" Content="SetTooltipToText2" Click="SetTooltip" Tag="Text 2" />
+			<Button x:Name="SetTooltipToEmptyStringButton" Content="SetTooltipToEmptyString" Click="SetTooltip" Tag="" />
+			<Button x:Name="SetTooltipToToolTipControlButton" Content="SetTooltipToToolTipControl" Click="SetTooltip">
+				<Button.Tag>
+					<ToolTip>
+						<StackPanel>
+							<Rectangle Fill="Pink" Height="16" Width="16" />
+							<TextBlock Text="Custom Tooltip Control" />
+						</StackPanel>
+					</ToolTip>
+				</Button.Tag>
+			</Button>
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_DynamicContent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_DynamicContent.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Uno.UI;
+
+namespace UITests.Windows_UI_Xaml_Controls.ToolTip
+{
+	[SampleControlInfo(nameof(ToolTip), nameof(ToolTip_DynamicContent), description: SampleDescription)]
+	public sealed partial class ToolTip_DynamicContent : Page
+	{
+		private const string SampleDescription =
+			"ToolTip can be updated on demand, with exception of 'null' that should disable the tooltip. " +
+			"Every other options, empty string included, should update the tooltip content, and re-enabled it if it was previously disabled with 'null'. \n" +
+			"https://github.com/unoplatform/uno/issues/6050 \n" +
+			"https://github.com/unoplatform/uno/issues/6200";
+
+		public ToolTip_DynamicContent()
+		{
+#if HAS_UNO
+			FeatureConfiguration.ToolTip.UseToolTips = true;
+#endif
+			this.InitializeComponent();
+		}
+
+		private void SetTooltip(object sender, RoutedEventArgs e)
+		{
+			var button = (Button)sender;
+			var tag = button.Tag;
+
+			ToolTipService.SetToolTip(TooltipTarget, tag);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_LeakTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_LeakTest.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_LeakTest"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ToolTip"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d">
+
+	<StackPanel>
+		<Button Content="RawText" ToolTipService.ToolTip="RawText" />
+		<Button Content="ToolTip">
+			<ToolTipService.ToolTip>
+				<ToolTip>
+					<StackPanel Orientation="Horizontal" Spacing="4">
+						<Rectangle Height="15" Width="15" Fill="Pink" />
+						<TextBlock Text="Asd" />
+					</StackPanel>
+				</ToolTip>
+			</ToolTipService.ToolTip>
+		</Button>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_LeakTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_LeakTest.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.ToolTip
+{
+	public sealed partial class ToolTip_LeakTest : UserControl
+	{
+		public ToolTip_LeakTest()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -61,6 +61,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow("Uno.UI.Samples.Content.UITests.ButtonTestsControl.AppBar_KeyBoard", 15)]
 		[DataRow("Uno.UI.Samples.Content.UITests.ButtonTestsControl.Buttons", 15)]
 		[DataRow("UITests.Windows_UI_Xaml.xLoadTests.xLoad_Test_For_Leak", 15)]
+		[DataRow("UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_LeakTest", 15)]
 		public async Task When_Add_Remove(object controlTypeRaw, int count)
 		{
 #if TRACK_REFS

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToolTipService.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToolTipService.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class ToolTipService 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty PlacementProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.RegisterAttached(
@@ -25,14 +25,14 @@ namespace Windows.UI.Xaml.Controls
 		#endif
 		// Skipping already declared property ToolTipProperty
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToolTipService.PlacementProperty.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.Controls.Primitives.PlacementMode GetPlacement( global::Windows.UI.Xaml.DependencyObject element)
 		{
 			return (global::Windows.UI.Xaml.Controls.Primitives.PlacementMode)element.GetValue(PlacementProperty);
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static void SetPlacement( global::Windows.UI.Xaml.DependencyObject element,  global::Windows.UI.Xaml.Controls.Primitives.PlacementMode value)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
@@ -46,6 +46,10 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		internal long CurrentHoverId { get; set; }
+
+		internal IDisposable _pointerEventSubscriptions;
+
 #pragma warning disable CS0649
 #pragma warning disable CS0169
 #pragma warning disable CS0414

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
@@ -48,7 +48,9 @@ namespace Windows.UI.Xaml.Controls
 
 		internal long CurrentHoverId { get; set; }
 
-		internal IDisposable _pointerEventSubscriptions;
+		internal IDisposable? OwnerEventSubscriptions { get; set; }
+
+		internal IDisposable? OwnerVisibilitySubscription { get; set; }
 
 #pragma warning disable CS0649
 #pragma warning disable CS0169

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTipService.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTipService.cs
@@ -2,11 +2,15 @@ using System;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Input;
 using Uno.UI;
+using Windows.UI.Xaml.Controls.Primitives;
+using Uno.Disposables;
 
 namespace Windows.UI.Xaml.Controls
 {
 	partial class ToolTipService
 	{
+		#region DependencyProperty: ToolTip
+
 		public static DependencyProperty ToolTipProperty { get; } =
 			DependencyProperty.RegisterAttached(
 				"ToolTip",
@@ -14,17 +18,37 @@ namespace Windows.UI.Xaml.Controls
 				typeof(ToolTipService),
 				new FrameworkPropertyMetadata(default, OnToolTipChanged));
 
-		public static object GetToolTip(DependencyObject element)
-		{
-			return element.GetValue(ToolTipProperty);
-		}
+		public static object GetToolTip(DependencyObject obj) => obj.GetValue(ToolTipProperty);
+		public static void SetToolTip(DependencyObject obj, object value) => obj.SetValue(ToolTipProperty, value);
 
-		public static void SetToolTip( global::Windows.UI.Xaml.DependencyObject element, object value)
-		{
-			element.SetValue(ToolTipProperty, value);
-		}
+		#endregion
+		#region DependencyProperty: Placement
 
-		private static void OnToolTipChanged(DependencyObject dependencyobject, DependencyPropertyChangedEventArgs args)
+		public static DependencyProperty PlacementProperty { get; } = DependencyProperty.RegisterAttached(
+			"Placement",
+			typeof(PlacementMode),
+			typeof(ToolTipService),
+			new PropertyMetadata(PlacementMode.Top, OnPlacementChanged));
+
+		public static PlacementMode GetPlacement(FrameworkElement obj) => (PlacementMode)obj.GetValue(PlacementProperty);
+		public static void SetPlacement(FrameworkElement obj, PlacementMode value) => obj.SetValue(PlacementProperty, value);
+
+		#endregion
+		#region DependencyProperty: ToolTipReference
+
+		internal static DependencyProperty ToolTipReferenceProperty { get; } = DependencyProperty.RegisterAttached(
+			"ToolTipReference",
+			typeof(ToolTip),
+			typeof(ToolTipService),
+			new PropertyMetadata(default(ToolTip)));
+
+		internal static ToolTip GetToolTipReference(DependencyObject obj) => (ToolTip)obj.GetValue(ToolTipReferenceProperty);
+		internal static void SetToolTipReference(DependencyObject obj, ToolTip value) => obj.SetValue(ToolTipReferenceProperty, value);
+
+		#endregion
+
+
+		private static void OnToolTipChanged(DependencyObject dependencyobject, DependencyPropertyChangedEventArgs e)
 		{
 			if (!FeatureConfiguration.ToolTip.UseToolTips)
 			{
@@ -36,62 +60,125 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			var toolTip = args.NewValue as ToolTip;
-
-			if (toolTip == null && args.NewValue != null)
+			if (e.NewValue is null)
 			{
-				toolTip = new ToolTip { Content = args.NewValue };
+				DisposePreviousToolTip();
+			}
+			else if (e.NewValue is ToolTip newToolTip)
+			{
+				var previousToolTip = GetToolTipReference(element);
+
+				// dispose the previous tooltip
+				if (previousToolTip != null && newToolTip != previousToolTip)
+				{
+					DisposePreviousToolTip(previousToolTip);
+				}
+
+				// setup new tooltip
+				if (newToolTip != previousToolTip)
+				{
+					SetupToolTip(newToolTip);
+				}
+			}
+			else
+			{
+				var previousTooltip = GetToolTipReference(element);
+				if (previousTooltip != null)
+				{
+					// update the old tooltip with new content
+					previousTooltip.Content = e.NewValue;
+				}
+				else
+				{
+					// setup a new tooltip
+					previousTooltip = new ToolTip { Content = e.NewValue };
+					SetupToolTip(previousTooltip);
+				}
 			}
 
-			if (toolTip != null)
+			void SetupToolTip(ToolTip tooltip)
 			{
-				// First time: we're subscribing to event handlers
+				tooltip.Placement = GetPlacement(tooltip);
+				tooltip.SetAnchor(GetPlacementTarget(element) ?? element);
 
-				long currentHoverId = 0;
+				SetToolTipReference(element, tooltip);
+				tooltip._pointerEventSubscriptions = SubscribeToEvents(element, tooltip);
+			}
+			void DisposePreviousToolTip(ToolTip tooltip = null)
+			{
+				tooltip ??= GetToolTipReference(element);
 
-				toolTip.SetAnchor(element);
+				SetToolTipReference(element, null);
+				tooltip._pointerEventSubscriptions?.Dispose();
+				tooltip._pointerEventSubscriptions = null;
+			}
+		}
 
-				element.Loaded += (snd, evt) =>
+		private static void OnPlacementChanged(DependencyObject dependencyobject, DependencyPropertyChangedEventArgs e)
+		{
+			if (GetToolTipReference(dependencyobject) is { } tooltip)
+			{
+				tooltip.Placement = (PlacementMode)e.NewValue;
+			}
+		}
+
+		private static IDisposable SubscribeToEvents(FrameworkElement control, ToolTip tooltip)
+		{
+			// event subscriptions
+			if (control.IsLoaded)
+			{
+				SubscribeToPointerEvents(control, null);
+			}
+			control.Loaded += SubscribeToPointerEvents;
+			control.Unloaded += UnsubscribeToPointerEvents;
+
+			void SubscribeToPointerEvents(object sender, RoutedEventArgs e)
+			{
+				control.PointerEntered += OnPointerEntered;
+				control.PointerExited += OnPointerExited;
+			}
+			void UnsubscribeToPointerEvents(object sender, RoutedEventArgs e)
+			{
+				control.PointerEntered -= OnPointerEntered;
+				control.PointerExited -= OnPointerExited;
+			}
+
+			return Disposable.Create(() =>
+			{
+				control.Loaded -= SubscribeToPointerEvents;
+				control.Unloaded -= UnsubscribeToPointerEvents;
+				UnsubscribeToPointerEvents(control, null);
+
+				tooltip.IsOpen = false;
+				tooltip.CurrentHoverId++;
+			});
+
+			// pointer event handlers
+			async void OnPointerEntered(object snd, PointerRoutedEventArgs evt)
+			{
+				await HoverTask(++tooltip.CurrentHoverId).ConfigureAwait(false);
+			}
+			void OnPointerExited(object snd, PointerRoutedEventArgs evt)
+			{
+				tooltip.CurrentHoverId++;
+				tooltip.IsOpen = false;
+			}
+			async Task HoverTask(long hoverId)
+			{
+				await Task.Delay(FeatureConfiguration.ToolTip.ShowDelay).ConfigureAwait(false);
+				if (tooltip.CurrentHoverId != hoverId)
 				{
-					element.PointerEntered += OnPointerEntered;
-					element.PointerExited += OnPointerExited;
-				};
-
-				element.Unloaded += (snd, evt) =>
-				{
-					toolTip.IsOpen = false;
-
-					element.PointerEntered -= OnPointerEntered;
-					element.PointerExited -= OnPointerExited;
-				};
-
-				void OnPointerEntered(object snd, PointerRoutedEventArgs evt)
-				{
-					var t = HoverTask(++currentHoverId);
+					return;
 				}
 
-				void OnPointerExited(object snd, PointerRoutedEventArgs evt)
+				if (control.IsLoaded)
 				{
-					currentHoverId++;
-					toolTip.IsOpen = false;
-				}
+					tooltip.IsOpen = true;
 
-				async Task HoverTask(long hoverId)
-				{
-					await Task.Delay(FeatureConfiguration.ToolTip.ShowDelay);
-					if (currentHoverId != hoverId)
+					await Task.Delay(FeatureConfiguration.ToolTip.ShowDuration).ConfigureAwait(false);
+					if (tooltip.CurrentHoverId == hoverId)
 					{
-						return;
-					}
-
-					if (element.IsLoaded)
-					{
-						toolTip.IsOpen = true;
-						await Task.Delay(FeatureConfiguration.ToolTip.ShowDuration);
-						if (currentHoverId == hoverId)
-						{
-							toolTip.IsOpen = false;
-						}
+						tooltip.IsOpen = false;
 					}
 				}
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): #internal, fixes #6200

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Tooltip remains opened when the host control is no longer visible

## What is the new behavior?
Tooltip should be closed in that case.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Internal Issue (If applicable): see cross-linked issue.