### PR TITLE
fix(Selector): firing order of data-bound dp & event

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1409,6 +1409,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Selection_Events.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_WithScrollViewer.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5134,6 +5138,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_UseTargetSize.xaml.cs">
       <DependentUpon>Image_UseTargetSize.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Selection_Events.xaml.cs">
+      <DependentUpon>ListView_Selection_Events.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_WithScrollViewer.xaml.cs">
       <DependentUpon>ListView_WithScrollViewer.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Selection_Events.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Selection_Events.xaml
@@ -1,0 +1,67 @@
+﻿<Page x:Class="UITests.Windows_UI_Xaml_Controls.ListView.ListView_Selection_Events"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ListView"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="1*" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="1*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<TextBlock Grid.Row="0"
+				   Text="Item for selection:" />
+		<ListView Grid.Row="1"
+				  x:Name="SampleListView"
+				  ItemsSource="{x:Bind ViewModel.Source}"
+				  SelectedIndex="{x:Bind ViewModel.SelectedIndex, Mode=TwoWay}"
+				  SelectedItem="{x:Bind ViewModel.SelectedItem, Mode=TwoWay}"
+				  SelectedValue="{x:Bind ViewModel.SelectedValue, Mode=TwoWay}"
+				  SelectionMode="Single"
+				  ScrollViewer.VerticalScrollBarVisibility="Auto">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<TextBlock AutomationProperties.AutomationId="{Binding}"
+							   Text="{Binding}" />
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+
+		<TextBlock Grid.Row="2"
+				   Text="Event Logs:" />
+		<!--<ListView Grid.Row="3"
+				  x:Name="LogListView">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<TextBlock Text="{Binding}"
+							   TextWrapping="Wrap" />
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>-->
+		<ScrollViewer Grid.Row="3"
+					  HorizontalScrollBarVisibility="Disabled"
+					  VerticalScrollBarVisibility="Auto">
+			<TextBox x:Name="EventLogs"
+					 IsReadOnly="True"
+					 AcceptsReturn="True"
+					 TextWrapping="Wrap" />
+		</ScrollViewer>
+
+
+		<StackPanel Grid.Row="4">
+			<Button x:Name="SetSelectIndexTo0Button"
+					Content="Set SelectionIndex to 0"
+					Click="SetSelectIndexTo0" />
+			<Button x:Name="ClearLogsButton"
+					Content="Clear Logs"
+					Click="ClearLogs" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Selection_Events.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Selection_Events.xaml.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace UITests.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfo("ListView", nameof(ListView_Selection_Events), description: "The sequence of events when selecting an item should happen in the same order when compared to uwp.")]
+	public sealed partial class ListView_Selection_Events : Page
+	{
+		private CustomViewModel ViewModel { get; } = new CustomViewModel();
+
+		public ListView_Selection_Events()
+		{
+			this.InitializeComponent();
+			SampleListView.SelectionChanged += (s, e) => AddLog(
+				"LV.SelectionChanged: (Item|Value|Index): " +
+				$"\n\t- lv:({Format(SampleListView.SelectedItem)}|{Format(SampleListView.SelectedValue)}|{Format(SampleListView.SelectedIndex)}), " +
+				$"\n\t- vm:({Format(ViewModel.SelectedItem)}|{Format(ViewModel.SelectedValue)}|{Format(ViewModel.SelectedIndex)})"
+			);
+			ViewModel.PropertyChanged += (s, e) =>
+			{
+				AddLog($"VM.PropertyChanged: [{e.PropertyName}]->{Format(GetValueFrom(e.PropertyName))}");
+
+				object GetValueFrom(string propertyName) => propertyName switch
+				{
+					nameof(CustomViewModel.SelectedItem) => ViewModel.SelectedItem,
+					nameof(CustomViewModel.SelectedValue) => ViewModel.SelectedValue,
+					nameof(CustomViewModel.SelectedIndex) => ViewModel.SelectedIndex,
+
+					_ => throw new ArgumentOutOfRangeException(propertyName),
+				};
+			};
+
+			string Format(object value) => value?.ToString() ?? "<null>";
+			void AddLog(string log)
+			{
+				//LogListView.Items.Add(log);
+				EventLogs.Text += (string.IsNullOrEmpty(EventLogs.Text) ? null : "\n") + log;
+			}
+		}
+		private void SetSelectIndexTo0(object sender, RoutedEventArgs e)
+		{
+			SampleListView.SelectedIndex = 0;
+		}
+		private void ClearLogs(object sender, RoutedEventArgs e)
+		{
+			//LogListView.Items.Clear();
+			EventLogs.Text = string.Empty;
+		}
+
+		// not using ViewModelBase because it would fire the same event twice, once as $"{propertyName}" and once as $"Item[{propertyName}]"...
+		private class CustomViewModel : INotifyPropertyChanged
+		{
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public string[] Source { get; } = Enumerable.Range(0, 5).Select(x => $"Item_{x}").ToArray();
+
+			#region SelectedItem
+			private object _selectedItem;
+			public object SelectedItem
+			{
+				get => _selectedItem;
+				set => RaiseAndSetIfChanged(ref _selectedItem, value);
+			}
+			#endregion
+			#region SelectedValue
+			private object _selectedValue;
+			public object SelectedValue
+			{
+				get => _selectedValue;
+				set => RaiseAndSetIfChanged(ref _selectedValue, value);
+			}
+			#endregion
+			#region SelectedIndex
+			private int _selectedIndex;
+			public int SelectedIndex
+			{
+				get => _selectedIndex;
+				set => RaiseAndSetIfChanged(ref _selectedIndex, value);
+			}
+			#endregion
+
+			protected void RaiseAndSetIfChanged<T>(ref T backingField, T value, [CallerMemberName] string propertyName = null)
+			{
+				if (!EqualityComparer<T>.Default.Equals(backingField, value))
+				{
+					backingField = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+				}
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Selection_Events.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Selection_Events.xaml.cs
@@ -63,9 +63,9 @@ namespace UITests.Windows_UI_Xaml_Controls.ListView
 		}
 
 		// not using ViewModelBase because it would fire the same event twice, once as $"{propertyName}" and once as $"Item[{propertyName}]"...
-		private class CustomViewModel : INotifyPropertyChanged
+		private class CustomViewModel : global::System.ComponentModel.INotifyPropertyChanged
 		{
-			public event PropertyChangedEventHandler PropertyChanged;
+			public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
 
 			public string[] Source { get; } = Enumerable.Range(0, 5).Select(x => $"Item_{x}").ToArray();
 
@@ -99,7 +99,7 @@ namespace UITests.Windows_UI_Xaml_Controls.ListView
 				if (!EqualityComparer<T>.Default.Equals(backingField, value))
 				{
 					backingField = value;
-					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+					PropertyChanged?.Invoke(this, new global::System.ComponentModel.PropertyChangedEventArgs(propertyName));
 				}
 			}
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -28,6 +28,8 @@ using FluentAssertions.Execution;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Windows.UI.Xaml.Data;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -1312,6 +1314,42 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(null, list.SelectedItem);
 		}
 
+		[TestMethod]
+		public async Task ZXC_When_Selection_Events()
+		{
+			var list = new ListView
+			{
+				ItemContainerStyle = NoSpaceContainerStyle,
+				ItemTemplate = FixedSizeItemTemplate
+			};
+
+			var items = Enumerable.Range(0, 4).Select(x => "Item_" + x).ToArray();
+			list.ItemsSource = items;
+			list.SelectedIndex = 0;
+
+			var model = new When_Selection_Events_DataContext();
+			list.DataContext = model;
+			list.SetBinding(Selector.SelectedIndexProperty, new Binding { Path = new PropertyPath(nameof(model.SelectedIndex)), Mode = BindingMode.TwoWay });
+			list.SetBinding(Selector.SelectedItemProperty, new Binding { Path = new PropertyPath(nameof(model.SelectedItem)), Mode = BindingMode.TwoWay });
+			list.SetBinding(Selector.SelectedValueProperty, new Binding { Path = new PropertyPath(nameof(model.SelectedValue)), Mode = BindingMode.TwoWay });
+
+			WindowHelper.WindowContent = list;
+			await WindowHelper.WaitForLoaded(list);
+			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+
+			list.SelectionChanged += (s, e) =>
+			{
+				Assert.AreEqual(list.SelectedItem, "Item_1");
+				Assert.AreEqual(list.SelectedValue, "Item_1");
+				Assert.AreEqual(model.SelectedIndex, 1);
+				Assert.AreEqual(model.SelectedItem, "Item_1");
+				Assert.AreEqual(model.SelectedValue, "Item_1");
+			};
+
+			// update selection
+			list.SelectedIndex = 1;
+		}
+
 		private bool ApproxEquals(double value1, double value2) => Math.Abs(value1 - value2) <= 2;
 
 		private class When_Removed_From_Tree_And_Selection_TwoWay_Bound_DataContext : INotifyPropertyChanged
@@ -1332,6 +1370,46 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 					{
 						PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(MySelection)));
 					}
