### PR TITLE
Support for `RenderTransform` with Android `LinearGradientBrush`

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
@@ -76,7 +76,7 @@
 					</Ellipse.Fill>
 				</Ellipse>
 			</StackPanel>
-			<TextBlock FontSize="15">Radial Gradient as border/stroke on a Rectangle/ Border / Ellipse </TextBlock>
+			<TextBlock FontSize="15">Radial Gradient as border/stroke on a Rectangle/ Border / Border with corner radius / Ellipse </TextBlock>
 			<StackPanel Orientation="Horizontal" Spacing="10">
 				<Rectangle Width="100" Height="100" StrokeThickness="40" Fill="DarkGray">
 					<Rectangle.Stroke>
@@ -103,6 +103,20 @@
 						</media:RadialGradientBrush>
 					</Border.BorderBrush>
 				</Border>
+
+				<Border Width="100" Height="100" CornerRadius="8" BorderThickness="40" Background="DarkGray">
+					<Border.BorderBrush>
+						<media:RadialGradientBrush FallbackColor="Red">
+							<GradientStop Color="Blue" Offset="0.0" />
+							<GradientStop Color="Yellow" Offset="0.2" />
+							<GradientStop Color="LimeGreen" Offset="0.4" />
+							<GradientStop Color="LightBlue" Offset="0.6" />
+							<GradientStop Color="Blue" Offset="0.8" />
+							<GradientStop Color="LightGray" Offset="1" />
+						</media:RadialGradientBrush>
+					</Border.BorderBrush>
+				</Border>
+
 				<Ellipse Width="100" Height="100" StrokeThickness="40" Fill="DarkGray">
 					<Ellipse.Stroke>
 						<media:RadialGradientBrush FallbackColor="Red">
@@ -217,6 +231,18 @@
 						</LinearGradientBrush>
 					</Border.BorderBrush>
 				</Border>
+				<Border Width="100" Height="100" CornerRadius="8" BorderThickness="40">
+					<Border.BorderBrush>
+						<LinearGradientBrush not_win:FallbackColor="Red">
+							<GradientStop Color="Blue" Offset="0.0" />
+							<GradientStop Color="Yellow" Offset="0.2" />
+							<GradientStop Color="LimeGreen" Offset="0.4" />
+							<GradientStop Color="LightBlue" Offset="0.6" />
+							<GradientStop Color="Blue" Offset="0.8" />
+							<GradientStop Color="LightGray" Offset="1" />
+						</LinearGradientBrush>
+					</Border.BorderBrush>
+				</Border>
 				<Rectangle Width="100" Height="100" StrokeThickness="40">
 					<Rectangle.Stroke>
 						<LinearGradientBrush MappingMode="Absolute" EndPoint="100,100" not_win:FallbackColor="Red">
@@ -238,6 +264,35 @@
 							<GradientStop Color="LightBlue" Offset="0.6" />
 							<GradientStop Color="Blue" Offset="0.8" />
 							<GradientStop Color="LightGray" Offset="1" />
+						</LinearGradientBrush>
+					</Border.BorderBrush>
+				</Border>
+
+				<Border Width="100" Height="100" CornerRadius="8" BorderThickness="40">
+					<Border.BorderBrush>
+						<LinearGradientBrush MappingMode="Absolute" EndPoint="100,100" not_win:FallbackColor="Red">
+							<GradientStop Color="Blue" Offset="0.0" />
+							<GradientStop Color="Yellow" Offset="0.2" />
+							<GradientStop Color="LimeGreen" Offset="0.4" />
+							<GradientStop Color="LightBlue" Offset="0.6" />
+							<GradientStop Color="Blue" Offset="0.8" />
+							<GradientStop Color="LightGray" Offset="1" />
+						</LinearGradientBrush>
+					</Border.BorderBrush>
+				</Border>
+			</StackPanel>
+			<TextBlock FontSize="15">Linear Gradient as Border with relative transform</TextBlock>
+			<StackPanel Orientation="Horizontal" Spacing="10">
+				<Border Width="100" Height="100" BorderThickness="40">
+					<Border.BorderBrush>
+						<LinearGradientBrush MappingMode="Absolute" StartPoint="0,0" EndPoint="0,2">
+							<LinearGradientBrush.RelativeTransform>
+								<ScaleTransform ScaleY="-1" CenterY="0.5"/>
+							</LinearGradientBrush.RelativeTransform>
+							<LinearGradientBrush.GradientStops>
+								<GradientStop Color="Yellow" Offset="1" />
+								<GradientStop Color="Red" Offset="1" />
+							</LinearGradientBrush.GradientStops>
 						</LinearGradientBrush>
 					</Border.BorderBrush>
 				</Border>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
