### PR TITLE
Composition and Skia improvements

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3818,6 +3818,12 @@
 			<Member 
 				fullName="System.Void Windows.Devices.Sensors.LightSensor..ctor()"
                 reason="Parameter-less ctor does not exist in UWP"/>
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionSurfaceBrush..ctor(Windows.UI.Composition.Compositor compositor)"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionSurfaceBrush..ctor(Windows.UI.Composition.Compositor compositor, Windows.UI.Composition.ICompositionSurface surface)"
+				reason="Should not be public" />
 		</Methods>
 		<Fields>
 		</Fields>

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/GradientBrush.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/GradientBrush.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Xaml.Media
 	#endif
 	public  partial class GradientBrush : global::Windows.UI.Xaml.Media.Brush
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.Media.GradientSpreadMethod SpreadMethod
 		{
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Media
 		#endif
 		// Skipping already declared property GradientStopsProperty
 		// Skipping already declared property MappingModeProperty
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty SpreadMethodProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/GradientSpreadMethod.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/GradientSpreadMethod.cs
@@ -2,19 +2,19 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum GradientSpreadMethod 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Pad,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Reflect,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Repeat,
 		#endif
 	}

--- a/src/Uno.UI/UI/Xaml/Media/Brush.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.skia.cs
@@ -2,6 +2,7 @@
 using System.Numerics;
 using Uno.Disposables;
 using Windows.UI.Composition;
+using Windows.UI;
 
 namespace Windows.UI.Xaml.Media
 {

--- a/src/Uno.UI/UI/Xaml/Media/Brush.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.skia.cs
@@ -66,11 +66,11 @@ namespace Windows.UI.Xaml.Media
 					)
 				.DisposeWith(disposables);
 
-				//gradientBrush.RegisterDisposablePropertyChangedCallback(
-				//		GradientBrush.OpacityProperty,
-				//		(s, e) => compositionBrush.Opacity = e.NewValue
-				//	)
-				//.DisposeWith(disposables);
+				gradientBrush.RegisterDisposablePropertyChangedCallback(
+						GradientBrush.OpacityProperty,
+						(s, e) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+					)
+				.DisposeWith(disposables);
 
 				gradientBrush.RegisterDisposablePropertyChangedCallback(
 						GradientBrush.SpreadMethodProperty,
@@ -194,7 +194,11 @@ namespace Windows.UI.Xaml.Media
 
 			gradientBrush.RegisterDisposablePropertyChangedCallback(
 					GradientBrush.GradientStopsProperty,
-					(s, e) => ConvertGradientColorStops(compositionBrush.Compositor, compositionBrush, (GradientStopCollection)e.NewValue)
+					(s, e) => ConvertGradientColorStops(
+						compositionBrush.Compositor,
+						compositionBrush,
+						(GradientStopCollection)e.NewValue,
+						((GradientBrush)s).Opacity)
 				)
 			.DisposeWith(disposables);
 
@@ -204,11 +208,15 @@ namespace Windows.UI.Xaml.Media
 				)
 			.DisposeWith(disposables);
 
-			//gradientBrush.RegisterDisposablePropertyChangedCallback(
-			//		GradientBrush.OpacityProperty,
-			//		(s, e) => compositionBrush.Opacity = e.NewValue
-			//	)
-			//.DisposeWith(disposables);
+			gradientBrush.RegisterDisposablePropertyChangedCallback(
+					GradientBrush.OpacityProperty,
+					(s, e) => ConvertGradientColorStops(
+						compositionBrush.Compositor,
+						compositionBrush,
+						((GradientBrush)s).GradientStops,
+						(double)e.NewValue)
+				)
+			.DisposeWith(disposables);
 
 			gradientBrush.RegisterDisposablePropertyChangedCallback(
 					GradientBrush.SpreadMethodProperty,
@@ -297,18 +305,18 @@ namespace Windows.UI.Xaml.Media
 			compositionBrush.RelativeTransformMatrix = gradientBrush.RelativeTransform?.MatrixCore ?? Matrix3x2.Identity; 
 			compositionBrush.ExtendMode = ConvertGradientExtendMode(gradientBrush.SpreadMethod);
 			compositionBrush.MappingMode = ConvertBrushMappingMode(gradientBrush.MappingMode);
-			ConvertGradientColorStops(compositor, compositionBrush, gradientBrush.GradientStops);
+			ConvertGradientColorStops(compositor, compositionBrush, gradientBrush.GradientStops, gradientBrush.Opacity);
 
 			return compositionBrush;
 		}
 
