### PR TITLE
docs: Update PR template to have a closing issue keyword

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-GitHub Issue (If applicable): #
+GitHub Issue (If applicable): closes #
 
 <!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
 


### PR DESCRIPTION
It's sometimes missed, causing the relevant issue to not be closed automatically.