### PR TITLE
fix: Ensure focus is lost when clicking outside app content

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -407,6 +407,7 @@ namespace Windows.UI.Xaml.Controls
 		protected override void OnPointerReleased(PointerRoutedEventArgs e)
 		{
 			IsDropDownOpen = true;
+			e.Handled = true;
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
@@ -10,6 +10,7 @@ using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Input;
 
 namespace Uno.UI.Xaml.Core
 {
@@ -27,6 +28,9 @@ namespace Uno.UI.Xaml.Core
 			_coreServices = coreServices ?? throw new System.ArgumentNullException(nameof(coreServices));
 			//Uno specific - flag as VisualTreeRoot for interop with existing logic
 			IsVisualTreeRoot = true;
+
+			PointerPressed += RootVisual_PointerPressed;
+			PointerReleased += RootVisual_PointerReleased;
 		}
 
 		/// <summary>
@@ -98,5 +102,42 @@ namespace Uno.UI.Xaml.Core
 
 			return finalSize;
 		}
+
+
+#if HAS_UNO
+		// Uno specific: To ensure focus is properly lost when clicking "outside" app's content,
+		// we set focus here. In case UWP, focus is set to the root ScrollViewer instead,
+		// but Uno does not have it on all targets yet.
+		private bool _isLeftButtonPressed = false;
+
+		private void RootVisual_PointerPressed(object sender, Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
+		{
+			if (e.Handled)
+			{
+				return;
+			}
+
+			var point = e.GetCurrentPoint(this);
+			_isLeftButtonPressed = point.Properties.IsLeftButtonPressed;
+		}
+
+		private void RootVisual_PointerReleased(object sender, Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
+		{
+			if (e.Handled)
+			{
+				return;
+			}
+			if (_isLeftButtonPressed)
+			{
+				_isLeftButtonPressed = false;
+				var element = FocusManager.GetFocusedElement();
+				if (element is UIElement uiElement)
+				{
+					uiElement.Unfocus();
+					e.Handled = true;
+				}
+			}
+		}
+#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
@@ -113,21 +113,12 @@ namespace Uno.UI.Xaml.Core
 
 		private void RootVisual_PointerPressed(object sender, Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
 		{
-			if (e.Handled)
-			{
-				return;
-			}
-
 			var point = e.GetCurrentPoint(this);
 			_isLeftButtonPressed = point.Properties.IsLeftButtonPressed;
 		}
 
 		private void RootVisual_PointerReleased(object sender, Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
 		{
-			if (e.Handled)
-			{
-				return;
-			}
 			if (_isLeftButtonPressed)
 			{
 				_isLeftButtonPressed = false;
@@ -143,10 +134,6 @@ namespace Uno.UI.Xaml.Core
 
 		private void RootVisual_PointerCanceled(object sender, PointerRoutedEventArgs e)
 		{
-			if (e.Handled)
-			{
-				return;
-			}
 			_isLeftButtonPressed = false;
 		}
 #endif

--- a/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
@@ -31,6 +31,7 @@ namespace Uno.UI.Xaml.Core
 
 			PointerPressed += RootVisual_PointerPressed;
 			PointerReleased += RootVisual_PointerReleased;
+			PointerCanceled += RootVisual_PointerCanceled;
 		}
 
 		/// <summary>
@@ -137,6 +138,16 @@ namespace Uno.UI.Xaml.Core
 					e.Handled = true;
 				}
 			}
+		}
+
+
+		private void RootVisual_PointerCanceled(object sender, PointerRoutedEventArgs e)
+		{
+			if (e.Handled)
+			{
+				return;
+			}
+			_isLeftButtonPressed = false;
 		}
 #endif
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6553

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Focus is not lost when clicking outside app content.


## What is the new behavior?

Top level handles focus if pointer release bubbles to it.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
fixes unoplatform/nventive-private#230
