### PR TITLE
fix: Can't use `GradientStopCollection` in XAML with `LinearGradientBrush`

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
@@ -94,36 +94,44 @@
 				<Border Width="100" Height="100" BorderThickness="40" Background="DarkGray">
 					<Border.BorderBrush>
 						<media:RadialGradientBrush FallbackColor="Red">
-							<GradientStop Color="Blue" Offset="0.0" />
-							<GradientStop Color="Yellow" Offset="0.2" />
-							<GradientStop Color="LimeGreen" Offset="0.4" />
-							<GradientStop Color="LightBlue" Offset="0.6" />
-							<GradientStop Color="Blue" Offset="0.8" />
-							<GradientStop Color="LightGray" Offset="1" />
+							<GradientStopCollection>
+								<GradientStop Color="Blue" Offset="0.0" />
+								<GradientStop Color="Yellow" Offset="0.2" />
+								<GradientStop Color="LimeGreen" Offset="0.4" />
+								<GradientStop Color="LightBlue" Offset="0.6" />
+								<GradientStop Color="Blue" Offset="0.8" />
+								<GradientStop Color="LightGray" Offset="1" />
+							</GradientStopCollection>
 						</media:RadialGradientBrush>
 					</Border.BorderBrush>
 				</Border>
 				<Ellipse Width="100" Height="100" StrokeThickness="40" Fill="DarkGray">
 					<Ellipse.Stroke>
 						<media:RadialGradientBrush FallbackColor="Red">
-							<GradientStop Color="Blue" Offset="0.0" />
-							<GradientStop Color="Yellow" Offset="0.2" />
-							<GradientStop Color="LimeGreen" Offset="0.4" />
-							<GradientStop Color="LightBlue" Offset="0.6" />
-							<GradientStop Color="Blue" Offset="0.8" />
-							<GradientStop Color="LightGray" Offset="1" />
+							<media:RadialGradientBrush.GradientStops>
+								<GradientStop Color="Blue" Offset="0.0" />
+								<GradientStop Color="Yellow" Offset="0.2" />
+								<GradientStop Color="LimeGreen" Offset="0.4" />
+								<GradientStop Color="LightBlue" Offset="0.6" />
+								<GradientStop Color="Blue" Offset="0.8" />
+								<GradientStop Color="LightGray" Offset="1" />
+							</media:RadialGradientBrush.GradientStops>
 						</media:RadialGradientBrush>
 					</Ellipse.Stroke>
 				</Ellipse>
 				<Ellipse Width="150" Height="100" StrokeThickness="40" Fill="DarkGray">
 					<Ellipse.Stroke>
 						<media:RadialGradientBrush FallbackColor="Red">
-							<GradientStop Color="Blue" Offset="0.0" />
-							<GradientStop Color="Yellow" Offset="0.2" />
-							<GradientStop Color="LimeGreen" Offset="0.4" />
-							<GradientStop Color="LightBlue" Offset="0.6" />
-							<GradientStop Color="Blue" Offset="0.8" />
-							<GradientStop Color="LightGray" Offset="1" />
+							<media:RadialGradientBrush.GradientStops>
+								<GradientStopCollection>
+									<GradientStop Color="Blue" Offset="0.0" />
+									<GradientStop Color="Yellow" Offset="0.2" />
+									<GradientStop Color="LimeGreen" Offset="0.4" />
+									<GradientStop Color="LightBlue" Offset="0.6" />
+									<GradientStop Color="Blue" Offset="0.8" />
+									<GradientStop Color="LightGray" Offset="1" />
+								</GradientStopCollection>
+							</media:RadialGradientBrush.GradientStops>
 						</media:RadialGradientBrush>
 					</Ellipse.Stroke>
 				</Ellipse>
@@ -157,24 +165,28 @@
 				<Rectangle Width="100" Height="100">
 					<Rectangle.Fill>
 						<LinearGradientBrush MappingMode="Absolute" EndPoint="100,100" not_win:FallbackColor="Red">
-							<GradientStop Color="Blue" Offset="0.0" />
-							<GradientStop Color="Yellow" Offset="0.2" />
-							<GradientStop Color="LimeGreen" Offset="0.4" />
-							<GradientStop Color="LightBlue" Offset="0.6" />
-							<GradientStop Color="Blue" Offset="0.8" />
-							<GradientStop Color="LightGray" Offset="1" />
+							<GradientStopCollection>
+								<GradientStop Color="Blue" Offset="0.0" />
+								<GradientStop Color="Yellow" Offset="0.2" />
+								<GradientStop Color="LimeGreen" Offset="0.4" />
+								<GradientStop Color="LightBlue" Offset="0.6" />
+								<GradientStop Color="Blue" Offset="0.8" />
+								<GradientStop Color="LightGray" Offset="1" />
+							</GradientStopCollection>
 						</LinearGradientBrush>
 					</Rectangle.Fill>
 				</Rectangle>
 				<Border Width="100" Height="100">
 					<Border.Background>
 						<LinearGradientBrush MappingMode="Absolute" EndPoint="100,100" not_win:FallbackColor="Red">
