### PR TITLE
fix: Support for non-UIElement ElementName binding in global ResourceDictionary

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -41,7 +41,7 @@ namespace SamplesApp
 	/// <summary>
 	/// Provides application-specific behavior to supplement the default Application class.
 	/// </summary>
-	sealed partial class App : Application
+	sealed public partial class App : Application
 	{
 		static App()
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -281,6 +281,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return IsType(xamlType, _appKitViewSymbol);
 		}
 
+		private bool IsDependencyObject(XamlObjectDefinition component)
+			=> GetType(component.Type).GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol));
+
+		private bool IsUIElement(XamlObjectDefinition component)
+			=> IsType(component.Type, _uiElementSymbol);
+
 		/// <summary>
 		/// Is the type derived from the native view type on a Xamarin platform?
 		/// </summary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_NonUINested.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_NonUINested.xaml
@@ -1,0 +1,32 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls.Binding_ElementName_In_Template_ItemsControl_NonUINested"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<ItemsControl x:Name="PrimaryActionsList" x:FieldModifier="public" Tag="42">
+		<ItemsControl.Template>
+			<ControlTemplate TargetType="ItemsControl">
+				<ItemsPresenter/>
+			</ControlTemplate>
+		</ItemsControl.Template>
+		<ItemsControl.ItemsPanel>
+			<ItemsPanelTemplate>
+				<StackPanel/>
+			</ItemsPanelTemplate>
+		</ItemsControl.ItemsPanel>
+		<ItemsControl.ItemTemplate>
+			<DataTemplate>
+				<Button x:Name="button" Tag="{Binding Tag, ElementName=PrimaryActionsList}">
+					<local:Binding_ElementName_In_Template_ItemsControl_NonUINested_Attached.NonUIObject>
+						<local:Binding_ElementName_In_Template_ItemsControl_NonUINested_DO
+							x:Name="myElement"
+							InnerProperty="{Binding Tag, ElementName=PrimaryActionsList}" />
+					</local:Binding_ElementName_In_Template_ItemsControl_NonUINested_Attached.NonUIObject>
+				</Button>
+			</DataTemplate>
+		</ItemsControl.ItemTemplate>
+	</ItemsControl>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_NonUINested.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_NonUINested.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_ElementName_In_Template_ItemsControl_NonUINested : Page
+	{
+		public Binding_ElementName_In_Template_ItemsControl_NonUINested()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public partial class Binding_ElementName_In_Template_ItemsControl_NonUINested_DO : DependencyObject
+	{
+		public object InnerProperty
+		{
+			get => (object)GetValue(InnerPropertyProperty);
+			set => SetValue(InnerPropertyProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for InnerProperty.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty InnerPropertyProperty =
+			DependencyProperty.Register("InnerProperty",
+							   typeof(object),
+							   typeof(Binding_ElementName_In_Template_ItemsControl_NonUINested_DO),
+							   new PropertyMetadata(null));
+	}
+
+	public partial class Binding_ElementName_In_Template_ItemsControl_NonUINested_Attached
+	{
+
+		public static Binding_ElementName_In_Template_ItemsControl_NonUINested_DO GetNonUIObject(DependencyObject obj) => (Binding_ElementName_In_Template_ItemsControl_NonUINested_DO)obj.GetValue(NonUIObjectProperty);
+
+		public static void SetNonUIObject(DependencyObject obj, Binding_ElementName_In_Template_ItemsControl_NonUINested_DO value) => obj.SetValue(NonUIObjectProperty, value);
+
+		// Using a DependencyProperty as the backing store for NonUIObject.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty NonUIObjectProperty =
+			DependencyProperty.RegisterAttached("NonUIObject",
+									   typeof(Binding_ElementName_In_Template_ItemsControl_NonUINested_DO),
+									   typeof(Binding_ElementName_In_Template_ItemsControl_NonUINested_Attached),
+									   new PropertyMetadata(null));
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_NonUINested_GlobalResources.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_NonUINested_GlobalResources.xaml
@@ -1,0 +1,15 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls.Binding_ElementName_NonUINested_GlobalResources"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<ResourceDictionary Source="Binding_ElementName_NonUINested_GlobalResources_Dictionary.xaml" />
+	</Page.Resources>
+
+	<ContentControl Content="42"
+					ContentTemplate="{StaticResource myItemsControlTemplate}" />
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_NonUINested_GlobalResources.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_NonUINested_GlobalResources.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_ElementName_NonUINested_GlobalResources : Page
+	{
+		public Binding_ElementName_NonUINested_GlobalResources()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public partial class Binding_ElementName_NonUINested_GlobalResources_DO : DependencyObject
+	{
+		public object InnerProperty
+		{
+			get => (object)GetValue(InnerPropertyProperty);
+			set => SetValue(InnerPropertyProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for InnerProperty.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty InnerPropertyProperty =
+			DependencyProperty.Register("InnerProperty",
+							   typeof(object),
+							   typeof(Binding_ElementName_NonUINested_GlobalResources_DO),
+							   new PropertyMetadata(null));
+	}
+
+	public partial class Binding_ElementName_NonUINested_GlobalResources_Attached
+	{
+
+		public static Binding_ElementName_NonUINested_GlobalResources_DO GetNonUIObject(DependencyObject obj) => (Binding_ElementName_NonUINested_GlobalResources_DO)obj.GetValue(NonUIObjectProperty);
+
+		public static void SetNonUIObject(DependencyObject obj, Binding_ElementName_NonUINested_GlobalResources_DO value) => obj.SetValue(NonUIObjectProperty, value);
+
+		// Using a DependencyProperty as the backing store for NonUIObject.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty NonUIObjectProperty =
+			DependencyProperty.RegisterAttached("NonUIObject",
+									   typeof(Binding_ElementName_NonUINested_GlobalResources_DO),
+									   typeof(Binding_ElementName_NonUINested_GlobalResources_Attached),
+									   new PropertyMetadata(null));
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_NonUINested_GlobalResources_Dictionary.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_NonUINested_GlobalResources_Dictionary.xaml
@@ -1,0 +1,34 @@
+﻿<ResourceDictionary
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<DataTemplate x:Key="myItemsControlTemplate">
+		<ItemsControl x:Name="PrimaryActionsList" x:FieldModifier="public" Tag="42">
+			<ItemsControl.Template>
+				<ControlTemplate TargetType="ItemsControl">
+					<ItemsPresenter/>
+				</ControlTemplate>
+			</ItemsControl.Template>
+			<ItemsControl.ItemsPanel>
+				<ItemsPanelTemplate>
+					<StackPanel/>
+				</ItemsPanelTemplate>
+			</ItemsControl.ItemsPanel>
+			<ItemsControl.ItemTemplate>
+				<DataTemplate>
+					<Button x:Name="button" Tag="{Binding Tag, ElementName=PrimaryActionsList}">
+						<local:Binding_ElementName_NonUINested_GlobalResources_Attached.NonUIObject>
+							<local:Binding_ElementName_NonUINested_GlobalResources_DO
+								x:Name="myElement"
+								InnerProperty="{Binding Tag, ElementName=PrimaryActionsList}" />
+						</local:Binding_ElementName_NonUINested_GlobalResources_Attached.NonUIObject>
+					</Button>
+				</DataTemplate>
+			</ItemsControl.ItemTemplate>
+		</ItemsControl>
+	</DataTemplate>
+</ResourceDictionary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
@@ -62,6 +62,46 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests
 		}
 
 		[TestMethod]
+		public void When_ElementName_In_Template_ItemsControl_NonUINested()
+		{
+			var SUT = new Binding_ElementName_In_Template_ItemsControl_NonUINested();
+
+			SUT.PrimaryActionsList.ItemsSource = new[] { "test" };
+
+			SUT.ForceLoaded();
+
+			var button = SUT.FindName("button") as Windows.UI.Xaml.Controls.Button;
+
+			Assert.AreEqual(SUT.PrimaryActionsList.Tag, button.Tag);
+			 
+			var nestedDO = Binding_ElementName_In_Template_ItemsControl_NonUINested_Attached.GetNonUIObject(button);
+
+			Assert.IsNotNull(nestedDO);
+			Assert.AreEqual(nestedDO.InnerProperty, button.Tag);
+		}
+
+		[TestMethod]
+		public void When_ElementName_NonUINested_GlobalResources()
+		{
+			var SUT = new Binding_ElementName_NonUINested_GlobalResources();
+
+			var primaryActionsList = SUT.FindName("PrimaryActionsList") as Windows.UI.Xaml.Controls.ItemsControl;
+
+			primaryActionsList.ItemsSource = new[] { "test" };
+
+			SUT.ForceLoaded();
+
+			var button = SUT.FindName("button") as Windows.UI.Xaml.Controls.Button;
+
+			Assert.AreEqual(primaryActionsList.Tag, button.Tag);
+
+			var nestedDO = Binding_ElementName_NonUINested_GlobalResources_Attached.GetNonUIObject(button);
+
+			Assert.IsNotNull(nestedDO);
+			Assert.AreEqual(nestedDO.InnerProperty, button.Tag);
+		}
+
+		[TestMethod]
 		public void When_ElementName_In_Template_In_Template()
 		{
 			var SUT = new Binding_ElementName_In_Template_In_Template();

--- a/src/Uno.UI/UI/Xaml/Markup/INameScope.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/INameScope.cs
@@ -12,6 +12,11 @@ namespace Windows.UI.Xaml.Markup
 	public interface INameScope
 	{
 		/// <summary>
+		/// Returns the top-level <see cref="DependencyObject"/> that defined this namescope
+		/// </summary>
+		DependencyObject Owner { get; }
+
+		/// <summary>
 		/// Returns an object that has the provided identifying name.
 		/// </summary>
 		/// <param name="name">The name identifier for the object being requested.</param>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- `ElementName` bindings hosted in a Global `ResourceDictionary` are now taken into account
- Non-UIElement `ElementName` bindings can not walk the tree to find elements outside of their immediate `NameScope`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