-		private static void ConvertGradientColorStops(Compositor compositor, CompositionGradientBrush compositionBrush, GradientStopCollection gradientStops)
+		private static void ConvertGradientColorStops(Compositor compositor, CompositionGradientBrush compositionBrush, GradientStopCollection gradientStops, double opacity)
 		{
 			compositionBrush.ColorStops.Clear();
 
 			foreach (var stop in gradientStops)
 			{
-				compositionBrush.ColorStops.Add(compositor.CreateColorGradientStop((float)stop.Offset, stop.Color));
+				compositionBrush.ColorStops.Add(compositor.CreateColorGradientStop((float)stop.Offset, stop.Color.WithOpacity(opacity)));
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/Brush.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.skia.cs
@@ -1,90 +1,341 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Uno.Extensions;
+using System.Numerics;
 using Uno.Disposables;
-using Windows.UI;
+using Windows.UI.Composition;
 
 namespace Windows.UI.Xaml.Media
 {
 	public abstract partial class Brush
 	{
-		internal delegate void ColorSetterHandler(Color color);
+		internal delegate void BrushSetterHandler(CompositionBrush brush);
 
-		internal static IDisposable AssignAndObserveBrush(Brush b, ColorSetterHandler colorSetter, Action imageBrushCallback = null)
+		/// <summary>
+		/// Registers observers for property changes on the specified Brush.
+		/// Note that skia implementation of this method should only be used for property observervation.
+		/// </summary>
+		internal static IDisposable AssignAndObserveBrush(Brush brush, Action<Color> colorSetter, Action imageBrushCallback = null)
 		{
-			var disposables = new CompositeDisposable();
-
-			if (b != null)
-			{
-				if (b is SolidColorBrush colorBrush)
-				{
-					colorSetter(colorBrush.ColorWithOpacity);
-
-					colorBrush.RegisterDisposablePropertyChangedCallback(
-						SolidColorBrush.ColorProperty,
-						(s, colorArg) => colorSetter((s as SolidColorBrush).ColorWithOpacity)
-					)
-					.DisposeWith(disposables);
-
-					colorBrush.RegisterDisposablePropertyChangedCallback(
-						SolidColorBrush.OpacityProperty,
-						(s, colorArg) => colorSetter((s as SolidColorBrush).ColorWithOpacity)
-					)
-					.DisposeWith(disposables);
-				}
-				//else if (b is ImageBrush imageBrush)
-				//{
-				//	Action<_Image> action = _ => colorSetter(SolidColorBrushHelper.Transparent.Color);
-
-				//	imageBrush.ImageChanged += action;
-
-				//	disposables.Add(() => imageBrush.ImageChanged -= action);
-				//}
-				else if (b is AcrylicBrush acrylicBrush)
-                {
-					colorSetter(acrylicBrush.FallbackColorWithOpacity);
-
-					acrylicBrush.RegisterDisposablePropertyChangedCallback(
-						AcrylicBrush.FallbackColorProperty,
-						(s, args) => colorSetter((s as AcrylicBrush).FallbackColorWithOpacity))
-						.DisposeWith(disposables);
-
-					acrylicBrush.RegisterDisposablePropertyChangedCallback(
-						AcrylicBrush.OpacityProperty,
-						(s, args) => colorSetter((s as AcrylicBrush).FallbackColorWithOpacity))
-						.DisposeWith(disposables);
-
-					return disposables;
-				}
-				else if (b is XamlCompositionBrushBase unsupportedCompositionBrush)
-				{
-					colorSetter(unsupportedCompositionBrush.FallbackColorWithOpacity);
-
-					unsupportedCompositionBrush.RegisterDisposablePropertyChangedCallback(
-						XamlCompositionBrushBase.FallbackColorProperty,
-						(s, colorArg) => colorSetter((s as XamlCompositionBrushBase).FallbackColorWithOpacity)
-					)
-					.DisposeWith(disposables);
-
-					unsupportedCompositionBrush.RegisterDisposablePropertyChangedCallback(
-						OpacityProperty,
-						(s, colorArg) => colorSetter((s as XamlCompositionBrushBase).FallbackColorWithOpacity)
-					)
-					.DisposeWith(disposables);
-				}
-				else
-				{
-					colorSetter(SolidColorBrushHelper.Transparent.Color);
-				}
-			}
-			else
+			if (brush == null)
 			{
 				colorSetter(SolidColorBrushHelper.Transparent.Color);
+
+				return null;
 			}
+
+			var disposables = new CompositeDisposable();
+			if (brush is SolidColorBrush colorBrush)
+			{
+				brush.RegisterDisposablePropertyChangedCallback(
+					SolidColorBrush.ColorProperty,
+					(s, colorArg) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+				)
+				.DisposeWith(disposables);
+
+				brush.RegisterDisposablePropertyChangedCallback(
+					SolidColorBrush.OpacityProperty,
+					(s, colorArg) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+				)
+				.DisposeWith(disposables);
+			}
+			else if (brush is GradientBrush gradientBrush)
+			{
+				if (gradientBrush is LinearGradientBrush linearGradient)
+				{
+					gradientBrush.RegisterDisposablePropertyChangedCallback(
+							LinearGradientBrush.StartPointProperty,
+							(s, e) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+						)
+					.DisposeWith(disposables);
+
+					gradientBrush.RegisterDisposablePropertyChangedCallback(
+							LinearGradientBrush.EndPointProperty,
+							(s, e) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+						)
+					.DisposeWith(disposables);
+				}
+
+				gradientBrush.RegisterDisposablePropertyChangedCallback(
+						GradientBrush.GradientStopsProperty,
+						(s, e) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+					)
+				.DisposeWith(disposables);
+
+				gradientBrush.RegisterDisposablePropertyChangedCallback(
+						GradientBrush.MappingModeProperty,
+						(s, e) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+					)
+				.DisposeWith(disposables);
+
+				//gradientBrush.RegisterDisposablePropertyChangedCallback(
+				//		GradientBrush.OpacityProperty,
+				//		(s, e) => compositionBrush.Opacity = e.NewValue
+				//	)
+				//.DisposeWith(disposables);
+
+				gradientBrush.RegisterDisposablePropertyChangedCallback(
+						GradientBrush.SpreadMethodProperty,
+						(s, e) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+					)
+				.DisposeWith(disposables);
+
+				gradientBrush.RegisterDisposablePropertyChangedCallback(
+						GradientBrush.RelativeTransformProperty,
+						(s, e) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+					)
+				.DisposeWith(disposables);
+			}
+			//else if (b is ImageBrush imageBrush)
+			//{
+			//}
+			else if (brush is AcrylicBrush acrylicBrush)
+			{
+				acrylicBrush.RegisterDisposablePropertyChangedCallback(
+						AcrylicBrush.FallbackColorProperty,
+						(s, e) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+					)
+				.DisposeWith(disposables);
+
+				acrylicBrush.RegisterDisposablePropertyChangedCallback(
+						AcrylicBrush.OpacityProperty,
+						(s, e) => colorSetter(SolidColorBrushHelper.Transparent.Color)
+					)
+				.DisposeWith(disposables);
+			}
+
+			colorSetter(SolidColorBrushHelper.Transparent.Color);
 
 			return disposables;
 		}
 
+		internal static IDisposable AssignAndObserveBrush(Brush brush, Compositor compositor, BrushSetterHandler brushSetter, Action imageBrushCallback = null)
+		{
+			if (brush == null)
+			{
+				brushSetter(null);
+
+				return null;
+			}
+
+			if (brush is SolidColorBrush colorBrush)
+			{
+				return AssignAndObserveSolidColorBrush(colorBrush, compositor, brushSetter);
+			}
+			else if (brush is GradientBrush gradientBrush)
+			{
+				return AssignAndObserveGradientBrush(gradientBrush, compositor, brushSetter);
+			}
+			//else if (b is ImageBrush imageBrush)
+			//{
+			//	Action<_Image> action = _ => colorSetter(SolidColorBrushHelper.Transparent.Color);
+
+			//	imageBrush.ImageChanged += action;
+
+			//	disposables.Add(() => imageBrush.ImageChanged -= action);
+			//}
+			else if (brush is AcrylicBrush acrylicBrush)
+			{
+				return AssignAndObserveAcrylicBrush(acrylicBrush, compositor, brushSetter);
+			}
+			else if (brush is XamlCompositionBrushBase xamlCompositionBrushBase)
+			{
+				return AssignAndObserveXamlCompositionBrush(xamlCompositionBrushBase, compositor, brushSetter);
+			}
+			else
+			{
+				return AssignAndObservePlaceholderBrush(compositor, brushSetter);
+			}
+		}
+
+		private static IDisposable AssignAndObserveSolidColorBrush(SolidColorBrush brush, Compositor compositor, BrushSetterHandler brushSetter)
+		{
+			var disposables = new CompositeDisposable();
+			
+			var compositionBrush = compositor.CreateColorBrush(brush.ColorWithOpacity);
+
+			brush.RegisterDisposablePropertyChangedCallback(
+				SolidColorBrush.ColorProperty,
+				(s, colorArg) => compositionBrush.Color = brush.ColorWithOpacity
+			)
+			.DisposeWith(disposables);
+
+			brush.RegisterDisposablePropertyChangedCallback(
+				SolidColorBrush.OpacityProperty,
+				(s, colorArg) => compositionBrush.Color = brush.ColorWithOpacity
+			)
+			.DisposeWith(disposables);
+
+			brushSetter(compositionBrush);
+
+			return disposables;
+		}
+
+		private static IDisposable AssignAndObserveGradientBrush(GradientBrush gradientBrush, Compositor compositor, BrushSetterHandler brushSetter)
+		{
+			var disposables = new CompositeDisposable();
+
+			var compositionBrush = CreateCompositionGradientBrush(gradientBrush, compositor);
+
+			if (gradientBrush is LinearGradientBrush linearGradient)
+			{
+				var clgb = (CompositionLinearGradientBrush)compositionBrush;
+
+				gradientBrush.RegisterDisposablePropertyChangedCallback(
+						LinearGradientBrush.StartPointProperty,
+						(s, e) => clgb.StartPoint = (Vector2)e.NewValue
+					)
+				.DisposeWith(disposables);
+
+				gradientBrush.RegisterDisposablePropertyChangedCallback(
+						LinearGradientBrush.EndPointProperty,
+						(s, e) => clgb.EndPoint = (Vector2)e.NewValue
+					)
+				.DisposeWith(disposables);
+			}
+
+			gradientBrush.RegisterDisposablePropertyChangedCallback(
+					GradientBrush.GradientStopsProperty,
+					(s, e) => ConvertGradientColorStops(compositionBrush.Compositor, compositionBrush, (GradientStopCollection)e.NewValue)
+				)
+			.DisposeWith(disposables);
+
+			gradientBrush.RegisterDisposablePropertyChangedCallback(
+					GradientBrush.MappingModeProperty,
+					(s, e) => compositionBrush.MappingMode = (CompositionMappingMode)e.NewValue
+				)
+			.DisposeWith(disposables);
+
+			//gradientBrush.RegisterDisposablePropertyChangedCallback(
+			//		GradientBrush.OpacityProperty,
+			//		(s, e) => compositionBrush.Opacity = e.NewValue
+			//	)
+			//.DisposeWith(disposables);
+
+			gradientBrush.RegisterDisposablePropertyChangedCallback(
+					GradientBrush.SpreadMethodProperty,
+					(s, e) => compositionBrush.ExtendMode = ConvertGradientExtendMode((GradientSpreadMethod)e.NewValue)
+				)
+			.DisposeWith(disposables);
+
+			gradientBrush.RegisterDisposablePropertyChangedCallback(
+					GradientBrush.RelativeTransformProperty,
+					(s, e) => compositionBrush.RelativeTransformMatrix = ((Transform)e.NewValue)?.MatrixCore ?? Matrix3x2.Identity
+				)
+			.DisposeWith(disposables);
+
+			brushSetter(compositionBrush);
+
+			return disposables;
+		}
+
+		private static IDisposable AssignAndObserveAcrylicBrush(AcrylicBrush acrylicBrush, Compositor compositor, BrushSetterHandler brushSetter)
+		{
+			var disposables = new CompositeDisposable();
+
+			var compositionBrush = compositor.CreateColorBrush(acrylicBrush.FallbackColorWithOpacity);
+
+			acrylicBrush.RegisterDisposablePropertyChangedCallback(
+				AcrylicBrush.FallbackColorProperty,
+				(s, colorArg) => compositionBrush.Color = acrylicBrush.FallbackColorWithOpacity
+			)
+			.DisposeWith(disposables);
+
+			acrylicBrush.RegisterDisposablePropertyChangedCallback(
+				AcrylicBrush.OpacityProperty,
+				(s, colorArg) => compositionBrush.Color = acrylicBrush.FallbackColorWithOpacity
+			)
+			.DisposeWith(disposables);
+
+			brushSetter(compositionBrush);
+
+			return disposables;
+		}
+
+		private static IDisposable AssignAndObserveXamlCompositionBrush(XamlCompositionBrushBase brush, Compositor compositor, BrushSetterHandler brushSetter)
+		{
+			var disposables = new CompositeDisposable();
+
+			var compositionBrush = brush.CompositionBrush;
+
+			//brush.RegisterDisposablePropertyChangedCallback(
+			//	XamlCompositionBrushBase.CompositionBrushProperty,
+			//	(s, e) => brushSetter(((CompositionBrush)e.NewValue))
+			//)
+			//.DisposeWith(disposables);
+
+			brushSetter(compositionBrush);
+
+			return disposables;
+		}
+
+		private static IDisposable AssignAndObservePlaceholderBrush(Compositor compositor, BrushSetterHandler brushSetter)
+		{
+			var disposables = new CompositeDisposable();
+
+			var compositionBrush = compositor.CreateColorBrush(SolidColorBrushHelper.Transparent.Color);
+
+			brushSetter(compositionBrush);
+
+			return disposables;
+		}
+
+		private static CompositionGradientBrush CreateCompositionGradientBrush(GradientBrush gradientBrush, Compositor compositor)
+		{
+			CompositionGradientBrush compositionBrush;
+			if (gradientBrush is LinearGradientBrush linearGradient)
+			{
+				CompositionLinearGradientBrush compositionLinearGradientBrush = compositor.CreateLinearGradientBrush();
+				compositionLinearGradientBrush.StartPoint = linearGradient.StartPoint.ToVector2();
+				compositionLinearGradientBrush.EndPoint = linearGradient.EndPoint.ToVector2();
+
+				compositionBrush = compositionLinearGradientBrush;
+			}
+			else
+			{
+				return null;
+			}
+
+			compositionBrush.RelativeTransformMatrix = gradientBrush.RelativeTransform?.MatrixCore ?? Matrix3x2.Identity; 
+			compositionBrush.ExtendMode = ConvertGradientExtendMode(gradientBrush.SpreadMethod);
+			compositionBrush.MappingMode = ConvertBrushMappingMode(gradientBrush.MappingMode);
+			ConvertGradientColorStops(compositor, compositionBrush, gradientBrush.GradientStops);
+
+			return compositionBrush;
+		}
+
+		private static void ConvertGradientColorStops(Compositor compositor, CompositionGradientBrush compositionBrush, GradientStopCollection gradientStops)
+		{
+			compositionBrush.ColorStops.Clear();
+
+			foreach (var stop in gradientStops)
+			{
+				compositionBrush.ColorStops.Add(compositor.CreateColorGradientStop((float)stop.Offset, stop.Color));
+			}
+		}
+
+		private static CompositionGradientExtendMode ConvertGradientExtendMode(GradientSpreadMethod spreadMethod)
+		{
+			switch (spreadMethod)
+			{
+				case GradientSpreadMethod.Repeat:
+					return CompositionGradientExtendMode.Wrap;
+				case GradientSpreadMethod.Reflect:
+					return CompositionGradientExtendMode.Mirror;
+				case GradientSpreadMethod.Pad:
+				default:
+					return CompositionGradientExtendMode.Clamp;
+			}
+		}
+
+		private static CompositionMappingMode ConvertBrushMappingMode(BrushMappingMode mappingMode)
+		{
+			switch (mappingMode)
+			{
+				case BrushMappingMode.Absolute:
+					return CompositionMappingMode.Absolute;
+				case BrushMappingMode.RelativeToBoundingBox:
+				default:
+					return CompositionMappingMode.Relative;
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/GradientBrush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GradientBrush.cs
@@ -41,12 +41,29 @@ namespace Windows.UI.Xaml.Media
 				"MappingMode",
 				typeof(BrushMappingMode),
 				typeof(GradientBrush),
-				new FrameworkPropertyMetadata(BrushMappingMode.RelativeToBoundingBox));
+				new FrameworkPropertyMetadata(
+					defaultValue: BrushMappingMode.RelativeToBoundingBox,
+					options: FrameworkPropertyMetadataOptions.AffectsRender));
 
 		public BrushMappingMode MappingMode
 		{
 			get => (BrushMappingMode)GetValue(MappingModeProperty);
 			set => SetValue(MappingModeProperty, value);
+		}
+
+		public static DependencyProperty SpreadMethodProperty { get; } =
+			DependencyProperty.Register(
+				nameof(SpreadMethod),
+				typeof(GradientSpreadMethod),
+				typeof(GradientBrush),
+				new FrameworkPropertyMetadata(
+					defaultValue: GradientSpreadMethod.Pad,
+					options: FrameworkPropertyMetadataOptions.AffectsRender));
+
+		public GradientSpreadMethod SpreadMethod
+		{
+			get => (GradientSpreadMethod)GetValue(SpreadMethodProperty);
+			set => SetValue(SpreadMethodProperty, value);
 		}
 
 		internal Color FallbackColorWithOpacity => GetColorWithOpacity(FallbackColor);

--- a/src/Uno.UI/UI/Xaml/Media/GradientSpreadMethod.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GradientSpreadMethod.cs
@@ -1,0 +1,9 @@
+﻿namespace Windows.UI.Xaml.Media
+{
+	public enum GradientSpreadMethod
+	{
+		Pad,
+		Reflect,
+		Repeat,
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Shapes/Rectangle.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Rectangle.skia.cs
@@ -10,6 +10,7 @@ using Uno.UI;
 using Windows.UI.Composition;
 using Windows.Foundation;
 using Windows.Graphics;
+using System.Numerics;
 
 namespace Windows.UI.Xaml.Shapes
 {
@@ -51,17 +52,30 @@ namespace Windows.UI.Xaml.Shapes
 
 		private SkiaGeometrySource2D GetGeometry(Size finalSize)
 		{
-			var area = new Rect(0, 0, finalSize.Width, finalSize.Height);
+			var strokeThickness = StrokeThickness;
+			var radiusX = RadiusX;
+			var radiusY = RadiusY;
 
-			var geometry = new SkiaGeometrySource2D();
-
-			if (Math.Max(RadiusX, RadiusY) > 0)
+			var offset = new Vector2((float)(strokeThickness * 0.5), (float)(strokeThickness * 0.5));
+			var size = new Vector2((float)finalSize.Width, (float)finalSize.Height);
+			
+			SkiaGeometrySource2D geometry;
+			if (radiusX == 0 || radiusY == 0)
 			{
-				geometry.Geometry.AddRoundRect(area.ToSKRect(), (float)RadiusX, (float)RadiusY);
+				// Simple rectangle
+				geometry = new SkiaGeometrySource2D(
+					CompositionGeometry.BuildRectangleGeometry(
+						offset,
+						size));
 			}
 			else
 			{
-				geometry.Geometry.AddRect(area.ToSKRect());
+				// Complex rectangle
+				geometry = new SkiaGeometrySource2D(
+					CompositionGeometry.BuildRoundedRectangleGeometry(
+						offset,
+						size,
+						new Vector2((float)radiusX, (float)radiusY)));
 			}
 
 			return geometry;

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.skia.cs
@@ -13,7 +13,6 @@ using Windows.UI.Composition;
 using Uno.Disposables;
 using System.IO.Compression;
 using SkiaSharp;
-using Windows.Devices.Usb;
 using System.Numerics;
 
 namespace Windows.UI.Xaml.Shapes
@@ -81,15 +80,8 @@ namespace Windows.UI.Xaml.Shapes
 
 				_pathSpriteShape.FillBrush = null;
 
-				switch(Fill)
-				{
-					case SolidColorBrush scb:
-						_fillSubscription.Disposable =
-							Brush.AssignAndObserveBrush(scb, c => _pathSpriteShape.FillBrush = Visual.Compositor.CreateColorBrush(c));
-						break;
-					case GradientBrush gb:
-						break;
-				}
+				_fillSubscription.Disposable =
+							Brush.AssignAndObserveBrush(Fill, Visual.Compositor, compositionBrush => _pathSpriteShape.FillBrush = compositionBrush);
 			}
 		}
 
@@ -103,12 +95,14 @@ namespace Windows.UI.Xaml.Shapes
 
 		private void UpdateStroke()
 		{
-			var brush = Stroke as SolidColorBrush ?? SolidColorBrushHelper.Transparent;
-
 			if (_pathSpriteShape != null)
 			{
+				_strokeSubscription.Disposable = null;
+
+				_pathSpriteShape.StrokeBrush = null;
+
 				_strokeSubscription.Disposable =
-					Brush.AssignAndObserveBrush(brush, c => _pathSpriteShape.StrokeBrush = Visual.Compositor.CreateColorBrush(c));
+							Brush.AssignAndObserveBrush(Stroke, Visual.Compositor, compositionBrush => _pathSpriteShape.StrokeBrush = compositionBrush);
 			}
 		}
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionColorGradientStop.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionColorGradientStop.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CompositionColorGradientStop : global::Windows.UI.Composition.CompositionObject
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  float Offset
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Color Color
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionColorGradientStopCollection.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionColorGradientStopCollection.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CompositionColorGradientStopCollection : global::System.Collections.Generic.IEnumerable<global::Windows.UI.Composition.CompositionColorGradientStop>,global::System.Collections.Generic.IList<global::Windows.UI.Composition.CompositionColorGradientStop>
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  uint Size
 		{
@@ -31,7 +31,7 @@ namespace Windows.UI.Composition
 		// Forced skipping of method Windows.UI.Composition.CompositionColorGradientStopCollection.GetMany(uint, Windows.UI.Composition.CompositionColorGradientStop[])
 		// Forced skipping of method Windows.UI.Composition.CompositionColorGradientStopCollection.ReplaceAll(Windows.UI.Composition.CompositionColorGradientStop[])
 		// Processing: System.Collections.Generic.IEnumerable<Windows.UI.Composition.CompositionColorGradientStop>
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		// DeclaringType: System.Collections.Generic.IEnumerable<Windows.UI.Composition.CompositionColorGradientStop>
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public global::System.Collections.Generic.IEnumerator<global::Windows.UI.Composition.CompositionColorGradientStop> GetEnumerator()
@@ -40,7 +40,7 @@ namespace Windows.UI.Composition
 		}
 		#endif
 		// Processing: System.Collections.IEnumerable
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		// DeclaringType: System.Collections.IEnumerable
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		 global::System.Collections.IEnumerator global::System.Collections.IEnumerable.GetEnumerator()
@@ -49,7 +49,7 @@ namespace Windows.UI.Composition
 		}
 		#endif
 		// Processing: System.Collections.Generic.IList<Windows.UI.Composition.CompositionColorGradientStop>
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		// DeclaringType: System.Collections.Generic.IList<Windows.UI.Composition.CompositionColorGradientStop>
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public int IndexOf( global::Windows.UI.Composition.CompositionColorGradientStop item)
@@ -57,7 +57,7 @@ namespace Windows.UI.Composition
 			throw new global::System.NotSupportedException();
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		// DeclaringType: System.Collections.Generic.IList<Windows.UI.Composition.CompositionColorGradientStop>
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public void Insert( int index,  global::Windows.UI.Composition.CompositionColorGradientStop item)
@@ -65,7 +65,7 @@ namespace Windows.UI.Composition
 			throw new global::System.NotSupportedException();
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		// DeclaringType: System.Collections.Generic.IList<Windows.UI.Composition.CompositionColorGradientStop>
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public void RemoveAt( int index)
@@ -73,7 +73,7 @@ namespace Windows.UI.Composition
 			throw new global::System.NotSupportedException();
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public global::Windows.UI.Composition.CompositionColorGradientStop this[int index]
 		{
@@ -88,7 +88,7 @@ namespace Windows.UI.Composition
 		}
 		#endif
 		// Processing: System.Collections.Generic.ICollection<Windows.UI.Composition.CompositionColorGradientStop>
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		// DeclaringType: System.Collections.Generic.ICollection<Windows.UI.Composition.CompositionColorGradientStop>
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public void Add( global::Windows.UI.Composition.CompositionColorGradientStop item)
@@ -96,7 +96,7 @@ namespace Windows.UI.Composition
 			throw new global::System.NotSupportedException();
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		// DeclaringType: System.Collections.Generic.ICollection<Windows.UI.Composition.CompositionColorGradientStop>
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public void Clear()
@@ -104,7 +104,7 @@ namespace Windows.UI.Composition
 			throw new global::System.NotSupportedException();
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		// DeclaringType: System.Collections.Generic.ICollection<Windows.UI.Composition.CompositionColorGradientStop>
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public bool Contains( global::Windows.UI.Composition.CompositionColorGradientStop item)
@@ -112,7 +112,7 @@ namespace Windows.UI.Composition
 			throw new global::System.NotSupportedException();
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		// DeclaringType: System.Collections.Generic.ICollection<Windows.UI.Composition.CompositionColorGradientStop>
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public void CopyTo( global::Windows.UI.Composition.CompositionColorGradientStop[] array,  int arrayIndex)
@@ -120,7 +120,7 @@ namespace Windows.UI.Composition
 			throw new global::System.NotSupportedException();
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		// DeclaringType: System.Collections.Generic.ICollection<Windows.UI.Composition.CompositionColorGradientStop>
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public bool Remove( global::Windows.UI.Composition.CompositionColorGradientStop item)
@@ -128,7 +128,7 @@ namespace Windows.UI.Composition
 			throw new global::System.NotSupportedException();
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public int Count
 		{
@@ -142,7 +142,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public bool IsReadOnly
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionEllipseGeometry.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionEllipseGeometry.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CompositionEllipseGeometry : global::Windows.UI.Composition.CompositionGeometry
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 Radius
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 Center
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionGradientBrush.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionGradientBrush.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CompositionGradientBrush : global::Windows.UI.Composition.CompositionBrush
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Matrix3x2 TransformMatrix
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 Scale
 		{
@@ -35,7 +35,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  float RotationAngleInDegrees
 		{
@@ -49,7 +49,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  float RotationAngle
 		{
@@ -63,7 +63,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 Offset
 		{
@@ -91,7 +91,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionGradientExtendMode ExtendMode
 		{
@@ -105,7 +105,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 CenterPoint
 		{
@@ -119,7 +119,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 AnchorPoint
 		{
@@ -133,7 +133,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionColorGradientStopCollection ColorStops
 		{
@@ -143,7 +143,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionMappingMode MappingMode
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionGradientExtendMode.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionGradientExtendMode.cs
@@ -2,19 +2,19 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum CompositionGradientExtendMode 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Clamp,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Wrap,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Mirror,
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionLineGeometry.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionLineGeometry.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CompositionLineGeometry : global::Windows.UI.Composition.CompositionGeometry
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 Start
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 End
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionLinearGradientBrush.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionLinearGradientBrush.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CompositionLinearGradientBrush : global::Windows.UI.Composition.CompositionGradientBrush
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 StartPoint
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 EndPoint
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionMappingMode.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionMappingMode.cs
@@ -2,16 +2,16 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum CompositionMappingMode 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Absolute,
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		Relative,
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionRadialGradientBrush.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionRadialGradientBrush.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CompositionRadialGradientBrush : global::Windows.UI.Composition.CompositionGradientBrush
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 GradientOriginOffset
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 EllipseRadius
 		{
@@ -35,7 +35,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 EllipseCenter
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionRectangleGeometry.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionRectangleGeometry.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CompositionRectangleGeometry : global::Windows.UI.Composition.CompositionGeometry
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 Size
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 Offset
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionRoundedRectangleGeometry.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/CompositionRoundedRectangleGeometry.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Composition
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CompositionRoundedRectangleGeometry : global::Windows.UI.Composition.CompositionGeometry
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 Size
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 Offset
 		{
@@ -35,7 +35,7 @@ namespace Windows.UI.Composition
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::System.Numerics.Vector2 CornerRadius
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/Compositor.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Composition/Compositor.cs
@@ -261,21 +261,21 @@ namespace Windows.UI.Composition
 			throw new global::System.NotImplementedException("The member CompositionBackdropBrush Compositor.CreateHostBackdropBrush() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionColorGradientStop CreateColorGradientStop()
 		{
 			throw new global::System.NotImplementedException("The member CompositionColorGradientStop Compositor.CreateColorGradientStop() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionColorGradientStop CreateColorGradientStop( float offset,  global::Windows.UI.Color color)
 		{
 			throw new global::System.NotImplementedException("The member CompositionColorGradientStop Compositor.CreateColorGradientStop(float offset, Color color) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionLinearGradientBrush CreateLinearGradientBrush()
 		{
@@ -335,14 +335,14 @@ namespace Windows.UI.Composition
 			throw new global::System.NotImplementedException("The member CompositionContainerShape Compositor.CreateContainerShape() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionEllipseGeometry CreateEllipseGeometry()
 		{
 			throw new global::System.NotImplementedException("The member CompositionEllipseGeometry Compositor.CreateEllipseGeometry() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionLineGeometry CreateLineGeometry()
 		{
@@ -358,14 +358,14 @@ namespace Windows.UI.Composition
 			throw new global::System.NotImplementedException("The member PathKeyFrameAnimation Compositor.CreatePathKeyFrameAnimation() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionRectangleGeometry CreateRectangleGeometry()
 		{
 			throw new global::System.NotImplementedException("The member CompositionRectangleGeometry Compositor.CreateRectangleGeometry() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionRoundedRectangleGeometry CreateRoundedRectangleGeometry()
 		{
@@ -431,7 +431,7 @@ namespace Windows.UI.Composition
 			throw new global::System.NotImplementedException("The member CompositionProjectedShadowReceiver Compositor.CreateProjectedShadowReceiver() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Composition.CompositionRadialGradientBrush CreateRadialGradientBrush()
 		{

--- a/src/Uno.UWP/UI/Composition/CompositionBrush.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionBrush.skia.cs
@@ -6,7 +6,7 @@ namespace Windows.UI.Composition
 {
 	public partial class CompositionBrush
 	{
-		internal virtual void UpdatePaint(SKPaint fillPaint)
+		internal virtual void UpdatePaint(SKPaint paint, SKRect bounds)
 		{
 		}
 	}

--- a/src/Uno.UWP/UI/Composition/CompositionClip.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionClip.cs
@@ -6,17 +6,59 @@ namespace Windows.UI.Composition
 {
 	public partial class CompositionClip : CompositionObject
 	{
+		private Matrix3x2 _transformMatrix = Matrix3x2.Identity;
+		private Vector2 _scale = new Vector2(1, 1);
+		private float _rotationAngleInDegrees;
+		private float _rotationAngle;
+		private Vector2 _offset = Vector2.Zero;
+		private Vector2 _centerPoint = Vector2.Zero;
+		private Vector2 _anchorPoint = Vector2.Zero;
+
 		internal CompositionClip(Compositor compositor) : base(compositor)
 		{
 
 		}
 
-		public Matrix3x2 TransformMatrix { get; set; }
-		public Vector2 Scale { get; set; }
-		public float RotationAngleInDegrees { get; set; }
-		public float RotationAngle { get; set; }
-		public Vector2 Offset { get; set; }
-		public Vector2 CenterPoint { get; set; }
-		public Vector2 AnchorPoint { get; set; }
+		public Matrix3x2 TransformMatrix
+		{
+			get => _transformMatrix;
+			set => SetProperty(ref _transformMatrix, value);
+		}
+
+		public Vector2 Scale
+		{
+			get => _scale;
+			set => SetProperty(ref _scale, value);
+		}
+
+		public float RotationAngleInDegrees
+		{
+			get => _rotationAngleInDegrees;
+			set => SetProperty(ref _rotationAngleInDegrees, value);
+		}
+
+		public float RotationAngle
+		{
+			get => _rotationAngle;
+			set => SetProperty(ref _rotationAngle, value);
+		}
+
+		public Vector2 Offset
+		{
+			get => _offset;
+			set => SetProperty(ref _offset, value);
+		}
+
+		public Vector2 CenterPoint
+		{
+			get => _centerPoint;
+			set => SetProperty(ref _centerPoint, value);
+		}
+
+		public Vector2 AnchorPoint
+		{
+			get => _anchorPoint;
+			set => SetProperty(ref _anchorPoint, value);
+		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionColorBrush.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionColorBrush.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using Windows.UI;
 
 namespace Windows.UI.Composition
 {

--- a/src/Uno.UWP/UI/Composition/CompositionColorBrush.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionColorBrush.cs
@@ -1,20 +1,14 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
-using Uno.Disposables;
-using Windows.UI;
 
 namespace Windows.UI.Composition
 {
 	public partial class CompositionColorBrush : CompositionBrush
 	{
-		private List<Action> _colorChangedHandlers = new List<Action>();
 		private Color _color;
 
-		internal CompositionColorBrush() => throw new NotSupportedException();
-
-		public CompositionColorBrush(Compositor compositor) : base(compositor)
+		internal CompositionColorBrush(Compositor compositor) : base(compositor)
 		{
 
 		}
@@ -22,22 +16,7 @@ namespace Windows.UI.Composition
 		public Color Color
 		{
 			get { return _color; }
-			set { _color = value; OnColorChanged(); }
-		}
-
-		private void OnColorChanged()
-		{
-			foreach (var handler in _colorChangedHandlers)
-			{
-				handler();
-			}
-		}
-
-		internal IDisposable RegisterColorChanged(Action onColorChanged)
-		{
-			_colorChangedHandlers.Add(onColorChanged);
-
-			return Disposable.Create(() => _colorChangedHandlers.Remove(onColorChanged));
+			set { SetProperty(ref _color, value); }
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionColorBrush.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionColorBrush.skia.cs
@@ -8,9 +8,9 @@ namespace Windows.UI.Composition
 {
 	public partial class CompositionColorBrush
 	{
-		internal override void UpdatePaint(SKPaint fillPaint)
+		internal override void UpdatePaint(SKPaint paint, SKRect bounds)
 		{
-			fillPaint.Color = Color.ToSKColor(Compositor.CurrentOpacity);
+			paint.Color = Color.ToSKColor(Compositor.CurrentOpacity);
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionColorGradientStop.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionColorGradientStop.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using Windows.UI;
+
 namespace Windows.UI.Composition
 {
 	public partial class CompositionColorGradientStop : CompositionObject

--- a/src/Uno.UWP/UI/Composition/CompositionColorGradientStop.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionColorGradientStop.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionColorGradientStop : CompositionObject
+	{
+		private float _offset;
+		private Color _color;
+
+		internal CompositionColorGradientStop(Compositor compositor)
+			: base(compositor)
+		{
+
+		}
+
+		public float Offset
+		{
+			get => _offset;
+			set => SetProperty(ref _offset, value);
+		}
+
+		public Color Color
+		{
+			get => _color;
+			set => SetProperty(ref _color, value);
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionColorGradientStopCollection.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionColorGradientStopCollection.cs
@@ -1,0 +1,144 @@
+﻿#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionColorGradientStopCollection : IList<CompositionColorGradientStop>
+	{
+		private readonly CompositionGradientBrush _owner;
+		private readonly List<CompositionColorGradientStop> _gradientStops;
+
+		internal CompositionColorGradientStopCollection(CompositionGradientBrush owner)
+		{
+			_owner = owner;
+			_gradientStops = new List<CompositionColorGradientStop>();
+		}
+
+		public CompositionColorGradientStop this[int index]
+		{
+			get => _gradientStops[index];
+			set
+			{
+				ThrowIfNull(value, nameof(value));
+
+				CompositionColorGradientStop oldValue = _gradientStops[index];
+				CompositionColorGradientStop newValue = value;
+
+				_gradientStops[index] = newValue;
+
+				OnItemAddedRemoved(oldValue, newValue);
+				InvalidateOwner();
+			}
+		}
+
+		public int Count => _gradientStops.Count;
+
+		public bool IsReadOnly => false;
+
+		public void Add(CompositionColorGradientStop item)
+		{
+			ThrowIfNull(item, nameof(item));
+
+			_gradientStops.Add(item);
+
+			OnItemAddedRemoved(null, item);
+			InvalidateOwner();
+		}
+
+		public void Clear()
+		{
+			_gradientStops.ForEach(x => OnItemAddedRemoved(x, null));
+			_gradientStops.Clear();
+
+			InvalidateOwner();
+		}
+
+		public bool Contains(CompositionColorGradientStop item)
+		{
+			ThrowIfNull(item, nameof(item));
+
+			return _gradientStops.Contains(item);
+		}
+
+		public void CopyTo(CompositionColorGradientStop[] array, int arrayIndex)
+		{
+			ThrowIfNull(array, nameof(array));
+
+			_gradientStops.CopyTo(array, arrayIndex);
+		}
+
+		public IEnumerator<CompositionColorGradientStop> GetEnumerator() => _gradientStops.GetEnumerator();
+
+		public int IndexOf(CompositionColorGradientStop item)
+		{
+			ThrowIfNull(item, nameof(item));
+
+			return _gradientStops.IndexOf(item);
+		}
+
+		public void Insert(int index, CompositionColorGradientStop item)
+		{
+			ThrowIfNull(item, nameof(item));
+
+			_gradientStops.Insert(index, item);
+
+			OnItemAddedRemoved(null, item);
+			InvalidateOwner();
+		}
+
+		public bool Remove(CompositionColorGradientStop item)
+		{
+			ThrowIfNull(item, nameof(item));
+
+			bool removed = _gradientStops.Remove(item);
+			if (removed)
+			{
+				OnItemAddedRemoved(item, null);
+				InvalidateOwner();
+			}
+
+			return removed;
+		}
+
+		public void RemoveAt(int index)
+		{
+			var item = _gradientStops[index];
+
+			_gradientStops.RemoveAt(index);
+
+			OnItemAddedRemoved(item, null);
+			InvalidateOwner();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => _gradientStops.GetEnumerator();
+
+		private void OnItemAddedRemoved(CompositionColorGradientStop? oldItem, CompositionColorGradientStop? newItem)
+		{
+			if (oldItem != null)
+			{
+				oldItem.RemoveContext(_owner, nameof(CompositionGradientBrush.ColorStops));
+			}
+
+			if (newItem != null)
+			{
+				newItem.AddContext(_owner, nameof(CompositionGradientBrush.ColorStops));
+			}
+		}
+
+		private void InvalidateOwner()
+		{
+			_owner.InvalidateColorStops();
+		}
+
+		private void ThrowIfNull<T>(T? item, string propertyName) where T : class
+		{
+			if (item == null)
+			{
+				throw new ArgumentNullException(propertyName);
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionEllipseGeometry.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionEllipseGeometry.cs
@@ -1,0 +1,29 @@
+﻿#nullable enable
+
+using System.Numerics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionEllipseGeometry : CompositionGeometry
+	{
+		private Vector2 _radius;
+		private Vector2 _center;
+
+		internal CompositionEllipseGeometry(Compositor compositor) : base(compositor)
+		{
+
+		}
+
+		public Vector2 Radius
+		{
+			get => _radius;
+			set => SetProperty(ref _radius, value); 
+		}
+
+		public Vector2 Center
+		{
+			get => _center;
+			set => SetProperty(ref _center, value);
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionEllipseGeometry.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionEllipseGeometry.skia.cs
@@ -1,0 +1,12 @@
+﻿#nullable enable
+
+using Windows.Graphics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionEllipseGeometry : CompositionGeometry
+	{
+		internal override IGeometrySource2D? BuildGeometry()
+			=> new SkiaGeometrySource2D(BuildEllipseGeometry(Center, Radius));
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionGeometricClip.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionGeometricClip.cs
@@ -2,20 +2,26 @@
 
 namespace Windows.UI.Composition
 {
-	public partial class CompositionGeometricClip : global::Windows.UI.Composition.CompositionClip
+	public partial class CompositionGeometricClip : CompositionClip
 	{
+		private CompositionViewBox? _viewBox;
+		private CompositionGeometry? _geometry;
+
 		public CompositionGeometricClip(Compositor compositor) : base(compositor)
 		{
 
 		}
+
 		public CompositionViewBox? ViewBox
 		{
-			get; set;
+			get => _viewBox;
+			set => SetProperty(ref _viewBox, value);
 		}
 
 		public CompositionGeometry? Geometry
 		{
-			get; set;
+			get => _geometry;
+			set => SetProperty(ref _geometry, value);
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionGeometry.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionGeometry.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using Windows.Graphics;
+
 namespace Windows.UI.Composition
 {
 	public partial class CompositionGeometry : CompositionObject
@@ -9,15 +11,12 @@ namespace Windows.UI.Composition
 
 		}
 
-		internal CompositionGeometry()
-		{
-
-		}
-
 		public float TrimStart { get; set; }
 
 		public float TrimOffset { get; set; }
 
 		public float TrimEnd { get; set; }
+
+		internal virtual IGeometrySource2D? BuildGeometry() => null;
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionGeometry.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionGeometry.skia.cs
@@ -1,0 +1,152 @@
+﻿#nullable enable
+
+using System;
+using System.Numerics;
+using SkiaSharp;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionGeometry : CompositionObject
+	{
+		/// <summary>
+		/// Kappa = (sqrt(2) - 1) * 4/3;
+		//  Used to calculate bezier control points for each of the circle four arcs. 
+		//  - Approximating a 1/4 circle with a bezier curve.
+		/// </summary>
+		private const double CIRCLE_BEZIER_KAPPA = 0.552284749830793398402251632279597438092895833835930764235;
+
+		internal static SKPath BuildLineGeometry(Vector2 start, Vector2 end)
+		{
+			SKPath path = new SKPath();
+
+			path.MoveTo(start.ToSKPoint());
+			path.LineTo(end.ToSKPoint());
+
+			return path;
+		}
+
+		internal static SKPath BuildRectangleGeometry(Vector2 offset, Vector2 size)
+		{
+			SKPath path = new SKPath();
+
+			// Top left
+			path.MoveTo(new SKPoint(offset.X, offset.Y));
+			// Top right
+			path.RLineTo(new SKPoint(size.X, 0));
+			// Bottom right
+			path.RLineTo(new SKPoint(0, size.Y));
+			// Bottom left
+			path.RLineTo(new SKPoint(-size.X, 0));
+			// Top left
+			path.Close();
+
+			return path;
+		}
+
+		internal static SKPath BuildRoundedRectangleGeometry(Vector2 offset, Vector2 size, Vector2 cornerRadius)
+		{
+			float radiusX = Clamp(cornerRadius.X, 0, size.X * 0.5f);
+			float radiusY = Clamp(cornerRadius.Y, 0, size.Y * 0.5f);
+
+			float bezierX = (float)((1.0 - CIRCLE_BEZIER_KAPPA) * radiusX);
+			float bezierY = (float)((1.0 - CIRCLE_BEZIER_KAPPA) * radiusY);
+
+			SKPath path = new SKPath();
+			var lastPoint = new SKPoint(offset.X + radiusX, offset.Y);
+
+			path.MoveTo(lastPoint);
+			// Top line
+			path.LineTo(lastPoint + new SKPoint(size.X - 2 * radiusX, 0));
+			lastPoint += new SKPoint(size.X - 2 * radiusX, 0);
+			// Top-right Arc
+			path.CubicTo(
+				lastPoint + new SKPoint(radiusX - bezierX, 0),   // 1st control point
+				lastPoint + new SKPoint(radiusX, bezierY),       // 2nd control point
+				lastPoint + new SKPoint(radiusX, radiusY));      // End point
+			lastPoint += new SKPoint(radiusX, radiusY);
+
+			// Right line
+			path.LineTo(lastPoint + new SKPoint(0, size.Y - 2 * radiusY));
+			lastPoint += new SKPoint(0, size.Y - 2 * radiusY);
+			// Bottom-right Arc
+			path.CubicTo(
+				lastPoint + new SKPoint(0, bezierY),             // 1st control point
+				lastPoint + new SKPoint(-bezierX, radiusY),      // 2nd control point
+				lastPoint + new SKPoint(-radiusX, radiusY));     // End point
+			lastPoint += new SKPoint(-radiusX, radiusY);
+
+			// Bottom line
+			path.LineTo(lastPoint + new SKPoint(-(size.X - 2 * radiusX), 0));
+			lastPoint = lastPoint + new SKPoint(-(size.X - 2 * radiusX), 0);
+			// Bottom-left Arc
+			path.CubicTo(
+				lastPoint + new SKPoint(-radiusX + bezierX, 0),  // 1st control point
+				lastPoint + new SKPoint(-radiusX, -bezierY),     // 2nd control point
+				lastPoint + new SKPoint(-radiusX, -radiusY));    // End point
+			lastPoint += new SKPoint(-radiusX, -radiusY);
+
+			// Left line
+			path.LineTo(lastPoint + new SKPoint(0, -(size.Y - 2 * radiusY)));
+			lastPoint += new SKPoint(0, -(size.Y - 2 * radiusY));
+			// Top-left Arc
+			path.CubicTo(
+				lastPoint + new SKPoint(0, -radiusY + bezierY),  // 1st control point
+				lastPoint + new SKPoint(bezierX, -radiusY),      // 2nd control point
+				lastPoint + new SKPoint(radiusX, -radiusY));     // End point
+
+			path.Close();
+
+			return path;
+		}
+
+		internal static SKPath BuildEllipseGeometry(Vector2 center, Vector2 radius)
+		{
+			SKRect rect = SKRect.Create(center.X - radius.X, center.Y - radius.Y, radius.X * 2, radius.Y * 2);
+
+			float bezierX = (float)((1.0 - CIRCLE_BEZIER_KAPPA) * radius.X);
+			float bezierY = (float)((1.0 - CIRCLE_BEZIER_KAPPA) * radius.Y);
+
+			// IMPORTANT:
+			// - The order of following operations is important for dashed strokes.
+			// - Stroke might get merged in the end.
+			// - WPF starts with bottom right ellipse arc.
+			// - TODO: Verify UWP behavior
+
+			SKPath path = new SKPath();
+
+			path.MoveTo(new SKPoint(rect.Right, rect.Top + radius.Y));
+			// Bottom-right Arc
+			path.CubicTo(
+				new SKPoint(rect.Right, rect.Bottom - bezierY),  // 1st control point
+				new SKPoint(rect.Right - bezierX, rect.Bottom),  // 2nd control point
+				new SKPoint(rect.Right - radius.X, rect.Bottom)); // End point
+
+			// Bottom-left Arc
+			path.CubicTo(
+				new SKPoint(rect.Left + bezierX, rect.Bottom),      // 1st control point
+				new SKPoint(rect.Left, rect.Bottom - bezierY),      // 2nd control point
+				new SKPoint(rect.Left, rect.Bottom - radius.Y));     // End point
+
+			// Top-left Arc
+			path.CubicTo(
+				new SKPoint(rect.Left, rect.Top + bezierY),           // 1st control point
+				new SKPoint(rect.Left + bezierX, rect.Top),           // 2nd control point
+				new SKPoint(rect.Left + radius.X, rect.Top));          // End point
+
+			// Top-right Arc
+			path.CubicTo(
+				new SKPoint(rect.Right - bezierX, rect.Top),       // 1st control point
+				new SKPoint(rect.Right, rect.Top + bezierY),       // 2nd control point
+				new SKPoint(rect.Right, rect.Top + radius.Y));      // End point
+
+			path.Close();
+
+			return path;
+		}
+
+		private static float Clamp(float value, float minValue, float maxValue)
+		{
+			return Math.Min(Math.Max(Math.Abs(value), minValue), maxValue);
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionGradientBrush.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionGradientBrush.cs
@@ -52,13 +52,21 @@ namespace Windows.UI.Composition
 		public float RotationAngleInDegrees
 		{
 			get => _rotationAngleInDegrees;
-			set { _rotationAngle = value * (float)(Math.PI / 180); SetProperty(ref _rotationAngleInDegrees, value); }
+			set
+			{
+				_rotationAngle = value * (float)(Math.PI / 180);
+				SetProperty(ref _rotationAngleInDegrees, value);
+			}
 		}
 
 		public float RotationAngle
 		{
 			get => _rotationAngle;
-			set { _rotationAngleInDegrees = value * 180 / (float)Math.PI; SetProperty(ref _rotationAngle, value); }
+			set
+			{
+				_rotationAngleInDegrees = value * 180 / (float)Math.PI;
+				SetProperty(ref _rotationAngle, value);
+			}
 		}
 
 		public Vector2 Offset

--- a/src/Uno.UWP/UI/Composition/CompositionGradientBrush.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionGradientBrush.cs
@@ -1,0 +1,109 @@
+﻿#nullable enable
+
+using System;
+using System.Numerics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionGradientBrush : CompositionBrush
+	{
+		private CompositionGradientExtendMode _extendMode;
+		private CompositionMappingMode _mappingMode;
+		private Matrix3x2 _transformMatrix = Matrix3x2.Identity;
+		private Matrix3x2 _relativeTransformMatrix = Matrix3x2.Identity;
+		private Vector2 _scale = new Vector2(1, 1);
+		private float _rotationAngleInDegrees;
+		private float _rotationAngle;
+		private Vector2 _offset;
+		private Vector2 _centerPoint;
+
+		internal CompositionGradientBrush(Compositor compositor)
+			: base(compositor)
+		{
+			ColorStops = new CompositionColorGradientStopCollection(this);
+		}
+
+		public CompositionColorGradientStopCollection ColorStops { get; }
+
+		public CompositionGradientExtendMode ExtendMode
+		{
+			get => _extendMode;
+			set => SetProperty(ref _extendMode, value); 
+		}
+
+		public CompositionMappingMode MappingMode
+		{
+			get => _mappingMode;
+			set => SetProperty(ref _mappingMode, value);
+		}
+
+		public Matrix3x2 TransformMatrix
+		{
+			get => _transformMatrix;
+			set => SetProperty(ref _transformMatrix, value);
+		}
+
+		public Vector2 Scale
+		{
+			get => _scale;
+			set => SetProperty(ref _scale, value);
+		}
+
+		public float RotationAngleInDegrees
+		{
+			get => _rotationAngleInDegrees;
+			set { _rotationAngle = value * (float)(Math.PI / 180); SetProperty(ref _rotationAngleInDegrees, value); }
+		}
+
+		public float RotationAngle
+		{
+			get => _rotationAngle;
+			set { _rotationAngleInDegrees = value * 180 / (float)Math.PI; SetProperty(ref _rotationAngle, value); }
+		}
+
+		public Vector2 Offset
+		{
+			get => _offset;
+			set => SetProperty(ref _offset, value);
+		}
+
+		public Vector2 CenterPoint
+		{
+			get => _centerPoint;
+			set => SetProperty(ref _centerPoint, value);
+		}
+
+		internal Matrix3x2 RelativeTransformMatrix
+		{
+			get => _relativeTransformMatrix;
+			set => SetProperty(ref _relativeTransformMatrix, value);
+		}
+
+		internal void InvalidateColorStops()
+		{
+			OnPropertyChanged(nameof(ColorStops), true);
+		}
+
+		private protected override void OnPropertyChangedCore(string? propertyName, bool isSubPropertyChange)
+		{
+			switch (propertyName)
+			{
+				case nameof(ColorStops):
+					OnColorStopsChanged(ColorStops);
+					break;
+				case nameof(ExtendMode):
+					OnExtendModeChanged(ExtendMode);
+					break;
+				case nameof(MappingMode):
+					OnMappingModeChanged(MappingMode);
+					break;
+				default:
+					break;
+			}
+		}
+
+		partial void OnExtendModeChanged(CompositionGradientExtendMode extendMode);
+		partial void OnColorStopsChanged(CompositionColorGradientStopCollection colorStops);
+		partial void OnMappingModeChanged(CompositionMappingMode mappingMode);
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionGradientBrush.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionGradientBrush.skia.cs
@@ -1,0 +1,133 @@
+﻿#nullable enable
+
+using System.Numerics;
+using SkiaSharp;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionGradientBrush
+	{
+		private bool _isColorStopsValid;
+
+		private SKColor[]? _colors;
+		private float[]? _colorPositions;
+		private SKShaderTileMode _tileMode;
+
+		private protected SKColor[]? Colors => _colors;
+		private protected float[]? ColorPositions => _colorPositions;
+		private protected SKShaderTileMode TileMode => _tileMode;
+
+		internal override sealed void UpdatePaint(SKPaint paint, SKRect bounds)
+		{
+			if (!_isColorStopsValid)
+			{
+				UpdateColorStops(ColorStops);
+			}
+
+			UpdatePaintCore(paint, bounds);
+		}
+
+		private protected virtual void UpdatePaintCore(SKPaint paint, SKRect bounds)
+		{
+
+		}
+
+		private protected SKMatrix CreateTransformMatrix(SKRect bounds)
+		{
+			var transform = SKMatrix.Identity;
+
+			// Translate to origin
+			if (CenterPoint != Vector2.Zero)
+			{
+				transform = SKMatrix.CreateTranslation(-CenterPoint.X, -CenterPoint.Y);
+			}
+
+			// Scaling
+			if (Scale != Vector2.One)
+			{
+				transform = transform.PostConcat(SKMatrix.CreateScale(Scale.X, Scale.Y));
+			}
+
+			// Rotating
+			if (RotationAngle != 0)
+			{
+				transform = transform.PostConcat(SKMatrix.CreateRotation(RotationAngle));
+			}
+
+			// Translating
+			if (Offset != Vector2.Zero)
+			{
+				transform = transform.PostConcat(SKMatrix.CreateTranslation(Offset.X, Offset.Y));
+			}
+
+			// Translate back
+			if (CenterPoint != Vector2.Zero)
+			{
+				transform = transform.PostConcat(SKMatrix.CreateTranslation(CenterPoint.X, CenterPoint.Y));
+			}
+
+			if (!TransformMatrix.IsIdentity)
+			{
+				transform = transform.PostConcat(TransformMatrix.ToSKMatrix());
+			}
+
+			var relativeTransform = RelativeTransformMatrix.IsIdentity ? SKMatrix.Identity : RelativeTransformMatrix.ToSKMatrix();
+			if (!relativeTransform.IsIdentity)
+			{
+				relativeTransform.TransX *= bounds.Width;
+				relativeTransform.TransY *= bounds.Height;
+
+				transform = transform.PostConcat(relativeTransform);
+			}
+
+			return transform;
+		}
+
+		private void UpdateColorStops(CompositionColorGradientStopCollection colorStops)
+		{
+			var stopCount = colorStops.Count;
+			var colors = _colors;
+			var colorPositions = _colorPositions;
+
+			if (colors == null || colors.Length != stopCount)
+			{
+				colors = new SKColor[stopCount];
+				colorPositions = new float[stopCount];
+			}
+
+			for (int i = 0; i < colorStops.Count; i++)
+			{
+				var gradientStop = colorStops[i];
+
+				colors[i] = gradientStop.Color.ToSKColor();
+				colorPositions![i] = gradientStop.Offset;
+			}
+
+			_colors = colors;
+			_colorPositions = colorPositions;
+			_isColorStopsValid = true;
+		}
+
+		partial void OnColorStopsChanged(CompositionColorGradientStopCollection colorStops) => _isColorStopsValid = false;
+
+		partial void OnExtendModeChanged(CompositionGradientExtendMode extendMode)
+		{
+			SKShaderTileMode tileMode;
+			switch (extendMode)
+			{
+				default:
+				case CompositionGradientExtendMode.Clamp:
+					tileMode = SKShaderTileMode.Clamp;
+					break;
+				case CompositionGradientExtendMode.Mirror:
+					tileMode = SKShaderTileMode.Mirror;
+					break;
+				case CompositionGradientExtendMode.Wrap:
+					tileMode = SKShaderTileMode.Repeat;
+					break;
+			}
+
+			_tileMode = tileMode;
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionGradientExtendMode.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionGradientExtendMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Windows.UI.Composition
+{
+	public enum CompositionGradientExtendMode
+	{
+		Clamp = 0,
+		Wrap = 1,
+		Mirror = 2
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionLineGeometry.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionLineGeometry.cs
@@ -1,0 +1,29 @@
+﻿#nullable enable
+
+using System.Numerics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionLineGeometry : CompositionGeometry
+	{
+		private Vector2 _start;
+		private Vector2 _end;
+
+		internal CompositionLineGeometry(Compositor compositor) : base(compositor)
+		{
+
+		}
+
+		public Vector2 Start
+		{
+			get => _start;
+			set => SetProperty(ref _start, value);
+		}
+
+		public Vector2 End
+		{
+			get => _end;
+			set => SetProperty(ref _end, value);
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionLineGeometry.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionLineGeometry.skia.cs
@@ -1,0 +1,11 @@
+﻿#nullable enable
+
+using Windows.Graphics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionLineGeometry : CompositionGeometry
+	{
+		internal override IGeometrySource2D? BuildGeometry() => new SkiaGeometrySource2D(BuildLineGeometry(Start, End));
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionLinearGradientBrush.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionLinearGradientBrush.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+
+using System.Numerics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionLinearGradientBrush : CompositionGradientBrush
+	{
+		private Vector2 _startPoint = Vector2.Zero;
+		private Vector2 _endPoint = new Vector2(1, 0);
+
+		internal CompositionLinearGradientBrush(Compositor compositor)
+			: base(compositor)
+		{
+
+		}
+
+		public Vector2 StartPoint
+		{
+			get => _startPoint;
+			set => SetProperty(ref _startPoint, value);
+		}
+
+		public Vector2 EndPoint
+		{
+			get => _endPoint;
+			set => SetProperty(ref _endPoint, value);
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionLinearGradientBrush.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionLinearGradientBrush.skia.cs
@@ -45,6 +45,7 @@ namespace Windows.UI.Composition
 			}
 
 			paint.Shader = shader;
+			paint.Color = SKColors.Black.WithAlpha((byte)(Compositor.CurrentOpacity * 255));
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionLinearGradientBrush.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionLinearGradientBrush.skia.cs
@@ -1,0 +1,50 @@
+﻿#nullable enable
+
+using SkiaSharp;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionLinearGradientBrush
+	{
+		private protected override void UpdatePaintCore(SKPaint paint, SKRect bounds)
+		{
+			var startPoint = StartPoint.ToSKPoint();
+			var endPoint = EndPoint.ToSKPoint();
+			var transform = CreateTransformMatrix(bounds);
+
+			// Transform the points into absolute coordinates.
+			if (MappingMode == CompositionMappingMode.Relative)
+			{
+				// If mapping is relative to bounding box, multiply points by bounds.
+				startPoint.X *= (float)bounds.Width;
+				startPoint.Y *= (float)bounds.Height;
+
+				endPoint.X *= (float)bounds.Width;
+				endPoint.Y *= (float)bounds.Height;
+			}
+
+			// Translate gradient points by bounds offset.
+			startPoint.X += bounds.Left;
+			startPoint.Y += bounds.Top;
+
+			endPoint.X += bounds.Left;
+			endPoint.Y += bounds.Top;
+			//
+
+			// Create linear gradient shader.
+			var shader = SKShader.CreateLinearGradient(
+				startPoint, endPoint,
+				Colors, ColorPositions,
+				TileMode, transform);
+
+			// Clean up old shader
+			if (paint.Shader != null)
+			{
+				paint.Shader.Dispose();
+				paint.Shader = null;
+			}
+
+			paint.Shader = shader;
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionMappingMode.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionMappingMode.cs
@@ -1,0 +1,8 @@
+﻿namespace Windows.UI.Composition
+{
+	public enum CompositionMappingMode
+	{
+		Absolute = 0,
+		Relative = 1
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionObject.Context.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionObject.Context.cs
@@ -1,0 +1,124 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionObject
+	{
+		private class ContextStore
+		{
+			private readonly object _lock = new object();
+			private List<ContextEntry>? _contextEntries = null;
+
+			public ContextStore()
+			{
+
+			}
+
+			public void AddContext(CompositionObject context, string? propertyName)
+			{
+				lock (_lock)
+				{
+					AddContextImpl(context, propertyName);
+				}
+			}
+
+			public void RemoveContext(CompositionObject context, string? propertyName)
+			{
+				lock (_lock)
+				{
+					RemoveContextImpl(context, propertyName);
+				}
+			}
+
+			public void RaiseChanged()
+			{
+				lock (_lock)
+				{
+					RaiseChangedImpl();
+				}
+			}
+
+			private void AddContextImpl(CompositionObject newContext, string? propertyName)
+			{
+				var contextEntries = _contextEntries;
+				if (contextEntries == null)
+				{
+					contextEntries = new List<ContextEntry>();
+					_contextEntries = contextEntries;
+				}
+
+				contextEntries.Add(new ContextEntry(newContext, propertyName));
+			}
+
+			private void RemoveContextImpl(CompositionObject oldContext, string? propertyName)
+			{
+				var contextEntries = _contextEntries;
+				if (contextEntries == null)
+				{
+					return;
+				}
+
+				for (int i = contextEntries.Count - 1; i >= 0; i--)
+				{
+					var contextEntry = contextEntries[i];
+
+					if (!contextEntry.Context.TryGetTarget(out CompositionObject? context))
+					{
+						// Clean up dead references.
+						contextEntries.RemoveAt(i);
+						continue;
+					}
+
+					if (context == oldContext && contextEntry.PropertyName == propertyName)
+					{
+						contextEntries.RemoveAt(i);
+						break;
+					}
+				}
+
+				if (contextEntries.Count == 0)
+				{
+					_contextEntries = null;
+				}
+			}
+
+			private void RaiseChangedImpl()
+			{
+				var contextEntries = _contextEntries;
+				if (contextEntries == null)
+				{
+					return;
+				}
+
+				for (int i = contextEntries.Count - 1; i >= 0; i--)
+				{
+					var contextEntry = contextEntries[i];
+
+					if (!contextEntry.Context.TryGetTarget(out CompositionObject? context))
+					{
+						// Clean up dead references.
+						contextEntries.RemoveAt(i);
+						continue;
+					}
+
+					context!.OnPropertyChanged(contextEntry.PropertyName, true);
+				}
+			}
+
+			private class ContextEntry
+			{
+				public ContextEntry(CompositionObject context, string? propertyName)
+				{
+					Context = new WeakReference<CompositionObject>(context);
+					PropertyName = propertyName;
+				}
+
+				public WeakReference<CompositionObject> Context { get; }
+				public string? PropertyName { get; }
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionObject.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionObject.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Windows.Foundation.Metadata;
 using Windows.UI.Core;
@@ -91,120 +90,6 @@ namespace Windows.UI.Composition
 		private protected virtual void OnPropertyChangedCore(string? propertyName, bool isSubPropertyChange)
 		{
 
-		}
-
-		private class ContextStore
-		{
-			private readonly object _lock = new object();
-			private List<ContextEntry>? _contextEntries = null;
-
-			public ContextStore()
-			{
-
-			}
-
-			public void AddContext(CompositionObject context, string? propertyName)
-			{
-				lock (_lock)
-				{
-					AddContextImpl(context, propertyName);
-				}
-			}
-
-			public void RemoveContext(CompositionObject context, string? propertyName)
-			{
-				lock (_lock)
-				{
-					RemoveContextImpl(context, propertyName);
-				}
-			}
-
-			public void RaiseChanged()
-			{
-				lock (_lock)
-				{
-					RaiseChangedImpl();
-				}
-			}
-
-			private void AddContextImpl(CompositionObject newContext, string? propertyName)
-			{
-				var contextEntries = _contextEntries;
-				if (contextEntries == null)
-				{
-					contextEntries = new List<ContextEntry>();
-					_contextEntries = contextEntries;
-				}
-
-				contextEntries.Add(new ContextEntry(newContext, propertyName));
-			}
-
-			private void RemoveContextImpl(CompositionObject oldContext, string? propertyName)
-			{
-				var contextEntries = _contextEntries;
-				if (contextEntries == null)
-				{
-					return;
-				}
-
-				for (int i = contextEntries.Count - 1; i >= 0; i--)
-				{
-					var contextEntry = contextEntries[i];
-
-					if (!contextEntry.Context.TryGetTarget(out CompositionObject? context))
-					{
-						// Clean up dead references.
-						contextEntries.RemoveAt(i);
-						continue;
-					}
-
-					if (context == oldContext && contextEntry.PropertyName == propertyName)
-					{
-						contextEntries.RemoveAt(i);
-						break;
-					}
-				}
-
-				if (contextEntries.Count == 0)
-				{
-					_contextEntries = null;
-				}
-			}
-
-			private void RaiseChangedImpl()
-			{
-				var contextEntries = _contextEntries;
-				if (contextEntries == null)
-				{
-					return;
-				}
-
-				for (int i = contextEntries.Count - 1; i >= 0; i--)
-				{
-					var contextEntry = contextEntries[i];
-
-					if (!contextEntry.Context.TryGetTarget(out CompositionObject? context))
-					{
-						// Clean up dead references.
-						contextEntries.RemoveAt(i);
-						continue;
-					}
-
-					context!.OnPropertyChanged(contextEntry.PropertyName, true);
-				}
-			}
-
-			private class ContextEntry
-			{
-				public ContextEntry(CompositionObject context, string? propertyName)
-				{
-					Context = new WeakReference<CompositionObject>(context);
-					PropertyName = propertyName;
-				}
-
-				public WeakReference<CompositionObject> Context { get; }
-				public string? PropertyName { get; }
-			}
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionObject.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionObject.cs
@@ -1,14 +1,16 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Windows.Foundation.Metadata;
 using Windows.UI.Core;
 
 namespace Windows.UI.Composition
 {
-	public partial class CompositionObject : global::System.IDisposable
+	public partial class CompositionObject : IDisposable
 	{
-		private object _gate = new object();
+		private readonly ContextStore _contextStore = new ContextStore();
 
 		internal CompositionObject()
 		{
@@ -25,17 +27,184 @@ namespace Windows.UI.Composition
 
 		public CoreDispatcher Dispatcher => CoreDispatcher.Main;
 
+		public string? Comment { get; set; }
+
 		public void StartAnimation(string propertyName, CompositionAnimation animation)
 		{
 			StartAnimationCore(propertyName, animation);
 		}
 
-		internal virtual void StartAnimationCore(string propertyName, CompositionAnimation animation) { }
-
 		public void StopAnimation(string propertyName)
 		{
+
 		}
 
-		public string? Comment { get; set; }
+		internal virtual void StartAnimationCore(string propertyName, CompositionAnimation animation) { }
+
+		internal void AddContext(CompositionObject context, string? propertyName)
+		{
+			_contextStore.AddContext(context, propertyName);
+		}
+
+		internal void RemoveContext(CompositionObject context, string? propertyName)
+		{
+			_contextStore.RemoveContext(context, propertyName);
+		}
+
+		private protected void SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+		{
+			var fieldCO = field as CompositionObject;
+			var valueCO = value as CompositionObject;
+			if (fieldCO != null || value != null)
+			{
+				OnCompositionPropertyChanged(fieldCO, valueCO, propertyName);
+			}
+
+			field = value;
+
+			OnPropertyChanged(propertyName, false);
+		}
+
+		private protected void OnChanged() => OnPropertyChanged(null, false);
+
+		private protected void OnCompositionPropertyChanged(CompositionObject? oldValue, CompositionObject? newValue) => OnCompositionPropertyChanged(oldValue, newValue, null);
+
+		private protected void OnCompositionPropertyChanged(CompositionObject? oldValue, CompositionObject? newValue, string? propertyName)
+		{
+			if (oldValue != null)
+			{
+				oldValue.RemoveContext(this, propertyName);
+			}
+
+			if (newValue != null)
+			{
+				newValue.AddContext(this, propertyName);
+			}
+		}
+
+		private protected void OnPropertyChanged(string? propertyName, bool isSubPropertyChange)
+		{
+			OnPropertyChangedCore(propertyName, isSubPropertyChange);
+			_contextStore.RaiseChanged();
+		}
+
+		private protected virtual void OnPropertyChangedCore(string? propertyName, bool isSubPropertyChange)
+		{
+
+		}
+
+		private class ContextStore
+		{
+			private readonly object _lock = new object();
+			private List<ContextEntry>? _contextEntries = null;
+
+			public ContextStore()
+			{
+
+			}
+
+			public void AddContext(CompositionObject context, string? propertyName)
+			{
+				lock (_lock)
+				{
+					AddContextImpl(context, propertyName);
+				}
+			}
+
+			public void RemoveContext(CompositionObject context, string? propertyName)
+			{
+				lock (_lock)
+				{
+					RemoveContextImpl(context, propertyName);
+				}
+			}
+
+			public void RaiseChanged()
+			{
+				lock (_lock)
+				{
+					RaiseChangedImpl();
+				}
+			}
+
+			private void AddContextImpl(CompositionObject newContext, string? propertyName)
+			{
+				var contextEntries = _contextEntries;
+				if (contextEntries == null)
+				{
+					contextEntries = new List<ContextEntry>();
+					_contextEntries = contextEntries;
+				}
+
+				contextEntries.Add(new ContextEntry(newContext, propertyName));
+			}
+
+			private void RemoveContextImpl(CompositionObject oldContext, string? propertyName)
+			{
+				var contextEntries = _contextEntries;
+				if (contextEntries == null)
+				{
+					return;
+				}
+
+				for (int i = contextEntries.Count - 1; i >= 0; i--)
+				{
+					var contextEntry = contextEntries[i];
+
+					if (!contextEntry.Context.TryGetTarget(out CompositionObject? context))
+					{
+						// Clean up dead references.
+						contextEntries.RemoveAt(i);
+						continue;
+					}
+
+					if (context == oldContext && contextEntry.PropertyName == propertyName)
+					{
+						contextEntries.RemoveAt(i);
+						break;
+					}
+				}
+
+				if (contextEntries.Count == 0)
+				{
+					_contextEntries = null;
+				}
+			}
+
+			private void RaiseChangedImpl()
+			{
+				var contextEntries = _contextEntries;
+				if (contextEntries == null)
+				{
+					return;
+				}
+
+				for (int i = contextEntries.Count - 1; i >= 0; i--)
+				{
+					var contextEntry = contextEntries[i];
+
+					if (!contextEntry.Context.TryGetTarget(out CompositionObject? context))
+					{
+						// Clean up dead references.
+						contextEntries.RemoveAt(i);
+						continue;
+					}
+
+					context!.OnPropertyChanged(contextEntry.PropertyName, true);
+				}
+			}
+
+			private class ContextEntry
+			{
+				public ContextEntry(CompositionObject context, string? propertyName)
+				{
+					Context = new WeakReference<CompositionObject>(context);
+					PropertyName = propertyName;
+				}
+
+				public WeakReference<CompositionObject> Context { get; }
+				public string? PropertyName { get; }
+			}
+		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionPathGeometry.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionPathGeometry.cs
@@ -1,14 +1,24 @@
 #nullable enable
 
+using Windows.Graphics;
+
 namespace Windows.UI.Composition
 {
 	public partial class CompositionPathGeometry : CompositionGeometry
 	{
+		private CompositionPath? _path;
+
 		internal CompositionPathGeometry(Compositor compositor, CompositionPath? path = null) : base(compositor)
 		{
 			Path = path;
 		}
 
-		public CompositionPath? Path { get; set; }
+		public CompositionPath? Path
+		{
+			get => _path;
+			set => SetProperty(ref _path, value);
+		}
+
+		internal override IGeometrySource2D? BuildGeometry() => Path?.GeometrySource;
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionRadialGradientBrush.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionRadialGradientBrush.cs
@@ -1,0 +1,37 @@
+﻿#nullable enable
+
+using System.Numerics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionRadialGradientBrush : CompositionGradientBrush
+	{
+		private Vector2 _gradientOriginOffset = Vector2.Zero;
+		private Vector2 _ellipseRadius = new Vector2(0.5f, 0.5f);
+		private Vector2 _ellipseCenter = new Vector2(0.5f, 0.5f);
+
+		internal CompositionRadialGradientBrush(Compositor compositor)
+			: base(compositor)
+		{
+
+		}
+
+		public Vector2 GradientOriginOffset
+		{
+			get => _gradientOriginOffset;
+			set => SetProperty(ref _gradientOriginOffset, value);
+		}
+
+		public Vector2 EllipseRadius
+		{
+			get => _ellipseRadius;
+			set => SetProperty(ref _ellipseRadius, value);
+		}
+
+		public Vector2 EllipseCenter
+		{
+			get => _ellipseCenter;
+			set => SetProperty(ref _ellipseCenter, value);
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionRadialGradientBrush.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionRadialGradientBrush.skia.cs
@@ -1,0 +1,133 @@
+﻿#nullable enable
+
+using SkiaSharp;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionRadialGradientBrush : CompositionGradientBrush
+	{
+		private protected override void UpdatePaintCore(SKPaint paint, SKRect bounds)
+		{
+			var center = EllipseCenter.ToSKPoint();
+			var gradientOrigin = EllipseCenter.ToSKPoint() + GradientOriginOffset.ToSKPoint();
+			var radius = EllipseRadius.ToSKPoint();
+			var transform = CreateTransformMatrix(bounds);
+
+			// Transform the points into absolute coordinates.
+			if (MappingMode == CompositionMappingMode.Relative)
+			{
+				// If the point are provided relative they must be multiplied by bounds.
+				center.X *= bounds.Width;
+				center.Y *= bounds.Height;
+
+				gradientOrigin.X *= bounds.Width;
+				gradientOrigin.Y *= bounds.Height;
+
+				radius.X *= bounds.Width;
+				radius.Y *= bounds.Height;
+			}
+
+			// Translate gradient points by bounds offset.
+			center.X += bounds.Left;
+			center.Y += bounds.Top;
+
+			gradientOrigin.X += bounds.Left;
+			gradientOrigin.Y += bounds.Top;
+			//
+
+			// SkiaSharp does not allow explicit definition of RadiusX and RadiusY.
+			// Compute transformation matrix to compensate.
+			ComputeRadiusAndScale(center, radius.X, radius.Y, out float gradientRadius, out SKMatrix matrix);
+
+			// Clean up old shader
+			if (paint.Shader != null)
+			{
+				paint.Shader.Dispose();
+				paint.Shader = null;
+			}
+
+			if (gradientRadius > 0)
+			{
+				// Create radial gradient shader.
+				SKShader shader =
+					SKShader.CreateTwoPointConicalGradient(
+						/* start */ gradientOrigin, /* start radius */ 0,
+						/* end */ center, /* gradient radius */ gradientRadius,
+						Colors, ColorPositions,
+						TileMode, transform.PreConcat(matrix));
+
+				paint.Shader = shader;
+			}
+			else
+			{
+				// With radius equal to 0, SkiaSharp does not draw anything.
+				// But we expect last gradient color.
+
+				// If there are no gradient stops available, use transparent.
+				SKColor color = SKColors.Transparent;
+				if (Colors!.Length > 0)
+				{
+					color = Colors[Colors.Length - 1];
+				}
+
+				paint.Color = color;
+			}
+		}
+
+		private void ComputeRadiusAndScale(SKPoint center, float radiusX, float radiusY, out float radius, out SKMatrix matrix)
+		{
+			matrix = SKMatrix.Identity;
+			if (radiusX == 0 || radiusY == 0)
+			{
+				// Handle this specific case as zero division would cause us troubles.
+				radius = 0;
+				return;
+			}
+
+			float scaleDownRatio;
+			if (radiusX >= radiusY)
+			{
+				// radiusX is larger, use it and scale down radiusY.
+				radius = radiusX;
+
+				scaleDownRatio = radiusY / radiusX;
+
+				SetScaleTranslate(
+					ref matrix,
+					/* scale x */ 1,
+					/* scale y */ scaleDownRatio,
+					/* translate x */ 0,
+					/* translate y */ center.Y - scaleDownRatio * center.Y);
+			}
+			else
+			{
+				// radiusY is larger, use it and scale down radiusX.
+				radius = radiusY;
+
+				scaleDownRatio = radiusX / radiusY;
+
+				SetScaleTranslate(
+					ref matrix,
+					/* scale x */ scaleDownRatio,
+					/* scale y */ 1,
+					/* translate x */ center.X - scaleDownRatio * center.X,
+					/* translate y */ 0);
+			}
+		}
+
+		private void SetScaleTranslate(ref SKMatrix matrix, float sx, float sy, float tx, float ty)
+		{
+			matrix.ScaleX = sx;
+			matrix.SkewX = 0;
+			matrix.TransX = tx;
+
+			matrix.SkewY = 0;
+			matrix.ScaleY = sy;
+			matrix.TransY = ty;
+
+			matrix.Persp0 = 0;
+			matrix.Persp1 = 0;
+			matrix.Persp2 = 1;
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionRadialGradientBrush.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionRadialGradientBrush.skia.cs
@@ -57,6 +57,7 @@ namespace Windows.UI.Composition
 						TileMode, transform.PreConcat(matrix));
 
 				paint.Shader = shader;
+				paint.Color = SKColors.Black.WithAlpha((byte)(Compositor.CurrentOpacity * 255));
 			}
 			else
 			{
@@ -70,7 +71,8 @@ namespace Windows.UI.Composition
 					color = Colors[Colors.Length - 1];
 				}
 
-				paint.Color = color;
+				double alpha = (color.Alpha / 255.0) * Compositor.CurrentOpacity;
+				paint.Color = color.WithAlpha((byte)(alpha * 255));
 			}
 		}
 

--- a/src/Uno.UWP/UI/Composition/CompositionRectangleGeometry.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionRectangleGeometry.cs
@@ -1,0 +1,29 @@
+﻿#nullable enable
+
+using System.Numerics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionRectangleGeometry : CompositionGeometry
+	{
+		private Vector2 _size;
+		private Vector2 _offset;
+
+		internal CompositionRectangleGeometry(Compositor compositor) : base(compositor)
+		{
+
+		}
+
+		public Vector2 Size
+		{
+			get => _size;
+			set => SetProperty(ref _size, value);
+		}
+
+		public Vector2 Offset
+		{
+			get => _offset;
+			set => SetProperty(ref _offset, value);
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionRectangleGeometry.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionRectangleGeometry.skia.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+
+using SkiaSharp;
+using Windows.Graphics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionRectangleGeometry : CompositionGeometry
+	{
+		internal override IGeometrySource2D? BuildGeometry()
+			=> new SkiaGeometrySource2D(BuildRectangleGeometry(Offset, Size));
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionRoundedRectangleGeometry.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionRoundedRectangleGeometry.cs
@@ -1,0 +1,36 @@
+﻿#nullable enable
+
+using System.Numerics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionRoundedRectangleGeometry : CompositionGeometry
+	{
+		private Vector2 _size;
+		private Vector2 _offset;
+		private Vector2 _cornerRadius;
+
+		internal CompositionRoundedRectangleGeometry(Compositor compositor) : base(compositor)
+		{
+
+		}
+
+		public Vector2 Size
+		{
+			get => _size;
+			set => SetProperty(ref _size, value);
+		}
+
+		public Vector2 Offset
+		{
+			get => _offset;
+			set => SetProperty(ref _offset, value);
+		}
+
+		public Vector2 CornerRadius
+		{
+			get => _cornerRadius;
+			set => SetProperty(ref _cornerRadius, value);
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionRoundedRectangleGeometry.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionRoundedRectangleGeometry.skia.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+
+using System.Numerics;
+using SkiaSharp;
+using Windows.Graphics;
+
+namespace Windows.UI.Composition
+{
+	public partial class CompositionRoundedRectangleGeometry : CompositionGeometry
+	{
+		internal override IGeometrySource2D? BuildGeometry()
+		{
+			SKPath? path;
+
+			Vector2 cornerRadius = CornerRadius;
+			if (cornerRadius.X == 0 || cornerRadius.Y == 0)
+			{
+				// Simple rectangle
+				path = BuildRectangleGeometry(Offset, Size);
+			}
+			else
+			{
+				// Complex rectangle
+				path = BuildRoundedRectangleGeometry(Offset, Size, CornerRadius);
+			}
+
+			return new SkiaGeometrySource2D(path);
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Composition/CompositionShape.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionShape.cs
@@ -5,24 +5,55 @@ using System.Numerics;
 
 namespace Windows.UI.Composition
 {
-	public partial class CompositionShape : global::Windows.UI.Composition.CompositionObject
+	public partial class CompositionShape : CompositionObject
 	{
+		private Matrix3x2 _transformMatrix = Matrix3x2.Identity;
+		private Vector2 _scale = new Vector2(1, 1);
+		private float _rotationAngleInDegrees;
+		private float _rotationAngle;
+		private Vector2 _offset;
+		private Vector2 _centerPoint;
+
 		internal CompositionShape() => throw new InvalidOperationException($"Use the Compositor ctor");
 
 		internal CompositionShape(Compositor compositor) : base(compositor)
 		{
 		}
 
-		public Matrix3x2 TransformMatrix { get; set; } = Matrix3x2.Identity;
+		public Matrix3x2 TransformMatrix
+		{
+			get => _transformMatrix;
+			set => SetProperty(ref _transformMatrix, value);
+		}
 
-		public Vector2 Scale { get; set; } = new Vector2(1, 1);
+		public Vector2 Scale
+		{
+			get => _scale;
+			set => SetProperty(ref _scale, value);
+		}
 
-		public float RotationAngleInDegrees { get; set; }
+		public float RotationAngleInDegrees
+		{
+			get => _rotationAngleInDegrees;
+			set => SetProperty(ref _rotationAngleInDegrees, value);
+		}
 
-		public float RotationAngle { get; set; }
+		public float RotationAngle
+		{
+			get => _rotationAngle;
+			set => SetProperty(ref _rotationAngle, value);
+		}
 
-		public Vector2 Offset { get; set; }
+		public Vector2 Offset
+		{
+			get => _offset;
+			set => SetProperty(ref _offset, value);
+		}
 
-		public Vector2 CenterPoint { get; set; }
+		public Vector2 CenterPoint
+		{
+			get => _centerPoint;
+			set => SetProperty(ref _centerPoint, value);
+		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionShapeCollection.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionShapeCollection.cs
@@ -1,17 +1,18 @@
 #nullable enable
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
 namespace Windows.UI.Composition
 {
-	public partial class CompositionShapeCollection : CompositionObject, IList<CompositionShape>, IEnumerable<CompositionShape>
+	public partial class CompositionShapeCollection : CompositionObject, IList<CompositionShape>
 	{
-		private List<CompositionShape> _shapes = new List<CompositionShape>();
-		private ShapeVisual shapeVisual;
+		private readonly List<CompositionShape> _shapes = new List<CompositionShape>();
+		private readonly ShapeVisual _shapeVisual;
 
 		internal CompositionShapeCollection(Compositor compositor, ShapeVisual shapeVisual) : base(compositor)
-			=> this.shapeVisual = shapeVisual;
+			=> this._shapeVisual = shapeVisual;
 
 		public int Count => _shapes.Count;
 
@@ -19,22 +20,60 @@ namespace Windows.UI.Composition
 			=> _shapes.IndexOf(item);
 
 		public void Insert(int index, CompositionShape item)
-			=> _shapes.Insert(index, item);
+		{
+			ThrowIfNull(item, nameof(item));
+
+			_shapes.Insert(index, item);
+
+			OnCompositionPropertyChanged(null, item);
+			OnChanged();
+		}
 
 		public void RemoveAt(int index)
-			=> _shapes.RemoveAt(index);
+		{
+			var shape = _shapes[index];
+
+			_shapes.RemoveAt(index);
+
+			OnCompositionPropertyChanged(shape, null);
+			OnChanged();
+		}
 
 		public CompositionShape this[int index]
 		{
 			get => _shapes[index];
-			set => _shapes[index] = value;
+			set
+			{
+				ThrowIfNull(value, nameof(value));
+
+				var oldShape = _shapes[index];
+
+				_shapes[index] = value;
+
+				OnCompositionPropertyChanged(oldShape, value);
+				OnChanged();
+			}
 		}
 
 		public void Add(CompositionShape item)
-			=> _shapes.Add(item);
+		{
+			ThrowIfNull(item, nameof(item));
+			_shapes.Add(item);
+
+			OnCompositionPropertyChanged(null, item);
+			OnChanged();
+		}
 
 		public void Clear()
-			=> _shapes.Clear();
+		{
+			foreach (var shape in _shapes)
+			{
+				OnCompositionPropertyChanged(shape, null);
+			}
+
+			_shapes.Clear();
+			OnChanged();
+		}
 
 		public bool Contains(CompositionShape item)
 			=> _shapes.Contains(item);
@@ -43,7 +82,22 @@ namespace Windows.UI.Composition
 			=> _shapes.CopyTo(array, arrayIndex);
 
 		public bool Remove(CompositionShape item)
-			=> _shapes.Remove(item);
+		{
+			ThrowIfNull(item, nameof(item));
+
+			int index = _shapes.IndexOf(item);
+			if (index < 0)
+			{
+				return false;
+			}
+
+			_shapes.RemoveAt(index);
+
+			OnCompositionPropertyChanged(item, null);
+			OnChanged();
+
+			return true;
+		}
 
 		public bool IsReadOnly => false;
 
@@ -52,5 +106,13 @@ namespace Windows.UI.Composition
 
 		IEnumerator IEnumerable.GetEnumerator()
 			=> _shapes.GetEnumerator();
+
+		private void ThrowIfNull<T>(T? item, string propertyName) where T : class
+		{
+			if (item == null)
+			{
+				throw new ArgumentNullException(propertyName);
+			}
+		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionSpriteShape.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionSpriteShape.cs
@@ -24,110 +24,74 @@ namespace Windows.UI.Composition
 
 		public float StrokeThickness
 		{
-			get => _strokeThickness; set
-			{
-				_strokeThickness = value;
-				Compositor.InvalidateRender();
-			}
+			get => _strokeThickness;
+			set => SetProperty(ref _strokeThickness, value);
 		}
 
 		public CompositionStrokeCap StrokeStartCap
 		{
-			get => _strokeStartCap; set
-			{
-				_strokeStartCap = value;
-				Compositor.InvalidateRender();
-			}
+			get => _strokeStartCap;
+			set => SetProperty(ref _strokeStartCap, value);
 		}
 
 		public float StrokeMiterLimit
 		{
-			get => _strokeMiterLimit; set
-			{
-				_strokeMiterLimit = value;
-				Compositor.InvalidateRender();
-			}
+			get => _strokeMiterLimit;
+			set => SetProperty(ref _strokeMiterLimit, value);
 		}
 
 		public CompositionStrokeLineJoin StrokeLineJoin
 		{
-			get => _strokeLineJoin; set
-			{
-				_strokeLineJoin = value;
-				Compositor.InvalidateRender();
-			}
+			get => _strokeLineJoin;
+			set => SetProperty(ref _strokeLineJoin, value);
 		}
 
 		public CompositionStrokeCap StrokeEndCap
 		{
-			get => _strokeEndCap; set
-			{
-				_strokeEndCap = value;
-				Compositor.InvalidateRender();
-			}
+			get => _strokeEndCap;
+			set => SetProperty(ref _strokeEndCap, value);
 		}
 
 		public float StrokeDashOffset
 		{
-			get => _strokeDashOffset; set
-			{
-				_strokeDashOffset = value;
-				Compositor.InvalidateRender();
-			}
+			get => _strokeDashOffset;
+			set => SetProperty(ref _strokeDashOffset, value);
 		}
 
 		public CompositionStrokeCap StrokeDashCap
 		{
-			get => _strokeDashCap; set
-			{
-				_strokeDashCap = value;
-				Compositor.InvalidateRender();
-			}
+			get => _strokeDashCap;
+			set => SetProperty(ref _strokeDashCap, value);
 		}
 
 		public CompositionBrush? StrokeBrush
 		{
-			get => _strokeBrush; set
-			{
-				_strokeBrush = value;
-				Compositor.InvalidateRender();
-			}
+			get => _strokeBrush;
+			set => SetProperty(ref _strokeBrush, value);
 		}
 
 		public bool IsStrokeNonScaling
 		{
-			get => _isStrokeNonScaling; set
-			{
-				_isStrokeNonScaling = value;
-				Compositor.InvalidateRender();
-			}
+			get => _isStrokeNonScaling;
+			set => SetProperty(ref _isStrokeNonScaling, value);
 		}
 
 		public CompositionGeometry? Geometry
 		{
-			get => _geometry; set
-			{
-				_geometry = value;
-				Compositor.InvalidateRender();
-			}
+			get => _geometry;
+			set => SetProperty(ref _geometry, value);
 		}
 
 		public CompositionBrush? FillBrush
 		{
-			get => _fillBrush; set
-			{
-				_fillBrush = value;
-				Compositor.InvalidateRender();
-			}
+			get => _fillBrush;
+			set => SetProperty(ref _fillBrush, value);
 		}
 
 		public CompositionStrokeDashArray? StrokeDashArray
 		{
-			get => _strokeDashArray; set
-			{
-				_strokeDashArray = value;
-				Compositor.InvalidateRender();
-			}
+			get => _strokeDashArray;
+			set => SetProperty(ref _strokeDashArray, value);
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionSurfaceBrush.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionSurfaceBrush.cs
@@ -1,6 +1,5 @@
 #nullable enable
 
-using System;
 using System.Numerics;
 
 namespace Windows.UI.Composition
@@ -19,134 +18,93 @@ namespace Windows.UI.Composition
 		private float _horizontalAlignmentRatio;
 		private bool _snapToPixels;
 		private float _verticalAlignmentRatio;
-		private CompositionBitmapInterpolationMode bitmapInterpolationMode;
+		private CompositionBitmapInterpolationMode _bitmapInterpolationMode;
 
-		internal event Action? PropertyChanged;
-
-		public CompositionSurfaceBrush(Compositor compositor) : base(compositor)
+		internal CompositionSurfaceBrush(Compositor compositor) : base(compositor)
 		{
 		}
 
-		public CompositionSurfaceBrush(Compositor compositor, ICompositionSurface surface) : base(compositor)
+		internal CompositionSurfaceBrush(Compositor compositor, ICompositionSurface surface) : base(compositor)
 		{
 			Surface = surface;
 		}
 
 		public float VerticalAlignmentRatio
 		{
-			get => _verticalAlignmentRatio; set
-			{
-				_verticalAlignmentRatio = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _verticalAlignmentRatio;
+			set => SetProperty(ref _verticalAlignmentRatio, value);
 		}
 
 		public ICompositionSurface? Surface
 		{
-			get => _surface; set
-			{
-				_surface = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _surface;
+			set => SetProperty(ref _surface, value);
 		}
 
 		public CompositionStretch Stretch
 		{
-			get => _stretch; set
-			{
-				_stretch = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _stretch;
+			set => SetProperty(ref _stretch, value);
 		}
 
 		public float HorizontalAlignmentRatio
 		{
-			get => _horizontalAlignmentRatio; set
-			{
-				_horizontalAlignmentRatio = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _horizontalAlignmentRatio;
+			set => SetProperty(ref _horizontalAlignmentRatio, value);
 		}
 
 		public CompositionBitmapInterpolationMode BitmapInterpolationMode
 		{
-			get => bitmapInterpolationMode; set
-			{
-				bitmapInterpolationMode = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _bitmapInterpolationMode;
+			set => SetProperty(ref _bitmapInterpolationMode, value);
 		}
 
 		public Matrix3x2 TransformMatrix
 		{
-			get => _transformMatrix; set
-			{
-				_transformMatrix = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _transformMatrix;
+			set => SetProperty(ref _transformMatrix, value);
 		}
 
 		public Vector2 Scale
 		{
-			get => _scale; set
-			{
-				_scale = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _scale;
+			set => SetProperty(ref _scale, value);
 		}
 
 		public float RotationAngleInDegrees
 		{
-			get => _rotationAngleInDegrees; set
-			{
-				_rotationAngleInDegrees = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _rotationAngleInDegrees;
+			set => SetProperty(ref _rotationAngleInDegrees, value);
 		}
 
 		public float RotationAngle
 		{
-			get => _rotationAngle; set
-			{
-				_rotationAngle = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _rotationAngle;
+			set => SetProperty(ref _rotationAngle, value);
 		}
 
 		public Vector2 Offset
 		{
-			get => _offset; set
-			{
-				_offset = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _offset;
+			set => SetProperty(ref _offset, value);
 		}
 
 		public Vector2 CenterPoint
 		{
-			get => _centerPoint; set
-			{
-				_centerPoint = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _centerPoint;
+			set => SetProperty(ref _centerPoint, value);
 		}
 
 		public Vector2 AnchorPoint
 		{
-			get => _anchorPoint; set
-			{
-				_anchorPoint = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _anchorPoint;
+			set => SetProperty(ref _anchorPoint, value);
 		}
 
 		public bool SnapToPixels
 		{
-			get => _snapToPixels; set
-			{
-				_snapToPixels = value;
-				PropertyChanged?.Invoke();
-			}
+			get => _snapToPixels;
+			set => SetProperty(ref _snapToPixels, value);
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CompositionSurfaceBrush.skia.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionSurfaceBrush.skia.cs
@@ -8,7 +8,7 @@ namespace Windows.UI.Composition
 {
 	public partial class CompositionSurfaceBrush : CompositionBrush
 	{
-		internal override void UpdatePaint(SKPaint fillPaint)
+		internal override void UpdatePaint(SKPaint fillPaint, SKRect bounds)
 		{
 			if (Surface is SkiaCompositionSurface scs)
 			{

--- a/src/Uno.UWP/UI/Composition/CompositionViewBox.cs
+++ b/src/Uno.UWP/UI/Composition/CompositionViewBox.cs
@@ -6,10 +6,45 @@ namespace Windows.UI.Composition
 {
 	public partial class CompositionViewBox : CompositionObject
 	{
-		public float VerticalAlignmentRatio { get; set; }
-		public CompositionStretch Stretch { get; set; }
-		public Vector2 Size { get; set; }
-		public Vector2 Offset { get; set; }
-		public float HorizontalAlignmentRatio { get; set; }
+		private float _verticalAlignmentRatio;
+		private CompositionStretch _stretch;
+		private Vector2 _size;
+		private Vector2 _offset;
+		private float _horizontalAlignmentRatio;
+
+		internal CompositionViewBox(Compositor compositor) : base (compositor)
+		{
+
+		}
+
+		public float VerticalAlignmentRatio
+		{
+			get => _verticalAlignmentRatio;
+			set => SetProperty(ref _verticalAlignmentRatio, value);
+		}
+
+		public CompositionStretch Stretch
+		{
+			get => _stretch;
+			set => SetProperty(ref _stretch, value);
+		}
+
+		public Vector2 Size
+		{
+			get => _size;
+			set => SetProperty(ref _size, value);
+		}
+
+		public Vector2 Offset
+		{
+			get => _offset;
+			set => SetProperty(ref _offset, value);
+		}
+
+		public float HorizontalAlignmentRatio
+		{
+			get => _horizontalAlignmentRatio;
+			set => SetProperty(ref _horizontalAlignmentRatio, value);
+		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/Compositor.cs
+++ b/src/Uno.UWP/UI/Composition/Compositor.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using Windows.UI;
+
 namespace Windows.UI.Composition
 {
 	public partial class Compositor : global::System.IDisposable

--- a/src/Uno.UWP/UI/Composition/Compositor.cs
+++ b/src/Uno.UWP/UI/Composition/Compositor.cs
@@ -1,7 +1,5 @@
 #nullable enable
 
-using Windows.UI;
-
 namespace Windows.UI.Composition
 {
 	public partial class Compositor : global::System.IDisposable
@@ -50,6 +48,18 @@ namespace Windows.UI.Composition
 		public CompositionPathGeometry CreatePathGeometry(CompositionPath path)
 			=> new CompositionPathGeometry(this, path);
 
+		public CompositionEllipseGeometry CreateEllipseGeometry()
+			=> new CompositionEllipseGeometry(this);
+
+		public CompositionLineGeometry CreateLineGeometry()
+			=> new CompositionLineGeometry(this);
+
+		public CompositionRectangleGeometry CreateRectangleGeometry()
+			=> new CompositionRectangleGeometry(this);
+
+		public CompositionRoundedRectangleGeometry CreateRoundedRectangleGeometry()
+			=> new CompositionRoundedRectangleGeometry(this);
+
 		public CompositionSurfaceBrush CreateSurfaceBrush()
 			=> new CompositionSurfaceBrush(this);
 
@@ -74,6 +84,21 @@ namespace Windows.UI.Composition
 				TopInset = topInset,
 				RightInset = rightInset,
 				BottomInset = bottomInset
+			};
+
+		public CompositionLinearGradientBrush CreateLinearGradientBrush()
+			=> new CompositionLinearGradientBrush(this);
+
+		public CompositionRadialGradientBrush CreateRadialGradientBrush()
+			=> new CompositionRadialGradientBrush(this);
+
+		public CompositionColorGradientStop CreateColorGradientStop()
+			=> new CompositionColorGradientStop(this);
+
+		public CompositionColorGradientStop CreateColorGradientStop(float offset, Color color)
+			=> new CompositionColorGradientStop(this) {
+				Offset = offset,
+				Color = color
 			};
 
 		internal void InvalidateRender() => InvalidateRenderPartial();

--- a/src/Uno.UWP/UI/Composition/ContainerVisual.cs
+++ b/src/Uno.UWP/UI/Composition/ContainerVisual.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Windows.UI.Composition
 {
-	public partial class ContainerVisual : global::Windows.UI.Composition.Visual
+	public partial class ContainerVisual : Visual
 	{
 		internal ContainerVisual() : base(null!) => throw new NotSupportedException("Use the ctor with Compositor");
 

--- a/src/Uno.UWP/UI/Composition/InsetClip.cs
+++ b/src/Uno.UWP/UI/Composition/InsetClip.cs
@@ -2,19 +2,40 @@
 
 namespace Windows.UI.Composition
 {
-	public  partial class InsetClip : CompositionClip
+	public partial class InsetClip : CompositionClip
 	{
-		public InsetClip(Compositor compositor) : base(compositor)
+		private float _topInset;
+		private float _rightInset;
+		private float _leftInset;
+		private float _bottomInset;
+
+		internal InsetClip(Compositor compositor) : base(compositor)
 		{
 
 		}
 
-		public float TopInset { get; set; }
+		public float TopInset
+		{
+			get => _topInset;
+			set => SetProperty(ref _topInset, value);
+		}
 
-		public  float RightInset { get; set; }
+		public float RightInset
+		{
+			get => _rightInset;
+			set => SetProperty(ref _rightInset, value);
+		}
 
-		public  float LeftInset { get; set; }
+		public float LeftInset
+		{
+			get => _leftInset;
+			set => SetProperty(ref _leftInset, value);
+		}
 
-		public  float BottomInset { get; set; }
+		public float BottomInset
+		{
+			get => _bottomInset;
+			set => SetProperty(ref _bottomInset, value);
+		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/ShapeVisual.cs
+++ b/src/Uno.UWP/UI/Composition/ShapeVisual.cs
@@ -2,15 +2,25 @@
 
 namespace Windows.UI.Composition
 {
-	public partial class ShapeVisual : global::Windows.UI.Composition.ContainerVisual
+	public partial class ShapeVisual : ContainerVisual
 	{
+		private CompositionViewBox? _viewBox;
+
 		public ShapeVisual(Compositor compositor)
 			: base(compositor)
 		{
 			Shapes = new CompositionShapeCollection(compositor, this);
+
+			// Add this as context for the shape collection so we get
+			// notified about changes in the shapes object graph.
+			OnCompositionPropertyChanged(null, Shapes, nameof(Shapes));
 		}
 
-		public CompositionViewBox? ViewBox { get; set; }
+		public CompositionViewBox? ViewBox
+		{
+			get => _viewBox;
+			set => SetProperty(ref _viewBox, value);
+		}
 
 		public CompositionShapeCollection Shapes { get; }
 	}

--- a/src/Uno.UWP/UI/Composition/SkiaExtensions.skia.cs
+++ b/src/Uno.UWP/UI/Composition/SkiaExtensions.skia.cs
@@ -27,6 +27,9 @@ namespace Windows.UI.Composition
 		public static SKColor ToSKColor(this Color color, double alphaMultiplier)
 			=> new SKColor(red: color.R, green: color.G, blue: color.B, alpha: (byte)(color.A * alphaMultiplier));
 
+		public static SKPoint ToSKPoint(this Vector2 vector)
+			=> new SKPoint(vector.X, vector.Y);
+
 		public static SKMatrix44 ToSKMatrix44(this Matrix4x4 m)
 		{
 			var ret = new SKMatrix44();

--- a/src/Uno.UWP/UI/Composition/SkiaGeometrySource2D.skia.cs
+++ b/src/Uno.UWP/UI/Composition/SkiaGeometrySource2D.skia.cs
@@ -15,12 +15,7 @@ namespace Windows.UI.Composition
 
 		public SkiaGeometrySource2D(SKPath source)
 		{
-			if (source == null)
-			{
-				throw new ArgumentNullException(nameof(source));
-			}
-
-			Geometry = source;
+			Geometry = source ?? throw new ArgumentNullException(nameof(source));
 		}
 
 		public SKPath Geometry { get; }

--- a/src/Uno.UWP/UI/Composition/SkiaGeometrySource2D.skia.cs
+++ b/src/Uno.UWP/UI/Composition/SkiaGeometrySource2D.skia.cs
@@ -2,19 +2,27 @@
 
 using SkiaSharp;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Windows.Graphics;
 
 namespace Windows.UI.Composition
 {
 	public class SkiaGeometrySource2D : IGeometrySource2D
 	{
-		public SkiaGeometrySource2D(SKPath? source = null)
+		public SkiaGeometrySource2D()
 		{
 			Geometry = new SKPath();
 		}
 
-		public SKPath? Geometry { get; }
+		public SkiaGeometrySource2D(SKPath source)
+		{
+			if (source == null)
+			{
+				throw new ArgumentNullException(nameof(source));
+			}
+
+			Geometry = source;
+		}
+
+		public SKPath Geometry { get; }
 	}
 }

--- a/src/Uno.UWP/UI/Composition/SpriteVisual.cs
+++ b/src/Uno.UWP/UI/Composition/SpriteVisual.cs
@@ -1,7 +1,5 @@
 #nullable enable
 
-using System;
-
 namespace Windows.UI.Composition
 {
 	public partial class SpriteVisual : ContainerVisual
@@ -15,18 +13,22 @@ namespace Windows.UI.Composition
 
 		public CompositionBrush? Brush
 		{
-			get
+			get => _brush;
+			set => SetProperty(ref _brush, value);
+		}
+
+		private protected override void OnPropertyChangedCore(string? propertyName, bool isSubPropertyChange)
+		{
+			// Call base implementation - Visual calls Compositor.InvalidateRender().
+			base.OnPropertyChangedCore(propertyName, isSubPropertyChange);
+
+			switch (propertyName)
 			{
-				return _brush;
-			}
-			set
-			{
-				var previousBrush = _brush;
-				if (_brush != value)
-				{
-					_brush = value;
-					OnBrushChangedPartial(_brush);
-				}
+				case nameof(Brush):
+					OnBrushChangedPartial(Brush);
+					break;
+				default:
+					break;
 			}
 		}
 

--- a/src/Uno.UWP/UI/Composition/SpriteVisual.skia.cs
+++ b/src/Uno.UWP/UI/Composition/SpriteVisual.skia.cs
@@ -1,20 +1,11 @@
 #nullable enable
 
-using System;
-using System.Collections.Generic;
-using System.Numerics;
 using SkiaSharp;
-using Uno.Disposables;
-using Uno.Extensions;
-using Uno.Logging;
-using Windows.UI.WebUI;
 
 namespace Windows.UI.Composition
 {
 	public partial class SpriteVisual : ContainerVisual
 	{
-		private readonly SerialDisposable _csbSubscription = new SerialDisposable();
-
 		private readonly SKPaint _paint
 			= new SKPaint()
 			{
@@ -23,20 +14,12 @@ namespace Windows.UI.Composition
 
 		partial void OnBrushChangedPartial(CompositionBrush? brush)
 		{
-			_csbSubscription.Disposable = null;
-
-			if (brush is CompositionSurfaceBrush csb)
-			{
-				csb.PropertyChanged += UpdatePaint;
-				_csbSubscription.Disposable = Disposable.Create(() => csb.PropertyChanged -= UpdatePaint);
-			}
-
 			UpdatePaint();
 		}
 
 		private void UpdatePaint()
 		{
-			Brush?.UpdatePaint(_paint);
+			Brush?.UpdatePaint(_paint, new SKRect(left: 0, top: 0, right: Size.X, bottom: Size.Y));
 		}
 
 		internal override void Render(SKSurface surface, SKImageInfo info)

--- a/src/Uno.UWP/UI/Composition/Visual.cs
+++ b/src/Uno.UWP/UI/Composition/Visual.cs
@@ -1,12 +1,10 @@
 #nullable enable
 
-using System;
 using System.Numerics;
-using Windows.UI.Core;
 
 namespace Windows.UI.Composition
 {
-	public partial class Visual : global::Windows.UI.Composition.CompositionObject
+	public partial class Visual : CompositionObject
 	{
 		private Vector2 _size;
 		private Vector3 _offset;
@@ -14,9 +12,10 @@ namespace Windows.UI.Composition
 		private Vector3 _centerPoint;
 		private float _rotationAngleInDegrees;
 		private Vector3 _rotationAxis = new Vector3(0, 0, 1);
-		private Matrix4x4 transformMatrix = Matrix4x4.Identity;
-		private bool isVisible = true;
-		private float opacity = 1.0f;
+		private Matrix4x4 _transformMatrix = Matrix4x4.Identity;
+		private bool _isVisible = true;
+		private float _opacity = 1.0f;
+		private CompositionCompositeMode _compositeMode;
 
 		internal Visual(Compositor compositor) : base(compositor)
 		{
@@ -27,59 +26,42 @@ namespace Windows.UI.Composition
 
 		public Matrix4x4 TransformMatrix
 		{
-			get => transformMatrix;
-			set
-			{
-				transformMatrix = value;
-				Compositor.InvalidateRender();
-			}
+			get => _transformMatrix;
+			set => SetProperty(ref _transformMatrix, value);
 		}
+
 		public Vector3 Offset
 		{
 			get => _offset;
-			set
-			{
-				_offset = value;
-				OnOffsetChanged(value);
-				Compositor.InvalidateRender();
-			}
+			set { SetProperty(ref _offset, value); OnOffsetChanged(value); }
 		}
 
 		partial void OnOffsetChanged(Vector3 value);
 
 		public bool IsVisible
 		{
-			get => isVisible;
-			set
-			{
-				isVisible = value;
-				Compositor.InvalidateRender();
-			}
+			get => _isVisible;
+			set => SetProperty(ref _isVisible, value);
 		}
 
-		public CompositionCompositeMode CompositeMode { get; set; }
+		public CompositionCompositeMode CompositeMode
+		{
+			get => _compositeMode;
+			set => SetProperty(ref _compositeMode, value);
+		}
 
 		public Vector3 CenterPoint
 		{
 			get => _centerPoint;
-			set
-			{
-				_centerPoint = value; OnCenterPointChanged(value);
-				Compositor.InvalidateRender();
-			}
+			set { SetProperty(ref _centerPoint, value); OnCenterPointChanged(value); }
 		}
 
 		partial void OnCenterPointChanged(Vector3 value);
 
-		public global::System.Numerics.Vector3 Scale
+		public Vector3 Scale
 		{
 			get => _scale;
-			set
-			{
-				_scale = value;
-				OnScaleChanged(value);
-				Compositor.InvalidateRender();
-			}
+			set { SetProperty(ref _scale, value); OnScaleChanged(value); }
 		}
 
 		partial void OnScaleChanged(Vector3 value);
@@ -87,11 +69,7 @@ namespace Windows.UI.Composition
 		public float RotationAngleInDegrees
 		{
 			get => _rotationAngleInDegrees;
-			set
-			{
-				_rotationAngleInDegrees = value; OnRotationAngleInDegreesChanged(value);
-				Compositor.InvalidateRender();
-			}
+			set { SetProperty(ref _rotationAngleInDegrees, value); OnRotationAngleInDegreesChanged(value); }
 		}
 
 		partial void OnRotationAngleInDegreesChanged(float value);
@@ -99,35 +77,37 @@ namespace Windows.UI.Composition
 		public Vector2 Size
 		{
 			get => _size;
-			set
-			{
-				_size = value; OnSizeChanged(value);
-				Compositor.InvalidateRender();
-			}
+			set { SetProperty(ref _size, value); OnSizeChanged(value); }
 		}
 
 		partial void OnSizeChanged(Vector2 value);
 
 		public float Opacity
 		{
-			get => opacity; set
-			{
-				opacity = value;
-				Compositor.InvalidateRender();
-			}
+			get => _opacity;
+			set => SetProperty(ref _opacity, value);
 		}
+
 		public Vector3 RotationAxis
 		{
 			get => _rotationAxis;
-			set
-			{
-				_rotationAxis = value; OnRotationAxisChanged(value);
-				Compositor.InvalidateRender();
-			}
+			set { SetProperty(ref _rotationAxis, value); OnRotationAxisChanged(value); }
 		}
 
 		partial void OnRotationAxisChanged(Vector3 value);
 
 		public ContainerVisual? Parent { get; set; }
+
+		private protected override void OnPropertyChangedCore(string? propertyName, bool isSubPropertyChange)
+		{
+			// TODO: Determine whether to invalidate renderer based on the fact whether we are attached to a CompositionTarget.
+			//bool isAttached = false;
+			//if (isAttached)
+			//{
+			//	Compositor.InvalidateRender();
+			//}
+
+			Compositor.InvalidateRender();
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #6562

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
- Feature

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
Following brush types are not implemented:
- CompositionColorGradientStop 
- CompositionColorGradientStopCollection 
- CompositionGradientBrush 
- CompositionLinearGradientBrush 
- CompositionRadialGradientBrush 

Following geometry types are not implemented:
- CompositionLineGeometry 
- CompositionRectangleGeometry 
- CompositionRoundedRectangleGeometry 
- CompositionEllipseGeometry 

Whenever a composition property (a property on a CompositionObject) changes it requires a custom logic to handle the change and possibly propagate a notification about the change further. This makes working with CompositionObjects difficult.

There is a bug in Rectangle.skia implementation causing stroke thickness to be ignored when calculating geometry.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Following brush types now implemented:
- CompositionColorGradientStop 
- CompositionColorGradientStopCollection 
- CompositionGradientBrush 
- CompositionLinearGradientBrush 
- CompositionRadialGradientBrush 

Following geometry types are now implemented:
- CompositionLineGeometry 
- CompositionRectangleGeometry 
- CompositionRoundedRectangleGeometry 
- CompositionEllipseGeometry 

Whenever a composition property changes a notification is now propagated to all CompositionObject contexts (context is an another CompositionObject to whose property is the modified CompositionObject assigned to). Those CompositionObjects then propagate the notification further to their own contexts. This usually stops at the Visual which uses this notification to invalidate the scene and causes scene redraw.
- Logic employed here is similar to what WPF does with its Freezables.

Rectangle geometry is now properly offsetted by its stroke thickness.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
