### PR TITLE
feat: Implement sizing methods for ApplicationView

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/ApplicationViewSizing.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/ApplicationViewSizing.xaml
@@ -2,17 +2,24 @@
     x:Class="UITests.Windows_UI_ViewManagement.ApplicationViewSizing"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
 
-    <StackPanel Spacing="12" Padding="12">
-		<controls:NumberBox Header="Width" x:Name="WidthInput" Value="500"  />
-		<controls:NumberBox Header="Height" x:Name="HeightInput" Value="500" />
+    <StackPanel Padding="12" Spacing="12">
+        <controls:NumberBox
+            x:Name="WidthInput"
+            Header="Width"
+            Value="500" />
+        <controls:NumberBox
+            x:Name="HeightInput"
+            Header="Height"
+            Value="500" />
         <Button Click="SetWindowSize_Click">Set window size</Button>
         <Button Click="SetMinWindowSize_Click">Set min window size</Button>
+        <Button Click="SetPreferredLaunchViewSize_Click">Set preferred launch view size</Button>
         <TextBlock>
             <Run FontWeight="Bold" Text="Last SizeChanged at:" />
             <Run x:Name="LastSizeTime" Text="" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/ApplicationViewSizing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/ApplicationViewSizing.xaml.cs
@@ -48,5 +48,10 @@ namespace UITests.Windows_UI_ViewManagement
 					WidthInput.Value,
 					HeightInput.Value));
 		}
+
+		void SetPreferredLaunchViewSize_Click(System.Object sender, Windows.UI.Xaml.RoutedEventArgs e)
+		{
+			ApplicationView.PreferredLaunchViewSize = new Size(WidthInput.Value, HeightInput.Value);
+		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkApplicationViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkApplicationViewExtension.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Windows.Foundation;
 using Windows.UI.ViewManagement;
 
 namespace Uno.UI.Runtime.Skia
@@ -32,6 +33,17 @@ namespace Uno.UI.Runtime.Skia
 		{
 			GtkHost.Window.Fullscreen();
 			return true;
+		}
+
+		public bool TryResizeView(Size size)
+		{
+			GtkHost.Window.Resize((int)size.Width, (int)size.Height);
+			return true;
+		}
+
+		public void SetPreferredMinSize(Size size)
+		{
+			GtkHost.Window.SetSizeRequest((int)size.Width, (int)size.Height);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -18,6 +18,8 @@ using Uno.UI.Runtime.Skia.GTK.Extensions.System;
 using Uno.UI.Runtime.Skia.GTK.UI.Core;
 using Uno.Extensions.Storage.Pickers;
 using Windows.Storage.Pickers;
+using Windows.UI.ViewManagement;
+using Windows.Foundation;
 using Uno.ApplicationModel.DataTransfer;
 using Uno.UI.Runtime.Skia.GTK.Extensions.ApplicationModel.DataTransfer;
 
@@ -65,7 +67,14 @@ namespace Uno.UI.Runtime.Skia
 
 			_isDispatcherThread = true;
 			_window = new Gtk.Window("Uno Host");
-			_window.SetDefaultSize(1024, 800);
+			Size preferredWindowSize = ApplicationView.PreferredLaunchViewSize;
+			if (preferredWindowSize != Size.Empty)
+			{ 
+				_window.SetDefaultSize((int)preferredWindowSize.Width, (int)preferredWindowSize.Height);
+			} else
+			{
+				_window.SetDefaultSize(1024, 800);
+			}
 			_window.SetPosition(Gtk.WindowPosition.Center);
 
 			_window.Realized += (s, e) =>

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -71,7 +71,8 @@ namespace Uno.UI.Runtime.Skia
 			if (preferredWindowSize != Size.Empty)
 			{ 
 				_window.SetDefaultSize((int)preferredWindowSize.Width, (int)preferredWindowSize.Height);
-			} else
+			}
+			else
 			{
 				_window.SetDefaultSize(1024, 800);
 			}

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/ApplicationViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/ApplicationViewExtension.cs
@@ -1,4 +1,7 @@
-﻿using Windows.UI.ViewManagement;
+﻿using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+using Windows.Foundation;
+using Windows.UI.ViewManagement;
 
 namespace Uno.UI.Runtime.Skia
 {
@@ -26,6 +29,23 @@ namespace Uno.UI.Runtime.Skia
 		public bool TryEnterFullScreenMode()
 		{
 			return true;
+		}
+
+		public bool TryResizeView(Size size)
+		{
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().LogWarning("Resizing windows is not yet supported on Linux frame buffer.");
+			}
+			return false;
+		}
+
+		public void SetPreferredMinSize(Size minSize)
+		{
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().LogWarning("Setting min size of windows is not yet supported on Linux frame buffer.");
+			}
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Tizen/TizenApplicationViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Tizen/TizenApplicationViewExtension.cs
@@ -40,5 +40,23 @@ namespace Uno.UI.Runtime.Skia
 			}
 			return false;
 		}
