### PR TITLE
feat: Support PasswordBox on Skia

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -13,6 +13,7 @@ using GtkWindow = Gtk.Window;
 using Object = GLib.Object;
 using Point = Windows.Foundation.Point;
 using Scale = Pango.Scale;
+using System.Diagnostics;
 
 namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 {
@@ -38,7 +39,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 		private Fixed GetWindowTextInputLayer()
 		{
 			// now we have the GtkEventBox
-			var overlay = (Overlay)((EventBox) _window.Child).Child;
+			var overlay = (Overlay)((EventBox)_window.Child).Child;
 			return overlay.Children.OfType<Fixed>().First();
 		}
 
@@ -53,7 +54,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 
 			_contentElement = textBox.ContentElement;
 
-			EnsureWidgetForAcceptsReturn(textBox.AcceptsReturn);
+			EnsureWidgetForAcceptsReturn(textBox.AcceptsReturn, isPassword: textBox is PasswordBox);
 			var textInputLayer = GetWindowTextInputLayer();
 			textInputLayer.Put(_currentInputWidget!, 0, 0);
 
@@ -107,7 +108,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 				return;
 			}
 
-			EnsureWidgetForAcceptsReturn(textBox.AcceptsReturn);
+			EnsureWidgetForAcceptsReturn(textBox.AcceptsReturn, isPassword: textBox is PasswordBox);
 
 			var fontDescription = new FontDescription
 			{
@@ -170,24 +171,29 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 		{
 			entry.IsEditable = !textBox.IsReadOnly;
 			entry.MaxLength = textBox.MaxLength;
-
 		}
 
-		private void EnsureWidgetForAcceptsReturn(bool acceptsReturn)
+		private void EnsureWidgetForAcceptsReturn(bool acceptsReturn, bool isPassword)
 		{
+			// On UWP, A PasswordBox doesn't have AcceptsReturn property.
+			// The property exists on Uno because PasswordBox incorrectly inherits TextBox.
+			// If we have PasswordBox, ignore AcceptsReturnValue and always use Gtk.Entry
+			acceptsReturn = acceptsReturn && !isPassword;
+
 			var isIncompatibleInputType =
 				(acceptsReturn && !(_currentInputWidget is TextView)) ||
 				(!acceptsReturn && !(_currentInputWidget is Entry));
 			if (isIncompatibleInputType)
 			{
 				var inputText = GetInputText();
-				_currentInputWidget = CreateInputWidget(acceptsReturn);
+				_currentInputWidget = CreateInputWidget(acceptsReturn, isPassword);
 				SetWidgetText(inputText ?? string.Empty);
 			}
 		}
 
-		private Widget CreateInputWidget(bool acceptsReturn)
+		private Widget CreateInputWidget(bool acceptsReturn, bool isPassword)
 		{
+			Debug.Assert(!acceptsReturn || !isPassword);
 			Widget widget;
 			if (acceptsReturn)
 			{
@@ -199,6 +205,12 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 			else
 			{
 				var entry = new Entry();
+				if (isPassword)
+				{
+					entry.InputPurpose = InputPurpose.Password;
+					entry.Visibility = false;
+				}
+
 				entry.Changed += WidgetTextChanged;
 				_textChangedDisposable.Disposable = Disposable.Create(() => entry.Changed -= WidgetTextChanged);
 				widget = entry;
@@ -260,6 +272,16 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 		{
 			UpdateSize();
 			UpdatePosition();
+		}
+
+		public void SetIsPassword(bool isPassword)
+		{
+			if (_currentInputWidget is Entry entry)
+			{
+				entry.Visibility = !isPassword;
+				// InputPurpose doesn't have any visual effects.
+				entry.InputPurpose = InputPurpose.Password;
+			}
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -279,8 +279,6 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 			if (_currentInputWidget is Entry entry)
 			{
 				entry.Visibility = !isPassword;
-				// InputPurpose doesn't have any visual effects.
-				entry.InputPurpose = InputPurpose.Password;
 			}
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -183,5 +183,9 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 			UpdatePosition();
 		}
 
+		public void SetIsPassword(bool isPassword)
+		{
+			// No support for now.
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.skia.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class PasswordBox
+	{
+		partial void SetPasswordScope(bool shouldHideText)
+		{
+			SetIsPassword(shouldHideText);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxExtension.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxExtension.skia.cs
@@ -15,5 +15,7 @@ namespace Uno.UI.Xaml.Controls.Extensions
 		void UpdatePosition();
 
 		void SetTextNative(string text);
-    }
+
+		void SetIsPassword(bool isPassword);
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -22,5 +22,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		partial void OnFocusStateChangedPartial(FocusState focusState) => _textBoxView?.OnFocusStateChanged(focusState);
+
+		protected void SetIsPassword(bool isPassword) => _textBoxView?.SetIsPassword(isPassword);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -45,7 +45,7 @@ namespace Windows.UI.Xaml.Controls
 
 		internal void SetTextNative(string text)
 		{
-			DisplayBlock.Text = text;
+			DisplayBlock.Text = new string('•', text.Length);
 			_textBoxExtension?.SetTextNative(text);
 		}
 
@@ -64,6 +64,8 @@ namespace Windows.UI.Xaml.Controls
 				DisplayBlock.Opacity = 1;
 			}
 		}
+
+		internal void SetIsPassword(bool isPassword) => _textBoxExtension?.SetIsPassword(isPassword);
 
 		internal void UpdateTextFromNative(string newText)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6396, closes #5767

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

No support for PasswordBox on Skia GTK


## What is the new behavior?

Supported


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
