### PR TITLE
feat: ActualTheme and ActualThemeChanged

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Theming/Given_Element_Theme.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Theming/Given_Element_Theme.cs
@@ -8,11 +8,15 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
 	[TestClass]
 	public partial class Given_Element_Theme
 	{
+		[TestInitialize]
+		public void Initialize()
+		{
+			UnitTestsApp.App.EnsureApplication();
+		}
+
 		[TestMethod]
 		public void RequestedTheme_Default()
 		{
-			var app = UnitTestsApp.App.EnsureApplication();
-
 			var border = new Border();
 			Assert.AreEqual(ElementTheme.Default, border.RequestedTheme);
 		}
@@ -20,9 +24,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
 		[TestMethod]
 		public void ActualTheme_Matching_App_Theme()
 		{
-			var app = UnitTestsApp.App.EnsureApplication();
-
-			var initialTheme = app.RequestedTheme == ApplicationTheme.Dark ?
+			var initialTheme = Application.Current.RequestedTheme == ApplicationTheme.Dark ?
 				ElementTheme.Dark : ElementTheme.Light;
 
 			var border = new Border();
@@ -30,7 +32,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
 
 			SwapSystemTheme();
 
-			var updatedTheme = app.RequestedTheme == ApplicationTheme.Dark ?
+			var updatedTheme = Application.Current.RequestedTheme == ApplicationTheme.Dark ?
 				ElementTheme.Dark : ElementTheme.Light;
 
 			Assert.AreEqual(updatedTheme, border.ActualTheme);
@@ -39,9 +41,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
 		[TestMethod]
 		public void ActualTheme_With_Explicit_RequestedTheme()
 		{
-			var app = UnitTestsApp.App.EnsureApplication();
-
-			app.SetExplicitRequestedTheme(ApplicationTheme.Dark);
+			Application.Current.SetExplicitRequestedTheme(ApplicationTheme.Dark);
 
 			var border = new Border();
 			Assert.AreEqual(ElementTheme.Dark, border.ActualTheme);
@@ -56,9 +56,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
 		[TestMethod]
 		public void ActualThemeChanged_Called_With_RequestedTheme()
 		{
-			var app = UnitTestsApp.App.EnsureApplication();
-
-			app.SetExplicitRequestedTheme(ApplicationTheme.Dark);
+			Application.Current.SetExplicitRequestedTheme(ApplicationTheme.Dark);
 
 			int callCounter = 0;
 			var border = new Border();

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Theming/Given_Element_Theme.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Theming/Given_Element_Theme.cs
@@ -1,0 +1,92 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
+{
+	[TestClass]
+	public partial class Given_Element_Theme
+	{
+		[TestMethod]
+		public void RequestedTheme_Default()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			var border = new Border();
+			Assert.AreEqual(ElementTheme.Default, border.RequestedTheme);
+		}
+
+		[TestMethod]
+		public void ActualTheme_Matching_App_Theme()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			var initialTheme = app.RequestedTheme == ApplicationTheme.Dark ?
+				ElementTheme.Dark : ElementTheme.Light;
+
+			var border = new Border();
+			Assert.AreEqual(initialTheme, border.ActualTheme);
+
+			SwapSystemTheme();
+
+			var updatedTheme = app.RequestedTheme == ApplicationTheme.Dark ?
+				ElementTheme.Dark : ElementTheme.Light;
+
+			Assert.AreEqual(updatedTheme, border.ActualTheme);
+		}
+
+		[TestMethod]
+		public void ActualTheme_With_Explicit_RequestedTheme()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			app.SetExplicitRequestedTheme(ApplicationTheme.Dark);
+
+			var border = new Border();
+			Assert.AreEqual(ElementTheme.Dark, border.ActualTheme);
+
+			border.RequestedTheme = ElementTheme.Light;
+			Assert.AreEqual(ElementTheme.Light, border.ActualTheme);
+
+			border.RequestedTheme = ElementTheme.Default;
+			Assert.AreEqual(ElementTheme.Dark, border.ActualTheme);
+		}
+
+		[TestMethod]
+		public void ActualThemeChanged_Called_With_RequestedTheme()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			app.SetExplicitRequestedTheme(ApplicationTheme.Dark);
+
+			int callCounter = 0;
+			var border = new Border();
+			border.ActualThemeChanged += (s, e) =>
+			{
+				callCounter++;
+			};
+
+			border.RequestedTheme = ElementTheme.Dark;
+			Assert.AreEqual(0, callCounter);
+
+			border.RequestedTheme = ElementTheme.Light;
+			Assert.AreEqual(1, callCounter);
+
+			border.RequestedTheme = ElementTheme.Default;
+			Assert.AreEqual(2, callCounter);
+		}
+
+		private static async Task<bool> SwapSystemTheme()
+		{
+			var currentTheme = Application.Current.RequestedTheme;
+			var targetTheme = currentTheme == ApplicationTheme.Light ?
+				ApplicationTheme.Dark :
+				ApplicationTheme.Light;
+			Application.Current.SetExplicitRequestedTheme(targetTheme);
+
+			Assert.AreEqual(targetTheme, Application.Current.RequestedTheme);
+			return true;
+		}
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
@@ -627,7 +627,7 @@ namespace Windows.UI.Xaml
 		#endif
 		// Skipping already declared event Windows.UI.Xaml.FrameworkElement.Unloaded
 		// Skipping already declared event Windows.UI.Xaml.FrameworkElement.Loading
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.FrameworkElement, object> ActualThemeChanged
 		{

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -151,11 +151,11 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		internal ElementTheme ActualElementTheme => (_themeSetExplicitly, RequestedTheme) switch
+		internal ElementTheme ActualElementTheme => RequestedTheme switch
 		{
-			(true, ApplicationTheme.Light) => ElementTheme.Light,
-			(true, ApplicationTheme.Dark) => ElementTheme.Dark,
-			_ => ElementTheme.Default
+			ApplicationTheme.Light => ElementTheme.Light,
+			ApplicationTheme.Dark => ElementTheme.Dark,
+			_ => throw new InvalidOperationException("Application's RequestedTheme is invalid."),
 		};
 
 		internal void SetExplicitRequestedTheme(ApplicationTheme? explicitTheme)

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -451,15 +451,18 @@ namespace Windows.UI.Xaml
 				Application.Current.SetExplicitRequestedTheme(Uno.UI.Extensions.ElementThemeExtensions.ToApplicationThemeOrDefault(newValue));
 			}
 
-			var actualThemeChanged =
-				// 1. Previously was default, and new explicit value differs from application theme
-				(oldValue == ElementTheme.Default && Application.Current?.ActualElementTheme != newValue) ||
-				//2. Previously was explicit, and new ActualTheme is different
-				(oldValue != ElementTheme.Default && oldValue != ActualTheme);
-
-			if (actualThemeChanged)
+			if (ActualThemeChanged != null)
 			{
-				ActualThemeChanged?.Invoke(this, null);
+				var actualThemeChanged =
+					// 1. Previously was default, and new explicit value differs from application theme
+					(oldValue == ElementTheme.Default && Application.Current?.ActualElementTheme != newValue) ||
+					// 2. Previously was explicit, and new ActualTheme is different
+					(oldValue != ElementTheme.Default && oldValue != ActualTheme);
+
+				if (actualThemeChanged)
+				{
+					ActualThemeChanged?.Invoke(this, null);
+				}
 			}
 		}
 
@@ -890,7 +893,7 @@ namespace Windows.UI.Xaml
 			_focusVisualBrushesInitialized = false;
 
 			// Trigger ActualThemeChanged if relevant
-			if (RequestedTheme == ElementTheme.Default)
+			if (ActualThemeChanged != null && RequestedTheme == ElementTheme.Default)
 			{
 				ActualThemeChanged?.Invoke(this, null);
 			}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -421,6 +421,11 @@ namespace Windows.UI.Xaml
 
 		#region Requested theme dependency property
 
+		// TODO Uno: ActualTheme should always be initialized with Application.Current.RequestedTheme,
+		// and should trigger ActualThemeChanged, when the element enters the visual tree, where some
+		// higher-level element has explicitly changed its RequestedTheme. This may could start working
+		// automatically when the RequestedTheme property supports inheritance.
+
 		public ElementTheme RequestedTheme
 		{
 			get => (ElementTheme)GetValue(RequestedThemeProperty);
@@ -442,16 +447,42 @@ namespace Windows.UI.Xaml
 			{
 				// This is an ultra-naive implementation... but nonetheless enables the common use case of overriding the system theme for
 				// the entire visual tree (since Application.RequestedTheme cannot be set after launch)
+				// This will also explicitly change the Application.Current.RequestedTheme, which does not happen in case of UWP.
 				Application.Current.SetExplicitRequestedTheme(Uno.UI.Extensions.ElementThemeExtensions.ToApplicationThemeOrDefault(newValue));
+			}
+
+			var actualThemeChanged =
+				// 1. Previously was default, and new explicit value differs from application theme
+				(oldValue == ElementTheme.Default && Application.Current?.ActualElementTheme != newValue) ||
+				//2. Previously was explicit, and new ActualTheme is different
+				(oldValue != ElementTheme.Default && oldValue != ActualTheme);
+
+			if (actualThemeChanged)
+			{
+				ActualThemeChanged?.Invoke(this, null);
 			}
 		}
 
 
 		#endregion
 
-		public ElementTheme ActualTheme => IsWindowRoot ?
-			Application.Current?.ActualElementTheme ?? ElementTheme.Default
-			: ElementTheme.Default;
+		/// <summary>
+		/// Gets or sets a value that determines the light-dark
+		/// preference for the overall theme of an app.
+		/// </summary>
+		/// <remarks>
+		/// This is always either Dark or Light. By default the color matches Application.Current.RequestedTheme.
+		/// When the FrameworkElement.RequestedTheme has non-default value, it has precedence.
+		/// When the value changes ActualThemeChanged event is triggered.
+		/// </remarks>
+		public ElementTheme ActualTheme => RequestedTheme == ElementTheme.Default ?
+			(Application.Current?.ActualElementTheme ?? ElementTheme.Light) :
+			RequestedTheme;
+
+		/// <summary>
+		/// Occurs when the ActualTheme property value has changed.
+		/// </summary>
+		public event TypedEventHandler<FrameworkElement, object> ActualThemeChanged;
 
 		[GeneratedDependencyProperty]
 		public static DependencyProperty FocusVisualSecondaryThicknessProperty { get; } = CreateFocusVisualSecondaryThicknessProperty();
@@ -857,6 +888,12 @@ namespace Windows.UI.Xaml
 
 			// After theme change, the focus visual brushes may not reflect the correct settings
 			_focusVisualBrushesInitialized = false;
+
+			// Trigger ActualThemeChanged if relevant
+			if (RequestedTheme == ElementTheme.Default)
+			{
+				ActualThemeChanged?.Invoke(this, null);
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6620

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

- `ActualTheme` can be `ElementTheme.Default`
- `ActualThemeChanged` is not implemented

## What is the new behavior?

- `ActualTheme` is never default
- `ActualThemeChanged` is triggered

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.