-							<GradientStop Color="Blue" Offset="0.0" />
-							<GradientStop Color="Yellow" Offset="0.2" />
-							<GradientStop Color="LimeGreen" Offset="0.4" />
-							<GradientStop Color="LightBlue" Offset="0.6" />
-							<GradientStop Color="Blue" Offset="0.8" />
-							<GradientStop Color="LightGray" Offset="1" />
+							<LinearGradientBrush.GradientStops>
+								<GradientStop Color="Blue" Offset="0.0" />
+								<GradientStop Color="Yellow" Offset="0.2" />
+								<GradientStop Color="LimeGreen" Offset="0.4" />
+								<GradientStop Color="LightBlue" Offset="0.6" />
+								<GradientStop Color="Blue" Offset="0.8" />
+								<GradientStop Color="LightGray" Offset="1" />
+							</LinearGradientBrush.GradientStops>
 						</LinearGradientBrush>
 					</Border.Background>
 				</Border>
@@ -184,12 +196,16 @@
 				<Rectangle Width="100" Height="100" StrokeThickness="40">
 					<Rectangle.Stroke>
 						<LinearGradientBrush not_win:FallbackColor="Red">
-							<GradientStop Color="Blue" Offset="0.0" />
-							<GradientStop Color="Yellow" Offset="0.2" />
-							<GradientStop Color="LimeGreen" Offset="0.4" />
-							<GradientStop Color="LightBlue" Offset="0.6" />
-							<GradientStop Color="Blue" Offset="0.8" />
-							<GradientStop Color="LightGray" Offset="1" />
+							<LinearGradientBrush.GradientStops>
+								<GradientStopCollection>
+									<GradientStop Color="Blue" Offset="0.0" />
+									<GradientStop Color="Yellow" Offset="0.2" />
+									<GradientStop Color="LimeGreen" Offset="0.4" />
+									<GradientStop Color="LightBlue" Offset="0.6" />
+									<GradientStop Color="Blue" Offset="0.8" />
+									<GradientStop Color="LightGray" Offset="1" />
+								</GradientStopCollection>
+							</LinearGradientBrush.GradientStops>
 						</LinearGradientBrush>
 					</Rectangle.Stroke>
 				</Rectangle>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
@@ -94,14 +94,12 @@
 				<Border Width="100" Height="100" BorderThickness="40" Background="DarkGray">
 					<Border.BorderBrush>
 						<media:RadialGradientBrush FallbackColor="Red">
-							<GradientStopCollection>
-								<GradientStop Color="Blue" Offset="0.0" />
-								<GradientStop Color="Yellow" Offset="0.2" />
-								<GradientStop Color="LimeGreen" Offset="0.4" />
-								<GradientStop Color="LightBlue" Offset="0.6" />
-								<GradientStop Color="Blue" Offset="0.8" />
-								<GradientStop Color="LightGray" Offset="1" />
-							</GradientStopCollection>
+							<GradientStop Color="Blue" Offset="0.0" />
+							<GradientStop Color="Yellow" Offset="0.2" />
+							<GradientStop Color="LimeGreen" Offset="0.4" />
+							<GradientStop Color="LightBlue" Offset="0.6" />
+							<GradientStop Color="Blue" Offset="0.8" />
+							<GradientStop Color="LightGray" Offset="1" />
 						</media:RadialGradientBrush>
 					</Border.BorderBrush>
 				</Border>
@@ -123,14 +121,12 @@
 					<Ellipse.Stroke>
 						<media:RadialGradientBrush FallbackColor="Red">
 							<media:RadialGradientBrush.GradientStops>
-								<GradientStopCollection>
-									<GradientStop Color="Blue" Offset="0.0" />
-									<GradientStop Color="Yellow" Offset="0.2" />
-									<GradientStop Color="LimeGreen" Offset="0.4" />
-									<GradientStop Color="LightBlue" Offset="0.6" />
-									<GradientStop Color="Blue" Offset="0.8" />
-									<GradientStop Color="LightGray" Offset="1" />
-								</GradientStopCollection>
+								<GradientStop Color="Blue" Offset="0.0" />
+								<GradientStop Color="Yellow" Offset="0.2" />
+								<GradientStop Color="LimeGreen" Offset="0.4" />
+								<GradientStop Color="LightBlue" Offset="0.6" />
+								<GradientStop Color="Blue" Offset="0.8" />
+								<GradientStop Color="LightGray" Offset="1" />
 							</media:RadialGradientBrush.GradientStops>
 						</media:RadialGradientBrush>
 					</Ellipse.Stroke>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -256,11 +256,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return IsType(xamlType, XamlConstants.Types.Panel);
 		}
 
-		private bool IsLinearGradientBrush(XamlType xamlType)
-		{
-			return IsType(xamlType, XamlConstants.Types.LinearGradientBrush);
-		}
-
 		private bool IsFrameworkElement(XamlType xamlType)
 		{
 			return IsType(xamlType, XamlConstants.Types.FrameworkElement);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2075,10 +2075,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								writer.AppendLineInvariant($"{setterPrefix}Color = {BuildColor(content)}");
 							}
 						}
-						else if (IsLinearGradientBrush(topLevelControl.Type))
-						{
-							BuildCollection(writer, isInline, setterPrefix + "GradientStops", implicitContentChild);
-						}
 						else if (IsInitializableCollection(topLevelControl))
 						{
 							var elementType = FindType(topLevelControl.Type);


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #6565


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Explicitly using `GradientStopCollection` with `LinearGradientBrush` fails source generation.


## What is the new behavior?

Removed specific handling for `LinearGradientBrush` as the source generator already correctly handles it even without this (verified on `RadialGradientBrush`)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
