### PR TITLE
fix: Ignore MarkupExtensionReturnType to match UWP behavior

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
@@ -125,7 +125,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			// MarkupExtension
 			public const string MarkupExtension = Markup + ".MarkupExtension";
 			public const string IMarkupExtensionOverrides = Markup + ".IMarkupExtensionOverrides";
-			public const string MarkupExtensionReturnTypeAttribute = Markup + ".MarkupExtensionReturnTypeAttribute";
 		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4069,24 +4069,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var markupTypeFullName = GetGlobalizedTypeName(markupType.GetFullName()!);
 			var xamlMarkupFullName = GetGlobalizedTypeName(XamlConstants.Types.IMarkupExtensionOverrides);
 
-			// Get the attribute from the custom markup extension class then get the return type specifed with MarkupExtensionReturnTypeAttribute
-			var attributeData = markupType.FindAttribute(XamlConstants.Types.MarkupExtensionReturnTypeAttribute);
-			var returnType = attributeData?.NamedArguments.FirstOrDefault(kvp => kvp.Key == "ReturnType").Value.Value;
-			var cast = string.Empty;
 			var provideValue = $"(({xamlMarkupFullName})(new {markupTypeFullName} {{ {properties} }})).ProvideValue()";
-
-			if (returnType != null)
+			string cast;
+			// Don't use the value from MarkupExtensionReturnType to match UWP behavior.
+			if (FindPropertyType(member.Member) is INamedTypeSymbol propertyType)
 			{
-				// A MarkupExtensionReturnType was specified, simply get type to cast against ProvideValue()
-				cast = $"({returnType})";
-			}
-			else if (FindPropertyType(member.Member) is INamedTypeSymbol propertyType)
-			{
-				// MarkupExtensionReturnType wasn't specified...
-
 				if (IsImplementingInterface(propertyType, _iConvertibleSymbol))
 				{
-					// ... and the target property implements IConvertible, therefore
+					// The target property implements IConvertible, therefore
 					// cast ProvideValue() using Convert.ChangeType
 					var targetTypeDisplay = propertyType.ToDisplayString();
 					var targetType = $"typeof({targetTypeDisplay})";
@@ -4097,14 +4087,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 				else
 				{
-					// ... and the target property is not an IConvertible, we cast
+					// The target property is not an IConvertible, we cast
 					// ProvideValue() using the type of the target property
 					cast = GetCastString(propertyType, null);
 				}
 			}
 			else
 			{
-				this.Log().Error($"Unable to determine the return type needed for the markup extension (a MarkupExtensionReturnType attribute is not available, and {member.Member} cannot be found).");
+				this.Log().Error($"Unable to determine the return type needed for the markup extension ('{member.Member}' cannot be found).");
 				return string.Empty;
 			}
 

--- a/src/SourceGenerators/XamlGenerationTests/MarkupExtensionReturnTypeShouldBeIgnored.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/MarkupExtensionReturnTypeShouldBeIgnored.xaml
@@ -1,0 +1,15 @@
+﻿<Page
+	x:Class="XamlGenerationTests.Shared.MarkupExtensionReturnTypeShouldBeIgnored"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:XamlGenerationTests.Shared"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ex="using:XamlGenerationTests.Shared"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+        <AppBarButton Icon="{ex:FontIcon Glyph=A}" />
+    </StackPanel>
+</Page>

--- a/src/SourceGenerators/XamlGenerationTests/MarkupExtensionReturnTypeShouldBeIgnored.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/MarkupExtensionReturnTypeShouldBeIgnored.xaml.cs
@@ -1,0 +1,28 @@
+﻿using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+
+namespace XamlGenerationTests.Shared
+{
+	public sealed partial class MarkupExtensionReturnTypeShouldBeIgnored : Page
+	{
+		public MarkupExtensionReturnTypeShouldBeIgnored()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+    [MarkupExtensionReturnType(ReturnType = typeof(int))]
+    public class FontIcon : MarkupExtension
+    {
+        public string Glyph { get; set; }
+
+        protected override object ProvideValue()
+        {
+            return new Windows.UI.Xaml.Controls.FontIcon()
+            {
+                Glyph = Glyph,
+                FontFamily = new Windows.UI.Xaml.Media.FontFamily("Segoe UI")
+            };
+        }
+    }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2919

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Cast is made to the type specified in the attribute, resulting in a compile-time error, while UWP don't error for this.

## What is the new behavior?

The attribute is now ignored.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
