### PR TITLE
Fix ordering of property change propagation and callbacks

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1629,10 +1629,10 @@ namespace Windows.UI.Xaml
 				uiElt.OnPropertyChanged2(eventArgs);
 			}
 
+			OnDependencyPropertyChanged(propertyDetails, eventArgs);
+
 			// Raise the changes for the callbacks register through RegisterPropertyChangedCallback.
 			propertyDetails.CallbackManager.RaisePropertyChanged(actualInstanceAlias, eventArgs);
-
-			OnDependencyPropertyChanged(propertyDetails, eventArgs);
 
 			// Raise the property change for generic handlers
 			for (var callbackIndex = 0; callbackIndex < _genericCallbacks.Data.Length; callbackIndex++)


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6496 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When property changes, its change callback were fired before its associated binding is applied. This caused issues for `NavigationView`, which used callback on `IsPaneOpen` coming from `SplitView` to adjust pane title visibility, but the new value was not yet propagated from `SplitView.IsPaneOpen`  to `NavigationView.IsPaneOpen` by virtue of binding, as it takes place *after* the callbacks are raised.

Order was:

```
SplitView.IsPaneOpen changed
SplitView.IsPaneOpen callbacks
NavigationView.IsPaneOpen changed
NavigationView.IsPaneOpen callbacks
```

## What is the new behavior?

New ordering is:

```
SplitView.IsPaneOpen changed
NavigationView.IsPaneOpen changed
NavigationView.IsPaneOpen callbacks
SplitView.IsPaneOpen callbacks
```

This matches UWP.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.