### PR TITLE
feat: Initial support for CoreWindow.GetKeyState

### DIFF
--- a/src/Uno.UI.Tests/Uno_UI_Core/Given_KeyboardStateTracker.cs
+++ b/src/Uno.UI.Tests/Uno_UI_Core/Given_KeyboardStateTracker.cs
@@ -1,0 +1,105 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Core;
+using Windows.System;
+using Windows.UI.Core;
+
+namespace Uno.UI.Tests.Uno_UI_Core
+{
+	[TestClass]
+	public class Given_KeyboardStateTracker
+	{
+		[TestMethod]
+		public void When_CleanSlate()
+		{
+			var state = KeyboardStateTracker.GetKeyState(VirtualKey.A);
+			Assert.AreEqual(CoreVirtualKeyStates.None, state);
+		}
+
+		[TestMethod]
+		public void When_Initial_Press_Locks()
+		{
+			KeyboardStateTracker.OnKeyDown(VirtualKey.B);
+
+			var state = KeyboardStateTracker.GetKeyState(VirtualKey.B);
+			Assert.AreEqual(CoreVirtualKeyStates.Down | CoreVirtualKeyStates.Locked, state);
+		}
+
+		[TestMethod]
+		public void When_Release_Keeps_Lock()
+		{
+			KeyboardStateTracker.OnKeyDown(VirtualKey.C);
+			KeyboardStateTracker.OnKeyUp(VirtualKey.C);
+
+			var state = KeyboardStateTracker.GetKeyState(VirtualKey.C);
+			Assert.AreEqual(CoreVirtualKeyStates.None | CoreVirtualKeyStates.Locked, state);
+		}
+
+		[TestMethod]
+		public void When_Second_Down_Unlocks()
+		{
+			KeyboardStateTracker.OnKeyDown(VirtualKey.D);
+			KeyboardStateTracker.OnKeyUp(VirtualKey.D);
+			KeyboardStateTracker.OnKeyDown(VirtualKey.D);
+
+			var state = KeyboardStateTracker.GetKeyState(VirtualKey.D);
+			Assert.AreEqual(CoreVirtualKeyStates.Down, state);
+		}
+
+		[TestMethod]
+		public void When_Second_Release_Keeps_Unlocked()
+		{
+			KeyboardStateTracker.OnKeyDown(VirtualKey.E);
+			KeyboardStateTracker.OnKeyUp(VirtualKey.E);
+			KeyboardStateTracker.OnKeyDown(VirtualKey.E);
+			KeyboardStateTracker.OnKeyUp(VirtualKey.E);
+
+			var state = KeyboardStateTracker.GetKeyState(VirtualKey.E);
+			Assert.AreEqual(CoreVirtualKeyStates.None, state);
+		}
+
+		[TestMethod]
+		public void When_Even_KeyDown()
+		{
+			for (int i = 0; i < 10; i++)
+			{
+				// Odd sequence unlocks
+				KeyboardStateTracker.OnKeyDown(VirtualKey.F);
+				KeyboardStateTracker.OnKeyUp(VirtualKey.F);
+
+				// Every even down should set lock
+				KeyboardStateTracker.OnKeyDown(VirtualKey.F);
+
+				var state = KeyboardStateTracker.GetKeyState(VirtualKey.F);
+				Assert.AreEqual(CoreVirtualKeyStates.Down, state);
+
+				KeyboardStateTracker.OnKeyUp(VirtualKey.F);
+
+				state = KeyboardStateTracker.GetKeyState(VirtualKey.F);
+				Assert.AreEqual(CoreVirtualKeyStates.None, state);
+			}
+		}
+
+		[TestMethod]
+		public void When_Odd_KeyDown()
+		{
+			for (int i = 0; i < 10; i++)
+			{
+				// Every odd down should not have lock
+				KeyboardStateTracker.OnKeyDown(VirtualKey.G);
+
+				var state = KeyboardStateTracker.GetKeyState(VirtualKey.G);
+				Assert.AreEqual(CoreVirtualKeyStates.Down | CoreVirtualKeyStates.Locked, state);
+
+				KeyboardStateTracker.OnKeyUp(VirtualKey.G);
+
+				state = KeyboardStateTracker.GetKeyState(VirtualKey.G);
+				Assert.AreEqual(CoreVirtualKeyStates.None | CoreVirtualKeyStates.Locked, state);
+
+				// Unlock sequence
+				KeyboardStateTracker.OnKeyDown(VirtualKey.G);
+				KeyboardStateTracker.OnKeyUp(VirtualKey.G);
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -627,6 +627,9 @@ namespace Windows.UI.Xaml
 				throw new InvalidOperationException($"Flag not defined for routed event {routedEvent.Name}.");
 			}
 
+			// TODO: This is just temporary workaround before proper
+			// keyboard event infrastructure is implemented everywhere
+			// (issue #6074)
 			if (routedEvent.IsKeyEvent)
 			{
 				TrackKeyState(routedEvent, args);

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -10,7 +10,7 @@ using Uno;
 using Uno.Extensions;
 using Uno.Logging;
 using Uno.UI;
-using Uno.UI.Core.Internal;
+using Uno.UI.Core;
 using Uno.UI.Extensions;
 using Uno.UI.Xaml;
 using Uno.UI.Xaml.Input;

--- a/src/Uno.UWP/UI/Core/CoreWindow.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.cs
@@ -3,7 +3,7 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
-using Uno.UI.Core.Internal;
+using Uno.UI.Core;
 using Windows.Foundation;
 using Windows.UI.Input;
 

--- a/src/Uno.UWP/UI/Core/CoreWindow.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.cs
@@ -3,6 +3,7 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
+using Uno.UI.Core.Internal;
 using Windows.Foundation;
 using Windows.UI.Input;
 
@@ -86,13 +87,11 @@ namespace Windows.UI.Core
 		public static CoreWindow? GetForCurrentThread()
 			=> _current; // UWP returns 'null' if on a BG thread
 
-		[Uno.NotImplemented]
 		public CoreVirtualKeyStates GetAsyncKeyState(System.VirtualKey virtualKey)
-			=> CoreVirtualKeyStates.None;
+			=> KeyboardStateTracker.GetKeyState(virtualKey);
 
-		[Uno.NotImplemented]
 		public CoreVirtualKeyStates GetKeyState(System.VirtualKey virtualKey)
-			=> CoreVirtualKeyStates.None;
+			=> KeyboardStateTracker.GetKeyState(virtualKey);
 
 		internal static void SetInvalidateRender(Action invalidateRender)
 			=> _invalidateRender = invalidateRender;

--- a/src/Uno.UWP/UI/Core/Internal/KeyboardStateTracker.cs
+++ b/src/Uno.UWP/UI/Core/Internal/KeyboardStateTracker.cs
@@ -2,7 +2,7 @@
 using Windows.System;
 using Windows.UI.Core;
 
-namespace Uno.UI.Core.Internal
+namespace Uno.UI.Core
 {
 	/// <summary>
 	/// Tracks keyboard key state.
@@ -38,17 +38,16 @@ namespace Uno.UI.Core.Internal
 				// The first key press should not cause Locked state.
 				_keyStates[key] = CoreVirtualKeyStates.Down;
 			}
+
+			if (!_keyStates[key].HasFlag(CoreVirtualKeyStates.Locked))
+			{
+				_keyStates[key] = CoreVirtualKeyStates.Down | CoreVirtualKeyStates.Locked;
+			}
 			else
 			{
-				if (!_keyStates[key].HasFlag(CoreVirtualKeyStates.Locked))
-				{
-					_keyStates[key] = CoreVirtualKeyStates.Down | CoreVirtualKeyStates.Locked;
-				}
-				else
-				{
-					_keyStates[key] = CoreVirtualKeyStates.Down;
-				}
+				_keyStates[key] = CoreVirtualKeyStates.Down;
 			}
+
 			SetStateOnNonSideKeys(key);
 		}
 
@@ -59,16 +58,14 @@ namespace Uno.UI.Core.Internal
 				// Edge case - key is released without previous press.
 				_keyStates[key] = CoreVirtualKeyStates.None;
 			}
+
+			if (_keyStates[key].HasFlag(CoreVirtualKeyStates.Locked))
+			{
+				_keyStates[key] = CoreVirtualKeyStates.None | CoreVirtualKeyStates.Locked;
+			}
 			else
 			{
-				if (_keyStates[key].HasFlag(CoreVirtualKeyStates.Locked))
-				{
-					_keyStates[key] = CoreVirtualKeyStates.None | CoreVirtualKeyStates.Locked;
-				}
-				else
-				{
-					_keyStates[key] = CoreVirtualKeyStates.None;
-				}
+				_keyStates[key] = CoreVirtualKeyStates.None;
 			}
 
 			SetStateOnNonSideKeys(key);

--- a/src/Uno.UWP/UI/Core/Internal/KeyboardStateTracker.cs
+++ b/src/Uno.UWP/UI/Core/Internal/KeyboardStateTracker.cs
@@ -4,10 +4,23 @@ using Windows.UI.Core;
 
 namespace Uno.UI.Core.Internal
 {
+	/// <summary>
+	/// Tracks keyboard key state.
+	/// </summary>
+	/// <remarks>
+	///	The behavior is based on description in https://docs.microsoft.com/en-us/uwp/api/windows.ui.core.corevirtualkeystates.
+	///	In UWP/WinUI, every key has a locked state (not only Caps Lock, etc.). The sequence of states is as follows:
+	///	(None) -> (Down) -> (None) -> (Down + Locked) -> (None + Locked) -> (Down) -> (None) -> etc.
+	/// </remarks>
 	internal static class KeyboardStateTracker
 	{
 		private static readonly Dictionary<VirtualKey, CoreVirtualKeyStates> _keyStates = new Dictionary<VirtualKey, CoreVirtualKeyStates>();
 
+		/// <summary>
+		/// Retrieves the current state for a given key.
+		/// </summary>
+		/// <param name="key">Key.</param>
+		/// <returns>Key state.</returns>
 		internal static CoreVirtualKeyStates GetKeyState(VirtualKey key)
 		{
 			if (_keyStates.TryGetValue(key, out var state))
@@ -22,18 +35,20 @@ namespace Uno.UI.Core.Internal
 		{
 			if (!_keyStates.ContainsKey(key))
 			{
-				_keyStates[key] = CoreVirtualKeyStates.None;
-			}
-
-			if (!_keyStates[key].HasFlag(CoreVirtualKeyStates.Locked))
-			{
-				_keyStates[key] = CoreVirtualKeyStates.Down | CoreVirtualKeyStates.Locked;
+				// The first key press should not cause Locked state.
+				_keyStates[key] = CoreVirtualKeyStates.Down;
 			}
 			else
 			{
-				_keyStates[key] = CoreVirtualKeyStates.Down;
+				if (!_keyStates[key].HasFlag(CoreVirtualKeyStates.Locked))
+				{
+					_keyStates[key] = CoreVirtualKeyStates.Down | CoreVirtualKeyStates.Locked;
+				}
+				else
+				{
+					_keyStates[key] = CoreVirtualKeyStates.Down;
+				}
 			}
-
 			SetStateOnNonSideKeys(key);
 		}
 
@@ -41,16 +56,19 @@ namespace Uno.UI.Core.Internal
 		{
 			if (!_keyStates.ContainsKey(key))
 			{
+				// Edge case - key is released without previous press.
 				_keyStates[key] = CoreVirtualKeyStates.None;
-			}
-
-			if (_keyStates[key].HasFlag(CoreVirtualKeyStates.Locked))
-			{
-				_keyStates[key] = CoreVirtualKeyStates.None | CoreVirtualKeyStates.Locked;
 			}
 			else
 			{
-				_keyStates[key] = CoreVirtualKeyStates.None;
+				if (_keyStates[key].HasFlag(CoreVirtualKeyStates.Locked))
+				{
+					_keyStates[key] = CoreVirtualKeyStates.None | CoreVirtualKeyStates.Locked;
+				}
+				else
+				{
+					_keyStates[key] = CoreVirtualKeyStates.None;
+				}
 			}
 
 			SetStateOnNonSideKeys(key);

--- a/src/Uno.UWP/UI/Core/Internal/KeyboardStateTracker.cs
+++ b/src/Uno.UWP/UI/Core/Internal/KeyboardStateTracker.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using Windows.System;
+using Windows.UI.Core;
+
+namespace Uno.UI.Core.Internal
+{
+	internal static class KeyboardStateTracker
+	{
+		private static readonly Dictionary<VirtualKey, CoreVirtualKeyStates> _keyStates = new Dictionary<VirtualKey, CoreVirtualKeyStates>();
+
+		internal static CoreVirtualKeyStates GetKeyState(VirtualKey key)
+		{
+			if (_keyStates.TryGetValue(key, out var state))
+			{
+				return state;
+			}
+
+			return CoreVirtualKeyStates.None;
+		}
+
+		internal static void OnKeyDown(VirtualKey key)
+		{
+			if (!_keyStates.ContainsKey(key))
+			{
+				_keyStates[key] = CoreVirtualKeyStates.None;
+			}
+
+			if (!_keyStates[key].HasFlag(CoreVirtualKeyStates.Locked))
+			{
+				_keyStates[key] = CoreVirtualKeyStates.Down | CoreVirtualKeyStates.Locked;
+			}
+			else
+			{
+				_keyStates[key] = CoreVirtualKeyStates.Down;
+			}
+
+			SetStateOnNonSideKeys(key);
+		}
+
+		internal static void OnKeyUp(VirtualKey key)
+		{
+			if (!_keyStates.ContainsKey(key))
+			{
+				_keyStates[key] = CoreVirtualKeyStates.None;
+			}
+
+			if (_keyStates[key].HasFlag(CoreVirtualKeyStates.Locked))
+			{
+				_keyStates[key] = CoreVirtualKeyStates.None | CoreVirtualKeyStates.Locked;
+			}
+			else
+			{
+				_keyStates[key] = CoreVirtualKeyStates.None;
+			}
+
+			SetStateOnNonSideKeys(key);
+		}
+
+		private static void SetStateOnNonSideKeys(VirtualKey key)
+		{
+			if (key == VirtualKey.LeftShift || key == VirtualKey.RightShift)
+			{
+				_keyStates[VirtualKey.Shift] = _keyStates[key];
+			}
+
+			if (key == VirtualKey.LeftControl || key == VirtualKey.RightControl)
+			{
+				_keyStates[VirtualKey.Control] = _keyStates[key];
+			}
+
+			if (key == VirtualKey.LeftMenu || key == VirtualKey.RightMenu)
+			{
+				_keyStates[VirtualKey.Menu] = _keyStates[key];
+			}
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): part of #5834 

## PR Type

What kind of change does this PR introduce?

- Feature
 
## What is the current behavior?

Key state is not tracked.


## What is the new behavior?

Key state is tracked for keyboard routed events (working on WASM and Skia currently).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.