### PR TITLE
Support for additional WASM file picker features

### DIFF
--- a/doc/articles/features/windows-storage-pickers.md
+++ b/doc/articles/features/windows-storage-pickers.md
@@ -5,18 +5,30 @@
 File pickers allow the user to pick a folder or a file on the local file system so that the application can work with it. The following table shows which file picker experiences are available across Uno Platform targets. For detailed information see the next sections.
 
 Legend
-  - ✅  Supported
-  - ⏸️ Partially supported (see below for more details)
-  - 🚫 Not supported
+  - ✔️  Supported
+  - 💬 Partially supported (see below for more details)
+  - ❌ Not supported
   
-| Picker         | UWP | WebAssembly | Android | iOS | macOS | WPF | GTK |
-|----------------|-----|-------------|---------|-----|-------|-----|-----|
-| FileOpenPicker | ✅   | ✅      (1)     | ✅       | ✅   | ✅     | ✅   | ✅  |
-| FileSavePicker | ✅   | ✅  (1)         | ✅       | ✅   | ✅     | ✅   | 🚫  |
-| FolderPicker   | ✅   | ✅           | ✅       | ⏸️ (2)|✅     | 🚫  | ✅  |
+| Picker         | UWP   | WebAssembly | Android | iOS   | macOS | WPF | GTK |
+|----------------|-------|-------------|---------|-------|-------|-----|-----|
+| FileOpenPicker | ✔️   | ✔️  (1)     | ✔️     | ✔️    | ✔️   | ✔️  | ✔️  |
+| FileSavePicker | ✔️   | ✔️  (1)     | ✔️     | ✔️    | ✔️   | ✔️  | ❌  |
+| FolderPicker   | ✔️   | ✔️          | ✔️     | 💬 (2)| ✔️   | ❌  | ✔️  |
 
-(1) - Multiple implementations supported - see WebAssembly section below
-(2) - See iOS section below
+*(1) - Multiple implementations supported - see WebAssembly section below*
+*(2) - See iOS section below*
+
+On some platforms, you can further customize the file picking experience by utilizing additional properties: 
+
+| Feature                 | UWP  | WebAssembly | Android | iOS | macOS | WPF | GTK |
+|-------------------------|------|-------------|---------|-----|-------|-----|-----|
+| SuggestedFileName       | ✔️   | ✔️         | ❌      | ❌ | ✔️   | ✔️  | ✔️ |
+| SuggestedStartLocation  | ✔️   | ✔️  (1)    | ❌      | ❌ | ✔️   | ✔️  | ✔️ |
+| SettingsIdentifier      | ✔️   | ✔️  (1)    | ✔️      | ❌ | ❌   | ❌  | ❌ |
+
+*(1) - Only for the native file pickers - see WebAssembly section below*
+
+On platforms where the additional features are not supported yet, setting them will not have any effect.
 
 ## Examples
 

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml
@@ -23,6 +23,7 @@
 			<TextBox Header="Settings identifier" Text="{x:Bind ViewModel.SettingsIdentifier, Mode=TwoWay}" />
             <TextBox Header="Commit button text" Text="{x:Bind ViewModel.CommitButtonText, Mode=TwoWay}" />
 
