### PR TITLE
fix(pointers): [iOS] Add support of proper bubbling of handled events

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/NestedHandling_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/NestedHandling_Tests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.Extensions;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Input
+{
+	[TestFixture]
+	public partial class NestedHandling_Tests : SampleControlUITestBase
+	{
+		private const string _sample = "UITests.Windows_UI_Input.PointersTests.NestedHandling";
+
+		[Test]
+		[AutoRetry]
+		public void When_NestedHandlesPressed_Then_ContainerStillGetsSubsequentEvents()
+		{
+			Run(_sample);
+
+			var target = _app.WaitForElement("_nested").Single().Rect;
+			_app.DragCoordinates(target.X + 10, target.Y + 10, target.Right - 10, target.Bottom - 10);
+
+			var result = _app.Marked("_result").GetDependencyPropertyValue("Text");
+			result.Should().Be("Pressed SUCCESS | Released SUCCESS");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -577,6 +577,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\NestedHandling.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\ScrollHandled.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4595,6 +4599,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_Shapes.xaml.cs">
       <DependentUpon>HitTest_Shapes.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\NestedHandling.xaml.cs">
+      <DependentUpon>NestedHandling.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\ScrollHandled.xaml.cs">
       <DependentUpon>ScrollHandled.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/NestedHandling.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/NestedHandling.xaml
@@ -1,0 +1,23 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Input.PointersTests.NestedHandling"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Input.PointersTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Border Width="300" Height="300" Background="DeepSkyBlue" x:Name="_container">
+			<Border Width="200" Height="200" Background="DeepPink" x:Name="_nested">
+				
+			</Border>
+		</Border>
+
+		<StackPanel Orientation="Horizontal">
+			<TextBlock Text="Result: " />
+			<TextBlock Text="**not run**" x:Name="_result" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/NestedHandling.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/NestedHandling.xaml.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Input.PointersTests
+{
+	[Sample(
+		"Pointers",
+		Description = "Press the pink square, move a bit and release while remaining on the pink square.")]
+	public sealed partial class NestedHandling : Page
+	{
+		public NestedHandling()
+		{
+			this.InitializeComponent();
+
+			int containerMoveCount = 0, nestedMoveCount = 0;
+			var even = true;
+
+			_nested.PointerPressed += (snd, e) =>
+			{
+				e.Handled = true;
+				_result.Text = "";
+				containerMoveCount = 0;
+				nestedMoveCount = 0;
+			};
+			_nested.PointerMoved += (snd, e) =>
+			{
+				// We filter out half of the events to validate that handled events are not always invalidly bubbled.
+				if (even) 
+				{
+					containerMoveCount++;
+				}
+				else
+				{
+					e.Handled = true;
+				}
+
+				even = !even;
+			};
+
+			_container.AddHandler(PointerPressedEvent, new PointerEventHandler((snd, e) => _result.Text += "Pressed SUCCESS"), handledEventsToo: true);
+			_container.PointerPressed += (snd, e) => _result.Text = "Pressed FAIL";
+			_container.PointerMoved += (snd, e) => nestedMoveCount++;
+			_container.PointerReleased += (snd, e) => _result.Text += $" | Released {(nestedMoveCount == containerMoveCount ? "SUCCESS" : "FAIL")}";
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/NestedHandling.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/NestedHandling.xaml.cs
@@ -18,7 +18,8 @@ namespace UITests.Windows_UI_Input.PointersTests
 {
 	[Sample(
 		"Pointers",
-		Description = "Press the pink square, move a bit and release while remaining on the pink square.")]
+		Description = "Press the pink square, move a bit and release while remaining on the pink square.",
+		IgnoreInSnapshotTests = true)]
 	public sealed partial class NestedHandling : Page
 	{
 		public NestedHandling()


### PR DESCRIPTION
fixes https://github.com/unoplatform/nventive-private/issues/220

## Bugfix / Feature
Add support of proper bublling of handled events

## What is the current behavior?
If a control handles the pressed event, parents won't receive any subsequent event

## What is the new behavior?
We no longer prevent bubbling of native pressed event, we instead filter them out on parents

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
