### PR TITLE
fix: Properly generate string literals using Roslyn API

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -24,6 +24,7 @@ using System.Runtime.CompilerServices;
 using Uno.UI.Xaml;
 using Uno.Disposables;
 using Uno.UI.SourceGenerators.BindableTypeProviders;
+using Microsoft.CodeAnalysis.CSharp;
 
 #if NETFRAMEWORK
 using GeneratorExecutionContext = Uno.SourceGeneration.GeneratorExecutionContext;
@@ -2288,7 +2289,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 											&& implicitValue.HasValueTrimmed()
 										)
 										{
-											writer.AppendLineInvariant(setterPrefix + contentProperty.Name + " = \"" + implicitValue + "\"");
+											writer.AppendLineInvariant(setterPrefix + contentProperty.Name + " = " + SyntaxFactory.Literal(implicitValue).ToString());
 
 											if (isInline)
 											{

--- a/src/SourceGenerators/XamlGenerationTests/EscapeContentString.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/EscapeContentString.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+    x:Class="XamlGenerationTests.Shared.EscapeContentString"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:XamlGenerationTests.Shared"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d ios android xamarin"
+	xmlns:ios="http://uno.ui/ios"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+        <ListView>
+          <RadioButton x:Name="TheRadioButton">"I'm really a Radio Button"</RadioButton>
+        <x:String>I'm just a string</x:String>
+        <Button>And I'm a Button!</Button>
+        </ListView>
+	</StackPanel>
+</UserControl>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4584

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix

## What is the current behavior?

Quotes are not escaped in generated code, causing compile-time errors.

## What is the new behavior?

Generate string literals using Roslyn API to mostly guarantee a valid syntax.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
