### PR TITLE
Fix visual transition support

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3927,7 +3927,7 @@
 		</Methods>
 		<Properties>
 			<Member
-				fullName=" Windows.UI.Xaml.Media.Animation.Timeline/TimelineState Windows.UI.Xaml.Media.Animation.Timeline::State()"
+				fullName="Windows.UI.Xaml.Media.Animation.Timeline/TimelineState Windows.UI.Xaml.Media.Animation.Timeline::State()"
 				reason="Not part of the UWP API" />
 			<Member
 				fullName="System.UInt32 Windows.UI.Composition.CompositionColorGradientStopCollection::Size()"

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3832,105 +3832,110 @@
 	</IgnoreSet>
 	
 	<IgnoreSet baseVersion="3.9.7">
-	  <Types>
-	  </Types>
-	  <Methods>
-		<!-- Focus management -->
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionColorBrush..ctor(Windows.UI.Composition.Compositor compositor)"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionColorGradientStop..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.UInt32 Windows.UI.Composition.CompositionColorGradientStopCollection.get_Size()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionColorGradientStopCollection.set_Count(System.Int32 value)"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionColorGradientStopCollection.set_IsReadOnly(System.Boolean value)"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionColorGradientStopCollection..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionEllipseGeometry..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Numerics.Vector2 Windows.UI.Composition.CompositionGradientBrush.get_AnchorPoint()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionGradientBrush.set_AnchorPoint(System.Numerics.Vector2 value)"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionGradientBrush..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionLinearGradientBrush..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionLineGeometry..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionRadialGradientBrush..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionRectangleGeometry..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionRoundedRectangleGeometry..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionSurfaceBrush..ctor(Windows.UI.Composition.Compositor compositor)"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionSurfaceBrush..ctor(Windows.UI.Composition.Compositor compositor, Windows.UI.Composition.ICompositionSurface surface)"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.CompositionViewBox..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Composition.InsetClip..ctor(Windows.UI.Composition.Compositor compositor)"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Xaml.Input.InertiaExpansionBehavior..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Xaml.Input.InertiaRotationBehavior..ctor()"
-			reason="Should not be public" />
-		<Member
-			fullName="System.Void Windows.UI.Xaml.Input.InertiaTranslationBehavior..ctor()"
-			reason="Should not be public" />
-		
-		<Member
-			fullName="Windows.UI.Xaml.Controls.Primitives.PlacementMode Windows.UI.Xaml.Controls.ToolTipService.GetPlacement(Windows.UI.Xaml.DependencyObject element)"
-			reason="INVALID REMOVE, TO ADJUST" />
-		<Member
-			fullName="System.Void Windows.UI.Xaml.Controls.ToolTipService.SetPlacement(Windows.UI.Xaml.DependencyObject element, Windows.UI.Xaml.Controls.Primitives.PlacementMode value)"
-			reason="INVALID REMOVE, TO ADJUST" />
-		<Member
-			fullName="System.Object Windows.UI.Xaml.Controls.ToolTipService.GetToolTip(Windows.UI.Xaml.DependencyObject element)"
-			reason="INVALID REMOVE, TO ADJUST" />
-		
-		<Member
-			fullName="System.Void Windows.UI.Xaml.Controls.ToolTipService.SetToolTip(Windows.UI.Xaml.DependencyObject element, System.Object value)"
-			reason="INVALID REMOVE, TO ADJUST" />
-		<Member
-			fullName="System.Boolean Windows.UI.Xaml.Controls.VirtualizingPanelLayout.ShouldInsertReorderingView(System.Double physicalExtentOffset)"
-			reason="INVALID REMOVE, TO ADJUST" />
+		<Methods>
+			<Member
+				fullName="Windows.UI.Xaml.Media.Animation.Timeline/TimelineState Windows.UI.Xaml.Media.Animation.Timeline.get_State()"
+				reason="Not part of the UWP API" />
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Media.Animation.Timeline.set_State(Windows.UI.Xaml.Media.Animation.Timeline/TimelineState value)"
+				reason="Not part of the UWP API" />
+			<!-- Focus management -->
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionColorBrush..ctor(Windows.UI.Composition.Compositor compositor)"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionColorGradientStop..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.UInt32 Windows.UI.Composition.CompositionColorGradientStopCollection.get_Size()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionColorGradientStopCollection.set_Count(System.Int32 value)"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionColorGradientStopCollection.set_IsReadOnly(System.Boolean value)"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionColorGradientStopCollection..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionEllipseGeometry..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Numerics.Vector2 Windows.UI.Composition.CompositionGradientBrush.get_AnchorPoint()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionGradientBrush.set_AnchorPoint(System.Numerics.Vector2 value)"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionGradientBrush..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionLinearGradientBrush..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionLineGeometry..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionRadialGradientBrush..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionRectangleGeometry..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionRoundedRectangleGeometry..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionSurfaceBrush..ctor(Windows.UI.Composition.Compositor compositor)"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionSurfaceBrush..ctor(Windows.UI.Composition.Compositor compositor, Windows.UI.Composition.ICompositionSurface surface)"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.CompositionViewBox..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Composition.InsetClip..ctor(Windows.UI.Composition.Compositor compositor)"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Input.InertiaExpansionBehavior..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Input.InertiaRotationBehavior..ctor()"
+				reason="Should not be public" />
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Input.InertiaTranslationBehavior..ctor()"
+				reason="Should not be public" />
+			
+			<Member
+				fullName="Windows.UI.Xaml.Controls.Primitives.PlacementMode Windows.UI.Xaml.Controls.ToolTipService.GetPlacement(Windows.UI.Xaml.DependencyObject element)"
+				reason="INVALID REMOVE, TO ADJUST" />
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Controls.ToolTipService.SetPlacement(Windows.UI.Xaml.DependencyObject element, Windows.UI.Xaml.Controls.Primitives.PlacementMode value)"
+				reason="INVALID REMOVE, TO ADJUST" />
+			<Member
+				fullName="System.Object Windows.UI.Xaml.Controls.ToolTipService.GetToolTip(Windows.UI.Xaml.DependencyObject element)"
+				reason="INVALID REMOVE, TO ADJUST" />
+			
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Controls.ToolTipService.SetToolTip(Windows.UI.Xaml.DependencyObject element, System.Object value)"
+				reason="INVALID REMOVE, TO ADJUST" />
+			<Member
+				fullName="System.Boolean Windows.UI.Xaml.Controls.VirtualizingPanelLayout.ShouldInsertReorderingView(System.Double physicalExtentOffset)"
+				reason="INVALID REMOVE, TO ADJUST" />
 
