### PR TITLE
fix: Hide MS Edge reveal password to avoid duplicate reveal buttons

### DIFF
--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -231,3 +231,8 @@ textarea {
   resize: none;
   overflow: hidden; /* Scrolling is handled by the parent ScrollViewer */
 }
+
+input::-ms-reveal,
+input::-ms-clear {
+  display: none;
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4565

## PR Type

What kind of change does this PR introduce?

- Bugfix

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Double reveal password buttons on MS Edge.

## What is the new behavior?

Hide MS Edge reveal password button.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