@@ -283,14 +283,14 @@
 			</StackPanel>
 			<TextBlock FontSize="15">Linear Gradient as Border with relative transform</TextBlock>
 			<StackPanel Orientation="Horizontal" Spacing="10">
-				<Border Width="100" Height="100" BorderThickness="40">
+				<Border Width="100" Height="100" BorderThickness="40" CornerRadius="8">
 					<Border.BorderBrush>
-						<LinearGradientBrush MappingMode="Absolute" StartPoint="0,0" EndPoint="0,2">
+						<LinearGradientBrush MappingMode="Absolute" StartPoint="0,0" EndPoint="0,40">
 							<LinearGradientBrush.RelativeTransform>
 								<ScaleTransform ScaleY="-1" CenterY="0.5"/>
 							</LinearGradientBrush.RelativeTransform>
 							<LinearGradientBrush.GradientStops>
-								<GradientStop Color="Yellow" Offset="1" />
+								<GradientStop Color="Blue" Offset="1" />
 								<GradientStop Color="Red" Offset="1" />
 							</LinearGradientBrush.GradientStops>
 						</LinearGradientBrush>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
@@ -281,7 +281,7 @@
 					</Border.BorderBrush>
 				</Border>
 			</StackPanel>
-			<TextBlock FontSize="15">Linear Gradient as Border with relative transform / with single stop</TextBlock>
+			<TextBlock FontSize="15">Linear Gradient as border/stroke with relative transform / with single stop</TextBlock>
 			<StackPanel Orientation="Horizontal" Spacing="10">
 				<Border Width="100" Height="100" BorderThickness="40" CornerRadius="8">
 					<Border.BorderBrush>
@@ -296,6 +296,19 @@
 						</LinearGradientBrush>
 					</Border.BorderBrush>
 				</Border>
+				<Rectangle Width="100" Height="100" StrokeThickness="40" RadiusX="8" RadiusY="8">
+					<Rectangle.Stroke>
+						<LinearGradientBrush MappingMode="Absolute" StartPoint="0,0" EndPoint="0,40">
+							<LinearGradientBrush.RelativeTransform>
+								<ScaleTransform ScaleY="-1" CenterY="0.5"/>
+							</LinearGradientBrush.RelativeTransform>
+							<LinearGradientBrush.GradientStops>
+								<GradientStop Color="Blue" Offset="1" />
+								<GradientStop Color="Red" Offset="1" />
+							</LinearGradientBrush.GradientStops>
+						</LinearGradientBrush>
+					</Rectangle.Stroke>
+				</Rectangle>
 				<Border Width="100" Height="100" BorderThickness="40" CornerRadius="8">
 					<Border.BorderBrush>
 						<LinearGradientBrush MappingMode="Absolute" StartPoint="0,0" EndPoint="0,40">
@@ -305,6 +318,15 @@
 						</LinearGradientBrush>
 					</Border.BorderBrush>
 				</Border>
+				<Rectangle Width="100" Height="100" StrokeThickness="40" RadiusX="8" RadiusY="8">
+					<Rectangle.Stroke>
+						<LinearGradientBrush MappingMode="Absolute" StartPoint="0,0" EndPoint="0,40">
+							<LinearGradientBrush.GradientStops>
+								<GradientStop Color="Red" Offset="0.5" />
+							</LinearGradientBrush.GradientStops>
+						</LinearGradientBrush>
+					</Rectangle.Stroke>
+				</Rectangle>
 			</StackPanel>
 			<TextBlock FontSize="15">Text with Radial/Linear gradient as foreground brush (fallback=green)</TextBlock>
 			<StackPanel Orientation="Horizontal" Spacing="10">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/GradientsPage.xaml
