### PR TITLE
fix: Don't include type name in doc comment due to roslyn bug

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/NativeCtor/NativeCtorsGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/NativeCtor/NativeCtorsGenerator.cs
@@ -59,7 +59,7 @@ namespace {0}
 	{{
 #if {2}
 		/// <summary>
-		/// Initializes a new instance of the <see cref=""{4}""/> class.
+		/// Initializes a new instance of the class.
 		/// </summary>
 		public {3}() {{ }}
 #endif
@@ -154,8 +154,7 @@ namespace {0}
 								typeSymbol.ContainingNamespace,
 								smallSymbolName,
 								NeedsExplicitDefaultCtor(typeSymbol),
-								SyntaxFacts.GetKeywordKind(typeSymbol.Name) == SyntaxKind.None ? typeSymbol.Name : "@" + typeSymbol.Name,
-								DocumentationCommentId.CreateReferenceId(typeSymbol)
+								SyntaxFacts.GetKeywordKind(typeSymbol.Name) == SyntaxKind.None ? typeSymbol.Name : "@" + typeSymbol.Name
 							)
 						);
 					}
@@ -180,8 +179,7 @@ namespace {0}
 								typeSymbol.ContainingNamespace,
 								smallSymbolName,
 								NeedsExplicitDefaultCtor(typeSymbol),
-								SyntaxFacts.GetKeywordKind(typeSymbol.Name) == SyntaxKind.None ? typeSymbol.Name : "@" + typeSymbol.Name,
-								DocumentationCommentId.CreateReferenceId(typeSymbol)
+								SyntaxFacts.GetKeywordKind(typeSymbol.Name) == SyntaxKind.None ? typeSymbol.Name : "@" + typeSymbol.Name
 							)
 						);
 					}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6733

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Invalid documentation comment for generic symbols.

## What is the new behavior?

Don't generate `<see cref="" />` at all.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
