### PR TITLE
fix: Fix checking symbol type when it's nullable ref type

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -320,8 +320,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private void TryGenerateWarningForInconsistentBaseType(IndentedStringBuilder writer, XamlObjectDefinition topLevelControl)
 		{
-			var xamlDefinedBaseType  = GetType(topLevelControl.Type);
-			var fullClassName        = _className.ns + "." + _className.className;
+			var xamlDefinedBaseType = GetType(topLevelControl.Type);
+			var fullClassName = _className.ns + "." + _className.className;
 			var classDefinedBaseType = FindType(fullClassName)?.BaseType;
 
 			if (!SymbolEqualityComparer.Default.Equals(xamlDefinedBaseType, classDefinedBaseType))
@@ -330,8 +330,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				if (locations != null && locations.Value.Length > 0)
 				{
 					var diagnostic = Diagnostic.Create(XamlCodeGenerationDiagnostics.GenericXamlWarningRule,
-					                                   locations.Value[0],
-					                                   $"{fullClassName} does not explicitly define the {xamlDefinedBaseType} base type in code behind.");
+													   locations.Value[0],
+													   $"{fullClassName} does not explicitly define the {xamlDefinedBaseType} base type in code behind.");
 					_generatorContext.ReportDiagnostic(diagnostic);
 				}
 				else
@@ -1493,7 +1493,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			TryAnnotateWithGeneratorSource(writer);
 			var targetTypeNode = GetMember(style, "TargetType");
 
-			if(targetTypeNode.Value == null)
+			if (targetTypeNode.Value == null)
 			{
 				throw new InvalidOperationException("TargetType cannot be empty");
 			}
