### PR TITLE
[Wasm] Added proper support for FillRule on Path Geometries

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Path_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Path_Tests.cs
@@ -25,10 +25,24 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			var scrn = TakeScreenshot("Rendered", true);
 
 			AssertHasColorAtCenter("MainTargetEvenOdd", Color.Beige);
+			AssertHasColorAtCenter("LeftTargetEvenOdd", Color.Beige);
 			AssertHasColorAtCenter("RightTargetEvenOdd", Color.Green);
+			AssertHasColorAtCenter("MainTargetEvenOdd2", Color.Beige);
+			AssertHasColorAtCenter("LeftTargetEvenOdd2", Color.Beige);
+			AssertHasColorAtCenter("RightTargetEvenOdd2", Color.Green);
+			AssertHasColorAtCenter("MainTargetEvenOdd3", Color.Beige);
+			AssertHasColorAtCenter("LeftTargetEvenOdd2", Color.Beige);
+			AssertHasColorAtCenter("RightTargetEvenOdd3", Color.Green);
 
 			AssertHasColorAtCenter("MainTargetNonZero", Color.Blue);
+			AssertHasColorAtCenter("LeftTargetNonZero", Color.Beige);
 			AssertHasColorAtCenter("RightTargetNonZero", Color.Blue);
+			AssertHasColorAtCenter("MainTargetNonZero2", Color.Blue);
+			AssertHasColorAtCenter("LeftTargetNonZero2", Color.Beige);
+			AssertHasColorAtCenter("RightTargetNonZero2", Color.Blue);
+			AssertHasColorAtCenter("MainTargetNonZero3", Color.Blue);
+			AssertHasColorAtCenter("LeftTargetNonZero3", Color.Beige);
+			AssertHasColorAtCenter("RightTargetNonZero3", Color.Blue);
 
 			void AssertHasColorAtCenter(string element, Color color)
 			{

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -4061,6 +4061,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PathTestsControl\Path_Geometries.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PathTestsControl\Path_Geometry.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6683,6 +6687,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PathTestsControl\Path_FillRule.xaml.cs">
       <DependentUpon>Path_FillRule.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PathTestsControl\Path_Geometries.xaml.cs">
+      <DependentUpon>Path_Geometries.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PathTestsControl\Path_Geometry.xaml.cs">
       <DependentUpon>Path_Geometry.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_Dynamic_Geometries.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_Dynamic_Geometries.xaml
@@ -10,47 +10,175 @@
 
 	<Page.Resources>
 		<local:ValueToPointConverter x:Key="toPoint" />
+		<local:ValueToRectConverter x:Key="toRect" Origin="10,10" />
 	</Page.Resources>
 
 	<ScrollViewer>
 		<StackPanel Spacing="8" Margin="20">
 
 			<StackPanel Orientation="Horizontal" Spacing="4">
-				<Border Background="Yellow" Width="80" Height="80">
-					<Path x:Name="path1" Stroke="Red">
-						<Path.Data>
-							<EllipseGeometry
-								Center="40,40"
-								RadiusX="{Binding Value, ElementName=ellipseRadiusX}"
-								RadiusY="{Binding Value, ElementName=ellipseRadiusY}"/>
-						</Path.Data>
-					</Path>
-				</Border>
-				<StackPanel>
-					<TextBlock FontWeight="Bold">Ellipse Geometry</TextBlock>
-					<Slider Header="RadiusX" x:Name="ellipseRadiusX" Minimum="10" Maximum="100" Value="40" />
-					<Slider Header="RadiusY" x:Name="ellipseRadiusY" Minimum="10" Maximum="100" Value="40" />
+				<StackPanel Orientation="Horizontal" Spacing="4">
+					<Border Background="Yellow" Width="80" Height="80">
+						<Path x:Name="path1" Stroke="Red">
+							<Path.Data>
+								<EllipseGeometry
+									Center="40,40"
+									RadiusX="{Binding Value, ElementName=ellipseRadiusX}"
+									RadiusY="{Binding Value, ElementName=ellipseRadiusY}"/>
+							</Path.Data>
+						</Path>
+					</Border>
+					<StackPanel>
+						<TextBlock FontWeight="Bold">Ellipse Geometry</TextBlock>
+						<Slider Header="RadiusX" x:Name="ellipseRadiusX" Minimum="10" Maximum="100" Value="40" />
+						<Slider Header="RadiusY" x:Name="ellipseRadiusY" Minimum="10" Maximum="100" Value="40" />
+					</StackPanel>
+				</StackPanel>
+
+				<StackPanel Orientation="Horizontal" Spacing="4">
+					<Border Background="Yellow" Width="80" Height="80">
+						<Path x:Name="path2" Stroke="Red">
+							<Path.Data>
+								<GeometryGroup>
+									<EllipseGeometry
+										Center="40,40"
+										RadiusX="{Binding Value, ElementName=ellipseGroupRadiusX}"
+										RadiusY="{Binding Value, ElementName=ellipseGroupRadiusY}"/>
+								</GeometryGroup>
+							</Path.Data>
+						</Path>
+					</Border>
+					<StackPanel>
+						<TextBlock FontWeight="Bold">Grouped Ellipse Geometry</TextBlock>
+						<Slider Header="RadiusX" x:Name="ellipseGroupRadiusX" Minimum="10" Maximum="100" Value="40" />
+						<Slider Header="RadiusY" x:Name="ellipseGroupRadiusY" Minimum="10" Maximum="100" Value="40" />
+					</StackPanel>
 				</StackPanel>
 			</StackPanel>
 
 			<StackPanel Orientation="Horizontal" Spacing="4">
-				<Border Background="Yellow" Width="80" Height="80">
-					<Path x:Name="path2" Stroke="Red">
-						<Path.Data>
-							<LineGeometry
-								StartPoint="{Binding Value, ElementName=lineStart, Converter={StaticResource toPoint}}"
-								EndPoint="{Binding Value, ElementName=lineEnd, Converter={StaticResource toPoint}}"/>
-						</Path.Data>
-					</Path>
-				</Border>
-				<StackPanel>
-					<TextBlock FontWeight="Bold">Line Geometry</TextBlock>
-					<Slider Header="Start" x:Name="lineStart" Minimum="10" Maximum="100" Value="20" />
-					<Slider Header="End" x:Name="lineEnd" Minimum="10" Maximum="100" Value="60" />
+				<StackPanel Orientation="Horizontal" Spacing="4">
+					<Border Background="Yellow" Width="80" Height="80">
+						<Path x:Name="path3" Stroke="Red" Margin="0,30">
+							<Path.Data>
+								<LineGeometry
+									StartPoint="{Binding Value, ElementName=lineStart, Converter={StaticResource toPoint}}"
+									EndPoint="{Binding Value, ElementName=lineEnd, Converter={StaticResource toPoint}}"/>
+							</Path.Data>
+						</Path>
+					</Border>
+					<StackPanel>
+						<TextBlock FontWeight="Bold">Line Geometry</TextBlock>
+						<Slider Header="Start" x:Name="lineStart" Minimum="10" Maximum="100" Value="20" />
+						<Slider Header="End" x:Name="lineEnd" Minimum="10" Maximum="100" Value="60" />
+					</StackPanel>
+				</StackPanel>
+
+				<StackPanel Orientation="Horizontal" Spacing="4">
+					<Border Background="Yellow" Width="80" Height="80">
+						<Path x:Name="path4" Stroke="Red" Margin="0,30">
+							<Path.Data>
+								<GeometryGroup>
+									<LineGeometry
+										StartPoint="{Binding Value, ElementName=lineGroupStart, Converter={StaticResource toPoint}}"
+										EndPoint="{Binding Value, ElementName=lineGroupEnd, Converter={StaticResource toPoint}}"/>
+								</GeometryGroup>
+							</Path.Data>
+						</Path>
+					</Border>
+					<StackPanel>
+						<TextBlock FontWeight="Bold">Grouped Line Geometry</TextBlock>
+						<Slider Header="Start" x:Name="lineGroupStart" Minimum="10" Maximum="100" Value="20" />
+						<Slider Header="End" x:Name="lineGroupEnd" Minimum="10" Maximum="100" Value="60" />
+					</StackPanel>
 				</StackPanel>
 			</StackPanel>
-			
-			
+
+			<StackPanel Orientation="Horizontal" Spacing="4">
+				<StackPanel Orientation="Horizontal" Spacing="4">
+					<Border Background="Yellow" Width="80" Height="80">
+						<Path x:Name="path5" Stroke="Red">
+							<Path.Data>
+								<PathGeometry>
+									<PathGeometry.Figures>
+										<PathFigure StartPoint="15,15" IsClosed="True">
+											<PathFigure.Segments>
+												<LineSegment Point="45,45" />
+												<BezierSegment Point1="55,30" Point2="35,30" Point3="45,15" />
+												<LineSegment Point="{Binding Value, ElementName=pathPoint, ConverterParameter=45, Converter={StaticResource toPoint}}" />
+												<BezierSegment Point1="5,30" Point2="25,30" Point3="15,15" />
+											</PathFigure.Segments>
+										</PathFigure>
+									</PathGeometry.Figures>
+								</PathGeometry>
+							</Path.Data>
+						</Path>
+					</Border>
+					<StackPanel>
+						<TextBlock FontWeight="Bold">Path Geometry</TextBlock>
+						<Slider Header="Size" x:Name="pathPoint" Minimum="5" Maximum="60" Value="15" />
+					</StackPanel>
+				</StackPanel>
+
+				<StackPanel Orientation="Horizontal" Spacing="4">
+					<Border Background="Yellow" Width="80" Height="80">
+						<Path x:Name="path6" Stroke="Red">
+							<Path.Data>
+								<PathGeometry>
+									<PathGeometry.Figures>
+										<PathFigure StartPoint="15,15" IsClosed="True">
+											<PathFigure.Segments>
+												<LineSegment Point="45,45" />
+												<BezierSegment Point1="55,30" Point2="35,30" Point3="45,15" />
+												<LineSegment Point="{Binding Value, ElementName=pathGroupPoint, ConverterParameter=45, Converter={StaticResource toPoint}}" />
+												<BezierSegment Point1="5,30" Point2="25,30" Point3="15,15" />
+											</PathFigure.Segments>
+										</PathFigure>
+									</PathGeometry.Figures>
+								</PathGeometry>
+							</Path.Data>
+						</Path>
+					</Border>
+					<StackPanel>
+						<TextBlock FontWeight="Bold">Grouped Path Geometry</TextBlock>
+						<Slider Header="Size" x:Name="pathGroupPoint" Minimum="5" Maximum="60" Value="15" />
+					</StackPanel>
+				</StackPanel>
+			</StackPanel>
+
+			<StackPanel Orientation="Horizontal" Spacing="4">
+				<StackPanel Orientation="Horizontal" Spacing="4">
+					<Border Background="Yellow" Width="80" Height="80">
+						<Path x:Name="path7" Stroke="Red">
+							<Path.Data>
+								<RectangleGeometry
+									Rect="{Binding Value, ElementName=rectSize, Converter={StaticResource toRect}}"/>
+							</Path.Data>
+						</Path>
+					</Border>
+					<StackPanel>
+						<TextBlock FontWeight="Bold">Rectangle Geometry</TextBlock>
+						<Slider Header="Size" x:Name="rectSize" Minimum="5" Maximum="60" Value="20" />
+					</StackPanel>
+				</StackPanel>
+
+				<StackPanel Orientation="Horizontal" Spacing="4">
+					<Border Background="Yellow" Width="80" Height="80">
+						<Path x:Name="path8" Stroke="Red">
+							<Path.Data>
+								<GeometryGroup>
+									<RectangleGeometry
+										Rect="{Binding Value, ElementName=rectGroupSize, Converter={StaticResource toRect}}"/>
+								</GeometryGroup>
+							</Path.Data>
+						</Path>
+					</Border>
+					<StackPanel>
+						<TextBlock FontWeight="Bold">Grouped Rectangle Geometry</TextBlock>
+						<Slider Header="Size" x:Name="rectGroupSize" Minimum="5" Maximum="60" Value="20" />
+					</StackPanel>
+				</StackPanel>
+			</StackPanel>
 		</StackPanel>
 	</ScrollViewer>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_Dynamic_Geometries.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_Dynamic_Geometries.xaml.cs
@@ -7,13 +7,13 @@ using Windows.UI.Xaml.Data;
 namespace UITests.Windows_UI_Xaml_Shapes.PathTestsControl
 {
 	[Sample]
-    public sealed partial class Path_Dynamic_Geometries : Page
-    {
-        public Path_Dynamic_Geometries()
-        {
-            this.InitializeComponent();
-        }
-    }
+	public sealed partial class Path_Dynamic_Geometries : Page
+	{
+		public Path_Dynamic_Geometries()
+		{
+			this.InitializeComponent();
+		}
+	}
 
 	internal class ValueToPointConverter : IValueConverter
 	{
@@ -22,6 +22,23 @@ namespace UITests.Windows_UI_Xaml_Shapes.PathTestsControl
 			if(targetType == typeof(Point))
 			{
 				return new Point(System.Convert.ToDouble(value), System.Convert.ToDouble(parameter));
+			}
+
+			return value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
+	}
+
+	internal class ValueToRectConverter : IValueConverter
+	{
+		public Point Origin { get; set; } = default;
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			if (targetType == typeof(Rect))
+			{
+				var v = System.Convert.ToDouble(value);
+				return new Rect(Origin, new Size(v, v));
 			}
 
 			return value;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_FillRule.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_FillRule.xaml
@@ -7,16 +7,35 @@
 			 mc:Ignorable="d"
 			 d:DesignHeight="300"
 			 d:DesignWidth="400">
-	<StackPanel>
-		<TextBlock Text="FillRule=EvenOdd"
-				   HorizontalAlignment="Center"
-				   Foreground="Green" />
+
+	<Grid HorizontalAlignment="Center" RowSpacing="5" ColumnSpacing="5">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="Auto" />
+		</Grid.ColumnDefinitions>
+
+		<TextBlock Grid.Column="1" Grid.Row="0">Path data</TextBlock>
+		<TextBlock Grid.Column="2" Grid.Row="0">PathFigures</TextBlock>
+		<TextBlock Grid.Column="3" Grid.Row="0">GeometryGroup</TextBlock>
+
+		<TextBlock Foreground="Green" Grid.Column="0" Grid.Row="1" VerticalAlignment="Center">FillRule=EvenOdd</TextBlock>
+		<TextBlock Foreground="Blue" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center">FillRule=NonZero</TextBlock>
+
 		<Grid VerticalAlignment="Center"
 			  Margin="5"
 			  BorderBrush="Brown"
 			  Background="Beige"
 			  BorderThickness="1"
-			  HorizontalAlignment="Center">
+			  HorizontalAlignment="Center"
+			  Grid.Column="1"
+			  Grid.Row="1">
 			<Border x:Name="MainTargetEvenOdd"
 					Height="91"
 					Width="91" />
@@ -25,20 +44,20 @@
 					Width="30"
 					HorizontalAlignment="Right" />
 			<Path x:Name="EvenOddPath"
-				  Data="F0M0,0L0,60 90,60 90,30 30,30 30,90 60,90 60,0z"
+				  Data="F0M0,0L0,60 90,60 90,30 30,30 30,90 60,90 60,0z M10,10 L20,10 20,80 10,80Z"
 				  StrokeThickness="1"
 				  Stroke="Black"
 				  Fill="Green" />
 		</Grid>
-		<TextBlock Text="FillRule=NonZero"
-				   HorizontalAlignment="Center"
-				   Foreground="Blue" />
+
 		<Grid VerticalAlignment="Center"
 			  Margin="5"
 			  BorderBrush="Brown"
 			  Background="Beige"
 			  BorderThickness="1"
-			  HorizontalAlignment="Center">
+			  HorizontalAlignment="Center"
+			  Grid.Column="1"
+			  Grid.Row="2">
 			<Border x:Name="MainTargetNonZero"
 					Height="91"
 					Width="91" />
@@ -47,10 +66,174 @@
 					Width="30"
 					HorizontalAlignment="Right" />
 			<Path x:Name="NonZeroPath"
-				  Data="F1M0,0L0,60 90,60 90,30 30,30 30,90 60,90 60,0z"
+				  Data="F1M0,0L0,60 90,60 90,30 30,30 30,90 60,90 60,0z M10,10 L20,10 20,80 10,80Z"
 				  StrokeThickness="1"
 				  Stroke="Black"
 				  Fill="Blue" />
 		</Grid>
-	</StackPanel>
+
+		<Grid VerticalAlignment="Center"
+			  Margin="5"
+			  BorderBrush="Brown"
+			  Background="Beige"
+			  BorderThickness="1"
+			  HorizontalAlignment="Center"
+			  Grid.Column="2"
+			  Grid.Row="1">
+			<Border x:Name="MainTargetEvenOdd2"
+					Height="91"
+					Width="91" />
+			<Border x:Name="RightTargetEvenOdd2"
+					Height="91"
+					Width="30"
+					HorizontalAlignment="Right" />
+			<Path x:Name="EvenOddPath2"
+				  StrokeThickness="1"
+				  Stroke="Black"
+				  Fill="Green">
+				<Path.Data>
+					<PathGeometry FillRule="EvenOdd">
+						<PathGeometry.Figures>
+							<PathFigure StartPoint="0,0" IsClosed="True">
+								<PathFigure.Segments>
+									<PolyLineSegment Points="0,60 90,60 90,30 30,30 30,90 60,90 60,0" />
+								</PathFigure.Segments>
+							</PathFigure>
+							<PathFigure StartPoint="10,10" IsClosed="True">
+								<PathFigure.Segments>
+									<PolyLineSegment Points="20,10 20,80 10,80" />
+								</PathFigure.Segments>
+							</PathFigure>
+						</PathGeometry.Figures>
+					</PathGeometry>
+				</Path.Data>
+			</Path>
+		</Grid>
+
+		<Grid VerticalAlignment="Center"
+			  Margin="5"
+			  BorderBrush="Brown"
+			  Background="Beige"
+			  BorderThickness="1"
+			  HorizontalAlignment="Center"
+			  Grid.Column="2"
+			  Grid.Row="2">
+			<Border x:Name="MainTargetNonZero2"
+					Height="91"
+					Width="91" />
+			<Border x:Name="RightTargetNonZero2"
+					Height="91"
+					Width="30"
+					HorizontalAlignment="Right" />
+			<Path x:Name="NonZeroPath2"
+				  StrokeThickness="1"
+				  Stroke="Black"
+				  Fill="Blue">
+				<Path.Data>
+					<PathGeometry FillRule="NonZero">
+						<PathGeometry.Figures>
+							<PathFigure StartPoint="0,0" IsClosed="True">
+								<PathFigure.Segments>
+									<PolyLineSegment Points="0,60 90,60 90,30 30,30 30,90 60,90 60,0" />
+								</PathFigure.Segments>
+							</PathFigure>
+							<PathFigure StartPoint="10,10" IsClosed="True">
+								<PathFigure.Segments>
+									<PolyLineSegment Points="20,10 20,80 10,80" />
+								</PathFigure.Segments>
+							</PathFigure>
+						</PathGeometry.Figures>
+					</PathGeometry>
+				</Path.Data>
+			</Path>
+		</Grid>
+
+		<Grid VerticalAlignment="Center"
+			  Margin="5"
+			  BorderBrush="Brown"
+			  Background="Beige"
+			  BorderThickness="1"
+			  HorizontalAlignment="Center"
+			  Grid.Column="3"
+			  Grid.Row="1">
+			<Border x:Name="MainTargetEvenOdd3"
+					Height="91"
+					Width="91" />
+			<Border x:Name="RightTargetEvenOdd3"
+					Height="91"
+					Width="30"
+					HorizontalAlignment="Right" />
+			<Path x:Name="EvenOddPath3"
+				  StrokeThickness="1"
+				  Stroke="Black"
+				  Fill="Green">
+				<Path.Data>
+					<GeometryGroup FillRule="EvenOdd">
+						<PathGeometry>
+							<PathGeometry.Figures>
+								<PathFigure StartPoint="0,0" IsClosed="True">
+									<PathFigure.Segments>
+										<PolyLineSegment Points="0,60 90,60 90,30 30,30 30,90 60,90 60,0" />
+									</PathFigure.Segments>
+								</PathFigure>
+							</PathGeometry.Figures>
+						</PathGeometry>
+						<PathGeometry>
+							<PathGeometry.Figures>
+								<PathFigure StartPoint="10,10" IsClosed="True">
+									<PathFigure.Segments>
+										<PolyLineSegment Points="20,10 20,80 10,80" />
+									</PathFigure.Segments>
+								</PathFigure>
+							</PathGeometry.Figures>
+						</PathGeometry>
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+		</Grid>
+
+		<Grid VerticalAlignment="Center"
+			  Margin="5"
+			  BorderBrush="Brown"
+			  Background="Beige"
+			  BorderThickness="1"
+			  HorizontalAlignment="Center"
+			  Grid.Column="3"
+			  Grid.Row="2">
+			<Border x:Name="MainTargetNonZero3"
+					Height="91"
+					Width="91" />
+			<Border x:Name="RightTargetNonZero3"
+					Height="91"
+					Width="30"
+					HorizontalAlignment="Right" />
+			<Path x:Name="NonZeroPath3"
+				  StrokeThickness="1"
+				  Stroke="Black"
+				  Fill="Blue">
+				<Path.Data>
+					<GeometryGroup FillRule="NonZero">
+						<PathGeometry>
+							<PathGeometry.Figures>
+								<PathFigure StartPoint="0,0" IsClosed="True">
+									<PathFigure.Segments>
+										<PolyLineSegment Points="0,60 90,60 90,30 30,30 30,90 60,90 60,0" />
+									</PathFigure.Segments>
+								</PathFigure>
+							</PathGeometry.Figures>
+						</PathGeometry>
+						<PathGeometry>
+							<PathGeometry.Figures>
+								<PathFigure StartPoint="10,10" IsClosed="True">
+									<PathFigure.Segments>
+										<PolyLineSegment Points="20,10 20,80 10,80" />
+									</PathFigure.Segments>
+								</PathFigure>
+							</PathGeometry.Figures>
+						</PathGeometry>
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+		</Grid>
+	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_FillRule.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_FillRule.xaml
@@ -39,6 +39,10 @@
 			<Border x:Name="MainTargetEvenOdd"
 					Height="91"
 					Width="91" />
+			<Border x:Name="LeftTargetEvenOdd"
+					Height="91"
+					Width="30"
+					HorizontalAlignment="Left" />
 			<Border x:Name="RightTargetEvenOdd"
 					Height="91"
 					Width="30"
@@ -61,6 +65,10 @@
 			<Border x:Name="MainTargetNonZero"
 					Height="91"
 					Width="91" />
+			<Border x:Name="LeftTargetNonZero"
+					Height="91"
+					Width="30"
+					HorizontalAlignment="Left" />
 			<Border x:Name="RightTargetNonZero"
 					Height="91"
 					Width="30"
@@ -83,6 +91,10 @@
 			<Border x:Name="MainTargetEvenOdd2"
 					Height="91"
 					Width="91" />
+			<Border x:Name="LeftTargetEvenOdd2"
+					Height="91"
+					Width="30"
+					HorizontalAlignment="Left" />
 			<Border x:Name="RightTargetEvenOdd2"
 					Height="91"
 					Width="30"
@@ -121,6 +133,10 @@
 			<Border x:Name="MainTargetNonZero2"
 					Height="91"
 					Width="91" />
+			<Border x:Name="LeftTargetNonZero2"
+					Height="91"
+					Width="30"
+					HorizontalAlignment="Left" />
 			<Border x:Name="RightTargetNonZero2"
 					Height="91"
 					Width="30"
@@ -159,6 +175,10 @@
 			<Border x:Name="MainTargetEvenOdd3"
 					Height="91"
 					Width="91" />
+			<Border x:Name="LeftTargetEvenOdd3"
+					Height="91"
+					Width="30"
+					HorizontalAlignment="Left" />
 			<Border x:Name="RightTargetEvenOdd3"
 					Height="91"
 					Width="30"
@@ -203,6 +223,10 @@
 			<Border x:Name="MainTargetNonZero3"
 					Height="91"
 					Width="91" />
+			<Border x:Name="LeftTargetNonZero3"
+					Height="91"
+					Width="30"
+					HorizontalAlignment="Left" />
 			<Border x:Name="RightTargetNonZero3"
 					Height="91"
 					Width="30"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_FillRule.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_FillRule.xaml.cs
@@ -1,20 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Uno.UI.Samples.Controls;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
+﻿using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-
-// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace UITests.Windows_UI_Xaml_Shapes.PathTestsControl
 {

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_Geometries.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_Geometries.xaml
@@ -1,0 +1,321 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Shapes.PathTestsControl.Path_Geometries"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Shapes.PathTestsControl"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="6">
+		<TextBlock FontSize="20">Path Geometries</TextBlock>
+
+		<Grid ColumnSpacing="5" RowSpacing="5">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="60" />
+				<ColumnDefinition Width="60" />
+				<ColumnDefinition Width="60" />
+				<ColumnDefinition Width="60" />
+			</Grid.ColumnDefinitions>
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="60" />
+				<RowDefinition Height="60" />
+				<RowDefinition Height="60" />
+				<RowDefinition Height="60" />
+			</Grid.RowDefinitions>
+
+			<TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Center">Ellipse</TextBlock>
+			<TextBlock Grid.Row="0" Grid.Column="2" HorizontalAlignment="Center">Line</TextBlock>
+			<TextBlock Grid.Row="0" Grid.Column="3" HorizontalAlignment="Center">Path</TextBlock>
+			<TextBlock Grid.Row="0" Grid.Column="4" HorizontalAlignment="Center">Rectangle</TextBlock>
+
+			<TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">Straight</TextBlock>
+			<TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center">Grouped</TextBlock>
+			<TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center">Straight Transformed</TextBlock>
+			<TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center">Grouped Transformed</TextBlock>
+
+			<Path
+				Grid.Row="1"
+				Grid.Column="1"
+				x:Name="EllipseStraight"
+				Fill="Violet"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<EllipseGeometry Center="30,30" RadiusX="25" RadiusY="15" />
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="1"
+				Grid.Column="2"
+				x:Name="LineStraight"
+				Fill="Violet"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<LineGeometry StartPoint="15,15" EndPoint="45,45" />
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="1"
+				Grid.Column="3"
+				x:Name="PathStraight"
+				Fill="Violet"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<PathGeometry>
+						<PathGeometry.Figures>
+							<PathFigure StartPoint="15,15" IsClosed="True">
+								<PathFigure.Segments>
+									<LineSegment Point="45,45" />
+									<BezierSegment Point1="55,30" Point2="35,30" Point3="45,15" />
+									<LineSegment Point="15,45" />
+									<BezierSegment Point1="5,30" Point2="25,30" Point3="15,15" />
+								</PathFigure.Segments>
+							</PathFigure>
+						</PathGeometry.Figures>
+					</PathGeometry>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="1"
+				Grid.Column="4"
+				x:Name="RectangleStraight"
+				Fill="Violet"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<RectangleGeometry Rect="10,15,40,30" />
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="2"
+				Grid.Column="1"
+				x:Name="EllipseGrouped"
+				Fill="Indigo"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<GeometryGroup>
+						<EllipseGeometry Center="30,30" RadiusX="25" RadiusY="15" />
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="2"
+				Grid.Column="2"
+				x:Name="LineGrouped"
+				Fill="Indigo"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<GeometryGroup>
+						<LineGeometry StartPoint="15,15" EndPoint="45,45" />
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="2"
+				Grid.Column="3"
+				x:Name="PathGrouped"
+				Fill="Indigo"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<GeometryGroup>
+						<PathGeometry>
+							<PathGeometry.Figures>
+								<PathFigure StartPoint="15,15" IsClosed="True">
+									<PathFigure.Segments>
+										<LineSegment Point="45,45" />
+										<BezierSegment Point1="55,30" Point2="35,30" Point3="45,15" />
+										<LineSegment Point="15,45" />
+										<BezierSegment Point1="5,30" Point2="25,30" Point3="15,15" />
+									</PathFigure.Segments>
+								</PathFigure>
+							</PathGeometry.Figures>
+						</PathGeometry>
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="2"
+				Grid.Column="4"
+				x:Name="RectangleGrouped"
+				Fill="Indigo"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<GeometryGroup>
+						<RectangleGeometry Rect="10,15,40,30" />
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="3"
+				Grid.Column="1"
+				x:Name="EllipseStraightTransformed"
+				Fill="Blue"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<EllipseGeometry Center="30,30" RadiusX="25" RadiusY="15">
+						<Geometry.Transform>
+							<CompositeTransform Rotation="15" CenterX="30" CenterY="30" ScaleX="1.15" ScaleY=".75" />
+						</Geometry.Transform>
+					</EllipseGeometry>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="3"
+				Grid.Column="2"
+				x:Name="LineStraightTransformed"
+				Fill="Blue"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<LineGeometry StartPoint="15,15" EndPoint="45,45">
+						<Geometry.Transform>
+							<CompositeTransform Rotation="15" CenterX="30" CenterY="30" ScaleX="1.15" ScaleY=".75" />
+						</Geometry.Transform>
+					</LineGeometry>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="3"
+				Grid.Column="3"
+				x:Name="PathStraightTransformed"
+				Fill="Blue"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<PathGeometry>
+						<Geometry.Transform>
+							<CompositeTransform Rotation="15" CenterX="30" CenterY="30" ScaleX="1.15" ScaleY=".75" />
+						</Geometry.Transform>
+						<PathGeometry.Figures>
+							<PathFigure StartPoint="15,15" IsClosed="True">
+								<PathFigure.Segments>
+									<LineSegment Point="45,45" />
+									<BezierSegment Point1="55,30" Point2="35,30" Point3="45,15" />
+									<LineSegment Point="15,45" />
+									<BezierSegment Point1="5,30" Point2="25,30" Point3="15,15" />
+								</PathFigure.Segments>
+							</PathFigure>
+						</PathGeometry.Figures>
+					</PathGeometry>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="3"
+				Grid.Column="4"
+				x:Name="RectangleStraightTransformed"
+				Fill="Blue"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<RectangleGeometry Rect="10,15,40,30">
+						<Geometry.Transform>
+							<CompositeTransform Rotation="15" CenterX="30" CenterY="30" ScaleX="1.15" ScaleY=".75" />
+						</Geometry.Transform>
+					</RectangleGeometry>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="4"
+				Grid.Column="1"
+				x:Name="EllipseGroupedTransformed"
+				Fill="Green"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<GeometryGroup>
+						<Geometry.Transform>
+							<CompositeTransform Rotation="15" CenterX="30" CenterY="30" ScaleX="1.15" ScaleY=".75" />
+						</Geometry.Transform>
+						<EllipseGeometry Center="30,30" RadiusX="25" RadiusY="15" />
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="4"
+				Grid.Column="2"
+				x:Name="LineGroupedTransformed"
+				Fill="Green"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<GeometryGroup>
+						<Geometry.Transform>
+							<CompositeTransform Rotation="15" CenterX="30" CenterY="30" ScaleX="1.15" ScaleY=".75" />
+						</Geometry.Transform>
+						<LineGeometry StartPoint="15,15" EndPoint="45,45" />
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="4"
+				Grid.Column="3"
+				x:Name="PathGroupedTransformed"
+				Fill="Green"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<GeometryGroup>
+						<Geometry.Transform>
+							<CompositeTransform Rotation="15" CenterX="30" CenterY="30" ScaleX="1.15" ScaleY=".75" />
+						</Geometry.Transform>
+						<PathGeometry>
+							<PathGeometry.Figures>
+								<PathFigure StartPoint="15,15" IsClosed="True">
+									<PathFigure.Segments>
+										<LineSegment Point="45,45" />
+										<BezierSegment Point1="55,30" Point2="35,30" Point3="45,15" />
+										<LineSegment Point="15,45" />
+										<BezierSegment Point1="5,30" Point2="25,30" Point3="15,15" />
+									</PathFigure.Segments>
+								</PathFigure>
+							</PathGeometry.Figures>
+						</PathGeometry>
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+
+			<Path
+				Grid.Row="4"
+				Grid.Column="4"
+				x:Name="RectangleGroupedTransformed"
+				Fill="Green"
+				Stroke="Black"
+				StrokeThickness="2">
+				<Path.Data>
+					<GeometryGroup>
+						<Geometry.Transform>
+							<CompositeTransform Rotation="15" CenterX="30" CenterY="30" ScaleX="1.15" ScaleY=".75" />
+						</Geometry.Transform>
+						<RectangleGeometry Rect="10,15,40,30" />
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+
+		</Grid>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_Geometries.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/PathTestsControl/Path_Geometries.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Shapes.PathTestsControl
+{
+	[Sample]
+	public sealed partial class Path_Geometries : Page
+	{
+		public Path_Geometries()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/EllipseGeometry.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/EllipseGeometry.wasm.cs
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media
 			return _svgElement;
 		}
 
-		internal override IFormattable RasterizePathData()
+		internal override IFormattable ToPathData()
 		{
 			var cx = Center.X;
 			var cy = Center.Y;

--- a/src/Uno.UI/UI/Xaml/Media/EllipseGeometry.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/EllipseGeometry.wasm.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
 using Uno.Extensions;
 using Uno.UI.DataBinding;
 using Windows.UI.Xaml.Wasm;
@@ -8,18 +9,20 @@ namespace Windows.UI.Xaml.Media
 {
 	partial class EllipseGeometry
 	{
-		private readonly SvgElement _svgElement = new SvgElement("ellipse");
+		private SvgElement? _svgElement;
 
 		partial void InitPartials()
 		{
 			this.RegisterDisposablePropertyChangedCallback(OnPropertyChanged);
-#if DEBUG
-			_svgElement.SetAttribute("uno-geometry-type", "EllipseGeometry");
-#endif
 		}
 
-		private void OnPropertyChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
+		private void OnPropertyChanged(ManagedWeakReference? instance, DependencyProperty property, DependencyPropertyChangedEventArgs? args)
 		{
+			if(_svgElement == null)
+			{
+				return;
+			}
+
 			if (property == CenterProperty)
 			{
 				var center = Center;
@@ -41,6 +44,31 @@ namespace Windows.UI.Xaml.Media
 			}
 		}
 
-		internal override SvgElement GetSvgElement() => _svgElement;
+		internal override SvgElement GetSvgElement()
+		{
+			if (_svgElement == null)
+			{
+				_svgElement = new SvgElement("ellipse");
+#if DEBUG
+				_svgElement.SetAttribute("uno-geometry-type", "EllipseGeometry");
+#endif
+
+				OnPropertyChanged(null, CenterProperty, null);
+				OnPropertyChanged(null, RadiusXProperty, null);
+				OnPropertyChanged(null, RadiusYProperty, null);
+			}
+
+			return _svgElement;
+		}
+
+		internal override IFormattable RasterizePathData()
+		{
+			var cx = Center.X;
+			var cy = Center.Y;
+			var rx = RadiusX;
+			var ry = RadiusY;
+
+			return $"M{cx},{cy - ry} A{rx},{ry} 0 0 0 {cx},{cy + ry} A{rx},{ry} 0 0 0 {cx},{cy - ry} Z";
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Geometry.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Geometry.wasm.cs
@@ -8,7 +8,7 @@ namespace Windows.UI.Xaml.Media
 	{
 		internal virtual SvgElement GetSvgElement() => throw new NotSupportedException($"{nameof(GetSvgElement)} is not implemented for {this}.");
 
-		internal virtual IFormattable RasterizePathData() => throw new NotSupportedException($"{nameof(RasterizePathData)} is not implemented for {this}.");
+		internal virtual IFormattable ToPathData() => throw new NotSupportedException($"{nameof(ToPathData)} is not implemented for {this}.");
 
 		internal virtual void Invalidate() { }
 	}

--- a/src/Uno.UI/UI/Xaml/Media/Geometry.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Geometry.wasm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Windows.UI.Xaml.Wasm;
 
 namespace Windows.UI.Xaml.Media
@@ -6,6 +7,8 @@ namespace Windows.UI.Xaml.Media
 	partial class Geometry
 	{
 		internal virtual SvgElement GetSvgElement() => throw new NotSupportedException($"{nameof(GetSvgElement)} is not implemented for {this}.");
+
+		internal virtual IFormattable RasterizePathData() => throw new NotSupportedException($"{nameof(RasterizePathData)} is not implemented for {this}.");
 
 		internal virtual void Invalidate() { }
 	}

--- a/src/Uno.UI/UI/Xaml/Media/GeometryData.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GeometryData.wasm.cs
@@ -5,6 +5,15 @@ namespace Windows.UI.Xaml.Media
 {
 	public class GeometryData : Geometry
 	{
+		// This is a special class to support the "Data Path" string on Wasm platform.
+		// Since the native underlying system (SVG) is using data paths "as is", there's
+		// no need to parse it in managed code, except to extract the FillRule.
+
+		// This special geometry will be created when setting a string data directly in XAML
+		// like this:
+		//
+		// <Path Data="M0,0 L10,10 20,10 20,20, 10,20 Z" />
+
 		private readonly SvgElement _svgElement = new SvgElement("path");
 
 		public string Data { get; }
@@ -19,6 +28,8 @@ namespace Windows.UI.Xaml.Media
 		{
 			if (data.StartsWith("F", StringComparison.InvariantCultureIgnoreCase) && data.Length > 2)
 			{
+				// TODO: support spaces between the F and the 0/1
+
 				FillRule = data[1] == '1' ? FillRule.Nonzero : FillRule.EvenOdd;
 				Data = data.Substring(2);
 			}
@@ -38,5 +49,8 @@ namespace Windows.UI.Xaml.Media
 		}
 
 		internal override SvgElement GetSvgElement() => _svgElement;
+
+		// There is no .RasterizePathData() on GeometryData, because it's not possible
+		// to have this in a GeometryGroup.
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/GeometryData.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GeometryData.wasm.cs
@@ -50,7 +50,7 @@ namespace Windows.UI.Xaml.Media
 
 		internal override SvgElement GetSvgElement() => _svgElement;
 
-		// There is no .RasterizePathData() on GeometryData, because it's not possible
+		// There is no .ToPathData() on GeometryData, because it's not possible
 		// to have this in a GeometryGroup.
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/GeometryGroup.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GeometryGroup.wasm.cs
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media
 
 		internal override void Invalidate()
 		{
-			var data = RasterizePathData().ToString(null, CultureInfo.InvariantCulture);
+			var data = ToPathData().ToString(null, CultureInfo.InvariantCulture);
 			GetSvgElement().SetAttribute("d", data);
 		}
 
@@ -88,7 +88,7 @@ namespace Windows.UI.Xaml.Media
 
 		private CompositeFormattable _compositeFormattable;
 
-		internal override IFormattable RasterizePathData()
+		internal override IFormattable ToPathData()
 		{
 			return _compositeFormattable ??= new CompositeFormattable(this);
 		}
@@ -108,7 +108,7 @@ namespace Windows.UI.Xaml.Media
 
 				foreach(var child in _owner.Children)
 				{
-					var childFormattable = child.RasterizePathData();
+					var childFormattable = child.ToPathData();
 					sb.Append(childFormattable.ToString(format, formatProvider));
 				}
 

--- a/src/Uno.UI/UI/Xaml/Media/GeometryGroup.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GeometryGroup.wasm.cs
@@ -45,13 +45,13 @@ namespace Windows.UI.Xaml.Media
 					oldGeometries.VectorChanged -= OnGeometriesChanged;
 				}
 
-				if(args?.NewValue is GeometryCollection newGeometries)
+				if((args?.NewValue ?? Children) is GeometryCollection newGeometries)
 				{
 					newGeometries.VectorChanged += OnGeometriesChanged;
 
 					newGeometries.SetParent(this);
 
-					foreach (var child in Children)
+					foreach (var child in newGeometries)
 					{
 						_svgElement.AddChild(child.GetSvgElement());
 					}

--- a/src/Uno.UI/UI/Xaml/Media/LineGeometry.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/LineGeometry.wasm.cs
@@ -1,4 +1,6 @@
 ﻿#nullable enable
+using System;
+using System.Collections.Generic;
 using Uno.Extensions;
 using Uno.UI.DataBinding;
 using Windows.UI.Xaml.Wasm;
@@ -7,18 +9,20 @@ namespace Windows.UI.Xaml.Media
 {
 	partial class LineGeometry
 	{
-		private readonly SvgElement _svgElement = new SvgElement("line");
+		private SvgElement? _svgElement;
 
 		partial void InitPartials()
 		{
 			this.RegisterDisposablePropertyChangedCallback(OnPropertyChanged);
-#if DEBUG
-			_svgElement.SetAttribute("uno-geometry-type", "LineGeometry");
-#endif
 		}
 
-			private void OnPropertyChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
+		private void OnPropertyChanged(ManagedWeakReference? instance, DependencyProperty property, DependencyPropertyChangedEventArgs? args)
 		{
+			if(_svgElement == null)
+			{
+				return;
+			}
+
 			if (property == StartPointProperty)
 			{
 				var point = StartPoint;
@@ -35,6 +39,28 @@ namespace Windows.UI.Xaml.Media
 			}
 		}
 
-		internal override SvgElement GetSvgElement() => _svgElement;
+		internal override SvgElement GetSvgElement()
+		{
+			if (_svgElement == null)
+			{
+				_svgElement = new SvgElement("line");
+#if DEBUG
+				_svgElement.SetAttribute("uno-geometry-type", "LineGeometry");
+#endif
+
+				OnPropertyChanged(null, StartPointProperty, null);
+				OnPropertyChanged(null, EndPointProperty, null);
+			}
+
+			return _svgElement;
+		}
+
+		internal override IFormattable RasterizePathData()
+		{
+			var p1 = StartPoint;
+			var p2 = EndPoint;
+
+			return $"M {p1.X},{p1.Y} L {p2.X}, {p2.Y} Z";
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/LineGeometry.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/LineGeometry.wasm.cs
@@ -55,7 +55,7 @@ namespace Windows.UI.Xaml.Media
 			return _svgElement;
 		}
 
-		internal override IFormattable RasterizePathData()
+		internal override IFormattable ToPathData()
 		{
 			var p1 = StartPoint;
 			var p2 = EndPoint;

--- a/src/Uno.UI/UI/Xaml/Media/PathGeometry.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/PathGeometry.wasm.cs
@@ -102,5 +102,7 @@ namespace Windows.UI.Xaml.Media
 		}
 
 		internal override SvgElement GetSvgElement() => _svgElement;
+
+		internal override IFormattable RasterizePathData() => $"{ToStreamGeometry(Figures)}";
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/PathGeometry.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/PathGeometry.wasm.cs
@@ -103,6 +103,6 @@ namespace Windows.UI.Xaml.Media
 
 		internal override SvgElement GetSvgElement() => _svgElement;
 
-		internal override IFormattable RasterizePathData() => $"{ToStreamGeometry(Figures)}";
+		internal override IFormattable ToPathData() => $"{ToStreamGeometry(Figures)}";
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.wasm.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System;
 using Uno.Extensions;
 using Uno.UI.DataBinding;
 using Windows.UI.Xaml.Wasm;
@@ -44,6 +45,13 @@ namespace Windows.UI.Xaml.Media
 				UpdateSvg();
 			}
 			return _svgElement;
+		}
+
+		internal override IFormattable RasterizePathData()
+		{
+			var rect = Rect;
+
+			return $"M{rect.Left},{rect.Top} L{rect.Right},{rect.Top} {rect.Right},{rect.Bottom} {rect.Left},{rect.Bottom} Z";
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.wasm.cs
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Media
 			return _svgElement;
 		}
 
-		internal override IFormattable RasterizePathData()
+		internal override IFormattable ToPathData()
 		{
 			var rect = Rect;
 


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/6782

# Bugfix
`FillRule` were not properly implemented when a `<GeometryGroup />` were used in a `<Path />` element.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
