### PR TITLE
Implement TextBox.Select, TextBox.SelectAll on all platforms, and SelectionStart, SelectionLength on Skia

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1789,6 +1789,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Selection.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_TextChanging.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5470,6 +5474,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_RoundedCorners.xaml.cs">
       <DependentUpon>TextBox_RoundedCorners.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Selection.xaml.cs">
+      <DependentUpon>TextBox_Selection.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_TextChanging.xaml.cs">
       <DependentUpon>TextBox_TextChanging.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Selection"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+		<controls:NumberBox x:Name="startNumber" PlaceholderText="Start" />
+		<controls:NumberBox x:Name="lengthNumber" PlaceholderText="Length" />
+		<TextBox x:Name="myTextBox" />
+		<Button Click="Select_OnClick" Content="Select"></Button>
+		<Button Click="SelectAll_OnClick" Content="Select all"></Button>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml.cs
@@ -1,8 +1,6 @@
 ﻿using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using static Uno.UI.FeatureConfiguration;
-
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
 {

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml.cs
@@ -1,0 +1,28 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using static Uno.UI.FeatureConfiguration;
+
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
+{
+	[Sample("TextBox")]
+	public sealed partial class TextBox_Selection : UserControl
+	{
+		public TextBox_Selection()
+		{
+			this.InitializeComponent();
+		}
+		private void Select_OnClick(object sender, RoutedEventArgs args)
+		{
+			myTextBox.Focus(FocusState.Programmatic);
+			myTextBox.Select((int)startNumber.Value, (int)lengthNumber.Value);
+		}
+
+		private void SelectAll_OnClick(object sender, RoutedEventArgs args)
+		{
+			myTextBox.Focus(FocusState.Programmatic);
+			myTextBox.SelectAll();
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -297,5 +297,37 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 			}
 			// TODO: Handle TextView..
 		}
+
+		public int GetSelectionStart()
+		{
+			if (_currentInputWidget is Entry entry)
+			{
+				entry.GetSelectionBounds(out var start, out _);
+				return start;
+			}
+			else if (_currentInputWidget is TextView textView)
+			{
+				textView.Buffer.GetSelectionBounds(out var start, out _);
+				return start.Offset; // TODO: Confirm this implementation is correct.
+			}
+
+			return 0;
+		}
+
+		public int GetSelectionLength()
+		{
+			if (_currentInputWidget is Entry entry)
+			{
+				entry.GetSelectionBounds(out var start, out var end);
+				return end - start;
+			}
+			else if (_currentInputWidget is TextView textView)
+			{
+				textView.Buffer.GetSelectionBounds(out var start, out var end);
+				return end.Offset - start.Offset;
+			}
+
+			return 0;
+		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -288,5 +288,14 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 				entry.Visibility = !isPassword;
 			}
 		}
+
+		public void Select(int start, int length)
+		{
+			if (_currentInputWidget is Entry entry)
+			{
+				entry.SelectRegion(start_pos: start, end_pos: start + length);
+			}
+			// TODO: Handle TextView..
+		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -189,5 +189,9 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 		}
 
 		public void Select(int start, int length) => _currentInputWidget?.Select(start, length);
+
+		public int GetSelectionStart() => _currentInputWidget?.SelectionStart ?? 0;
+
+		public int GetSelectionLength() => _currentInputWidget?.SelectionLength ?? 0;
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -187,5 +187,7 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 		{
 			// No support for now.
 		}
+
+		public void Select(int start, int length) => _currentInputWidget?.Select(start, length);
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/TextBoxTests/Given_TextBox.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/TextBoxTests/Given_TextBox.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -49,6 +44,50 @@ namespace Uno.UI.Tests.TextBoxTests
 
 			Assert.AreEqual("Rhubarb", textBox.Text);
 			Assert.AreEqual(1, callbackCount);
+		}
+
+		[TestMethod]
+		public void Calling_Select_With_NegativeValues()
+		{
+			var textBox = new TextBox();
+			Assert.ThrowsException<ArgumentException>(() => textBox.Select(0, -1));
+			Assert.ThrowsException<ArgumentException>(() => textBox.Select(-1, 0));
+		}
+
+		[TestMethod]
+		public void Calling_Select_With_In_Range_Values()
+		{
+			var textBox = new TextBox();
+			textBox.Text = "0123456789";
+			Assert.AreEqual(0, textBox.SelectionStart);
+			Assert.AreEqual(0, textBox.SelectionLength);
+			textBox.Select(1, 7);
+			Assert.AreEqual(1, textBox.SelectionStart);
+			Assert.AreEqual(7, textBox.SelectionLength);
+		}
+
+		[TestMethod]
+		public void Calling_Select_With_Out_Of_Range_Length()
+		{
+			var textBox = new TextBox();
+			textBox.Text = "0123456789";
+			Assert.AreEqual(0, textBox.SelectionStart);
+			Assert.AreEqual(0, textBox.SelectionLength);
+			textBox.Select(1, 20);
+			Assert.AreEqual(1, textBox.SelectionStart);
+			Assert.AreEqual(10, textBox.SelectionLength);
+		}
+
+		[TestMethod]
+		public void Calling_Select_With_Out_Of_Range_Start()
+		{
+			var textBox = new TextBox();
+			textBox.Text = "0123456789";
+			Assert.AreEqual(0, textBox.SelectionStart);
+			Assert.AreEqual(0, textBox.SelectionLength);
+			textBox.Select(20, 5);
+			Assert.AreEqual(10, textBox.SelectionStart);
+			Assert.AreEqual(0, textBox.SelectionLength);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -463,14 +463,14 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.SelectionChanged.remove
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.remove
-		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+		#if false || false || false || false || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public  void Select( int start,  int length)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "void TextBox.Select(int start, int length)");
 		}
 		#endif
