### PR TITLE
fix: FileOpenPicker should show file extensions similar to UWP

### DIFF
--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.wasm.cs
@@ -94,7 +94,7 @@ namespace Windows.Storage.Pickers
 
 				var fullAcceptType = new NativeFilePickerAcceptType()
 				{
-					Description = "All",
+					Description = "All files",
 					Accept = new[] { fullAcceptItem }
 				};
 


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #6487

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?

- Bugfix


<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Code: 
```C#
			var picker = new Windows.Storage.Pickers.FileOpenPicker();
			picker.ViewMode = Windows.Storage.Pickers.PickerViewMode.Thumbnail;
			picker.SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.PicturesLibrary;
			picker.FileTypeFilter.Add(".jpg");
			picker.FileTypeFilter.Add(".jpeg");
			picker.FileTypeFilter.Add(".png");
```

`FileOpenPicker` shows unrelated file types when it encounters a known MIME type, on Chrome and Edge, and unintentionally groups `jpg` and `jpeg` together.

![image](https://user-images.githubusercontent.com/57174311/126029691-b49d2854-31cb-4f60-a9fb-5965e963c773.png)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

`FileOpenPicker` shows each file type on one line, and another line shows the superset of all file types specified.

![image](https://user-images.githubusercontent.com/57174311/126029758-bb4cfb08-a311-406a-9030-6c64f2cbceeb.png)


<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
