### PR TITLE
chore(snapshots): Ensure all snapshots in UI Tests are disposed to prevent leaks

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/BenchmarkDotNetTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/BenchmarkDotNetTests.cs
@@ -59,7 +59,7 @@ namespace SamplesApp.UITests.Runtime
 
 			_app.WaitForElement(runButton);
 
-			TakeScreenshot("Begin", ignoreInSnapshotCompare: true);
+			using var _1 = TakeScreenshot("Begin", ignoreInSnapshotCompare: true);
 
 			_app.FastTap(runButton);
 
@@ -82,7 +82,7 @@ namespace SamplesApp.UITests.Runtime
 						Console.WriteLine($"Loop: Test changed now:{DateTimeOffset.Now} lastChange: {lastChange}");
 
 						lastChange = DateTimeOffset.Now;
-						TakeScreenshot($"Run {newValue}", ignoreInSnapshotCompare: true);
+						using var __ = TakeScreenshot($"Run {newValue}", ignoreInSnapshotCompare: true);
 					}
 				}
 				catch(Exception e)
@@ -104,7 +104,7 @@ namespace SamplesApp.UITests.Runtime
 
 			TestContext.AddTestAttachment(finalFile, "benchmark-results.zip");
 
-			TakeScreenshot("Runtime Tests Results", ignoreInSnapshotCompare: true);
+			using var _2 = TakeScreenshot("Runtime Tests Results", ignoreInSnapshotCompare: true);
 		}
 
 		private static string ArchiveResults(QueryEx benchmarkControl)

--- a/src/SamplesApp/SamplesApp.UITests/CommandBar/UnoSamples_Tests.CommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/CommandBar/UnoSamples_Tests.CommandBar.cs
@@ -28,19 +28,19 @@ namespace SamplesApp.UITests.CommandBar
 				_app.WaitForElement(_app.Marked("TextBlockWidthTest"));
 
 				// Initial state
-				TakeScreenshot("CommandBar - LongTitle - 1 - Initial State");
+				using var _1 = TakeScreenshot("CommandBar - LongTitle - 1 - Initial State");
 
 				// Set orientation Landscape
 				_app.SetOrientationLandscape();
-				TakeScreenshot("CommandBar - LongTitle - 2 - Orientation Landscape");
+				using var _2 = TakeScreenshot("CommandBar - LongTitle - 2 - Orientation Landscape");
 
 				// Set orientation Portrait
 				_app.SetOrientationPortrait();
-				TakeScreenshot("CommandBar - LongTitle - 3 - Orientation Portrait");
+				using var _3 = TakeScreenshot("CommandBar - LongTitle - 3 - Orientation Portrait");
 
 				// Set orientation Landscape (Again)
 				_app.SetOrientationLandscape();
-				TakeScreenshot("CommandBar - LongTitle - 4 - Orientation Landscape");
+				using var _4 = TakeScreenshot("CommandBar - LongTitle - 4 - Orientation Landscape");
 			}
 			finally
 			{

--- a/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
@@ -87,7 +87,7 @@ namespace SamplesApp.UITests.Runtime
 					$"{tests.Length} unit test(s) failed.\n\tFailing Tests:\n{string.Join("", tests)}\n\n---\n\tDetails:\n{details}");
 			}
 
-			TakeScreenshot("Runtime Tests Results",	ignoreInSnapshotCompare: true);
+			using var _ = TakeScreenshot("Runtime Tests Results",	ignoreInSnapshotCompare: true);
 		}
 
 

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -121,7 +121,7 @@ namespace SamplesApp.UITests
 				&& TestContext.CurrentContext.Result.Outcome != ResultState.Ignored
 			)
 			{
-				TakeScreenshot($"{TestContext.CurrentContext.Test.Name} - Tear down on error", ignoreInSnapshotCompare: true);
+				using var _ = TakeScreenshot($"{TestContext.CurrentContext.Test.Name} - Tear down on error", ignoreInSnapshotCompare: true);
 			}
 		}
 
