### PR TITLE
fix: Initial focus on Page

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Page/Page.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Page/Page.mux.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Controls
 					this.SetFocusedElement(
 						this,
 						FocusState.Programmatic,
-						false /*animateIfBringIntoView*/);
+						animateIfBringIntoView: false);
 					return;
 				}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Page/Page.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Page/Page.mux.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Uno.Extensions;
 using Uno.UI.Extensions;
 using Uno.UI.Xaml.Core;
+using Uno.UI.Xaml.Input;
 using Windows.UI.Xaml.Automation.Peers;
 
 namespace Windows.UI.Xaml.Controls
@@ -19,6 +20,7 @@ namespace Windows.UI.Xaml.Controls
 		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
+
 			var spCurrentFocusedElement = this.GetFocusedElement();
 
 			var focusManager = VisualTree.GetFocusManagerForElement(this);
@@ -26,6 +28,17 @@ namespace Windows.UI.Xaml.Controls
 
 			if (setDefaultFocus && spCurrentFocusedElement == null)
 			{
+				// Uno specific: If the page is focusable itself, we want to
+				// give it focus instead of the first element.
+				if (FocusProperties.IsFocusable(this))
+				{
+					this.SetFocusedElement(
+						this,
+						FocusState.Programmatic,
+						false /*animateIfBringIntoView*/);
+					return;
+				}
+
 				// Set the focus on the first focusable control
 				var spFirstFocusableElementCDO = focusManager?.GetFirstFocusableElement(this);
 
@@ -36,6 +49,8 @@ namespace Windows.UI.Xaml.Controls
 					focusManager.InitialFocus = true;
 
 					TrySetFocusedElement(spFirstFocusableElementDO);
+					
+					focusManager.InitialFocus = false;
 				}
 
 				if (spFirstFocusableElementCDO == null)

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.Android.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Windows.UI.Xaml.Controls;
 using Android.Graphics;
 using Windows.UI.ViewManagement;
+using Uno.UI.Xaml.Core;
 
 namespace Windows.UI.Xaml.Input
 {
@@ -18,7 +19,13 @@ namespace Windows.UI.Xaml.Input
 			// TODO Uno: Handle Hyperlink focus
 			if (element is Control control)
 			{
-				control.RequestFocus();
+				var focusManager = VisualTree.GetFocusManagerForElement(control);
+				if (element is Android.Views.View androidView &&
+					androidView.Focusable &&
+					focusManager?.InitialFocus == false) // Do not focus natively on initial focus so the soft keyboard is not opened
+				{
+					control.RequestFocus();
+				}
 
 				// Forcefully try to bring the control into view when keyboard is open to accommodate adjust nothing mode
 				if (InputPane.GetForCurrentView().Visible)

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.iOS.cs
@@ -5,11 +5,21 @@ using System.Text;
 using UIKit;
 using Uno.UI.Extensions;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.ViewManagement;
+using Uno.UI.Xaml.Core;
 
 namespace Windows.UI.Xaml.Input
 {
 	public partial class FocusManager
-	{		
-		private static void FocusNative(UIElement control) => control?.BecomeFirstResponder();
+	{
+		private static void FocusNative(UIElement control)
+		{
+			var focusManager = VisualTree.GetFocusManagerForElement(control);
+			if (control?.CanBecomeFirstResponder == true &&
+				focusManager?.InitialFocus == false)  // Do not focus natively on initial focus so the soft keyboard is not opened
+			{
+				control.BecomeFirstResponder();
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.macOS.cs
@@ -10,6 +10,12 @@ namespace Windows.UI.Xaml.Input
 {
 	public partial class FocusManager
 	{
-		private static void FocusNative(UIElement control) => control?.BecomeFirstResponder();
+		private static void FocusNative(UIElement control)
+		{
+			if (control?.CanBecomeFirstResponder == true)
+			{
+				control.BecomeFirstResponder();
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.macOS.cs
@@ -12,9 +12,9 @@ namespace Windows.UI.Xaml.Input
 	{
 		private static void FocusNative(UIElement control)
 		{
-			if (control?.CanBecomeFirstResponder == true)
+			if (control?.AcceptsFirstResponder() == true)
 			{
-				control.BecomeFirstResponder();
+				Window.Current?.NativeWindow?.MakeFirstResponder(control);
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -82,6 +82,14 @@ namespace Windows.UI.Xaml.Input
 				return false;
 			}
 
+			var focusManager = VisualTree.GetFocusManagerForElement(element);
+
+			if (focusManager?.InitialFocus == true)
+			{
+				 // Do not focus natively on initial focus so the soft keyboard is not opened
+				return false;
+			}
+
 			if (element is TextBox textBox)
 			{
 				return textBox.FocusTextView();

--- a/src/Uno.UI/UI/Xaml/Window.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.macOS.cs
@@ -1,18 +1,18 @@
-using CoreGraphics;
-using Foundation;
 using System;
+using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
 using AppKit;
+using CoreGraphics;
+using Foundation;
+using Uno.UI;
+using Uno.UI.Controls;
+using Uno.UI.Xaml.Core;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI.Core;
-using Uno.UI.Controls;
-using System.Drawing;
 using Windows.UI.ViewManagement;
-using Uno.UI;
 using Windows.UI.Xaml.Controls;
-using Uno.UI.Xaml.Core;
 
 namespace Windows.UI.Xaml
 {
@@ -61,6 +61,8 @@ namespace Windows.UI.Xaml
 
 			InitializeCommon();
 		}
+
+		internal NSWindow NativeWindow => _window;
 
 		private void ObserveOrientationAndSize()
 		{


### PR DESCRIPTION


GitHub Issue (If applicable): fixes #6650

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Previously, the first focusable child was focused on Page, even if the Page itself was focusable. 

## What is the new behavior?

Now the Page can be focused itself, which matches UWP. In addition, on initial focus we avoid opening the InputPane in case the initial focused element is a TextBox.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.