### PR TITLE
[iOS][Android] DatePicker: Added a new UseNativeMinMaxDates property

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePicker_Features.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePicker_Features.xaml
@@ -41,6 +41,8 @@
 				<ComboBoxItem Tag="2020">min 2020</ComboBoxItem>
 				<ComboBoxItem Tag="2025">min 2025</ComboBoxItem>
 				<ComboBoxItem Tag="2030">min 2030</ComboBoxItem>
+				<ComboBoxItem Tag="lastweek">lastweek</ComboBoxItem>
+				<ComboBoxItem Tag="today">today</ComboBoxItem>
 			</ComboBox>
 			<ComboBox x:Name="maxYear">
 				<ComboBoxItem Tag="1980">max 1980</ComboBoxItem>
@@ -53,6 +55,8 @@
 				<ComboBoxItem Tag="2035">max 2035</ComboBoxItem>
 				<ComboBoxItem Tag="2040">max 2040</ComboBoxItem>
 				<ComboBoxItem Tag="2045">max 2045</ComboBoxItem>
+				<ComboBoxItem Tag="today">today</ComboBoxItem>
+				<ComboBoxItem Tag="nextweek">nextweek</ComboBoxItem>
 			</ComboBox>
 		</StackPanel>
 		<TextBlock FontSize="16">DatePicker</TextBlock>
@@ -126,6 +130,7 @@
 		</StackPanel>
 		<TextBlock FontSize="16">NativeDatePickerFlyout &amp; (iOS &amp; Android only)</TextBlock>
 		<StackPanel Orientation="Horizontal" Spacing="7">
+			<ToggleButton x:Name="useNativeMinMaxDates">UseNativeMinMaxDates</ToggleButton>
 			<Button x:Name="btnWithNativeFlyout">
 				<Button.Flyout>
 					<android:NativeDatePickerFlyout
@@ -133,6 +138,7 @@
 						Date="{x:Bind PickedDate, Mode=TwoWay}"
 						MinYear="{x:Bind DtYear(minYear.SelectedItem), Mode=OneWay}"
 						MaxYear="{x:Bind DtYear(maxYear.SelectedItem), Mode=OneWay}"
+						UseNativeMinMaxDates="{Binding IsChecked, ElementName=useNativeMinMaxDates}"
 						CalendarIdentifier="{Binding SelectedItem.Content, ElementName=calendarIdentifier, FallbackValue=GregorianCalendar}"
 						DayVisible="{Binding IsChecked, ElementName=dayVisible}"
 						MonthVisible="{Binding IsChecked, ElementName=monthVisible}"
@@ -142,6 +148,7 @@
 						Date="{x:Bind PickedDate, Mode=TwoWay}"
 						MinYear="{x:Bind DtYear(minYear.SelectedItem), Mode=OneWay}"
 						MaxYear="{x:Bind DtYear(maxYear.SelectedItem), Mode=OneWay}"
+						UseNativeMinMaxDates="{Binding IsChecked, ElementName=useNativeMinMaxDates}"
 						CalendarIdentifier="{Binding SelectedItem.Content, ElementName=calendarIdentifier, FallbackValue=GregorianCalendar}"
 						DayVisible="{Binding IsChecked, ElementName=dayVisible}"
 						MonthVisible="{Binding IsChecked, ElementName=monthVisible}"
@@ -159,6 +166,7 @@
 		<StackPanel Orientation="Horizontal" Spacing="7">
 			<DatePicker
 				xamarin:UseNativeStyle="True"
+				xamarin:UseNativeMinMaxDates="{Binding IsChecked, ElementName=useNativeMinMaxDates}"
 				x:Name="nativeDatePicker"
 				Date="{x:Bind PickedDate, Mode=TwoWay}"
 				MinYear="{x:Bind DtYear(minYear.SelectedItem), Mode=OneWay}"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePicker_Features.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/DatePicker/DatePicker_Features.xaml.cs
