### PR TITLE
fix(iOS): [Window] Null pointer exception

### DIFF
--- a/src/Uno.UI/Controls/Window.iOS.cs
+++ b/src/Uno.UI/Controls/Window.iOS.cs
@@ -345,9 +345,8 @@ namespace Uno.UI.Controls
 				return false;
 			}
 
-			var superViews = view.FindSuperviews().ToList();
+			var superViews = view.FindSuperviews().Trim().ToList();
 			superViews.Insert(0, view);
-
 			return superViews.Any(superView => _attachedProperties.GetValue(superView, NeedsKeyboardAttachedPropertyKey, () => default(bool?)).GetValueOrDefault());
 		}
 

--- a/src/Uno.UI/Controls/Window.iOS.cs
+++ b/src/Uno.UI/Controls/Window.iOS.cs
@@ -340,6 +340,11 @@ namespace Uno.UI.Controls
 
 		private static bool GetNeedsKeyboard(UIView view)
 		{
+			if (view == null)
+			{
+				return false;
+			}
+
 			var superViews = view.FindSuperviews().ToList();
 			superViews.Insert(0, view);
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type
related to https://github.com/unoplatform/nventive-private/issues/238


What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
App crashes (NPE) on iOS when using VoiceOver and navigating back and forth between views when a popup window is open.

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

## What is the new behavior?
Avoid the crash by checking for null.


<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
