### PR TITLE
fix: Allow trailing 'px' for grid length

### DIFF
--- a/src/SourceGenerators/XamlGenerationTests/Grid.Test.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/Grid.Test.xaml
@@ -22,6 +22,9 @@
 			<ColumnDefinition Width="auto" />
 			<ColumnDefinition Width="1*" />
 			<ColumnDefinition Width="1.5*" />
+            <ColumnDefinition Width="300px" />
+            <ColumnDefinition Width="300 px" />
+            <ColumnDefinition Width="300 px " />
 		</Grid.ColumnDefinitions>
 
 		<TextBlock Grid.Row="1" Grid.Column="1" Grid.RowSpan="1" Grid.ColumnSpan="1" />

--- a/src/SourceGenerators/XamlGenerationTests/Grid.Test.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/Grid.Test.xaml
@@ -22,9 +22,19 @@
 			<ColumnDefinition Width="auto" />
 			<ColumnDefinition Width="1*" />
 			<ColumnDefinition Width="1.5*" />
-            <ColumnDefinition Width="300px" />
-            <ColumnDefinition Width="300 px" />
-            <ColumnDefinition Width="300 px " />
+			<ColumnDefinition Width="300px" />
+			<ColumnDefinition Width="300 px" />
+			<ColumnDefinition Width="300 px " />
+			<ColumnDefinition Width="300 PX " />
+			<ColumnDefinition Width="300in" />
+			<ColumnDefinition Width="300 IN" />
+			<ColumnDefinition Width="300 iN " />
+			<ColumnDefinition Width="300cM" />
+			<ColumnDefinition Width="300 cm" />
+			<ColumnDefinition Width="300 CM " />
+			<ColumnDefinition Width="300pT" />
+			<ColumnDefinition Width="300 PT" />
+			<ColumnDefinition Width="300 pt " />
 		</Grid.ColumnDefinitions>
 
 		<TextBlock Grid.Row="1" Grid.Column="1" Grid.RowSpan="1" Grid.ColumnSpan="1" />

--- a/src/Uno.UI/UI/Xaml/GridLength.cs
+++ b/src/Uno.UI/UI/Xaml/GridLength.cs
@@ -74,6 +74,11 @@ namespace Windows.UI.Xaml
 			}
 			else
 			{
+				if (trimmed.EndsWith("px"))
+				{
+					trimmed = trimmed.Substring(0, trimmed.Length - 2);
+				}
+
 				if (double.TryParse(trimmed, NumberStyles.Any & ~NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var value))
 				{
 					return new GridLength(value, GridUnitType.Pixel);

--- a/src/Uno.UI/UI/Xaml/GridLength.cs
+++ b/src/Uno.UI/UI/Xaml/GridLength.cs
@@ -74,7 +74,10 @@ namespace Windows.UI.Xaml
 			}
 			else
 			{
-				if (trimmed.EndsWith("px"))
+				if (trimmed.EndsWith("px", StringComparison.OrdinalIgnoreCase) ||
+					trimmed.EndsWith("cm", StringComparison.OrdinalIgnoreCase) ||
+					trimmed.EndsWith("in", StringComparison.OrdinalIgnoreCase) ||
+					trimmed.EndsWith("pt", StringComparison.OrdinalIgnoreCase))
 				{
 					trimmed = trimmed.Substring(0, trimmed.Length - 2);
 				}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5081

## PR Type

What kind of change does this PR introduce?


- Bugfix

## What is the current behavior?

A trailing `px` suffix in grid length throws an exception.

## What is the new behavior?

A trailing `px` suffix is now allowed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