-	  </Methods>
-	  <Fields>
-	  </Fields>
-	  <Properties>
-		<Member
+		</Methods>
+		<Properties>
+			<Member
+				fullName=" Windows.UI.Xaml.Media.Animation.Timeline/TimelineState Windows.UI.Xaml.Media.Animation.Timeline::State()"
+				reason="Not part of the UWP API" />
+			<Member
 				fullName="System.UInt32 Windows.UI.Composition.CompositionColorGradientStopCollection::Size()"
 				reason="Method not in UWP contract" />
-		<Member
-			fullName="System.Numerics.Vector2 Windows.UI.Composition.CompositionGradientBrush::AnchorPoint()"
-			reason="Method not in UWP contract" />
-	  </Properties>
+			<Member
+				fullName="System.Numerics.Vector2 Windows.UI.Composition.CompositionGradientBrush::AnchorPoint()"
+				reason="Method not in UWP contract" />
+		</Properties>
 	</IgnoreSet>
 	<!--
 	Supported nodes (please keep at the bottom of this file):

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -493,6 +493,16 @@ namespace Uno.UI
 #endif
 		}
 
+		public static class VisualState
+		{
+			/// <summary>
+			/// When this is set, the <see cref="Windows.UI.Xaml.VisualState.Setters"/> will be applied synchronously when changing state,
+			/// unlike UWP which waits the for the end of the <see cref="VisualTransition.Storyboard"/> (if any) to apply them.
+			/// </summary>
+			/// <remarks>This flag is for backward compatibility with old versions of uno and should not be turned on.</remarks>
+			public static bool ApplySettersBeforeTransition { get; set; } = false;
+		}
+
 		public static class WebView
 		{
 #if __ANDROID__

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
@@ -251,9 +251,9 @@ namespace Windows.UI.Xaml.Media.Animation
 					_scheduledFrames.Add(
 						CoreDispatcher.Main.RunAsync(
 							CoreDispatcherPriority.Normal,
-							async () =>
+							async ct =>
 							{
-								await Task.Delay(dueTime);
+								await Task.Delay(dueTime, ct);
 								update();
 							}
 						)

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
@@ -287,6 +287,7 @@ namespace Windows.UI.Xaml.Media.Animation
 					((ITimeline)child).Stop();
 				}
 			}
+
 			State = TimelineState.Stopped;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -24,7 +24,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			State = TimelineState.Stopped;
 		}
 
