### PR TITLE
docs: Autofill searchbar when loading with search result url

### DIFF
--- a/doc/templates/uno/styles/docfx.js
+++ b/doc/templates/uno/styles/docfx.js
@@ -43,11 +43,19 @@ $(function () {
     const wpNavBar = document.getElementById('menu-menu-principal');
     const items = wpNavBar.getElementsByTagName('a');
     for(let i = 0; i < items.length; i++) {
-
-      if(items[i].href.includes(docsUrl) && path.includes(docsUrl)){
+      
+      if(items[i].href.includes(docsUrl) && path.includes(docsUrl) && !items[i].href.includes('#')){
         $(items[i]).addClass('activepath');
       }
     }
+
+    const queryString = window.location.search;
+    if(queryString){
+      const queryStringComponents = queryString.split('=');
+      const searchParam = queryStringComponents.slice(-1)[0];
+      $('#search-query').val(decodeURI(searchParam));
+    }
+
   });
 
   // Add this event listener when needed

--- a/doc/templates/uno/styles/docfx.js
+++ b/doc/templates/uno/styles/docfx.js
@@ -43,7 +43,7 @@ $(function () {
     const wpNavBar = document.getElementById('menu-menu-principal');
     const items = wpNavBar.getElementsByTagName('a');
     for(let i = 0; i < items.length; i++) {
-      
+
       if(items[i].href.includes(docsUrl) && path.includes(docsUrl) && !items[i].href.includes('#')){
         $(items[i]).addClass('activepath');
       }


### PR DESCRIPTION

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

Fix: "Developpers" is highlighted docs 
Feature: The search bar remains static when loading from a search result URL


## What is the new behavior?

Fix: "Developpers" is no longer highlighted in docs 
Feature: The search bar now autofills based on the search query in the URL


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
before
![image](https://user-images.githubusercontent.com/62605510/124974180-802a3580-dffa-11eb-8b48-0b1c84a8475f.png)
after 
![Capture](https://user-images.githubusercontent.com/62605510/124974224-8cae8e00-dffa-11eb-806c-1babfb3c12e1.PNG)



Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