@@ -286,7 +286,7 @@ namespace SamplesApp.UITests
 
 			if (!skipInitialScreenshot)
 			{
-				TakeScreenshot(metadataName.Replace(".", "_"));
+				using var _ = TakeScreenshot(metadataName.Replace(".", "_"));
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
@@ -43,72 +43,72 @@ namespace SamplesApp.UITests
 				// Setting focus on normalTextBox
 				_app.FastTap(normalTextBox);
 				_app.Wait(1);
-				TakeScreenshot("0 - Focus on normalTextBox ", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("0 - Focus on normalTextBox ", ignoreInSnapshotCompare: true);
 
 				// Removing focus on normalTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("0 - Remove Focus on normalTextBox", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Keyboard predicted text can change*/);
+				using var _2 = TakeScreenshot("0 - Remove Focus on normalTextBox", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Keyboard predicted text can change*/);
 			}
 
 			{
 				// Setting focus on normalTextBox
 				_app.FastTap(filledTextBox);
 				_app.Wait(1);
-				TakeScreenshot("1 - Focus on filledTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("1 - Focus on filledTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on normalTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("1 - Remove Focus on filledTextBox", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Keyboard predicted text can change*/);
+				using var _2 = TakeScreenshot("1 - Remove Focus on filledTextBox", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Keyboard predicted text can change*/);
 			}
 
 			{
 				// Setting focus on placeholderTextTextBox
 				_app.FastTap(placeholderTextTextBox);
 				_app.Wait(1);
-				TakeScreenshot("2 - Focus on placeholderTextTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("2 - Focus on placeholderTextTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on placeholderTextTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("2 - Remove Focus on placeholderTextTextBox");
+				using var _2 = TakeScreenshot("2 - Remove Focus on placeholderTextTextBox");
 			}
 
 			{
 				// Setting focus on disabledTextBox
 				_app.FastTap(disabledTextBox);
 				_app.Wait(1);
-				TakeScreenshot("3 - Focus on disabledTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("3 - Focus on disabledTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on disabledTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("3 - Remove Focus on disabledTextBox");
+				using var _2 = TakeScreenshot("3 - Remove Focus on disabledTextBox");
 			}
 
 			{
 				// Setting focus on multilineTextBox
 				_app.FastTap(multilineTextBox);
 				_app.Wait(1);
-				TakeScreenshot("4 - Focus on multilineTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("4 - Focus on multilineTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on multilineTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("4 - Remove Focus on multilineTextBox");
+				using var _2 = TakeScreenshot("4 - Remove Focus on multilineTextBox");
 			}
 
 			{
 				// Setting focus on numberTextBox
 				_app.FastTap(numberTextBox);
 				_app.Wait(1);
-				TakeScreenshot("5 - Focus on numberTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("5 - Focus on numberTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on numberTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("5 - Remove Focus on numberTextBox");
+				using var _2 = TakeScreenshot("5 - Remove Focus on numberTextBox");
 			}
 		}
 
@@ -139,72 +139,72 @@ namespace SamplesApp.UITests
 				// Setting focus on normalTextBox
 				_app.FastTap(normalTextBox);
 				_app.Wait(1);
-				TakeScreenshot("0 - Focus on normalTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("0 - Focus on normalTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on normalTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("0 - Remove Focus on normalTextBox", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Keyboard predicted text can change*/);
+				using var _2 = TakeScreenshot("0 - Remove Focus on normalTextBox", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Keyboard predicted text can change*/);
 			}
 
 			{
 				// Setting focus on normalTextBox
 				_app.FastTap(filledTextBox);
 				_app.Wait(1);
-				TakeScreenshot("1 - Focus on filledTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("1 - Focus on filledTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on normalTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("1 - Remove Focus on filledTextBox", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Keyboard predicted text can change*/);
+				using var _2 = TakeScreenshot("1 - Remove Focus on filledTextBox", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Keyboard predicted text can change*/);
 			}
 
 			{
 				// Setting focus on placeholderTextTextBox
 				_app.FastTap(placeholderTextTextBox);
 				_app.Wait(1);
-				TakeScreenshot("2 - Focus on placeholderTextTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("2 - Focus on placeholderTextTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on placeholderTextTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("2 - Remove Focus on placeholderTextTextBox");
+				using var _2 = TakeScreenshot("2 - Remove Focus on placeholderTextTextBox");
 			}
 
 			{
 				// Setting focus on disabledTextBox
 				_app.FastTap(disabledTextBox);
 				_app.Wait(1);
-				TakeScreenshot("3 - Focus on disabledTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("3 - Focus on disabledTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on disabledTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("3 - Remove Focus on disabledTextBox");
+				using var _2 = TakeScreenshot("3 - Remove Focus on disabledTextBox");
 			}
 
 			{
 				// Setting focus on multilineTextBox
 				_app.FastTap(multilineTextBox);
 				_app.Wait(1);
-				TakeScreenshot("4 - Focus on multilineTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("4 - Focus on multilineTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on multilineTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("4 - Remove Focus on multilineTextBox");
+				using var _2 = TakeScreenshot("4 - Remove Focus on multilineTextBox");
 			}
 
 			{
 				// Setting focus on numberTextBox
 				_app.FastTap(numberTextBox);
 				_app.Wait(1);
-				TakeScreenshot("5 - Focus on numberTextBox", ignoreInSnapshotCompare: true);
+				using var _1 = TakeScreenshot("5 - Focus on numberTextBox", ignoreInSnapshotCompare: true);
 
 				// Removing focus on numberTextBox
 				_app.TapCoordinates(0f, 0f);
 				_app.Wait(1);
-				TakeScreenshot("5 - Remove Focus on numberTextBox");
+				using var _2 = TakeScreenshot("5 - Remove Focus on numberTextBox");
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Popup.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Popup.cs
@@ -31,7 +31,7 @@ namespace SamplesApp.UITests
 			var PopupText = _app.Marked("DismissablePopupText");
 
 			// Assert initial state 
-			TakeScreenshot("Popup - Dismissable - 1 - InitialState");
+			using var _1 = TakeScreenshot("Popup - Dismissable - 1 - InitialState");
 			Assert.AreEqual(null, PopupText.GetDependencyPropertyValue("Text")?.ToString());
 
 			OpenDismissablePopupButton.FastTap();
@@ -39,13 +39,13 @@ namespace SamplesApp.UITests
 			_app.WaitForElement(PopupText, timeout: TimeSpan.FromSeconds(5));
 
 			// Assert after opening dismissable 
-			TakeScreenshot("Popup - Dismissable - 2 - Open");
+			using var _2 = TakeScreenshot("Popup - Dismissable - 2 - Open");
 			Assert.AreEqual("Test", PopupText.GetDependencyPropertyValue("Text")?.ToString());
 
 			_app.TapCoordinates(10,100);
 
 			// Assert after dismiss
-			TakeScreenshot("Popup - Dismissable - 3 - Dismissable");
+			using var _3 = TakeScreenshot("Popup - Dismissable - 3 - Dismissable");
 			Assert.AreEqual(null, PopupText.GetDependencyPropertyValue("Text")?.ToString());
 		}
 
@@ -64,7 +64,7 @@ namespace SamplesApp.UITests
 			var PopupText = _app.Marked("NonDismissablePopupText");
 
 			// Assert initial state 
-			TakeScreenshot("Popup - Non Dismissable - 1 - InitialState");
+			using var _1 = TakeScreenshot("Popup - Non Dismissable - 1 - InitialState");
 			Assert.AreEqual(null, PopupText.GetDependencyPropertyValue("Text")?.ToString());
 
 			OpenNonDismissablePopupButton.FastTap();
@@ -73,13 +73,13 @@ namespace SamplesApp.UITests
 			_app.WaitForElement(PopupText, timeout: TimeSpan.FromSeconds(5));
 
 			// Assert after opening dismissable 
-			TakeScreenshot("Popup - Non Dismissable - 2 - Open");
+			using var _2 = TakeScreenshot("Popup - Non Dismissable - 2 - Open");
 			Assert.AreEqual("Test", PopupText.GetDependencyPropertyValue("Text")?.ToString());
 
 			_app.TapCoordinates(10, 100);
 
 			// Assert after trying to dismiss
-			TakeScreenshot("Popup - Non Dismissable - 3 - Try Dismiss");
+			using var _3 = TakeScreenshot("Popup - Non Dismissable - 3 - Try Dismiss");
 			Assert.AreEqual("Test", PopupText.GetDependencyPropertyValue("Text")?.ToString());
 		}
 
@@ -98,7 +98,7 @@ namespace SamplesApp.UITests
 			var PopupText = _app.Marked("NoFixedHeightPopupText");
 
 			// Assert initial state 
-			TakeScreenshot("Popup - No Fixed Height - 1 - InitialState");
+			using var _1 = TakeScreenshot("Popup - No Fixed Height - 1 - InitialState");
 			Assert.AreEqual(null, PopupText.GetDependencyPropertyValue("Text")?.ToString());
 
 			OpenNoFixedHeightPopupButton.FastTap();
@@ -106,7 +106,7 @@ namespace SamplesApp.UITests
 			_app.WaitForElement(PopupText, timeout: TimeSpan.FromSeconds(5));
 
 			// Assert after opening dismissable 
-			TakeScreenshot("Popup - No Fixed Height - 2 - Open");
+			using var _2 = TakeScreenshot("Popup - No Fixed Height - 2 - Open");
 			Assert.AreEqual("Test", PopupText.GetDependencyPropertyValue("Text")?.ToString());
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Touch.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Touch.cs
@@ -33,7 +33,7 @@ namespace SamplesApp.UITests
 
 				Assert.AreEqual("0 - button inside grid", touchLog.GetDependencyPropertyValue<string>("Text"));
 
-				TakeScreenshot("0 - button inside grid");
+				using var _ = TakeScreenshot("0 - button inside grid");
 			}
 
 			{
@@ -49,7 +49,7 @@ namespace SamplesApp.UITests
 
 				Assert.AreEqual("1 - button under grid", touchLog.GetDependencyPropertyValue<string>("Text"));
 
-				TakeScreenshot("0 - button inside grid");
+				using var _ = TakeScreenshot("0 - button inside grid");
 			}
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ContentControlTests/ContentControlBehaviorTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ContentControlTests/ContentControlBehaviorTests.cs
@@ -19,14 +19,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ContentControlTests
 			Run("SamplesApp.Windows_UI_Xaml_Controls.ContentControlNoTemplateNoContent");
 
 			_app.WaitForElement("CContentControl");
-			TakeScreenshot($"CContentControl");
-			TabWaitAndThenScreenshot("bntContentClear");
-
-			void TabWaitAndThenScreenshot(string buttonName)
-			{
-				_app.Marked(buttonName).FastTap();
-				TakeScreenshot($"ContentControlNoTemplateNoContent - {buttonName}");
-			}
+			using var _1 = TakeScreenshot($"CContentControl");
+			_app.Marked("bntContentClear").FastTap();
+			using var _2 = TakeScreenshot($"ContentControlNoTemplateNoContent - {"bntContentClear"}");
 
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_Basics_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_Basics_Automated.cs
@@ -80,7 +80,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			_app.TapCoordinates(automatedBounds.X + 15, automatedBounds.CenterY);
 			_app.DragCoordinates(sourceBounds.CenterX, sourceBounds.CenterY, goAway ? targetBounds.Right + 10 : targetBounds.CenterX, targetBounds.CenterY);
 
-			TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+			using var _ = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 
 			var raw = output.GetDependencyPropertyValue<string>("Text");
 			var logEntries = raw

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -74,7 +74,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 
 			_app.DragCoordinates(x, srcY, x, dstY);
 
-			var result = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+			using var result = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 
 			ImageAssert.HasColorAt(result, x, dstY, _items[from], tolerance: 10);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_Nested_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_Nested_Automated.cs
@@ -50,7 +50,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			_app.TapCoordinates(automatedBounds.X + 15, automatedBounds.CenterY);
 			_app.DragCoordinates(sourceBounds.CenterX, sourceBounds.CenterY, targetBounds.CenterX, goAway ? parentTargetBounds.Bottom + 10 : targetBounds.CenterY);
 
-			TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+			using var _ = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 
 			var raw = output.GetDependencyPropertyValue<string>("Text");
 			var logEntries = raw

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerTests/UnoSamples_Tests.FocusManager.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerTests/UnoSamples_Tests.FocusManager.cs
@@ -30,13 +30,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - Border - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - Border - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - Border - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - Border - 2 - After Selection");
 		}
 
 		[Test]
@@ -54,13 +54,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - Button - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - Button - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyButton");
-			TakeScreenshot("FocusManager - GetFocusedElement - Button - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - Button - 2 - After Selection");
 		}
 
 		[Test]
@@ -78,7 +78,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - Button - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - LostFocus - Button - 1 - Initial State");
 
 			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyButton");
@@ -87,7 +87,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert Click outside
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - Button - 2 - Click outside");
+			using var _2 = TakeScreenshot("FocusManager - LostFocus - Button - 2 - Click outside");
 		}
 
 		[Test]
@@ -105,13 +105,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - CheckBox - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - CheckBox - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyCheckBox");
-			TakeScreenshot("FocusManager - GetFocusedElement - CheckBox - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - CheckBox - 2 - After Selection");
 		}
 
 		[Test]
@@ -129,7 +129,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>"); ;
-			TakeScreenshot("FocusManager - LostFocus - CheckBox - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - LostFocus - CheckBox - 1 - Initial State");
 
 			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyCheckBox");
@@ -138,7 +138,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert Click outside
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - CheckBox - 3 - Click outside");
+			using var _2 = TakeScreenshot("FocusManager - LostFocus - CheckBox - 3 - Click outside");
 		}
 
 		[Test]
@@ -156,13 +156,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - Grid - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - Grid - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - Grid - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - Grid - 2 - After Selection");
 		}
 
 		[Test]
@@ -180,7 +180,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - HyperlinkButton - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - HyperlinkButton - 1 - Initial State");
 
 			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyHyperlinkButton");
@@ -189,7 +189,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert Click outside
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - HyperlinkButton - 2 - Click outside");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - HyperlinkButton - 2 - Click outside");
 		}
 
 		[Test]
