### PR TITLE
VS 17.0 Preview 3 fixes

### DIFF
--- a/build/uno.winui.single-project.targets
+++ b/build/uno.winui.single-project.targets
@@ -87,12 +87,12 @@
 
   <ItemGroup Condition=" '$(SingleProject)' == 'true' ">
 	<ProjectCapability Include="MauiSingleProject" />
+	
 	<ProjectCapability Include="LaunchProfiles" />
-
-	<!-- Optional - Enables a list of TFM's and device categories in the debug menu -->
-	<!-- This allows easily toggling of debug target TFM by selecting the platform -->
-	<!-- If removed, Top level debug targets show as a list of devices for the selected TFM -->
-	<ProjectCapability Include="XamarinStaticLaunchProfiles" />
+	<!-- If VS is older than Dev17 -->
+	<ProjectCapability Include="XamarinStaticLaunchProfiles" Condition=" '$(VisualStudioVersion)' != '' and '$(VisualStudioVersion)' &lt; '17.0' " />
+	<!-- Otherwise define LaunchProfilesGroupByPlatformFilters by default -->
+	<ProjectCapability Include="LaunchProfilesGroupByPlatformFilters" Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &gt;= '17.0' " />
   </ItemGroup>
 
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -40,6 +40,7 @@
 	<UNO_UWP_BUILD>true</UNO_UWP_BUILD>
 	<DefineConstants Condition="'$(UNO_UWP_BUILD)'!='true'">$(DefineConstants);HAS_UNO_WINUI</DefineConstants>
 
