### PR TITLE
feat: detect the mixing of the Uno.UI and Uno.WinUI libraries.

### DIFF
--- a/build/uno.winui.targets
+++ b/build/uno.winui.targets
@@ -8,6 +8,12 @@
 		<_IsUnoPlatform>true</_IsUnoPlatform>
 	</PropertyGroup>
 
+	<Target Name="ValidateUnoUIAndUnoWinUIExclusion" BeforeTargets="BeforeBuild">
+		<Error Code="UNOB0001"
+		Text="Cannot build with both Uno.WinUI and Uno.UI nuget packages referenced."
+		Condition="'$(PkgUno_UI)'!='' and '$(PkgUno_WinUI)'!=''" />
+	</Target>
+
 	<Import Project="$(SourceGeneratorBasePath)Uno.UI.SourceGenerators.props" />
 	<Import Project="$(UnoUIMSBuildTasksTargetPath)Uno.UI.Tasks.targets" />
 	<Target Name="_UnoFeatureDefines"


### PR DESCRIPTION
GitHub Issue (If applicable): #6532 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix
- Feature

## What is the current behavior?

When a project with target Uno.UI adds a nuget package that implicitly depends on Uno.WinUI, SourceCodeGenerator throws "An item with the same key has already been added".


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
The build system generate an error indicating that the Uno.UI and Uno.WinUI libraries cannot be mixed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
Fixes #6532