### PR TITLE
fix: Fix .NET Native Logging missing metadata

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/UWP/Properties/Default.rd.xml
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/UWP/Properties/Default.rd.xml
@@ -25,6 +25,8 @@
     
     
     <!-- Add your application specific runtime directives here. -->
+    <Assembly Dynamic="Required All" Name="Microsoft.Extensions.Options" />
+    <Assembly Dynamic="Required All" Name="Microsoft.Extensions.Logging" />
 
 
   </Application>

--- a/src/SolutionTemplate/UnoSolutionTemplate/UWP/Properties/Default.rd.xml
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UWP/Properties/Default.rd.xml
@@ -25,6 +25,8 @@
     
     
     <!-- Add your application specific runtime directives here. -->
+    <Assembly Dynamic="Required All" Name="Microsoft.Extensions.Options" />
+    <Assembly Dynamic="Required All" Name="Microsoft.Extensions.Logging" />
 
 
   </Application>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5590

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

After updating the Microsoft.Extensions.Logging libraries to latest in UWP head, the .NET Native release build of apps crashes at startup with:

> System.Reflection.MissingMetadataException: ''Microsoft.Extensions.Options.IPostConfigureOptions<>' is missing metadata.

The issue is discussed here: dotnet/runtime#44697

## What is the new behavior?

No crash.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