+            <TextBox Header="Suggested file name" Text="{x:Bind ViewModel.SuggestedFileName, Mode=TwoWay}" />
             <StackPanel Orientation="Horizontal" Spacing="4">
                 <Button Click="{x:Bind ViewModel.PickSuggestedSaveFile}" Content="Pick suggested save file" />
                 <Button Click="{x:Bind ViewModel.PickSuggestedSaveFile}" Content="Clear" />

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -1024,21 +1024,21 @@ declare namespace Windows.Storage {
 declare namespace Windows.Storage.Pickers {
     class FileOpenPicker {
         static isNativeSupported(): boolean;
-        static nativePickFilesAsync(multiple: boolean, showAllEntry: boolean, fileTypesJson: string): Promise<string>;
+        static nativePickFilesAsync(multiple: boolean, showAllEntry: boolean, fileTypesJson: string, id: string, startIn: StartInDirectory): Promise<string>;
         static uploadPickFilesAsync(multiple: boolean, targetPath: string, accept: string): Promise<string>;
     }
 }
 declare namespace Windows.Storage.Pickers {
     class FileSavePicker {
         static isNativeSupported(): boolean;
-        static nativePickSaveFileAsync(showAllEntry: boolean, fileTypesJson: string): Promise<string>;
+        static nativePickSaveFileAsync(showAllEntry: boolean, fileTypesJson: string, suggestedFileName: string, id: string, startIn: StartInDirectory): Promise<string>;
         static SaveAs(fileName: string, dataPtr: any, size: number): void;
     }
 }
 declare namespace Windows.Storage.Pickers {
     class FolderPicker {
         static isNativeSupported(): boolean;
-        static pickSingleFolderAsync(): Promise<string>;
+        static pickSingleFolderAsync(id: string, startIn: StartInDirectory): Promise<string>;
     }
 }
 declare namespace Uno.Storage.Pickers {

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -3499,7 +3499,7 @@ var Windows;
                 static isNativeSupported() {
                     return typeof showOpenFilePicker === "function";
                 }
-                static async nativePickFilesAsync(multiple, showAllEntry, fileTypesJson) {
+                static async nativePickFilesAsync(multiple, showAllEntry, fileTypesJson, id, startIn) {
                     if (!FileOpenPicker.isNativeSupported()) {
                         return JSON.stringify([]);
                     }
@@ -3507,6 +3507,8 @@ var Windows;
                         excludeAcceptAllOption: !showAllEntry,
                         multiple: multiple,
                         types: [],
+                        id: id,
+                        startIn: startIn
                     };
                     const acceptTypes = JSON.parse(fileTypesJson);
                     for (const acceptType of acceptTypes) {
@@ -3578,14 +3580,19 @@ var Windows;
                 static isNativeSupported() {
                     return typeof showSaveFilePicker === "function";
                 }
-                static async nativePickSaveFileAsync(showAllEntry, fileTypesJson) {
+                static async nativePickSaveFileAsync(showAllEntry, fileTypesJson, suggestedFileName, id, startIn) {
                     if (!FileSavePicker.isNativeSupported()) {
                         return null;
                     }
                     const options = {
                         excludeAcceptAllOption: !showAllEntry,
                         types: [],
+                        id: id,
+                        startIn: startIn
                     };
+                    if (suggestedFileName != "") {
+                        options.suggestedName = suggestedFileName;
+                    }
                     const acceptTypes = JSON.parse(fileTypesJson);
                     for (const acceptType of acceptTypes) {
                         const pickerAcceptType = {
@@ -3637,12 +3644,16 @@ var Windows;
                 static isNativeSupported() {
                     return typeof showDirectoryPicker === "function";
                 }
-                static async pickSingleFolderAsync() {
+                static async pickSingleFolderAsync(id, startIn) {
                     if (!FolderPicker.isNativeSupported()) {
                         return null;
                     }
                     try {
-                        const selectedFolder = await showDirectoryPicker();
+                        const options = {
+                            id: id,
+                            startIn: startIn
+                        };
+                        const selectedFolder = await showDirectoryPicker(options);
                         const info = Uno.Storage.NativeStorageItem.getInfos(selectedFolder)[0];
                         return JSON.stringify(info);
                     }

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -3505,10 +3505,10 @@ var Windows;
                     }
                     const options = {
                         excludeAcceptAllOption: !showAllEntry,
-                        multiple: multiple,
-                        types: [],
                         id: id,
-                        startIn: startIn
+                        multiple: multiple,
+                        startIn: startIn,
+                        types: [],
                     };
                     const acceptTypes = JSON.parse(fileTypesJson);
                     for (const acceptType of acceptTypes) {
@@ -3586,9 +3586,9 @@ var Windows;
                     }
                     const options = {
                         excludeAcceptAllOption: !showAllEntry,
-                        types: [],
                         id: id,
-                        startIn: startIn
+                        startIn: startIn,
+                        types: [],
                     };
                     if (suggestedFileName != "") {
                         options.suggestedName = suggestedFileName;
@@ -3651,7 +3651,7 @@ var Windows;
                     try {
                         const options = {
                             id: id,
-                            startIn: startIn
+                            startIn: startIn,
                         };
                         const selectedFolder = await showDirectoryPicker(options);
                         const info = Uno.Storage.NativeStorageItem.getInfos(selectedFolder)[0];

--- a/src/Uno.UI/ts/Windows/Storage/Pickers/FileOpenPicker.ts
+++ b/src/Uno.UI/ts/Windows/Storage/Pickers/FileOpenPicker.ts
@@ -19,10 +19,10 @@
 
 			const options: OpenFilePickerOptions = {
 				excludeAcceptAllOption: !showAllEntry,
-				multiple: multiple,
-				types: [],
 				id: id,
-				startIn: startIn
+				multiple: multiple,
+				startIn: startIn,
+				types: [],
 			};
 
 			const acceptTypes = <Uno.Storage.Pickers.NativeFilePickerAcceptType[]>JSON.parse(fileTypesJson);

--- a/src/Uno.UI/ts/Windows/Storage/Pickers/FileOpenPicker.ts
+++ b/src/Uno.UI/ts/Windows/Storage/Pickers/FileOpenPicker.ts
@@ -8,7 +8,10 @@
 		public static async nativePickFilesAsync(
 			multiple: boolean,
 			showAllEntry: boolean,
-			fileTypesJson: string): Promise<string> {
+			fileTypesJson: string,
+			id: string,
+			startIn: StartInDirectory
+		): Promise<string> {
 
 			if (!FileOpenPicker.isNativeSupported()) {
 				return JSON.stringify([]);
@@ -18,6 +21,8 @@
 				excludeAcceptAllOption: !showAllEntry,
 				multiple: multiple,
 				types: [],
+				id: id,
+				startIn: startIn
 			};
 
 			const acceptTypes = <Uno.Storage.Pickers.NativeFilePickerAcceptType[]>JSON.parse(fileTypesJson);

--- a/src/Uno.UI/ts/Windows/Storage/Pickers/FileSavePicker.ts
+++ b/src/Uno.UI/ts/Windows/Storage/Pickers/FileSavePicker.ts
@@ -5,7 +5,12 @@
 			return typeof showSaveFilePicker === "function";
 		}
 
-		public static async nativePickSaveFileAsync(showAllEntry: boolean, fileTypesJson: string, suggestedFileName: string, id: string, startIn: StartInDirectory): Promise<string> {
+		public static async nativePickSaveFileAsync(
+			showAllEntry: boolean,
+			fileTypesJson: string,
+			suggestedFileName: string,
+			id: string,
+			startIn: StartInDirectory): Promise<string> {
 
 			if (!FileSavePicker.isNativeSupported()) {
 				return null;
@@ -13,9 +18,9 @@
 
 			const options: SaveFilePickerOptions = {
 				excludeAcceptAllOption: !showAllEntry,
-				types: [],
 				id: id,
-				startIn: startIn
+				startIn: startIn,
+				types: [],
 			};
 
 			if (suggestedFileName != "") {

--- a/src/Uno.UI/ts/Windows/Storage/Pickers/FileSavePicker.ts
+++ b/src/Uno.UI/ts/Windows/Storage/Pickers/FileSavePicker.ts
@@ -5,7 +5,7 @@
 			return typeof showSaveFilePicker === "function";
 		}
 
-		public static async nativePickSaveFileAsync(showAllEntry: boolean, fileTypesJson: string): Promise<string> {
+		public static async nativePickSaveFileAsync(showAllEntry: boolean, fileTypesJson: string, suggestedFileName: string, id: string, startIn: StartInDirectory): Promise<string> {
 
 			if (!FileSavePicker.isNativeSupported()) {
 				return null;
@@ -14,7 +14,13 @@
 			const options: SaveFilePickerOptions = {
 				excludeAcceptAllOption: !showAllEntry,
 				types: [],
+				id: id,
+				startIn: startIn
 			};
+
+			if (suggestedFileName != "") {
+				options.suggestedName = suggestedFileName;
+			}
 
 			const acceptTypes = <Uno.Storage.Pickers.NativeFilePickerAcceptType[]>JSON.parse(fileTypesJson);
 

--- a/src/Uno.UI/ts/Windows/Storage/Pickers/FolderPicker.Native.ts
+++ b/src/Uno.UI/ts/Windows/Storage/Pickers/FolderPicker.Native.ts
@@ -13,7 +13,7 @@
 			try {
 				const options: DirectoryPickerOptions = {
 					id: id,
-					startIn: startIn
+					startIn: startIn,
 				};
 
 				const selectedFolder = await showDirectoryPicker(options);

--- a/src/Uno.UI/ts/Windows/Storage/Pickers/FolderPicker.Native.ts
+++ b/src/Uno.UI/ts/Windows/Storage/Pickers/FolderPicker.Native.ts
@@ -5,13 +5,18 @@
 			return typeof showDirectoryPicker === "function";
 		}
 
-		public static async pickSingleFolderAsync(): Promise<string> {
+		public static async pickSingleFolderAsync(id: string, startIn: StartInDirectory): Promise<string> {
 			if (!FolderPicker.isNativeSupported()) {
 				return null;
 			}
 
 			try {
-				const selectedFolder = await showDirectoryPicker();
+				const options: DirectoryPickerOptions = {
+					id: id,
+					startIn: startIn
+				};
+
+				const selectedFolder = await showDirectoryPicker(options);
 
 				const info = Uno.Storage.NativeStorageItem.getInfos(selectedFolder)[0];
 				return JSON.stringify(info);

--- a/src/Uno.UI/ts/types/wicg-file-system-access/index.d.ts
+++ b/src/Uno.UI/ts/types/wicg-file-system-access/index.d.ts
@@ -28,6 +28,17 @@ declare class BaseFileSystemHandle {
 }
 
 declare global {
+
+	type WellKnownDirectory =
+		"desktop" |
+		"documents" |
+		"downloads" |
+		"music" |
+		"pictures" |
+		"videos";
+
+	type StartInDirectory = WellKnownDirectory | FileSystemHandle;
+
 	interface FilePickerAcceptType {
 		description?: string;
 		accept: Record<string, string | string[]>;
@@ -36,6 +47,8 @@ declare global {
 	interface FilePickerOptions {
 		types?: FilePickerAcceptType[];
 		excludeAcceptAllOption?: boolean;
+		id?: string;
+		startIn?: StartInDirectory;
 	}
 
 	interface OpenFilePickerOptions extends FilePickerOptions {
@@ -43,10 +56,15 @@ declare global {
 	}
 
 	// tslint:disable-next-line:no-empty-interface
-	interface SaveFilePickerOptions extends FilePickerOptions { }
+	interface SaveFilePickerOptions extends FilePickerOptions {
+		suggestedName?: string;
+	}
 
 	// tslint:disable-next-line:no-empty-interface
-	interface DirectoryPickerOptions { }
+	interface DirectoryPickerOptions {
+		id?: string;
+		startIn?: StartInDirectory;
+	}
 
 	type FileSystemPermissionMode = 'read' | 'readwrite';
 

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.wasm.cs
@@ -10,6 +10,7 @@ using Uno;
 using Uno.Foundation;
 using Uno.Helpers.Serialization;
 using Uno.Storage.Internal;
+using Uno.Storage.Pickers;
 using Uno.Storage.Pickers.Internal;
 
 namespace Windows.Storage.Pickers
@@ -62,8 +63,9 @@ namespace Windows.Storage.Pickers
 			var fileTypeAcceptTypes = BuildFileTypesMap();
 			var fileTypeAcceptTypesJson = JsonHelper.Serialize(fileTypeAcceptTypes);
 			var fileTypeMapParameter = WebAssemblyRuntime.EscapeJs(fileTypeAcceptTypesJson);
-
-			var nativeStorageItemInfosJson = await WebAssemblyRuntime.InvokeAsync($"{JsType}.nativePickFilesAsync({multipleParameter},{showAllEntryParameter},'{fileTypeMapParameter}')");
+			var id = WebAssemblyRuntime.EscapeJs(SettingsIdentifier ?? "");
+			var startIn = SuggestedStartLocation.ToStartInDirectory();
+			var nativeStorageItemInfosJson = await WebAssemblyRuntime.InvokeAsync($"{JsType}.nativePickFilesAsync({multipleParameter},{showAllEntryParameter},'{fileTypeMapParameter}','{id}','{startIn}')");
 			var infos = JsonHelper.Deserialize<NativeStorageItemInfo[]>(nativeStorageItemInfosJson);
 
 			var results = new List<StorageFile>();

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.wasm.cs
@@ -63,7 +63,7 @@ namespace Windows.Storage.Pickers
 			var fileTypeAcceptTypes = BuildFileTypesMap();
 			var fileTypeAcceptTypesJson = JsonHelper.Serialize(fileTypeAcceptTypes);
 			var fileTypeMapParameter = WebAssemblyRuntime.EscapeJs(fileTypeAcceptTypesJson);
-			var id = WebAssemblyRuntime.EscapeJs(SettingsIdentifier ?? "");
+			var id = WebAssemblyRuntime.EscapeJs(SettingsIdentifier);
 			var startIn = SuggestedStartLocation.ToStartInDirectory();
 			var nativeStorageItemInfosJson = await WebAssemblyRuntime.InvokeAsync($"{JsType}.nativePickFilesAsync({multipleParameter},{showAllEntryParameter},'{fileTypeMapParameter}','{id}','{startIn}')");
 			var infos = JsonHelper.Deserialize<NativeStorageItemInfo[]>(nativeStorageItemInfosJson);

--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
@@ -10,6 +10,7 @@ using Uno;
 using Uno.Foundation;
 using Uno.Helpers.Serialization;
 using Uno.Storage.Internal;
+using Uno.Storage.Pickers;
 using Uno.Storage.Pickers.Internal;
 
 namespace Windows.Storage.Pickers
@@ -49,7 +50,12 @@ namespace Windows.Storage.Pickers
 			var showAllEntryParameter = "true";
 			var fileTypeMapParameter = JsonHelper.Serialize(BuildFileTypesMap());
 
-			var promise = $"{JsType}.nativePickSaveFileAsync({showAllEntryParameter},'{WebAssemblyRuntime.EscapeJs(fileTypeMapParameter)}')";
+			var suggestedFileName = string.IsNullOrEmpty(SuggestedFileName) ?
+				"" : WebAssemblyRuntime.EscapeJs(SuggestedFileName);
+			var id = WebAssemblyRuntime.EscapeJs(SettingsIdentifier ?? "");
+
+			var startIn = SuggestedStartLocation.ToStartInDirectory();
+			var promise = $"{JsType}.nativePickSaveFileAsync({showAllEntryParameter},'{WebAssemblyRuntime.EscapeJs(fileTypeMapParameter)}','{suggestedFileName}','{id}','{startIn}')";
 			var nativeStorageItemInfo = await WebAssemblyRuntime.InvokeAsync(promise);
 			if (nativeStorageItemInfo is null)
 			{

--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
@@ -50,9 +50,9 @@ namespace Windows.Storage.Pickers
 			var showAllEntryParameter = "true";
 			var fileTypeMapParameter = JsonHelper.Serialize(BuildFileTypesMap());
 
-			var suggestedFileName = string.IsNullOrEmpty(SuggestedFileName) ?
-				"" : WebAssemblyRuntime.EscapeJs(SuggestedFileName);
-			var id = WebAssemblyRuntime.EscapeJs(SettingsIdentifier ?? "");
+			var suggestedFileName = SuggestedFileName != "" ? WebAssemblyRuntime.EscapeJs(SuggestedFileName) : "";
+
+			var id = WebAssemblyRuntime.EscapeJs(SettingsIdentifier);
 
 			var startIn = SuggestedStartLocation.ToStartInDirectory();
 			var promise = $"{JsType}.nativePickSaveFileAsync({showAllEntryParameter},'{WebAssemblyRuntime.EscapeJs(fileTypeMapParameter)}','{suggestedFileName}','{id}','{startIn}')";

--- a/src/Uno.UWP/Storage/Pickers/FolderPicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FolderPicker.wasm.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Uno.Foundation;
 using Uno.Helpers.Serialization;
 using Uno.Storage.Internal;
+using Uno.Storage.Pickers;
 
 namespace Windows.Storage.Pickers
 {
@@ -20,7 +21,10 @@ namespace Windows.Storage.Pickers
 				throw new NotSupportedException("Could not handle the request using any picker implementation.");
 			}
 
-			var pickedFolderJson = await WebAssemblyRuntime.InvokeAsync($"{JsType}.pickSingleFolderAsync()");
+			var id = WebAssemblyRuntime.EscapeJs(SettingsIdentifier ?? "");
+			var startIn = SuggestedStartLocation.ToStartInDirectory();
+
+			var pickedFolderJson = await WebAssemblyRuntime.InvokeAsync($"{JsType}.pickSingleFolderAsync('{id}','{startIn}')");
 
 			if (pickedFolderJson is null)
 			{

--- a/src/Uno.UWP/Storage/Pickers/FolderPicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FolderPicker.wasm.cs
@@ -21,7 +21,7 @@ namespace Windows.Storage.Pickers
 				throw new NotSupportedException("Could not handle the request using any picker implementation.");
 			}
 
-			var id = WebAssemblyRuntime.EscapeJs(SettingsIdentifier ?? "");
+			var id = WebAssemblyRuntime.EscapeJs(SettingsIdentifier);
 			var startIn = SuggestedStartLocation.ToStartInDirectory();
 
 			var pickedFolderJson = await WebAssemblyRuntime.InvokeAsync($"{JsType}.pickSingleFolderAsync('{id}','{startIn}')");

--- a/src/Uno.UWP/Storage/Pickers/Internal/PickerLocationIdExtensions.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/Internal/PickerLocationIdExtensions.wasm.cs
@@ -4,6 +4,16 @@ namespace Uno.Storage.Pickers
 {
 	internal static class PickerLocationIdExtensions
 	{
+		/// <summary>
+		/// Converts the specified location to a JS Native File System Access
+		/// startIn directory.
+		/// </summary>
+		/// <param name="location">The PickerLocationId to convert.</param>
+		/// <returns>The JS Native File System Access startIn directory.</returns>
+		/// <remarks>
+		/// See https://wicg.github.io/file-system-access/#api-filepickeroptions-starting-directory
+		/// for the list of supported starting directories.
+		/// </remarks>
 		internal static string ToStartInDirectory(this PickerLocationId location) =>
 			location switch
 			{

--- a/src/Uno.UWP/Storage/Pickers/Internal/PickerLocationIdExtensions.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/Internal/PickerLocationIdExtensions.wasm.cs
@@ -1,0 +1,19 @@
+﻿using Windows.Storage.Pickers;
+
+namespace Uno.Storage.Pickers
+{
+	internal static class PickerLocationIdExtensions
+	{
+		internal static string ToStartInDirectory(this PickerLocationId location) =>
+			location switch
+			{
+				PickerLocationId.DocumentsLibrary => "documents",
+				PickerLocationId.Desktop => "desktop",
+				PickerLocationId.Downloads => "downloads",
+				PickerLocationId.MusicLibrary => "music",
+				PickerLocationId.PicturesLibrary => "pictures",
+				PickerLocationId.VideosLibrary => "videos",
+				_ => ""
+			};
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6612, closes #6513

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Not supported

## What is the new behavior?

Added support for the following properties on native WASM file pickers

- `SuggestedStartLocation`
- `SuggestedFileName`
- `SettingsIdentifier`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.