### PR TITLE
fix: Avoid LinkerSafe deprecated warning on iOS

### DIFF
--- a/src/Uno.UI.FluentTheme/AssemblyInfo.cs
+++ b/src/Uno.UI.FluentTheme/AssemblyInfo.cs
@@ -9,7 +9,10 @@ using global::System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Uno.UI.Tests")]
 
 #if __IOS__
+#pragma warning disable CS0618 // Type or member is obsolete
 [assembly: Foundation.LinkerSafe]
+#pragma warning restore CS0618 // Type or member is obsolete
+[assembly: AssemblyMetadata("IsTrimmable", "True")]
 #elif __ANDROID__
 [assembly: Android.LinkerSafe]
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): N/A

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Warning treated as error on iOS.

## What is the new behavior?

No warning, no error.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.