### PR TITLE
perf: [Android] Improve DisplayInformation performance

### DIFF
--- a/src/Uno.UI/Extensions/ViewHelper.Android.cs
+++ b/src/Uno.UI/Extensions/ViewHelper.Android.cs
@@ -100,12 +100,11 @@ namespace Uno.UI
 
 		public static void RefreshFontScale()
 		{
-			using (Android.Util.DisplayMetrics displayMetrics = Android.App.Application.Context.Resources.DisplayMetrics)
-			{
-				AdjustScaledDensity(displayMetrics);
+			using Android.Util.DisplayMetrics displayMetrics = Android.App.Application.Context.Resources.DisplayMetrics;
 
-				_cachedScaledDensity = displayMetrics.ScaledDensity;
-			}
+			AdjustScaledDensity(displayMetrics);
+
+			_cachedScaledDensity = displayMetrics.ScaledDensity;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -76,8 +76,8 @@ namespace Windows.UI.Xaml
 
 		internal void RaiseNativeSizeChanged()
 		{
-			var display = (ContextHelper.Current as Activity)?.WindowManager?.DefaultDisplay;
-			var fullScreenMetrics = new DisplayMetrics();
+			using var display = (ContextHelper.Current as Activity)?.WindowManager?.DefaultDisplay;
+			using var fullScreenMetrics = new DisplayMetrics();
 
 #pragma warning disable 618
 			display?.GetMetrics(outMetrics: fullScreenMetrics);

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
@@ -234,20 +234,18 @@ namespace Windows.Graphics.Display
 
 		private void RefreshDisplayMetricsCache()
 		{
-			var displayMetrics = new DisplayMetrics();
-			using (var windowManager = CreateWindowManager())
+			using var displayMetrics = new DisplayMetrics();
+			using var windowManager = CreateWindowManager();
+			if (windowManager.DefaultDisplay is { } defaultDisplay)
 			{
-				if (windowManager.DefaultDisplay is { } defaultDisplay)
-				{
-					defaultDisplay.GetRealMetrics(displayMetrics);
+				defaultDisplay.GetRealMetrics(displayMetrics);
 
-					_cachedDisplayMetrics = new DisplayMetricsCache(displayMetrics);
-					_cachedRotation = windowManager.DefaultDisplay.Rotation;
-				}
-				else
-				{
-					throw new InvalidOperationException("Failed to get the default display information");
-				}
+				_cachedDisplayMetrics = new DisplayMetricsCache(displayMetrics);
+				_cachedRotation = windowManager.DefaultDisplay.Rotation;
+			}
+			else
+			{
+				throw new InvalidOperationException("Failed to get the default display information");
 			}
 		}
 
@@ -265,11 +263,17 @@ namespace Windows.Graphics.Display
 			}
 
 			public float Density { get; }
+
 			public DisplayMetricsDensity DensityDpi { get; }
+
 			public int HeightPixels { get; }
+
 			public float ScaledDensity { get; }
+
 			public int WidthPixels { get; }
+
 			public float Xdpi { get; }
+
 			public float Ydpi { get; }
 		}
 	}

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
@@ -1,4 +1,5 @@
 #if __ANDROID__
+#nullable enable
 using System;
 using Android.App;
 using Android.Content;
