### PR TITLE
fix: Allow separating by spaces and/or commas

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -154,6 +154,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// If set, code generated from XAML will be annotated with the source method and line # in this file, for easier debugging.
 		/// </summary>
 		private readonly bool _shouldAnnotateGeneratedXaml;
+		private static readonly Regex splitRegex = new Regex(@"(\s*,\s*|\s+)");
 
 		private string ParseContextPropertyAccess =>
 			 (_isTopLevelDictionary, _isInSingletonInstance) switch
@@ -4373,16 +4374,16 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						return "new System.Drawing.PointF(" + AppendFloatSuffix(GetMemberValue()) + ")";
 
 					case "System.Drawing.Size":
-						return "new System.Drawing.Size(" + splitAndJoin(memberValue) + ")";
+						return "new System.Drawing.Size(" + SplitAndJoin(memberValue) + ")";
 
 					case "Windows.Foundation.Size":
-						return "new Windows.Foundation.Size(" + splitAndJoin(memberValue) + ")";
+						return "new Windows.Foundation.Size(" + SplitAndJoin(memberValue) + ")";
 
 					case "Windows.UI.Xaml.Media.Matrix":
-						return "new Windows.UI.Xaml.Media.Matrix(" + splitAndJoin(memberValue) + ")";
+						return "new Windows.UI.Xaml.Media.Matrix(" + SplitAndJoin(memberValue) + ")";
 
 					case "Windows.Foundation.Point":
-						return "new Windows.Foundation.Point(" + splitAndJoin(memberValue) + ")";
+						return "new Windows.Foundation.Point(" + SplitAndJoin(memberValue) + ")";
 
 					case "Windows.UI.Xaml.Input.InputScope":
 						return "new global::Windows.UI.Xaml.Input.InputScope { Names = { new global::Windows.UI.Xaml.Input.InputScopeName { NameValue = global::Windows.UI.Xaml.Input.InputScopeNameValue." + memberValue + "} } }";
@@ -4443,8 +4444,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				throw new Exception("Unable to convert {0} for {1} with type {2}".InvariantCultureFormat(memberValue, memberName, propertyType));
 
-				static string? splitAndJoin(string? value)
-					=> value == null ? null : Regex.Replace(value, @"(\s*,\s*|\s+)", ", "));
+				static string? SplitAndJoin(string? value)
+					=> value == null ? null : splitRegex.Replace(value, ", ");
 			}
 		}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4373,16 +4373,16 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						return "new System.Drawing.PointF(" + AppendFloatSuffix(GetMemberValue()) + ")";
 
 					case "System.Drawing.Size":
-						return "new System.Drawing.Size(" + memberValue + ")";
+						return "new System.Drawing.Size(" + splitAndJoin(memberValue) + ")";
 
 					case "Windows.Foundation.Size":
-						return "new Windows.Foundation.Size(" + memberValue + ")";
+						return "new Windows.Foundation.Size(" + splitAndJoin(memberValue) + ")";
 
 					case "Windows.UI.Xaml.Media.Matrix":
-						return "new Windows.UI.Xaml.Media.Matrix(" + memberValue + ")";
+						return "new Windows.UI.Xaml.Media.Matrix(" + splitAndJoin(memberValue) + ")";
 
 					case "Windows.Foundation.Point":
-						return "new Windows.Foundation.Point(" + memberValue + ")";
+						return "new Windows.Foundation.Point(" + splitAndJoin(memberValue) + ")";
 
 					case "Windows.UI.Xaml.Input.InputScope":
 						return "new global::Windows.UI.Xaml.Input.InputScope { Names = { new global::Windows.UI.Xaml.Input.InputScopeName { NameValue = global::Windows.UI.Xaml.Input.InputScopeNameValue." + memberValue + "} } }";
@@ -4442,6 +4442,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 
 				throw new Exception("Unable to convert {0} for {1} with type {2}".InvariantCultureFormat(memberValue, memberName, propertyType));
+
+				static string? splitAndJoin(string? value)
+					=> value == null ? null : string.Join(", ", Regex.Split(value, @"(\s*?,\s*|\s+)"));
 			}
 		}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -154,7 +154,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// If set, code generated from XAML will be annotated with the source method and line # in this file, for easier debugging.
 		/// </summary>
 		private readonly bool _shouldAnnotateGeneratedXaml;
-		private static readonly Regex splitRegex = new Regex(@"(\s*,\s*|\s+)");
+		private static readonly Regex splitRegex = new Regex(@"\s*,\s*|\s+");
 
 		private string ParseContextPropertyAccess =>
 			 (_isTopLevelDictionary, _isInSingletonInstance) switch

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4444,7 +4444,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				throw new Exception("Unable to convert {0} for {1} with type {2}".InvariantCultureFormat(memberValue, memberName, propertyType));
 
 				static string? splitAndJoin(string? value)
