### PR TITLE
fix(Style): [Wasm] don't hide exceptions happening during style application

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Style.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Style.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UI.Extensions;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_Style
+	{
+#if !NETFX_CORE // Control template does not support lambda parameter
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_StyleFailsToApply()
+		{
+			var style = new Style()
+			{
+				Setters =
+				{
+					new Setter(ContentControl.TemplateProperty, new ControlTemplate(() => throw new Exception("Inner exception")))
+				}
+			};
+
+			var e = Assert.ThrowsException<Exception>(() => new ContentControl() { Style = style });
+			Assert.AreEqual("Inner exception", e.Message);
+		}
+#endif
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5096

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Avoids raising `Error while unstacking precedence. Should be ExplicitStyle, got .` when an exception happens during a style application.

This change will allow for the underlying exception to be visible in the application logs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
