### PR TITLE
fix: Null-check focus children in tab order

### DIFF
--- a/src/Uno.UI/UI/Xaml/Input/Internal/FocusProperties.cs
+++ b/src/Uno.UI/UI/Xaml/Input/Internal/FocusProperties.cs
@@ -292,7 +292,7 @@ namespace Uno.UI.Xaml.Input
 		{
 			if (parent is UIElement uiElement)
 			{
-				return uiElement.GetChildrenInTabFocusOrderInternal();
+				return uiElement.GetChildrenInTabFocusOrderInternal() ?? Array.Empty<DependencyObject?>();
 			}
 
 			return GetFocusChildren(parent);

--- a/src/Uno.UI/UI/Xaml/Input/Internal/FocusProperties.cs
+++ b/src/Uno.UI/UI/Xaml/Input/Internal/FocusProperties.cs
@@ -292,7 +292,7 @@ namespace Uno.UI.Xaml.Input
 		{
 			if (parent is UIElement uiElement)
 			{
-				return uiElement.GetChildrenInTabFocusOrderInternal() ?? Array.Empty<DependencyObject?>();
+				return uiElement.GetChildrenInTabFocusOrderInternal() ?? Array.Empty<DependencyObject>();
 			}
 
 			return GetFocusChildren(parent);

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -509,7 +509,7 @@ namespace Windows.UI.Xaml
 			return focusUpdated;
 		}
 
-		protected virtual IEnumerable<DependencyObject> GetChildrenInTabFocusOrder()
+		protected virtual IEnumerable<DependencyObject>? GetChildrenInTabFocusOrder()
 		{
 			var children = FocusProperties.GetFocusChildren(this);
 			if (children != null && /*!children->IsLeaving() && */children.Length > 0)
@@ -519,7 +519,7 @@ namespace Windows.UI.Xaml
 			return Array.Empty<DependencyObject>();
 		}
 
-		internal IEnumerable<DependencyObject> GetChildrenInTabFocusOrderInternal() => GetChildrenInTabFocusOrder();
+		internal IEnumerable<DependencyObject>? GetChildrenInTabFocusOrderInternal() => GetChildrenInTabFocusOrder();
 
 		internal bool IsOccluded(UIElement? childElement, Rect elementBounds)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6667 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

NRE

## What is the new behavior?

No NRE :-) 


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