@@ -207,7 +207,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - HyperlinkButton - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - LostFocus - HyperlinkButton - 1 - Initial State");
 
 			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyHyperlinkButton");
@@ -216,7 +216,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert Click outside
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - HyperlinkButton - 2 - Click outside");
+			using var _2 = TakeScreenshot("FocusManager - LostFocus - HyperlinkButton - 2 - Click outside");
 		}
 
 		[Test]
@@ -234,13 +234,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - Image - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - Image - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - Image - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - Image - 2 - After Selection");
 		}
 
 		[Test]
@@ -258,13 +258,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - Rectangle - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - Rectangle - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - Rectangle - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - Rectangle - 2 - After Selection");
 		}
 
 		[Test]
@@ -282,13 +282,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - TextBlock - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - TextBlock - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - TextBlock - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - TextBlock - 2 - After Selection");
 		}
 
 		[Test]
@@ -306,14 +306,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - TextBoxMultiLine - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - TextBoxMultiLine - 1 - Initial State");
 
 			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "TextBoxMultiLine");
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "TextBoxMultiLine");
-			TakeScreenshot("FocusManager - GetFocusedElement - TextBoxMultiLine - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - TextBoxMultiLine - 2 - After Selection");
 		}
 
 		[Test]
@@ -331,7 +331,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - TextBoxMultiLine - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - LostFocus - TextBoxMultiLine - 1 - Initial State");
 
 			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "TextBoxMultiLine");
@@ -340,7 +340,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert Click outside
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - TextBoxMultiLine - 2 - Click outside");
+			using var _2 = TakeScreenshot("FocusManager - LostFocus - TextBoxMultiLine - 2 - Click outside");
 		}
 
 		[Test]
@@ -358,13 +358,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - TextBoxSingleLine - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - TextBoxSingleLine - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "TextBoxSingleLine");
-			TakeScreenshot("FocusManager - GetFocusedElement - TextBoxSingleLine - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - TextBoxSingleLine - 2 - After Selection");
 		}
 
 		[Test]
@@ -382,7 +382,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - TextBoxSingleLine - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - LostFocus - TextBoxSingleLine - 1 - Initial State");
 
 			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "TextBoxSingleLine");
@@ -391,7 +391,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert Click outside
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - TextBoxSingleLine - 2 - Click outside");
+			using var _2 = TakeScreenshot("FocusManager - LostFocus - TextBoxSingleLine - 2 - Click outside");
 		}
 
 		[Test]
@@ -409,13 +409,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - ToggleButton - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - ToggleButton - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyToggleButton");
-			TakeScreenshot("FocusManager - GetFocusedElement - ToggleButton - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - ToggleButton - 2 - After Selection");
 		}
 
 		[Test]
@@ -433,7 +433,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - ToggleButton - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - LostFocus - ToggleButton - 1 - Initial State");
 
 			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyToggleButton");
@@ -442,7 +442,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert Click outside
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - ToggleButton - 2 - Click outside");
+			using var _2 = TakeScreenshot("FocusManager - LostFocus - ToggleButton - 2 - Click outside");
 		}
 
 		[Test]
@@ -460,13 +460,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - ComboBox - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - ComboBox - 1 - Initial State");
 
 			combo.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyComboBox");
-			TakeScreenshot("FocusManager - GetFocusedElement - ComboBox - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - ComboBox - 2 - After Selection");
 
 			// Close the combo to not pollute other tests
 			_app.TapCoordinates(20, 100);
@@ -487,7 +487,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - ComboBox - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - LostFocus - ComboBox - 1 - Initial State");
 
 			combo.FastTap();
 
@@ -498,7 +498,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert Click outside
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - ComboBox - 2 - Click outside");
+			using var _2 = TakeScreenshot("FocusManager - LostFocus - ComboBox - 2 - Click outside");
 		}
 
 		[Test]
@@ -517,7 +517,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - ComboBoxItem - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - ComboBoxItem - 1 - Initial State");
 
 			comboBox.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyComboBox");
@@ -526,7 +526,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyComboBox");
-			TakeScreenshot("FocusManager - GetFocusedElement - ComboBoxItem - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - ComboBoxItem - 2 - After Selection");
 		}
 
 		[Test]
@@ -545,7 +545,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - ComboBoxItem - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - LostFocus - ComboBoxItem - 1 - Initial State");
 
 			comboBox.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyComboBox");
@@ -557,7 +557,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert Click outside
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - ComboBoxItem - 2 - Click outside");
+			using var _2 = TakeScreenshot("FocusManager - LostFocus - ComboBoxItem - 2 - Click outside");
 		}
 
 		[Test]
@@ -576,13 +576,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - ScrollViewer - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - ScrollViewer - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - ScrollViewer - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - ScrollViewer - 2 - After Selection");
 		}
 
 		[Test]
@@ -601,13 +601,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - GetFocusedElement - ListViewItem - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - GetFocusedElement - ListViewItem - 1 - Initial State");
 
 			frameworkElement.FastTap();
 
 			// Assert After Selection 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyListViewItem");
-			TakeScreenshot("FocusManager - GetFocusedElement - ListViewItem - 2 - After Selection");
+			using var _2 = TakeScreenshot("FocusManager - GetFocusedElement - ListViewItem - 2 - After Selection");
 		}
 
 		[Test]
@@ -626,7 +626,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert initial state 
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - ListViewItem - 1 - Initial State");
+			using var _1 = TakeScreenshot("FocusManager - LostFocus - ListViewItem - 1 - Initial State");
 
 			frameworkElement.FastTap();
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "MyListViewItem");
@@ -635,7 +635,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 			// Assert Click outside
 			_app.WaitForDependencyPropertyValue(txtCurrentFocused, "Text", "<none>");
-			TakeScreenshot("FocusManager - LostFocus - ListViewItem - 2 - Click outside");
+			using var _2 = TakeScreenshot("FocusManager - LostFocus - ListViewItem - 2 - Click outside");
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BitmapIconTests/UnoSamples_Tests.BitmapIcon.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BitmapIconTests/UnoSamples_Tests.BitmapIcon.cs
@@ -25,7 +25,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.BitmapIconTests
 			var icon2 = _app.Marked("icon2");
 			_app.WaitForElement(colorChange);
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			_app.FastTap(colorChange);
 
@@ -35,7 +35,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.BitmapIconTests
 			_app.WaitForDependencyPropertyValue(icon1, "Foreground", "[SolidColorBrush #FFFFFF00]");
 			_app.WaitForDependencyPropertyValue(icon2, "Foreground", "[SolidColorBrush #FF008000]");
 
