### PR TITLE
fix: Disable light-dismissing MessageDialog

### DIFF
--- a/build/ios-uitest-run.sh
+++ b/build/ios-uitest-run.sh
@@ -41,7 +41,8 @@ else
 			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests' or \
 			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.WUXProgressRingTests' or \
 			class = 'SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests.DragDrop_ListViewReorder_Automated' or \
-			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests'
+			namespace = 'SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests' or \
+			namespace = 'SamplesApp.UITests.MessageDialogTests'
 		"
 	elif [ "$UITEST_AUTOMATED_GROUP" == '2' ];
 	then

--- a/src/SamplesApp/SamplesApp.UITests/Constants.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Constants.cs
@@ -9,7 +9,7 @@ namespace SamplesApp.UITests
 {
 	public partial class Constants
 	{
-		public const string WebAssemblyDefaultUri = "http://localhost:55838/";
+		public const string WebAssemblyDefaultUri = "https://localhost:44309/";
 		public const string iOSAppName = "uno.platform.uitestsample";
 		public const string AndroidAppName = "uno.platform.unosampleapp";
 		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";

--- a/src/SamplesApp/SamplesApp.UITests/MessageDialogTests/MessageDialogTest.cs
+++ b/src/SamplesApp/SamplesApp.UITests/MessageDialogTests/MessageDialogTest.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.MessageDialogTests
+{
+	[TestFixture]
+	public partial class MessageDialogTest : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // Skipping Wasm due to: OpenQA.Selenium.UnhandledAlertException : unexpected alert open: {Alert text : Content}
+		public void When_Click_Outside_Dialog_Expect_No_Dismiss()
+		{
+			Run("UITests.Shared.MessageDialogTests.MessageDialogTest");
+			var button = _app.Marked("showDialogBtn");
+			button.FastTap();
+
+			// A little animation happens. Sleep to reliably compare screenshots
+			Thread.Sleep(1000);
+
+			using var screenshot = TakeScreenshot("BeforeClicking");
+
+			var label = _app.Marked("labelOutside");
+			_app.WaitForElement(label);
+			label.FastTap();
+			using var screenshot2 = TakeScreenshot("AfterClicking");
+
+			ImageAssert.AreEqual(screenshot, screenshot2);
+
+			// Close the dialog.
+			var chkBox = _app.Marked("chkBox");
+			chkBox.SetDependencyPropertyValue("IsChecked", "True");
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/MessageDialogTests/MessageDialogTest.cs
+++ b/src/SamplesApp/SamplesApp.UITests/MessageDialogTests/MessageDialogTest.cs
@@ -11,7 +11,9 @@ namespace SamplesApp.UITests.MessageDialogTests
 	{
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)] // Skipping Wasm due to: OpenQA.Selenium.UnhandledAlertException : unexpected alert open: {Alert text : Content}
+		// iOS tracked by: https://github.com/unoplatform/uno/issues/6936
+		// Skipping Wasm due to: OpenQA.Selenium.UnhandledAlertException : unexpected alert open: {Alert text : Content}
+		[ActivePlatforms(Platform.Android)]
 		public void When_Click_Outside_Dialog_Expect_No_Dismiss()
 		{
 			Run("UITests.Shared.MessageDialogTests.MessageDialogTest");

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -32,6 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <Folder Include="MessageDialogTests\" />
 	  <Folder Include="Windows_UI_Xaml_Shapes\Basics_Shapes_Tests_EpectedResults\" />
 	</ItemGroup>
 

--- a/src/SamplesApp/UITests.Shared/MessageDialogTests/MessageDialogTest.xaml
+++ b/src/SamplesApp/UITests.Shared/MessageDialogTests/MessageDialogTest.xaml
@@ -1,0 +1,23 @@
+﻿<Page
+    x:Class="UITests.Shared.MessageDialogTests.MessageDialogTest"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.MessageDialog"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*"/>
+			<RowDefinition Height="auto"/>
+		</Grid.RowDefinitions>
+
+		<StackPanel>
+			<Button Grid.Row="0" x:Name="showDialogBtn" Content="Show dialog" Click="OnClick" />
+			<CheckBox x:Name="chkBox" Checked="OnCheckedChanged" Unchecked="OnCheckedChanged" />
+		</StackPanel>
+		<TextBlock Grid.Row="1" x:Name="labelOutside" Text="Text at bottom to be outside the bounds of the dialog" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/MessageDialogTests/MessageDialogTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/MessageDialogTests/MessageDialogTest.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.UI.Popups;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Shared.MessageDialogTests
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[Sample("MessageDialogTest")]
+	public sealed partial class MessageDialogTest : Page
+    {
+		private IAsyncOperation<IUICommand> _asyncOperation;
+
+		public MessageDialogTest()
+        {
+            this.InitializeComponent();
+        }
+
+		private async void OnClick(object sender, RoutedEventArgs e)
+		{
+			var dialog = new Windows.UI.Popups.MessageDialog("Content", "Title");
+			_asyncOperation = dialog.ShowAsync();
+			_ = await _asyncOperation;
+		}
+
+		private void OnCheckedChanged(object sender, RoutedEventArgs e)
+		{
+			_asyncOperation.Cancel();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -21,6 +21,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)MessageDialogTests\MessageDialogTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\AnimatedIconTests\AnimatedIconPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4255,6 +4259,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Lottie\LottieProgressPage.xaml.cs">
       <DependentUpon>LottieProgressPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)MessageDialogTests\MessageDialogTest.xaml.cs">
+      <DependentUpon>MessageDialogTest.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\AnimatedIconTests\AnimatedIconPage.xaml.cs">
       <DependentUpon>AnimatedIconPage.xaml</DependentUpon>

--- a/src/Uno.UWP/UI/Popups/MessageDialog.Android.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.Android.cs
@@ -45,6 +45,7 @@ namespace Windows.UI.Popups
 						.SetTitle(Title ?? "")
 						.SetMessage(Content ?? "")
 						.SetOnCancelListener(new DialogListener(this, invokedCommand))
+						.SetCancelable(false)
 						.Create(),
 					(alertDialog, commandInfo) =>
 					{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1950

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix

## What is the current behavior?

MessageDialog can be light-dismissed

## What is the new behavior?

MessageDialog can't be light-dismissed.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
