### PR TITLE
Add ability to drop external content into wasm app

### DIFF
--- a/doc/articles/features/pointers-keyboard-and-other-user-inputs.md
+++ b/doc/articles/features/pointers-keyboard-and-other-user-inputs.md
@@ -163,14 +163,20 @@ The table and sections below describe supported functionality and limitations fo
 
 |          | From uno app to external                         | From external app to uno                        |
 | -------- | ------------------------------------------------ | ------------------------                        |
-| Android  | No _in progress_                                 | No _in progress_                                |
+| Android  | No                                               | No                                              |
 | iOS      | No                                               | No                                              |
-| Wasm     | No                                               | No                                              |
+| Wasm     | No                                               | Yes (Text, Link, Image, File, Html, Rtf)        |
 | macOS    | Yes (Text, Link, Image, Html, Rtf)               | Yes (Text, Link, Image, File, Html, Rtf)        |
 | Skia WPF | Yes (Text, Link, Image, File, Html, Rtf)         | Yes (Text, Link, Image, File, Html, Rtf)        |
 | Skia GTK | No                                               | No                                              |
 
 * "Link" may refer to WebLink, ApplicationLink or Uri formats
+
+#### Wasm Limitations
+1. When dragging content from external app to uno, you cannot retreive the content from the `DataPackage` before the `Drop` event.
+   This a limitations of web browsers.
+   Any attempt to read it before the `Drop` will result into a timeout exception after a hard coded delay of 10 seconds.
+2. When dragging some uris from external app to uno, only the first uri will be accessible throught the **WebLink** standard format ID.
 
 #### macOS Limitations
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/TSBindings/TSBindingsGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/TSBindings/TSBindingsGenerator.cs
@@ -108,12 +108,12 @@ namespace Uno.UI.SourceGenerators.TSBindings
 						sb.AppendLineInvariant($"public {field.Name} : {GetTSFieldType(field.Type)};");
 					}
 
-					if (messageType.Name.EndsWith("Params"))
+					if (messageType.Name.EndsWith("Params") || messageType.Name.EndsWith("EventArgs"))
 					{
 						GenerateUnmarshaler(messageType, sb, packValue);
 					}
 
-					if (messageType.Name.EndsWith("Return"))
+					if (messageType.Name.EndsWith("Return") || messageType.Name.EndsWith("EventArgs"))
 					{
 						GenerateMarshaler(messageType, sb, packValue);
 					}

--- a/src/Uno.Foundation.Runtime.WebAssembly/Interop/TSInteropMarshaller.HandleRef.wasm.cs
+++ b/src/Uno.Foundation.Runtime.WebAssembly/Interop/TSInteropMarshaller.HandleRef.wasm.cs
@@ -1,0 +1,98 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Uno.Extensions;
+
+namespace Uno.Foundation.Interop
+{
+	internal static partial class TSInteropMarshaller
+	{
+		/// <summary>
+		/// A reference to an instance of <typeparamref name="T"/> shared between javascript and managed code.
+		/// </summary>
+		/// <typeparam name="T">The type of the shared value</typeparam>
+		public sealed class HandleRef<T> : IDisposable
+			where T : struct
+		{
+			private readonly string? _jsDisposeMethodName;
+
+			private int _isDisposed = 0;
+
+			/// <summary>
+			/// DO NOT USE, use <see cref="TSInteropMarshaller.Allocate{T}"/> instead.
+			/// </summary>
+			public HandleRef(string? jsDisposeMethodName)
+			{
+				_jsDisposeMethodName = jsDisposeMethodName;
+				Type = typeof(T);
+				Handle = Marshal.AllocHGlobal(Marshal.SizeOf(Type));
+
+				DumpStructureLayout(Type);
+
+				// Make sure to init the allocated memory
+				Marshal.StructureToPtr(default(T), Handle, false);
+			}
+
+			/// <summary>
+			/// The type of the shared instance.
+			/// </summary>
+			public Type Type { get; }
+
+			/// <summary>
+			/// The pointer of the shared instance.
+			/// </summary>
+			public IntPtr Handle { get; }
+
+			/// <summary>
+			/// The value of the shared instance.
+			/// Getting or setting this value will read/write the value from/into the shared memory space.
+			/// </summary>
+			public T Value
+			{
+				get
+				{
+					CheckDisposed();
+					return (T)(Marshal.PtrToStructure(Handle, Type)!);
+				}
+				set
+				{
+					CheckDisposed();
+					Marshal.StructureToPtr(value, Handle, true);
+				}
+			}
+
+			private void CheckDisposed()
+			{
+				if (_isDisposed != 0)
+				{
+					throw new ObjectDisposedException(GetType().Name, "Marshalled object have been disposed.");
+				}
+			}
+
+			/// <inheritdoc />
+			public void Dispose()
+			{
+				if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
+				{
+					Marshal.DestroyStructure(Handle, Type);
+					Marshal.FreeHGlobal(Handle);
+
+					if (_jsDisposeMethodName.HasValue())
+					{
+						WebAssemblyRuntime.InvokeJSUnmarshalled(_jsDisposeMethodName!, Handle);
+					}
+
+					GC.SuppressFinalize(this);
+				}
+			}
+
+			~HandleRef()
+			{
+				Dispose();
+			}
+		}
+	}
+}

--- a/src/Uno.Foundation.Runtime.WebAssembly/Interop/TSInteropMarshaller.wasm.cs
+++ b/src/Uno.Foundation.Runtime.WebAssembly/Interop/TSInteropMarshaller.wasm.cs
@@ -156,7 +156,7 @@ namespace Uno.Foundation.Interop
 				get
 				{
 					CheckDisposed();
-					return (T)Marshal.PtrToStructure(Handle, Type);
+					return (T)(Marshal.PtrToStructure(Handle, Type)!);
 				}
 				set
 				{

--- a/src/Uno.UI/UI/Xaml/Application.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Application.wasm.cs
@@ -43,6 +43,10 @@ namespace Windows.UI.Xaml
 			Current = this;
 			Package.SetEntryAssembly(this.GetType().Assembly);
 
+			global::Uno.Foundation.Extensibility.ApiExtensibility.Register(
+				typeof(global::Windows.ApplicationModel.DataTransfer.DragDrop.Core.IDragDropExtension),
+				o => new global::Windows.ApplicationModel.DataTransfer.DragDrop.Core.DragDropExtension());
+
 			CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.Normal, Initialize);
 
 			ObserveApplicationVisibility();