-			TakeScreenshot("Changed");
+			using var _2 = TakeScreenshot("Changed");
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CheckBoxTests/UnoSamples_CheckBox.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CheckBoxTests/UnoSamples_CheckBox.cs
@@ -45,17 +45,17 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ButtonTests
 			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Checked threeState01 True");
 
-			TakeScreenshot("Checked");
+			using var _1 = TakeScreenshot("Checked");
 
 			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Indeterminate threeState01 ");
 
-			TakeScreenshot("Indeterminate");
+			using var _2 = TakeScreenshot("Indeterminate");
 
 			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Unchecked threeState01 False");
 
-			TakeScreenshot("Unchecked");
+			using var _3 = TakeScreenshot("Unchecked");
 
 			_app.FastTap(twoState01);
 			_app.WaitForText(result, "Checked threeState01 True");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
@@ -133,7 +133,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			var popupResult = _app.WaitForElement("PopupBorder").First();
 
-			TakeScreenshot("Opened");
+			using var _1 = TakeScreenshot("Opened");
 
 			Assert.AreEqual(popupResult.Rect.Width, sampleControlResult.Rect.Width, "The popup must stretch horizontally");
 			Assert.IsTrue(popupResult.Rect.Height < sampleControlResult.Rect.Height / 2, "The popup should not stretch to the height of the screen");
@@ -142,7 +142,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			_app.WaitForNoElement("PopupBorder");
 
-			TakeScreenshot("Closed");
+			using var _2 = TakeScreenshot("Closed");
 		}
 
 		[Test]
@@ -159,7 +159,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			_app.FastTap(values2);
 
-			TakeScreenshot("Opened");
+			using var _1 = TakeScreenshot("Opened");
 
 			var popupResult = _app.WaitForElement("PopupBorder").First();
 
@@ -170,7 +170,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			_app.WaitForNoElement("PopupBorder");
 
-			TakeScreenshot("Closed");
+			using var _2 = TakeScreenshot("Closed");
 		}
 
 		[Test]
@@ -199,7 +199,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			_app.WaitForElement(_app.Marked("DisablingComboBox"));
 			var disablingComboBox = _app.Marked("DisablingComboBox");
 
-			TakeScreenshot("ComboBox Enabled");
+			using var _1 = TakeScreenshot("ComboBox Enabled");
 
 			_app.FastTap("ToggleDisabledButton");
 
@@ -212,7 +212,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			Assert.AreEqual("Test Toggle Disabled ComboBox", headerContentPresenter.GetDependencyPropertyValue("Content"));
 
-			TakeScreenshot("ComboBox Disabled");
+			using var _2 = TakeScreenshot("ComboBox Disabled");
 		}
 
 		[Test]
@@ -234,7 +234,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			ToggleComboBox();
 			// Third time's the bug
 
-			var scrn = TakeScreenshot("ComboBox open");
+			using var scrn = TakeScreenshot("ComboBox open");
 			var rect = _app.GetPhysicalRect("ViewfinderBorder");
 
 			ImageAssert.HasColorAt(scrn, rect.CenterX, rect.CenterY, Color.Tomato);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.NativeCommandBar.cs
@@ -65,7 +65,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 			try
 			{
-				var firstScreenShot = TakeScreenshot("FirstOrientation");
+				using var firstScreenShot = TakeScreenshot("FirstOrientation");
 
 				var firstCommandBarRect = _app.GetRect("TheCommandBar");
 				var firstYellowBorderRect = _app.GetRect("TheBorder");
@@ -84,7 +84,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 				await ToggleOrientation();
 
-				var secondScreenShot = TakeScreenshot("SecondOrientation");
+				using var secondScreenShot = TakeScreenshot("SecondOrientation");
 
 				var secondCommandBarRect = _app.GetRect("TheCommandBar");
 				var secondYellowBorderRect = _app.GetRect("TheBorder");
@@ -97,7 +97,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 				await ToggleOrientation();
 
-				var thirdScreenShot = TakeScreenshot("thirdOrientation");
+				using var thirdScreenShot = TakeScreenshot("thirdOrientation");
 
 				var thirdCommandBarRect = _app.GetRect("TheCommandBar");
 				var thirdYellowBorderRect = _app.GetRect("TheBorder");
@@ -139,14 +139,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 			var myCommandBarResult = _app.Query(myCommandBar).First();
 
-			TakeScreenshot("Default");
+			using var _1 = TakeScreenshot("Default");
 
 			var innerTextBoxResult = _app.Query(innerTextBox).First();
 			Assert.IsTrue(innerTextBoxResult.Rect.Width <= myCommandBarResult.Rect.Width / 2, "TextBox Width is too large");
 
 			horizontalValue.SetDependencyPropertyValue("SelectedItem", "Stretch");
 
-			TakeScreenshot("Stretch");
+			using var _2 = TakeScreenshot("Stretch");
 
 			innerTextBoxResult = _app.Query(innerTextBox).First();
 			Assert.IsTrue(innerTextBoxResult.Rect.Width > myCommandBarResult.Rect.Width * .75, "TextBox Width is not large enough");
@@ -156,7 +156,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 			innerTextBoxResult = _app.Query(innerTextBox).First();
 			Assert.IsTrue(innerTextBoxResult.Rect.Width <= myCommandBarResult.Rect.Width / 2, "TextBox Width is too large");
 
-			TakeScreenshot("Left");
+			using var _3 = TakeScreenshot("Left");
 		}
 
 		[Test]
@@ -196,11 +196,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 
 			_app.WaitForElement("Page2CommandBar");
 
-			var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
+			using var initial = TakeScreenshot("initial", ignoreInSnapshotCompare: true);
 
 			_app.Wait(TimeSpan.FromMilliseconds(500));
 
-			var final = TakeScreenshot("final", ignoreInSnapshotCompare: true);
+			using var final = TakeScreenshot("final", ignoreInSnapshotCompare: true);
 
 			ImageAssert.AreEqual(initial, final);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.XamlCommandBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/CommandBarTests/UnoSamples_Tests.XamlCommandBar.cs
@@ -28,23 +28,23 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.CommandBarTests
 			_app.WaitForElement(_app.Marked("shuffleButton"));
 			_app.WaitForDependencyPropertyValue(shuffleButton, "IsChecked", false);
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			_app.FastTap(shuffleButton);
 			_app.WaitForDependencyPropertyValue(shuffleButton, "IsChecked", true);
 			_app.WaitForDependencyPropertyValue(clickResult, "Text", "Shuffle");
 
-			TakeScreenshot("AfterShuffle");
+			using var _2 = TakeScreenshot("AfterShuffle");
 
 			_app.FastTap(playButton);
 			_app.WaitForDependencyPropertyValue(clickResult, "Text", "Play");
 
-			TakeScreenshot("AfterPlay");
+			using var _3 = TakeScreenshot("AfterPlay");
 
 			_app.FastTap(appBarContentButton);
 			_app.WaitForDependencyPropertyValue(clickResult, "Text", "Click me");
 
-			TakeScreenshot("AfterClickMe");
+			using var _4 = TakeScreenshot("AfterClickMe");
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
@@ -41,7 +41,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var primaryButton = _app.Marked("PrimaryButton");
 			_app.WaitForElement(primaryButton);
 
-			CurrentTestTakeScreenShot("Primary Button");
+			using var _ = CurrentTestTakeScreenShot("Primary Button");
 
 			_app.FastTap(primaryButton);
 
@@ -68,7 +68,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var primaryButton = _app.Marked("PrimaryButton");
 			_app.WaitForElement(primaryButton);
 
-			CurrentTestTakeScreenShot("Primary Button");
+			using var _1 = CurrentTestTakeScreenShot("Primary Button");
 
 			_app.FastTap(primaryButton);
 
@@ -79,7 +79,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var secondaryButton = _app.Marked("SecondaryButton");
 			_app.WaitForElement(secondaryButton);
 
-			CurrentTestTakeScreenShot("Secondary Button");
+			using var _2 = CurrentTestTakeScreenShot("Secondary Button");
 
 			_app.FastTap(secondaryButton);
 
@@ -106,7 +106,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var primaryButton = _app.Marked("PrimaryButton");
 			_app.WaitForElement(primaryButton);
 
