### PR TITLE
fix: Use explicit Lazy initializer

### DIFF
--- a/src/Uno.UI/DirectUI/DXamlCore.cs
+++ b/src/Uno.UI/DirectUI/DXamlCore.cs
@@ -14,7 +14,7 @@ namespace DirectUI
 {
 	internal class DXamlCore
 	{
-		private static readonly Lazy<DXamlCore> _current = new Lazy<DXamlCore>();
+		private static readonly Lazy<DXamlCore> _current = new Lazy<DXamlCore>(() => new DXamlCore());
 
 		private BuildTreeService? _buildTreeService;
 		private BudgetManager? _budgetManager;

--- a/src/Uno.UI/UI/Xaml/Internal/CoreServices.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/CoreServices.cs
@@ -13,7 +13,7 @@ namespace Uno.UI.Xaml.Core
 {
 	internal class CoreServices
 	{
-		private static Lazy<CoreServices> _instance = new Lazy<CoreServices>();
+		private static Lazy<CoreServices> _instance = new Lazy<CoreServices>(() => new CoreServices());
 
 		private VisualTree? _mainVisualTree = null;
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6409, fixes https://github.com/unoplatform/nventive-private/issues/229, fixes https://github.com/unoplatform/nventive-private/issues/228, fixes https://github.com/unoplatform/nventive-private/issues/225

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Apps fail to startup with linker enabled.

## What is the new behavior?

Previously DXamlCore and CoreServices used Lazy without explicit initializer parameter. While this worked for debug build, linker removed the "unused" parameterless constructors for these types and reflection then could not find and use them. Using the explicit initializer ensures the constructor is explicitly used and is not linked away.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.