@@ -30,12 +30,21 @@ namespace UITests.Windows_UI_Xaml_Controls.DatePicker
 
 		public DateTimeOffset DtYear(object o)
 		{
+			var now = DateTimeOffset.Now;
 			if (o is SelectorItem item && item.Tag is string tag && !string.IsNullOrEmpty(tag))
 			{
+				switch (tag)
+				{
+					case "lastweek": return now.AddDays(-7);
+					case "nextweek": return now.AddDays(7);
+					case "today": return now;
+				}
+
 				var year = Convert.ToUInt16(tag);
 				return new DateTime(year, 1, 1, 0, 0, 0);
 			}
-			return DateTimeOffset.Now;
+
+			return now;
 		}
 
 		public string DtString(object o)

--- a/src/Uno.Foundation/UnoOnlyAttribute.cs
+++ b/src/Uno.Foundation/UnoOnlyAttribute.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace Uno
 {
 	/// <summary>
-	/// This member is only available in Uno and not part of the UWP contract.
+	/// This member is only available in Uno and not part of the UWP/WinUI contract.
 	/// </summary>
 	[System.AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = false)]
 	public sealed class UnoOnlyAttribute : Attribute

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.Flyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.Flyout.cs
@@ -12,6 +12,7 @@ namespace Windows.UI.Xaml.Controls
 		private const bool DEFAULT_NATIVE_STYLE = false;
 #endif
 
+		[UnoOnly]
 		public static DependencyProperty UseNativeStyleProperty { get; } = DependencyProperty.Register(
 			"UseNativeStyle",
 			typeof(bool),
@@ -19,15 +20,36 @@ namespace Windows.UI.Xaml.Controls
 			new FrameworkPropertyMetadata(DEFAULT_NATIVE_STYLE));
 
 		/// <summary>
-		/// If we should use the native picker for the platform.
+		/// [UnoOnly] If we should use the native picker for the platform.
 		/// IMPORTANT: must be set before the first time the picker is opened.
 		/// </summary>
+		[UnoOnly]
 		public bool UseNativeStyle
 		{
 			get => (bool)GetValue(UseNativeStyleProperty);
 			set => SetValue(UseNativeStyleProperty, value);
 		}
 
+		[UnoOnly]
+		public static DependencyProperty UseNativeMinMaxDatesProperty { get; } = DependencyProperty.Register(
+			"UseNativeMinMaxDates",
+			typeof(bool),
+			typeof(DatePicker),
+			new FrameworkPropertyMetadata(false));
+
+		/// <summary>
+		/// [UnoOnly] When using native pickers (through the UseNativeStyle property),
+		/// setting this to true will interpret MinYear/MaxYear as MinDate and MaxDate.
+		/// </summary>
+		/// <remarks>
+		/// This property has no effect when not using native pickers.
+		/// </remarks>
+		[UnoOnly]
+		public bool UseNativeMinMaxDates
+		{
+			get => (bool)GetValue(UseNativeMinMaxDatesProperty);
+			set => SetValue(UseNativeMinMaxDatesProperty, value);
+		}
 
 		/// <summary>
 		/// FlyoutPresenterStyle is an Uno-only property to allow the styling of the DatePicker's FlyoutPresenter.
@@ -39,6 +61,7 @@ namespace Windows.UI.Xaml.Controls
 			set => this.SetValue(FlyoutPresenterStyleProperty, value);
 		}
 