-			CurrentTestTakeScreenShot("Primary Button");
+			using var _1 = CurrentTestTakeScreenShot("Primary Button");
 
 			_app.FastTap(primaryButton);
 
@@ -115,11 +115,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var secondaryButton = _app.Marked("SecondaryButton");
 			_app.WaitForElement(secondaryButton);
 
-			CurrentTestTakeScreenShot("Secondary Button");
+			using var _2 = CurrentTestTakeScreenShot("Secondary Button");
 
 			_app.FastTap(secondaryButton);
 
-			CurrentTestTakeScreenShot("Closed");
+			using var _3 = CurrentTestTakeScreenShot("Closed");
 		}
 
 		[Test]
@@ -142,7 +142,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var secondaryButton = _app.Marked("SecondaryButton");
 			_app.WaitForElement(secondaryButton);
 
-			CurrentTestTakeScreenShot("Secondary Button");
+			using var _ = CurrentTestTakeScreenShot("Secondary Button");
 
 			_app.FastTap(secondaryButton);
 
@@ -170,7 +170,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var primaryButton = _app.Marked("PrimaryButton");
 			_app.WaitForElement(primaryButton);
 
-			CurrentTestTakeScreenShot("Primary Button");
+			using var _ = CurrentTestTakeScreenShot("Primary Button");
 
 			_app.FastTap(primaryButton);
 
@@ -198,7 +198,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var closeButton = _app.Marked("CloseButton");
 			_app.WaitForElement(closeButton);
 
-			CurrentTestTakeScreenShot("Close Button");
+			using var _ = CurrentTestTakeScreenShot("Close Button");
 
 			_app.FastTap(closeButton);
 
@@ -225,7 +225,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var dialogInnerButton = _app.Marked("dialogInnerButton");
 			_app.WaitForElement(dialogInnerButton);
 
-			CurrentTestTakeScreenShot("Secondary Button");
+			using var _1 = CurrentTestTakeScreenShot("Secondary Button");
 
 			_app.FastTap(dialogInnerButton);
 
@@ -239,7 +239,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			var dialogTextBinding = _app.Marked("dialogTextBinding");
 			_app.WaitForDependencyPropertyValue(dialogTextBinding, "Text", "This is some text");
 
-			CurrentTestTakeScreenShot("Secondary Button");
+			using var _2 = CurrentTestTakeScreenShot("Secondary Button");
 
 			var primaryButton = _app.Marked("SecondaryButton");
 			_app.FastTap(primaryButton);
@@ -390,22 +390,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 
 			// initial state
 			_app.WaitForElement(showDialogButton);
-			var initialScreenshot = CurrentTestTakeScreenShot("0 Initial State");
+			using var initialScreenshot = CurrentTestTakeScreenShot("0 Initial State");
 
 			// open dialog
 			_app.FastTap(showDialogButton);
 			_app.WaitForElement(primaryButton);
-			var dialogOpenedScreenshot = CurrentTestTakeScreenShot("1 ContentDialog Opened");
+			using var dialogOpenedScreenshot = CurrentTestTakeScreenShot("1 ContentDialog Opened");
 
 			// tapping outside of dialog
 			var dialogRect = _app.GetRect(dialogSpace);
 			_app.TapCoordinates(dialogRect.CenterX, dialogRect.Bottom + 50);
-			var dialogStillOpenedScreenshot = CurrentTestTakeScreenShot("2 ContentDialog Still Opened");
+			using var dialogStillOpenedScreenshot = CurrentTestTakeScreenShot("2 ContentDialog Still Opened");
 
 			// close dialog
 			_app.FastTap(primaryButton);
 			_app.Wait(seconds: 1);
-			var dialogClosedScreenshot = CurrentTestTakeScreenShot("3 ContentDialog Closed");
+			using var dialogClosedScreenshot = CurrentTestTakeScreenShot("3 ContentDialog Closed");
 
 			// compare
 			var comparableRect = GetOsComparableRect();

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -132,7 +132,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 
 			button.FastTap();
 
-			TakeScreenshot("DatePicker - Flyout", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Status bar appears with clock*/);
+			using var _ = TakeScreenshot("DatePicker - Flyout", ignoreInSnapshotCompare: AppInitializer.GetLocalPlatform() == Platform.Android /*Status bar appears with clock*/);
 
 			_app.TapCoordinates(20, 20);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.BitmapSource.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.BitmapSource.cs
@@ -37,7 +37,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			_app.WaitForDependencyPropertyValue(loadStateElement, "Text", "ImageOpened");
 
 			// Take screenshot
-			TakeScreenshot("ImageSource_PixelSize - Result");
+			using var _ = TakeScreenshot("ImageSource_PixelSize - Result");
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -25,12 +25,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			var button = _app.Marked("_update");
 			_app.WaitForElement(button);
 
-			var screenshotBefore = TakeScreenshot("WriteableBitmap_Invalidate - Before");
+			using var screenshotBefore = TakeScreenshot("WriteableBitmap_Invalidate - Before");
 
 			button.FastTap();
 
 			// Take screenshot
-			var screenshotAfter = TakeScreenshot("WriteableBitmap_Invalidate - Result");
+			using var screenshotAfter = TakeScreenshot("WriteableBitmap_Invalidate - Result");
 
 			ImageAssert.AreNotEqual(screenshotBefore, screenshotAfter);
 		}
@@ -46,12 +46,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			_app.WaitForElement(button);
 			button.FastTap();
 
-			var screenshotBefore = TakeScreenshot("WriteableBitmap_MultiInvalidate - Before");
+			using var screenshotBefore = TakeScreenshot("WriteableBitmap_MultiInvalidate - Before");
 
 			button.FastTap();
 
 			// Take screenshot
-			var screenshotAfter = TakeScreenshot("WriteableBitmap_MultiInvalidate - After");
+			using var screenshotAfter = TakeScreenshot("WriteableBitmap_MultiInvalidate - After");
 
 			ImageAssert.AreNotEqual(screenshotBefore, screenshotAfter);
 		}
@@ -149,7 +149,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 				picker.SetDependencyPropertyValue("Mode", "S" + i);
 				_app.WaitForDependencyPropertyValue(currentModeButton, "Content", (i * 16).ToString("00"));
 
-				TakeScreenshot("Mode-" + i);
+				using var _ = TakeScreenshot("Mode-" + i);
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Margins.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Margins.cs
@@ -67,7 +67,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			}
 
 			// Take screenshot
-			TakeScreenshot("WriteableBitmap_Invalidate - Result");
+			using var _ = TakeScreenshot("WriteableBitmap_Invalidate - Result");
 		}
 
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
@@ -66,7 +66,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			{
 				_app.Marked(buttonName).FastTap();
 				_app.Wait(TimeSpan.FromSeconds(2));
-				TakeScreenshot($"ListView_ItemPanel_HotSwap - {buttonName}");
+				using var _ = TakeScreenshot($"ListView_ItemPanel_HotSwap - {buttonName}");
 			}
 		}
 
@@ -81,7 +81,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			var textResult = _app.Marked("TextResult");
 			_app.WaitForText(textResult, "Success");
 
-			TakeScreenshot($"ListView_VirtualizePanelAdaptaterIdCache");
+			using var _ = TakeScreenshot($"ListView_VirtualizePanelAdaptaterIdCache");
 		}
 
 		[Test]
@@ -105,7 +105,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 			_app.WaitForText("StateTextBlock", "Measured");
 
-			TakeScreenshot("before scroll");
+			using var _1 = TakeScreenshot("before scroll");
 
 			var measureTextBefore = _app.GetText("MeasureCountTextBlock");
 			var initialMeasureCount = int.Parse(measureTextBefore);
@@ -114,7 +114,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 			_app.WaitForText("ResultTextBlock", "Scrolled");
 
-			TakeScreenshot("after scroll");
+			using var _2 = TakeScreenshot("after scroll");
 
 			var measureTextAfter = _app.GetText("MeasureCountTextBlock");
 			var finalMeasureCount = int.Parse(measureTextAfter);
@@ -129,7 +129,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 			_app.WaitForText("StatusTextBlock", "Finished");
 
-			TakeScreenshot("after layout");
+			using var _ = TakeScreenshot("after layout");
 
 			var heightStr = _app.GetText("HeightTextBlock");
 			var height = float.Parse(heightStr, NumberStyles.Float, NumberFormatInfo.InvariantInfo);
