### PR TITLE
fix: Hide NavigationView back button on Android by default

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -2072,7 +2072,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			var visibility = IsBackButtonVisible;
 			// Uno specific: When Auto, we hide the back button on Android as per the Android
-			// design guidelines.
+			// design guidelines - see first paragraph of https://developer.android.com/guide/navigation/navigation-custom-back
 			bool isAndroid = AnalyticsInfo.VersionInfo.DeviceFamily.StartsWith("Android", StringComparison.InvariantCultureIgnoreCase);
 			return (visibility == NavigationViewBackButtonVisible.Visible || (visibility == NavigationViewBackButtonVisible.Auto && (!SharedHelpers.IsOnXbox() && !isAndroid)));
 		}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -15,6 +15,7 @@ using Windows.ApplicationModel.Core;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.System;
+using Windows.System.Profile;
 using Windows.UI.Composition;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
@@ -2070,7 +2071,10 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool ShouldShowBackOrCloseButton()
 		{
 			var visibility = IsBackButtonVisible;
-			return (visibility == NavigationViewBackButtonVisible.Visible || (visibility == NavigationViewBackButtonVisible.Auto && !SharedHelpers.IsOnXbox()));
+			// Uno specific: When Auto, we hide the back button on Android as per the Android
+			// design guidelines.
+			bool isAndroid = AnalyticsInfo.VersionInfo.DeviceFamily.StartsWith("Android", StringComparison.InvariantCultureIgnoreCase);
+			return (visibility == NavigationViewBackButtonVisible.Visible || (visibility == NavigationViewBackButtonVisible.Auto && (!SharedHelpers.IsOnXbox() && !isAndroid)));
 		}
 
 		// The automation name and tooltip for the pane toggle button changes depending on whether it is open or closed

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewBackButtonVisible.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewBackButtonVisible.cs
@@ -24,7 +24,9 @@ namespace Microsoft.UI.Xaml.Controls
 		/// The system chooses whether or not to display
 		/// the back button, depending on the device/form factor.
 		/// On phones, tablets, desktops, and hubs, the back button
-		/// is visible. On Xbox/TV, the back button is collapsed.
+		/// is visible (except on Android, where it is not displayed
+		/// as per Android guidelines). On Xbox/TV, the back button
+		/// is collapsed.
 		/// </summary>
 		Auto = 2,
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6495 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Back button is always shown on all Uno targets.

## What is the new behavior?

Back button will be hidden by default on `NavigationView` when visibility is set to `Auto`, to match Android design guidelines.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.