### PR TITLE
fix(flyout): Ensure namescope propagation for flyout content

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -210,5 +210,26 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 
 			_app.TapCoordinates(10, 100);
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.Browser)] // Test authoring problem on iOS
+		public void Flyout_Namescope()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.FlyoutTests.Flyout_Namescope");
+
+			var button01 = _app.Marked("Control1");
+			var result1 = _app.Marked("result1");
+			var result2 = _app.Marked("result2");
+			var closeButton = _app.Marked("closeButton");
+
+			_app.FastTap(button01);
+			_app.WaitForElement(closeButton);
+
+			_app.WaitForDependencyPropertyValue(result1, "Text", "Top");
+			_app.WaitForDependencyPropertyValue(result2, "Text", "Control1_Tag");
+
+			_app.FastTap(closeButton);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1269,6 +1269,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Namescope.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_TemplatedParent.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5047,6 +5051,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Local.xaml.cs">
       <DependentUpon>Flyout_Local.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Namescope.xaml.cs">
+      <DependentUpon>Flyout_Namescope.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_TemplatedParent.xaml.cs">
       <DependentUpon>Flyout_TemplatedParent.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Namescope.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Namescope.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.FlyoutTests.Flyout_Namescope"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.Flyout"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+        <Button x:Name="Control1" Content="Empty cart" Tag="Control1_Tag">
+            <Button.Flyout>
+                <Flyout x:Name="flyoutCtl" Placement="Top">
+                    <StackPanel>
+                        <TextBlock x:Name="result1" Text="{Binding Placement, ElementName=flyoutCtl}"/>
+                        <TextBlock x:Name="result2" Text="{Binding Tag, ElementName=Control1}"/>
+                        <TextBlock Style="{ThemeResource BaseTextBlockStyle}"
+                                   Text="All items will be removed. Do you want to continue?"
+                                   Margin="0,0,0,12" />
+                        <Button x:Name="closeButton"  Click="DeleteConfirmation_Click" Content="Yes, empty my cart" />
+                    </StackPanel>
+                </Flyout>
+            </Button.Flyout>
+        </Button>
+    </Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Namescope.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Namescope.xaml.cs
@@ -1,0 +1,23 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.FlyoutTests
+{
+	[SampleControlInfo("Flyout", "Namescope")]
+	public sealed partial class Flyout_Namescope : UserControl
+	{
+		public Flyout_Namescope()
+		{
+			this.InitializeComponent();
+		}
+
+		private void DeleteConfirmation_Click(object sender, RoutedEventArgs e)
+		{
+			if(Control1.Flyout is Windows.UI.Xaml.Controls.Flyout f)
+			{
+				f.Hide();
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_In_Template.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_In_Template.xaml
@@ -1,0 +1,36 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls.Binding_ElementName_In_Template_In_Template"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	
+	<Grid>
+		<ContentControl x:Name="topLevel" x:FieldModifier="public" Tag="42">
+			<ContentControl.ContentTemplate>
+				<DataTemplate>
+					<ItemsControl>
+						<ItemsControl.Template>
+							<ControlTemplate TargetType="ItemsControl">
+								<ItemsPresenter/>
+							</ControlTemplate>
+						</ItemsControl.Template>
+						<ItemsControl.ItemsPanel>
+							<ItemsPanelTemplate>
+								<StackPanel/>
+							</ItemsPanelTemplate>
+						</ItemsControl.ItemsPanel>
+						<ItemsControl.ItemTemplate>
+							<DataTemplate>
+								<TextBlock x:Name="innerTextBlock" Text="{Binding Tag, ElementName=topLevel}" />
+							</DataTemplate>
+						</ItemsControl.ItemTemplate>
+						<x:String>1</x:String>
+					</ItemsControl>
+				</DataTemplate>
+			</ContentControl.ContentTemplate>
+		</ContentControl>
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_In_Template.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_In_Template.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_ElementName_In_Template_In_Template : Page
+	{
+		public Binding_ElementName_In_Template_In_Template()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
@@ -46,7 +46,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests
 
 			Assert.AreEqual(SUT.topLevel.Tag, tb.Text);
 		}
-		      
+
 		[TestMethod]
 		public void When_ElementName_In_Template_ItemsControl()
 		{
@@ -59,6 +59,18 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests
 			var button = SUT.FindName("button") as Windows.UI.Xaml.Controls.Button;
 
 			Assert.AreEqual(SUT.PrimaryActionsList.Tag, button.Tag);
+		}
+
+		[TestMethod]
+		public void When_ElementName_In_Template_In_Template()
+		{
+			var SUT = new Binding_ElementName_In_Template_In_Template();
+
+			SUT.ForceLoaded();
+
+			var tb = SUT.FindName("innerTextBlock") as Windows.UI.Xaml.Controls.TextBlock;
+
+			Assert.AreEqual(SUT.topLevel.Tag, tb.Text);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
@@ -7,6 +7,7 @@ using Uno.UI.DataBinding;
 using Uno.UI.Extensions;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.Controls;
 
 #if XAMARIN_IOS
 using View = UIKit.UIView;
@@ -84,6 +85,21 @@ namespace Windows.UI.Xaml.Controls
 
 				flyout._presenter.Content = args.NewValue;
 			}
+
+			flyout.SynchronizeNamescope();
+
+			if(args.OldValue is DependencyObject oldDO)
+			{
+				oldDO.ClearValue(NameScope.NameScopeProperty);
+			}
+		}
+
+		private void SynchronizeNamescope()
+		{
+			if (NameScope.GetNameScope(this) is { } scope && Content is DependencyObject content)
+			{
+				NameScope.SetNameScope(content, scope);
+			}
 		}
 		#endregion
 
@@ -118,6 +134,8 @@ namespace Windows.UI.Xaml.Controls
 			_presenter = new FlyoutPresenter();
 			SetPresenterStyle();
 			_presenter.Content = Content;
+
+			SynchronizeNamescope();
 
 			return _presenter;
 		}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensure `NameScope` propagation for flyout content, so that `ElementName` bindings can reach the flyout and its ancestors. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
