### PR TITLE
fix: Hide open flyouts when MessageDialog is shown

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Popups/Given_MessageDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Popups/Given_MessageDialog.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
-using Android.Widget;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Popups/Given_MessageDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Popups/Given_MessageDialog.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Android.Widget;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Popups;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Media;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Popups
+{
+	[TestClass]
+	public class Given_MessageDialog
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task Should_Close_Open_Popups()
+		{
+			var button = new Windows.UI.Xaml.Controls.Button();
+			var flyout = new Flyout();
+			FlyoutBase.SetAttachedFlyout(button, flyout);
+			WindowHelper.WindowContent = button;
+			Assert.AreEqual(0, VisualTreeHelper.GetOpenPopups(Window.Current).Count);
+			FlyoutBase.ShowAttachedFlyout(button);
+			Assert.AreEqual(1, VisualTreeHelper.GetOpenPopups(Window.Current).Count);
+			var messageDialog = new MessageDialog("Hello");
+			var asyncOperation = messageDialog.ShowAsync();
+			Assert.AreEqual(0, VisualTreeHelper.GetOpenPopups(Window.Current).Count);
+			asyncOperation.Cancel();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Popups/Given_MessageDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Popups/Given_MessageDialog.cs
@@ -15,6 +15,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Popups
 	[TestClass]
 	public class Given_MessageDialog
 	{
+#if !__WASM__
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task Should_Close_Open_Popups()
@@ -31,5 +32,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Popups
 			Assert.AreEqual(0, VisualTreeHelper.GetOpenPopups(Window.Current).Count);
 			asyncOperation.Cancel();
 		}
+#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -55,7 +55,8 @@ namespace Windows.UI.Xaml
 			ApiInformation.RegisterAssembly(typeof(Application).Assembly);
 			ApiInformation.RegisterAssembly(typeof(Windows.Storage.ApplicationData).Assembly);
 
-			Uno.DispatcherTimerHelper.SetDispatcherTimerGetter(() => new DispatcherTimer());
+			Uno.Helpers.DispatcherTimerProxy.SetDispatcherTimerGetter(() => new DispatcherTimer());
+			Uno.Helpers.VisualTreeHelperProxy.SetCloseAllPopupsAction(() => Media.VisualTreeHelper.CloseAllPopups());
 
 			InitializePartialStatic();
 		}

--- a/src/Uno.UWP/Helpers/DispatcherTimerProxy.cs
+++ b/src/Uno.UWP/Helpers/DispatcherTimerProxy.cs
@@ -1,12 +1,10 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
-namespace Uno
+namespace Uno.Helpers
 {
-	internal static class DispatcherTimerHelper
+	internal static class DispatcherTimerProxy
 	{
 		private static Func<IDispatcherTimer>? _getter;
 

--- a/src/Uno.UWP/Helpers/VisualTreeHelperProxy.cs
+++ b/src/Uno.UWP/Helpers/VisualTreeHelperProxy.cs
@@ -1,0 +1,15 @@
+﻿#nullable enable
+
+using System;
+
+namespace Uno.Helpers
+{
+	internal static class VisualTreeHelperProxy
+	{
+		private static Action? _closeAllPopups;
+
+		public static void CloseAllPopups() => _closeAllPopups?.Invoke();
+
+		public static void SetCloseAllPopupsAction(Action closeAllPopups) => _closeAllPopups = closeAllPopups;
+	}
+}

--- a/src/Uno.UWP/UI/Popups/MessageDialog.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Uno.Helpers;
 using Windows.Foundation;
 using Windows.UI.Core;
 
@@ -52,6 +53,8 @@ namespace Windows.UI.Popups
 
 		public IAsyncOperation<IUICommand> ShowAsync()
 		{
+			VisualTreeHelperProxy.CloseAllPopups();
+
 			var invokedCommand = new TaskCompletionSource<IUICommand>();
 
 			return AsyncOperation.FromTask<IUICommand>(async ct =>

--- a/src/Uno.UWP/UI/Popups/MessageDialog.wasm.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.wasm.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Uno.Extensions;
+using Uno.Helpers;
 using Windows.Foundation;
 using Windows.UI.Core;
 
@@ -16,6 +17,8 @@ namespace Windows.UI.Popups
 
 		public IAsyncOperation<IUICommand> ShowAsync()
 		{
+			VisualTreeHelperProxy.CloseAllPopups();
+
 			var command = $"Uno.UI.WindowManager.current.alert(\"{Uno.Foundation.WebAssemblyRuntime.EscapeJs(Content)}\");";
 			Uno.Foundation.WebAssemblyRuntime.InvokeJS(command);
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1929

## PR Type

What kind of change does this PR introduce?

- Bugfix

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

flyouts not closed when a MessageDialog is shown.


## What is the new behavior?

They are now closed, matching UWP behavior.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
