### PR TITLE
fix: Make IsIntermediate setter internal

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3953,6 +3953,9 @@
 			<Member
 				fullName="System.Void Windows.UI.Xaml.Controls.Panel.set_CornerRadius(Windows.UI.Xaml.CornerRadius value)"
 				reason="Align Panel DPs" />
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Controls.ScrollViewerViewChangedEventArgs.set_IsIntermediate(System.Boolean value)"
+				reason="Aligned visibility with UWP" />
 		</Methods>
 		<Events>
 			<Member

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewerViewChangedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewerViewChangedEventArgs.cs
@@ -6,6 +6,6 @@ namespace Windows.UI.Xaml.Controls
 {
 	public sealed partial class ScrollViewerViewChangedEventArgs
 	{
-		public bool IsIntermediate { get; set; }
+		public bool IsIntermediate { get; internal set; }
     }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6682

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Public API not matching UWP

## What is the new behavior?

Make the setter internal so there is no public setter as in UWP.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