@@ -11,7 +12,10 @@ namespace Windows.Graphics.Display
 {
 	public sealed partial class DisplayInformation
 	{
-		private static DisplayInformation _instance;
+		private static DisplayInformation? _instance;
+
+		private DisplayMetricsCache _cachedDisplayMetrics;
+		private SurfaceOrientation _cachedRotation;
 
 		private static DisplayInformation InternalGetForCurrentView()
 		{
@@ -39,6 +43,11 @@ namespace Windows.Graphics.Display
 			}
 		}
 
+		partial void Initialize()
+		{
+			RefreshDisplayMetricsCache();
+		}
+
 		public DisplayOrientations CurrentOrientation => GetCurrentOrientation();
 
 		
@@ -51,61 +60,21 @@ namespace Windows.Graphics.Display
 
 
 		public uint ScreenHeightInRawPixels
-		{
-			get
-			{
-				using (var realDisplayMetrics = CreateRealDisplayMetrics())
-				{
-					return (uint)realDisplayMetrics.HeightPixels;
-				}
-			}
-		}
+			=> (uint)_cachedDisplayMetrics.HeightPixels;
 
 		public uint ScreenWidthInRawPixels
-		{
-			get
-			{
-				using (var realDisplayMetrics = CreateRealDisplayMetrics())
-				{
-					return (uint)realDisplayMetrics.WidthPixels;
-				}
-			}
-		}
-		
+			=> (uint)_cachedDisplayMetrics.WidthPixels;
+
 		public double RawPixelsPerViewPixel
-		{
-			get
-			{
-				using (var realDisplayMetrics = CreateRealDisplayMetrics())
-				{
-					return 1.0f * (int)realDisplayMetrics.DensityDpi / (int)DisplayMetricsDensity.Default;
-				}
-			}
-		}
+			=> 1.0f * (int)_cachedDisplayMetrics.DensityDpi / (int)DisplayMetricsDensity.Default;
 
 		public float LogicalDpi
-		{
-			get
-			{
-				using (var realDisplayMetrics = CreateRealDisplayMetrics())
-				{
-					// DisplayMetrics of 1.0 matches 100%, or UWP's default 96.0 DPI.
-					// https://stuff.mit.edu/afs/sipb/project/android/docs/reference/android/util/DisplayMetrics.html#density
-					return realDisplayMetrics.Density * BaseDpi;
-				}
-			}
-		}
+			// DisplayMetrics of 1.0 matches 100%, or UWP's default 96.0 DPI.
+			// https://stuff.mit.edu/afs/sipb/project/android/docs/reference/android/util/DisplayMetrics.html#density
+			=> _cachedDisplayMetrics.Density * BaseDpi;
 
 		public ResolutionScale ResolutionScale
-		{
-			get
-			{
-				using (var realDisplayMetrics = CreateRealDisplayMetrics())
-				{
-					return (ResolutionScale)(int)(realDisplayMetrics.Density * 100);
-				}
-			}
-		}
+			=> (ResolutionScale)(int)(_cachedDisplayMetrics.Density * 100);
 
 		/// <summary>
 		/// Gets the raw dots per inch (DPI) along the x axis of the display monitor.
@@ -115,15 +84,7 @@ namespace Windows.Graphics.Display
 		/// defaults to 0 if not set
 		/// </remarks>
 		public float RawDpiX
-		{
-			get
-			{
-				using (var realDisplayMetrics = CreateRealDisplayMetrics())
-				{
-					return realDisplayMetrics.Xdpi;
-				}
-			}
-		}
+			=> _cachedDisplayMetrics.Xdpi;
 
 		/// <summary>
 		/// Gets the raw dots per inch (DPI) along the y axis of the display monitor.
@@ -133,15 +94,7 @@ namespace Windows.Graphics.Display
 		/// defaults to 0 if not set
 		/// </remarks>
 		public float RawDpiY
-		{
-			get
-			{
-				using (var realDisplayMetrics = CreateRealDisplayMetrics())
-				{
-					return realDisplayMetrics.Ydpi;
-				}
-			}
-		}
+			=> _cachedDisplayMetrics.Ydpi;
 
 		/// <summary>
 		/// Diagonal size of the display in inches.
@@ -154,13 +107,10 @@ namespace Windows.Graphics.Display
 		{
 			get
 			{
-				using (var realDisplayMetrics = CreateRealDisplayMetrics())
-				{
-					var x = Math.Pow((uint)realDisplayMetrics.WidthPixels / realDisplayMetrics.Xdpi, 2);
-					var y = Math.Pow((uint)realDisplayMetrics.HeightPixels / realDisplayMetrics.Ydpi, 2);
-					var screenInches = Math.Sqrt(x + y);
-					return screenInches;
-				}
+				var x = Math.Pow((uint)_cachedDisplayMetrics.WidthPixels / _cachedDisplayMetrics.Xdpi, 2);
+				var y = Math.Pow((uint)_cachedDisplayMetrics.HeightPixels / _cachedDisplayMetrics.Ydpi, 2);
+				var screenInches = Math.Sqrt(x + y);
+				return screenInches;
 			}
 		}
 
@@ -175,13 +125,13 @@ namespace Windows.Graphics.Display
 		{
 			using (var windowManager = CreateWindowManager())
 			{
-				var orientation = ContextHelper.Current.Resources.Configuration.Orientation;
+				var orientation = ContextHelper.Current.Resources!.Configuration!.Orientation;
 				if (orientation == Android.Content.Res.Orientation.Undefined)
 				{
 					return DisplayOrientations.None;
 				}
 
-				var rotation = windowManager.DefaultDisplay.Rotation;
+				var rotation = _cachedRotation;
 				bool isLandscape;
 				switch (rotation)
 				{
@@ -208,94 +158,119 @@ namespace Windows.Graphics.Display
 		{
 			using (var windowManager = CreateWindowManager())
 			{
-				var rotation = windowManager.DefaultDisplay.Rotation;
-				using (var displayMetrics = new DisplayMetrics())
+				int width = _cachedDisplayMetrics.WidthPixels;
+				int height = _cachedDisplayMetrics.HeightPixels;
+
+				if (width == height)
 				{
-#pragma warning disable 618
-					windowManager.DefaultDisplay.GetMetrics(displayMetrics);
-#pragma warning restore 618
+					//square device, can't tell orientation
+					return DisplayOrientations.None;
+				}
 
-					int width = displayMetrics.WidthPixels;
-					int height = displayMetrics.HeightPixels;
-
-					if (width == height)
+				if (NativeOrientation == DisplayOrientations.Portrait)
+				{
+					switch (_cachedRotation)
 					{
-						//square device, can't tell orientation
-						return DisplayOrientations.None;
+						case SurfaceOrientation.Rotation0:
+							return DisplayOrientations.Portrait;
+						case SurfaceOrientation.Rotation90:
+							return DisplayOrientations.Landscape;
+						case SurfaceOrientation.Rotation180:
+							return DisplayOrientations.PortraitFlipped;
+						case SurfaceOrientation.Rotation270:
+							return DisplayOrientations.LandscapeFlipped;
+						default:
+							//invalid rotation
+							return DisplayOrientations.None;
 					}
-
-					if (NativeOrientation == DisplayOrientations.Portrait)
+				}
+				else if (NativeOrientation == DisplayOrientations.Landscape)
+				{
+					//device is landscape or square
+					switch (_cachedRotation)
 					{
-						switch (rotation)
-						{
-							case SurfaceOrientation.Rotation0:
-								return DisplayOrientations.Portrait;
-							case SurfaceOrientation.Rotation90:
-								return DisplayOrientations.Landscape;
-							case SurfaceOrientation.Rotation180:
-								return DisplayOrientations.PortraitFlipped;
-							case SurfaceOrientation.Rotation270:
-								return DisplayOrientations.LandscapeFlipped;
-							default:
-								//invalid rotation
-								return DisplayOrientations.None;
-						}
+						case SurfaceOrientation.Rotation0:
+							return DisplayOrientations.Landscape;
+						case SurfaceOrientation.Rotation90:
+							return DisplayOrientations.Portrait;
+						case SurfaceOrientation.Rotation180:
+							return DisplayOrientations.LandscapeFlipped;
+						case SurfaceOrientation.Rotation270:
+							return DisplayOrientations.PortraitFlipped;
+						default:
+							//invalid rotation
+							return DisplayOrientations.None;
 					}
-					else if (NativeOrientation == DisplayOrientations.Landscape)
-					{
-						//device is landscape or square
-						switch (rotation)
-						{
-							case SurfaceOrientation.Rotation0:
-								return DisplayOrientations.Landscape;
-							case SurfaceOrientation.Rotation90:
-								return DisplayOrientations.Portrait;
-							case SurfaceOrientation.Rotation180:
-								return DisplayOrientations.LandscapeFlipped;
-							case SurfaceOrientation.Rotation270:
-								return DisplayOrientations.PortraitFlipped;
-							default:
-								//invalid rotation
-								return DisplayOrientations.None;
-						}
-					}
-					else
-					{
-						//fallback
-						return DisplayOrientations.None;
-					}
+				}
+				else
+				{
+					//fallback
+					return DisplayOrientations.None;
 				}
 			}
 		}
 
 		private IWindowManager CreateWindowManager()
 		{
-			return ContextHelper.Current.GetSystemService(Context.WindowService).JavaCast<IWindowManager>();
+			if(ContextHelper.Current.GetSystemService(Context.WindowService) is { } windowService)
+			{
+				return windowService.JavaCast<IWindowManager>();;
+			}
+
+			throw new InvalidOperationException("Failed to get the system Window Service");
 		}
 
-		private DisplayMetrics CreateRealDisplayMetrics()
+		partial void StartOrientationChanged()
+			=> _lastKnownOrientation = CurrentOrientation;
+
+		partial void StartDpiChanged()
+			=> _lastKnownDpi = LogicalDpi;
+
+		internal void HandleConfigurationChange()
+		{
+			RefreshDisplayMetricsCache();
+			OnDisplayMetricsChanged();
+		}
+
+		private void RefreshDisplayMetricsCache()
 		{
 			var displayMetrics = new DisplayMetrics();
 			using (var windowManager = CreateWindowManager())
 			{
-				windowManager.DefaultDisplay.GetRealMetrics(displayMetrics);
+				if (windowManager.DefaultDisplay is { } defaultDisplay)
+				{
+					defaultDisplay.GetRealMetrics(displayMetrics);
+
+					_cachedDisplayMetrics = new DisplayMetricsCache(displayMetrics);
+					_cachedRotation = windowManager.DefaultDisplay.Rotation;
+				}
+				else
+				{
+					throw new InvalidOperationException("Failed to get the default display information");
+				}
 			}
-			return displayMetrics;
 		}
 
-		partial void StartOrientationChanged()
+		private class DisplayMetricsCache
 		{
-			_lastKnownOrientation = CurrentOrientation;
-		}
+			public DisplayMetricsCache(DisplayMetrics displayMetric)
+			{
+				Density = displayMetric.Density;
+				DensityDpi = displayMetric.DensityDpi;
+				HeightPixels = displayMetric.HeightPixels;
+				ScaledDensity = displayMetric.ScaledDensity;
+				WidthPixels = displayMetric.WidthPixels;
+				Xdpi = displayMetric.Xdpi;
+				Ydpi = displayMetric.Ydpi;
+			}
 
-		partial void StartDpiChanged()
-		{
-			_lastKnownDpi = LogicalDpi;
-		}
-
-		internal void HandleConfigurationChange()
-		{
-			OnDisplayMetricsChanged();
+			public float Density { get; }
+			public DisplayMetricsDensity DensityDpi { get; }
+			public int HeightPixels { get; }
+			public float ScaledDensity { get; }
+			public int WidthPixels { get; }
+			public float Xdpi { get; }
+			public float Ydpi { get; }
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/6752

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Peformance

## What is the new behavior?

Improved general performance for Android implementation of `DisplayInformation`.

Note that we may need to add a configuration change flag here:

https://github.com/unoplatform/uno/blob/54ad32f85c75fb2e09af0045cf6820e58cdb8255/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs#L23

to follow changes for scaling, and maybe others.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
