### PR TITLE
fix(template): Preprocessor directives refers to .NET 6

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Shared/App.xaml.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Shared/App.xaml.cs
@@ -59,7 +59,7 @@ namespace $ext_safeprojectname$
             }
 #endif
 
-#if NET5_0 && WINDOWS
+#if NET6_0_OR_GREATER && WINDOWS
             _window = new Window();
             _window.Activate();
 #else
@@ -86,7 +86,7 @@ namespace $ext_safeprojectname$
                 _window.Content = rootFrame;
             }
 
-#if !(NET5_0 && WINDOWS)
+#if !(NET6_0_OR_GREATER && WINDOWS)
             if (e.PrelaunchActivated == false)
 #endif
             {


### PR DESCRIPTION
WinUI project has incorrect build, because target framework version is .NET 6, but preprocessor directives still refers to .NET 5.
As the result, WinUI project trying to create UWP window, rather than Win32.

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
WinUI build just crushes on Window creating.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.