### PR TITLE
fix: Handle justified text for TextBlock on Android

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1685,6 +1685,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_JustifiedText.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Layout.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5394,6 +5398,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_IsTextSelectionEnabled.xaml.cs">
       <DependentUpon>TextBlock_IsTextSelectionEnabled.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_JustifiedText.xaml.cs">
+      <DependentUpon>TextBlock_JustifiedText.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Layout.xaml.cs">
       <DependentUpon>TextBlock_Layout.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_JustifiedText.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_JustifiedText.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_JustifiedText"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBlockControl"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<TextBlock Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+					   MaxLines="4"
+					   TextWrapping="Wrap"
+					   TextAlignment="Justify"
+					   HorizontalAlignment="Left" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_JustifiedText.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_JustifiedText.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[Sample("TextBlockControl", "TextBlock_JustifiedText")]
+    public sealed partial class TextBlock_JustifiedText : Page
+    {
+        public TextBlock_JustifiedText()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -724,15 +724,21 @@ namespace Windows.UI.Xaml.Controls
 				}
 				else
 				{
-					Layout = StaticLayout.Builder.Obtain(_textFormatted, 0, _textFormatted.Length(), _paint, width)
-					.SetLineSpacing(_addedSpacing = GetSpacingAdd(_paint), 1)
-					.SetMaxLines(maxLines)
-					.SetEllipsize(_ellipsize)
-					.SetEllipsizedWidth(width)
-					.SetAlignment(_layoutAlignment)
-					.SetIncludePad(true)
-					.SetJustificationMode(_justificationMode)
-					.Build();
+					var builder = StaticLayout.Builder.Obtain(_textFormatted, 0, _textFormatted.Length(), _paint, width)
+						.SetLineSpacing(_addedSpacing = GetSpacingAdd(_paint), 1)
+						.SetMaxLines(maxLines)
+						.SetEllipsize(_ellipsize)
+						.SetEllipsizedWidth(width)
+						.SetAlignment(_layoutAlignment)
+						.SetIncludePad(true);
+
+					// JustificationMode was introduced in Android 8.
+					if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.O)
+					{
+						builder.SetJustificationMode(_justificationMode);
+					}
+
+					Layout = builder.Build();
 				}
 
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -112,6 +112,7 @@ namespace Windows.UI.Xaml.Controls
 		private TextPaint _paint;
 		private TextUtils.TruncateAt _ellipsize;
 		private Android.Text.Layout.Alignment _layoutAlignment;
+		private JustificationMode _justificationMode;
 
 		/// <summary>
 		/// Used by unit tests to verify that the displayed color matches the nominal managed color.
@@ -175,15 +176,21 @@ namespace Windows.UI.Xaml.Controls
 			{
 				case TextAlignment.Center:
 					_layoutAlignment = Android.Text.Layout.Alignment.AlignCenter;
+					_justificationMode = JustificationMode.None;
 					break;
 
 				case TextAlignment.Right:
 					_layoutAlignment = Android.Text.Layout.Alignment.AlignOpposite;
+					_justificationMode = JustificationMode.None;
 					break;
-
+				case TextAlignment.Justify:
+					_layoutAlignment = Android.Text.Layout.Alignment.AlignNormal;
+					_justificationMode = JustificationMode.InterWord;
+					break;
 				default:
 				case TextAlignment.Left:
 					_layoutAlignment = Android.Text.Layout.Alignment.AlignNormal;
+					_justificationMode = JustificationMode.None;
 					break;
 			}
 		}
@@ -404,6 +411,7 @@ namespace Windows.UI.Xaml.Controls
 				_paint,
 				IsLayoutConstrainedByMaxLines ? TruncateEnd : _ellipsize, // .SetMaxLines() won't work on Android unless the ellipsize "END" is used.
 				_layoutAlignment,
+				_justificationMode,
 				TextWrapping,
 				MaxLines,
 				availableSize,
@@ -445,6 +453,7 @@ namespace Windows.UI.Xaml.Controls
 			private readonly Java.Lang.ICharSequence _textFormatted;
 			private readonly TextUtils.TruncateAt _ellipsize;
 			private readonly Android.Text.Layout.Alignment _layoutAlignment;
+			private readonly JustificationMode _justificationMode;
 			private readonly TextWrapping _textWrapping;
 			private readonly int _maxLines;
 			private readonly bool _exactWidth;
@@ -475,6 +484,7 @@ namespace Windows.UI.Xaml.Controls
 				TextPaint paint,
 				TextUtils.TruncateAt ellipsize,
 				Android.Text.Layout.Alignment layoutAlignment,
+				JustificationMode isJustifiedText,
 				TextWrapping textWrapping,
 				int maxLines,
 				Size availableSize,
@@ -488,6 +498,7 @@ namespace Windows.UI.Xaml.Controls
 				_paint = paint;
 				_ellipsize = ellipsize;
 				_layoutAlignment = layoutAlignment;
+				_justificationMode = isJustifiedText;
 				_textWrapping = textWrapping;
 				_maxLines = maxLines;
 				AvailableSize = availableSize;
@@ -720,6 +731,7 @@ namespace Windows.UI.Xaml.Controls
 					.SetEllipsizedWidth(width)
 					.SetAlignment(_layoutAlignment)
 					.SetIncludePad(true)
+					.SetJustificationMode(_justificationMode)
 					.Build();
 				}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5218

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Justified text not handled on Android.

## What is the new behavior?

It's now handled.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