-		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+		#if false || false || false || false || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public  void SelectAll()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -464,14 +464,14 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.remove
 		#if false || false || false || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
+		[global::Uno.NotImplemented("__NETSTD_REFERENCE__")]
 		public  void Select( int start,  int length)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "void TextBox.Select(int start, int length)");
 		}
 		#endif
 		#if false || false || false || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
+		[global::Uno.NotImplemented("__NETSTD_REFERENCE__")]
 		public  void SelectAll()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "void TextBox.SelectAll()");

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -463,14 +463,14 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.SelectionChanged.remove
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.remove
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || false || false || false || false || false || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void Select( int start,  int length)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "void TextBox.Select(int start, int length)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || false || false || false || false || false || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void SelectAll()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -11,7 +11,7 @@ namespace Windows.UI.Xaml.Controls
 		// Skipping already declared property TextAlignment
 		// Skipping already declared property Text
 		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public  int SelectionStart
 		{
 			get
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 		#endif
 		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public  int SelectionLength
 		{
 			get
@@ -430,7 +430,7 @@ namespace Windows.UI.Xaml.Controls
 			nameof(CanPasteClipboardContent), typeof(bool),
 			typeof(global::Windows.UI.Xaml.Controls.TextBox),
 			new FrameworkPropertyMetadata(default(bool)));
-		#endif
+#endif
 		// Skipping already declared method Windows.UI.Xaml.Controls.TextBox.TextBox()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.TextBox()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.Text.get
@@ -463,15 +463,15 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.SelectionChanged.remove
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.remove
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public  void Select( int start,  int length)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "void TextBox.Select(int start, int length)");
 		}
 		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public  void SelectAll()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "void TextBox.SelectAll()");

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -463,14 +463,14 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.SelectionChanged.remove
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.remove
-		#if false || false || false || false || false || __NETSTD_REFERENCE__ || false
+		#if false || false || false || false || false || false || false
 		[global::Uno.NotImplemented("__NETSTD_REFERENCE__")]
 		public  void Select( int start,  int length)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "void TextBox.Select(int start, int length)");
 		}
 		#endif
-		#if false || false || false || false || false || __NETSTD_REFERENCE__ || false
+		#if false || false || false || false || false || false || false
 		[global::Uno.NotImplemented("__NETSTD_REFERENCE__")]
 		public  void SelectAll()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -10,7 +10,7 @@ namespace Windows.UI.Xaml.Controls
 		// Skipping already declared property TextWrapping
 		// Skipping already declared property TextAlignment
 		// Skipping already declared property Text
