### PR TITLE
fix: Fix visual state for disabled selector items

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/TabViewTests/Given_TabView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/TabViewTests/Given_TabView.cs
@@ -367,6 +367,14 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.TabViewTests
 
 		[Test]
 		[AutoRetry]
+		public void VerifyDisabledTabHasCorrectVisualState()
+		{
+			var disabledTabStateText = _app.Marked("DisabledTabStateText");
+			Assert.AreEqual("Disabled tab state: Disabled", disabledTabStateText.GetText());
+		}
+
+		[Test]
+		[AutoRetry]
 		public void VerifySizingBehaviorOnTabCloseComingFromNonScroll()
 		{
 			int pixelTolerance = 10;

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TabViewTests/TabViewPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TabViewTests/TabViewPage.xaml
@@ -265,7 +265,7 @@
 										<controls:SymbolIconSource Symbol="Placeholder"/>
 									</controls:TabViewItem.IconSource>
 
-									<TextBlock Padding="16">Content</TextBlock>
+									<TextBlock Padding="16" x:Name="DisabledTabStateText">Disabled tab state:</TextBlock>
 								</controls:TabViewItem>
 
 							</controls:TabView.TabItems>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TabViewTests/TabViewPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TabViewTests/TabViewPage.xaml.cs
@@ -23,6 +23,7 @@ using Windows.ApplicationModel.DataTransfer;
 using MUXControlsTestApp.Utilities;
 using System.Threading.Tasks;
 using Uno.UI.Samples.Controls;
+using System.Linq;
 
 namespace UITests.Microsoft_UI_Xaml_Controls.TabViewTests
 {
@@ -42,7 +43,7 @@ namespace UITests.Microsoft_UI_Xaml_Controls.TabViewTests
 		public TabViewPage()
 		{
 			this.InitializeComponent();
-
+			Loaded += TabViewPage_Loaded;
 			_iconSource = new SymbolIconSource();
 			_iconSource.Symbol = Symbol.Placeholder;
 
@@ -56,6 +57,17 @@ namespace UITests.Microsoft_UI_Xaml_Controls.TabViewTests
 				itemSource.Add(item);
 			}
 			DataBindingTabView.TabItemsSource = itemSource;
+		}
+
+		private void TabViewPage_Loaded(object sender, RoutedEventArgs e)
+		{
+			var layoutRoot = (Grid)VisualTreeHelper.GetChild(DisabledTab, 0);
+			VisualStateManager.GetVisualStateGroups(layoutRoot).Single(s => s.Name == "DisabledStates").CurrentStateChanged += CurrentStateChanged;
+		}
+
+		private void CurrentStateChanged(object sender, VisualStateChangedEventArgs e)
+		{
+			DisabledTabStateText.Text = "Disabled tab state: " + e.NewState.Name;
 		}
 
 		protected

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -253,6 +253,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 #endif
 
 			UpdateCommonStates();
+
+			// TODO: This may need to be adjusted later when we remove the Visual State mixins.
 			var state = IsEnabled ? DisabledStates.Enabled : DisabledStates.Disabled;
 			VisualStateManager.GoToState(this, state, true);
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -253,6 +253,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 #endif
 
 			UpdateCommonStates();
+			var state = IsEnabled ? DisabledStates.Enabled : DisabledStates.Disabled;
+			VisualStateManager.GoToState(this, state, true);
 		}
 
 #if __IOS__


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4722

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Disabled tab doesn't get the correct visual state

## What is the new behavior?

It now has the correct visual state.

![image](https://user-images.githubusercontent.com/31348972/129022119-c1b0dcff-f0ad-45bb-8531-b3fd7ecf2c02.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
