### PR TITLE
Correctly check if the TextBox is PasswordBox before obscuring text

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -14,10 +14,13 @@ namespace Windows.UI.Xaml.Controls
 		private readonly ITextBoxViewExtension _textBoxExtension;
 
 		private readonly WeakReference<TextBox> _textBox;
+		private readonly bool _isPasswordBox;
+		private bool _isPasswordRevealed;
 
 		public TextBoxView(TextBox textBox)
 		{
 			_textBox = new WeakReference<TextBox>(textBox);
+			_isPasswordBox = textBox is PasswordBox;
 			if (!ApiExtensibility.CreateInstance(this, out _textBoxExtension))
 			{
 				if (this.Log().IsEnabled(LogLevel.Warning))
@@ -45,7 +48,18 @@ namespace Windows.UI.Xaml.Controls
 
 		internal void SetTextNative(string text)
 		{
-			DisplayBlock.Text = new string('•', text.Length);
+			// TODO: Inheritance hierarchy is wrong in Uno. PasswordBox shouldn't inherit TextBox.
+			// This needs to be moved to PasswordBox when it's separated from TextBox (likely in Uno 4).
+			if (_isPasswordBox && !_isPasswordRevealed)
+			{
+				// TODO: PasswordChar isn't currently implemented. It should be used here when implemented.
+				DisplayBlock.Text = new string('•', text.Length);
+			}
+			else
+			{
+				DisplayBlock.Text = text;
+			}
+
 			_textBoxExtension?.SetTextNative(text);
 		}
 
@@ -65,7 +79,11 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		internal void SetIsPassword(bool isPassword) => _textBoxExtension?.SetIsPassword(isPassword);
+		internal void SetIsPassword(bool isPassword)
+		{
+			_isPasswordRevealed = !isPassword;
+			_textBoxExtension?.SetIsPassword(isPassword);
+		}
 
 		internal void UpdateTextFromNative(string newText)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): Addresses regression introduced in #6768, and also fixes the implementation of the same PR

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- TextBox was incorrectly obscuring text.
- PasswordBox wasn't correctly accounting for programmatically changes of reveal mode


## What is the new behavior?

Fix both problems.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