-		#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  int SelectionStart
 		{
@@ -24,7 +24,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  int SelectionLength
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -10,34 +10,8 @@ namespace Windows.UI.Xaml.Controls
 		// Skipping already declared property TextWrapping
 		// Skipping already declared property TextAlignment
 		// Skipping already declared property Text
-		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
-		public  int SelectionStart
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int TextBox.SelectionStart is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "int TextBox.SelectionStart");
-			}
-		}
-		#endif
-		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
-		public  int SelectionLength
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int TextBox.SelectionLength is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "int TextBox.SelectionLength");
-			}
-		}
-		#endif
+		// Skipping already declared property SelectionStart
+		// Skipping already declared property SelectionLength
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string SelectedText
@@ -463,20 +437,8 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.SelectionChanged.remove
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.TextBox.ContextMenuOpening.remove
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented("__NETSTD_REFERENCE__")]
-		public  void Select( int start,  int length)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "void TextBox.Select(int start, int length)");
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented("__NETSTD_REFERENCE__")]
-		public  void SelectAll()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "void TextBox.SelectAll()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.TextBox.Select(int, int)
+		// Skipping already declared method Windows.UI.Xaml.Controls.TextBox.SelectAll()
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.Rect GetRectFromCharacterIndex( int charIndex,  bool trailingEdge)

--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/SecureTextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/SecureTextBoxView.macOS.cs
@@ -119,7 +119,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public NSString[] ValidAttributesForMarkedText => null;
 
-		public static DependencyProperty ForegroundProperty { get ; } =
+		public static DependencyProperty ForegroundProperty { get; } =
 			DependencyProperty.Register(
 				"Foreground",
 				typeof(Brush),
@@ -164,6 +164,14 @@ namespace Windows.UI.Xaml.Controls
 		public void RefreshFont()
 		{
 			UpdateFont();
+		}
+
+		public void Select(int start, int length)
+		{
+			if (CurrentEditor != null)
+			{
+				CurrentEditor.SelectedRange = new NSRange(start: start, len: length);
+			}
 		}
 
 		public override bool BecomeFirstResponder()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxExtension.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxExtension.skia.cs
@@ -17,5 +17,7 @@ namespace Uno.UI.Xaml.Controls.Extensions
 		void SetTextNative(string text);
 
 		void SetIsPassword(bool isPassword);
+
+		void Select(int start, int length);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxExtension.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxExtension.skia.cs
@@ -19,5 +19,9 @@ namespace Uno.UI.Xaml.Controls.Extensions
 		void SetIsPassword(bool isPassword);
 
 		void Select(int start, int length);
+
+		int GetSelectionStart();
+
+		int GetSelectionLength();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxView.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxView.iOSmacOS.cs
@@ -29,9 +29,6 @@ namespace Windows.UI.Xaml.Controls
 
 		Brush Foreground { get; set; }
 		void SetTextNative(string text);
-
-#if __MACOS__
 		void Select(int start, int length);
-#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxView.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxView.iOSmacOS.cs
@@ -29,5 +29,9 @@ namespace Windows.UI.Xaml.Controls
 
 		Brush Foreground { get; set; }
 		void SetTextNative(string text);
+
+#if __MACOS__
+		void Select(int start, int length);
+#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxView.iOS.cs
@@ -167,7 +167,7 @@ namespace Windows.UI.Xaml.Controls
 			set { SetValue(ForegroundProperty, value); }
 		}
 
-		public static DependencyProperty ForegroundProperty { get ; } =
+		public static DependencyProperty ForegroundProperty { get; } =
 			DependencyProperty.Register(
 				"Foreground",
 				typeof(Brush),
@@ -232,5 +232,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			UpdateFont();
 		}
+
+		public void Select(int start, int length)
+			=> SelectedTextRange = this.GetTextRange(start: start, end: start + length);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using UIKit;
 using Uno.Extensions;
+using Uno.UI.Extensions;
 using Windows.UI.Xaml.Media;
 using Uno.UI.Controls;
 using Windows.UI;
@@ -198,6 +199,9 @@ namespace Windows.UI.Xaml.Controls
 		{
 			UpdateFont();
 		}
+
+		public void Select(int start, int length)
+			=> SelectedTextRange = this.GetTextRange(start: start, end: start + length);
 
 		public override UITextRange SelectedTextRange
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -122,7 +122,7 @@ namespace Windows.UI.Xaml.Controls
 			set { this.SetValue(ImeOptionsProperty, value); }
 		}
 
-		public static DependencyProperty ImeOptionsProperty { get ; } =
+		public static DependencyProperty ImeOptionsProperty { get; } =
 			DependencyProperty.Register("ImeOptions",
 				typeof(ImeAction),
 				typeof(TextBox),
@@ -187,6 +187,11 @@ namespace Windows.UI.Xaml.Controls
 				return wantsFocus;
 			}
 		}
