### PR TITLE
fix: Correctly handle SelectedIndex when out of range

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ComboBoxTests/Given_ComboBox.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ComboBoxTests/Given_ComboBox.cs
@@ -120,5 +120,34 @@ namespace Uno.UI.Tests.ComboBoxTests
 			comboBox.Items.RemoveAt(2);
 			Assert.AreEqual<int>(-1, comboBox.SelectedIndex);
 		}
+
+		[TestMethod]
+		public void When_Index_Is_Out_Of_Range_And_Later_Becomes_Valid()
+		{
+			var comboBox = new ComboBox();
+			comboBox.SelectedIndex = 2;
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(2, comboBox.SelectedIndex);
+		}
+
+		[TestMethod]
+		public void When_Index_Is_Explicitly_Set_To_Negative_After_Out_Of_Range_Value()
+		{
+			var comboBox = new ComboBox();
+			comboBox.SelectedIndex = 2;
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.SelectedIndex = -1; // While SelectedIndex was already -1 (assert above), this *does* make a difference.
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex); // Will no longer become 2
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -227,7 +227,16 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		public int SelectedIndex
 		{
-			get => (int)this.GetValue(SelectedIndexProperty);
+			get
+			{
+				var value = (int)this.GetValue(SelectedIndexProperty);
+				if (value < 0  || value >= NumberOfItems)
+				{
+					return -1;
+				}
+
+				return value;
+			}
 			set => this.SetValue(SelectedIndexProperty, value);
 		}
 
@@ -518,10 +527,19 @@ namespace Windows.UI.Xaml.Controls.Primitives
 					{
 						ChangeSelectedItem(selectorItem, false, true);
 					}
-					// If the item is inserted before the currently selected one, increase the selected index.
+					// If the item is inserted before the currently selected one, increase the selected index unless it will become out of bounds.
 					else if (iVCE.CollectionChange == CollectionChange.ItemInserted && (int)iVCE.Index <= SelectedIndex)
 					{
-						SelectedIndex++;
+						// This basically means that SelectedIndex was previously out of bounds (causing the property to return -1)
+						// But it's now a valid value after an item is added (causing the property to return non-negative value).
+						if (SelectedIndex == NumberOfItems - 1)
+						{
+							OnSelectedIndexChanged(-1, SelectedIndex);
+						}
+						else
+						{
+							SelectedIndex++;
+						}
 					}
 				}
 				else if (iVCE.CollectionChange == CollectionChange.ItemRemoved)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4686

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Setting SelectedIndex = 0 (for example) when there is no items doesn't match UWP behavior in two ways:

- The getter returns 0 instead of -1 (not visual difference)
- When an item is added, it doesn't return 0 (causing *visual* difference).

Note on the second point:

- Before #6742, it was returning the correct value. But the visual issue still exists since OnSelectedIndexChanged wasn't called. So no re-rendering was happening when the value becomes valid.

## What is the new behavior?

Match UWP

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
