### PR TITLE
Various improvements around brushes

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3465,6 +3465,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\DynamicBrushes_On_Shapes.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\RevealBrush_Fallback.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6173,6 +6177,9 @@
       <DependentUpon>Brushes_ImplicitConvert.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\ColorPresenter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\DynamicBrushes_On_Shapes.xaml.cs">
+      <DependentUpon>DynamicBrushes_On_Shapes.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\BrushesTests\RevealBrush_Fallback.xaml.cs">
       <DependentUpon>RevealBrush_Fallback.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/DynamicBrushes_On_Shapes.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/DynamicBrushes_On_Shapes.xaml
@@ -1,0 +1,60 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Media.BrushesTests.DynamicBrushes_On_Shapes"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Margin="20" Spacing="6">
+		<Border>
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<Border x:Name="border1" Width="50" Height="60" />
+				<Ellipse x:Name="shape1" Width="50" Height="60" />
+				<Rectangle x:Name="shape2" Width="50" Height="60">
+					<Rectangle.Fill>
+						<ImageBrush ImageSource="ms-appx:///Assets/uno-overalls.jpg" />
+					</Rectangle.Fill>
+				</Rectangle>
+				<Path x:Name="shape3" Width="60" Height="60" Stretch="UniformToFill" Data="M 100 100 L 300 100 L 200 300 z" />
+			</StackPanel>
+		</Border>
+		<TextBlock x:Name="txt" />
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Button Click="SetFill" Tag="null">NULL FILL</Button>
+			<Button Click="SetFill" Tag="solid1">Solid1</Button>
+			<Button Click="SetFill" Tag="solid2">Solid2</Button>
+			<Button Click="SetFill" Tag="linear">Linear Gradient</Button>
+			<Button Click="SetFill" Tag="radial">Radial Gradient</Button>
+			<Button Click="SetFill" Tag="img1">Image 1</Button>
+			<Button Click="SetFill" Tag="img2">Image 2</Button>
+		</StackPanel>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<TextBlock>Solid1:</TextBlock>
+			<RadioButton GroupName="Solid1" Click="SetColor" Background="Red" IsChecked="True">Red</RadioButton>
+			<RadioButton GroupName="Solid1" Click="SetColor" Background="Blue">Blue</RadioButton>
+			<RadioButton GroupName="Solid1" Click="SetColor" Background="Yellow">Yellow</RadioButton>
+			<RadioButton GroupName="Solid1" Click="SetColor" Background="Green">Green</RadioButton>
+		</StackPanel>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<TextBlock>Solid1:</TextBlock>
+			<RadioButton GroupName="Solid2" Click="SetColor" Background="Red">Red</RadioButton>
+			<RadioButton GroupName="Solid2" Click="SetColor" Background="Blue" IsChecked="True">Blue</RadioButton>
+			<RadioButton GroupName="Solid2" Click="SetColor" Background="Yellow">Yellow</RadioButton>
+			<RadioButton GroupName="Solid2" Click="SetColor" Background="Green">Green</RadioButton>
+		</StackPanel>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<TextBlock>Image1:</TextBlock>
+			<RadioButton GroupName="Image1" Click="SetImage" Tag="ms-appx:///Assets/RatingControl.png" IsChecked="True">Star</RadioButton>
+			<RadioButton GroupName="Image1" Click="SetImage" Tag="ms-appx:///Assets/Formats/uno-overalls.jpg">Overalls</RadioButton>
+			<RadioButton GroupName="Image1" Click="SetImage" Tag="ms-appx:///Assets/test_image_100_100.png">Logo</RadioButton>
+		</StackPanel>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<TextBlock>Image2:</TextBlock>
+			<RadioButton GroupName="Image2" Click="SetImage" Tag="ms-appx:///Assets/RatingControl.png">Star</RadioButton>
+			<RadioButton GroupName="Image2" Click="SetImage" Tag="ms-appx:///Assets/Formats/uno-overalls.jpg" IsChecked="True">Overalls</RadioButton>
+			<RadioButton GroupName="Image2" Click="SetImage" Tag="ms-appx:///Assets/test_image_100_100.png">Logo</RadioButton>
+		</StackPanel>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/DynamicBrushes_On_Shapes.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/BrushesTests/DynamicBrushes_On_Shapes.xaml.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace UITests.Windows_UI_Xaml_Media.BrushesTests
+{
+	[Sample]
+	public sealed partial class DynamicBrushes_On_Shapes : Page
+	{
+		private int shape1LayoutCount;
+		private int shape2LayoutCount;
+		private int shape3LayoutCount;
+
+		private SolidColorBrush _solid1 = new SolidColorBrush { Color = Colors.Red };
+		private SolidColorBrush _solid2 = new SolidColorBrush { Color = Colors.Blue };
+
+		private ImageBrush _image1 = new ImageBrush { ImageSource = new BitmapImage { UriSource = new Uri("ms-appx:///Assets/RatingControl.png") } };
+		private ImageBrush _image2 = new ImageBrush { ImageSource = new BitmapImage { UriSource = new Uri("ms-appx:///Assets/Formats/uno-overalls.jpg") } };
+
+		public DynamicBrushes_On_Shapes()
+		{
+			this.InitializeComponent();
+
+			shape1.LayoutUpdated += (snd, evt) =>
+			{
+				shape1LayoutCount++;
+				UpdateText();
+			};
+			shape2.LayoutUpdated += (snd, evt) =>
+			{
+				shape2LayoutCount++;
+				UpdateText();
+			};
+			shape3.LayoutUpdated += (snd, evt) =>
+			{
+				shape3LayoutCount++;
+				UpdateText();
+			};
+
+			void UpdateText()
+			{
+				//txt.Text = $"Layout Updated: {shape1LayoutCount}, {shape2LayoutCount}, {shape3LayoutCount}";
+			}
+
+		}
+
+		private void SetFill(object sender, RoutedEventArgs e)
+		{
+			if (sender is Button btn)
+			{
+				var brush = GetBrush(btn.Tag as string);
+				border1.Background = brush;
+				shape1.Fill = brush;
+				shape2.Fill = brush;
+				shape3.Fill = brush;
+			}
+		}
+
+		private Brush GetBrush(string tag)
+		{
+			switch (tag)
+			{
+				case "null": return null;
+				case "solid1": return _solid1;
+				case "solid2": return _solid2;
+				case "linear":
+					return new LinearGradientBrush
+					{
+						StartPoint = new Point(0, 0),
+						EndPoint = new Point(1, 1),
+						GradientStops =
+					{
+						new GradientStop { Offset = 0, Color = Colors.Red },
+						new GradientStop { Offset = .3, Color = Colors.Blue },
+						new GradientStop { Offset = .5, Color = Colors.Yellow },
+						new GradientStop { Offset = 1, Color = Colors.Violet }
+					}
+					};
+				case "radial":
+					return new RadialGradientBrush
+					{
+						GradientStops =
+						{
+							new GradientStop { Offset = 0, Color = Colors.Red },
+							new GradientStop { Offset = .3, Color = Colors.Blue },
+							new GradientStop { Offset = .5, Color = Colors.Yellow },
+							new GradientStop { Offset = 1, Color = Colors.Violet }
+						}
+					};
+				case "img1":
+					return _image1;
+				case "img2":
+					return _image2;
+				default:
+					throw new Exception();
+			}
+		}
+
+		private void SetColor(object sender, RoutedEventArgs e)
+		{
+			if (sender is RadioButton radioButton)
+			{
+				var brush = radioButton.GroupName.EndsWith("1") ? _solid1 : _solid2;
+				var color = (radioButton.Background as SolidColorBrush)?.Color ?? throw new Exception();
+				brush.Color = color;
+			}
+		}
+		private void SetImage(object sender, RoutedEventArgs e)
+		{
+			if (sender is RadioButton radioButton)
+			{
+				var brush = radioButton.GroupName.EndsWith("1") ? _image1 : _image2;
+				var image = radioButton.Tag as string;
+
+				brush.ImageSource = new BitmapImage { UriSource = new Uri(image) };
+			}
+		}
+	}
+}

