### PR TITLE
Enumeration over ApplicationDataContainer

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationDataContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationDataContainer.cs
@@ -188,6 +188,25 @@ namespace Uno.UI.Samples.Tests.Windows_Storage
 		}
 
 		[TestMethod]
+		public void When_EnumerateOverValues()
+		{
+			var SUT = ApplicationData.Current.LocalSettings;
+
+			SUT.Values.Add("enumerate_over_values_one", "11");
+			SUT.Values.Add("enumerate_over_values_two", "22");
+			SUT.Values.Add("enumerate_over_values_three", "33");
+
+			List<string> keysPresent = SUT.Values.Keys.ToList();
+
+			foreach(var value in SUT.Values)
+			{
+				keysPresent.Remove(value.Key);
+			}
+
+			Assert.AreEqual(0, keysPresent.Count);
+		}
+
+		[TestMethod]
 		public void When_NullValueSetViaIndexer()
 		{
 			var SUT = ApplicationData.Current.LocalSettings;

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.Android.cs
@@ -117,7 +117,11 @@ namespace Windows.Storage
 				=> throw new NotSupportedException();
 
 			public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
-				=> throw new NotSupportedException();
+			{
+				return _preferences
+					.All
+					.GetEnumerator();
+			}
 
 			public bool Remove(string key)
 			{
@@ -143,7 +147,7 @@ namespace Windows.Storage
 				return false;
 			}
 
-			IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
+			IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 		}
 	}
 }

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.iOSmacOS.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.iOSmacOS.cs
@@ -99,7 +99,12 @@ namespace Windows.Storage
 				=> throw new NotSupportedException();
 
 			public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
-				=> throw new NotSupportedException();
+			{
+				return NSUserDefaults.StandardUserDefaults
+					.ToDictionary()
+					.Select(k => new KeyValuePair<string, object>(k.Key.ToString(), DataTypeSerializer.Deserialize(k.Key.ToString())))
+					.GetEnumerator();
+			}
 
 			public bool Remove(string key)
 			{
@@ -123,7 +128,7 @@ namespace Windows.Storage
 				return false;
 			}
 
-			IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
+			IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 		}
 	}
 }

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.skia.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.skia.cs
@@ -202,7 +202,7 @@ namespace Windows.Storage
 				=> throw new NotSupportedException();
 
 			public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
-				=> throw new NotSupportedException();
+				=> _values.Select(v => new KeyValuePair<string, object>(v.Key, v.Value)).GetEnumerator();
 
 			public bool Remove(string key)
 			{
@@ -227,7 +227,7 @@ namespace Windows.Storage
 				return false;
 			}
 
-			IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
+			IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 		}
 	}
 }

--- a/src/Uno.UWP/Storage/ApplicationDataContainer.wasm.cs
+++ b/src/Uno.UWP/Storage/ApplicationDataContainer.wasm.cs
@@ -127,7 +127,18 @@ namespace Windows.Storage
 				=> throw new NotSupportedException();
 
 			public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
-				=> throw new NotSupportedException();
+			{
+				List<KeyValuePair<string, object>> kvps = new List<KeyValuePair<string, object>>();
+
+				for (int index = 0; index < Count; index++)
+				{
+					var key = ApplicationDataContainerInterop.GetKeyByIndex(_locality, index);
+					var value = ApplicationDataContainerInterop.GetValueByIndex(_locality, index);
+					kvps.Add(new KeyValuePair<string, object>(key, value));
+				}
+
+				return kvps.GetEnumerator();
+			}
 
 			public bool Remove(string key)
 			{
@@ -149,7 +160,7 @@ namespace Windows.Storage
 				return false;
 			}
 
-			IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
+			IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
 			private void ReadFromLegacyFile()
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6419

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Cannot enumerate over ApplicationData.Current.LocalSettings.Values

## What is the new behavior?

Can enumerate over ApplicationData.Current.LocalSettings.Values


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