+
+		partial void SelectPartial(int start, int length)
+			=> _textBoxView.SetSelection(start: start, stop: start + length);
+
+		public void SelectAll() => _textBoxView.SelectAll();
 
 		/// <summary>
 		/// Applies PreventKeyboardDisplayOnProgrammaticFocus by temporarily disabling soft input display.

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -191,7 +191,7 @@ namespace Windows.UI.Xaml.Controls
 		partial void SelectPartial(int start, int length)
 			=> _textBoxView.SetSelection(start: start, stop: start + length);
 
-		public void SelectAll() => _textBoxView.SelectAll();
+		partial void SelectAllPartial() => _textBoxView.SelectAll();
 
 		/// <summary>
 		/// Applies PreventKeyboardDisplayOnProgrammaticFocus by temporarily disabling soft input display.

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -802,7 +802,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void SelectPartial(int start, int length);
 
-		partial void SelectAll();
+		partial void SelectAllPartial();
 
 		internal override bool CanHaveChildren() => true;
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -797,7 +797,12 @@ namespace Windows.UI.Xaml.Controls
 			OnSelectionChanged();
 		}
 
+		public void SelectAll() => SelectAllPartial();
+
+
 		partial void SelectPartial(int start, int length);
+
+		partial void SelectAll();
 
 		internal override bool CanHaveChildren() => true;
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -766,12 +766,12 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (start < 0)
 			{
-				throw new ArgumentOutOfRangeException(nameof(start), $"'{start}' cannot be negative.");
+				throw new ArgumentException($"'{start}' cannot be negative.", nameof(start));
 			}
 
 			if (length < 0)
 			{
-				throw new ArgumentOutOfRangeException(nameof(length), $"'{length}' cannot be negative.");
+				throw new ArgumentException($"'{length}' cannot be negative.", nameof(length));
 			}
 
 			// TODO: Test and adjust (if needed) this logic for surrogate pairs.

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -788,7 +788,13 @@ namespace Windows.UI.Xaml.Controls
 				length = textLength - start;
 			}
 
+			if (SelectionStart == start && SelectionLength == length)
+			{
+				return;
+			}
+
 			SelectPartial(start, length);
+			OnSelectionChanged();
 		}
 
 		partial void SelectPartial(int start, int length);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -762,6 +762,37 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnVerticalContentAlignmentChangedPartial(VerticalAlignment oldVerticalContentAlignment, VerticalAlignment newVerticalContentAlignment);
 
+		public void Select(int start, int length)
+		{
+			if (start < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(start), $"'{start}' cannot be negative.");
+			}
+
+			if (length < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(length), $"'{length}' cannot be negative.");
+			}
+
+			// TODO: Test and adjust (if needed) this logic for surrogate pairs.
+
+			var textLength = Text.Length;
+
+			if (start >= textLength)
+			{
+				start = textLength;
+				length = 0;
+			}
+			else if (start + length > textLength)
+			{
+				length = textLength - start;
+			}
+
+			SelectPartial(start, length);
+		}
+
+		partial void SelectPartial(int start, int length);
+
 		internal override bool CanHaveChildren() => true;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