+		[UnoOnly]
 		public static DependencyProperty FlyoutPresenterStyleProperty { get; } =
 			DependencyProperty.Register(
 				nameof(FlyoutPresenterStyle),

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -858,6 +858,12 @@ namespace Windows.UI.Xaml.Controls
 			_flyout.MaxYear = MaxYear;
 			_flyout.Date = SelectedDate ?? Date;
 
+			// UnoOnly
+			if (_flyout is NativeDatePickerFlyout nativeFlyout)
+			{
+				nativeFlyout.UseNativeMinMaxDates = UseNativeMinMaxDates;
+			}
+
 			ShowPickerFlyout();
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#if __IOS__ || __ANDROID__
+#define SUPPORTS_NATIVE_DATEPICKER
+#endif
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
@@ -858,11 +861,13 @@ namespace Windows.UI.Xaml.Controls
 			_flyout.MaxYear = MaxYear;
 			_flyout.Date = SelectedDate ?? Date;
 
+#if SUPPORTS_NATIVE_DATEPICKER
 			// UnoOnly
 			if (_flyout is NativeDatePickerFlyout nativeFlyout)
 			{
 				nativeFlyout.UseNativeMinMaxDates = UseNativeMinMaxDates;
 			}
+#endif
 
 			ShowPickerFlyout();
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -14,6 +14,30 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class DatePickerSelector
 	{
+		public static DependencyProperty UseNativeMinMaxDatesProperty { get; } = DependencyProperty.Register(
+			"UseNativeMinMaxDates",
+			typeof(bool),
+			typeof(DatePickerSelector),
+			new FrameworkPropertyMetadata(false, propertyChangedCallback: OnUseNativeMinMaxDatesChanged));
+
+		/// <summary>
+		/// Setting this to true will interpret MinYear/MaxYear as MinDate and MaxDate.
+		/// </summary>
+		public bool UseNativeMinMaxDates
+		{
+			get => (bool)GetValue(UseNativeMinMaxDatesProperty);
+			set => SetValue(UseNativeMinMaxDatesProperty, value);
+		}
+
+		private static void OnUseNativeMinMaxDatesChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+		{
+			if (o is DatePickerSelector selector)
+			{
+				selector.UpdateMinMaxYears();
+			}
+		}
+
+
 		private UIDatePicker _picker;
 		private NSDate _initialValue;
 		private NSDate _newValue;
@@ -107,8 +131,11 @@ namespace Windows.UI.Xaml.Controls
 			var calendar = new NSCalendar(NSCalendarType.Gregorian);
 
 			winCalendar.SetDateTime(MaxYear);
-			winCalendar.Month = winCalendar.LastMonthInThisYear;
-			winCalendar.Day = winCalendar.LastDayInThisMonth;
+			if (!UseNativeMinMaxDates)
+			{
+				winCalendar.Month = winCalendar.LastMonthInThisYear;
+				winCalendar.Day = winCalendar.LastDayInThisMonth;
+			}
 
 			var maximumDateComponents = new NSDateComponents
 			{
@@ -120,8 +147,11 @@ namespace Windows.UI.Xaml.Controls
 			_picker.MaximumDate = calendar.DateFromComponents(maximumDateComponents);
 
 			winCalendar.SetDateTime(MinYear);
-			winCalendar.Month = winCalendar.FirstMonthInThisYear;
-			winCalendar.Day = winCalendar.FirstDayInThisMonth;
+			if (!UseNativeMinMaxDates)
+			{
+				winCalendar.Month = winCalendar.FirstMonthInThisYear;
+				winCalendar.Day = winCalendar.FirstDayInThisMonth;
+			}
 
 			var minimumDateComponents = new NSDateComponents
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.Android.cs
@@ -14,6 +14,21 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private DatePickerDialog _dialog;
 
+		public static DependencyProperty UseNativeMinMaxDatesProperty { get; } = DependencyProperty.Register(
+			"UseNativeMinMaxDates",
+			typeof(bool),
+			typeof(NativeDatePickerFlyout),
+			new FrameworkPropertyMetadata(false));
+
+		/// <summary>
+		/// Setting this to true will interpret MinYear/MaxYear as MinDate and MaxDate.
+		/// </summary>
+		public bool UseNativeMinMaxDates
+		{
+			get => (bool)GetValue(UseNativeMinMaxDatesProperty);
+			set => SetValue(UseNativeMinMaxDatesProperty, value);
+		}
+
 		public NativeDatePickerFlyout()
 		{
 			this.RegisterPropertyChangedCallback(DateProperty, OnDateChanged);
@@ -49,13 +64,21 @@ namespace Windows.UI.Xaml.Controls
 			//Removes title that is unnecessary as it is a duplicate -> http://stackoverflow.com/questions/33486643/remove-title-from-datepickerdialog 
 			_dialog.SetTitle("");
 
-			var minYearCalendar = Calendar.Instance;
-			minYearCalendar.Set(MinYear.Year, MinYear.Month - 1, MinYear.Day, MinYear.Hour, MinYear.Minute, MinYear.Second);
-			_dialog.DatePicker.MinDate = minYearCalendar.TimeInMillis;
+			if (UseNativeMinMaxDates)
+			{
+				_dialog.DatePicker.MinDate = MinYear.ToUnixTimeMilliseconds();
+				_dialog.DatePicker.MaxDate = MaxYear.ToUnixTimeMilliseconds();
+			}
+			else
+			{
+				var minYearCalendar = Calendar.Instance;
+				minYearCalendar.Set(MinYear.Year, MinYear.Month - 1, MinYear.Day, MinYear.Hour, MinYear.Minute, MinYear.Second);
+				_dialog.DatePicker.MinDate = minYearCalendar.TimeInMillis;
 
-			var maxYearCalendar = Calendar.Instance;
-			maxYearCalendar.Set(MaxYear.Year, MaxYear.Month - 1, MaxYear.Day, MaxYear.Hour, MaxYear.Minute, MaxYear.Second);
-			_dialog.DatePicker.MaxDate = maxYearCalendar.TimeInMillis;
+				var maxYearCalendar = Calendar.Instance;
+				maxYearCalendar.Set(MaxYear.Year, MaxYear.Month - 1, MaxYear.Day, MaxYear.Hour, MaxYear.Minute, MaxYear.Second);
+				_dialog.DatePicker.MaxDate = maxYearCalendar.TimeInMillis;
+			}
 
 			_dialog.DismissEvent += OnDismiss;
 			_dialog.Show();

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.iOS.cs
@@ -40,7 +40,7 @@ namespace Windows.UI.Xaml.Controls
 			"UseNativeMinMaxDates",
 			typeof(bool),
 			typeof(NativeDatePickerFlyout),
-			new FrameworkPropertyMetadata(false, propertyChangedCallback: OnUseNativeMinMaxDatesChanged));
+			new FrameworkPropertyMetadata(false));
 
 		/// <summary>
 		/// Setting this to true will interpret MinYear/MaxYear as MinDate and MaxDate.
@@ -49,13 +49,6 @@ namespace Windows.UI.Xaml.Controls
 		{
 			get => (bool)GetValue(UseNativeMinMaxDatesProperty);
 			set => SetValue(UseNativeMinMaxDatesProperty, value);
-		}
-
-		private static void OnUseNativeMinMaxDatesChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-		{
-			if (o is NativeDatePickerFlyout selector)
-			{
-			}
 		}
 
 		public NativeDatePickerFlyout()

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.iOS.cs
@@ -36,6 +36,28 @@ namespace Windows.UI.Xaml.Controls
 		}
 		private DatePickerSelector _selector;
 
+		public static DependencyProperty UseNativeMinMaxDatesProperty { get; } = DependencyProperty.Register(
+			"UseNativeMinMaxDates",
+			typeof(bool),
+			typeof(NativeDatePickerFlyout),
+			new FrameworkPropertyMetadata(false, propertyChangedCallback: OnUseNativeMinMaxDatesChanged));
+
+		/// <summary>
+		/// Setting this to true will interpret MinYear/MaxYear as MinDate and MaxDate.
+		/// </summary>
+		public bool UseNativeMinMaxDates
+		{
+			get => (bool)GetValue(UseNativeMinMaxDatesProperty);
+			set => SetValue(UseNativeMinMaxDatesProperty, value);
+		}
+
+		private static void OnUseNativeMinMaxDatesChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+		{
+			if (o is NativeDatePickerFlyout selector)
+			{
+			}
+		}
+
 		public NativeDatePickerFlyout()
 		{
 			Opening += DatePickerFlyout_Opening;
@@ -72,12 +94,9 @@ namespace Windows.UI.Xaml.Controls
 
 			_isInitialized = true;
 
-			Content = _selector = new DatePickerSelector()
-			{
-				MinYear = MinYear,
-				MaxYear = MaxYear
-			};
+			Content = _selector = new DatePickerSelector();
 
+			BindToContent("UseNativeMinMaxDates");
 			BindToContent("MinYear");
 			BindToContent("MaxYear");
 		}
@@ -237,7 +256,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void BindToContent(string propertyName)
 		{
-			this.Binding(propertyName, propertyName, Content, BindingMode.TwoWay);
+			Content.Binding(propertyName, propertyName, this, BindingMode.OneWay);
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/5575

# Feature

Added a new UseNativeMinMaxDates property on DatePicker & NativeDatePickerFlyout to allow the picker to be restricted to some date instead of just the year.  Properties `MinYear` and `MaxYear` are still used for that since they are already of type `DateTimeOffset`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