+				}
+			}
+		}
+
+		private class When_Selection_Events_DataContext : INotifyPropertyChanged
+		{
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			#region SelectedItem
+			private object _selectedItem;
+			public object SelectedItem
+			{
+				get => _selectedItem;
+				set => RaiseAndSetIfChanged(ref _selectedItem, value);
+			}
+			#endregion
+			#region SelectedValue
+			private object _selectedValue;
+			public object SelectedValue
+			{
+				get => _selectedValue;
+				set => RaiseAndSetIfChanged(ref _selectedValue, value);
+			}
+			#endregion
+			#region SelectedIndex
+			private int _selectedIndex;
+
+			public int SelectedIndex
+			{
+				get => _selectedIndex;
+				set => RaiseAndSetIfChanged(ref _selectedIndex, value);
+			}
+			#endregion
+
+			protected void RaiseAndSetIfChanged<T>(ref T backingField, T value, [CallerMemberName] string propertyName = null)
+			{
+				if (!EqualityComparer<T>.Default.Equals(backingField, value))
+				{
+					backingField = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 				}
 			}
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -1315,7 +1315,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
-		public async Task ZXC_When_Selection_Events()
+		public async Task When_Selection_Events()
 		{
 			var list = new ListView
 			{
@@ -1352,9 +1352,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		private bool ApproxEquals(double value1, double value2) => Math.Abs(value1 - value2) <= 2;
 
-		private class When_Removed_From_Tree_And_Selection_TwoWay_Bound_DataContext : INotifyPropertyChanged
+		private class When_Removed_From_Tree_And_Selection_TwoWay_Bound_DataContext : global::System.ComponentModel.INotifyPropertyChanged
 		{
-			public event PropertyChangedEventHandler PropertyChanged;
+			public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
 
 			public string[] MyItems { get; } = new[] { "Red beans", "Rice" };
 
@@ -1368,15 +1368,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 					_mySelection = value;
 					if (changing)
 					{
-						PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(MySelection)));
+						PropertyChanged?.Invoke(this, new global::System.ComponentModel.PropertyChangedEventArgs(nameof(MySelection)));
 					}
 				}
 			}
 		}
 