@@ -79,6 +79,8 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		partial void SelectAllPartial() => Select(0, Text.Length);
+
 		internal MultilineTextBoxView MultilineTextBox
 		{
 			get

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
@@ -75,7 +75,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (_textBoxView != null)
 			{
-				_textBoxView.SelectedTextRange = _textBoxView.GetTextRange(start: start, end: start + length);
+				_textBoxView.Select(start, length);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
@@ -71,6 +71,14 @@ namespace Windows.UI.Xaml.Controls
 			_textBoxView?.UpdateTextAlignment();
 		}
 
+		partial void SelectPartial(int start, int length)
+		{
+			if (_textBoxView != null)
+			{
+				_textBoxView.SelectedTextRange = _textBoxView.GetTextRange(start: start, end: start + length);
+			}
+		}
+
 		internal MultilineTextBoxView MultilineTextBox
 		{
 			get
@@ -267,7 +275,7 @@ namespace Windows.UI.Xaml.Controls
 			set { SetValue(ReturnKeyTypeProperty, value); }
 		}
 
-		public static DependencyProperty ReturnKeyTypeProperty { get ; } =
+		public static DependencyProperty ReturnKeyTypeProperty { get; } =
 			DependencyProperty.Register(
 				"ReturnKeyType",
 				typeof(UIReturnKeyType),
@@ -304,7 +312,7 @@ namespace Windows.UI.Xaml.Controls
 			set { SetValue(KeyboardAppearanceProperty, value); }
 		}
 
-		public static DependencyProperty KeyboardAppearanceProperty { get ; } =
+		public static DependencyProperty KeyboardAppearanceProperty { get; } =
 			DependencyProperty.Register(
 				"KeyboardAppearance",
 				typeof(UIKeyboardAppearance),

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
@@ -61,6 +61,8 @@ namespace Windows.UI.Xaml.Controls
 			_textBoxView?.Select(start, length);
 		}
 
+		partial void SelectAllPartial() => Select(0, Text.Length);
+
 		private void UpdateTextBoxView()
 		{
 			if (_contentElement != null)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
@@ -63,6 +63,14 @@ namespace Windows.UI.Xaml.Controls
 		{
 		}
 
+		partial void SelectPartial(int start, int length)
+		{
+			if (_textBoxView != null)
+			{
+				_textBoxView.SelectedTextRange = _textBoxView.GetTextRange(start: start, end: start + length);
+			}
+		}
+
 		private void UpdateTextBoxView()
 		{
 			if (_contentElement != null)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
@@ -1,16 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Uno.UI;
-using Windows.UI.Xaml.Data;
-using AppKit;
+﻿using AppKit;
 using CoreGraphics;
 using Uno.UI.Extensions;
 using Uno.Extensions;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Input;
-using Uno.Client;
-using Foundation;
 using Uno.Logging;
 
 namespace Windows.UI.Xaml.Controls
@@ -65,10 +58,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void SelectPartial(int start, int length)
 		{
-			if (_textBoxView != null)
-			{
-				_textBoxView.SelectedTextRange = _textBoxView.GetTextRange(start: start, end: start + length);
-			}
+			_textBoxView?.Select(start, length);
 		}
 
 		private void UpdateTextBoxView()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.net.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.net.cs
@@ -9,5 +9,9 @@ namespace Windows.UI.Xaml.Controls
 		private TextBoxView _textBoxView;
 
 		private void UpdateTextBoxView() { }
+
+		public int SelectionStart { get; set; }
+
+		public int SelectionLength { get; set; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.netstdref.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.netstdref.cs
@@ -9,5 +9,9 @@ namespace Windows.UI.Xaml.Controls
 		private TextBoxView _textBoxView;
 
 		private void UpdateTextBoxView() { }
+
+		public int SelectionStart { get; set; }
+
+		public int SelectionLength { get; set; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -23,6 +23,13 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnFocusStateChangedPartial(FocusState focusState) => _textBoxView?.OnFocusStateChanged(focusState);
 
+		partial void SelectPartial(int start, int length)
+		{
+			_textBoxView?.Select(start, length);
+		}
+
+		public void SelectAll() => Select(0, Text.Length);
+
 		protected void SetIsPassword(bool isPassword) => _textBoxView?.SetIsPassword(isPassword);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -28,7 +28,7 @@ namespace Windows.UI.Xaml.Controls
 			_textBoxView?.Select(start, length);
 		}
 
-		public void SelectAll() => Select(0, Text.Length);
+		partial void SelectAllPartial() => Select(0, Text.Length);
 
 		public int SelectionStart
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -30,6 +30,19 @@ namespace Windows.UI.Xaml.Controls
 
 		public void SelectAll() => Select(0, Text.Length);
 
+		public int SelectionStart
+		{
+			get => _textBoxView?.GetSelectionStart() ?? 0;
+			set => Select(start: value, length: SelectionLength);
+		}
+
+		public int SelectionLength
+		{
+			get => _textBoxView?.GetSelectionLength() ?? 0;
+			set => Select(SelectionStart, value);
+		}
+
+
 		protected void SetIsPassword(bool isPassword) => _textBoxView?.SetIsPassword(isPassword);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -1,4 +1,5 @@
 ﻿using Uno.Extensions;
+using Uno.Foundation;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 
@@ -115,6 +116,13 @@ namespace Windows.UI.Xaml.Controls
 		private void ApplyEnabled(bool? isEnabled = null) => _textBoxView?.SetEnabled(isEnabled ?? IsEnabled);
 
 		private void ApplyIsReadonly(bool? isReadOnly = null) => _textBoxView?.SetIsReadOnly(isReadOnly ?? IsReadOnly);
+
+		partial void SelectPartial(int start, int length)
+		{
+			_textBoxView?.Select(start, length);
+		}
+
+		public void SelectAll() => Select(0, Text.Length);
 
 		public int SelectionStart
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -122,7 +122,7 @@ namespace Windows.UI.Xaml.Controls
 			_textBoxView?.Select(start, length);
 		}
 
-		public void SelectAll() => Select(0, Text.Length);
+		partial void SelectAllPartial() => Select(0, Text.Length);
 
 		public int SelectionStart
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
@@ -152,7 +152,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public NSString[] ValidAttributesForMarkedText => null;
 
-		public static DependencyProperty ForegroundProperty { get ; } =
+		public static DependencyProperty ForegroundProperty { get; } =
 			DependencyProperty.Register(
 				"Foreground",
 				typeof(Brush),
@@ -211,6 +211,14 @@ namespace Windows.UI.Xaml.Controls
 			_textBox.GetTarget()?.Focus(FocusState.Pointer);
 
 			return base.BecomeFirstResponder();
+		}
+
+		public void Select(int start, int length)
+		{
+			if (CurrentEditor != null)
+			{
+				CurrentEditor.SelectedRange = new NSRange(start: start, len: length);
+			}
 		}
 
 		public void InsertText(NSObject insertString) => throw new NotImplementedException();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -63,6 +63,11 @@ namespace Windows.UI.Xaml.Controls
 			_textBoxExtension?.SetTextNative(text);
 		}
 
+		internal void Select(int start, int length)
+		{
+			_textBoxExtension.Select(start, length);
+		}
+
 		internal void OnForegroundChanged(Brush brush) => DisplayBlock.Foreground = brush;
 
 		internal void OnFocusStateChanged(FocusState focusState)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -44,7 +44,12 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		internal int GetSelectionStart() => _textBoxExtension?.GetSelectionStart() ?? 0;
+
+		internal int GetSelectionLength() => _textBoxExtension?.GetSelectionLength() ?? 0;
+
 		public TextBlock DisplayBlock { get; } = new TextBlock();
+
 
 		internal void SetTextNative(string text)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -8,6 +8,7 @@ using Uno.Logging;
 using Windows.Foundation;
 using System.Globalization;
 using Uno.Disposables;
+using Uno.Foundation;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -104,6 +105,9 @@ namespace Windows.UI.Xaml.Controls
 
 			InvalidateMeasure();
 		}
+
+		internal void Select(int start, int length)
+			=> WebAssemblyRuntime.InvokeJS($"document.getElementById({HtmlId}).setSelectionRange({start}, {start + length})");
 
 		protected override Size MeasureOverride(Size availableSize) => MeasureView(availableSize);
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -107,7 +107,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		internal void Select(int start, int length)
-			=> WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.current.select({HtmlId}, {start}, {length})");
+			=> WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.current.selectInputRange({HtmlId}, {start}, {length})");
 
 		protected override Size MeasureOverride(Size availableSize) => MeasureView(availableSize);
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -107,7 +107,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		internal void Select(int start, int length)
-			=> WebAssemblyRuntime.InvokeJS($"document.getElementById({HtmlId}).setSelectionRange({start}, {start + length})");
+			=> WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.current.select({HtmlId}, {start}, {length})");
 
 		protected override Size MeasureOverride(Size availableSize) => MeasureView(availableSize);
 

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -583,6 +583,7 @@ declare namespace Uno.UI {
         private numberToCssColor;
         setCursor(cssCursor: string): string;
         getNaturalImageSize(imageUrl: string): Promise<string>;
+        select(elementId: number, start: number, length: number): void;
     }
 }
 interface PointerEvent {

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -1936,6 +1936,9 @@ var Uno;
                     this.containerElement.appendChild(img);
                 });
             }
+            select(elementId, start, length) {
+                this.getView(elementId).setSelectionRange(start, start + length);
+            }
         }
         WindowManager._isHosted = false;
         WindowManager._isLoadEventsEnabled = false;

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -2076,6 +2076,10 @@ namespace Uno.UI {
 			});
 		}
 
+		public select(elementId: number, start: number, length: number) {
+			(this.getView(elementId) as HTMLInputElement).setSelectionRange(start, start + length);
+		}
+
 	}
 
 	if (typeof define === "function") {

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -2076,7 +2076,7 @@ namespace Uno.UI {
 			});
 		}
 
-		public select(elementId: number, start: number, length: number) {
+		public selectInputRange(elementId: number, start: number, length: number) {
 			(this.getView(elementId) as HTMLInputElement).setSelectionRange(start, start + length);
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6822

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Feature

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

- TextBox.Select and TextBox.SelectAll not implemented on all platforms.
- TextBox.SelectionStart, TextBox.SelectionLength not implemented on Skia.

## What is the new behavior?

Implemented

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
