### PR TITLE
Implemented `.Bounds` for Geometry

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3726,10 +3726,10 @@
 			<Member
 				fullName="System.Void Uno.UI.Controls.Legacy.HorizontalGridView.OnIsEnabledChanged(System.Boolean oldValue, System.Boolean newValue)"
 				reason="Internal method which is not part of the UWP API" />
-			
+
 			<Member
 				fullName="System.Boolean Windows.UI.Xaml.UIElement.DispatchEvent(System.Int32 handle, System.String eventName, System.String eventArgs)"
-				reason="Public only for marshaling purposes, need to change return value" />			
+				reason="Public only for marshaling purposes, need to change return value" />
 
 		</Methods>
 		<Fields>
@@ -3742,7 +3742,7 @@
 		</Fields>
 		<Properties>
 		</Properties>
-	</IgnoreSet>	
+	</IgnoreSet>
 	<IgnoreSet baseVersion="3.8.11">
 		<Types>
 		</Types>
@@ -3762,7 +3762,7 @@
 				reason="Should not be public" />
 			<Member
 				fullName="System.Void Windows.UI.Xaml.Input.LosingFocusEventArgs..ctor()"
-				reason="Should not be public" />		
+				reason="Should not be public" />
 			<Member
 				fullName="System.Void Windows.UI.Xaml.Input.GettingFocusEventArgs..ctor()"
 				reason="Should not be public" />
@@ -3806,12 +3806,16 @@
 			<Member
 				fullName="System.Void Windows.Storage.CachedFileManager..ctor()"
 				reason="Should not be public" />
+
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Media.Geometry..ctor()"
+				reason="Not part of the UWP API" />
 		</Methods>
 		<Fields>
 		</Fields>
 		<Properties>
 		</Properties>
-	</IgnoreSet>	
+	</IgnoreSet>
 	<!--
 	Supported nodes (please keep at the bottom of this file):
 		<Types>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -508,7 +508,16 @@ namespace Uno.UI.Samples.Tests
 			IDisposable consoleRegistration = default;
 			CustomConsoleOutput testConsoleOutput = default;
 