+	<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Uno.Foundation/Collections/ObservableVectorEnumerableWrapper.cs
+++ b/src/Uno.Foundation/Collections/ObservableVectorEnumerableWrapper.cs
@@ -7,10 +7,12 @@ using Windows.Foundation.Collections;
 
 namespace Windows.Foundation.Collections
 {
+#if !NET6_0_OR_GREATER // moved to linker file
 #if __IOS__
 	[global::Foundation.Preserve(AllMembers = true)]
 #elif __ANDROID__
 	[Android.Runtime.Preserve(AllMembers = true)]
+#endif
 #endif
 	internal class ObservableVectorEnumerableWrapper : ObservableVectorWrapper, IObservableVector<object>
 	{

--- a/src/Uno.Foundation/Collections/ObservableVectorListWrapper.cs
+++ b/src/Uno.Foundation/Collections/ObservableVectorListWrapper.cs
@@ -7,10 +7,12 @@ using Windows.Foundation.Collections;
 
 namespace Windows.Foundation.Collections
 {
+#if !NET6_0_OR_GREATER // moved to linker file
 #if __IOS__
 	[global::Foundation.Preserve(AllMembers = true)]
 #elif __ANDROID__
 	[Android.Runtime.Preserve(AllMembers = true)]
+#endif
 #endif
 	internal class ObservableVectorListWrapper : ObservableVectorWrapper, IObservableVector<object>
 	{

--- a/src/Uno.Foundation/Collections/ObservableVectorWrapper.cs
+++ b/src/Uno.Foundation/Collections/ObservableVectorWrapper.cs
@@ -9,10 +9,12 @@ using Windows.Foundation.Collections;
 
 namespace Windows.Foundation.Collections
 {
+#if !NET6_0_OR_GREATER // moved to linker file
 #if __IOS__
 	[global::Foundation.Preserve(AllMembers = true)]
 #elif __ANDROID__
 	[Android.Runtime.Preserve(AllMembers = true)]
+#endif
 #endif
 	internal class ObservableVectorWrapper
 	{

--- a/src/Uno.Foundation/LinkerDefinition.net6.xml
+++ b/src/Uno.Foundation/LinkerDefinition.net6.xml
@@ -1,0 +1,7 @@
+﻿<linker>
+  <assembly fullname="Uno.Foundation">
+	<type fullname="Windows.Foundation.Collections.ObservableVectorListWrapper" />
+	<type fullname="Windows.Foundation.Collections.ObservableVectorListWrapper" />
+	<type fullname="Windows.Foundation.Collections.ObservableVectorWrapper" />
+  </assembly>
+</linker>

--- a/src/Uno.Foundation/Uno.Foundation.net6.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.net6.csproj
@@ -31,6 +31,12 @@
 		<PackageReference Include="Uno.Diagnostics.Eventing" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<EmbeddedResource Include="LinkerDefinition.net6.xml">
+			<LogicalName>$(AssemblyName).xml</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>
+
 	<ItemGroup Condition="$(_IsNetStd) or $(_IsNet)">
 		<PackageReference Include="System.Memory" />
 	</ItemGroup>

--- a/src/Uno.UI.Toolkit/CommandBarExtensions.cs
+++ b/src/Uno.UI.Toolkit/CommandBarExtensions.cs
@@ -7,10 +7,12 @@ using Windows.UI.Xaml.Media;
 
 namespace Uno.UI.Toolkit
 {
+#if !NET6_0_OR_GREATER // Moved to the linker definition file
 #if __IOS__
 	[global::Foundation.PreserveAttribute(AllMembers = true)]
 #elif __ANDROID__
 	[Android.Runtime.PreserveAttribute(AllMembers = true)]
+#endif
 #endif
 	public static class CommandBarExtensions
 	{

--- a/src/Uno.UI.Toolkit/LinkerDefinition.net6.0.xml
+++ b/src/Uno.UI.Toolkit/LinkerDefinition.net6.0.xml
@@ -1,0 +1,9 @@
+﻿<linker>
+  <assembly fullname="Uno.UI.Toolkit">
+	<type fullname="Uno.UI.Toolkit.CommandBarExtensions"/>
+	<type fullname="Uno.UI.Toolkit.MenuFlyoutItemExtensions"/>
+	<type fullname="Uno.UI.Toolkit.UIElementExtensions"/>
+	<type fullname="Uno.UI.Toolkit.MenuFlyoutExtensions"/>
+	<type fullname="Uno.UI.Toolkit.SplitViewExtensions"/>
+  </assembly>
+</linker>

--- a/src/Uno.UI.Toolkit/MenuFlyoutExtensions.cs
+++ b/src/Uno.UI.Toolkit/MenuFlyoutExtensions.cs
@@ -6,14 +6,16 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Toolkit
 {
+#if !NET6_0_OR_GREATER // Moved to the linker definition file
 #if __IOS__
 	[global::Foundation.PreserveAttribute(AllMembers = true)]
 #elif __ANDROID__
 	[Android.Runtime.PreserveAttribute(AllMembers = true)]
 #endif
+#endif
 	public class MenuFlyoutExtensions
 	{
-		#region Property: CancelTextIosOverride
+#region Property: CancelTextIosOverride
 
 		public static DependencyProperty CancelTextIosOverrideProperty { get; } = DependencyProperty.RegisterAttached(
 			"CancelTextIosOverride",
@@ -24,6 +26,6 @@ namespace Uno.UI.Toolkit
 		public static string GetCancelTextIosOverride(MenuFlyout obj) => (string)obj.GetValue(CancelTextIosOverrideProperty);
 
 		public static void SetCancelTextIosOverride(MenuFlyout obj, string value) => obj.SetValue(CancelTextIosOverrideProperty, value);
-		#endregion
+#endregion
 	}
 }

--- a/src/Uno.UI.Toolkit/MenuFlyoutItemExtensions.cs
+++ b/src/Uno.UI.Toolkit/MenuFlyoutItemExtensions.cs
@@ -8,14 +8,16 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Toolkit
 {
+#if !NET6_0_OR_GREATER // Moved to the linker definition file
 #if __IOS__
 	[global::Foundation.PreserveAttribute(AllMembers = true)]
 #elif __ANDROID__
 	[Android.Runtime.PreserveAttribute(AllMembers = true)]
 #endif
+#endif
 	public static class MenuFlyoutItemExtensions
 	{
-		#region IsDestructive
+#region IsDestructive
 
 		public static DependencyProperty IsDestructiveProperty { get; } =
 			DependencyProperty.RegisterAttached(
@@ -35,6 +37,6 @@ namespace Uno.UI.Toolkit
 			return (bool)menuFlyoutItem.GetValue(IsDestructiveProperty);
 		}
 
-		#endregion
+#endregion
 	}
 }

--- a/src/Uno.UI.Toolkit/SplitViewExtensions.cs
+++ b/src/Uno.UI.Toolkit/SplitViewExtensions.cs
@@ -8,14 +8,16 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Toolkit
 {
+#if !NET6_0_OR_GREATER // Moved to the linker definition file
 #if __IOS__
 	[global::Foundation.PreserveAttribute(AllMembers = true)]
 #elif __ANDROID__
 	[Android.Runtime.PreserveAttribute(AllMembers = true)]
 #endif
+#endif
 	public static class SplitViewExtensions
     {
-		#region IsPaneEnabled
+#region IsPaneEnabled
 
 		public static DependencyProperty IsPaneEnabledProperty { get; } =
 			DependencyProperty.RegisterAttached(
@@ -35,6 +37,6 @@ namespace Uno.UI.Toolkit
 			return (bool)splitView.GetValue(IsPaneEnabledProperty);
 		}
 
-		#endregion
+#endregion
 	}
 }

--- a/src/Uno.UI.Toolkit/UIElementExtensions.cs
+++ b/src/Uno.UI.Toolkit/UIElementExtensions.cs
@@ -22,10 +22,12 @@ using CoreGraphics;
 
 namespace Uno.UI.Toolkit
 {
+#if !NET6_0_OR_GREATER // Moved to the linker definition file
 #if __IOS__
 	[global::Foundation.PreserveAttribute(AllMembers = true)]
 #elif __ANDROID__
 	[Android.Runtime.PreserveAttribute(AllMembers = true)]
+#endif
 #endif
 	public static class UIElementExtensions
 	{

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.net6.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.net6.csproj
@@ -44,11 +44,6 @@
 		<PackageReference Include="Uno.Core.Build" />
 	</ItemGroup>
 
-  <ItemGroup Condition=" $(IsMonoAndroid) or $(IsXamarinIOS) or $(IsXamarinMac) ">
-		<Reference Include="System.Numerics" />
-		<Reference Include="System.Numerics.Vectors" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.UI\Uno.UI.net6.csproj">
 			<Name>Uno.UI</Name>
@@ -71,6 +66,12 @@
 	<ItemGroup>
 		<Page Remove="Themes\Generic.xaml" />
 		<Page Include="Themes\Generic.xaml" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Include="LinkerDefinition.net6.0.xml">
+			<LogicalName>$(AssemblyName).xml</LogicalName>
+		</EmbeddedResource>
 	</ItemGroup>
 
 	<Import Project="..\SourceGenerators\Uno.UI.SourceGenerators\Content\Uno.UI.SourceGenerators.props" />

--- a/src/Uno.UI/BaseActivity.Android.cs
+++ b/src/Uno.UI/BaseActivity.Android.cs
@@ -177,7 +177,7 @@ namespace Uno.UI
 
 		partial void InnerCreate(Android.OS.Bundle bundle) => SetAsCurrent();
 
-		partial void InnerCreateWithPersistedState(Android.OS.Bundle bundle, PersistableBundle persistentState) => SetAsCurrent();
+		partial void InnerCreateWithPersistedState(Bundle savedInstanceState, PersistableBundle persistentState) => SetAsCurrent();
 
 		partial void InnerStart()
 		{

--- a/src/Uno.UI/LinkerDefinition.net6.0-android.xml
+++ b/src/Uno.UI/LinkerDefinition.net6.0-android.xml
@@ -1,0 +1,10 @@
+﻿<linker>
+  <assembly fullname="Uno.UI">
+	<type fullname="Windows.UI.Xaml.ApplicationActivity">
+	  <method name="GetTypeAssemblyFullName" />
+	</type>
+	<type fullname="Windows.UI.Xaml.NativeApplication">
+	  <method name="GetTypeAssemblyFullName" />
+	</type>
+  </assembly>
+</linker>

--- a/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
@@ -327,7 +327,9 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		/// <param name="type">A type full name</param>
 		/// <returns>The assembly that contains the specified type</returns>
+#if !NET6_0_OR_GREATER
 		[Android.Runtime.Preserve]
+#endif
 		[Java.Interop.Export]
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		public static string GetTypeAssemblyFullName(string type) => Type.GetType(type)?.Assembly.FullName;

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -320,7 +320,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			_popup.IsOpen = true;
 		}
 
-		partial void SetPopupPositionPartial(UIElement placementTarget, Point? absolutePosition);
+		partial void SetPopupPositionPartial(UIElement placementTarget, Point? positionInTarget);
 
 		partial void OnDataContextChangedPartial(DependencyPropertyChangedEventArgs e)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Android.cs
@@ -79,7 +79,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		partial void RemoveGroupItems(int groupIndex, int count)
+		partial void RemoveGroupItems(int groupIndex, int groupCount)
 		{
 			var adapter = NativePanel?.CurrentAdapter;
 			if (adapter == null)
@@ -87,9 +87,9 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			if (count > 0)
+			if (groupCount > 0)
 			{
-				adapter.NotifyItemRangeRemoved(GetDisplayIndexFromIndexPath(Uno.UI.IndexPath.FromRowSection(0, groupIndex)), count);
+				adapter.NotifyItemRangeRemoved(GetDisplayIndexFromIndexPath(Uno.UI.IndexPath.FromRowSection(0, groupIndex)), groupCount);
 				NativePanel?.NativeLayout?.NotifyCollectionChange(groupOperation: null);
 			}
 		}
@@ -182,11 +182,11 @@ namespace Windows.UI.Xaml.Controls
 			return base.IndexFromContainerInner(container);
 		}
 
-		partial void PrepareNativeLayout(VirtualizingPanelLayout layouter)
+		partial void PrepareNativeLayout(VirtualizingPanelLayout layout)
 		{
-			layouter.XamlParent = this;
+			layout.XamlParent = this;
 			var disposables = new CompositeDisposable();
-			PropertyChangedCallback headerFooterCallback = (_, __) => layouter.UpdateHeaderAndFooter();
+			PropertyChangedCallback headerFooterCallback = (_, __) => layout.UpdateHeaderAndFooter();
 			this.RegisterDisposablePropertyChangedCallback(HeaderProperty, headerFooterCallback).DisposeWith(disposables);
 			this.RegisterDisposablePropertyChangedCallback(FooterProperty, headerFooterCallback).DisposeWith(disposables);
 			this.RegisterDisposablePropertyChangedCallback(HeaderTemplateProperty, headerFooterCallback).DisposeWith(disposables);

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -160,9 +160,9 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		partial void OnAreStickyGroupHeadersEnabledChangedPartialNative(bool oldValue, bool newValue)
+		partial void OnAreStickyGroupHeadersEnabledChangedPartialNative(bool oldAreStickyGroupHeadersEnabled, bool newAreStickyGroupHeadersEnabled)
 		{
-			if (newValue != oldValue)
+			if (newAreStickyGroupHeadersEnabled != oldAreStickyGroupHeadersEnabled)
 			{
 				InvalidateLayout();
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
@@ -112,7 +112,7 @@ namespace Windows.UI.Xaml.Controls
 			ApplyLightDismissOverlayMode();
 		}
 
-		partial void OnPopupPanelChangedPartial(PopupPanel oldHost, PopupPanel newHost);
+		partial void OnPopupPanelChangedPartial(PopupPanel previousPanel, PopupPanel newPanel);
 
 		protected override void OnVerticalOffsetChanged(double oldVerticalOffset, double newVerticalOffset)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.cs
@@ -43,7 +43,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnUnloadedPartial();
 
-		partial void OnIsActiveChangedPartial(bool newValue);
+		partial void OnIsActiveChangedPartial(bool isActive);
 
 #if !UNO_REFERENCE_API && !__MACOS__ && !__NETSTD_REFERENCE__
 

--- a/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ProgressRing/ProgressRing.iOS.cs
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnUnloadedPartial() => TrySetNativeAnimating();
 	
-		partial void OnIsActiveChangedPartial(bool _) => TrySetNativeAnimating();
+		partial void OnIsActiveChangedPartial(bool isActive) => TrySetNativeAnimating();
 
 		partial void TrySetNativeAnimating()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOSmacOS.cs
@@ -309,9 +309,9 @@ namespace Windows.UI.Xaml.Controls
 		[Obsolete("https://github.com/unoplatform/uno/pull/1591")]
 		public static bool MustUseWebKitWebView() => true;
 
-		partial void OnScrollEnabledChangedPartial(bool isScrollingEnabled)
+		partial void OnScrollEnabledChangedPartial(bool scrollingEnabled)
 		{
-			_nativeWebView.SetScrollingEnabled(isScrollingEnabled);
+			_nativeWebView.SetScrollingEnabled(scrollingEnabled);
 		}
 
 		private bool VerifyNativeWebViewAvailability()

--- a/src/Uno.UI/UI/Xaml/NativeApplication.cs
+++ b/src/Uno.UI/UI/Xaml/NativeApplication.cs
@@ -118,7 +118,9 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		/// <param name="type">A type full name</param>
 		/// <returns>The assembly that contains the specified type</returns>
+#if !NET6_0_OR_GREATER
 		[Android.Runtime.Preserve]
+#endif
 		[Export]
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		public static string GetTypeAssemblyFullName(string type) => Type.GetType(type)?.Assembly.FullName;

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.iOS.cs
@@ -253,7 +253,7 @@ namespace Windows.UI.Xaml
 		#endregion
 
 		#region TouchesManager (Alter the parents native scroll view to make sure to receive all touches)
-		partial void OnManipulationModeChanged(ManipulationModes _, ManipulationModes newMode)
+		partial void OnManipulationModeChanged(ManipulationModes oldMode, ManipulationModes newMode)
 			// As we have to walk the tree and this method may be invoked too early, we don't try to track the state between the old and the new mode
 			=> PrepareParentTouchesManagers(newMode);
 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -288,7 +288,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		partial void OnVisibilityChangedPartial(Visibility oldValue, Visibility newVisibility);
+		partial void OnVisibilityChangedPartial(Visibility oldValue, Visibility newValue);
 
 		[NotImplemented]
 		protected virtual AutomationPeer OnCreateAutomationPeer() => new AutomationPeer();

--- a/src/Uno.UI/Uno.UI.net6.csproj
+++ b/src/Uno.UI/Uno.UI.net6.csproj
@@ -155,6 +155,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<EmbeddedResource Include="LinkerDefinition.$(TargetFramework).xml" Condition="exists('LinkerDefinition.$(TargetFramework).xml')">
+		  <LogicalName>$(AssemblyName).xml</LogicalName>
+		</EmbeddedResource>
 		<EmbeddedResource Include="Microsoft\UI\Xaml\Controls\ProgressRing\ProgressRingIntdeterminate.json" />
 	</ItemGroup>
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Add support for net6 compilation in VS 17.0 Preview 3 (partials signatures includes names)
- Disable implicit global usings (to be removed in .NET 6 RC1)
- Adjust project capabilities for net6-ios/android detection
- Remove usage of deprecated `[Preserve]` in favor of linker definition file

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
