### PR TITLE
feat: Improve error reporting with Roslyn-hosted generators

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2269,6 +2269,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 			catch (Exception e)
 			{
+#if NETFRAMEWORK
 				throw new InvalidOperationException(
 					"An error occurred when processing {0} at line {1}:{2} ({3}) : {4}"
 					.InvariantCultureFormat(
@@ -2280,6 +2281,15 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					)
 					, e
 				);
+#else
+				throw new XamlParsingException(
+					$"An error was found in {topLevelControl.Type.Name}"
+					, e
+					, topLevelControl.LineNumber
+					, topLevelControl.LinePosition
+					, _fileDefinition.FilePath
+				);
+#endif
 			}
 		}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
@@ -1,4 +1,5 @@
-﻿#nullable enable
+﻿extern alias __uno;
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -70,9 +71,17 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				return null;
 			}
+			catch (__uno::Uno.Xaml.XamlParseException e)
+			{
+				throw new XamlParsingException(e.Message, null, e.LineNumber, e.LinePosition, file);
+			}
+			catch (XmlException e)
+			{
+				throw new XamlParsingException(e.Message, null, e.LineNumber, e.LinePosition, file);
+			}
 			catch (Exception e)
 			{
-				throw new InvalidOperationException($"Failed to parse file {file}", e);
+				throw new XamlParsingException($"Failed to parse file", e, 1, 1, file);
 			}
 		}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlParsingException.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlParsingException.cs
@@ -1,0 +1,37 @@
+﻿#nullable enable
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Uno.UI.SourceGenerators.XamlGenerator
+{
+	/// <summary>
+	/// Defines a XAML parsing exception to be raised from the generator
+	/// </summary>
+	[Serializable]
+	internal class XamlParsingException : Exception
+	{
+		public XamlParsingException()
+		{
+		}
+
+		public XamlParsingException(string message) : base(message)
+		{
+		}
+
+		public XamlParsingException(string message, Exception? innerException, int lineNumber, int linePosition, string filePath) : base(message, innerException)
+		{
+			LineNumber = lineNumber;
+			LinePosition = linePosition;
+			FilePath = filePath;
+		}
+
+		protected XamlParsingException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+
+		public int? LineNumber { get; }
+		public int? LinePosition { get; }
+		public string? FilePath { get; }
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/6373

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

XAML Parsing errors when running with roslyn-hosted generators (without Uno.SourceGenerationTasks) are now minimally reported using the diagnostics API instead of aggregate exceptions. The line/column information is also tentatively added to improve IDE navigation.

This change also avoid raising exceptions that the Microsoft telemetry will incorrect track.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