-		private class When_Selection_Events_DataContext : INotifyPropertyChanged
+		private class When_Selection_Events_DataContext : global::System.ComponentModel.INotifyPropertyChanged
 		{
-			public event PropertyChangedEventHandler PropertyChanged;
+			public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
 
 			#region SelectedItem
 			private object _selectedItem;
@@ -1409,7 +1409,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				if (!EqualityComparer<T>.Default.Equals(backingField, value))
 				{
 					backingField = value;
-					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+					PropertyChanged?.Invoke(this, new global::System.ComponentModel.PropertyChangedEventArgs(propertyName));
 				}
 			}
 		}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
@@ -99,11 +99,9 @@ namespace Uno.UI.Tests.ListViewBaseTests
 			SUT.SelectionChanged += (s, e) =>
 			{
 				selectionChanged++;
-				Assert.AreEqual(item, SUT.SelectedItem);
 
-				// In windows, when programmatically changed, the bindings are updated *after*
-				// the event is raised, but *before* when the SelectedItem is changed from the UI.
-				Assert.IsNull(model.SelectedItem);
+				Assert.AreEqual(item, SUT.SelectedItem);
+				Assert.AreEqual(item, model.SelectedItem);
 			};
 
 			SUT.SelectedIndex = 0;

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -53,6 +53,19 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		}
 
