### PR TITLE
fix(macOS): contentControl intercepts pointer events

### DIFF
--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -54,6 +54,19 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</netstdref:Setter>
+		<macos:Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="ContentControl">
+					<ContentPresenter Content="{TemplateBinding Content}"
+									  ContentTemplate="{TemplateBinding ContentTemplate}"
+									  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+									  Margin="{TemplateBinding Padding}"
+									  ContentTransitions="{TemplateBinding ContentTransitions}"
+									  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+									  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+				</ControlTemplate>
+			</Setter.Value>
+		</macos:Setter>
 	</Style>
 
 	<!-- FRAMEWORK STYLES -->

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -217,7 +217,7 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		internal HitTestability GetHitTestVisibility()
 		{
-#if __WASM__ || __SKIA__
+#if __WASM__ || __SKIA__ || __MACOS__
 			return HitTestVisibility;
 #else
 			// This is a coalesced HitTestVisible and should be unified with it

--- a/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
@@ -109,6 +109,12 @@ namespace Windows.UI.Xaml
 		public override bool AcceptsFirstResponder()
 			=> true; // This is required to receive the KeyDown / KeyUp. Note: Key events are then bubble in managed.
 
+
+		internal static void LoadingRootElement(UIElement visualTreeRoot) { }
+
+		internal static void RootElementLoaded(UIElement visualTreeRoot) =>
+			visualTreeRoot.SetHitTestVisibilityForRoot();
+
 		private protected override void OnNativeKeyDown(NSEvent evt)
 		{
 			var args = new KeyRoutedEventArgs(this, VirtualKeyHelper.FromKeyCode(evt.KeyCode))

--- a/src/Uno.UI/UI/Xaml/Window.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.macOS.cs
@@ -87,9 +87,13 @@ namespace Windows.UI.Xaml
 					throw new InvalidOperationException("The root visual could not be created.");
 				}
 
+				UIElement.LoadingRootElement(_rootVisual);
+
 				_mainController.View = _rootVisual;
 				_rootVisual.Frame = _window.Frame;
 				_rootVisual.AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
+
+				UIElement.RootElementLoaded(_rootVisual);
 			}
 
 			_rootBorder.Child?.RemoveFromSuperview();


### PR DESCRIPTION
GitHub Issue (If applicable): #
closes #6418 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
ContentControl in a Window is intercepting the pointer events

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
