### PR TITLE
refactor: Move samples app list to be generated

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -200,6 +200,7 @@
   <Import Project="..\UITests.Shared\UITests.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="..\Benchmarks.Shared\Benchmarks.Shared.projitems" Label="Shared" />
+	<Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.targets" />
   <Target Name="GenerateBuild" DependsOnTargets="SignAndroidPackage" AfterTargets="Build" Condition="'$(BuildingInsideVisualStudio)'=='' and '$(UnoSampleAppDisableAPKGeneration)'==''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
      Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
+++ b/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
@@ -52,6 +52,8 @@
 	<Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.Shared.projitems" Label="Shared" />
 
 	<Import Project="..\Benchmarks.Shared\Benchmarks.Shared.projitems" Label="Shared" />
+	
+	<Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.targets" />
 
 	<ItemGroup>
 		<Content Update="@(Content)" CopyToOutputDirectory="PreserveNewest" />

--- a/src/SamplesApp/SamplesApp.UITests.Generator/CategoryBucketGenerator.cs
+++ b/src/SamplesApp/SamplesApp.UITests.Generator/CategoryBucketGenerator.cs
@@ -8,7 +8,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.MSBuild;
 using Uno.RoslynHelpers;
 using Uno.SourceGeneration;
 
@@ -29,7 +28,8 @@ namespace Uno.Samples.UITest.Generator
 
 		private void GenerateTests(SourceGeneratorContext context)
 		{
-			if(int.TryParse(Environment.GetEnvironmentVariable("UNO_UITEST_BUCKET_COUNT"), out var bucketCount))
+			if (context.Compilation.Assembly.Name == "SamplesApp.UITests"
+				&& int.TryParse(Environment.GetEnvironmentVariable("UNO_UITEST_BUCKET_COUNT"), out var bucketCount))
 			{
 				_testAttribute = context.Compilation.GetTypeByMetadataName("NUnit.Framework.TestAttribute");
 

--- a/src/SamplesApp/SamplesApp.UITests.Generator/SamplesListGenerator.cs
+++ b/src/SamplesApp/SamplesApp.UITests.Generator/SamplesListGenerator.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Uno.RoslynHelpers;
+using Uno.SourceGeneration;
+
+namespace Uno.Samples.UITest.Generator
+{
+	public class SamplesListGenerator : SourceGenerator
+	{
+		private INamedTypeSymbol _sampleControlInfoSymbol;
+		private INamedTypeSymbol _sampleSymbol;
+
+		public override void Execute(SourceGeneratorContext context)
+		{
+#if DEBUG
+			// Debugger.Launch();
+#endif
+			if (context.Compilation.Assembly.Name != "SamplesApp.UITests")
+			{
+				GenerateTests(context);
+			}
+		}
+
+		private void GenerateTests(SourceGeneratorContext context)
+		{
+			_sampleControlInfoSymbol = context.Compilation.GetTypeByMetadataName("Uno.UI.Samples.Controls.SampleControlInfoAttribute");
+			_sampleSymbol = context.Compilation.GetTypeByMetadataName("Uno.UI.Samples.Controls.SampleAttribute");
+
+			var query = from typeSymbol in context.Compilation.SourceModule.GlobalNamespace.GetNamespaceTypes()
+						let info = typeSymbol.FindAttributeFlattened(_sampleSymbol) ?? typeSymbol.FindAttributeFlattened(_sampleControlInfoSymbol)
+						where info != null
+						select typeSymbol;
+
+			query = query.Distinct();
+
+			GenerateSamplesList(context, query);
+		}
+
+		private void GenerateSamplesList(SourceGeneratorContext context, IEnumerable<INamedTypeSymbol> query)
+		{
+			var builder = new IndentedStringBuilder();
+
+			builder.AppendLineInvariant("using System;");
+
+			using (builder.BlockInvariant($"namespace SampleControl.Presentation"))
+			{
+				using (builder.BlockInvariant($"partial class SampleChooserViewModel"))
+				{
+					using (builder.BlockInvariant($"internal Type[] _allSamples = new Type[]"))
+					{
+						foreach (var type in query)
+						{
+							builder.AppendLineInvariant($"typeof({type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}),");
+						}
+					}
+
+					builder.AppendLineInvariant(";");
+				}
+			}
+
+			context.AddCompilationUnit("AllSamplesList", builder.ToString());
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests.Generator/SnapShotTestGenerator.cs
+++ b/src/SamplesApp/SamplesApp.UITests.Generator/SnapShotTestGenerator.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.MSBuild;
 using Uno.RoslynHelpers;
 using Uno.SourceGeneration;
 
@@ -25,8 +24,10 @@ namespace Uno.Samples.UITest.Generator
 #if DEBUG
 			// Debugger.Launch();
 #endif
-
-			GenerateTests(context, "Uno.UI.Samples");
+			if (context.Compilation.Assembly.Name == "SamplesApp.UITests")
+			{
+				GenerateTests(context, "Uno.UI.Samples");
+			}
 		}
 
 		private void GenerateTests(SourceGeneratorContext context, string assembly)

--- a/src/SamplesApp/SamplesApp.UITests.Generator/Uno.Samples.UITest.Generator.csproj
+++ b/src/SamplesApp/SamplesApp.UITests.Generator/Uno.Samples.UITest.Generator.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFramework>net47</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	</PropertyGroup>
 	
 	<ItemGroup>

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -20,7 +20,7 @@
 	</ItemGroup> 
 	  
 	<ItemGroup>
-		<SourceGenerator Include="..\SamplesApp.UITests.Generator\Bin\$(Configuration)\net47\Uno.Samples.UITest.Generator.dll" />
+		<SourceGenerator Include="..\SamplesApp.UITests.Generator\bin\$(Configuration)\Uno.Samples.UITest.Generator.dll" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(DocsGeneration)'==''">

--- a/src/SamplesApp/SamplesApp.UWP/SamplesApp.UWP.csproj
+++ b/src/SamplesApp/SamplesApp.UWP/SamplesApp.UWP.csproj
@@ -155,8 +155,9 @@
   </ItemGroup>
   <Import Project="..\SamplesApp.Shared\SamplesApp.Shared.projitems" Label="Shared" Condition="Exists('..\SamplesApp.Shared\SamplesApp.Shared.projitems')" />
   <Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.Shared.projitems" Label="Shared" />
+	<Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.targets" />
   <Import Project="..\UITests.Shared\UITests.Shared.projitems" Label="Shared" />
-  <Import Project="..\Benchmarks.Shared\Benchmarks.Shared.projitems" Label="Shared" />
+	<Import Project="..\Benchmarks.Shared\Benchmarks.Shared.projitems" Label="Shared" />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -577,15 +577,10 @@ namespace SampleControl.Presentation
 		private List<SampleChooserCategory> GetSamples()
 		{
 			var categories =
-#if !__WASM__
-				from assembly in GetAllAssembies().AsParallel()
-#else
-				from assembly in GetAllAssembies()
-#endif
-				from type in FindDefinedAssemblies(assembly)
-				let sampleAttribute = FindSampleAttribute(type)
+				from type in _allSamples
+				let sampleAttribute = FindSampleAttribute(type.GetTypeInfo())
 				where sampleAttribute != null
-				let content = GetContent(type, sampleAttribute)
+				let content = GetContent(type.GetTypeInfo(), sampleAttribute)
 				from category in content.Categories
 				group content by category into contentByCategory
 				orderby contentByCategory.Key.ToLower(CultureInfo.CurrentUICulture)

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.Shared.projitems
@@ -114,4 +114,7 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)SamplesApp.UnitTests.targets" />
+  </ItemGroup>
 </Project>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.targets
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.targets
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project>
+  <ItemGroup>
+	<SourceGenerator Include="$(MSBuildThisFileDirectory)..\SamplesApp.UITests.Generator\bin\$(Configuration)\Uno.Samples.UITest.Generator.dll" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DocsGeneration)'==''">
+	<ProjectReference Include="$(MSBuildThisFileDirectory)..\SamplesApp.UITests.Generator\Uno.Samples.UITest.Generator.csproj">
+	  <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+	  <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+	  <UndefineProperties>TargetFramework;RuntimeIdentifier;TargetFrameworks;RuntimeIdentifiers</UndefineProperties>
+	</ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -121,4 +121,6 @@
 
 	<Import Project="..\..\..\build\*.WebAssembly.props" />
 	<Import Project="..\..\..\build\*.WebAssembly.targets" />
+
+	<Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.targets" />
 </Project>

--- a/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
+++ b/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
@@ -197,7 +197,8 @@
   <Import Project="..\..\SourceGenerators\sourcegenerators.local.props" />
   <Import Project="..\SamplesApp.Shared\SamplesApp.Shared.projitems" Label="Shared" Condition="Exists('..\SamplesApp.Shared\SamplesApp.Shared.projitems')" />
   <Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.Shared.projitems" Label="Shared" />
-  <Import Project="..\UITests.Shared\UITests.Shared.projitems" Label="Shared" />
+	<Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.targets" />
+	<Import Project="..\UITests.Shared\UITests.Shared.projitems" Label="Shared" />
   <Import Project="..\Benchmarks.Shared\Benchmarks.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Target Name="VS16Mac_RemoveSystemMemory" BeforeTargets="ResolveAssemblyReferences">

--- a/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
+++ b/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
@@ -129,7 +129,8 @@
   <Import Project="..\UITests.Shared\UITests.Shared.projitems" Label="Shared" Condition="Exists('..\UITests.Shared\UITests.Shared.projitems')" />
   <Import Project="..\SamplesApp.Shared\SamplesApp.Shared.projitems" Label="Shared" Condition="Exists('..\SamplesApp.Shared\SamplesApp.Shared.projitems')" />
   <Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.Shared.projitems" Label="Shared" />
-  <ItemGroup>
+	<Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.targets" />
+	<ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-128.png" />
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-128%402x.png" />

--- a/src/SamplesApp/SamplesApp.net6mobile/SamplesApp.net6mobile.csproj
+++ b/src/SamplesApp/SamplesApp.net6mobile/SamplesApp.net6mobile.csproj
@@ -109,6 +109,7 @@
   <Import Project="..\SamplesApp.Shared\SamplesApp.Shared.projitems" Label="Shared" Condition="Exists('..\SamplesApp.Shared\SamplesApp.Shared.projitems')" />
   <Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.Shared.projitems" Label="Shared" />
   <Import Project="..\UITests.Shared\UITests.Shared.projitems" Label="Shared" />
+	<Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.targets" />
 
 	<Import Project="..\..\Uno.CrossTargetting.props" />
 	<Import Project="..\..\..\build\uno.winui.single-project.targets" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

This brings the load time from 10s to 2s in debug wasm interpreted.

This is the cause of some UI/Runtime tests failures as the app takes a longer time to start.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