-		protected internal enum TimelineState
+		internal enum TimelineState
 		{
 			Active,
 			Filling,
@@ -46,7 +46,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// An internally-used property which is essentially equivalent to <see cref="Storyboard.GetCurrentState"/>, except that it 
 		/// distinguishes <see cref="TimelineState.Active"/> from <see cref="TimelineState.Paused"/>.
 		/// </summary>
-		protected internal TimelineState State { get; set; }
+		internal TimelineState State { get; private protected set; }
 
 		public TimeSpan? BeginTime
 		{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -24,7 +24,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			State = TimelineState.Stopped;
 		}
 
-		protected enum TimelineState
+		protected internal enum TimelineState
 		{
 			Active,
 			Filling,
@@ -46,7 +46,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// An internally-used property which is essentially equivalent to <see cref="Storyboard.GetCurrentState"/>, except that it 
 		/// distinguishes <see cref="TimelineState.Active"/> from <see cref="TimelineState.Paused"/>.
 		/// </summary>
-		protected TimelineState State { get; set; }
+		protected internal TimelineState State { get; set; }
 
 		public TimeSpan? BeginTime
 		{

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -857,7 +857,6 @@ namespace Windows.UI.Xaml
 
 			handledInManaged |= SetPressed(args, false, muteEvent: ctx.IsLocalOnly || !isOverOrCaptured);
 
-			
 			// Note: We process the UpEvent between Release and Exited as the gestures like "Tap"
 			//		 are fired between those events.
 			if (_gestures.IsValueCreated)
@@ -873,6 +872,7 @@ namespace Windows.UI.Xaml
 				}
 			}
 
+#if !UNO_HAS_MANAGED_POINTERS // Captures release are handled a root level
 			// We release the captures on up but only after the released event and processed the gesture
 			// Note: For a "Tap" with a finger the sequence is Up / Exited / Lost, so we let the Exit raise the capture lost
 			// Note: If '!isOver', that means that 'IsCaptured == true' otherwise 'isOverOrCaptured' would have been false.
@@ -880,6 +880,7 @@ namespace Windows.UI.Xaml
 			{
 				handledInManaged |= SetNotCaptured(args);
 			}
+#endif
 
 			return handledInManaged;
 		}
@@ -898,12 +899,14 @@ namespace Windows.UI.Xaml
 				global::Windows.UI.Xaml.Window.Current.DragDrop.ProcessMoved(args);
 			}
 
+#if !UNO_HAS_MANAGED_POINTERS // Captures release are handled a root level
 			// We release the captures on exit when pointer if not pressed
 			// Note: for a "Tap" with a finger the sequence is Up / Exited / Lost, so the lost cannot be raised on Up
 			if (!IsPressed(args.Pointer))
 			{
 				handledInManaged |= SetNotCaptured(args);
 			}
+#endif
 
 			return handledInManaged;
 		}
@@ -990,9 +993,9 @@ namespace Windows.UI.Xaml
 				_pendingRaisedEvent = (null, null, null);
 			}
 		}
-		#endregion
+#endregion
 
-		#region Pointer over state (Updated by the partial API OnNative***, should not be updated externaly)
+#region Pointer over state (Updated by the partial API OnNative***, should not be updated externaly)
 		/// <summary>
 		/// Indicates if a pointer (no matter the pointer) is currently over the element (i.e. OverState)
 		/// WARNING: This might not be maintained for all controls, cf. remarks.
@@ -1039,9 +1042,9 @@ namespace Windows.UI.Xaml
 				return RaisePointerEvent(PointerExitedEvent, args);
 			}
 		}
-		#endregion
+#endregion
 
-		#region Pointer pressed state (Updated by the partial API OnNative***, should not be updated externaly)
+#region Pointer pressed state (Updated by the partial API OnNative***, should not be updated externaly)
 		private readonly HashSet<uint> _pressedPointers = new HashSet<uint>();
 
 		/// <summary>
@@ -1113,9 +1116,9 @@ namespace Windows.UI.Xaml
 		}
 
 		private void ClearPressed() => _pressedPointers.Clear();
-		#endregion
+#endregion
 
