### PR TITLE
fix: Handle SelectedIndex properly when removing/adding before the selected index

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ComboBoxTests/Given_ComboBox.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ComboBoxTests/Given_ComboBox.cs
@@ -70,5 +70,55 @@ namespace Uno.UI.Tests.ComboBoxTests
 			Assert.IsNotNull(comboBox.InternalItemsPanelRoot);
 			Assert.IsNotNull(comboBox.ItemsPanelRoot);
 		}
-    }
+
+		[TestMethod]
+		public void When_New_Item_Is_Inserted_Before_SelectedIndex()
+		{
+			var comboBox = new ComboBox();
+			string[] items = new string[] { "string1", "string2", "string3", "string4" };
+			foreach (string item in items.Reverse())
+			{
+				ComboBoxItem ni = new ComboBoxItem { Content = item, IsSelected = item == "string3" };
+				comboBox.Items.Insert(0, ni);
+			}
+
+			Assert.AreEqual<int>(2, comboBox.SelectedIndex);
+		}
+
+		[TestMethod]
+		public void When_Item_Is_Removed_Before_SelectedIndex()
+		{
+			var comboBox = new ComboBox();
+			string[] items = new string[] { "string1", "string2", "string3", "string4" };
+			foreach (string item in items)
+			{
+				ComboBoxItem ni = new ComboBoxItem { Content = item, IsSelected = item == "string3" };
+				comboBox.Items.Add(ni);
+			}
+
+			Assert.AreEqual<int>(2, comboBox.SelectedIndex);
+
+
+			comboBox.Items.RemoveAt(0);
+			Assert.AreEqual<int>(1, comboBox.SelectedIndex);
+		}
+
+		[TestMethod]
+		public void When_Removed_Item_Is_The_SelectedIndex()
+		{
+			var comboBox = new ComboBox();
+			string[] items = new string[] { "string1", "string2", "string3", "string4" };
+			foreach (string item in items)
+			{
+				ComboBoxItem ni = new ComboBoxItem { Content = item, IsSelected = item == "string3" };
+				comboBox.Items.Add(ni);
+			}
+
+			Assert.AreEqual<int>(2, comboBox.SelectedIndex);
+
+
+			comboBox.Items.RemoveAt(2);
+			Assert.AreEqual<int>(-1, comboBox.SelectedIndex);
+		}
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -518,6 +518,24 @@ namespace Windows.UI.Xaml.Controls.Primitives
 					{
 						ChangeSelectedItem(selectorItem, false, true);
 					}
+					// If the item is inserted before the currently selected one, increase the selected index.
+					else if (iVCE.CollectionChange == CollectionChange.ItemInserted && (int)iVCE.Index <= SelectedIndex)
+					{
+						SelectedIndex++;
+					}
+				}
+				else if (iVCE.CollectionChange == CollectionChange.ItemRemoved)
+				{
+					// If the removed item is the currently selected one, Set SelectedIndex to -1
+					if ((int)iVCE.Index == SelectedIndex)
+					{
+						SelectedIndex = -1;
+					}
+					// But if it's before the currently selected one, decrement SelectedIndex
+					else if ((int)iVCE.Index < SelectedIndex)
+					{
+						SelectedIndex--;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6739

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Adding/removing item before SelectedIndex doesn't affect the value of SelectedIndex

## What is the new behavior?

It's now changing properly (matching UWP behavior)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
