### PR TITLE
fix(appbarbutton): [iOS] Fix AppBarButton icon sometimes disappearing

### DIFF
--- a/src/Uno.UI/Controls/AppBarButtonRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/AppBarButtonRenderer.iOS.cs
@@ -12,6 +12,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Uno.Extensions;
 using Uno.Logging;
+using Uno.UI.Extensions;
 
 namespace Uno.UI.Controls
 {
@@ -87,7 +88,7 @@ namespace Uno.UI.Controls
 				{
 					case BitmapIcon bitmap:
 						native.Image = UIImageHelper.FromUri(bitmap.UriSource);
-						native.CustomView = null;
+						native.ClearCustomView();
 						native.Title = null;
 						break;
 
@@ -97,7 +98,7 @@ namespace Uno.UI.Controls
 					default:
 						this.Log().WarnIfEnabled(() => $"{GetType().Name ?? "FontIcon, PathIcon and SymbolIcon"} are not supported. Use BitmapIcon instead with UriSource.");
 						native.Image = null;
-						native.CustomView = null;
+						native.ClearCustomView();
 						// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set. 
 						// We default to an empty string to ensure it is added.
 						native.Title = string.Empty;
@@ -110,7 +111,7 @@ namespace Uno.UI.Controls
 				{
 					case string text:
 						native.Image = null;
-						native.CustomView = null;
+						native.ClearCustomView();
 						native.Title = text;
 						break;
 
@@ -132,7 +133,7 @@ namespace Uno.UI.Controls
 
 					default:
 						native.Image = null;
-						native.CustomView = null;
+						native.ClearCustomView();
 						// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set. 
 						// We default to an empty string to ensure it is added.
 						native.Title = string.Empty;

--- a/src/Uno.UI/Extensions/UIBarButtonItemExtensions.iOS.cs
+++ b/src/Uno.UI/Extensions/UIBarButtonItemExtensions.iOS.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Uno.Extensions;
+using UIKit;
+
+namespace Uno.UI.Extensions
+{
+	internal static class UIBarButtonItemExtensions
+	{
+		/// <summary>
+		/// In some narrow circumstances (eg when the page is unloaded, but not always) setting CustomView to null can trigger a native exception,
+		/// even if it's already null. To avoid this, skip redundantly setting it to null.
+		/// </summary>
+		public static void ClearCustomView(this UIBarButtonItem barButtonItem)
+		{
+			if (barButtonItem?.CustomView != null)
+			{
+				barButtonItem.CustomView = null;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes bug which occurs in narrow circumstances* where AppBarButton icon would disappear after navigating away from page then back.

*The bug occurs when properties of the AppBarButton are modified, causing Render() to be called, after navigating away; setting CustomView to null triggers a native exception similar to this one: https://stackoverflow.com/questions/53219042/self-navigationitem-rightbarbuttonitem-customview-nil-crash

The bug surfaced after recent changes to MenuFlyout (https://github.com/unoplatform/uno/pull/6571), but seems more a timing issue rather than directly related to those changes. The bug didn't occur in a standalone repro mimicking the configuration of the app for which it was reported.

GitHub Issue (If applicable): closes https://github.com/unoplatform/nventive-private/issues/243

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
