### PR TITLE
fix: WASM TextBox getting focus when part of recycled template

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -38,6 +38,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
+#if HAS_UNO
 		[TestMethod]
 		public async Task When_Template_Recycled()
 		{
@@ -52,7 +53,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				await WindowHelper.WaitForLoaded(textBox);
 
 				FocusManager.GettingFocus += OnGettingFocus;
-
 				textBox.OnTemplateRecycled();
 			}
 			finally
@@ -65,6 +65,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.Fail("Focus should not move");
 			}
 		}
+#endif
 
 		[TestMethod]
 		public async Task When_Fluent_And_Theme_Changed()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -9,6 +9,7 @@ using Windows.UI;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
+using Windows.UI.Xaml.Input;
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -37,6 +38,33 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
+		[TestMethod]
+		public async Task When_Template_Recycled()
+		{
+			try
+			{
+				var textBox = new TextBox
+				{
+					Text = "Test"
+				};
+
+				WindowHelper.WindowContent = textBox;
+				await WindowHelper.WaitForLoaded(textBox);
+
+				FocusManager.GettingFocus += OnGettingFocus;
+
+				textBox.OnTemplateRecycled();
+			}
+			finally
+			{
+				FocusManager.GettingFocus -= OnGettingFocus;
+			}
+
+			static void OnGettingFocus(object sender, GettingFocusEventArgs args)
+			{
+				Assert.Fail("Focus should not move");
+			}
+		}
 
 		[TestMethod]
 		public async Task When_Fluent_And_Theme_Changed()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -104,7 +104,7 @@ namespace Windows.UI.Xaml.Controls
 			if (buttonRef != null)
 			{
 				var thisRef = (this as IWeakReferenceProvider).WeakReference;
-				buttonRef.Command = new DelegateCommand(() => (thisRef.Target as TextBox)?.DeleteText());
+				buttonRef.Command = new DelegateCommand(() => (thisRef.Target as TextBox)?.DeleteButtonClick());
 			}
 
 			InitializePropertiesPartial();
@@ -724,17 +724,20 @@ namespace Windows.UI.Xaml.Controls
 			return Text; //This may have been modified by BeforeTextChanging, TextChanging, DP callback, etc
 		}
 
-		private void DeleteText()
+		private void DeleteButtonClick()
 		{
 			Text = string.Empty;
-			OnTextClearedPartial();
+			OnDeleteButtonClickPartial();
 		}
 
-		partial void OnTextClearedPartial();
+		partial void OnDeleteButtonClickPartial();
 
 		internal void OnSelectionChanged() => SelectionChanged?.Invoke(this, new RoutedEventArgs(this));
 
-		public void OnTemplateRecycled() => DeleteText();
+		public void OnTemplateRecycled()
+		{
+			Text = string.Empty;
+		}
 
 		protected override AutomationPeer OnCreateAutomationPeer() => new TextBoxAutomationPeer(this);
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -9,7 +9,7 @@ namespace Windows.UI.Xaml.Controls
 		private TextBoxView _textBoxView;
 		
 		protected override bool IsDelegatingFocusToTemplateChild() => true; // _textBoxView
-		partial void OnTextClearedPartial() => FocusTextView();
+		partial void OnDeleteButtonClickPartial() => FocusTextView();
 		internal bool FocusTextView() => FocusManager.FocusNative(_textBoxView);
 
 		private void UpdateTextBoxView()


### PR DESCRIPTION
GitHub Issue (If applicable): part of #5834

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When template with `TextBox` is recycled, it automatically gives the `TextBox` focus.

## What is the new behavior?

Does not happen anymore.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.