@@ -145,7 +145,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 			_app.WaitForText("StatusTextBlock", "Ready");
 
-			TakeScreenshot("1 item");
+			using var _1 = TakeScreenshot("1 item");
 
 			var heightStrBefore = _app.GetText("HeightTextBlock");
 			var heightBefore = float.Parse(heightStrBefore, NumberStyles.Float, NumberFormatInfo.InvariantInfo);
@@ -154,7 +154,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 			_app.WaitForText("StatusTextBlock", "Finished");
 
-			TakeScreenshot("3 items");
+			using var _2 = TakeScreenshot("3 items");
 
 			var heightStrAfter = _app.GetText("HeightTextBlock");
 			var heightAfter = float.Parse(heightStrAfter, NumberStyles.Float, NumberFormatInfo.InvariantInfo);
@@ -299,7 +299,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 				_app.WaitForText("itemsStackPanelListSelectedItem", "1");
 			}
 
-			TakeScreenshot("Both Selection Changed");
+			using var _ = TakeScreenshot("Both Selection Changed");
 		}
 
 		[Test]
@@ -469,7 +469,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 			{
 				_app.FastTap(AutomateButton);
 				_app.WaitForText(StatusText, automationStep);
-				TakeScreenshot(automationStep);
+				using var _ = TakeScreenshot(automationStep);
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutTests.cs
@@ -23,12 +23,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 
 			_app.WaitForElement(_app.Marked("mfiButton"));
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			// step 1: press button to show menu
 			_app.FastTap(_app.Marked("mfiButton"));
 
-			TakeScreenshot("menuShown");
+			using var _2 = TakeScreenshot("menuShown");
 
 			// step 2: click MenuFlyoutItem
 			_app.FastTap(_app.Marked("mfiItem"));
@@ -36,7 +36,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			// step 3: check result
 			_app.WaitForText(_app.Marked("mfiResult"), "success");
 
-			TakeScreenshot("AfterSuccess");
+			using var _3 = TakeScreenshot("AfterSuccess");
 		}
 
 		[Test]
@@ -47,10 +47,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 
 			_app.WaitForElement(_app.Marked("Help"));
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			_app.FastTap(_app.Marked("Help"));
-			TakeScreenshot("menuShown");
+			using var _2 = TakeScreenshot("menuShown");
 
 			_app.FastTap(_app.Marked("MenuViewHelp"));
 			_app.WaitForText(_app.Marked("results"), "View Help");
@@ -72,7 +72,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			_app.FastTap(_app.Marked("MenuAutoSave"));
 			_app.WaitForText(_app.Marked("results"), "Auto Save");
 
-			TakeScreenshot("AfterSuccess");
+			using var _3 = TakeScreenshot("AfterSuccess");
 		}
 
 		[Test]
@@ -85,13 +85,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			_app.WaitForElement(_app.Marked("fileMenu"));
 			var result = _app.Marked("result");
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			void Validate(string topMenu, string item, string expectedResult)
 			{
 				_app.FastTap(_app.Marked(topMenu));
 
-				TakeScreenshot(item);
+				using var _ = TakeScreenshot(item);
 
 				_app.FastTap(_app.Marked(item));
 
@@ -102,7 +102,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			Validate("fileMenu", "openMenu", "click text:Open...");
 			Validate("fileMenu", "xamlUIMenu", "xamluicommand param:xamlUIMenu");
 
-			TakeScreenshot("AfterSuccess");
+			using var _2 = TakeScreenshot("AfterSuccess");
 		}
 
 		[Test]
@@ -115,13 +115,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			_app.WaitForElement(_app.Marked("editMenu"));
 			var result = _app.Marked("result");
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			void Validate(string topMenu, string item, string expectedResult, bool initialCheckedState)
 			{
 				_app.FastTap(_app.Marked(topMenu));
 
-				TakeScreenshot(item);
+				using var _ = TakeScreenshot(item);
 
 				var itemQuery = _app.Marked(item);
 
@@ -136,7 +136,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			Validate("editMenu", "RepeatToggleMenuFlyoutItem", "click text:Repeat", false);
 			Validate("editMenu", "ShuffleToggleMenuFlyoutItem", "click text:Shuffle", false);
 
-			TakeScreenshot("AfterSuccess");
+			using var _2 = TakeScreenshot("AfterSuccess");
 		}
 
 		[Test]
@@ -149,21 +149,21 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			_app.WaitForElement(_app.Marked("fileMenu"));
 			var result = _app.Marked("result");
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			_app.FastTap(_app.Marked("fileMenu"));
 
-			TakeScreenshot("fileMenu");
+			using var _2 = TakeScreenshot("fileMenu");
 
 			_app.FastTap(_app.Marked("newMenu"));
 
-			TakeScreenshot("newMenu");
+			using var _3 = TakeScreenshot("newMenu");
 
 			_app.FastTap(_app.Marked("plainTextMenu"));
 
 			_app.WaitForText(result, "command param:Plain Text");
 
-			TakeScreenshot("AfterSuccess");
+			using var _4 = TakeScreenshot("AfterSuccess");
 		}
 
 		[Test]
@@ -176,22 +176,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			_app.WaitForElement(_app.Marked("fileMenu"));
 			var result = _app.Marked("result");
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			var fileMenu = _app.Marked("fileMenu");
 			_app.FastTap(fileMenu);
 
-			TakeScreenshot("fileMenu");
+			using var _2 = TakeScreenshot("fileMenu");
 
 			_app.FastTap(_app.Marked("disabledItem"));
 
-			TakeScreenshot("disabledItem");
+			using var _3 = TakeScreenshot("disabledItem");
 
 			Task.Delay(250);
 
 			_app.WaitForElement("disabledItem");
 
-			TakeScreenshot("AfterSuccess");
+			using var _4 = TakeScreenshot("AfterSuccess");
 
 			_app.Tap(fileMenu);
 		}
@@ -207,11 +207,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			_app.WaitForElement(_app.Marked("fileMenu"));
 			var result = _app.Marked("result");
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			_app.Tap(fileMenu);
 
-			TakeScreenshot("fileMenu");
+			using var _2 = TakeScreenshot("fileMenu");
 
 			var exitMenu = _app.Marked("exitMenu");
 			_app.WaitForElement(exitMenu);
@@ -222,7 +222,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 
 			_app.WaitForNoElement("exitItem");
 
-			TakeScreenshot("AfterSuccess");
+			using var _3 = TakeScreenshot("AfterSuccess");
 		}
 
 		[Test]
@@ -238,7 +238,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			var myBorderRect = _app.Query(_app.Marked("myBorder")).First().Rect;
 			_app.TouchAndHoldCoordinates(myBorderRect.CenterX, myBorderRect.CenterY);
 
-			TakeScreenshot("opened");
+			using var _ = TakeScreenshot("opened");
 
 			_app.FastTap(_app.Marked("testItem1"));
 			Assert.AreEqual("click: test1", result.GetText());

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
@@ -82,25 +82,25 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 			_app.Wait(0.25f);
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", true);
 			_app.WaitForElement(popupContent);
-			TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup opened");
+			using var _1 = TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup opened");
 
 			// 2. Tap on content should keep the popup opened
 			popupContent.FastTap();
 			_app.Wait(0.25f);
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", true);
-			TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup stays open when tap on content");
+			using var _2 = TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup stays open when tap on content");
 
 			// 2. Tap out of the popup should keep the pop opened
 			var screenRect = _app.Marked("sampleContent").FirstResult().Rect;
 			_app.TapCoordinates(10, screenRect.Bottom - 10); // click elsewhere on the page
 			_app.Wait(0.25f);
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", true);
-			TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup stays open when tap out of popup");
+			using var _3 = TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup stays open when tap out of popup");
 
 			// 3. Close the popup (to make sure to not pollute other tests)
 			toggleButton.FastTap(); // should dismiss here
 			_app.WaitForDependencyPropertyValue(toggleButton, "IsChecked", false);