@@ -2554,7 +2554,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						using (TryTernaryForLinkerHint(writer, resource))
 						{
 							writer.AppendLineInvariant("new global::Uno.UI.Xaml.WeakResourceInitializer(this, {0})", initializerName);
-						}					}
+						}
+					}
 					else
 					{
 						using (TryTernaryForLinkerHint(writer, resource))
@@ -3065,7 +3066,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								nameMember = member;
 								var value = member.Value?.ToString();
 
-								if(value == null)
+								if (value == null)
 								{
 									throw new InvalidOperationException("The Name property cannot be empty");
 								}
@@ -3128,7 +3129,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								member.Member.DeclaringType?.Name == "Storyboard"
 							)
 							{
-								if(member.Value == null)
+								if (member.Value == null)
 								{
 									throw new InvalidOperationException($"The TargetName property cannot be empty");
 								}
@@ -3158,7 +3159,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								member.Member.DeclaringType?.Name == "Storyboard"
 							)
 							{
-								if(member.Value == null)
+								if (member.Value == null)
 								{
 									throw new InvalidOperationException($"The TargetProperty property cannot be empty");
 								}
@@ -3381,7 +3382,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 									var parts = eventTarget.Split('.');
 
-									for (var i = 0; i < parts.Length-1; i++)
+									for (var i = 0; i < parts.Length - 1; i++)
 									{
 										var next = currentType.GetAllMembersWithName(parts[i]).FirstOrDefault();
 
@@ -3410,7 +3411,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							{
 								var dataTypeObject = FindMember(isInsideDataTemplate.xamlObject!, "DataType", XamlConstants.XamlXmlNamespace);
 
-								if(dataTypeObject?.Value == null)
+								if (dataTypeObject?.Value == null)
 								{
 									throw new Exception($"Unable to find x:DataType in enclosing DataTemplate for x:Bind event");
 								}
@@ -3737,7 +3738,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					}
 					else if (IsAttachedProperty(member))
 					{
-						if(closureName == null)
+						if (closureName == null)
 						{
 							throw new InvalidOperationException("A closure name is required for attached properties");
 						}
@@ -4047,7 +4048,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				.FirstOrDefault(o => IsCustomMarkupExtensionType(o.Type));
 			var markupType = GetMarkupExtensionType(markupTypeDef?.Type);
 
-			if(markupType == null || markupTypeDef == null)
+			if (markupType == null || markupTypeDef == null)
 			{
 				throw new InvalidOperationException($"Unable to find markup extension type for ");
 			}
@@ -4285,24 +4286,24 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 
 				propertyType = FindUnderlyingType(propertyType);
+				switch (propertyType.SpecialType)
+				{
+					case SpecialType.System_Int32:
+					case SpecialType.System_Int64:
+					case SpecialType.System_Int16:
+					case SpecialType.System_Byte:
+						return GetMemberValue();
+					case SpecialType.System_Single:
+					case SpecialType.System_Double:
+						return GetFloatingPointLiteral(GetMemberValue(), propertyType, owner);
+					case SpecialType.System_String:
+						return "\"" + DoubleEscape(memberValue) + "\"";
+					case SpecialType.System_Boolean:
+						return bool.Parse(GetMemberValue()).ToString().ToLowerInvariant();
+				}
+
 				switch (propertyType.ToDisplayString())
 				{
-					case "int":
-					case "long":
-					case "short":
-					case "byte":
-						return GetMemberValue();
-
-					case "float":
-					case "double":
-						return GetFloatingPointLiteral(GetMemberValue(), propertyType, owner);
-
-					case "string":
-						return "\"" + DoubleEscape(memberValue) + "\"";
-
-					case "bool":
-						return Boolean.Parse(GetMemberValue()).ToString().ToLowerInvariant();
-
 					case XamlConstants.Types.Brush:
 					case XamlConstants.Types.SolidColorBrush:
 						return BuildBrush(GetMemberValue());
@@ -4736,7 +4737,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 				else if (memberName == "ElementName")
 				{
-					if(m.Value == null)
+					if (m.Value == null)
 					{
 						throw new InvalidOperationException($"The property ElementName cannot be empty");
 					}
@@ -5155,7 +5156,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					|| typeName == "TemplateBinding"
 					)
 				{
-					if(owner == null)
+					if (owner == null)
 					{
 						throw new InvalidOperationException($"An owner is required for {typeName}");
 					}
@@ -5288,7 +5289,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					{
 						var propertyType = FindType(xamlObjectDefinition.Type);
 						var implicitContent = FindImplicitContentMember(xamlObjectDefinition);
-						if(implicitContent == null)
+						if (implicitContent == null)
 						{
 							throw new InvalidOperationException($"Unable to find content value on {xamlObjectDefinition}");
 						}
@@ -5558,8 +5559,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								}
 
 								var isInsideFrameworkTemplate = IsMemberInsideFrameworkTemplate(definition).isInside;
-
-								if ( (!_isTopLevelDictionary || isInsideFrameworkTemplate)
+								if ((!_isTopLevelDictionary || isInsideFrameworkTemplate)
 									&& (HasXBindMarkupExtension(definition) || HasMarkupExtensionNeedingComponent(definition)))
 								{
 									var componentName = $"_component_{ CurrentScope.ComponentCount}";
@@ -5793,7 +5793,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				if (xamlObjectDefinition.Type.Name == "Double" || xamlObjectDefinition.Type.Name == "Single")
 				{
-					if(initializer.Value == null)
+					if (initializer.Value == null)
 					{
 						throw new InvalidOperationException($"Initializer value for {xamlObjectDefinition.Type.Name} cannot be empty");
 					}

--- a/src/SourceGenerators/XamlGenerationTests/NullableProperty.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/NullableProperty.xaml
@@ -1,0 +1,21 @@
+﻿<Page
+    x:Class="XamlGenerationTests.Shared.NullableProperty"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:e="using:XamlGenerationTests.Dedoose.Extensions"
+    mc:Ignorable="d"
+    >
+    <Grid 
+        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+        e:GridExtensions.ColumnsAndRows="*,A,*;*,A,*"
+        >
+		<TextBlock 
+            Grid.Column="1" 
+            Grid.Row="1" 
+            Text="Hello, world!" 
+            FontSize="100" 
+            />
+    </Grid>
+</Page>

--- a/src/SourceGenerators/XamlGenerationTests/NullableProperty_GridExtensions.cs
+++ b/src/SourceGenerators/XamlGenerationTests/NullableProperty_GridExtensions.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+#if WPF_APP
+using System.Windows;
+using System.Windows.Controls;
+#else
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+#endif
+
+#nullable enable
+
+namespace XamlGenerationTests.Dedoose.Extensions
+{
+    public static class GridExtensions
+    {
+        #region ColumnsAndRows
+
+        public static readonly DependencyProperty ColumnsAndRowsProperty =
+            DependencyProperty.RegisterAttached(
+                nameof(ColumnsAndRowsProperty).Replace("Property", string.Empty),
+                typeof(string),
+                typeof(GridExtensions),
+                new PropertyMetadata(string.Empty, OnColumnsAndRowsChanged));
+
+        public static string? GetColumnsAndRows(DependencyObject element)
+        {
+            return (string?)element.GetValue(ColumnsAndRowsProperty);
+        }
+
+        public static void SetColumnsAndRows(DependencyObject element, string? value)
+        {
+            element.SetValue(ColumnsAndRowsProperty, value);
+        }
+
+        private static void OnColumnsAndRowsChanged(
+            DependencyObject element,
+            DependencyPropertyChangedEventArgs args)
+        {
+		    var grid = (Grid)element;
+            var columnsAndRows = (string)args.NewValue;
+
+            grid.ColumnDefinitions.Clear();
+            grid.RowDefinitions.Clear();
+
+            if (string.IsNullOrWhiteSpace(columnsAndRows))
+            {
+                return;
+            }
+
+            var values = columnsAndRows.Split(';');
+            foreach (var value in (values.ElementAtOrDefault(0) ?? "*").Split(','))
+            {
+                grid.ColumnDefinitions.Add(new ColumnDefinition
+                {
+                    Width = GridLengthConverter.ConvertFromInvariantString(value),
+                });
+            }
+            foreach (var value in (values.ElementAtOrDefault(1) ?? "*").Split(','))
+            {
+                grid.RowDefinitions.Add(new RowDefinition
+                {
+                    Height = GridLengthConverter.ConvertFromInvariantString(value),
+                });
+            }
+        }
+
+        #endregion
+
+        #region Columns
+
+        public static readonly DependencyProperty ColumnsProperty =
+            DependencyProperty.RegisterAttached(
+                nameof(ColumnsProperty).Replace("Property", string.Empty),
+                typeof(string),
+                typeof(GridExtensions),
+                new PropertyMetadata(string.Empty, OnColumnsChanged));
+
+        public static string? GetColumns(DependencyObject element)
+        {
+            return (string?)element.GetValue(ColumnsProperty);
+        }
+
+        public static void SetColumns(DependencyObject element, string? value)
+        {
+            element.SetValue(ColumnsProperty, value);
+        }
+
+        private static void OnColumnsChanged(
+            DependencyObject element,
+            DependencyPropertyChangedEventArgs args)
+        {
+		    var grid = (Grid)element;
+			var columns = (string)args.NewValue;
+
+            element.SetValue(ColumnsAndRowsProperty, $"{columns};*");
+        }
+
+        #endregion
+
+        #region Rows
+
+        public static readonly DependencyProperty RowsProperty =
+            DependencyProperty.RegisterAttached(
+                nameof(RowsProperty).Replace("Property", string.Empty),
+                typeof(string),
+                typeof(GridExtensions),
+                new PropertyMetadata(string.Empty, OnRowsChanged));
+
+        public static string? GetRows(DependencyObject element)
+        {
+            return (string?)element.GetValue(RowsProperty);
+        }
+
+        public static void SetRows(DependencyObject element, string? value)
+        {
+            element.SetValue(RowsProperty, value);
+        }
+
+        private static void OnRowsChanged(
+            DependencyObject element,
+            DependencyPropertyChangedEventArgs args)
+        {
+            var rows = (string)args.NewValue;
+            element.SetValue(ColumnsAndRowsProperty, $"*;{rows}");
+        }
+
+        #endregion
+
+        #region GridLengthConverter
+
+        /// <summary>
+        /// https://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/Windows/GridLengthConverter.cs
+        /// </summary>
+        private class GridLengthConverter
+        {
+            public static GridLength ConvertFromInvariantString(string text)
+            {
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    return new GridLength(1, GridUnitType.Star);
+                }
+                if (text.ToUpperInvariant() == "AUTO")
+                {
+                    return GridLength.Auto;
+                }
+
+                if (text.Contains("*"))
+                {
+                    var value = text.Replace("*", string.Empty);
+
+                    return new GridLength(
+                        string.IsNullOrWhiteSpace(value)
+                            ? 1
+                            : Convert.ToDouble(value, CultureInfo.InvariantCulture),
+                        GridUnitType.Star);
+                }
+
+                return new GridLength(Convert.ToDouble(text, CultureInfo.InvariantCulture));
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6688, closes #5829, closes #4591

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`string?` not matched as `string`.


## What is the new behavior?

Both are considered the same via the check of `SpecialType`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
