### PR TITLE
fix(iOS): RadioButton Command when VoiceOver is On

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.cs
@@ -319,6 +319,11 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		{
 			Click?.Invoke(this, new RoutedEventArgs(args?.OriginalSource ?? this));
 
+			InvokeCommand();
+		}
+
+		internal void InvokeCommand()
+		{
 			try
 			{
 				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.cs
@@ -124,7 +124,14 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		internal void AutomationPeerToggle()
 		{
+			var oldValue = IsChecked;
 			OnToggle();
+			var newValue = IsChecked;
+
+			if ((!oldValue.HasValue || !oldValue.Value) && newValue == true)
+			{
+				InvokeCommand();
+			}
 		}
 
 		protected override AutomationPeer OnCreateAutomationPeer()


### PR DESCRIPTION
GitHub Issue (If applicable): #
fixes https://github.com/unoplatform/nventive-private/issues/231

## PR Type

What kind of change does this PR introduce?
- Bugfix
- 
## What is the current behavior?
On iOS When using RadioButton with VoiceOver on, the Command is not executed on a RadioButton button when the CheckedChanged.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
**Note:** Please use the sample app attached to the Ticket to manually test this fix. Not possible to test using Unit Test/ UITest / 

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