@@ -281,7 +281,7 @@
 					</Border.BorderBrush>
 				</Border>
 			</StackPanel>
-			<TextBlock FontSize="15">Linear Gradient as Border with relative transform</TextBlock>
+			<TextBlock FontSize="15">Linear Gradient as Border with relative transform / with single stop</TextBlock>
 			<StackPanel Orientation="Horizontal" Spacing="10">
 				<Border Width="100" Height="100" BorderThickness="40" CornerRadius="8">
 					<Border.BorderBrush>
@@ -292,6 +292,15 @@
 							<LinearGradientBrush.GradientStops>
 								<GradientStop Color="Blue" Offset="1" />
 								<GradientStop Color="Red" Offset="1" />
+							</LinearGradientBrush.GradientStops>
+						</LinearGradientBrush>
+					</Border.BorderBrush>
+				</Border>
+				<Border Width="100" Height="100" BorderThickness="40" CornerRadius="8">
+					<Border.BorderBrush>
+						<LinearGradientBrush MappingMode="Absolute" StartPoint="0,0" EndPoint="0,40">
+							<LinearGradientBrush.GradientStops>
+								<GradientStop Color="Red" Offset="0.5" />
 							</LinearGradientBrush.GradientStops>
 						</LinearGradientBrush>
 					</Border.BorderBrush>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrushWithRotateTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrushWithRotateTransform.xaml
@@ -20,7 +20,7 @@
 			<DataTemplate>
 				<Border Width="150" Height="200">
 					<Border.Background>
-						<ImageBrush ImageSource="http://homepages.cae.wisc.edu/~ece533/images/fruits.png"
+						<ImageBrush ImageSource="ms-appx:///Assets/ingredient2.png"
 									Stretch="UniformToFill">
 							<ImageBrush.RelativeTransform>
 								<RotateTransform Angle="45" CenterX=".5" CenterY=".5"/>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrushWithScaleTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrushWithScaleTransform.xaml
@@ -21,7 +21,7 @@
 				<Grid>
 				<Border Width="150" Height="200">
 					<Border.Background>
-						<ImageBrush ImageSource="http://homepages.cae.wisc.edu/~ece533/images/fruits.png"
+							<ImageBrush ImageSource="ms-appx:///Assets/ingredient2.png"
 									Stretch="UniformToFill">
 							<ImageBrush.RelativeTransform>
 								<ScaleTransform ScaleX="1.5" ScaleY="1.5" CenterX=".5" CenterY=".5"/>

