### PR TITLE
fix(msal): Move package generation to nuspec for net6 compatibility

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -258,6 +258,7 @@
 		<ItemGroup>
 			<_NuspecFiles Include=".\Uno.WinUI.nuspec" />
 			<_NuspecFiles Include=".\Uno.WinUI.Lottie.nuspec" />
+			<_NuspecFiles Include=".\Uno.WinUI.MSAL.nuspec" />
 			<_NuspecFiles Include=".\Uno.WinUI.RemoteControl.nuspec" />
 			<_NuspecFiles Include=".\Uno.WinUI.Skia.Gtk.nuspec" />
 			<_NuspecFiles Include=".\Uno.WinUI.Skia.Linux.FrameBuffer.nuspec" />
@@ -293,6 +294,7 @@
 		<!-- Update package ID based on WinUI / UWP source tree -->
 		<XmlPoke XmlInputPath=".\Uno.WinUI.nuspec" Query="/x:package/x:metadata/x:id" Value="$(PackageNamePrefix)" Namespaces="$(NugetNamespace)" />
 		<XmlPoke XmlInputPath=".\Uno.WinUI.Lottie.nuspec" Query="/x:package/x:metadata/x:id" Value="$(PackageNamePrefix).Lottie" Namespaces="$(NugetNamespace)" />
+		<XmlPoke XmlInputPath=".\Uno.WinUI.MSAL.nuspec" Query="/x:package/x:metadata/x:id" Value="$(PackageNamePrefix).MSAL" Namespaces="$(NugetNamespace)" />
 		<XmlPoke XmlInputPath=".\Uno.WinUI.RemoteControl.nuspec" Query="/x:package/x:metadata/x:id" Value="$(PackageNamePrefix).RemoteControl" Namespaces="$(NugetNamespace)" />
 		<XmlPoke XmlInputPath=".\Uno.WinUI.Skia.Gtk.nuspec" Query="/x:package/x:metadata/x:id" Value="$(PackageNamePrefix).Skia.Gtk" Namespaces="$(NugetNamespace)" />
 		<XmlPoke XmlInputPath=".\Uno.WinUI.Skia.Linux.FrameBuffer.nuspec" Query="/x:package/x:metadata/x:id" Value="$(PackageNamePrefix).Skia.Linux.FrameBuffer" Namespaces="$(NugetNamespace)" />
@@ -303,6 +305,7 @@
 		<!-- Update package Title based on WinUI / UWP source tree -->
 		<XmlPoke XmlInputPath=".\Uno.WinUI.nuspec" Query="/x:package/x:metadata/x:title" Value="$(PackageNamePrefix)" Namespaces="$(NugetNamespace)" />
 		<XmlPoke XmlInputPath=".\Uno.WinUI.Lottie.nuspec" Query="/x:package/x:metadata/x:title" Value="$(PackageNamePrefix).Lottie" Namespaces="$(NugetNamespace)" />
+		<XmlPoke XmlInputPath=".\Uno.WinUI.MSAL.nuspec" Query="/x:package/x:metadata/x:title" Value="$(PackageNamePrefix).MSAL" Namespaces="$(NugetNamespace)" />
 		<XmlPoke XmlInputPath=".\Uno.WinUI.RemoteControl.nuspec" Query="/x:package/x:metadata/x:title" Value="$(PackageNamePrefix).RemoteControl" Namespaces="$(NugetNamespace)" />
 		<XmlPoke XmlInputPath=".\Uno.WinUI.Skia.Gtk.nuspec" Query="/x:package/x:metadata/x:title" Value="$(PackageNamePrefix).Skia.Gtk" Namespaces="$(NugetNamespace)" />
 		<XmlPoke XmlInputPath=".\Uno.WinUI.Skia.Linux.FrameBuffer.nuspec" Query="/x:package/x:metadata/x:title" Value="$(PackageNamePrefix).Skia.Linux.FrameBuffer" Namespaces="$(NugetNamespace)" />
@@ -401,6 +404,7 @@
 		<!-- Create the packages -->
 		<Exec Command="$(NuGetBin) pack Uno.WinUI.nuspec -Verbosity Detailed -Version &quot;$(GITVERSION_SemVer)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
 		<Exec Command="$(NuGetBin) pack Uno.WinUI.Lottie.nuspec -Verbosity Detailed -Version &quot;$(GITVERSION_SemVer)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
+		<Exec Command="$(NuGetBin) pack Uno.WinUI.MSAL.nuspec -Verbosity Detailed -Version &quot;$(GITVERSION_SemVer)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
 		<Exec Command="$(NuGetBin) pack Uno.WinUI.RemoteControl.nuspec -Verbosity Detailed -Version &quot;$(GITVERSION_SemVer)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
 		<Exec Command="$(NuGetBin) pack Uno.WinUI.Skia.Gtk.nuspec -Verbosity Detailed -Version &quot;$(GITVERSION_SemVer)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />
 		<Exec Command="$(NuGetBin) pack Uno.WinUI.Skia.Linux.FrameBuffer.nuspec -Verbosity Detailed -Version &quot;$(GITVERSION_SemVer)&quot; -Properties &quot;$(NuSpecProperties)&quot;" />

