### PR TITLE
fix: Add 'base.' to make sure we not access generated property with same base name

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -20,6 +20,7 @@ using Uno.UI.Xaml;
 using Uno.Disposables;
 using Uno.UI.SourceGenerators.BindableTypeProviders;
 using Microsoft.CodeAnalysis.CSharp;
+using System.Diagnostics;
 
 #if NETFRAMEWORK
 using GeneratorExecutionContext = Uno.SourceGeneration.GeneratorExecutionContext;
@@ -650,7 +651,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			using (TrySetDefaultBindMode(topLevelControl))
 			{
 				RegisterAndBuildResources(writer, topLevelControl, isInInitializer: false);
-				BuildProperties(writer, topLevelControl, isInline: false, returnsContent: isDirectUserControlChild);
+				BuildProperties(writer, topLevelControl, isInline: false, returnsContent: isDirectUserControlChild, useBase: true);
 
 				writer.AppendLineInvariant(";");
 
@@ -1982,7 +1983,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 		}
 
-		private bool BuildProperties(IIndentedStringBuilder writer, XamlObjectDefinition topLevelControl, bool isInline = true, bool returnsContent = false, string? closureName = null)
+		private bool BuildProperties(IIndentedStringBuilder writer, XamlObjectDefinition topLevelControl, bool isInline = true, bool returnsContent = false, string? closureName = null, bool useBase = false)
 		{
 			TryAnnotateWithGeneratorSource(writer);
 			try
@@ -2169,9 +2170,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 										if (IsInitializableProperty(contentProperty))
 										{
+											string contentPropertyName = useBase ? $"base.{contentProperty.Name}" : contentProperty.Name;
 											if (isInline)
 											{
-												using (writer.BlockInvariant(contentProperty.Name + " = "))
+												using (writer.BlockInvariant($"{contentPropertyName} = "))
 												{
 													foreach (var child in implicitContentChild.Objects)
 													{
@@ -2184,7 +2186,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 											{
 												foreach (var inner in implicitContentChild.Objects)
 												{
-													writer.AppendLine($"{contentProperty.Name}.Add(");
+													writer.AppendLine($"{contentPropertyName}.Add(");
 
 													BuildChild(writer, implicitContentChild, inner);
 
@@ -2259,7 +2261,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 											// A localized value is available. Ignore this implicit content as localized resources take precedence over XAML.
 											!isLocalized)
 										{
-											writer.AppendLineInvariant(setterPrefix + contentProperty.Name + " = ");
+											// At the time of writing, if useBase is true, setterPrefix will be empty.
+											// This assertion serves as reminder to re-evaluate the logic if setterPrefix becomes a non-null.
+											Debug.Assert(!useBase || setterPrefix.Length == 0);
+											writer.AppendLineInvariant((useBase ? "base." : string.Empty) + setterPrefix + contentProperty.Name + " = ");
 
 											if (implicitContentChild.Objects.Count > 1)
 											{
@@ -5326,8 +5331,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			TryAnnotateWithGeneratorSource(writer);
 			if (HasIsParsing(objectDefinition.Type))
 			{
-				writer.AppendLineInvariant("IsParsing = true");
-				writer.AppendLineInvariant(isInitializer ? "," : ";");
+				// Append [base.]IsParsing = true(, or ;)
+				writer.AppendLineInvariant($"{(!isInitializer ? "base." : string.Empty)}IsParsing = true{(isInitializer ? "," : ";")}");
 			}
 		}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -5331,8 +5331,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			TryAnnotateWithGeneratorSource(writer);
 			if (HasIsParsing(objectDefinition.Type))
 			{
-				// Append [base.]IsParsing = true(, or ;)
-				writer.AppendLineInvariant($"{(!isInitializer ? "base." : string.Empty)}IsParsing = true{(isInitializer ? "," : ";")}");
+				var basePrefix = !isInitializer ? "base." : string.Empty;
+				var initializerSuffix = isInitializer ? "," : ";";
+				writer.AppendLineInvariant($"{basePrefix}IsParsing = true{initializerSuffix}");
 			}
 		}
 

--- a/src/SourceGenerators/XamlGenerationTests/Issue5054.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/Issue5054.xaml
@@ -1,0 +1,14 @@
+<Page
+    x:Class="XamlGenerationTests.Shared.Issue5054"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:XamlGenerationTests.Shared"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:core="using:XamlGenerationTests.Core"
+    mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="Placeholder stuff" x:Name="Content"/>
+	</Grid>
+</Page>

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -22,15 +22,15 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid11.0'">
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4"/>
-		<PackageReference Include="Xamarin.AndroidX.AppCompat"/>
-		<PackageReference Include="Xamarin.AndroidX.RecyclerView"/>
+		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
+		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
+		<PackageReference Include="Xamarin.AndroidX.RecyclerView" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid10.0'">
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4"/>
-		<PackageReference Include="Xamarin.AndroidX.AppCompat"/>
-		<PackageReference Include="Xamarin.AndroidX.RecyclerView"/>
+		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
+		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
+		<PackageReference Include="Xamarin.AndroidX.RecyclerView" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -38,6 +38,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <None Remove="Issue5054.xaml" />
 	  <None Remove="NamedColorsTest.xaml" />
 	  <None Remove="NonDPAssignableTest.xaml" />
 	  <None Remove="StoryboardTargetTest.xaml" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5054

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When the source generator is generating a property with name "Content", it shadows the base `Content` property, which causes issues when it's meant to access the base "Content" property.

## What is the new behavior?

Access the property with `base.` prefix to make sure we access the desired property.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