-					=> value == null ? null : string.Join(", ", Regex.Split(value, @"(\s*?,\s*|\s+)"));
+					=> value == null ? null : Regex.Replace(value, @"(\s*,\s*|\s+)", ", "));
 			}
 		}
 

--- a/src/SourceGenerators/XamlGenerationTests/SeparatingMatrixTransformBySpaces.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/SeparatingMatrixTransformBySpaces.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl x:Class="XamlGenerationTests.Shared.SeparatingMatrixTransformBySpaces"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:XamlGenerationTests.Shared"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:xamarin="http://uno.ui/xamarin"
+			 mc:Ignorable="d xamarin"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<StackPanel>
+		<Rectangle>
+            <Rectangle.RenderTransform>
+                <MatrixTransform Matrix="1.1048446 0 0 1.1959561 -67.035883 -96.098854"/>
+            </Rectangle.RenderTransform>
+        </Rectangle>
+        <Rectangle>
+            <Rectangle.RenderTransform>
+                <!-- Mixing commas and spaces is allowed. -->
+                <MatrixTransform Matrix="1.1048446, 0, 0,1.1959561 -67.035883 -96.098854"/>
+            </Rectangle.RenderTransform>
+        </Rectangle>
+	</StackPanel>
+
+</UserControl>

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -996,7 +996,7 @@ namespace Uno.UI.DataBinding
 			}
 		}
 
-		private static readonly Regex _splitRegex = new Regex(@"(\s*,\s*|\s+)");
+		private static readonly Regex _splitRegex = new Regex(@"\s*,\s*|\s+");
 
 		static string[] Split(string value)
 			=> _splitRegex.Split(value);

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -997,7 +997,7 @@ namespace Uno.UI.DataBinding
 		}
 
 		static string[] Split(string value)
-			=> Regex.Split(value, @"(\s*?,\s*|\s+)");
+			=> Regex.Split(value, @"(\s*,\s*|\s+)");
 	}
 }
 #endif

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -996,8 +996,10 @@ namespace Uno.UI.DataBinding
 			}
 		}
 
+		private static readonly Regex _splitRegex = new Regex(@"(\s*,\s*|\s+)");
+
 		static string[] Split(string value)
-			=> Regex.Split(value, @"(\s*,\s*|\s+)");
+			=> _splitRegex.Split(value);
 	}
 }
 #endif

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -12,6 +12,7 @@ using Windows.Foundation;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI;
 using Uno.UI.Extensions;
+using System.Text.RegularExpressions;
 
 #if XAMARIN_ANDROID
 using View = Android.Views.View;
@@ -486,10 +487,9 @@ namespace Uno.UI.DataBinding
 		{
 			if (outputType == typeof(Windows.UI.Xaml.Media.Matrix))
 			{
-				var fields = input
-					.Split(new[] { ',' })
-					?.Select(v => double.Parse(v, CultureInfo.InvariantCulture))
-					?.ToArray();
+				var fields = Split(input)
+					.Select(v => double.Parse(v, CultureInfo.InvariantCulture))
+					.ToArray();
 
 				output = new Windows.UI.Xaml.Media.Matrix(fields[0], fields[1], fields[2], fields[3], fields[4], fields[5]);
 				return true;
@@ -502,10 +502,9 @@ namespace Uno.UI.DataBinding
 		{
 			if (outputType == typeof(System.Drawing.PointF))
 			{
-				var fields = input
-					.Split(new[] { ',' })
-					?.Select(v => float.Parse(v, CultureInfo.InvariantCulture))
-					?.ToArray();
+				var fields = Split(input)
+					.Select(v => float.Parse(v, CultureInfo.InvariantCulture))
+					.ToArray();
 
 				if (fields?.Length == 2)
 				{
@@ -527,10 +526,9 @@ namespace Uno.UI.DataBinding
 		{
 			if (outputType == typeof(Windows.Foundation.Point))
 			{
-				var fields = input
-					.Split(new[] { ',' })
-					?.Select(v => double.Parse(v, CultureInfo.InvariantCulture))
-					?.ToArray();
+				var fields = Split(input)
+					.Select(v => double.Parse(v, CultureInfo.InvariantCulture))
+					.ToArray();
 
 				if (fields?.Length == 2)
 				{
@@ -997,6 +995,9 @@ namespace Uno.UI.DataBinding
 				return false;
 			}
 		}
+
+		static string[] Split(string value)
+			=> Regex.Split(value, @"(\s*?,\s*|\s+)");
 	}
 }
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4564

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type


- Bugfix

## What is the current behavior?

The following isn't allowed and generates invalid code.

```xml
<MatrixTransform Matrix="1.1048446 0 0 1.1959561 -67.035883 -96.098854"/>
```

## What is the new behavior?

It's now allowed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
