### PR TITLE
feat: Add support for DataContext inheritance for non-UIElement

### DIFF
--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
@@ -918,7 +918,6 @@ namespace Uno.UI.Tests.BinderTests
 			Assert.AreEqual(42, SUT.Property2);
 		}
 
-
 		[TestMethod]
 		public void When_Parent_Collected()
 		{
@@ -950,6 +949,52 @@ namespace Uno.UI.Tests.BinderTests
 			SUT.SetParent(null);
 
 			Assert.AreEqual(2, parentChanged);
+		}
+
+		[TestMethod]
+		public void When_NonUI_DependencyObject_NonUISub_Content()
+		{
+			var SUT = new NonUIDependencyObject();
+			SUT.SetBinding(NonUIDependencyObject.MyValueProperty, new Binding("MyModelValue"));
+			var SUT2 = new NonUIDependencyObject();
+			SUT2.SetBinding(NonUIDependencyObject.MyValueProperty, new Binding("MyModelValue"));
+			var model = new NonUIDependencyObject_Model();
+
+			Assert.AreEqual(-1, SUT2.MyValue);
+			Assert.AreEqual(-1, SUT.MyValue);
+
+			SUT.SubProperty = SUT2;
+
+			Assert.AreEqual(-1, SUT2.MyValue);
+			Assert.AreEqual(-1, SUT.MyValue);
+
+			SUT.DataContext = model;
+
+			Assert.AreEqual(0, SUT2.MyValue);
+			Assert.AreEqual(0, SUT.MyValue);
+		}
+
+		[TestMethod]
+		public void When_UI_DependencyObject_NonUISub_Content()
+		{
+			var SUT = new UIDependencyObject();
+			SUT.SetBinding(UIDependencyObject.MyValueProperty, new Binding("MyModelValue"));
+			var SUT2 = new NonUIDependencyObject();
+			SUT2.SetBinding(NonUIDependencyObject.MyValueProperty, new Binding("MyModelValue"));
+			var model = new NonUIDependencyObject_Model();
+
+			Assert.AreEqual(-1, SUT2.MyValue);
+			Assert.AreEqual(-1, SUT.MyValue);
+
+			SUT.SubProperty = SUT2;
+
+			Assert.AreEqual(-1, SUT2.MyValue);
+			Assert.AreEqual(-1, SUT.MyValue);
+
+			SUT.DataContext = model;
+
+			Assert.AreEqual(0, SUT2.MyValue);
+			Assert.AreEqual(0, SUT.MyValue);
 		}
 
 		public partial class BaseTarget : DependencyObject
@@ -1354,6 +1399,68 @@ namespace Uno.UI.Tests.BinderTests
 		public object ConvertBack(object value, Type targetType, object parameter, string language)
 		{
 			throw new NotImplementedException();
+		}
+	}
+
+	public partial class UIDependencyObject : FrameworkElement
+	{
+		public DependencyObject SubProperty
+		{
+			get { return (DependencyObject)GetValue(SubPropertyProperty); }
+			set { SetValue(SubPropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty SubPropertyProperty =
+			DependencyProperty.Register("SubProperty", typeof(DependencyObject), typeof(UIDependencyObject), new PropertyMetadata(null));
+
+		public int MyValue
+		{
+			get { return (int)GetValue(MyValueProperty); }
+			set { SetValue(MyValueProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for MyValue.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyValueProperty =
+			DependencyProperty.Register("MyValue", typeof(int), typeof(UIDependencyObject), new PropertyMetadata(-1));
+
+	}
+
+	public partial class NonUIDependencyObject : DependencyObject
+	{
+		public DependencyObject SubProperty
+		{
+			get { return (DependencyObject)GetValue(SubPropertyProperty); }
+			set { SetValue(SubPropertyProperty, value); }
+		}
+
+		public static readonly DependencyProperty SubPropertyProperty =
+			DependencyProperty.Register("SubProperty", typeof(DependencyObject), typeof(NonUIDependencyObject), new PropertyMetadata(null));
+
+		public int MyValue
+		{
+			get { return (int)GetValue(MyValueProperty); }
+			set { SetValue(MyValueProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for MyValue.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyValueProperty =
+			DependencyProperty.Register("MyValue", typeof(int), typeof(NonUIDependencyObject), new PropertyMetadata(-1));
+
+	}
+
+	public class NonUIDependencyObject_Model : System.ComponentModel.INotifyPropertyChanged
+	{
+		private int myModelValue;
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		public int MyModelValue
+		{
+			get => myModelValue; set
+			{
+				myModelValue = value;
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(MyModelValue)));
+			}
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The `DataContext` now propagates properly to non-`UIElement` `DependencyObject`-typed values in dependency properties. This behavior is generally used to data bind dependency objects in XAML for advanced configurations.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
