### PR TITLE
fix: Remove redundant pdb copy for WebAssembly Compatibility

### DIFF
--- a/src/Uno.UI.Runtime.WebAssembly.Compatibility/Uno.UI.Runtime.WebAssembly.Compatibility.csproj
+++ b/src/Uno.UI.Runtime.WebAssembly.Compatibility/Uno.UI.Runtime.WebAssembly.Compatibility.csproj
@@ -36,14 +36,12 @@
 		</PropertyGroup>
 		<ItemGroup>
 			<_OutputFiles Include="@(TargetPathWithTargetPlatformMoniker)" />
-			<_OutputFilesPDB Include="@(TargetPathWithTargetPlatformMoniker-&gt;'%(RecursiveDir)%(Filename).pdb)" />
 		</ItemGroup>
 		<MakeDir Directories="$(_TargetNugetFolder)" />
 
 		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
 
 		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
-		<Copy SourceFiles="@(_OutputFilesPDB)" DestinationFiles="@(_OutputFilesPDB->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
 	</Target>
 
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Build changes

## What is the current behavior?

Override Uno.UI nuget package for building wasm (netstandard 2.0)

- **error MSB4023: Cannot evaluate the item metadata "%(Filename)". The item metadata "%(Filename)" cannot be applied to the path "@(TargetPathWithTargetPlatformMoniker->'.pdb)". Illegal characters in path.**
-  **error MSB3030: Could not copy the file "Uno.UI.Wasm.pdb" because it was not found.**


## What is the new behavior?
No more building errors.

Removed redundant pdb copy for WebAssembly Compatibility since the first copy task already copies the Uno.UI.Wasm.pdb to the nuget override folder.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