--- a/src/Uno.UI/Controls/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.UI/Controls/AppBarButtonRenderer.Android.cs
@@ -168,7 +168,7 @@ namespace Uno.UI.Controls
 			}
 
 			// Background
-			var backgroundColor = (element.Background as SolidColorBrush)?.ColorWithOpacity;
+			var backgroundColor = Brush.GetColorWithOpacity(element.Background);
 			if (backgroundColor != null)
 			{
 				_appBarButtonWrapper.SetBackgroundColor((Android.Graphics.Color)backgroundColor);

--- a/src/Uno.UI/Controls/CommandBarRenderer.Android.cs
+++ b/src/Uno.UI/Controls/CommandBarRenderer.Android.cs
@@ -173,7 +173,7 @@ namespace Uno.UI.Controls
 			native.Subtitle = element.GetValue(SubtitleProperty) as string;
 
 			// Background
-			var backgroundColor = (element.Background as SolidColorBrush)?.ColorWithOpacity;
+			var backgroundColor = Brush.GetColorWithOpacity(element.Background);
 			if (backgroundColor != null)
 			{
 				native.SetBackgroundColor((Android.Graphics.Color)backgroundColor);
@@ -184,7 +184,7 @@ namespace Uno.UI.Controls
 			}
 
 			// Foreground
-			var foregroundColor = (element.Foreground as SolidColorBrush)?.ColorWithOpacity;
+			var foregroundColor = Brush.GetColorWithOpacity(element.Foreground);
 			if (foregroundColor != null)
 			{
 				native.SetTitleTextColor((Android.Graphics.Color)foregroundColor);
@@ -247,7 +247,7 @@ namespace Uno.UI.Controls
 				}
 
 				// CommandBarExtensions.BackButtonForeground
-				var backButtonForeground = (element.GetValue(BackButtonForegroundProperty) as SolidColorBrush)?.ColorWithOpacity;
+				var backButtonForeground = Brush.GetColorWithOpacity(element.GetValue(BackButtonForegroundProperty) as Brush);
 				if (backButtonForeground != null)
 				{
 					switch (native.NavigationIcon)

--- a/src/Uno.UI/Controls/NSStringAttributesHelper.macOS.cs
+++ b/src/Uno.UI/Controls/NSStringAttributesHelper.macOS.cs
@@ -77,7 +77,7 @@ namespace Uno.UI
 			var font = NSFontHelper.TryGetFont((float)tuple.fontSize, tuple.fontWeight, tuple.fontStyle, tuple.fontFamily, tuple.preferredBodyFontSize);
 			var attributes = new NSStringAttributes()
 			{
-				ForegroundColor = (tuple.foreground as SolidColorBrush)?.ColorWithOpacity,
+				ForegroundColor = Brush.GetColorWithOpacity(tuple.foreground),
 				Font = font,
 				BaselineOffset = GetBaselineOffset(),
 				UnderlineStyle = (int)((tuple.textDecorations & TextDecorations.Underline) == TextDecorations.Underline

--- a/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOS.cs
@@ -21,9 +21,9 @@ namespace Windows.UI.Xaml.Controls
 
 		private void ApplyForeground()
 		{
-			if (_native != null && Foreground is SolidColorBrush foregroundColorBrush)
+			if (_native != null && Foreground is { } foreground)
 			{
-				_native.Color = foregroundColorBrush.ColorWithOpacity;
+				_native.Color = Brush.GetColorWithOpacity(foreground);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
@@ -164,13 +164,9 @@ namespace Windows.UI.Xaml.Media
 
 			if (maskingPath == null)
 			{
-				if (background is SolidColorBrush solidBrush)
+				if (Brush.GetColorWithOpacity(background) is { } color)
 				{
-					return new ColorDrawable(solidBrush.ColorWithOpacity);
-				}
-				else if (background is AcrylicBrush acrylicBrush)
-				{
-					return new ColorDrawable(acrylicBrush.FallbackColorWithOpacity);
+					return new ColorDrawable(color);
 				}
 
 				if (fillPaint != null)

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.wasm.cs
@@ -87,17 +87,17 @@ namespace Windows.UI.Xaml.Media
 
 			void OnStretchChanged(DependencyObject dependencyobject, DependencyPropertyChangedEventArgs args)
 			{
-				SetPreserveAspectRatio();
+				preserveAspectRatio = SetPreserveAspectRatio();
 			}
 
 			void OnAlignmentChanged(DependencyObject dependencyobject, DependencyPropertyChangedEventArgs args)
 			{
-				SetPreserveAspectRatio();
+				preserveAspectRatio = SetPreserveAspectRatio();
 			}
 
 			void OnTargetLayoutUpdated(object sender, object e)
 			{
-				SetPreserveAspectRatio();
+				preserveAspectRatio = SetPreserveAspectRatio();
 			}
 
 			subscriptionDisposable.Disposable = ImageSource?.Subscribe(OnSourceOpened);
@@ -120,8 +120,13 @@ namespace Windows.UI.Xaml.Media
 							("height", "100%"),
 							("preserveAspectRatio", preserveAspectRatio),
 							("href", _imageUri)
-
 						);
+
+						// Clear any previous image, if any
+						foreach(var previousChild in pattern.GetChildren())
+						{
+							pattern.RemoveChild(previousChild);
+						}
 
 						pattern.AddChild(image);
 


### PR DESCRIPTION
# Bug fixes + improvements
* On WASM, dynamically changing the properties of an `<ImageBrush />` were leading to strange result
* A new sample for dynamic brushes
* Unify the way the fallback color is applied throughout the platform.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
