### PR TITLE
fix(SourceGenerators): Use custom initializer for Duration

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -5644,6 +5644,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					case XamlConstants.Types.GridLength:
 					case XamlConstants.Types.CornerRadius:
 					case XamlConstants.Types.Brush:
+					case XamlConstants.Types.Duration:
 					case "UIKit.UIColor":
 					case "Windows.UI.Color":
 					case "Color":

--- a/src/SourceGenerators/XamlGenerationTests/GlobalStaticResources02.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/GlobalStaticResources02.xaml
@@ -113,5 +113,5 @@
 
 		<x:Double x:Key="MyHeightNonLocal">33</x:Double>
 		<x:Boolean x:Key="MyAcceptsReturnNonLocal">true</x:Boolean>
-
+	<Duration x:Key="MaterialTextBoxAnimationDuration">0:0:0.25</Duration>
 </ResourceDictionary>


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/227

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

```xml
<Duration x:Key="MaterialTextBoxAnimationDuration">0:0:0.25</Duration>
```
Would result in the following generated code:

```csharp
["MaterialTextBoxAnimationDuration"] = 
new global::Windows.UI.Xaml.Duration
{
}
```

## What is the new behavior?
```xml
<Duration x:Key="MaterialTextBoxAnimationDuration">0:0:0.25</Duration>
```
Results in the following generated code:

```csharp
["MaterialTextBoxAnimationDuration"] = 
new Duration(global::System.TimeSpan.FromTicks(2500000 /* 0:0:0.25 */))
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