--- a/src/Uno.UI/Extensions/Matrix3x2Extensions.Android.cs
+++ b/src/Uno.UI/Extensions/Matrix3x2Extensions.Android.cs
@@ -1,0 +1,19 @@
+﻿using System.Numerics;
+
+namespace Uno.UI.Extensions
+{
+	internal static class Matrix3x2Extensions
+	{
+		public static Android.Graphics.Matrix ToNative(this Matrix3x2 matrix)
+		{
+			var nativeMatrix = new Android.Graphics.Matrix();
+			nativeMatrix.SetValues(new[]
+			{
+				matrix.M11, matrix.M21, matrix.M31,
+				matrix.M12, matrix.M22, matrix.M32,
+				0, 0, 1
+			});
+			return nativeMatrix;
+		}
+	}
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Media/RadialGradientBrush.Android.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Media/RadialGradientBrush.Android.cs
@@ -43,7 +43,7 @@ namespace Microsoft.UI.Xaml.Media
 			var width = destinationRect.Width;
 			var height = destinationRect.Height;
 
-			var transform = RelativeTransform?.ToNative(size: new Windows.Foundation.Size(width, height), isBrush: true);
+			var transform = RelativeTransform?.ToNativeMatrix(size: new Windows.Foundation.Size(width, height));
 
 			var shader = new RadialGradient(
 				(float)center.X,

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
@@ -225,7 +225,7 @@ namespace Windows.UI.Xaml.Media
 
 			matrix.SetRectToRect(sourceRect.ToRectF(), destinationRect.ToRectF(), Android.Graphics.Matrix.ScaleToFit.Fill);
 
-			RelativeTransform?.ToNativeMatrix(matrix, size: new Size(drawRect.Width, drawRect.Height));
+			RelativeTransform?.ToNativeMatrix(matrix, size: new Size(sourceRect.Width, sourceRect.Height));
 			return matrix;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
@@ -225,7 +225,7 @@ namespace Windows.UI.Xaml.Media
 
 			matrix.SetRectToRect(sourceRect.ToRectF(), destinationRect.ToRectF(), Android.Graphics.Matrix.ScaleToFit.Fill);
 
-			RelativeTransform?.ToNative(matrix, new Size(drawRect.Width, drawRect.Height), isBrush: true);
+			RelativeTransform?.ToNativeMatrix(matrix, size: new Size(drawRect.Width, drawRect.Height));
 			return matrix;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/LinearGradientBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/LinearGradientBrush.Android.cs
@@ -3,6 +3,8 @@ using Uno.Extensions;
 using Uno.UI;
 using Uno.UI.Extensions;
 using Rect = Windows.Foundation.Rect;
+using Point = Windows.Foundation.Point;
+using Size = Windows.Foundation.Size;
 
 namespace Windows.UI.Xaml.Media
 {
@@ -32,7 +34,7 @@ namespace Windows.UI.Xaml.Media
 			Android.Graphics.Matrix nativeTransformMatrix = null;
 			if (RelativeTransform != null)
 			{
-				var matrix = RelativeTransform.ToMatrix(Foundation.Point.Zero, new Windows.Foundation.Size(width, height));
+				var matrix = RelativeTransform.ToMatrix(Point.Zero, new Size(width, height));
 				matrix.M31 *= (float)width;
 				matrix.M32 *= (float)height;
 				nativeTransformMatrix = matrix.ToNative();

--- a/src/Uno.UI/UI/Xaml/Media/Transform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Transform.Android.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Numerics;
+using Uno.UI;
 using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Media
@@ -11,9 +12,23 @@ namespace Windows.UI.Xaml.Media
 	{
 		private bool _isAnimating;
 
-		internal virtual Android.Graphics.Matrix ToNative(Android.Graphics.Matrix targetMatrix = null, Size size = new Size(), bool isBrush = false)
+		internal Android.Graphics.Matrix ToNativeMatrix(Android.Graphics.Matrix targetMatrix = null, Point origin = new Point(), Size size = new Size())
 		{
-			throw new NotImplementedException();
+			var matrix = ToMatrix(origin, size);
+
+			if (targetMatrix == null)
+			{
+				targetMatrix = new Android.Graphics.Matrix();
+			}
+
+			targetMatrix.SetValues(new[]
+			{
+				matrix.M11, matrix.M21, matrix.M31,
+				matrix.M12, matrix.M22, matrix.M32,
+				0, 0, 1
+			});
+
+			return targetMatrix;
 		}
 
 		// Currently we support only one view par transform.

--- a/src/Uno.UI/UI/Xaml/Media/Transform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Transform.Android.cs
@@ -23,8 +23,8 @@ namespace Windows.UI.Xaml.Media
 
 			targetMatrix.SetValues(new[]
 			{
-				matrix.M11, matrix.M21, matrix.M31,
-				matrix.M12, matrix.M22, matrix.M32,
+				matrix.M11, matrix.M21, matrix.M31 * (float)size.Width,
+				matrix.M12, matrix.M22, matrix.M32 * (float)size.Height,
 				0, 0, 1
 			});
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6748, closes #1359

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

- `LinearGradientBrush` on Android does not work with `RenderTrasnfrom`
- `LinearGradientBrush` on Android does not work with a single stop
- `ImageBrush` with `RenderTransform` throws `NotImplementedException`


## What is the new behavior?

Works.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.