### PR TITLE
fix: Parse XAML 'Run Inlines' correctly in Span

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/InlineTextInSpan.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/InlineTextInSpan.xaml
@@ -1,0 +1,12 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml.UIElementTests.InlineTextInSpan"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<StackPanel>
+		<TextBlock><Span>Where <Italic>did</Italic> my text go?</Span></TextBlock>
+	</StackPanel>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
@@ -462,7 +462,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private bool IsLiteralInlineText(object value, XamlMemberDefinition member, XamlObjectDefinition xamlObject)
 		{
 			return value is string
-				&& xamlObject.Type.Name == "TextBlock"
+				&& (xamlObject.Type.Name == "TextBlock" || xamlObject.Type.Name == "Span")
 				&& (member.Member.Name == "_UnknownContent" || member.Member.Name == "Inlines");
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3041

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Code not generated for inline text within a span.

## What is the new behavior?

Code is correctly generated.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
