### PR TITLE
docs: fix for anchor target being displayed under the menu

### DIFF
--- a/doc/templates/uno/styles/docfx.js
+++ b/doc/templates/uno/styles/docfx.js
@@ -1103,20 +1103,8 @@ $(function () {
       scrollIfAnchor(window.location.hash);
     }
 
-    /**
-     * If the click event's target was an anchor, fix the scroll position.
-     */
-    function delegateAnchors(e) {
-      var elem = e.target;
-
-      if (scrollIfAnchor(elem.getAttribute('href'), true)) {
-        e.preventDefault();
-      }
-    }
-
     $(window).on('hashchange', scrollToCurrent);
     // Exclude tabbed content case
-    $('a:not([data-tab])').click(delegateAnchors);
     scrollToCurrent();
 
     $(document).ready(function(){


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
In-doc anchors do not set the target properly, making it appear under the menu

## What is the new behavior?

In-doc anchors display targets in the right spot

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

before 
![image](https://user-images.githubusercontent.com/62605510/124618675-fd607980-de45-11eb-965f-b3e9ead5a847.png)
after
![image](https://user-images.githubusercontent.com/62605510/124618784-16692a80-de46-11eb-981e-3c3840dabcae.png)



Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
