### PR TITLE
fix(BindableDrawerLayout): unable to add removed pane back

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SplitViewTests/BindableDrawerLayoutTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SplitViewTests/BindableDrawerLayoutTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.SplitViewTests
+{
+	[TestFixture]
+	public partial class BindableDrawerLayoutTests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void When_Pane_IsReset()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.SplitView.BindableDrawerLayout_ChangePane");
+			_app.WaitForElement("RootSplitView");
+
+			// validate BindableDrawerLayout pane can be set to null and restore later
+
+			_app.Tap("ManualOpenPaneButton");
+			Assert.IsTrue(_app.Marked("DrawerContent").HasResults());
+
+			_app.Tap("SetPaneToNullButton");
+			Assert.IsFalse(_app.Marked("DrawerContent").HasResults());
+
+			_app.Tap("SetPaneToSkyBlueGridButton");
+			Assert.IsTrue(_app.Marked("DrawerContent").HasResults());
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1593,6 +1593,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SplitView\BindableDrawerLayout_ChangePane.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SplitView\SplitViewClip.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5253,6 +5257,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\Slider_Header.xaml.cs">
       <DependentUpon>Slider_Header.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SplitView\BindableDrawerLayout_ChangePane.xaml.cs">
+      <DependentUpon>BindableDrawerLayout_ChangePane.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SplitView\SplitViewClip.xaml.cs">
       <DependentUpon>SplitViewClip.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SplitView/BindableDrawerLayout_ChangePane.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SplitView/BindableDrawerLayout_ChangePane.xaml
@@ -1,0 +1,48 @@
+﻿<Page x:Class="UITests.Windows_UI_Xaml_Controls.SplitView.BindableDrawerLayout_ChangePane"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Windows_UI_Xaml_Controls.SplitView"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:android="http://uno.ui/android"
+	  mc:Ignorable="d android"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<SplitView x:Name="RootSplitView" OpenPaneLength="312">
+			<!-- mimic LeftDrawerSplitViewStyle -->
+			<android:SplitView.Template>
+				<ControlTemplate TargetType="SplitView">
+					<BindableDrawerLayout LeftPaneOpenLength="{TemplateBinding OpenPaneLength}"
+										  LeftPane="{TemplateBinding Pane}"
+										  LeftPaneBackground="{TemplateBinding PaneBackground}"
+										  IsLeftPaneOpen="{TemplateBinding IsPaneOpen, Mode=TwoWay}"
+										  IsLeftPaneEnabled="{Binding (toolkit:SplitViewExtensions.IsPaneEnabled), RelativeSource={RelativeSource TemplatedParent}}"
+										  Content="{TemplateBinding Content}" />
+				</ControlTemplate>
+			</android:SplitView.Template>
+			
+			<SplitView.Content>
+				<Grid>
+					<TextBlock TextWrapping="WrapWholeWords">
+						Created to test (Left|Right)DrawerSplitViewStyle where setting the Pane to null and then to an UIElement would brick the BindableDrawerLayout.
+					</TextBlock>
+				</Grid>
+			</SplitView.Content>
+			<SplitView.Pane>
+				<Grid AutomationProperties.AutomationId="DrawerContent"
+					  Background="Pink"
+					  VerticalAlignment="Stretch"
+					  HorizontalAlignment="Stretch" />
+			</SplitView.Pane>
+		</SplitView>
+
+		<StackPanel VerticalAlignment="Bottom" Spacing="5">
+			<Button x:Name="ManualOpenPaneButton" Content="ManualOpenPane" Click="ManualOpenPane" />
+			<Button x:Name="ManualClosePaneButton" Content="ManualClosePane" Click="ManualClosePane" />
+			<Button x:Name="SetPaneToNullButton" Content="SetPaneToNull" Click="SetPaneTo" />
+			<Button x:Name="SetPaneToSkyBlueGridButton" Content="SetPaneToSkyBlueGrid" Click="SetPaneTo" Tag="SkyBlue" />
+			<Button x:Name="SetPaneToPinkGridButton" Content="SetPaneToPinkGrid" Click="SetPaneTo" Tag="Pink" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SplitView/BindableDrawerLayout_ChangePane.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SplitView/BindableDrawerLayout_ChangePane.xaml.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Uno.UI.Samples.Controls;
+using Uno.Extensions;
+using Windows.UI.Xaml.Automation;
+
+namespace UITests.Windows_UI_Xaml_Controls.SplitView
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo("SplitView", nameof(BindableDrawerLayout_ChangePane))]
+	public sealed partial class BindableDrawerLayout_ChangePane : Page
+	{
+		public BindableDrawerLayout_ChangePane()
+		{
+			this.InitializeComponent();
+		}
+		private void ManualOpenPane(object sender, RoutedEventArgs e) => RootSplitView.IsPaneOpen = true;
+
+		private void ManualClosePane(object sender, RoutedEventArgs e) => RootSplitView.IsPaneOpen = false;
+
+		private void SetPaneTo(object sender, RoutedEventArgs e)
+		{
+			var tag = (string)((Button)sender).Tag;
+
+			RootSplitView.Pane = tag switch
+			{
+				"SkyBlue" => CreateGrid(Windows.UI.Colors.SkyBlue),
+				"Pink" => CreateGrid(Windows.UI.Colors.Pink),
+
+				_ => null,
+			};
+
+			UIElement CreateGrid(Windows.UI.Color color) => new Grid
+			{
+				Background = new SolidColorBrush(color),
+				HorizontalAlignment = HorizontalAlignment.Stretch,
+				VerticalAlignment = VerticalAlignment.Stretch,
+			}.Apply(x => AutomationProperties.SetAutomationId(x, "DrawerContent"));
+		}
+
+		private void SetPaneToPinkGrid(object sender, RoutedEventArgs e)
+		{
+			RootSplitView.Pane = new Grid
+			{
+				Background = new SolidColorBrush(Windows.UI.Colors.Pink),
+				HorizontalAlignment = HorizontalAlignment.Stretch,
+				VerticalAlignment = VerticalAlignment.Stretch,
+			};
+		}
+	}
+}

--- a/src/Uno.UI/Controls/BindableDrawerLayout.Android.cs
+++ b/src/Uno.UI/Controls/BindableDrawerLayout.Android.cs
@@ -247,6 +247,7 @@ namespace Uno.UI.Controls
 			else if (newValue == null && _rightPane.Parent == this)
 			{
 				RemoveView(_rightPane);
+				_rightPane.SetParent(null);
 			}
 
 			_rightPane.Child = newValue;
@@ -370,6 +371,7 @@ namespace Uno.UI.Controls
 			else if (newValue == null && _leftPane.Parent == this)
 			{
 				RemoveView(_leftPane);
+				_leftPane.SetParent(null);
 			}
 
 			_leftPane.Child = newValue;


### PR DESCRIPTION
GitHub Issue (If applicable): _(private)_

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Attempting to set `SplitView.Pane` (with `LeftDrawerSplitViewStyle`) to null and then restoring it back cause the control to stop working.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
The _leftPane was removed, but its parent was not cleared, 
causing the 2nd part of 1st condition to fail when adding it back.

Internal Issue (If applicable):
resolved unoplatform/nventive-private#224