### PR TITLE
feat: [WPF] Adds support for ConnectionProfile

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/Networking/Connectivity/ConnectionProfileExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/Networking/Connectivity/ConnectionProfileExtension.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Windows.Networking.Connectivity;
+
+namespace Uno.Extensions.Networking.Connectivity
+{
+	internal class ConnectionProfileExtension : IConnectionProfileExtension
+	{
+		private readonly object _connectionProfile;
+		public ConnectionProfileExtension(object owner)
+		{
+			if (!(owner is ConnectionProfile connectionProfile))
+				throw new InvalidOperationException($"Owner of {nameof(ConnectionProfileExtension)} must be a {nameof(ConnectionProfile)}.");
+
+			_connectionProfile = connectionProfile;
+		}
+
+		[DllImport("wininet.dll")]
+		extern static bool InternetGetConnectedState(out int connectionDescription, int reservedValue);
+
+		public NetworkConnectivityLevel GetNetworkConnectivityLevel() =>
+			InternetGetConnectedState(out _, 0) ?
+				NetworkConnectivityLevel.InternetAccess : NetworkConnectivityLevel.None;
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/Networking/Connectivity/WindowsConnectionProfileExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/Networking/Connectivity/WindowsConnectionProfileExtension.cs
@@ -1,16 +1,20 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Runtime.InteropServices;
 using Windows.Networking.Connectivity;
 
 namespace Uno.Extensions.Networking.Connectivity
 {
-	internal class ConnectionProfileExtension : IConnectionProfileExtension
+	internal class WindowsConnectionProfileExtension : IConnectionProfileExtension
 	{
 		private readonly object _connectionProfile;
-		public ConnectionProfileExtension(object owner)
+		public WindowsConnectionProfileExtension(object owner)
 		{
 			if (!(owner is ConnectionProfile connectionProfile))
-				throw new InvalidOperationException($"Owner of {nameof(ConnectionProfileExtension)} must be a {nameof(ConnectionProfile)}.");
+			{
+				throw new InvalidOperationException($"Owner of {nameof(WindowsConnectionProfileExtension)} must be a {nameof(ConnectionProfile)}.");
+			}
 
 			_connectionProfile = connectionProfile;
 		}

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -19,12 +19,14 @@ using Uno.UI.Xaml.Controls.Extensions;
 using Uno.UI.Xaml.Core;
 using Windows.Graphics.Display;
 using Windows.System;
+using Windows.Networking.Connectivity;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using WinUI = Windows.UI.Xaml;
 using Uno.UI.Xaml.Controls.Extensions;
 using Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls;
 using Uno.Extensions.System;
+using Uno.Extensions.Networking.Connectivity;
 using WpfApplication = System.Windows.Application;
 using WpfCanvas = System.Windows.Controls.Canvas;
 using WpfControl = System.Windows.Controls.Control;
@@ -58,6 +60,7 @@ namespace Uno.UI.Skia.Platform
 			ApiExtensibility.Register(typeof(Windows.ApplicationModel.DataTransfer.DragDrop.Core.IDragDropExtension), o => new WpfDragDropExtension(o));
 			ApiExtensibility.Register(typeof(IFileOpenPickerExtension), o => new FileOpenPickerExtension(o));
 			ApiExtensibility.Register(typeof(IFileSavePickerExtension), o => new FileSavePickerExtension(o));
+			ApiExtensibility.Register(typeof(IConnectionProfileExtension), o => new ConnectionProfileExtension(o));
 			ApiExtensibility.Register<TextBoxView>(typeof(ITextBoxViewExtension), o => new TextBoxViewExtension(o));
 			ApiExtensibility.Register(typeof(ILauncherExtension), o => new LauncherExtension(o));
 		}

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -60,7 +60,7 @@ namespace Uno.UI.Skia.Platform
 			ApiExtensibility.Register(typeof(Windows.ApplicationModel.DataTransfer.DragDrop.Core.IDragDropExtension), o => new WpfDragDropExtension(o));
 			ApiExtensibility.Register(typeof(IFileOpenPickerExtension), o => new FileOpenPickerExtension(o));
 			ApiExtensibility.Register(typeof(IFileSavePickerExtension), o => new FileSavePickerExtension(o));
-			ApiExtensibility.Register(typeof(IConnectionProfileExtension), o => new ConnectionProfileExtension(o));
+			ApiExtensibility.Register(typeof(IConnectionProfileExtension), o => new WindowsConnectionProfileExtension(o));
 			ApiExtensibility.Register<TextBoxView>(typeof(ITextBoxViewExtension), o => new TextBoxViewExtension(o));
 			ApiExtensibility.Register(typeof(ILauncherExtension), o => new LauncherExtension(o));
 		}

--- a/src/Uno.UWP/Networking/Connectivity/ConnectionProfile.skia.cs
+++ b/src/Uno.UWP/Networking/Connectivity/ConnectionProfile.skia.cs
@@ -1,4 +1,6 @@
-﻿using Uno.Foundation.Extensibility;
+﻿#nullable enable
+
+using Uno.Foundation.Extensibility;
 
 namespace Windows.Networking.Connectivity
 {

--- a/src/Uno.UWP/Networking/Connectivity/ConnectionProfile.skia.cs
+++ b/src/Uno.UWP/Networking/Connectivity/ConnectionProfile.skia.cs
@@ -1,17 +1,18 @@
-﻿namespace Windows.Networking.Connectivity
+﻿using Uno.Foundation.Extensibility;
+
+namespace Windows.Networking.Connectivity
 {
 	public partial class ConnectionProfile
     {
+		private IConnectionProfileExtension _connectionProfileExtension;
+
 		internal static ConnectionProfile GetInternetConnectionProfile() =>
 			new ConnectionProfile();
 
-		private ConnectionProfile()
-		{
-		}
+		private ConnectionProfile() =>
+			ApiExtensibility.CreateInstance(this, out _connectionProfileExtension);
 
-		private NetworkConnectivityLevel GetNetworkConnectivityLevelImpl()
-		{
-			return NetworkConnectivityLevel.None;
-		}
+		private NetworkConnectivityLevel GetNetworkConnectivityLevelImpl() =>
+			_connectionProfileExtension?.GetNetworkConnectivityLevel() ?? NetworkConnectivityLevel.None;
 	}
 }

--- a/src/Uno.UWP/Networking/Connectivity/Internal/IConnectionProfileExtension.skia.cs
+++ b/src/Uno.UWP/Networking/Connectivity/Internal/IConnectionProfileExtension.skia.cs
@@ -1,0 +1,7 @@
+﻿namespace Windows.Networking.Connectivity
+{
+	internal interface IConnectionProfileExtension
+	{
+		NetworkConnectivityLevel GetNetworkConnectivityLevel();
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #6435

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Retrieving the `NetworkConnectivityLevel` on any Skia target always returns `NetworkConnectivityLevel.None` as it is not implemented.

## What is the new behavior?
Now in the WPF Skia target when you request the `NetworkConnectivityLevel` it will return either
- `NetworkConnectivityLevel.InternetAccess`
- `NetworkConnectivityLevel.None`

### Screenshots
**No Internet**
![image](https://user-images.githubusercontent.com/17751436/125330641-05705b80-e315-11eb-94ea-e3cd49656a5e.png)

**Internet**
![image](https://user-images.githubusercontent.com/17751436/125330697-128d4a80-e315-11eb-8aa7-ead2a883a69b.png)

### Example usage
```c#
var currentConnectivity = NetworkConnectivityLevel.None;
var profile = NetworkInformation.GetInternetConnectionProfile();
if (profile != null)
  currentConnectivity = profile.GetNetworkConnectivityLevel();
```

In this example we can now retrieve the correct connectivity level and `currentConnectivity` will either be `None` or `InternetAccess`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
I want to address the unchecked boxes on the PR checklist
- Docs - I don't think documentation updates are necessary as this applies to the UWP API and doesn't introduce any changes to it
- Unit Tests/UI Tests - This code should be covered by the existing unit tests as I used the Uno Samples app. If there is more work to do on this, I would like some guidance on what I need to do. More than willing to add additional tests.
- Validated PR Screenshots - I am not 100% sure what this means, I have added 2 screenshots demonstrating the functionality with the WPF Skia Uno Sample

Internal Issue (If applicable):
N/A