+
+		public bool TryResizeView(Size size)
+        {
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().LogWarning("Resizing windows is not yet supported on Tizen.");
+			}
+			return false;
+		}
+		public void SetPreferredMinSize()
+		{
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().LogWarning("Setting min size of windows is not yet supported on Tizen.");
+			}
+		}
+
+
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Tizen/TizenApplicationViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Tizen/TizenApplicationViewExtension.cs
@@ -41,22 +41,21 @@ namespace Uno.UI.Runtime.Skia
 			return false;
 		}
 
-		public bool TryResizeView(Size size)
-        {
+		public bool TryResizeView(Windows.Foundation.Size size)
+		{
 			if (this.Log().IsEnabled(LogLevel.Warning))
 			{
 				this.Log().LogWarning("Resizing windows is not yet supported on Tizen.");
 			}
 			return false;
 		}
-		public void SetPreferredMinSize()
+
+		public void SetPreferredMinSize(Windows.Foundation.Size minSize)
 		{
 			if (this.Log().IsEnabled(LogLevel.Warning))
 			{
 				this.Log().LogWarning("Setting min size of windows is not yet supported on Tizen.");
 			}
 		}
-
-
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfApplicationViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfApplicationViewExtension.cs
@@ -29,6 +29,19 @@ namespace Uno.UI.Skia.Platform
 		private bool _isFullScreen = false;
 		private (WindowStyle WindowStyle, WindowState WindowState) _previousModes;
 
+		public void SetPreferredMinSize(Windows.Foundation.Size size)
+		{
+			_mainWpfWindow.MinWidth = size.Width;
+			_mainWpfWindow.MinHeight = size.Height;
+		}
+
+		public bool TryResizeView(Windows.Foundation.Size size)
+		{
+			_mainWpfWindow.Width = size.Width;
+			_mainWpfWindow.Height = size.Height;
+			return true;
+		}
+
 		public bool TryEnterFullScreenMode()
 		{
 			if (_isFullScreen || _mainWpfWindow.WindowStyle == WindowStyle.None)

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -31,6 +31,7 @@ using WpfApplication = System.Windows.Application;
 using WpfCanvas = System.Windows.Controls.Canvas;
 using WpfControl = System.Windows.Controls.Control;
 using WpfFrameworkPropertyMetadata = System.Windows.FrameworkPropertyMetadata;
+using Windows.UI.ViewManagement;
 using Uno.UI.Xaml;
 using Uno.UI.Runtime.Skia.Wpf;
 using Uno.ApplicationModel.DataTransfer;
@@ -133,6 +134,13 @@ namespace Uno.UI.Skia.Platform
 			WpfApplication.Current.Activated += Current_Activated;
 			WpfApplication.Current.Deactivated += Current_Deactivated;
 			WpfApplication.Current.MainWindow.StateChanged += MainWindow_StateChanged;
+
+			Windows.Foundation.Size preferredWindowSize = ApplicationView.PreferredLaunchViewSize;
+			if (preferredWindowSize != Windows.Foundation.Size.Empty)
+			{
+				WpfApplication.Current.MainWindow.Width = (int)preferredWindowSize.Width;
+				WpfApplication.Current.MainWindow.Height = (int)preferredWindowSize.Height;
+			}
 
 			SizeChanged += WpfHost_SizeChanged;
 			Loaded += WpfHost_Loaded;

--- a/src/Uno.UI/UI/Xaml/Window.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.macOS.cs
@@ -37,8 +37,18 @@ namespace Windows.UI.Xaml
 		public Window()
 		{
 			var style = NSWindowStyle.Closable | NSWindowStyle.Resizable | NSWindowStyle.Titled | NSWindowStyle.Miniaturizable;
-			var rect = new CoreGraphics.CGRect(100, 100, 1024, 768);
-			_window = new Uno.UI.Controls.Window(rect, style, NSBackingStore.Buffered, false);
+
+			Foundation.Size preferredWindowSize = ApplicationView.PreferredLaunchViewSize;
+			if (preferredWindowSize != Foundation.Size.Empty)
+			{
+				var rect = new CoreGraphics.CGRect(100, 100, (int)preferredWindowSize.Width, (int)preferredWindowSize.Height);
+				_window = new Uno.UI.Controls.Window(rect, style, NSBackingStore.Buffered, false);
+			}
+			else
+			{
+				var rect = new CoreGraphics.CGRect(100, 100, 1024, 768);
+				_window = new Uno.UI.Controls.Window(rect, style, NSBackingStore.Buffered, false);
+			}
 
 			_mainController = ViewControllerGenerator?.Invoke() ?? new RootViewController();
 

--- a/src/Uno.UI/UI/Xaml/Window.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.macOS.cs
@@ -38,8 +38,8 @@ namespace Windows.UI.Xaml
 		{
 			var style = NSWindowStyle.Closable | NSWindowStyle.Resizable | NSWindowStyle.Titled | NSWindowStyle.Miniaturizable;
 
-			Foundation.Size preferredWindowSize = ApplicationView.PreferredLaunchViewSize;
-			if (preferredWindowSize != Foundation.Size.Empty)
+			var preferredWindowSize = ApplicationView.PreferredLaunchViewSize;
+			if (preferredWindowSize != Windows.Foundation.Size.Empty)
 			{
 				var rect = new CoreGraphics.CGRect(100, 100, (int)preferredWindowSize.Width, (int)preferredWindowSize.Height);
 				_window = new Uno.UI.Controls.Window(rect, style, NSBackingStore.Buffered, false);

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.ViewManagement/ApplicationView.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.ViewManagement/ApplicationView.cs
@@ -182,7 +182,7 @@ namespace Windows.UI.ViewManagement
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Foundation.Size PreferredLaunchViewSize
 		{
@@ -240,14 +240,14 @@ namespace Windows.UI.ViewManagement
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.ViewManagement.ApplicationView", "void ApplicationView.ShowStandardSystemOverlays()");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  bool TryResizeView( global::Windows.Foundation.Size value)
 		{
 			throw new global::System.NotImplementedException("The member bool ApplicationView.TryResizeView(Size value) is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  void SetPreferredMinSize( global::Windows.Foundation.Size minSize)
 		{
@@ -322,7 +322,7 @@ namespace Windows.UI.ViewManagement
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static int GetApplicationViewIdForWindow( global::Windows.UI.Core.ICoreWindow window)
-		{
+	 	{
 			throw new global::System.NotImplementedException("The member int ApplicationView.GetApplicationViewIdForWindow(ICoreWindow window) is not implemented in Uno.");
 		}
 		#endif

--- a/src/Uno.UWP/UI/ViewManagement/ApplicationView.cs
+++ b/src/Uno.UWP/UI/ViewManagement/ApplicationView.cs
@@ -11,12 +11,16 @@ using Uno.Extensions;
 using Uno.Logging;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Windows.Storage;
 
 namespace Windows.UI.ViewManagement
 {
 	public partial class ApplicationView
 		: IApplicationViewSpanningRects
 	{
+		private const string PreferredLaunchViewWidthKey = "__Uno.PreferredLaunchViewSizeKey.Width";
+		private const string PreferredLaunchViewHeightKey = "__Uno.PreferredLaunchViewSizeKey.Height";
+
 		private static ApplicationView _instance = new ApplicationView();
 
 		private ApplicationViewTitleBar _titleBar = new ApplicationViewTitleBar();
@@ -88,6 +92,31 @@ namespace Windows.UI.ViewManagement
 				return (_applicationViewSpanningRects as INativeDualScreenProvider)?.IsSpanned == true
 					? ApplicationViewMode.Spanning
 					: ApplicationViewMode.Default;
+			}
+		}
+
+		public static Size PreferredLaunchViewSize
+		{
+			get
+			{
+				if (ApplicationData.Current.LocalSettings.Values.TryGetValue(PreferredLaunchViewWidthKey, out var widthObject) &&
+					ApplicationData.Current.LocalSettings.Values.TryGetValue(PreferredLaunchViewHeightKey, out var heightObject))
+				{
+					double width = (double)widthObject;
+					double height = (double)heightObject;
+
+					return new Size(width, height);
+				}
+				return Size.Empty;
+			}
+
+			set
+			{
+				double width = value.Width;
+				double height = value.Height;
+
+				ApplicationData.Current.LocalSettings.Values[PreferredLaunchViewWidthKey] = width;
+				ApplicationData.Current.LocalSettings.Values[PreferredLaunchViewHeightKey] = height;
 			}
 		}
 

--- a/src/Uno.UWP/UI/ViewManagement/ApplicationView.cs
+++ b/src/Uno.UWP/UI/ViewManagement/ApplicationView.cs
@@ -100,11 +100,10 @@ namespace Windows.UI.ViewManagement
 			get
 			{
 				if (ApplicationData.Current.LocalSettings.Values.TryGetValue(PreferredLaunchViewWidthKey, out var widthObject) &&
-					ApplicationData.Current.LocalSettings.Values.TryGetValue(PreferredLaunchViewHeightKey, out var heightObject))
+					ApplicationData.Current.LocalSettings.Values.TryGetValue(PreferredLaunchViewHeightKey, out var heightObject) &&
+					widthObject is double width &&
+					heightObject is double height)
 				{
-					double width = (double)widthObject;
-					double height = (double)heightObject;
-
 					return new Size(width, height);
 				}
 				return Size.Empty;

--- a/src/Uno.UWP/UI/ViewManagement/ApplicationView.macOS.cs
+++ b/src/Uno.UWP/UI/ViewManagement/ApplicationView.macOS.cs
@@ -13,6 +13,7 @@ namespace Windows.UI.ViewManagement
     partial class ApplicationView
     {
 	    private string _title = string.Empty;
+		private Size _preferredMinSize = Size.Empty;
 
 		internal void SetCoreBounds(NSWindow keyWindow, Foundation.Rect windowBounds)
 		{
@@ -40,7 +41,7 @@ namespace Windows.UI.ViewManagement
 			}
 		}
 
-		public bool IsFullScreen
+        public bool IsFullScreen
 		{
 			get
 			{
@@ -72,6 +73,10 @@ namespace Windows.UI.ViewManagement
 		{
 			VerifyKeyWindowInitialized();
 
+			if (value.Width < _preferredMinSize.Width || value.Height < _preferredMinSize.Height)
+			{
+				return false;
+			}
 			var window = NSApplication.SharedApplication.KeyWindow;
 			var frame = window.Frame;
 			frame.Size = value;
@@ -85,6 +90,7 @@ namespace Windows.UI.ViewManagement
 
 			var window = NSApplication.SharedApplication.KeyWindow;
 			window.MinSize = new CGSize(minSize.Width, minSize.Height);
+			_preferredMinSize = minSize;
 		}
 
 		internal void SyncTitleWithWindow(NSWindow window)

--- a/src/Uno.UWP/UI/ViewManagement/ApplicationView.skia.cs
+++ b/src/Uno.UWP/UI/ViewManagement/ApplicationView.skia.cs
@@ -8,12 +8,14 @@ using System.Globalization;
 using Uno.Foundation.Extensibility;
 using Uno.Disposables;
 using Windows.ApplicationModel;
+using Windows.Storage;
 
 namespace Windows.UI.ViewManagement
 {
 	partial class ApplicationView : IApplicationViewEvents
 	{
 		private readonly IApplicationViewExtension _applicationViewExtension;
+		private Size _preferredMinSize = Size.Empty;
 
 		public ApplicationView()
 		{
@@ -32,6 +34,21 @@ namespace Windows.UI.ViewManagement
 		public bool TryEnterFullScreenMode() => _applicationViewExtension.TryEnterFullScreenMode();
 
 		public void ExitFullScreenMode() => _applicationViewExtension.ExitFullScreenMode();
+
+		public bool TryResizeView(Size value)
+		{
+			if (value.Width < _preferredMinSize.Width || value.Height < _preferredMinSize.Height)
+			{
+				return false;
+			}
+			return _applicationViewExtension.TryResizeView(value);
+		}
+
+		public void SetPreferredMinSize(Size minSize)
+		{
+			_applicationViewExtension.SetPreferredMinSize(minSize);
+			_preferredMinSize = minSize;
+		}
 	}
 
 	internal interface IApplicationViewExtension
@@ -41,6 +58,10 @@ namespace Windows.UI.ViewManagement
 		bool TryEnterFullScreenMode();
 
 		void ExitFullScreenMode();
+
+		bool TryResizeView(Size size);
+
+		void SetPreferredMinSize(Size minSize);
 	}
 
 	internal interface IApplicationViewEvents


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6136

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Following methods had no effect:
- ApplicationView.TryResizeView
- ApplicationView.SetPreferredMinSize
- ApplicationView.PreferredLaunchViewSize

## What is the new behavior?

Windows sizing methods now work for Skia and macOS platforms.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