-			TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup closed"); // We add a screen shot in order to make sure that the check of the bool IsChecked is valid!
+			using var _4 = TakeScreenshot("Popup_Simple - NonDismissiblePopup - Popup closed"); // We add a screen shot in order to make sure that the check of the bool IsChecked is valid!
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollBarTests/UnoSamples_Tests.ScrollBar.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollBarTests/UnoSamples_Tests.ScrollBar.cs
@@ -36,11 +36,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollBarTests
 
 			_app.WaitForElement(indicatorModeCombo);
 
-			TakeScreenshot("Startup");
+			using var _1 = TakeScreenshot("Startup");
 
 			indicatorModeCombo.SetDependencyPropertyValue("SelectedValue", "MouseIndicator");
 
-			TakeScreenshot("initial indicators");
+			using var _2 = TakeScreenshot("initial indicators");
 
 			verticalScrollBarSmallDecrease.FastTap();
 
@@ -82,11 +82,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollBarTests
 
 			_app.WaitForElement(indicatorModeCombo);
 
-			TakeScreenshot("Startup");
+			using var _1 = TakeScreenshot("Startup");
 
 			indicatorModeCombo.SetDependencyPropertyValue("SelectedValue", "MouseIndicator");
 
-			TakeScreenshot("initial indicators");
+			using var _2 = TakeScreenshot("initial indicators");
 
 			horizontalScrollBarSmallDecrease.FastTap();
 
@@ -126,11 +126,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollBarTests
 
 			_app.WaitForElement(indicatorModeCombo);
 
-			TakeScreenshot("Startup");
+			using var _1 = TakeScreenshot("Startup");
 
 			indicatorModeCombo.SetDependencyPropertyValue("SelectedValue", "MouseIndicator");
 
-			TakeScreenshot("initial indicators");
+			using var _2 = TakeScreenshot("initial indicators");
 
 			var thumbResult = _app.Query(horizontalScrollBarThumb).First();
 
@@ -160,11 +160,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollBarTests
 
 			_app.WaitForElement(indicatorModeCombo);
 
-			TakeScreenshot("Startup");
+			using var _1 = TakeScreenshot("Startup");
 
 			indicatorModeCombo.SetDependencyPropertyValue("SelectedValue", "MouseIndicator");
 
-			TakeScreenshot("initial indicators");
+			using var _2 = TakeScreenshot("initial indicators");
 
 			var thumbResult = _app.Query(verticalScrollBarThumb).First();
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ScrollViewerTests/UnoSamples_Tests.ScrolViewer.cs
@@ -37,7 +37,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 			_app.DragCoordinates(sut.Rect.X + 10, sut.Rect.Y + 110, sut.Rect.X + 10, sut.Rect.Y + 10);
 
 			validate.FastTap();
-			TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+			using var _ = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 			_app.WaitForDependencyPropertyValue(result, "Text", "SUCCESS");
 		}
 
@@ -59,7 +59,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 			_app.DragCoordinates(sut.Rect.X + 10, sut.Rect.Y + 110, sut.Rect.X + 10, sut.Rect.Y + 10);
 
 			validate.FastTap();
-			TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+			using var _ = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 			_app.WaitForDependencyPropertyValue(result, "Text", "SUCCESS");
 		}
 
@@ -116,7 +116,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ScrollViewerTests
 
 			void AssertCurrentColor(string description, Color color)
 			{
-				var scrn = TakeScreenshot(description);
+				using var scrn = TakeScreenshot(description);
 				ImageAssert.HasColorAt(scrn, rect.CenterX, rect.CenterY, color);
 			}
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -88,10 +88,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			var tb2 = _app.Marked("tb2");
 
 			tb1.FastTap();
-			TakeScreenshot("tb1 focused", ignoreInSnapshotCompare: true);
+			using var _1 = TakeScreenshot("tb1 focused", ignoreInSnapshotCompare: true);
 
 			tb2.FastTap();
-			TakeScreenshot("tb2 focused", ignoreInSnapshotCompare: true);
+			using var _2 = TakeScreenshot("tb2 focused", ignoreInSnapshotCompare: true);
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
@@ -186,7 +186,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 
 			picker.FastTap();
 
-			TakeScreenshot("TimePicker - Flyout", ignoreInSnapshotCompare: true);
+			using var _ = TakeScreenshot("TimePicker - Flyout", ignoreInSnapshotCompare: true);
 
 			// Dismiss the flyout
 			_app.TapCoordinates(10, 10);
@@ -208,7 +208,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 			// Wait for the picker to appear
 			_app.WaitForElement(x => x.Class("UIPickerView"));
 
-			TakeScreenshot("TimePicker - Flyout", ignoreInSnapshotCompare: true);
+			using var _ = TakeScreenshot("TimePicker - Flyout", ignoreInSnapshotCompare: true);
 
 			// Dismiss the flyout
 			_app.Tap(x => x.Marked("AcceptButton"));

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToolTipTests/ToolTip_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ToolTipTests/ToolTip_Tests.cs
@@ -38,7 +38,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ToolTipTests
 
 			_app.Marked("richToolTip").FirstResult().Should().NotBeNull("1.2s after click, should have a tooltip");
 
-			TakeScreenshot("opened-tooltip");
+			using var _1 = TakeScreenshot("opened-tooltip");
 
 			Thread.Sleep(7200);
 
@@ -48,7 +48,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ToolTipTests
 
 			Thread.Sleep(1200);
 
-			TakeScreenshot("opened-textonly-tooltip");
+			using var _2 = TakeScreenshot("opened-textonly-tooltip");
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WebViewTests/UnoSamples_Test_NavigateToString.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WebViewTests/UnoSamples_Test_NavigateToString.cs
@@ -23,7 +23,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.WebViewTests
 
 			_app.WaitForElement(_app.Marked("startButton"));
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			var startButton = _app.Marked("startButton");
 			var clickResult = _app.Marked("WebView_NavigateToStringResult");
@@ -37,7 +37,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.WebViewTests
 			_app.FastTap(startButton);
 			_app.WaitForText(clickResult, "success");   // timeout here means: bug reappear
 
-			TakeScreenshot("AfterSuccess");
+			using var _2 = TakeScreenshot("AfterSuccess");
 
 		}
 
@@ -50,7 +50,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.WebViewTests
 
 			_app.WaitForElement(_app.Marked("NavigateToAnchorButton"));
 
-			TakeScreenshot("Initial");
+			using var _1 = TakeScreenshot("Initial");
 
 			var navigationCompletedTextBlock = _app.Marked("NavigationCompletedTextBlock");
 			var navigateToAnchorButton = _app.Marked("NavigateToAnchorButton");
@@ -62,13 +62,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.WebViewTests
 			_app.FastTap(navigateToAnchorButton);
 			_app.WaitForText(navigationCompletedTextBlock, "https://nv-assets.azurewebsites.net/tests/docs/WebView_NavigateToAnchor.html#section-1");
 
-			TakeScreenshot("navigate to anchor");
+			using var _2 = TakeScreenshot("navigate to anchor");
 
 			// user click in the browser itself
 			_app.FastTap(clickAnchorButton);
 			_app.WaitForText(navigationCompletedTextBlock, "https://nv-assets.azurewebsites.net/tests/docs/WebView_NavigateToAnchor.html#page-4");
 
-			TakeScreenshot("click anchor");
+			using var _3 = TakeScreenshot("click anchor");
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Capture_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Capture_Tests.cs
@@ -61,7 +61,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			_app.WaitForElement(target);
 			act(target);
 
-			TakeScreenshot("Result");
+			using var _ = TakeScreenshot("Result");
 
 			_app.WaitForDependencyPropertyValue(result, "Text", "SUCCESS");
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DragCoordinates_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/DragCoordinates_Tests.cs
@@ -27,18 +27,18 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 
 			_app.WaitForElement(rootCanvas);
 
-			TakeScreenshot("tb01 - Initial");
+			using var _1 = TakeScreenshot("tb01 - Initial");
 
 			_app.WaitForDependencyPropertyValue(topValue, "Text", "0");
 			_app.WaitForDependencyPropertyValue(leftValue, "Text", "0");
 
-			TakeScreenshot("DragBorder01 - Step 1");
+			using var _2 = TakeScreenshot("DragBorder01 - Step 1");
 
 			var topBorderRect = _app.Query(myBorder).First().Rect;
 
 			_app.DragCoordinates(topBorderRect.CenterX, topBorderRect.CenterY, topBorderRect.CenterX + 50, topBorderRect.CenterY + 50);
 
