### PR TITLE
fix: Adjust for missing symbols when running on macOS 10.14

### DIFF
--- a/build/android-uitest-run.sh
+++ b/build/android-uitest-run.sh
@@ -3,16 +3,18 @@ set -euo pipefail
 IFS=$'\n\t'
 
 export BUILDCONFIGURATION=Release
-export ANDROID_HOME=$BUILD_SOURCESDIRECTORY/build/android-sdk
 
 cd $BUILD_SOURCESDIRECTORY/build
 
-mkdir android-sdk
-pushd android-sdk
-# URL from https://developer.android.com/studio/index.html#command-tools
-wget https://dl.google.com/android/repository/commandlinetools-mac-6200805_latest.zip
-unzip commandlinetools-mac-6200805_latest.zip
-popd
+# This block allows to override the Android SDK
+# disabled until hosted agents move to macOS 11
+#
+# export ANDROID_HOME=$BUILD_SOURCESDIRECTORY/build/android-sdk
+#wget https://dl.google.com/android/repository/commandlinetools-mac-7302050_latest.zip
+#unzip commandlinetools-mac-7302050_latest.zip
+#rm commandlinetools-mac-7302050_latest.zip
+#mkdir -p $ANDROID_HOME/cmdline-tools/latest
+#cp -R cmdline-tools/ $ANDROID_HOME/sdk/cmdline-tools/latest/
 
 # uncomment the following lines to override the installed Xamarin.Android SDK
 # wget -nv https://jenkins.mono-project.com/view/Xamarin.Android/job/xamarin-android-d16-2/49/Azure/processDownloadRequest/xamarin-android/xamarin-android/bin/BuildRelease/Xamarin.Android.Sdk-OSS-9.4.0.59_d16-2_6d9b105.pkg
@@ -66,6 +68,9 @@ source $BUILD_SOURCESDIRECTORY/build/android-uitest-wait-systemui.sh
 
 # list active devices
 $ANDROID_HOME/platform-tools/adb devices
+
+# Workaround for https://github.com/microsoft/appcenter/issues/1451
+$ANDROID_HOME/platform-tools/adb shell settings put global hidden_api_policy 1
 
 echo "Emulator started"
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Use bundled android SDK for emulators, instead of downloading one. More recent builds from Google are referencing macOS 11 dylib, which fails on macOS 10.15 hosted agents.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
