### PR TITLE
docs: changed alert hover to only display in intro

### DIFF
--- a/doc/articles/intro.md
+++ b/doc/articles/intro.md
@@ -4,7 +4,7 @@
 
 <div class="col-md-6 col-xs-12 ">
 <a href="get-started.md">
-<div class="alert alert-info">
+<div class="alert alert-info alert-hover">
 
 #### Get started
 
@@ -16,7 +16,7 @@ Set up with your OS and IDE of choice.
 
 <div class="col-md-6 col-xs-12 ">
 <a href="tutorials-intro.md">
-<div class="alert alert-info">
+<div class="alert alert-info alert-hover">
 
 #### How-tos and tutorials
 
@@ -28,7 +28,7 @@ See real-world examples with working code.
 
 <div class="col-md-6 col-xs-12 ">
 <a href="using-uno-ui.md">
-<div class="alert alert-info">
+<div class="alert alert-info alert-hover">
 
 #### Developing with Uno Platform
 
@@ -40,7 +40,7 @@ Learn the principles of cross-platform development with Uno.
 
 <div class="col-md-6 col-xs-12 ">
 <a href="implemented-views.md">
-<div class="alert alert-info">
+<div class="alert alert-info alert-hover">
 
 #### API reference
 

--- a/doc/templates/uno/styles/scss/main.scss
+++ b/doc/templates/uno/styles/scss/main.scss
@@ -32,6 +32,9 @@ body {
         color: $dgray;
         padding: 26px 16px;
         transition: transform .2s;
+    }
+
+    .alert-hover {
         &:hover {
             transform: scale(1.05);
             border-color: $blue;


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Alert boxes change style on hover everywhere in the documentation


## What is the new behavior?

Hover style now has it's own class which is only used in the intro


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


## Other information
before
![image](https://user-images.githubusercontent.com/62605510/124133984-5dbf7780-da50-11eb-96e2-c9652da345a0.png)
after
![image](https://user-images.githubusercontent.com/62605510/124134076-77f95580-da50-11eb-86ef-621f3d5af5c7.png)