-			TakeScreenshot("DragBorder01 - Step 2");
+			using var _3 = TakeScreenshot("DragBorder01 - Step 2");
 
 			_app.WaitForDependencyPropertyValue(topValue, "Text", "50");
 			_app.WaitForDependencyPropertyValue(leftValue, "Text", "50");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/EventSequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/EventSequence_Tests.cs
@@ -70,7 +70,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			tap(target);
 			validate.FastTap();
 
-			TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+			using var _ = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 
 			_app.WaitForDependencyPropertyValue(result, "Text", "SUCCESS");
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
@@ -25,7 +25,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			var rect = _app.WaitForElement("_thumb").Single().Rect;
 			_app.DragCoordinates(rect.X + 10, rect.Y + 10, rect.X - 100, rect.Y - 100);
 
-			TakeScreenshot("Result");
+			using var _ = TakeScreenshot("Result");
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/ScrollViewer_Pointer_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/ScrollViewer_Pointer_Tests.cs
@@ -39,25 +39,25 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 			_app.DragCoordinates(leftLow, leftHigh);
 			WaitForDragged();
-			TakeScreenshot("After drag on grid");
+			using var _1 = TakeScreenshot("After drag on grid");
 			Reset();
 
 			_app.DragCoordinates(centerLow, centerHigh);
 			if (GetIsTouchInteraction())
 			{
 				WaitForUndragged(); // Interaction is swallowed by ScrollViewer in touch
-				TakeScreenshot("After drag on ScrollViewer - touch");
+				using var _ = TakeScreenshot("After drag on ScrollViewer - touch");
 			}
 			else
 			{
 				WaitForDragged(); // When using mouse the ScrollViewer will not swallow the drag
-				TakeScreenshot("After drag on ScrollViewer - mouse");
+				using var _ = TakeScreenshot("After drag on ScrollViewer - mouse");
 			}
 			Reset();
 
 			_app.DragCoordinates(rightLow, rightHigh);
 			WaitForDragged(); // ScrollViewer is unscrollable, PointerMoved will be surfaced to parent (in both touch and mouse mode)
-			TakeScreenshot("After drag on non-scrolling ScrollViewer");
+			using var _2 = TakeScreenshot("After drag on non-scrolling ScrollViewer");
 
 
 			void WaitForUndragged() => _app.WaitForText("StatusTextBlock", "Not dragged");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/GeometryTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/GeometryTests.cs
@@ -24,7 +24,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 
 			var rect = _app.GetPhysicalRect("HostBorder");
 
-			var scrn = TakeScreenshot("Rendered", ignoreInSnapshotCompare: true);
+			using var scrn = TakeScreenshot("Rendered", ignoreInSnapshotCompare: true);
 
 			ImageAssert.HasColorAt(scrn, rect.CenterX, rect.CenterY, Color.Red);
 		}
@@ -40,7 +40,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 
 			var rect = _app.GetPhysicalRect("HostBorder");
 
-			var scrn = TakeScreenshot("Rendered", ignoreInSnapshotCompare: true);
+			using var scrn = TakeScreenshot("Rendered", ignoreInSnapshotCompare: true);
 
 			ImageAssert.HasColorAt(scrn, rect.CenterX, rect.CenterY, Color.Green);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.ArcSegment.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.ArcSegment.cs
@@ -27,7 +27,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 			_app.WaitForElement(path);
 
 			// Take an initial screenshot
-			TakeScreenshot("Initial State");
+			using var _ = TakeScreenshot("Initial State");
 		}
 	}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.BezierSegment.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.BezierSegment.cs
@@ -27,7 +27,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 			_app.WaitForElement(path);
 
 			// Take an initial screenshot
-			TakeScreenshot("Initial State");
+			using var _ = TakeScreenshot("Initial State");
 		}
 	}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.LineSegmentPage.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.LineSegmentPage.cs
@@ -26,7 +26,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 			_app.WaitForElement(path);
 
 			// Take an initial screenshot
-			TakeScreenshot("Initial State", ignoreInSnapshotCompare: true);
+			using var _ = TakeScreenshot("Initial State", ignoreInSnapshotCompare: true);
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Path_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Path_Tests.cs
@@ -22,7 +22,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 
 			_app.WaitForElement("MainTargetEvenOdd");
 
-			var scrn = TakeScreenshot("Rendered", true);
+			using var scrn = TakeScreenshot("Rendered", true);
 
 			AssertHasColorAtCenter("MainTargetEvenOdd", Color.Beige);
 			AssertHasColorAtCenter("LeftTargetEvenOdd", Color.Beige);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Shapes_Tests.cs
@@ -22,14 +22,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Shapes.PolylinePage");
 			_app.WaitForElement("DPolyline");
-			TakeScreenshot($"PolylinePage");
+			using var _ = TakeScreenshot($"PolylinePage");
 			TabWaitAndThenScreenshot("ChangeShape");
 
 			void TabWaitAndThenScreenshot(string buttonName)
 			{
 				_app.Marked(buttonName).FastTap();
 				_app.WaitForElement("DPolyline");
-				TakeScreenshot($"PolylinePage - {buttonName}");
+				using var _ = TakeScreenshot($"PolylinePage - {buttonName}");
 			}
 		}
 
@@ -39,14 +39,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Shapes.PolygonPage");
 			_app.WaitForElement("DPolygon");
-			TakeScreenshot($"PolygonPage");
+			using var _ = TakeScreenshot($"PolygonPage");
 			TabWaitAndThenScreenshot("ChangeShape");
 
 			void TabWaitAndThenScreenshot(string buttonName)
 			{
 				_app.Marked(buttonName).FastTap();
 				_app.WaitForElement("DPolygon");
-				TakeScreenshot($"PolygonPage - {buttonName}");
+				using var _ = TakeScreenshot($"PolygonPage - {buttonName}");
 			}
 		}
 
@@ -58,7 +58,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 
 			_app.WaitForElement("DPolygon");
 			_app.Marked("ClearShape").FastTap();
-			TakeScreenshot($"PolygonPage - ClearShape");
+			using var _1 = TakeScreenshot($"PolygonPage - ClearShape");
 
 			_app.Marked("ChangeShape").FastTap();
 			var widthzize = _app.Query(_app.Marked("DPolygon")).First().Rect.Width;
@@ -66,7 +66,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			if (widthzize == 0)
 				Assert.Fail("Shape not changed");
 
-			TakeScreenshot($"PolygonPage - ChangeShape-After clear");
+			using var _2 = TakeScreenshot($"PolygonPage - ChangeShape-After clear");
 		}
 
 		[Test]
@@ -77,7 +77,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 
 			_app.WaitForElement("DPolyline");
 			_app.Marked("ClearShape").FastTap();
-			TakeScreenshot($"PolylinePage - ClearShape");
+			using var _1 = TakeScreenshot($"PolylinePage - ClearShape");
 
 			_app.Marked("ChangeShape").FastTap();
 			var widthzize = _app.Query(_app.Marked("DPolyline")).First().Rect.Width;
@@ -85,7 +85,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			if(widthzize == 0)
 				Assert.Fail("Shape not changed");
 
-			TakeScreenshot($"PolylinePage - ChangeShape-After clear");
+			using var _2 = TakeScreenshot($"PolylinePage - ChangeShape-After clear");
 		}
 
 		[Test]
@@ -115,7 +115,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Shapes.LinePage");
 			_app.WaitForElement("DLinePage");
-			TakeScreenshot($"LinePage");
+			using var _ = TakeScreenshot($"LinePage");
 		}
 
 		[Test]
@@ -126,7 +126,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 
 			_app.WaitForText("StatusTextBlock", "Is bound");
 
-			var screenshot = TakeScreenshot("Complete");
+			using var screenshot = TakeScreenshot("Complete");
 
 			var bounds = _app.GetRect("TargetRectangle");
 
@@ -138,7 +138,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 		public void Default_StrokeThickness()
 		{
 			const string red = "#FF0000";
-			string reddish = GetReddish();
+			var reddish = GetReddish();
 
 			var shapeExpectations = new[]
 		   {


### PR DESCRIPTION
# CI/Tests improvements

## What is the current behavior?
A lot of `.TakeScreenshot()` result were not disposed, leaking opened files and bitmaps in memory on the CI server during build.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