-		#region Pointer capture state (Updated by the partial API OnNative***, should not be updated externaly)
+#region Pointer capture state (Updated by the partial API OnNative***, should not be updated externaly)
 		/*
 		 * About pointer capture
 		 *
@@ -1129,7 +1132,7 @@ namespace Windows.UI.Xaml
 
 		private List<Pointer> _localExplicitCaptures;
 
-		#region Capture public (and internal) API ==> This manages only Explicit captures
+#region Capture public (and internal) API ==> This manages only Explicit captures
 		public static DependencyProperty PointerCapturesProperty { get; } = DependencyProperty.Register(
 			"PointerCaptures",
 			typeof(IReadOnlyList<Pointer>),
@@ -1196,7 +1199,7 @@ namespace Windows.UI.Xaml
 
 			Release(PointerCaptureKind.Explicit);
 		}
-		#endregion
+#endregion
 
 		partial void CapturePointerNative(Pointer pointer);
 		partial void ReleasePointerNative(Pointer pointer);
@@ -1295,9 +1298,9 @@ namespace Windows.UI.Xaml
 			relatedArgs.Handled = false;
 			return RaisePointerEvent(PointerCaptureLostEvent, relatedArgs);
 		}
-		#endregion
+#endregion
 
-		#region Drag state (Updated by the RaiseDrag***, should not be updated externaly)
+#region Drag state (Updated by the RaiseDrag***, should not be updated externaly)
 		private HashSet<long> _draggingOver;
 
 		/// <summary>
@@ -1329,6 +1332,6 @@ namespace Windows.UI.Xaml
 		{
 			_draggingOver?.Clear();
 		}
-		#endregion
+#endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
@@ -30,6 +30,11 @@ namespace Windows.UI.Xaml
 		/// The xaml scope in force at the time the VisualStateGroup was created.
 		/// </summary>
 		private readonly XamlScope _xamlScope;
+		private (VisualState state, VisualTransition transition) _current;
+
+		public event VisualStateChangedEventHandler CurrentStateChanging;
+
+		public event VisualStateChangedEventHandler CurrentStateChanged;
 
 		public VisualStateGroup()
 		{
@@ -40,6 +45,8 @@ namespace Windows.UI.Xaml
 
 			this.RegisterParentChangedCallback(this, OnParentChanged);
 		}
+
+		public VisualState CurrentState => _current.state;
 
 		public string Name { get; set; }
 
@@ -67,7 +74,6 @@ namespace Windows.UI.Xaml
 			internal set { this.SetValue(StatesProperty, value); }
 		}
 
-		// Using a DependencyProperty as the backing store for States.  This enables animation, styling, binding, etc...
 		public static DependencyProperty StatesProperty { get; } =
 			DependencyProperty.Register(
 				"States",
@@ -101,16 +107,13 @@ namespace Windows.UI.Xaml
 			internal set { this.SetValue(TransitionsProperty, value); }
 		}
 
-		// Using a DependencyProperty as the backing store for Transitions.  This enables animation, styling, binding, etc...
 		public static DependencyProperty TransitionsProperty { get; } =
 			DependencyProperty.Register(
 				"Transitions",
 				typeof(IList<VisualTransition>),
 				typeof(VisualStateGroup),
 				new FrameworkPropertyMetadata(
-					defaultValue: null,
-					propertyChangedCallback: (s, e) => ((VisualStateGroup)s)?.OnTransitionsChanged(e)
-				)
+					defaultValue: null)
 			);
 
 		#endregion
@@ -137,16 +140,10 @@ namespace Windows.UI.Xaml
 			RefreshStateTriggers();
 		}
 
-		//Adds Event Handlers when collections changed
-		private void OnTransitionsChanged(DependencyPropertyChangedEventArgs e)
+		private void OnParentChanged(object instance, object key, DependencyObjectParentChangedEventArgs args)
 		{
+			RefreshStateTriggers(force: true);
 		}
-
-		public VisualState CurrentState { get; internal set; }
-
-		public event VisualStateChangedEventHandler CurrentStateChanging;
-
-		public event VisualStateChangedEventHandler CurrentStateChanged;
 
 		internal void RaiseCurrentStateChanging(VisualState oldState, VisualState newState)
 		{
@@ -175,80 +172,60 @@ namespace Windows.UI.Xaml
 			return (this.GetParent() as FrameworkElement)?.FindFirstParent<Control>();
 		}
 
-		internal void GoToState(IFrameworkElement element, VisualState state, VisualState originalState, bool useTransitions, Action onStateChanged)
+		internal void GoToState(
+			IFrameworkElement element,
+			VisualState state,
+			bool useTransitions,
+			Action onStateChanged)
 		{
+			global::System.Diagnostics.Debug.Assert(state is null || States.Contains(state));
+
 			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 			{
 				this.Log().DebugFormat("Go to state [{0}/{1}] on [{2}]", Name, state?.Name, element);
 			}
 
-			var transition = FindTransition(originalState?.Name, state?.Name);
+			var current = _current;
+			var target = (state, transition: FindTransition(current.state?.Name, state?.Name));
 
-			EventHandler<object> onComplete = null;
-
-			onComplete = (s, a) =>
+			// Stops running animations (transition or state's storyboard)
+			// Note about animations (as of 2021-08-16 win 19043):
+			//		Any "running animation", either from the current transition or the current state's storyboard,
+			//		is being "paused" for properties that are going to be animated by the "next animation" (again transition or target state's storyboard),
+			//		and rollbacked for properties that won't be animated anymore.
+			var runningAnimation = current.transition?.Storyboard is { } currentTransition
+				&& currentTransition.State != Timeline.TimelineState.Stopped
+					? currentTransition
+					: current.state?.Storyboard;
+			var nextAnimation = target.transition?.Storyboard ?? target.state?.Storyboard;
+			if (runningAnimation != null)
 			{
-				onStateChanged();
-
-				if (state?.Storyboard == null)
+				if(nextAnimation is null)
 				{
-					return;
+					runningAnimation.Stop();
 				}
+				else
+				{
+					runningAnimation.TurnOverAnimationsTo(nextAnimation);
+				}
+			}
 
-				state.Storyboard.Completed -= onComplete;
-			};
-
-			EventHandler<object> onTransitionComplete = null;
-
-			onTransitionComplete = (s, a) =>
+			// Rollback setters that won't be re-set by the target state setters
+			// Note about setters and transition (as of 2021-08-16 win 19043):
+			//		* if current and target state have setters for the same property,
+			//		  the value of the current is kept as is and updated only once at the end of the transition
+			//		* if current has a setter which is not updated by the target state
+			//		  the value is rollbacked before the transition
+			//		* if the target has a setter for a property that was not affected by the current
+			//		  the value is applied only at the end of the transition
+			if (current.state is {} currentState)
 			{
-				if (transition?.Storyboard != null && useTransitions)
+				foreach (var setter in currentState.Setters.OfType<Setter>())
 				{
-					transition.Storyboard.Completed -= onTransitionComplete;
-
-					if (state?.Storyboard != null)
+					if (element != null && (target.state?.Setters.OfType<Setter>().Any(o => o.HasSameTarget(setter, DependencyPropertyValuePrecedences.Animations, element)) ?? false))
 					{
-						transition.Storyboard.TurnOverAnimationsTo(state.Storyboard);
-					}
-				}
-
-				//Starts Storyboard Animation
-				if (state?.Storyboard == null)
-				{
-					onComplete(this, null);
-				}
-				else if (state != null)
-				{
-					state.Storyboard.Completed += onComplete;
-					state.Storyboard.Begin();
-				}
-			};
-
-			//Stops Previous Storyboard Animation
-			if (originalState != null)
-			{
-				if (originalState.Storyboard != null)
-				{
-					if (transition?.Storyboard != null)
-					{
-						originalState.Storyboard.TurnOverAnimationsTo(transition.Storyboard);
-					}
-					else if (state?.Storyboard != null)
-					{
-						originalState.Storyboard.TurnOverAnimationsTo(state.Storyboard);
-					}
-					else
-					{
-						originalState.Storyboard.Stop();
-					}
-				}
-
-				foreach (var setter in this.CurrentState.Setters.OfType<Setter>())
-				{
-					if (element != null && (state?.Setters.OfType<Setter>().Any(o => o.HasSameTarget(setter, DependencyPropertyValuePrecedences.Animations, element)) ?? false))
-					{
-						// PERF: We clear the value of the current setter only if there isn't any setter in the target state
-						// which changes the same target property.
+						// We clear the value of the current setter only if there isn't any setter in the target state
+						// which changes the same target property (for perf ... and UWP behavior support regarding transition animation).
 
 						if (this.Log().IsEnabled(LogLevel.Debug))
 						{
@@ -262,78 +239,136 @@ namespace Windows.UI.Xaml
 				}
 			}
 
-#if !HAS_EXPENSIVE_TRYFINALLY
-			try
-#endif
-			{
-				ResourceResolver.PushNewScope(_xamlScope);
+			_current = target;
 
-				this.CurrentState = state;
-				if (this.CurrentState != null && element != null)
+			// For backward compatibility, we may apply the setters before the end of the transition.
+			if (FeatureConfiguration.VisualState.ApplySettersBeforeTransition)
+			{
+				ApplyTargetStateSetters();
+			}
+
+			// Finally effectively apply the target state!
+			if (useTransitions && target.transition?.Storyboard is { } transitionAnimation)
+			{
+				// Note: As of 2021-08-16 win 19043, if the transitionAnimation is Repeat=Forever, we actually never apply the state!
+
+				transitionAnimation.Completed += OnTransitionCompleted;
+				transitionAnimation.Begin();
+
+				void OnTransitionCompleted(object s, object a)
 				{
-					foreach (var setter in this.CurrentState.Setters.OfType<Setter>())
+					transitionAnimation.Completed -= OnTransitionCompleted;
+
+					if (target.state?.Storyboard is { } stateAnimation)
+					{
+						transitionAnimation.TurnOverAnimationsTo(stateAnimation);
+					}
+
+					ApplyTargetState();
+				}
+			}
+			else
+			{
+				ApplyTargetState();
+			}
+
+			void ApplyTargetState()
+			{
+				// Apply target state setters (the right time to do it!) 
+				if (!FeatureConfiguration.VisualState.ApplySettersBeforeTransition)
+				{
+					ApplyTargetStateSetters();
+				}
+
+				// Starts target state animation
+				if (target.state?.Storyboard is { } stateAnimation)
+				{
+					stateAnimation.Completed += OnStateStoryboardCompleted;
+					stateAnimation.Begin();
+
+					void OnStateStoryboardCompleted(object s, object a)
+					{
+						state.Storyboard.Completed -= OnStateStoryboardCompleted;
+						onStateChanged();
+					}
+				}
+				else
+				{
+					onStateChanged();
+				}
+			}
+
+			void ApplyTargetStateSetters()
+			{
+				if (target.state is null || element is null)
+				{
+					return;
+				}
+
+#if !HAS_EXPENSIVE_TRYFINALLY
+				try
+#endif
+				{
+					ResourceResolver.PushNewScope(_xamlScope);
+
+					foreach (var setter in target.state.Setters.OfType<Setter>())
 					{
 						setter.ApplyValue(DependencyPropertyValuePrecedences.Animations, element);
 					}
 				}
-
-				if (transition?.Storyboard == null || !useTransitions)
-				{
-					onTransitionComplete(this, null);
-				}
-				else
-				{
-					transition.Storyboard.Completed += onTransitionComplete;
-					transition.Storyboard.Begin();
-				}
-			}
 #if !HAS_EXPENSIVE_TRYFINALLY
-			finally
+				finally
 #endif
-			{
-				ResourceResolver.PopScope();
+				{
+					ResourceResolver.PopScope();
+				}
 			}
 		}
 
 		private VisualTransition FindTransition(string oldStateName, string newStateName)
 		{
-			if (oldStateName.IsNullOrEmpty() || newStateName.IsNullOrEmpty())
-			{
-				return null;
-			}
+			var hasOld = oldStateName.HasValue();
+			var hasNew = newStateName.HasValue();
 
-			var perfectMatch = Transitions.FirstOrDefault(vt =>
-				string.Equals(vt.From, oldStateName) &&
-				string.Equals(vt.To, newStateName));
-
-			if (perfectMatch != null)
+			if (hasOld && hasNew && Transitions.FirstOrDefault(Match(oldStateName, newStateName)) is { } perfectMatch)
 			{
 				return perfectMatch;
 			}
 
-			var fromMatch = Transitions.FirstOrDefault(vt =>
-				string.Equals(vt.From, oldStateName) &&
-				vt.To == null);
-
-			if (fromMatch != null)
+			if (hasOld && Transitions.FirstOrDefault(Match(oldStateName, null)) is { } fromMatch)
 			{
 				return fromMatch;
 			}
 
-			var toMatch = Transitions.FirstOrDefault(vt =>
-				vt.From == null &&
-				string.Equals(vt.To, newStateName));
+			if (hasNew && Transitions.FirstOrDefault(Match(null, newStateName)) is { } newMatch)
+			{
+				return newMatch;
+			}
 
-			return toMatch;
+			return default;
+
+			Func<VisualTransition, bool> Match(string from, string to)
+				=> tr => string.Equals(tr.From, oldStateName) && string.Equals(tr.To, newStateName);
 		}
 
 		internal void RefreshStateTriggers(bool force = false)
 		{
 			var newState = GetActiveTrigger();
 			var oldState = CurrentState;
-			if (!force && newState == oldState)
+			if (newState == oldState)
 			{
-				return;
+				if (!force)
+				{
+					return;
+				}
+				else if (newState is null)
+				{
+					// The 'force' has no effect is both old and new states are 'null'
+					// (setting the parent for the first time in control's init)
+					// we however raise the state changed for backward compatibility.
+					OnStateChanged();
+					return;
+				}
 			}
 
 			if (this.Log().IsEnabled(LogLevel.Debug))
@@ -347,13 +382,9 @@ namespace Windows.UI.Xaml
 			}
 
 			var parent = this.GetParent() as IFrameworkElement;
-			GoToState(parent, newState, CurrentState, false, OnStateChanged);
+			GoToState(parent, newState, false, OnStateChanged);
 		}
 
-		private void OnParentChanged(object instance, object key, DependencyObjectParentChangedEventArgs args)
-		{
-			RefreshStateTriggers(force: true);
-		}
 
 		/// <remarks>
 		/// This method is not using LINQ for performance considerations.
@@ -416,6 +447,7 @@ namespace Windows.UI.Xaml
 			return winnerState;
 		}
 
-		public override string ToString() => Name ?? $"<unnamed group {GetHashCode()}>";
+		public override string ToString()
+			=> Name ?? $"<unnamed group {GetHashCode()}>";
 	}
 }

--- a/src/Uno.UI/UI/Xaml/VisualStateManager.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateManager.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Uno.Extensions;
 using Uno.Logging;
 using Uno.Diagnostics.Eventing;
@@ -11,11 +12,12 @@ namespace Windows.UI.Xaml
 {
 	public partial class VisualStateManager : DependencyObject
 	{
-		private readonly static IEventProvider _trace = Tracing.Get(TraceProvider.Id);
+		private static readonly IEventProvider _trace = Tracing.Get(TraceProvider.Id);
+		private static readonly ILogger _log = typeof(VisualStateManager).Log();
 
 		public static class TraceProvider
 		{
-			public readonly static Guid Id = Guid.Parse("{2F38E5F4-90A2-4872-BD49-3696F897BAD1}");
+			public static readonly Guid Id = Guid.Parse("{2F38E5F4-90A2-4872-BD49-3696F897BAD1}");
 
 			public const int StoryBoard_GoToState = 1;
 		}
@@ -37,8 +39,7 @@ namespace Windows.UI.Xaml
 			obj.SetValue(VisualStateGroupsProperty, value);
 		}
 
-		// Using a DependencyProperty as the backing store for VisualStateGroups.  This enables animation, styling, binding, etc...
-		public static DependencyProperty VisualStateGroupsProperty { get ; } =
+		public static DependencyProperty VisualStateGroupsProperty { get; } =
 			DependencyProperty.RegisterAttached(
 				"VisualStateGroups",
 				typeof(IList<VisualStateGroup>),
@@ -92,7 +93,7 @@ namespace Windows.UI.Xaml
 			obj.SetValue(VisualStateManagerProperty, value);
 		}
 
-		internal static DependencyProperty VisualStateManagerProperty { get ; } =
+		internal static DependencyProperty VisualStateManagerProperty { get; } =
 			DependencyProperty.RegisterAttached("VisualStateManager", typeof(VisualStateManager), typeof(VisualStateManager), new FrameworkPropertyMetadata(null));
 
 		#endregion
@@ -100,12 +101,11 @@ namespace Windows.UI.Xaml
 		public static bool GoToState(Control control, string stateName, bool useTransitions)
 		{
 			var templateRoot = control.GetTemplateRoot();
-
-			if (templateRoot == null)
+			if (templateRoot is null)
 			{
-				if (typeof(VisualStateManager).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				if (_log.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 				{
-					typeof(VisualStateManager).Log().DebugFormat("Failed to set state [{0}], unable to find template root on [{1}]", stateName, control);
+					_log.DebugFormat("Failed to set state [{0}], unable to find template root on [{1}]", stateName, control);
 				}
 
 				return false;
@@ -115,9 +115,9 @@ namespace Windows.UI.Xaml
 			{
 				if (fe.GoToElementState(stateName, useTransitions))
 				{
-					if (typeof(VisualStateManager).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+					if (_log.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 					{
-						typeof(VisualStateManager).Log().DebugFormat($"GoToElementStateCore({stateName}) override on [{control}]");
+						_log.DebugFormat($"GoToElementStateCore({stateName}) override on [{control}]");
 					}
 
 					return true;
@@ -125,12 +125,11 @@ namespace Windows.UI.Xaml
 			}
 
 			var groups = GetVisualStateGroups(templateRoot);
-
-			if (groups == null)
+			if (groups is null)
 			{
-				if (typeof(VisualStateManager).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				if (_log.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 				{
-					typeof(VisualStateManager).Log().DebugFormat("Failed to set state [{0}], no visual state group on [{1}]", stateName, control);
+					_log.DebugFormat("Failed to set state [{0}], no visual state group on [{1}]", stateName, control);
 				}
 
 				return false;
@@ -138,54 +137,42 @@ namespace Windows.UI.Xaml
 
 			// Get all the groups with a state that matches the state name
 			var (group, state) = GetValidGroupAndState(stateName, groups);
-
-			if (group == null)
+			if (group is null)
 			{
-				if (typeof(VisualStateManager).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				if (_log.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 				{
-					typeof(VisualStateManager).Log().DebugFormat("Failed to set state [{0}], there are no matching groups on [{1}]", stateName, control);
+					_log.DebugFormat("Failed to set state [{0}], there are no matching groups on [{1}]", stateName, control);
 				}
 
 				return false;
 			}
 
 			var vsm = GetVisualStateManager(control);
-
-			if (vsm == null)
+			if (vsm is null)
 			{
-				if (typeof(VisualStateManager).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				if (_log.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 				{
-					typeof(VisualStateManager).Log().DebugFormat("Failed to set state [{0}], there is no VisualStateManagr on [{1}]", stateName, control);
+					_log.DebugFormat("Failed to set state [{0}], there is no VisualStateManagr on [{1}]", stateName, control);
 				}
 
 				return false;
 			}
 
-			var output = vsm.GoToStateCore(control, templateRoot, stateName, group, state, useTransitions);
+
+			var output = templateRoot is FrameworkElement fwRoot
+				? vsm.GoToStateCore(control, fwRoot, stateName, group, state, useTransitions)
+				: vsm.GoToStateCorePrivateBaseImplementation(control, group, state, useTransitions); // For backward compatibility!
+				
 #if __WASM__
 			TryAssignDOMVisualStates(groups, templateRoot);
 #endif
 			return output;
 		}
 
-		private static (VisualStateGroup, VisualState) GetValidGroupAndState(string stateName, IList<VisualStateGroup> groups)
-		{
-			foreach (var group in groups)
-			{
-				foreach (var state in group.States)
-				{
-					if (state.Name?.Equals(stateName) ?? false)
-					{
-						return (group, state);
-					}
-				}
-			}
+		protected virtual bool GoToStateCore(Control control, FrameworkElement templateRoot, string stateName, VisualStateGroup group, VisualState state, bool useTransitions)
+			=> GoToStateCorePrivateBaseImplementation(control, group, state, useTransitions);
 
-			return (null, null);
-		}
-
-		protected virtual bool GoToStateCore(Control control, FrameworkElement templateRoot, string stateName, VisualStateGroup group, VisualState state, bool useTransitions) => GoToStateCore(control, (IFrameworkElement) templateRoot, stateName, group, state, useTransitions);
-		private bool GoToStateCore(Control control, IFrameworkElement templateRoot, string stateName, VisualStateGroup group, VisualState state, bool useTransitions)
+		private bool GoToStateCorePrivateBaseImplementation(Control control, VisualStateGroup group, VisualState state, bool useTransitions)
 		{
 #if IS_UNO
 			if (_trace.IsEnabled)
@@ -196,7 +183,7 @@ namespace Windows.UI.Xaml
 					new[] {
 						control.GetType()?.ToString(),
 						control?.GetDependencyObjectId().ToString(),
-						stateName,
+						state.Name,
 						useTransitions ? "UseTransitions" : "NoTransitions"
 					}
 				);
@@ -204,8 +191,7 @@ namespace Windows.UI.Xaml
 #endif
 
 			var originalState = group.CurrentState;
-
-			if (VisualState.Equals(originalState, state))
+			if (object.Equals(originalState, state))
 			{
 				// Already in the right state
 				return true;
@@ -220,13 +206,10 @@ namespace Windows.UI.Xaml
 			group.GoToState(
 				control,
 				state,
-				originalState,
 				useTransitions,
 				() =>
 				{
-					var innerControl = wr?.Target as Control;
-
-					if (innerControl != null)
+					if (wr?.Target is Control)
 					{
 						RaiseCurrentStateChanged(group, originalState, state);
 					}
@@ -269,6 +252,22 @@ namespace Windows.UI.Xaml
 				.FirstOrDefault();
 
 			return group?.CurrentState;
+		}
+
+		private static (VisualStateGroup, VisualState) GetValidGroupAndState(string stateName, IList<VisualStateGroup> groups)
+		{
+			foreach (var group in groups)
+			{
+				foreach (var state in group.States)
+				{
+					if (state.Name?.Equals(stateName) ?? false)
+					{
+						return (group, state);
+					}
+				}
+			}
+
+			return (null, null);
 		}
 	}
 }


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/6744

## Bugfix
Multiple fixes about transition to fix `ScrollBar` disappearing from `ScrollViewer`

## What is the current behavior?
* When we define a `VisualTransition` between states, its `Storyboard` is not cancelled when changing to another state (driving the `VerticalScrollBar` to be set to `None` with a delay even if the scrollbars are needed again)
* When stopped, the `DoubleAnimationUsingKeyFrame` does not cancel its frames
* When using a `VisualTransition`, the `VisualState.Setters` of the target state are applied synchronously in the `GoToState` while they should be be applied only once the `VisualTransition.Storyboard` completes, if any.
* On skia, when the pointer leaves a control we propagate a silent pointer up to update the internal state (like UWP), but this also release the pointer capture if any.

## What is the new behavior?
🙃

## PR Checklist
- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- ~~[ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ Tests on animations are out of scope for now
- [ ] Validated PR `Screenshots Compare Test Run` results.
- ~~[ ] Contains **NO** breaking changes~~ `Setters` are now applied after `VisualTransition.Storyboard`
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
