### PR TITLE
fix: Don't generate invalid code when x:Load and StaticResource markup is used

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_DataTemplate_In_ResDict.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_DataTemplate_In_ResDict.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl
+	x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad_DataTemplate_In_ResDict"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+	<UserControl.Resources>
+		<ResourceDictionary Source="When_xLoad_DataTemplate_In_ResDict_Global.xaml"/>
+	</UserControl.Resources>
+
+	<Grid>
+		<Grid.Resources>
+			<SolidColorBrush x:Key="MyBrush" Color="Red"/>
+		</Grid.Resources>
+		<ContentControl ContentTemplate="{StaticResource MyContainerTemplate}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_DataTemplate_In_ResDict.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_DataTemplate_In_ResDict.xaml.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_DataTemplate_In_ResDict : UserControl
+	{
+		public When_xLoad_DataTemplate_In_ResDict()
+		{
+			this.InitializeComponent();
+		}
+
+		public bool MyVisibility
+		{
+			get { return (bool)GetValue(MyVisibilityProperty); }
+			set { SetValue(MyVisibilityProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for MyVisibility.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyVisibilityProperty =
+			DependencyProperty.Register("MyVisibility", typeof(bool), typeof(When_xLoad_DataTemplate_In_ResDict), new PropertyMetadata(false));
+	}
+
+	public class When_xLoad_DataTemplate_In_ResDict_Model : System.ComponentModel.INotifyPropertyChanged
+	{
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		private bool visible;
+
+		public bool Visible
+		{
+			get { return visible; }
+			set
+			{
+				visible = value;
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(Visible)));
+			}
+		}
+
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_DataTemplate_In_ResDict_Global.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_DataTemplate_In_ResDict_Global.xaml
@@ -1,0 +1,24 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:xamarin="http://uno.ui/xamarin"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d xamarin">
+
+<DataTemplate x:Key="MyContainerTemplate" x:DataType="local:When_xLoad_DataTemplate_In_ResDict_Model">
+	<StackPanel>
+		<TextBlock x:Name="tb01"
+					Text="Please fill in the empty form fields."
+					x:Load="{x:Bind Visible, Mode=OneWay}"
+					Margin="15"
+					Foreground="{StaticResource MyBrush}" />
+		<TextBlock x:Name="tb02"
+					Text="Please fill in the empty form fields."
+					Margin="15"
+					Foreground="{StaticResource MyBrush}" />
+	</StackPanel>
+</DataTemplate>
+
+</ResourceDictionary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -154,5 +154,36 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			var borders = SUT.EnumerateAllChildren().OfType<Border>();
 			Assert.AreEqual(0, borders.Count());
 		}
+
+		[TestMethod]
+		public void When_xLoad_DataTemplate_In_ResDict()
+		{
+			var SUT = new When_xLoad_DataTemplate_In_ResDict();
+
+			SUT.ForceLoaded();
+
+			var stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+			Assert.AreEqual(1, stubs.Count());
+
+			var tb02 = SUT.FindName("tb02") as TextBlock;
+			Assert.IsNotNull(tb02);
+
+			var model = new When_xLoad_DataTemplate_In_ResDict_Model();
+			SUT.DataContext = model;
+
+			stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+			Assert.AreEqual(1, stubs.Count());
+
+			model.Visible = true;
+
+			stubs = SUT.EnumerateAllChildren().OfType<ElementStub>();
+			Assert.AreEqual(0, stubs.Count());
+
+			Assert.AreEqual("[SolidColorBrush #FFFF0000]", tb02.Foreground?.ToString());
+
+			var tb01 = SUT.FindName("tb01") as TextBlock;
+			// This assertion is incorrect because of https://github.com/unoplatform/uno/issues/6700
+			Assert.AreEqual("[SolidColorBrush #FF000000]", tb01.Foreground?.ToString());
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/6700, https://github.com/unoplatform/nventive-private/issues/238#issuecomment-895189012

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The build fails when load-time bound `{StaticResource}` is used in `x:Load` marked control.

## What is the new behavior?

The build does not fail any more, but the static resource is not yet properly updated, see https://github.com/unoplatform/uno/issues/6700 for details.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
