### PR TITLE
fix: Fix sr-Cyrl resources loading

### DIFF
--- a/src/Uno.UI.Tests/Resources/Given_ResourceCandidate.cs
+++ b/src/Uno.UI.Tests/Resources/Given_ResourceCandidate.cs
@@ -55,6 +55,7 @@ namespace Uno.UI.Tests.Resources
 		[DataRow(@"Assets\logo.lang-fr-CA.png", @"Assets\logo.png", null, "fr-CA", null)]
 		[DataRow(@"Assets\logo.lang-fr-CA.scale-200.png", @"Assets\logo.png", "200", "fr-CA", null)]
 		[DataRow(@"Assets\logo.scale-200.lang-fr-CA.png", @"Assets\logo.png", "200", "fr-CA", null)]
+		[DataRow(@"Assets\sr-Cyrl\logo.png", @"Assets\logo.png", null, "sr-Cyrl", null)]
 		[TestMethod]
 		public void When_Parse(string relativePath, string logicalPath, string scale, string language, string custom)
 		{

--- a/src/Uno.UWP/ApplicationModel/Resources/Core/ResourceQualifier.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/Core/ResourceQualifier.cs
@@ -57,8 +57,14 @@ namespace Windows.ApplicationModel.Resources.Core
 				{
 					var cultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures);
 					var ietfLanguageTags = cultures.Select(c => c.IetfLanguageTag);
+					var ietfLanguageParentTags = cultures.Select(c => c.Parent.IetfLanguageTag);
 					var twoLetterLanguageTags = cultures.Select(c => c.TwoLetterISOLanguageName);
-					_languageTags = new HashSet<string>(Enumerable.Concat(ietfLanguageTags, twoLetterLanguageTags).Distinct());
+
+					var allCulture = Enumerable.Concat(
+						ietfLanguageTags,
+						twoLetterLanguageTags.Concat(ietfLanguageParentTags));
+
+					_languageTags = new HashSet<string>(allCulture.Distinct());
 				}
 
 				return _languageTags;


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6302

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes partial matching of three-parts culture info, like `sr-Cyrl-BA` when generating resource files.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