--- a/build/Uno.WinUI.MSAL.nuspec
+++ b/build/Uno.WinUI.MSAL.nuspec
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata minClientVersion="5.0">
+	<id>Uno.WinUI.MSAL</id>
+	<version>0.0.1</version>
+	<authors>nventive</authors>
+	<icon>uno.png</icon>
+	<projectUrl>https://github.com/unoplatform/uno</projectUrl>
+	<license type="expression">Apache-2.0</license>
+	<iconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</iconUrl>
+	<description>This package provides the extensions to MSAL (Microsoft.Identity.Client) for an Uno Platform application.</description>
+	<copyright>nventive</copyright>
+	<repository type="git" url="https://github.com/unoplatform/uno.git" branch="$branch$" commit="$commitid$" />
+	<dependencies>
+	  <group targetFramework="MonoAndroid10.0">
+		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+	  </group>
+	  <group targetFramework="MonoAndroid11.0">
+		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+	  </group>
+	  <group targetFramework="Xamarin.iOS1.0">
+		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+	  </group>
+	  <group targetFramework="Xamarin.Mac2.0">
+		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+	  </group>
+	  <group targetFramework=".NETStandard2.0">
+		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+	  </group>
+	  <group targetFramework="UAP10.0.17763">
+		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+	  </group>
+	  <group targetFramework="net6.0-android30.0">
+		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+	  </group>
+	  <group targetFramework="net6.0-ios13.6">
+		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+	  </group>
+	  <group targetFramework="net6.0-maccatalyst13.5">
+		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+	  </group>
+	  <group targetFramework="net6.0-macos10.15">
+		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+	  </group>
+	</dependencies>
+	<frameworkAssemblies>
+	  <frameworkAssembly assemblyName="Java.Interop" targetFramework="MonoAndroid11.0, MonoAndroid10.0" />
+	</frameworkAssemblies>
+  </metadata>
+
+  <files>
+	<file src="..\src\Common\uno.png" target="/" />
+	
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\netstandard2.0\Uno.UI.MSAL.*" target="lib\netstandard2.0" />
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\xamarinios10\Uno.UI.MSAL.*" target="lib\xamarinios10" />
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\xamarinmac20\Uno.UI.MSAL.*" target="lib\xamarinmac20" />
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\MonoAndroid11.0\Uno.UI.MSAL.*" target="lib\MonoAndroid11.0" />
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\MonoAndroid10.0\Uno.UI.MSAL.*" target="lib\MonoAndroid10.0" />
+
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\uap10.0.17763\Uno.UI.MSAL.*" target="lib\uap10.0.17763" />
+
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-android\Uno.UI.MSAL.*" target="lib\net6.0-android" />
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-ios\Uno.UI.MSAL.*" target="lib\net6.0-ios" />
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-maccatalyst\Uno.UI.MSAL.*" target="lib\net6.0-maccatalyst" />
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-macos\Uno.UI.MSAL.*" target="lib\net6.0-macos" />
+
+	<!-- Build targets -->
+	<file src="..\src\AddIns\Uno.UI.MSAL\buildTransitive\*" target="buildTransitive" />
+
+	<!-- netstandard2.0 WebAssembly -->
+	<file src="..\src\AddIns\Uno.UI.MSAL\Bin\Uno.UI.MSAL.Wasm\Release\netstandard2.0\Uno.UI.MSAL.*" target="uno-runtime\webassembly" />
+
+	<!-- netstandard2.0 Skia -->
+	<file src="..\src\AddIns\Uno.UI.MSAL\Bin\Uno.UI.MSAL.Skia\Release\netstandard2.0\Uno.UI.MSAL.*" target="uno-runtime\skia" />
+
+  </files>
+
+</package>

--- a/build/ci/.azure-devops-package.yml
+++ b/build/ci/.azure-devops-package.yml
@@ -117,17 +117,6 @@ jobs:
       OverWrite: false
       flattenFolders: false
 
-  - task: CopyFiles@2
-    displayName: Copy net6 build packages
-    condition: always()
-    inputs:
-      SourceFolder: $(Agent.WorkFolder)/NugetPackages-Artifacts/vslatest-net6
-      Contents: '*.nupkg'
-      TargetFolder: $(build.artifactstagingdirectory)\vslatest
-      CleanTargetFolder: false
-      OverWrite: true
-      flattenFolders: false
-
   - task: PowerShell@2
     displayName: Authenticode Sign Packages
     inputs:

--- a/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.csproj
+++ b/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.csproj
@@ -13,7 +13,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
 		<Authors>nventive</Authors>
 		<PackageProjectUrl>https://github.com/unoplatform/uno</PackageProjectUrl>
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>

--- a/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.net6.csproj
+++ b/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.net6.csproj
@@ -20,7 +20,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
 		<Authors>nventive</Authors>
 		<PackageProjectUrl>https://github.com/unoplatform/uno</PackageProjectUrl>
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/6596

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restores the non-net6 targets in the Uno.UI.MSAL nuget package

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