-			if (consoleOutput.IsChecked ?? false)
+			bool isConsoleOutput = false;
+			bool isRunningIgnored = false;
+
+			await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+			{
+				isConsoleOutput = consoleOutput.IsChecked ?? false;
+				isRunningIgnored = runIgnored.IsChecked ?? false;
+			});
+
+			if (isConsoleOutput)
 			{
 				var previousOutput = Console.Out;
 
@@ -521,7 +530,7 @@ namespace Uno.UI.Samples.Tests
 
 			try
 			{
-				var shouldRunIgnored = runIgnored.IsChecked ?? false;
+				var shouldRunIgnored = isRunningIgnored;
 
 				foreach (var testMethod in tests)
 				{

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -244,9 +244,9 @@ namespace Windows.Foundation
 		public void Union(Rect rect)
 		{
 			var left = Math.Min(Left, rect.Left);
-			var right = Math.Max(left + Width, rect.Right);
+			var right = Math.Max(Left + Width, rect.Right);
 			var top = Math.Min(Top, rect.Top);
-			var bottom = Math.Max(top + Height, rect.Bottom);
+			var bottom = Math.Max(Top + Height, rect.Bottom);
 			this = new Rect(left, top, right - left, bottom - top);
 		}
 

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
@@ -100,7 +100,7 @@ namespace Private.Infrastructure
 						return false;
 					}
 
-					if (element is Control control && control.FindFirstChild<UIElement>(includeCurrent: false) == null)
+					if (element is Control control && control.FindFirstChild<FrameworkElement>(includeCurrent: false) == null)
 					{
 						return false;
 					}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_Geometry.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_Geometry.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+using Windows.UI.Xaml.Media;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_Geometry
+	{
+		[TestMethod]
+		public void RectangleGeometry_CheckBounds_CompositeTransform()
+		{
+			var geometry = new RectangleGeometry
+			{
+				Rect = new Rect(0, 0, 100, 100),
+				Transform = new CompositeTransform { CenterX = 50, CenterY = 50, Rotation = 45 }
+			};
+
+			geometry.Bounds.Should().Be(new Rect(-20.7, -20.7, 141.4, 141.4), 0.1);
+		}
+
+		[TestMethod]
+		public void RectangleGeometry_CheckBounds_TranslateTransform()
+		{
+			var geometry = new RectangleGeometry
+			{
+				Rect = new Rect(0, 0, 100, 100),
+				Transform = new TranslateTransform { X=20, Y=40 }
+			};
+
+			geometry.Bounds.Should().Be(new Rect(20, 40, 100, 100));
+		}
+
+		[TestMethod]
+		public void RectangleGeometry_CheckBounds_ScaleTransform()
+		{
+			var geometry = new RectangleGeometry
+			{
+				Rect = new Rect(0, 0, 100, 100),
+				Transform = new ScaleTransform { CenterX = 50, CenterY = 150, ScaleX = 2, ScaleY = 0.5 }
+			};
+
+			geometry.Bounds.Should().Be(new Rect(-50, 75, 200, 50), 0.1);
+		}
+
+		[TestMethod]
+		public void RectangleGeometry_CheckBounds_Origin()
+		{
+			var geometry = new RectangleGeometry
+			{
+				Rect = new Rect(100, 100, 100, 100)
+			};
+
+			geometry.Bounds.Should().Be(new Rect(100, 100, 100, 100), 0.1);
+		}
+
+		[TestMethod]
+		public void RectangleGeometry_CheckBounds_Origin_CompositeTransform()
+		{
+			var geometry = new RectangleGeometry
+			{
+				Rect = new Rect(100, 100, 100, 100),
+				Transform = new CompositeTransform { CenterX = 150, CenterY = 150, Rotation = 45 }
+			};
+
+			geometry.Bounds.Should().Be(new Rect(79.3, 79.3, 141.4, 141.4), 0.1);
+		}
+
+		[TestMethod]
+		public void Composite_RectangleGeometry_CheckBounds_Origin()
+		{
+			var geometry1 = new RectangleGeometry
+			{
+				Rect = new Rect(100, 100, 100, 100)
+			};
+			var geometry2 = new RectangleGeometry
+			{
+				Rect = new Rect(10, 10, 10, 10)
+			};
+
+			var geometry = new GeometryGroup();
+			geometry.Children.Add(geometry1);
+			geometry.Children.Add(geometry2);
+
+			using var _ = new AssertionScope();
+
+			geometry1.Bounds.Should().Be(new Rect(100, 100, 100, 100), 0.1);
+			geometry2.Bounds.Should().Be(new Rect(10, 10, 10, 10), 0.1);
+			geometry.Bounds.Should().Be(new Rect(10, 10, 190, 190), 0.1);
+		}
+
+		[TestMethod]
+		public void Composite_RectangleGeometry_CheckBounds_Origin_CompositeTransform()
+		{
+			var geometry1 = new RectangleGeometry
+			{
+				Rect = new Rect(100, 100, 100, 100),
+				Transform = new CompositeTransform { CenterX = 150, CenterY = 150, Rotation = 45, TranslateX = 100, TranslateY = -100 }
+			};
+			var geometry2 = new RectangleGeometry
+			{
+				Rect = new Rect(200, 200, 100, 100),
+				Transform = new CompositeTransform { CenterX = 350, CenterY = 350, ScaleX=2, ScaleY = 0.5 }
+			};
+
+			var geometry = new GeometryGroup();
+			geometry.Children.Add(geometry1);
+			geometry.Children.Add(geometry2);
+
+			using var _ = new AssertionScope();
+
+			geometry1.Bounds.Should().Be(new Rect(179, -21, 141.5, 141.5), 0.5);
+			geometry2.Bounds.Should().Be(new Rect(50, 275, 200, 50), 0.5);
+			geometry.Bounds.Should().Be(new Rect(50, -21, 271, 346), 0.5);
+		}
+
+		[TestMethod]
+		public void EmptyGeometryGroup_CheckBounds()
+		{
+			(new GeometryGroup()).Bounds.Should().Be(default(Rect));
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(Exception))] // Catastrophic Failure on UWP
+		public void EmptyGeometry_CheckBounds()
+		{
+			Console.WriteLine(Geometry.Empty.Bounds);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -1,12 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid11.0;xamarinmac20;uap10.0.17763</TargetFrameworks>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;xamarinios10;monoandroid11.0;xamarinmac20;uap10.0.17763</TargetFrameworks>
 		
-    <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
-    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
+		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		
 		<UnoRuntimeIdentifier Condition="'$(TargetFramework)'=='netstandard2.0'">Reference</UnoRuntimeIdentifier>
+
+		<NoWarn>$(NoWarn);CS0168;CS0219;CS0067;CS0162</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
@@ -100,13 +102,13 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <Compile Include="Tests\Windows_UI_Xaml_Controls\HtmlElementAttributeTests\Given_HtmlElementAttribute.Wasm.cs" />
+		<Compile Include="Tests\Windows_UI_Xaml_Controls\HtmlElementAttributeTests\Given_HtmlElementAttribute.Wasm.cs" />
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <Page Update="Tests\Windows_UI_Xaml\Controls\xLoad_xBind.xaml">
-	    <SubType>Designer</SubType>
-	  </Page>
+		<Page Update="Tests\Windows_UI_Xaml\Controls\xLoad_xBind.xaml">
+			<SubType>Designer</SubType>
+		</Page>
 	</ItemGroup>
 
 	<Import Project="..\SourceGenerators\Uno.UI.SourceGenerators\Content\Uno.UI.SourceGenerators.props" />

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/Geometry.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/Geometry.cs
@@ -10,16 +10,6 @@ namespace Windows.UI.Xaml.Media
 		// Skipping already declared property Transform
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.Foundation.Rect Bounds
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member Rect Geometry.Bounds is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.Media.Geometry Empty
 		{
 			get

--- a/src/Uno.UI/Mock/ViewExtensions.netstdref.cs
+++ b/src/Uno.UI/Mock/ViewExtensions.netstdref.cs
@@ -18,7 +18,12 @@ namespace Uno.UI
 
 		internal static FrameworkElement GetTopLevelParent(this UIElement view) => throw new NotImplementedException();
 
-		internal static T FindFirstChild<T>(this FrameworkElement root, bool includeCurrent) where T : FrameworkElement
+		internal static T FindFirstChild<T>(this FrameworkElement root, bool includeCurrent = true) where T : FrameworkElement
+		{
+			throw new NotImplementedException();
+		}
+
+		internal static T FindFirstChild<T>(this FrameworkElement root, Func<T, bool> selector, bool includeCurrent = true) where T : FrameworkElement
 		{
 			throw new NotImplementedException();
 		}

--- a/src/Uno.UI/UI/Xaml/Media/Geometry.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Geometry.cs
@@ -3,6 +3,7 @@ using Windows.UI.Xaml;
 using System;
 using System.ComponentModel;
 using Uno.Media;
+using Windows.Foundation;
 
 #if XAMARIN_IOS_UNIFIED
 using Foundation;
@@ -24,7 +25,7 @@ namespace Windows.UI.Xaml.Media
 	[TypeConverter(typeof(GeometryConverter))]
 	public partial class Geometry : DependencyObject, IDisposable
 	{
-		public Geometry()
+		internal Geometry()
 		{
 			InitializeBinder();
 		}
@@ -36,6 +37,13 @@ namespace Windows.UI.Xaml.Media
 #else
 			return Parsers.ParseGeometry(data);
 #endif
+		}
+
+		public Windows.Foundation.Rect Bounds => ComputeBounds();
+
+		private protected virtual Windows.Foundation.Rect ComputeBounds()
+		{
+			throw new NotImplementedException($"Bounds property is not implemented on {GetType().Name}.");
 		}
 
 		#region Transform

--- a/src/Uno.UI/UI/Xaml/Media/GeometryGroup.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GeometryGroup.cs
@@ -1,4 +1,6 @@
+using Windows.Foundation;
 using Windows.UI.Xaml.Markup;
+using Uno.UI;
 
 namespace Windows.UI.Xaml.Media
 {
@@ -51,5 +53,34 @@ namespace Windows.UI.Xaml.Media
 			);
 
 		#endregion
+
+		private protected override Rect ComputeBounds()
+		{
+			Rect? bounds = default;
+
+			foreach(var geometry in Children)
+			{
+				if(bounds is { } b)
+				{
+					bounds = b.UnionWith(geometry.Bounds);
+				}
+				else
+				{
+					bounds = geometry.Bounds;
+				}
+			}
+
+			if(bounds is { } result)
+			{
+				if(Transform is { } t)
+				{
+					return t.TransformBounds(result);
+				}
+
+				return result;
+			}
+
+			return default;
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.cs
@@ -66,5 +66,17 @@ namespace Windows.UI.Xaml.Media
 #endif
 
 		#endregion
+
+		private protected override Rect ComputeBounds()
+		{
+			if(Transform is { } transform)
+			{
+				return transform.TransformBounds(Rect);
+			}
+			else
+			{
+				return Rect;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/6413

# Feature
Implementation of `.Bounds` on 2 simple _geometries_: `RectangleGeometry` & `GeometryGroup`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