--- a/src/Uno.UI/UI/Xaml/DragDrop/DragDropExtension.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragDropExtension.wasm.cs
@@ -92,9 +92,9 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 		{
 			try
 			{
-				if (_log.IsEnabled(LogLevel.Debug))
+				if (_log.IsEnabled(LogLevel.Trace))
 				{
-					_log.Debug("Receiving native drop event.");
+					_log.Trace("Receiving native drop event.");
 				}
 
 				if (_current?._args is { } args)
@@ -125,9 +125,9 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 
 		private DragDropExtensionEventArgs OnNativeDragAndDrop(DragDropExtensionEventArgs args)
 		{
-			if (_log.IsEnabled(LogLevel.Debug))
+			if (_log.IsEnabled(LogLevel.Trace))
 			{
-				_log.Info($"Received native drop event: {args}");
+				_log.Trace($"Received native drop event: {args}");
 			}
 
 			DataPackageOperation? acceptedOperation = DataPackageOperation.None;
@@ -163,17 +163,17 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 					var data = CreateDataPackage(args.dataItems);
 					var info = new CoreDragInfo(drop, data.GetView(), allowed);
 
-					if (_log.IsEnabled(LogLevel.Information))
+					if (_log.IsEnabled(LogLevel.Debug))
 					{
-						_log.Info($"Starting new native drop operation {drop.Id}");
+						_log.Debug($"Starting new native drop operation {drop.Id}");
 					}
 
 					_pendingNativeDrop = drop;
 					info.RegisterCompletedCallback(result =>
 					{
-						if (_log.IsEnabled(LogLevel.Information))
+						if (_log.IsEnabled(LogLevel.Debug))
 						{
-							_log.Info($"Completed native drop operation #{drop.Id}: {result}");
+							_log.Debug($"Completed native drop operation #{drop.Id}: {result}");
 						}
 
 						if (_pendingNativeDrop == drop)
@@ -224,14 +224,14 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 			}
 
 			// Note about images:
-			//		There is not no common types for image drag and drop in browsers.
-			//		Only FF provides a data of kind "string" ("other" when coming from the same page) and type "application/x-moz-nativeimage",
-			//		but the content marshalling doen't seems to works properly, and anyway there are no equivalent custom type for chromium :(
+			//		There is no common type for image drag and drop in browsers.
+			//		Only FireFox provides data of the kind "string" ("other" when coming from the same page) and type "application/x-moz-nativeimage",
+			//		but the content marshalling doesn't seem to work properly, and there are no equivalent custom type for chromium :(
 			//		Consequently the only way to get a "Bitmap" data in the package is by D&Ding a file with a MIME type starting by "image/"
 			// Note about unknown types:
-			//		we don't don't support any other "kind" (we can have an "other" when D&Ding an image within the same page on FF),
-			//		as we don't have have any way to properly retrieve the data.
-			//		We however support do propagate any "string" that does not have a standard MIME type so we don't restrict too much applications.
+			//		we don't support any other "kind" (we can have an "other" when D&Ding an image within the same page on FF),
+			//		as we don't have any way to properly retrieve the data.
+			//		We however support to propagate any "string" that does not have a standard MIME type so we don't restrict too much applications.
 
 			var package = new DataPackage();
 			var entries = JsonHelper.Deserialize<DataEntry[]>(dataItems);
@@ -288,7 +288,8 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 
 		private static async Task<IReadOnlyList<IStorageItem>> RetrieveFiles(CancellationToken ct, params int[] itemsIds)
 		{
-			var infosRaw = await WebAssemblyRuntime.InvokeAsync($"{_jsType}.retrieveFiles({string.Join(", ", itemsIds.Select(id => id.ToStringInvariant()))})", ct);
+			var rawItemsIds = string.Join(", ", itemsIds.Select(id => id.ToStringInvariant()));
+			var infosRaw = await WebAssemblyRuntime.InvokeAsync($"{_jsType}.retrieveFiles({rawItemsIds})", ct);
 			var infos = JsonHelper.Deserialize<NativeStorageItemInfo[]>(infosRaw);
 			var items = infos.Select(StorageFile.GetFromNativeInfo).ToList();
 
@@ -399,9 +400,9 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 
 			public void Update(DragDropExtensionEventArgs args)
 			{
-				if (_log.IsEnabled(LogLevel.Debug))
+				if (_log.IsEnabled(LogLevel.Trace))
 				{
-					_log.Info($"Updating native drop operation #{Id} ({args.eventName})");
+					_log.Trace($"Updating native drop operation #{Id} ({args.eventName})");
 				}
 
 				_args = args;

--- a/src/Uno.UI/UI/Xaml/DragDrop/DragDropExtension.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragDropExtension.wasm.cs
@@ -1,0 +1,364 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.Storage.Streams;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Input;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml.Controls;
+using Uno;
+using Uno.Extensions;
+using Uno.Foundation;
+using Uno.Foundation.Extensibility;
+using Uno.Foundation.Interop;
+using Uno.Helpers.Serialization;
+using Uno.Logging;
+using Uno.Storage.Internal;
+using Uno.UI;
+using Uno.UI.Xaml;
+
+// As IDragDropExtension is internal, the generated registration cannot be used.
+// [assembly: ApiExtension(typeof(Windows.ApplicationModel.DataTransfer.DragDrop.Core.IDragDropExtension), typeof(Windows.ApplicationModel.DataTransfer.DragDrop.Core.DragDropExtension))]
+
+namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
+{
+	internal class DragDropExtension : IDragDropExtension
+	{
+		private const string _jsType = "Windows.ApplicationModel.DataTransfer.DragDrop.Core.DragDropExtension";
+
+		private static DragDropExtension? _current;
+
+		private readonly CoreDragDropManager _manager;
+
+		private int _isInitialized;
+		private TSInteropMarshaller.HandleRef<DragDropExtensionEventArgs>? _args;
+		private NativeDrop? _pendingNativeDrop;
+
+		public DragDropExtension()
+		{
+			_manager = CoreDragDropManager.GetForCurrentView()
+				?? throw new InvalidOperationException("No CoreDragDropManager available for current thread.");
+
+			if (Interlocked.CompareExchange(ref _current, null, this) != null)
+			{
+				throw new InvalidOperationException(
+					"Multi-window (multi-threading) is not supported yet by DragDropExtension. "
+					+ "Only one instance is allowed per app.");
+			}
+
+			// For now we enable the D&DExtension sync at creation and we don't support disable.
+			// This allow us to prevent a drop of a content on an app which actually don't support D&D
+			// (would drive the browser to open the dragged file and "dismiss" the app).
+			Enable();
+		}
+
+		private void Enable()
+		{
+			if (Interlocked.CompareExchange(ref _isInitialized, 1, 0) == 0)
+			{
+				_args = TSInteropMarshaller.Allocate<DragDropExtensionEventArgs>(
+					"UnoStatic_Windows_ApplicationModel_DataTransfer_DragDrop_Core_DragDropExtension:enable",
+					"UnoStatic_Windows_ApplicationModel_DataTransfer_DragDrop_Core_DragDropExtension:disable");
+			}
+			else
+			{
+				throw new InvalidOperationException("Multiple DragDropExtension is not supported yet.");
+			}
+		}
+
+		/// <inheritdoc />
+		void IDragDropExtension.StartNativeDrag(CoreDragInfo info)
+		{
+			// There is no way to programmatically initiate a DragAndDrop in browsers.
+			// We instead have to rely on the native drag and drop support.
+		}
+
+		[Preserve]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static string OnNativeDragAndDrop()
+		{
+			if (_current?._args is {} args)
+			{
+				args.Value = _current.OnNativeDragAndDrop(args.Value);
+				return "true";
+			}
+			else
+			{
+				return "false";
+			}
+		}
+
+		private DragDropExtensionEventArgs OnNativeDragAndDrop(DragDropExtensionEventArgs args)
+		{
+			var acceptedOperation = DataPackageOperation.None;
+			switch (args.eventName)
+			{
+				case "dragenter":
+					_pendingNativeDrop = new NativeDrop(args);
+
+					var allowed = ToDataPackageOperation(args.allowedOperations);
+					var data = CreateDataPackage(args.dataItems);
+					var info = new CoreDragInfo(_pendingNativeDrop, data.GetView(), allowed);
+
+					_manager.DragStarted(info);
+					break;
+
+				case "dragover" when _pendingNativeDrop != null:
+					_pendingNativeDrop.Update(args);
+					acceptedOperation = _manager.ProcessMoved(_pendingNativeDrop);
+					break;
+
+				case "dragleave" when _pendingNativeDrop != null:
+					_pendingNativeDrop.Update(args);
+					acceptedOperation = _manager.ProcessAborted(_pendingNativeDrop);
+					_pendingNativeDrop = null;
+					break;
+
+				case "drop" when _pendingNativeDrop != null:
+					_pendingNativeDrop.Update(args);
+					acceptedOperation = _manager.ProcessDropped(_pendingNativeDrop);
+					_pendingNativeDrop = null;
+					break;
+			}
+
+			return new DragDropExtensionEventArgs { acceptedOperation = ToNativeOperation(acceptedOperation) };
+		}
+
+		private DataPackage CreateDataPackage(string dataItems)
+		{
+			if (dataItems is null)
+			{
+				throw new ArgumentNullException(nameof(dataItems), "The dataItems is full-filled only for selected events!");
+			}
+
+			var package = new DataPackage();
+			var entries = JsonHelper
+				.Deserialize<DataEntry[]>(dataItems)
+				.GroupBy(item => item.Kind)
+				.ToDictionary(group => group.Key);
+
+			if (entries.TryGetValue("file", out var files))
+			{
+				entries.Remove("file"); // Remove so we can detect "other types"
+
+				var ids = files
+					.Select(item => item.Id)
+					.ToArray();
+				package.SetDataProvider(
+					StandardDataFormats.StorageItems,
+					async ct => await RetrieveFiles(ct, ids));
+
+				// There is no kind for image, but when we drag and drop an image from a browser to another one, we sometimes get it as a file.
+				var image = files.FirstOrDefault(file => file.Type.StartsWith("image/"));
+				if (image.Type != null)
+				{
+					package.SetDataProvider(
+						StandardDataFormats.Bitmap,
+						async ct => RandomAccessStreamReference.CreateFromFile((IStorageFile)(await RetrieveFiles(ct, image.Id)).Single()));
+				}
+			}
+
+			if (entries.TryGetValue("string", out var texts))
+			{
+				entries.Remove("string"); // Remove so we can detect "other types"
+
+				foreach (var text in texts)
+				{
+					var (formatId, provider) = GetTextProvider(text.Id, text.Type);
+
+					package.SetDataProvider(formatId, provider);
+				}
+
+				// There is not equivalent custom type for chromium :(
+				if (!package.Contains(StandardDataFormats.Bitmap)
+					&& texts.FirstOrDefault(text => text.Type.Equals("application/x-moz-nativeimage")) is {} textImage)
+				{
+					package.SetDataProvider(
+						StandardDataFormats.Bitmap,
+						async ct =>
+						{
+							var imageData = await RetrieveText(ct, textImage.Id);
+							var imageStream = new MemoryStream(Encoding.UTF8.GetBytes(imageData));
+
+							return RandomAccessStreamReference.CreateFromStream(imageStream.AsRandomAccessStream());
+						});
+				}
+			}
+
+			if (entries.Any() || this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().Warn($"Types not supported for drag and drop operations: {string.Join(", ", entries.Keys)}");
+			}
+
+			return package;
+		}
+
+		private struct DataEntry
+		{
+			public int Id;
+			public string Kind;
+			public string Type;
+		}
+
+		private static (string formatId, FuncAsync<object> provider) GetTextProvider(int id, string type)
+			=> type switch
+			{
+				"text/uri-list" => // https://datatracker.ietf.org/doc/html/rfc2483#section-5
+					(StandardDataFormats.WebLink,
+					async ct => new Uri((await RetrieveText(ct, id))
+						.Split(new[]{'\r','\n'}, StringSplitOptions.RemoveEmptyEntries)
+						.Where(line => !line.StartsWith("#"))
+						.First())),
+				"text/plain" => (StandardDataFormats.Text, async ct => await RetrieveText(ct, id)),
+				"text/html" => (StandardDataFormats.Html, async ct => await RetrieveText(ct, id)),
+				"text/rtf" => (StandardDataFormats.Rtf, async ct => await RetrieveText(ct, id)),
+				_ => (type, async ct => await RetrieveText(ct, id))
+			};
+
+		private static async Task<IReadOnlyList<IStorageItem>> RetrieveFiles(CancellationToken ct, params int[] itemsIds)
+		{
+			var infosRaw = await WebAssemblyRuntime.InvokeAsync($"{_jsType}.retrieveFiles({string.Join(", ", itemsIds.Select(id => id.ToStringInvariant()))})", ct);
+			var infos = JsonHelper.Deserialize<NativeStorageItemInfo[]>(infosRaw);
+			var items = infos.Select(StorageFile.GetFromNativeInfo).ToList();
+
+			return items;
+		}
+
+		private static async Task<string> RetrieveText(CancellationToken ct, int itemId)
+		{
+			using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct, new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token);
+			var text = await WebAssemblyRuntime.InvokeAsync($"{_jsType}.retrieveText({itemId.ToStringInvariant()})", cts.Token);
+
+			return text;
+		}
+
+		private static DataPackageOperation ToDataPackageOperation(string allowedOperations)
+			=> allowedOperations.ToLowerInvariant() switch
+			{
+				// https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/effectAllowed#values
+				"none" => DataPackageOperation.None,
+				"copy" => DataPackageOperation.Copy,
+				"copyLink" => DataPackageOperation.Copy | DataPackageOperation.Link,
+				"copyMove" => DataPackageOperation.Copy | DataPackageOperation.Move,
+				"link" => DataPackageOperation.Link,
+				"linkMove" => DataPackageOperation.Link | DataPackageOperation.Move,
+				"move" => DataPackageOperation.Move,
+				"all" => DataPackageOperation.Copy | DataPackageOperation.Move | DataPackageOperation.Link,
+				"uninitialized" => DataPackageOperation.Copy | DataPackageOperation.Move | DataPackageOperation.Link,
+				_ => DataPackageOperation.None
+			};
+
+		private static string ToNativeOperation(DataPackageOperation acceptedOperation)
+		{
+			// If multiple flags set (which should not!), the UWP precedence is Link > Copy > Move
+			// This is the same logic used in the DragView.ToGlyph 
+			if (acceptedOperation.HasFlag(DataPackageOperation.Link))
+			{
+				return "link";
+			}
+			else if (acceptedOperation.HasFlag(DataPackageOperation.Copy))
+			{
+				return "copy";
+			}
+			else if (acceptedOperation.HasFlag(DataPackageOperation.Move))
+			{
+				return "move";
+			}
+			else // None
+			{
+				return "none";
+			}
+		}
+
+		private class NativeDrop : IDragEventSource
+		{
+			private static long _nextId = 0;
+			private DragDropExtensionEventArgs _args;
+
+			public NativeDrop(DragDropExtensionEventArgs args)
+			{
+				_args = args;
+			}
+
+			/// <inheritdoc />
+			public long Id { get; } = Interlocked.Increment(ref _nextId);
+
+			/// <inheritdoc />
+			public uint FrameId => PointerRoutedEventArgs.ToFrameId(_args.timestamp);
+
+			/// <inheritdoc />
+			public (Point location, DragDropModifiers modifier) GetState()
+			{
+				var position = new Point(_args.x, _args.y);
+				var modifier = DragDropModifiers.None;
+
+				var buttons = (WindowManagerInterop.HtmlPointerButtonsState)_args.buttons;
+				if (buttons.HasFlag(WindowManagerInterop.HtmlPointerButtonsState.Left))
+				{
+					modifier |= DragDropModifiers.LeftButton;
+				}
+				if (buttons.HasFlag(WindowManagerInterop.HtmlPointerButtonsState.Middle))
+				{
+					modifier |= DragDropModifiers.MiddleButton;
+				}
+				if (buttons.HasFlag(WindowManagerInterop.HtmlPointerButtonsState.Right))
+				{
+					modifier |= DragDropModifiers.RightButton;
+				}
+
+				if (_args.shift)
+				{
+					modifier |= DragDropModifiers.Shift;
+				}
+				if (_args.ctrl)
+				{
+					modifier |= DragDropModifiers.Control;
+				}
+				if (_args.alt)
+				{
+					modifier |= DragDropModifiers.Alt;
+				}
+
+				return (position, modifier);
+			}
+
+			/// <inheritdoc />
+			public Point GetPosition(object? relativeTo)
+				=> PointerRoutedEventArgs.ToRelativePosition(new Point(_args.x, _args.y), relativeTo as UIElement);
+
+			public void Update(DragDropExtensionEventArgs args)
+				=> _args = args;
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 8)]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public struct DragDropExtensionEventArgs
+		{
+			public string eventName;
+			public double timestamp;
+			public double x;
+			public double y;
+			public int buttons; // HtmlPointerButtonsState
+			public bool shift;
+			public bool ctrl;
+			public bool alt;
+			public string allowedOperations;
+			public string acceptedOperation;
+
+			// Note: This should be an array, but it's currently not supported by marshaling for return values.
+			public string dataItems; // Filled only for eventName == dragenter
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/DragDrop/DragDropExtension.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragDropExtension.wasm.cs
@@ -88,7 +88,7 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 
 		[Preserve]
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static string OnNativeDragAndDrop()
+		public static string OnNativeDropEvent()
 		{
 			try
 			{
@@ -99,7 +99,7 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 
 				if (_current?._args is { } args)
 				{
-					args.Value = _current.OnNativeDragAndDrop(args.Value);
+					args.Value = _current.OnNativeDropEvent(args.Value);
 					return "true";
 				}
 				else
@@ -123,7 +123,7 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 			}
 		}
 
-		private DragDropExtensionEventArgs OnNativeDragAndDrop(DragDropExtensionEventArgs args)
+		private DragDropExtensionEventArgs OnNativeDropEvent(DragDropExtensionEventArgs args)
 		{
 			if (_log.IsEnabled(LogLevel.Trace))
 			{

--- a/src/Uno.UI/UI/Xaml/DragDrop/DragDropExtension.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragDropExtension.wasm.cs
@@ -36,6 +36,7 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 {
 	internal class DragDropExtension : IDragDropExtension
 	{
+		private const long _textReadTimeoutTicks = 10 * TimeSpan.TicksPerSecond;
 		private const string _jsType = "Windows.ApplicationModel.DataTransfer.DragDrop.Core.DragDropExtension";
 		private static readonly ILogger _log = typeof(DragDropExtension).Log();
 
@@ -298,7 +299,7 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 
 		private static async Task<string> RetrieveText(CancellationToken ct, int itemId)
 		{
-			using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct, new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token);
+			using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct, new CancellationTokenSource(TimeSpan.FromTicks(_textReadTimeoutTicks)).Token);
 			var text = await WebAssemblyRuntime.InvokeAsync($"{_jsType}.retrieveText({itemId.ToStringInvariant()})", cts.Token);
 
 			return text;

--- a/src/Uno.UI/UI/Xaml/DragDrop/DragRoot.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragRoot.cs
@@ -15,6 +15,7 @@ namespace Windows.UI.Xaml
 			VerticalAlignment = VerticalAlignment.Stretch;
 			HorizontalAlignment = HorizontalAlignment.Stretch;
 			Background = new SolidColorBrush(Colors.Transparent);
+			IsHitTestVisible = false;
 		}
 
 		public int PendingDragCount => Children.Count;

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.wasm.cs
@@ -104,37 +104,35 @@ namespace Windows.UI.Xaml.Input
 
 		private static ulong ToTimeStamp(double timestamp)
 		{
-			if (!_bootTime.HasValue)
-			{
-				_bootTime = (ulong)(double.Parse(WebAssemblyRuntime.InvokeJS("Date.now() - performance.now()"), CultureInfo.InvariantCulture) * TimeSpan.TicksPerMillisecond);
-			}
+			_bootTime ??= (ulong)(double.Parse(WebAssemblyRuntime.InvokeJS("Date.now() - performance.now()"), CultureInfo.InvariantCulture) * TimeSpan.TicksPerMillisecond);
 
 			return _bootTime.Value + (ulong)(timestamp * TimeSpan.TicksPerMillisecond);
 		}
 
-		private static uint ToFrameId(double timestamp)
-		{
+		internal static uint ToFrameId(double timestamp)
 			// Known limitation: After 49 days, we will overflow the uint and frame IDs will restart at 0.
-			return (uint)(timestamp % uint.MaxValue);
-		}
+			=> (uint)(timestamp % uint.MaxValue);
+
+		internal static Point ToRelativePosition(Point absolutePosition, UIElement relativeTo)
+			=> relativeTo == null
+				? absolutePosition
+				: relativeTo.TransformToVisual(null).Inverse.TransformPoint(absolutePosition);
 
 		private static PointerUpdateKind ToUpdateKind(WindowManagerInterop.HtmlPointerButtonUpdate update, PointerPointProperties props)
-		{
-			switch (update)
+			=> update switch
 			{
-				case WindowManagerInterop.HtmlPointerButtonUpdate.Left when props.IsLeftButtonPressed: return PointerUpdateKind.LeftButtonPressed;
-				case WindowManagerInterop.HtmlPointerButtonUpdate.Left: return PointerUpdateKind.LeftButtonReleased;
-				case WindowManagerInterop.HtmlPointerButtonUpdate.Middle when props.IsMiddleButtonPressed: return PointerUpdateKind.MiddleButtonPressed;
-				case WindowManagerInterop.HtmlPointerButtonUpdate.Middle: return PointerUpdateKind.MiddleButtonReleased;
-				case WindowManagerInterop.HtmlPointerButtonUpdate.Right when props.IsRightButtonPressed: return PointerUpdateKind.RightButtonPressed;
-				case WindowManagerInterop.HtmlPointerButtonUpdate.Right: return PointerUpdateKind.RightButtonReleased;
-				case WindowManagerInterop.HtmlPointerButtonUpdate.X1 when props.IsXButton1Pressed: return PointerUpdateKind.XButton1Pressed;
-				case WindowManagerInterop.HtmlPointerButtonUpdate.X1: return PointerUpdateKind.XButton1Released;
-				case WindowManagerInterop.HtmlPointerButtonUpdate.X2 when props.IsXButton2Pressed: return PointerUpdateKind.XButton1Pressed;
-				case WindowManagerInterop.HtmlPointerButtonUpdate.X2: return PointerUpdateKind.XButton1Released;
-				default: return PointerUpdateKind.Other;
-			}
-		}
+				WindowManagerInterop.HtmlPointerButtonUpdate.Left when props.IsLeftButtonPressed => PointerUpdateKind.LeftButtonPressed,
+				WindowManagerInterop.HtmlPointerButtonUpdate.Left => PointerUpdateKind.LeftButtonReleased,
+				WindowManagerInterop.HtmlPointerButtonUpdate.Middle when props.IsMiddleButtonPressed => PointerUpdateKind.MiddleButtonPressed,
+				WindowManagerInterop.HtmlPointerButtonUpdate.Middle => PointerUpdateKind.MiddleButtonReleased,
+				WindowManagerInterop.HtmlPointerButtonUpdate.Right when props.IsRightButtonPressed => PointerUpdateKind.RightButtonPressed,
+				WindowManagerInterop.HtmlPointerButtonUpdate.Right => PointerUpdateKind.RightButtonReleased,
+				WindowManagerInterop.HtmlPointerButtonUpdate.X1 when props.IsXButton1Pressed => PointerUpdateKind.XButton1Pressed,
+				WindowManagerInterop.HtmlPointerButtonUpdate.X1 => PointerUpdateKind.XButton1Released,
+				WindowManagerInterop.HtmlPointerButtonUpdate.X2 when props.IsXButton2Pressed => PointerUpdateKind.XButton1Pressed,
+				WindowManagerInterop.HtmlPointerButtonUpdate.X2 => PointerUpdateKind.XButton1Released,
+				_ => PointerUpdateKind.Other
+			};
 		#endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.EventRegistration.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.EventRegistration.wasm.cs
@@ -263,17 +263,25 @@ namespace Windows.UI.Xaml
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static int DispatchEvent(int handle, string eventName, string eventArgs)
 		{
-			// Dispatch to right object, if we can find it
-			if (GetElementFromHandle(handle) is UIElement element)
+			try
 			{
-				return (int)element.InternalDispatchEvent(eventName, nativeEventPayload: eventArgs);
-			}
-			else
-			{
-				Console.Error.WriteLine($"No UIElement found for htmlId \"{handle}\"");
-			}
+				// Dispatch to right object, if we can find it
+				if (GetElementFromHandle(handle) is UIElement element)
+				{
+					return (int)element.InternalDispatchEvent(eventName, nativeEventPayload: eventArgs);
+				}
+				else
+				{
+					Console.Error.WriteLine($"No UIElement found for htmlId \"{handle}\"");
+				}
 
-			return (int)HtmlEventDispatchResult.NotDispatched;
+				return (int)HtmlEventDispatchResult.NotDispatched;
+			}
+			catch (Exception error)
+			{
+				Console.Error.WriteLine("Failed to dispatch event: " + error);
+				throw;
+			}
 		}
 
 		private readonly Dictionary<string, EventRegistration> _eventHandlers = new Dictionary<string, EventRegistration>(StringComparer.OrdinalIgnoreCase);

--- a/src/Uno.UI/UI/Xaml/UIElement.EventRegistration.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.EventRegistration.wasm.cs
@@ -263,8 +263,10 @@ namespace Windows.UI.Xaml
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static int DispatchEvent(int handle, string eventName, string eventArgs)
 		{
+#if DEBUG
 			try
 			{
+#endif
 				// Dispatch to right object, if we can find it
 				if (GetElementFromHandle(handle) is UIElement element)
 				{
@@ -276,12 +278,14 @@ namespace Windows.UI.Xaml
 				}
 
 				return (int)HtmlEventDispatchResult.NotDispatched;
+#if DEBUG
 			}
 			catch (Exception error)
 			{
 				Console.Error.WriteLine("Failed to dispatch event: " + error);
 				throw;
 			}
+#endif
 		}
 
 		private readonly Dictionary<string, EventRegistration> _eventHandlers = new Dictionary<string, EventRegistration>(StringComparer.OrdinalIgnoreCase);

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -235,8 +235,10 @@ namespace Windows.UI.Xaml
 
 		private void InitDragAndDrop()
 		{
-			DragDrop = new DragDropManager(this);
-			CoreDragDropManager.SetForCurrentView(DragDrop);
+			var coreManager = CoreDragDropManager.CreateForCurrentView(); // So it's ready to be accessed by ui manager and platform extension
+			var uiManager = DragDrop = new DragDropManager(this);
+
+			coreManager.SetUIManager(uiManager);
 		}
 
 		internal IDisposable OpenDragAndDrop(DragView dragView)

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -702,8 +702,8 @@ declare namespace Windows.ApplicationModel.DataTransfer {
 }
 declare namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core {
     class DragDropExtension {
-        private static _dispatchDragAndDropMethod;
-        private static _dispatchDragAndDropArgs;
+        private static _dispatchDropEventMethod;
+        private static _dispatchDragDropArgs;
         private static _current;
         private static _nextDropId;
         private _dropHandler;

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -700,6 +700,21 @@ declare namespace Windows.ApplicationModel.DataTransfer {
         static showShareUI(title: string, text: string, url: string): Promise<string>;
     }
 }
+declare namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core {
+    class DragDropExtension {
+        private static _dispatchDragAndDropMethod;
+        private static _dispatchDragAndDropArgs;
+        private static _current;
+        private _pendingDropData;
+        static enable(pArgs: number): void;
+        static disable(pArgs: number): void;
+        constructor();
+        dispose(): void;
+        private dispatchDropEvent;
+        static retrieveFiles(itemIds: number[]): Promise<Uno.Storage.NativeStorageItemInfo[]>;
+        static retrieveText(itemId: number): Promise<string>;
+    }
+}
 declare namespace Uno.Devices.Enumeration.Internal.Providers.Midi {
     class MidiDeviceClassProvider {
         static findDevices(findInputDevices: boolean): string;
@@ -1241,6 +1256,21 @@ declare class ApplicationDataContainer_TryGetValueParams {
 declare class ApplicationDataContainer_TryGetValueReturn {
     Value: string;
     HasValue: boolean;
+    marshal(pData: number): void;
+}
+declare class DragDropExtensionEventArgs {
+    eventName: string;
+    timestamp: number;
+    x: number;
+    y: number;
+    buttons: number;
+    shift: boolean;
+    ctrl: boolean;
+    alt: boolean;
+    allowedOperations: string;
+    acceptedOperation: string;
+    dataItems: string;
+    static unmarshal(pData: number): DragDropExtensionEventArgs;
     marshal(pData: number): void;
 }
 declare class StorageFolderMakePersistentParams {

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -705,14 +705,18 @@ declare namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core {
         private static _dispatchDragAndDropMethod;
         private static _dispatchDragAndDropArgs;
         private static _current;
+        private static _nextDropId;
+        private _dropHandler;
+        private _pendingDropId;
         private _pendingDropData;
         static enable(pArgs: number): void;
         static disable(pArgs: number): void;
         constructor();
         dispose(): void;
         private dispatchDropEvent;
-        static retrieveFiles(itemIds: number[]): Promise<Uno.Storage.NativeStorageItemInfo[]>;
         static retrieveText(itemId: number): Promise<string>;
+        static retrieveFiles(itemIds: number | number[]): Promise<string>;
+        private static getAsFile;
     }
 }
 declare namespace Uno.Devices.Enumeration.Internal.Providers.Midi {
@@ -994,14 +998,15 @@ declare namespace Uno.Storage {
 declare namespace Uno.Storage {
     class NativeStorageItem {
         private static generateGuidBinding;
-        private static _guidToHandleMap;
-        private static _handleToGuidMap;
-        static addHandle(guid: string, handle: FileSystemHandle): void;
-        static removeHandle(guid: string): void;
-        static getHandle(guid: string): FileSystemHandle;
-        static getGuid(handle: FileSystemHandle): string;
-        static getInfos(...handles: FileSystemHandle[]): NativeStorageItemInfo[];
-        private static storeHandles;
+        private static _guidToItemMap;
+        private static _itemToGuidMap;
+        static addItem(guid: string, item: FileSystemHandle | File): void;
+        static removeItem(guid: string): void;
+        static getItem(guid: string): FileSystemHandle | File;
+        static getFile(guid: string): Promise<File>;
+        static getGuid(item: FileSystemHandle | File): string;
+        static getInfos(...items: Array<FileSystemHandle | File>): NativeStorageItemInfo[];
+        private static storeItems;
         private static generateGuids;
     }
 }
@@ -1260,16 +1265,17 @@ declare class ApplicationDataContainer_TryGetValueReturn {
 }
 declare class DragDropExtensionEventArgs {
     eventName: string;
+    allowedOperations: string;
+    acceptedOperation: string;
+    dataItems: string;
     timestamp: number;
     x: number;
     y: number;
+    id: number;
     buttons: number;
     shift: boolean;
     ctrl: boolean;
     alt: boolean;
-    allowedOperations: string;
-    acceptedOperation: string;
-    dataItems: string;
     static unmarshal(pData: number): DragDropExtensionEventArgs;
     marshal(pData: number): void;
 }

--- a/src/Uno.UI/ts/Interop/AsyncInteropHelper.ts
+++ b/src/Uno.UI/ts/Interop/AsyncInteropHelper.ts
@@ -28,10 +28,22 @@
 						}
 					})
 					.catch(err => {
-						AsyncInteropHelper.dispatchErrorMethod(handle, err);
+						if (typeof err == "string") {
+							AsyncInteropHelper.dispatchErrorMethod(handle, err);
+						} else if (err.message && err.stack) {
+							AsyncInteropHelper.dispatchErrorMethod(handle, err.message + "\n" + err.stack);
+						} else {
+							AsyncInteropHelper.dispatchErrorMethod(handle, "" + err);
+						}
 					});
 			} catch (err) {
-				AsyncInteropHelper.dispatchErrorMethod(handle, err);
+				if (typeof err == "string") {
+					AsyncInteropHelper.dispatchErrorMethod(handle, err);
+				} else if (err.message && err.stack) {
+					AsyncInteropHelper.dispatchErrorMethod(handle, err.message + "\n" + err.stack);
+				} else {
+					AsyncInteropHelper.dispatchErrorMethod(handle, "" + err);
+				}
 			}
 		}
 	}

--- a/src/Uno.UI/ts/MonoSupport.ts
+++ b/src/Uno.UI/ts/MonoSupport.ts
@@ -31,6 +31,7 @@ namespace MonoSupport {
 					jsCallDispatcher.registerScope("UnoStatic", Uno.UI.WindowManager);
 					jsCallDispatcher.registerScope("UnoStatic_Windows_Storage_StorageFolder", Windows.Storage.StorageFolder);
 					jsCallDispatcher.registerScope("UnoStatic_Windows_Storage_ApplicationDataContainer", Windows.Storage.ApplicationDataContainer);
+					jsCallDispatcher.registerScope("UnoStatic_Windows_ApplicationModel_DataTransfer_DragDrop_Core_DragDropExtension", Windows.ApplicationModel.DataTransfer.DragDrop.Core.DragDropExtension);
 					jsCallDispatcher._isUnoRegistered = true;
 				}
 

--- a/src/Uno.UI/ts/Windows/ApplicationModel/DataTransfer/DragAndDropExtension.ts
+++ b/src/Uno.UI/ts/Windows/ApplicationModel/DataTransfer/DragAndDropExtension.ts
@@ -1,0 +1,134 @@
+﻿namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core {
+
+	export class DragDropExtension {
+		// https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API
+
+		private static _dispatchDragAndDropMethod: any;
+		private static _dispatchDragAndDropArgs: number;
+		private static _current: DragDropExtension;
+
+		private _pendingDropData: DataTransfer;
+
+		public static enable(pArgs: number): void {
+			if (DragDropExtension._current) {
+				throw new Error("A DragDropExtension has already been enabled");
+			}
+
+			this._dispatchDragAndDropMethod = (<any>Module).mono_bind_static_method("[Uno.UI] Windows.ApplicationModel.DataTransfer.DragDrop.Core.DragDropExtension:OnNativeDragAndDrop");
+			this._dispatchDragAndDropArgs = pArgs;
+
+			this._current = new DragDropExtension();
+		}
+
+		public static disable(pArgs: number): void {
+			if (DragDropExtension._dispatchDragAndDropArgs != pArgs) {
+				throw new Error("The current DragDropExtension does not match the provided args");
+			}
+
+			DragDropExtension._current.dispose();
+			DragDropExtension._current = null;
+		}
+
+		constructor() {
+			// Events fired on the drop target
+			// Note: dragenter and dragover events will enable drop on the app
+			document.addEventListener("dragenter", this.dispatchDropEvent);
+			document.addEventListener("dragover", this.dispatchDropEvent);
+			document.addEventListener("dragleave", this.dispatchDropEvent); // Seems to be raised also on drop?
+			document.addEventListener("drop", this.dispatchDropEvent);
+
+			// Events fired on the draggable target (the source element)
+			//document.addEventListener("dragstart", this.dispatchDragStart);
+			//document.addEventListener("drag", this.dispatchDrag);
+			//document.addEventListener("dragend", this.dispatchDragEnd);
+		}
+
+		public dispose() {
+			// Events fired on the drop target
+			// Note: dragenter and dragover events will enable drop on the app
+			document.removeEventListener("dragenter", this.dispatchDropEvent);
+			document.removeEventListener("dragover", this.dispatchDropEvent);
+			document.removeEventListener("dragleave", this.dispatchDropEvent); // Seems to be raised also on drop?
+			document.removeEventListener("drop", this.dispatchDropEvent);
+
+			// Events fired on the draggable target (the source element)
+			//document.removeEventListener("dragstart", this.dispatchDragStart);
+			//document.removeEventListener("drag", this.dispatchDrag);
+			//document.removeEventListener("dragend", this.dispatchDragEnd);
+		}
+
+		private dispatchDropEvent(evt: DragEvent): any {
+			// We must keep a reference to the dataTransfer in order to be able to retrieve data items
+			this._pendingDropData = evt.dataTransfer;
+
+			// Prepare args
+			let args = new DragDropExtensionEventArgs();
+			args.eventName = evt.type;
+			args.timestamp = evt.timeStamp;
+			args.x = evt.clientX;
+			args.y = evt.clientY;
+			args.buttons = evt.buttons;
+			args.shift = evt.shiftKey;
+			args.ctrl = evt.ctrlKey;
+			args.alt = evt.altKey;
+			if (evt.type == "dragenter") { // We use the dataItems only for enter, no needs to copy them every times!
+				const items = new Array<any>();
+				for (let itemId = 0; itemId < evt.dataTransfer.items.length; itemId++) {
+					const item = evt.dataTransfer.items[itemId];
+					items.push({ id: itemId, kind: item.kind, type: item.type });
+				}
+				args.dataItems = JSON.stringify(items);
+
+				args.allowedOperations = evt.dataTransfer.effectAllowed;
+			} else {
+				// Must be set for marshaling
+				args.dataItems = "";
+				args.allowedOperations = "";
+			}
+			args.acceptedOperation = "none";
+
+			// Raise the managed event
+			args.marshal(DragDropExtension._dispatchDragAndDropArgs);
+			DragDropExtension._dispatchDragAndDropMethod();
+
+			// Read response from managed code
+			args = DragDropExtensionEventArgs.unmarshal(DragDropExtension._dispatchDragAndDropArgs);
+
+			evt.dataTransfer.dropEffect = ((args.acceptedOperation) as any);
+
+			// No matter if the managed code handled the event, we want to prevent thee default behavior (like opening a drop link)
+			evt.preventDefault();
+		}
+
+		public static async retrieveFiles(itemIds: number[]): Promise<Uno.Storage.NativeStorageItemInfo[]> {
+
+			const data = DragDropExtension._current?._pendingDropData;
+			if (data == null) {
+				throw new Error("No pending drag and drop data.");
+			}
+
+			const fileHandles: FileSystemHandle[] = [];
+			for (let id of itemIds) {
+				fileHandles.push(await data.items[id].getAsFileSystemHandle());
+			}
+
+			return Uno.Storage.NativeStorageItem.getInfos(...fileHandles);
+		}
+
+		public static async retrieveText(itemId: number): Promise<string> {
+
+			const data = DragDropExtension._current?._pendingDropData;
+			if (data == null) {
+				throw new Error("No pending drag and drop data.");
+			}
+
+			return new Promise((resolve, reject) => {
+				var timeout = setTimeout(() => reject("Timeout: for security reason, you cannot access data before drop."), 15000);
+				data.items[itemId].getAsString(str => {
+					clearTimeout(timeout);
+					resolve(str);
+				});
+			});
+		}
+	}
+}

--- a/src/Uno.UI/ts/Windows/Storage/NativeStorageFile.ts
+++ b/src/Uno.UI/ts/Windows/Storage/NativeStorageFile.ts
@@ -3,8 +3,7 @@
 	export class NativeStorageFile {
 
 		public static async getBasicPropertiesAsync(guid: string): Promise<string> {
-			const handle = <FileSystemFileHandle>NativeStorageItem.getHandle(guid);
-			var file = await handle.getFile();
+			const file = await NativeStorageItem.getFile(guid);
 			var propertyString = "";
 			propertyString += file.size;
 			propertyString += "|";

--- a/src/Uno.UI/ts/Windows/Storage/NativeStorageFolder.ts
+++ b/src/Uno.UI/ts/Windows/Storage/NativeStorageFolder.ts
@@ -9,7 +9,7 @@
 		 */
 		public static async createFolderAsync(parentGuid: string, folderName: string): Promise<string> {
 			try {
-				const parentHandle = <FileSystemDirectoryHandle>NativeStorageItem.getHandle(parentGuid);
+				const parentHandle = <FileSystemDirectoryHandle>NativeStorageItem.getItem(parentGuid);
 
 				const newDirectoryHandle = await parentHandle.getDirectoryHandle(folderName, {
 					create: true,
@@ -31,7 +31,7 @@
 		 */
 		public static async createFileAsync(parentGuid: string, fileName: string): Promise<string> {
 			try {
-				const parentHandle = <FileSystemDirectoryHandle>NativeStorageItem.getHandle(parentGuid);
+				const parentHandle = <FileSystemDirectoryHandle>NativeStorageItem.getItem(parentGuid);
 
 				const newFileHandle = await parentHandle.getFileHandle(fileName, {
 					create: true,
@@ -53,7 +53,7 @@
 		 * @returns A GUID of the folder if found, otherwise null.
 		 */
 		public static async tryGetFolderAsync(parentGuid: string, folderName: string): Promise<string> {
-			const parentHandle = <FileSystemDirectoryHandle>NativeStorageItem.getHandle(parentGuid);
+			const parentHandle = <FileSystemDirectoryHandle>NativeStorageItem.getItem(parentGuid);
 
 			let nestedDirectoryHandle: FileSystemDirectoryHandle = undefined;
 
@@ -77,7 +77,7 @@
 		* @returns A GUID of the folder if found, otherwise null.
 		*/
 		public static async tryGetFileAsync(parentGuid: string, fileName: string): Promise<string> {
-			const parentHandle = <FileSystemDirectoryHandle>NativeStorageItem.getHandle(parentGuid);
+			const parentHandle = <FileSystemDirectoryHandle>NativeStorageItem.getItem(parentGuid);
 
 			let fileHandle: FileSystemFileHandle = undefined;
 
@@ -96,7 +96,7 @@
 
 		public static async deleteItemAsync(parentGuid: string, itemName: string): Promise<string> {
 			try {
-				const parentHandle = <FileSystemDirectoryHandle>NativeStorageItem.getHandle(parentGuid);
+				const parentHandle = <FileSystemDirectoryHandle>NativeStorageItem.getItem(parentGuid);
 
 				await parentHandle.removeEntry(itemName, { recursive: true });
 
@@ -134,7 +134,7 @@
 		}
 
 		private static async getEntriesAsync(guid: string, includeFiles: boolean, includeDirectories: boolean): Promise<string> {
-			const folderHandle = <FileSystemDirectoryHandle>NativeStorageItem.getHandle(guid);
+			const folderHandle = <FileSystemDirectoryHandle>NativeStorageItem.getItem(guid);
 
 			var entries: FileSystemHandle[] = [];
 

--- a/src/Uno.UI/ts/Windows/Storage/NativeStorageItem.ts
+++ b/src/Uno.UI/ts/Windows/Storage/NativeStorageItem.ts
@@ -21,7 +21,7 @@
 		}
 
 		public static async getFile(guid: string): Promise<File> {
-			const item = this.getItem(guid);
+			const item = NativeStorageItem.getItem(guid);
 
 			if (item instanceof File) {
 				return item as File;
@@ -41,10 +41,10 @@
 		}
 
 		public static getInfos(...items: Array<FileSystemHandle|File>): NativeStorageItemInfo[] {
-			var itemsWithoutGuids: Array<FileSystemHandle|File> = [];
+			const itemsWithoutGuids: Array<FileSystemHandle|File> = [];
 
-			for (var item of items) {
-				var guid = NativeStorageItem.getGuid(item);
+			for (const item of items) {
+				const guid = NativeStorageItem.getGuid(item);
 				if (!guid) {
 					itemsWithoutGuids.push(item);
 				}
@@ -52,11 +52,11 @@
 
 			NativeStorageItem.storeItems(itemsWithoutGuids);
 
-			var results: NativeStorageItemInfo[] = [];
+			const results: NativeStorageItemInfo[] = [];
 
-			for (var item of items) {
-				var guid = NativeStorageItem.getGuid(item);
-				var info = new NativeStorageItemInfo();
+			for (const item of items) {
+				const guid = NativeStorageItem.getGuid(item);
+				const info = new NativeStorageItemInfo();
 				info.id = guid;
 				info.name = item.name;
 				info.isFile = item instanceof File || (item as FileSystemHandle).kind === "file";
@@ -67,8 +67,8 @@
 		}
 
 		private static storeItems(handles: Array<FileSystemHandle|File>) {
-			var missingGuids = NativeStorageItem.generateGuids(handles.length);
-			for (var i = 0; i < handles.length; i++) {
+			const missingGuids = NativeStorageItem.generateGuids(handles.length);
+			for (let i = 0; i < handles.length; i++) {
 				NativeStorageItem.addItem(missingGuids[i], handles[i]);
 			}
 		}
@@ -78,7 +78,7 @@
 				NativeStorageItem.generateGuidBinding = (<any>Module).mono_bind_static_method("[Uno] Uno.Storage.NativeStorageItem:GenerateGuids");
 			}
 
-			var guids = NativeStorageItem.generateGuidBinding(count);
+			const guids = NativeStorageItem.generateGuidBinding(count);
 			return guids.split(";");
 		}
 	}

--- a/src/Uno.UI/ts/Windows/Storage/NativeStorageItem.ts
+++ b/src/Uno.UI/ts/Windows/Storage/NativeStorageItem.ts
@@ -2,58 +2,74 @@
 	export class NativeStorageItem {
 
 		private static generateGuidBinding: (count: number) => string;
-		private static _guidToHandleMap: Map<string, FileSystemHandle> = new Map<string, FileSystemHandle>();
-		private static _handleToGuidMap: Map<FileSystemHandle, string> = new Map<FileSystemHandle, string>();
+		private static _guidToItemMap: Map<string, FileSystemHandle|File> = new Map<string, FileSystemHandle|File>();
+		private static _itemToGuidMap: Map<FileSystemHandle|File, string> = new Map<FileSystemHandle|File, string>();
 
-		public static addHandle(guid: string, handle: FileSystemHandle) {
-			NativeStorageItem._guidToHandleMap.set(guid, handle);
-			NativeStorageItem._handleToGuidMap.set(handle, guid);
+		public static addItem(guid: string, item: FileSystemHandle | File) {
+			NativeStorageItem._guidToItemMap.set(guid, item);
+			NativeStorageItem._itemToGuidMap.set(item, guid);
 		}
 
-		public static removeHandle(guid: string) {
-			const handle = NativeStorageItem._guidToHandleMap.get(guid);
-			NativeStorageItem._guidToHandleMap.delete(guid);
-			NativeStorageItem._handleToGuidMap.delete(handle);
+		public static removeItem(guid: string) {
+			const handle = NativeStorageItem._guidToItemMap.get(guid);
+			NativeStorageItem._guidToItemMap.delete(guid);
+			NativeStorageItem._itemToGuidMap.delete(handle);
 		}
 
-		public static getHandle(guid: string): FileSystemHandle {
-			return NativeStorageItem._guidToHandleMap.get(guid);
+		public static getItem(guid: string): FileSystemHandle|File {
+			return NativeStorageItem._guidToItemMap.get(guid);
 		}
 
-		public static getGuid(handle: FileSystemHandle): string {
-			return NativeStorageItem._handleToGuidMap.get(handle);
+		public static async getFile(guid: string): Promise<File> {
+			const item = this.getItem(guid);
+
+			if (item instanceof File) {
+				return item as File;
+			}
+			if (item instanceof FileSystemFileHandle) {
+				return await (item as FileSystemFileHandle).getFile();
+			}
+			if (item instanceof FileSystemDirectoryHandle) {
+				throw new Error("Item " + guid + " is a directory handle. You cannot use it as a File!");
+			}
+
+			throw new Error("Item " + guid + " is of an unknown type. You cannot use it as a File!");
 		}
 
-		public static getInfos(... handles: FileSystemHandle[]): NativeStorageItemInfo[] {
-			var handlesWithoutGuids: FileSystemHandle[] = [];
+		public static getGuid(item: FileSystemHandle | File): string {
+			return NativeStorageItem._itemToGuidMap.get(item);
+		}
 
-			for (var handle of handles) {
-				var guid = NativeStorageItem.getGuid(handle);
+		public static getInfos(...items: Array<FileSystemHandle|File>): NativeStorageItemInfo[] {
+			var itemsWithoutGuids: Array<FileSystemHandle|File> = [];
+
+			for (var item of items) {
+				var guid = NativeStorageItem.getGuid(item);
 				if (!guid) {
-					handlesWithoutGuids.push(handle);
+					itemsWithoutGuids.push(item);
 				}
 			}
 
-			NativeStorageItem.storeHandles(handlesWithoutGuids);
+			NativeStorageItem.storeItems(itemsWithoutGuids);
 
 			var results: NativeStorageItemInfo[] = [];
 
-			for (var handle of handles) {
-				var guid = NativeStorageItem.getGuid(handle);
+			for (var item of items) {
+				var guid = NativeStorageItem.getGuid(item);
 				var info = new NativeStorageItemInfo();
 				info.id = guid;
-				info.name = handle.name;
-				info.isFile = handle.kind === "file";
+				info.name = item.name;
+				info.isFile = item instanceof File || (item as FileSystemHandle).kind === "file";
 				results.push(info);
 			}
 
 			return results;
 		}
 
-		private static storeHandles(handles: FileSystemHandle[]) {
+		private static storeItems(handles: Array<FileSystemHandle|File>) {
 			var missingGuids = NativeStorageItem.generateGuids(handles.length);
 			for (var i = 0; i < handles.length; i++) {
-				NativeStorageItem.addHandle(missingGuids[i], handles[i]);
+				NativeStorageItem.addItem(missingGuids[i], handles[i]);
 			}
 		}
 

--- a/src/Uno.UI/ts/Windows/Storage/Streams/NativeFileReadStream.ts
+++ b/src/Uno.UI/ts/Windows/Storage/Streams/NativeFileReadStream.ts
@@ -10,8 +10,7 @@
 		}
 
 		public static async openAsync(streamId: string, fileId: string): Promise<string> {
-			const handle = <FileSystemFileHandle>NativeStorageItem.getHandle(fileId);
-			const file = await handle.getFile();
+			const file = await NativeStorageItem.getFile(fileId);
 			const fileSize = file.size;
 			const stream = new NativeFileReadStream(file);
 			NativeFileReadStream._streamMap.set(streamId, stream);

--- a/src/Uno.UI/tsBindings/DragDropExtensionEventArgs.ts
+++ b/src/Uno.UI/tsBindings/DragDropExtensionEventArgs.ts
@@ -1,0 +1,139 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class DragDropExtensionEventArgs
+{
+	/* Pack=8 */
+	public eventName : string;
+	public timestamp : number;
+	public x : number;
+	public y : number;
+	public buttons : number;
+	public shift : boolean;
+	public ctrl : boolean;
+	public alt : boolean;
+	public allowedOperations : string;
+	public acceptedOperation : string;
+	public dataItems : string;
+	public static unmarshal(pData:number) : DragDropExtensionEventArgs
+	{
+		const ret = new DragDropExtensionEventArgs();
+		
+		{
+			const ptr = Module.getValue(pData + 0, "*");
+			if(ptr !== 0)
+			{
+				ret.eventName = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.eventName = null;
+			}
+		}
+		
+		{
+			ret.timestamp = Number(Module.getValue(pData + 8, "double"));
+		}
+		
+		{
+			ret.x = Number(Module.getValue(pData + 16, "double"));
+		}
+		
+		{
+			ret.y = Number(Module.getValue(pData + 24, "double"));
+		}
+		
+		{
+			ret.buttons = Number(Module.getValue(pData + 32, "i32"));
+		}
+		
+		{
+			ret.shift = Boolean(Module.getValue(pData + 40, "i32"));
+		}
+		
+		{
+			ret.ctrl = Boolean(Module.getValue(pData + 48, "i32"));
+		}
+		
+		{
+			ret.alt = Boolean(Module.getValue(pData + 56, "i32"));
+		}
+		
+		{
+			const ptr = Module.getValue(pData + 64, "*");
+			if(ptr !== 0)
+			{
+				ret.allowedOperations = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.allowedOperations = null;
+			}
+		}
+		
+		{
+			const ptr = Module.getValue(pData + 72, "*");
+			if(ptr !== 0)
+			{
+				ret.acceptedOperation = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.acceptedOperation = null;
+			}
+		}
+		
+		{
+			const ptr = Module.getValue(pData + 80, "*");
+			if(ptr !== 0)
+			{
+				ret.dataItems = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.dataItems = null;
+			}
+		}
+		return ret;
+	}
+	public marshal(pData:number)
+	{
+		
+		{
+			const stringLength = lengthBytesUTF8(this.eventName);
+			const pString = Module._malloc(stringLength + 1);
+			stringToUTF8(this.eventName, pString, stringLength + 1);
+			Module.setValue(pData + 0, pString, "*");
+		}
+		Module.setValue(pData + 8, this.timestamp, "double");
+		Module.setValue(pData + 16, this.x, "double");
+		Module.setValue(pData + 24, this.y, "double");
+		Module.setValue(pData + 32, this.buttons, "i32");
+		Module.setValue(pData + 40, this.shift, "i32");
+		Module.setValue(pData + 48, this.ctrl, "i32");
+		Module.setValue(pData + 56, this.alt, "i32");
+		
+		{
+			const stringLength = lengthBytesUTF8(this.allowedOperations);
+			const pString = Module._malloc(stringLength + 1);
+			stringToUTF8(this.allowedOperations, pString, stringLength + 1);
+			Module.setValue(pData + 64, pString, "*");
+		}
+		
+		{
+			const stringLength = lengthBytesUTF8(this.acceptedOperation);
+			const pString = Module._malloc(stringLength + 1);
+			stringToUTF8(this.acceptedOperation, pString, stringLength + 1);
+			Module.setValue(pData + 72, pString, "*");
+		}
+		
+		{
+			const stringLength = lengthBytesUTF8(this.dataItems);
+			const pString = Module._malloc(stringLength + 1);
+			stringToUTF8(this.dataItems, pString, stringLength + 1);
+			Module.setValue(pData + 80, pString, "*");
+		}
+	}
+}

--- a/src/Uno.UI/tsBindings/DragDropExtensionEventArgs.ts
+++ b/src/Uno.UI/tsBindings/DragDropExtensionEventArgs.ts
@@ -1,18 +1,19 @@
 /* TSBindingsGenerator Generated code -- this code is regenerated on each build */
 class DragDropExtensionEventArgs
 {
-	/* Pack=8 */
+	/* Pack=4 */
 	public eventName : string;
+	public allowedOperations : string;
+	public acceptedOperation : string;
+	public dataItems : string;
 	public timestamp : number;
 	public x : number;
 	public y : number;
+	public id : number;
 	public buttons : number;
 	public shift : boolean;
 	public ctrl : boolean;
 	public alt : boolean;
-	public allowedOperations : string;
-	public acceptedOperation : string;
-	public dataItems : string;
 	public static unmarshal(pData:number) : DragDropExtensionEventArgs
 	{
 		const ret = new DragDropExtensionEventArgs();
@@ -31,35 +32,7 @@ class DragDropExtensionEventArgs
 		}
 		
 		{
-			ret.timestamp = Number(Module.getValue(pData + 8, "double"));
-		}
-		
-		{
-			ret.x = Number(Module.getValue(pData + 16, "double"));
-		}
-		
-		{
-			ret.y = Number(Module.getValue(pData + 24, "double"));
-		}
-		
-		{
-			ret.buttons = Number(Module.getValue(pData + 32, "i32"));
-		}
-		
-		{
-			ret.shift = Boolean(Module.getValue(pData + 40, "i32"));
-		}
-		
-		{
-			ret.ctrl = Boolean(Module.getValue(pData + 48, "i32"));
-		}
-		
-		{
-			ret.alt = Boolean(Module.getValue(pData + 56, "i32"));
-		}
-		
-		{
-			const ptr = Module.getValue(pData + 64, "*");
+			const ptr = Module.getValue(pData + 4, "*");
 			if(ptr !== 0)
 			{
 				ret.allowedOperations = String(Module.UTF8ToString(ptr));
@@ -72,7 +45,7 @@ class DragDropExtensionEventArgs
 		}
 		
 		{
-			const ptr = Module.getValue(pData + 72, "*");
+			const ptr = Module.getValue(pData + 8, "*");
 			if(ptr !== 0)
 			{
 				ret.acceptedOperation = String(Module.UTF8ToString(ptr));
@@ -85,7 +58,7 @@ class DragDropExtensionEventArgs
 		}
 		
 		{
-			const ptr = Module.getValue(pData + 80, "*");
+			const ptr = Module.getValue(pData + 12, "*");
 			if(ptr !== 0)
 			{
 				ret.dataItems = String(Module.UTF8ToString(ptr));
@@ -95,6 +68,38 @@ class DragDropExtensionEventArgs
 			{
 				ret.dataItems = null;
 			}
+		}
+		
+		{
+			ret.timestamp = Number(Module.getValue(pData + 16, "double"));
+		}
+		
+		{
+			ret.x = Number(Module.getValue(pData + 24, "double"));
+		}
+		
+		{
+			ret.y = Number(Module.getValue(pData + 32, "double"));
+		}
+		
+		{
+			ret.id = Number(Module.getValue(pData + 40, "i32"));
+		}
+		
+		{
+			ret.buttons = Number(Module.getValue(pData + 44, "i32"));
+		}
+		
+		{
+			ret.shift = Boolean(Module.getValue(pData + 48, "i32"));
+		}
+		
+		{
+			ret.ctrl = Boolean(Module.getValue(pData + 52, "i32"));
+		}
+		
+		{
+			ret.alt = Boolean(Module.getValue(pData + 56, "i32"));
 		}
 		return ret;
 	}
@@ -107,33 +112,34 @@ class DragDropExtensionEventArgs
 			stringToUTF8(this.eventName, pString, stringLength + 1);
 			Module.setValue(pData + 0, pString, "*");
 		}
-		Module.setValue(pData + 8, this.timestamp, "double");
-		Module.setValue(pData + 16, this.x, "double");
-		Module.setValue(pData + 24, this.y, "double");
-		Module.setValue(pData + 32, this.buttons, "i32");
-		Module.setValue(pData + 40, this.shift, "i32");
-		Module.setValue(pData + 48, this.ctrl, "i32");
-		Module.setValue(pData + 56, this.alt, "i32");
 		
 		{
 			const stringLength = lengthBytesUTF8(this.allowedOperations);
 			const pString = Module._malloc(stringLength + 1);
 			stringToUTF8(this.allowedOperations, pString, stringLength + 1);
-			Module.setValue(pData + 64, pString, "*");
+			Module.setValue(pData + 4, pString, "*");
 		}
 		
 		{
 			const stringLength = lengthBytesUTF8(this.acceptedOperation);
 			const pString = Module._malloc(stringLength + 1);
 			stringToUTF8(this.acceptedOperation, pString, stringLength + 1);
-			Module.setValue(pData + 72, pString, "*");
+			Module.setValue(pData + 8, pString, "*");
 		}
 		
 		{
 			const stringLength = lengthBytesUTF8(this.dataItems);
 			const pString = Module._malloc(stringLength + 1);
 			stringToUTF8(this.dataItems, pString, stringLength + 1);
-			Module.setValue(pData + 80, pString, "*");
+			Module.setValue(pData + 12, pString, "*");
 		}
+		Module.setValue(pData + 16, this.timestamp, "double");
+		Module.setValue(pData + 24, this.x, "double");
+		Module.setValue(pData + 32, this.y, "double");
+		Module.setValue(pData + 40, this.id, "i32");
+		Module.setValue(pData + 44, this.buttons, "i32");
+		Module.setValue(pData + 48, this.shift, "i32");
+		Module.setValue(pData + 52, this.ctrl, "i32");
+		Module.setValue(pData + 56, this.alt, "i32");
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.cs
@@ -73,7 +73,7 @@ namespace Windows.ApplicationModel.DataTransfer
 				}
 				catch (Exception e)
 				{
-					this.Log().Error($"Failed to asynchronously retrieve the data for od '{formatId}'", e);
+					this.Log().Error($"Failed to asynchronously retrieve the data for id '{formatId}'", e);
 				}
 				finally
 				{

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.cs
@@ -41,6 +41,16 @@ namespace Windows.ApplicationModel.DataTransfer
 
 		public DataPackagePropertySet Properties { get; } = new DataPackagePropertySet();
 
+		internal bool Contains(string formatId)
+		{
+			if (formatId is null)
+			{
+				throw new ArgumentNullException(nameof(formatId));
+			}
+
+			return _data.ContainsKey(formatId);
+		}
+
 		public void SetData(string formatId, object value)
 		{
 			ImmutableInterlocked.Update(ref _data, SetDataCore, (formatId, value));

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DragDrop/Core/CoreDragDropManager.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DragDrop/Core/CoreDragDropManager.cs
@@ -16,26 +16,41 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 		public static CoreDragDropManager? GetForCurrentView()
 			=> _current;
 
-		internal static void SetForCurrentView(IDragDropManager manager)
-			=> _current = new CoreDragDropManager(manager);
+		internal static CoreDragDropManager CreateForCurrentView()
+			=> _current = new CoreDragDropManager();
 
 		public event TypedEventHandler<CoreDragDropManager, CoreDropOperationTargetRequestedEventArgs>? TargetRequested;
 
-		private readonly IDragDropManager _manager;
+		private IDragDropManager? _manager;
 
 		public bool AreConcurrentOperationsEnabled
 		{
-			get => _manager.AreConcurrentOperationsEnabled;
-			set => _manager.AreConcurrentOperationsEnabled = value;
+			get => _manager?.AreConcurrentOperationsEnabled ?? false;
+			set
+			{
+				if (_manager is null)
+				{
+					return;
+				}
+
+				_manager.AreConcurrentOperationsEnabled = value;
+			}
 		}
 
-		private CoreDragDropManager(IDragDropManager manager)
+		private CoreDragDropManager()
 		{
-			_manager = manager;
 		}
+
+		internal void SetUIManager(IDragDropManager manager)
+			=> _manager ??= manager ?? throw new ArgumentNullException(nameof(manager));
 
 		internal void DragStarted(CoreDragInfo info)
 		{
+			if (_manager is null)
+			{
+				return;
+			}
+
 			if (TargetRequested is {} handler)
 			{
 				var args = new CoreDropOperationTargetRequestedEventArgs();
@@ -55,11 +70,80 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 			}
 		}
 
+		/// <summary>
+		/// This method is expected to be invoked each time a pointer involved in a drag operation is moved,
+		/// no matter if the drag operation has been initiated from this app or from an external app.
+		/// </summary>
+		/// <returns>
+		/// The last accepted operation.
+		/// Be aware that due to the async processing of dragging in UWP, this might not be the up to date.
+		/// </returns>
+		internal DataPackageOperation ProcessMoved(IDragEventSource src)
+			=> _manager?.ProcessMoved(src) ?? DataPackageOperation.None;
+
+		/// <summary>
+		/// This method is expected to be invoked when pointer involved in a drag operation is released,
+		/// no matter if the drag operation has been initiated from this app or from an external app.
+		/// </summary>
+		/// <returns>
+		/// The last accepted operation.
+		/// Be aware that due to the async processing of dragging in UWP, this might not be the up to date.
+		/// </returns>
+		internal DataPackageOperation ProcessDropped(IDragEventSource src)
+			=> _manager?.ProcessDropped(src) ?? DataPackageOperation.None;
+
+		/// <summary>
+		/// This method is expected to be invoked when pointer involved in a drag operation
+		/// is lost for operation initiated by the current app,
+		/// or left the window (a.k.a. the "virtual pointer" is lost) for operation initiated by an other app.
+		/// </summary>
+		/// <returns>
+		/// The last accepted operation.
+		/// Be aware that due to the async processing of dragging in UWP, this might not be the up to date.
+		/// </returns>
+		internal DataPackageOperation ProcessAborted(IDragEventSource src)
+			=> _manager?.ProcessAborted(src) ?? DataPackageOperation.None;
+
 		internal interface IDragDropManager
 		{
 			bool AreConcurrentOperationsEnabled { get; set; }
 
+			/// <summary>
+			/// This method initiate a new dragging operation.
+			/// This method must be followed by either ProcessDropped, either ProcessAborted. 
+			/// </summary>
 			void BeginDragAndDrop(CoreDragInfo info, ICoreDropOperationTarget? target = null);
+
+			/// <summary>
+			/// This method is expected to be invoked each time a pointer involved in a drag operation is moved,
+			/// no matter if the drag operation has been initiated from this app or from an external app.
+			/// </summary>
+			/// <returns>
+			/// The last accepted operation.
+			/// Be aware that due to the async processing of dragging in UWP, this might not be the up to date.
+			/// </returns>
+			DataPackageOperation ProcessMoved(IDragEventSource src);
+
+			/// <summary>
+			/// This method is expected to be invoked when pointer involved in a drag operation is released,
+			/// no matter if the drag operation has been initiated from this app or from an external app.
+			/// </summary>
+			/// <returns>
+			/// The last accepted operation.
+			/// Be aware that due to the async processing of dragging in UWP, this might not be the up to date.
+			/// </returns>
+			DataPackageOperation ProcessDropped(IDragEventSource src);
+
+			/// <summary>
+			/// This method is expected to be invoked when pointer involved in a drag operation
+			/// is lost for operation initiated by the current app,
+			/// or left the window (a.k.a. the "virtual pointer" is lost) for operation initiated by an other app.
+			/// </summary>
+			/// <returns>
+			/// The last accepted operation.
+			/// Be aware that due to the async processing of dragging in UWP, this might not be the up to date.
+			/// </returns>
+			DataPackageOperation ProcessAborted(IDragEventSource src);
 		}
 	}
 }

--- a/src/Uno.UWP/Storage/StorageFile.native.wasm.cs
+++ b/src/Uno.UWP/Storage/StorageFile.native.wasm.cs
@@ -14,8 +14,11 @@ namespace Windows.Storage
 {
 	public partial class StorageFile
 	{
-		internal static StorageFile GetFromNativeInfo(NativeStorageItemInfo info, StorageFolder? parent = null) =>
-			new StorageFile(new NativeStorageFile(info, parent));
+		internal static StorageFile GetFromNativeInfo(NativeStorageItemInfo info)
+			=> new StorageFile(new NativeStorageFile(info, default));
+
+		internal static StorageFile GetFromNativeInfo(NativeStorageItemInfo info, StorageFolder? parent)
+			=> new StorageFile(new NativeStorageFile(info, parent));
 
 		internal sealed class NativeStorageFile : ImplementationBase
 		{


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/6293

## Feature
Add ability to drop external content into wasm app

## What is the current behavior?
We cannot drop external content into app on WASM

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ _Not testable_
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