+		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
+		{
+			base.OnPropertyChanged2(args);
+
+			if (args.Property == SelectedItemProperty)
+			{
+				OnSelectedItemChanged(args.OldValue, args.NewValue, updateItemSelectedState: true);
+			}
+			else if (args.Property == SelectedIndexProperty)
+			{
+				OnSelectedIndexChanged((int)args.OldValue, (int)args.NewValue);
+			}
+		}
 
 		protected override void OnApplyTemplate()
 		{
@@ -65,10 +78,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			"SelectedItem",
 			typeof(object),
 			typeof(Selector),
-			new FrameworkPropertyMetadata(
-				defaultValue: null,
-				propertyChangedCallback: (s, e) => (s as Selector).OnSelectedItemChanged(e.OldValue, e.NewValue, updateItemSelectedState: true)
-			)
+			new FrameworkPropertyMetadata(defaultValue: null)
 		);
 
 		public object SelectedItem
@@ -223,10 +233,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		// Using a DependencyProperty as the backing store for SelectedIndex.  This enables animation, styling, binding, etc...
 		public static DependencyProperty SelectedIndexProperty { get; } =
-			DependencyProperty.Register("SelectedIndex", typeof(int), typeof(Selector), new FrameworkPropertyMetadata(-1,
-				(s, e) => (s as Selector).OnSelectedIndexChanged((int)e.OldValue, (int)e.NewValue)
-			)
-		);
+			DependencyProperty.Register("SelectedIndex", typeof(int), typeof(Selector), new FrameworkPropertyMetadata(-1));
 
 		internal virtual void OnSelectedIndexChanged(int oldSelectedIndex, int newSelectedIndex)
 		{

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1618,9 +1618,7 @@ namespace Windows.UI.Xaml
 			// Raise the callback for backing fields update before PropertyChanged to get
 			// the backingfield updated, in case the PropertyChanged handler reads the
 			// dependency property value through the cache.
-			propertyMetadata.RaiseBackingFieldUpdate(actualInstanceAlias, newValue);
-
-			OnDependencyPropertyChanged(propertyDetails, eventArgs);
+			propertyMetadata.RaiseBackingFieldUpdate(actualInstanceAlias, newValue);			
 
 			// Raise the changes for the callback register to the property itself
 			propertyMetadata.RaisePropertyChanged(actualInstanceAlias, eventArgs);

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1623,13 +1623,16 @@ namespace Windows.UI.Xaml
 			// Raise the changes for the callback register to the property itself
 			propertyMetadata.RaisePropertyChanged(actualInstanceAlias, eventArgs);
 
+			// Ensure binding is propagated
+			OnDependencyPropertyChanged(propertyDetails, eventArgs);
+
 			// Raise the common property change callback of WinUI
+			// This is raised *after* the data bound properties are updated
+			// but before the registered property callbacks
 			if (actualInstanceAlias is UIElement uiElt)
 			{
 				uiElt.OnPropertyChanged2(eventArgs);
 			}
-
-			OnDependencyPropertyChanged(propertyDetails, eventArgs);
 
 			// Raise the changes for the callbacks register through RegisterPropertyChangedCallback.
 			propertyDetails.CallbackManager.RaisePropertyChanged(actualInstanceAlias, eventArgs);

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1620,6 +1620,8 @@ namespace Windows.UI.Xaml
 			// dependency property value through the cache.
 			propertyMetadata.RaiseBackingFieldUpdate(actualInstanceAlias, newValue);
 
+			OnDependencyPropertyChanged(propertyDetails, eventArgs);
+
 			// Raise the changes for the callback register to the property itself
 			propertyMetadata.RaisePropertyChanged(actualInstanceAlias, eventArgs);
 
@@ -1629,10 +1631,10 @@ namespace Windows.UI.Xaml
 				uiElt.OnPropertyChanged2(eventArgs);
 			}
 
+			OnDependencyPropertyChanged(propertyDetails, eventArgs);
+
 			// Raise the changes for the callbacks register through RegisterPropertyChangedCallback.
 			propertyDetails.CallbackManager.RaisePropertyChanged(actualInstanceAlias, eventArgs);
-
-			OnDependencyPropertyChanged(propertyDetails, eventArgs);
 
 			// Raise the property change for generic handlers
 			for (var callbackIndex = 0; callbackIndex < _genericCallbacks.Data.Length; callbackIndex++)


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #5792, fixes #6496

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
SelectionChanged event were being fired before SelectedItem binding could be updated.


## What is the new behavior?
SelectedItem binding will be updated before the SelectionChanged event is fired.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information