### PR TITLE
fix: Add missing __SKIA__ in defined constants

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/buildTransitive/Uno.UI.Runtime.Skia.Gtk.targets
+++ b/src/Uno.UI.Runtime.Skia.Gtk/buildTransitive/Uno.UI.Runtime.Skia.Gtk.targets
@@ -8,7 +8,7 @@
 		  BeforeTargets="PrepareForBuild">
 
 	<PropertyGroup>
-	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_GTK</UnoDefineConstants>
+	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_GTK;__SKIA__</UnoDefineConstants>
 	</PropertyGroup>
 
 	<!-- Merge the UnoDefineConstants with the existing constants -->

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/buildTransitive/Uno.UI.Runtime.Skia.Linux.FrameBuffer.targets
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/buildTransitive/Uno.UI.Runtime.Skia.Linux.FrameBuffer.targets
@@ -8,7 +8,7 @@
 		  BeforeTargets="PrepareForBuild">
 
 	<PropertyGroup>
-	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_LINUX_FB</UnoDefineConstants>
+	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_LINUX_FB;__SKIA__</UnoDefineConstants>
 	</PropertyGroup>
 
 	<!-- Merge the UnoDefineConstants with the existing constants -->

--- a/src/Uno.UI.Runtime.Skia.Tizen/buildTransitive/Uno.UI.Runtime.Skia.Tizen.targets
+++ b/src/Uno.UI.Runtime.Skia.Tizen/buildTransitive/Uno.UI.Runtime.Skia.Tizen.targets
@@ -8,7 +8,7 @@
 		  BeforeTargets="PrepareForBuild">
 
 	<PropertyGroup>
-	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_TIZEN</UnoDefineConstants>
+	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_TIZEN;__SKIA__</UnoDefineConstants>
 	</PropertyGroup>
 
 	<!-- Merge the UnoDefineConstants with the existing constants -->

--- a/src/Uno.UI.Runtime.Skia.Wpf/buildTransitive/Uno.UI.Runtime.Skia.Wpf.targets
+++ b/src/Uno.UI.Runtime.Skia.Wpf/buildTransitive/Uno.UI.Runtime.Skia.Wpf.targets
@@ -5,7 +5,7 @@
 		  BeforeTargets="PrepareForBuild">
 
 	<PropertyGroup>
-	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_WPF</UnoDefineConstants>
+	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_WPF;__SKIA__</UnoDefineConstants>
 	</PropertyGroup>
 
 	<!-- Merge the UnoDefineConstants with the existing constants -->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`#if __SKIA__` in an Uno app doesn't work. It already works for `__WASM__` via:

https://github.com/unoplatform/uno/blob/89b65f580b1ad2622ff81170f3fee95a8f945eca/src/Uno.UI.Runtime.WebAssembly/buildTransitive/Uno.UI.Runtime.WebAssembly.targets#L11

## What is the new behavior?

It works now the same way `__WASM__` is.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
