### PR TITLE
CachedFileManager for all targets, improved docs for WASM pickers

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3802,6 +3802,10 @@
 			<Member
 				fullName="AppKit.NSView Windows.UI.Xaml.Input.FocusManager.InnerFindNextFocusableElement(Windows.UI.Xaml.Input.FocusNavigationDirection focusNavigationDirection)"
 				reason="Should not be public" />
+
+			<Member
+				fullName="System.Void Windows.Storage.CachedFileManager..ctor()"
+				reason="Should not be public" />
 		</Methods>
 		<Fields>
 		</Fields>

--- a/doc/articles/features/windows-storage.md
+++ b/doc/articles/features/windows-storage.md
@@ -56,3 +56,9 @@ Given than in the project there's the following declaration:
 Those methods are not supported yet, however Uno supports to create a `RandomAccessStreamReference` from an `Uri` (`RandomAccessStreamReference.CreateFromUri`), but note that on WASM downloading a file from a random server usually causes some issues with [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS). 
 Make sure to configure the server that hosts the file accordingly.
 
+## Support for `CachedFileManager`
+
+For all targets except WebAssembly, the `CachedFileManager` does not provide any functionality and its methods immediately return. This allows to easily write code which requires deferring updates on UWP and sharing it across all targets.
+
+In case of WebAssembly, the behavior of `CachedFileManager` depends on whether the app uses the **File System Access API** or **Download picker**. This is described in detail in [file pickers documentation](windows-storage-pickers.md#WebAssembly).
+

--- a/src/Uno.UI/Resources/Strings/cs-CZ/Resources.resw
+++ b/src/Uno.UI/Resources/Strings/cs-CZ/Resources.resw
@@ -129,7 +129,10 @@
   <data name="StorageProviderLocalDisplayName" xml:space="preserve">
     <value>Tento počítač</value>
   </data>
-  <data name="StorageProviderNativeWasmDisplayName" xml:space="preserve">
+  <data name="StorageProviderWasmDownloadPickerName" xml:space="preserve">
+    <value>WASM dialog pro stažení</value>
+  </data>
+  <data name="StorageProviderWasmNativeDisplayName" xml:space="preserve">
     <value>JS File Access API</value>
   </data>
 </root>

--- a/src/Uno.UI/Resources/Strings/en/Resources.resw
+++ b/src/Uno.UI/Resources/Strings/en/Resources.resw
@@ -129,7 +129,7 @@
   <data name="StorageProviderLocalDisplayName" xml:space="preserve">
     <value>This PC</value>
   </data>
-  <data name="StorageProviderNativeWasmDisplayName" xml:space="preserve">
+  <data name="StorageProviderWasmNativeDisplayName" xml:space="preserve">
     <value>JS File Access API</value>
   </data>
   <data name="TEXT_CALENDARDATEPICKER_DEFAULT_PLACEHOLDER_TEXT" xml:space="preserve">
@@ -140,5 +140,8 @@
   </data>
   <data name="UIA_FLIPVIEW_NEXT" xml:space="preserve">
     <value>Next</value>
+  </data>
+  <data name="StorageProviderWasmDownloadPickerName" xml:space="preserve">
+    <value>WASM Download picker</value>
   </data>
 </root>

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Provider/FileUpdateStatus.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Provider/FileUpdateStatus.cs
@@ -2,28 +2,28 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage.Provider
 {
-#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-#if __ANDROID__ || __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
+#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public enum FileUpdateStatus 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Incomplete,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Complete,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		UserInputNeeded,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		CurrentlyUnavailable,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Failed,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		CompleteAndRenamed,
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/CachedFileManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/CachedFileManager.cs
@@ -2,19 +2,19 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Storage
 {
-#if __ANDROID__ || __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 	[global::Uno.NotImplemented]
 	#endif
-	public  partial class CachedFileManager 
+	public partial class CachedFileManager 
 	{
-#if __ANDROID__ || __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static void DeferUpdates( global::Windows.Storage.IStorageFile file)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Storage.CachedFileManager", "void CachedFileManager.DeferUpdates(IStorageFile file)");
 		}
 #endif
-#if __ANDROID__ || __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461","__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Provider.FileUpdateStatus> CompleteUpdatesAsync( global::Windows.Storage.IStorageFile file)
 		{

--- a/src/Uno.UWP/Storage/CachedFileManager.cs
+++ b/src/Uno.UWP/Storage/CachedFileManager.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.Storage.Provider;
+
+namespace Windows.Storage
+{
+	/// <summary>
+	/// Lets apps manage real-time updates to files.
+	/// </summary>
+	public static partial class CachedFileManager
+    {
+		/// <summary>
+		/// Lets apps defer real-time updates for a specified file.
+		/// </summary>
+		/// <param name="file">The file to defer updates for.</param>
+		/// <remarks>
+		/// In case of Uno Platform, this method currently
+		/// does not have any impact.
+		/// </remarks>
+		public static void DeferUpdates(IStorageFile file)
+		{
+		}
+
+		/// <summary>
+		/// Initiates updates for the specified file. This method contacts the app that provided the file to perform the updates.
+		/// </summary>
+		/// <param name="file">The file to update.</param>
+		/// <returns>
+		/// When this method completes, it returns a FileUpdateStatus
+		/// enum value that describes the status of the updates to the file.
+		/// </returns>
+		/// <remarks>
+		///	On most Uno Platform targets, this method immediately returns
+		///	success, as the file is already updated. In case of WASM using
+		///	the download file picker, this triggers the download file dialog.
+		/// </remarks>
+		public static IAsyncOperation<FileUpdateStatus> CompleteUpdatesAsync(IStorageFile file) =>
+			AsyncOperation.FromTask(ct => CompleteUpdatesTaskAsync(file, ct));
+	}
+}

--- a/src/Uno.UWP/Storage/CachedFileManager.cs
+++ b/src/Uno.UWP/Storage/CachedFileManager.cs
@@ -9,7 +9,7 @@ namespace Windows.Storage
 	/// Lets apps manage real-time updates to files.
 	/// </summary>
 	public static partial class CachedFileManager
-    {
+	{
 		/// <summary>
 		/// Lets apps defer real-time updates for a specified file.
 		/// </summary>

--- a/src/Uno.UWP/Storage/CachedFileManager.other.cs
+++ b/src/Uno.UWP/Storage/CachedFileManager.other.cs
@@ -5,10 +5,10 @@ using Windows.Storage.Provider;
 
 namespace Windows.Storage
 {
-	public static partial class CachedFileManager
+    public static partial class CachedFileManager
     {
-		private static Task<FileUpdateStatus> CompleteUpdatesTaskAsync(IStorageFile file, CancellationToken token) =>
-			Task.FromResult(FileUpdateStatus.Complete);
-	}
+        private static Task<FileUpdateStatus> CompleteUpdatesTaskAsync(IStorageFile file, CancellationToken token) =>
+            Task.FromResult(FileUpdateStatus.Complete);
+    }
 }
 #endif

--- a/src/Uno.UWP/Storage/CachedFileManager.other.cs
+++ b/src/Uno.UWP/Storage/CachedFileManager.other.cs
@@ -1,0 +1,14 @@
+﻿#if !__WASM__
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Storage.Provider;
+
+namespace Windows.Storage
+{
+	public static partial class CachedFileManager
+    {
+		private static Task<FileUpdateStatus> CompleteUpdatesTaskAsync(IStorageFile file, CancellationToken token) =>
+			Task.FromResult(FileUpdateStatus.Complete);
+	}
+}
+#endif

--- a/src/Uno.UWP/Storage/CachedFileManager.wasm.cs
+++ b/src/Uno.UWP/Storage/CachedFileManager.wasm.cs
@@ -1,45 +1,38 @@
-using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Uno.Foundation;
-using Windows.Foundation;
-using Windows.Foundation.Metadata;
+using Uno.Storage.Internal;
 using Windows.Storage.Provider;
 
 namespace Windows.Storage
 {
-	public partial class CachedFileManager
+	public static partial class CachedFileManager
 	{
-		public static void DeferUpdates(IStorageFile file)
+		private static async Task<FileUpdateStatus> CompleteUpdatesTaskAsync(IStorageFile file, CancellationToken token)
 		{
-			// The method does nothing in wasm since we don't really acces the filesystem.
-		}
-
-
-		public static IAsyncOperation<FileUpdateStatus> CompleteUpdatesAsync(IStorageFile file) => DownloadFile(file).AsAsyncOperation();
-
-		private async static Task<FileUpdateStatus> DownloadFile(IStorageFile file)
-		{
-			var stream = await file.OpenStreamForReadAsync();
-			byte[] data;
-
-			using (var reader = new BinaryReader(stream))
+			if (file is StorageFile storageFile && storageFile.Provider == StorageProviders.WasmDownloadPicker)
 			{
-				data = reader.ReadBytes((int)stream.Length);
-			}
+				var stream = await file.OpenStreamForReadAsync();
+				byte[] data;
 
-			var gch = GCHandle.Alloc(data, GCHandleType.Pinned);
-			var pinnedData = gch.AddrOfPinnedObject();
+				using (var reader = new BinaryReader(stream))
+				{
+					data = reader.ReadBytes((int)stream.Length);
+				}
 
-			try
-			{
-				WebAssemblyRuntime.InvokeJS($"Windows.Storage.Pickers.FileSavePicker.SaveAs('{file.Name}', {pinnedData}, {data.Length})");
-			}
-			finally
-			{
-				gch.Free();
+				var gch = GCHandle.Alloc(data, GCHandleType.Pinned);
+				var pinnedData = gch.AddrOfPinnedObject();
+
+				try
+				{
+					WebAssemblyRuntime.InvokeJS($"Windows.Storage.Pickers.FileSavePicker.SaveAs('{file.Name}', {pinnedData}, {data.Length})");
+				}
+				finally
+				{
+					gch.Free();
+				}
 			}
 
 			return FileUpdateStatus.Complete;

--- a/src/Uno.UWP/Storage/CachedFileManager.wasm.cs
+++ b/src/Uno.UWP/Storage/CachedFileManager.wasm.cs
@@ -8,34 +8,34 @@ using Windows.Storage.Provider;
 
 namespace Windows.Storage
 {
-	public static partial class CachedFileManager
-	{
-		private static async Task<FileUpdateStatus> CompleteUpdatesTaskAsync(IStorageFile file, CancellationToken token)
-		{
-			if (file is StorageFile storageFile && storageFile.Provider == StorageProviders.WasmDownloadPicker)
-			{
-				var stream = await file.OpenStreamForReadAsync();
-				byte[] data;
+    public static partial class CachedFileManager
+    {
+        private static async Task<FileUpdateStatus> CompleteUpdatesTaskAsync(IStorageFile file, CancellationToken token)
+        {
+            if (file is StorageFile storageFile && storageFile.Provider == StorageProviders.WasmDownloadPicker)
+            {
+                var stream = await file.OpenStreamForReadAsync();
+                byte[] data;
 
-				using (var reader = new BinaryReader(stream))
-				{
-					data = reader.ReadBytes((int)stream.Length);
-				}
+                using (var reader = new BinaryReader(stream))
+                {
+                    data = reader.ReadBytes((int)stream.Length);
+                }
 
-				var gch = GCHandle.Alloc(data, GCHandleType.Pinned);
-				var pinnedData = gch.AddrOfPinnedObject();
+                var gch = GCHandle.Alloc(data, GCHandleType.Pinned);
+                var pinnedData = gch.AddrOfPinnedObject();
 
-				try
-				{
-					WebAssemblyRuntime.InvokeJS($"Windows.Storage.Pickers.FileSavePicker.SaveAs('{file.Name}', {pinnedData}, {data.Length})");
-				}
-				finally
-				{
-					gch.Free();
-				}
-			}
+                try
+                {
+                    WebAssemblyRuntime.InvokeJS($"Windows.Storage.Pickers.FileSavePicker.SaveAs('{file.Name}', {pinnedData}, {data.Length})");
+                }
+                finally
+                {
+                    gch.Free();
+                }
+            }
 
-			return FileUpdateStatus.Complete;
-		}
-	}
+            return FileUpdateStatus.Complete;
+        }
+    }
 }

--- a/src/Uno.UWP/Storage/Internal/StorageProviders.cs
+++ b/src/Uno.UWP/Storage/Internal/StorageProviders.cs
@@ -7,7 +7,9 @@ namespace Uno.Storage.Internal
 		public static StorageProvider Local { get; } = new StorageProvider("computer", "StorageProviderLocalDisplayName");
 
 #if __WASM__
-		public static StorageProvider NativeWasm { get; } = new StorageProvider("jsfileaccessapi", "StorageProviderNativeWasmDisplayName");
+		public static StorageProvider WasmDownloadPicker { get; } = new StorageProvider("wasmdownloadpicker", "StorageProviderWasmDownloadPickerName");
+
+		public static StorageProvider WasmNative { get; } = new StorageProvider("jsfileaccessapi", "StorageProviderWasmNativeDisplayName");
 #endif
 
 #if __ANDROID__

--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
@@ -98,6 +98,7 @@ namespace Windows.Storage.Pickers
 				// The mime type is chosen by the extension, and we cannot reliably send multiple mime type in the browser
 				var fileName = SuggestedFileName + extension;
 				SuggestedSaveFile = await temporaryFolder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting);
+				SuggestedSaveFile.ProviderOverride = StorageProviders.WasmDownloadPicker;
 			}
 			return SuggestedSaveFile;
 		}

--- a/src/Uno.UWP/Storage/Provider/FileUpdateStatus.cs
+++ b/src/Uno.UWP/Storage/Provider/FileUpdateStatus.cs
@@ -1,0 +1,44 @@
+﻿namespace Windows.Storage.Provider
+{
+	/// <summary>
+	/// Describes the status of a file update request.
+	/// </summary>
+	public enum FileUpdateStatus
+	{
+		/// <summary>
+		/// The file update was not fully completed and should be retried.
+		/// </summary>
+		Incomplete,
+
+		/// <summary>
+		/// The file update was completed successfully.
+		/// </summary>
+		Complete,
+
+		/// <summary>
+		/// User input (like credentials) is needed to update the file.
+		/// </summary>
+		UserInputNeeded,
+
+		/// <summary>
+		/// The remote version of the file was not updated because the storage location
+		/// wasn't available. The file remains valid and subsequent updates
+		/// to the file may succeed.
+		/// </summary>
+		CurrentlyUnavailable,
+
+		/// <summary>
+		/// The file is now invalid and can't be updated now or in the future. For example,
+		/// this could occur if the remote version of the file was deleted.
+		/// </summary>
+		Failed,
+
+		/// <summary>
+		/// The file update was completed successfully and the file has been renamed.
+		/// For example, this could occur if the user chose to save their changes under
+		/// a different file name because of conflicting changes made to the remote
+		/// version of the file.
+		/// </summary>
+		CompleteAndRenamed,
+	}
+}

--- a/src/Uno.UWP/Storage/StorageFile.cs
+++ b/src/Uno.UWP/Storage/StorageFile.cs
@@ -41,7 +41,12 @@ namespace Windows.Storage
 
 		internal ImplementationBase Implementation { get; }
 
-		public StorageProvider Provider => Implementation.Provider;
+		/// <summary>
+		/// Allows internal Uno implementations to override the storage provider.
+		/// </summary>
+		internal StorageProvider? ProviderOverride { get; set; }
+
+		public StorageProvider Provider => ProviderOverride ?? Implementation.Provider;
 
 		public string Path => Implementation.Path;
 

--- a/src/Uno.UWP/Storage/StorageFile.native.wasm.cs
+++ b/src/Uno.UWP/Storage/StorageFile.native.wasm.cs
@@ -39,7 +39,7 @@ namespace Windows.Storage
 				_parent = parent;
 			}
 
-			public override StorageProvider Provider => StorageProviders.NativeWasm;
+			public override StorageProvider Provider => StorageProviders.WasmNative;
 
 			public override string Name => _fileName;
 

--- a/src/Uno.UWP/Storage/StorageFolder.native.wasm.cs
+++ b/src/Uno.UWP/Storage/StorageFolder.native.wasm.cs
@@ -41,7 +41,7 @@ namespace Windows.Storage
 				_parent = parent;
 			}
 
-			public override StorageProvider Provider => StorageProviders.NativeWasm;
+			public override StorageProvider Provider => StorageProviders.WasmNative;
 
 			public static async Task<StorageFolder?> GetPrivateRootAsync()
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5920, closes #6075

## PR Type

What kind of change does this PR introduce?

- Feature
- Documentation content changes

## What is the current behavior?

- `CachedFileManager` throws on non-WASM targets
- Docs on `FileSavePicker` are not clear


## What is the new behavior?

- `CachedFileManager` works everywhere (no-op on non-WASM targets)
- `CachedFileManager` on WASM transparently handles native file save picker vs. download picker
- Docs on `FileSavePicker` are improved


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.