### PR TITLE
fix: Apply coercion before value is set, propagate focus properties from flyout

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
@@ -390,7 +390,6 @@ namespace SamplesApp.UITests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.iOS, Platform.Browser)] // Android is disabled https://github.com/unoplatform/uno/issues/1630
 		public void TextBox_Disable()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Disabled");

--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.Keyboard.cs
@@ -390,6 +390,7 @@ namespace SamplesApp.UITests
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Browser)] // Android is disabled https://github.com/unoplatform/uno/issues/1630
 		public void TextBox_Disable()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Disabled");

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.RuntimeTests.Helpers;
-using Windows.UI;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
-using Windows.UI.Xaml.Input;
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -17,7 +12,6 @@ using UIKit;
 #elif __MACOS__
 using AppKit;
 #else
-using Uno.UI;
 #endif
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
@@ -95,6 +89,25 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 				Assert.AreEqual(lightThemeForeground, (placeholderTextContentPresenter.Foreground as SolidColorBrush)?.Color);
 			}
+		}
+
+		[TestMethod]
+		public async Task When_BeforeTextChanging()
+		{
+			var textBox = new TextBox
+			{
+				Text = "Test"
+			};
+
+			WindowHelper.WindowContent = textBox;
+			await WindowHelper.WaitForLoaded(textBox);
+
+			textBox.BeforeTextChanging += (s, e) =>
+			{
+				Assert.AreEqual("Test", textBox.Text);
+			};
+
+			textBox.Text = "Something";
 		}
 	}
 }

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
@@ -1,15 +1,15 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Windows.UI.Xaml.Data;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Windows.UI.Xaml;
 using System.Threading;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Shapes;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.Xaml;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Shapes;
 
 namespace Uno.UI.Tests.BinderTests
 {
@@ -612,6 +612,51 @@ namespace Uno.UI.Tests.BinderTests
 			var coercedValue = SUT.GetValue(testProperty);
 
 			Assert.AreEqual("customValue", coercedValue);
+		}
+
+		[TestMethod]
+		public void When_CoerceValue_Reads_Property_Value()
+		{
+			var SUT = new MockDependencyObject();
+
+			var previousValue = "Previous";
+			var newValue = "New";
+
+			Action callback = null;
+
+			object Coerce(object dependencyObject, object baseValue)
+			{
+				callback?.Invoke();
+
+				return baseValue;
+			}
+
+			var property = DependencyProperty.Register(
+				nameof(When_CoerceValue_Reads_Property_Value),
+				typeof(string),
+				typeof(MockDependencyObject),
+				new PropertyMetadata(
+					"",
+					null,
+					Coerce
+				)
+			);
+
+			callback = () =>
+			{
+				var currentValue = SUT.GetValue(property);
+				Assert.AreEqual("", currentValue);
+			};
+
+			SUT.SetValue(property, previousValue);
+
+			callback = () =>
+			{
+				var currentValue = SUT.GetValue(property);
+				Assert.AreEqual(previousValue, currentValue);
+			};
+
+			SUT.SetValue(property, newValue);
 		}
 
 		[TestMethod]
@@ -1244,12 +1289,14 @@ namespace Uno.UI.Tests.BinderTests
 
 			var registration1 = SUT.RegisterPropertyChangedCallback(
 				SimpleDependencyObject1.MyPropertyProperty,
-				(s, e) => {
+				(s, e) =>
+				{
 					invocations++;
 
 					registration2 = SUT.RegisterPropertyChangedCallback(
 						SimpleDependencyObject1.MyPropertyProperty,
-						(s2, e2) => {
+						(s2, e2) =>
+						{
 							invocations2++;
 						}
 					);
@@ -1754,7 +1801,8 @@ namespace Uno.UI.Tests.BinderTests
 			DependencyProperty.Register("MyProperty", typeof(string), typeof(SimpleDependencyObject1),
 				new PropertyMetadata(
 					"default1",
-					(s, e) => {
+					(s, e) =>
+					{
 						(s as SimpleDependencyObject1).PropertyChangedCallbacks.Add("changed1: " + e.NewValue);
 						(s as SimpleDependencyObject1).ChangedCallbackCount++;
 					}
@@ -1861,7 +1909,7 @@ namespace Uno.UI.Tests.BinderTests
 
 		private bool OnProvideDefaultValue(DependencyProperty property, out object defaultValue)
 		{
-			if(property == MyPropertyProperty)
+			if (property == MyPropertyProperty)
 			{
 				defaultValue = 42;
 

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/FlyoutTests/Given_Flyout.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/FlyoutTests/Given_Flyout.cs
@@ -54,6 +54,102 @@ namespace Uno.UI.Tests.FlyoutTests
 		}
 
 		[TestMethod]
+		public void When_Focus_Properties_Set_On_Flyout_Propagate_To_Content()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			var appContent = new Grid() { Name = "test" };
+			var SUT = new Button();
+			var flyoutContent = new Grid()
+			{
+				Children =
+				{
+					SUT
+				}
+			};
+
+			var flyout = new Flyout()
+			{
+				AllowFocusOnInteraction = false,
+				AllowFocusWhenDisabled = true,
+				Content = flyoutContent
+			};
+
+			var flyoutOwner = new Button()
+			{				
+				Flyout = flyout
+			};
+
+			appContent.AddChild(flyoutOwner);
+
+			app.HostView.Children.Add(appContent);
+
+			appContent.Measure(new Size(20, 20));
+			appContent.Arrange(new Rect(0, 0, 20, 20));
+
+			flyout.ShowAt(flyoutOwner);
+
+			Assert.AreEqual(false, SUT.AllowFocusOnInteraction);
+			Assert.AreEqual(true, SUT.AllowFocusWhenDisabled);
+
+			// Change values
+			flyout.AllowFocusOnInteraction = true;
+			flyout.AllowFocusWhenDisabled = false;
+
+			Assert.AreEqual(true, SUT.AllowFocusOnInteraction);
+			Assert.AreEqual(false, SUT.AllowFocusWhenDisabled);
+		}
+
+		[TestMethod]
+		public void When_Focus_Properties_Set_On_Flyout_Propagate_To_Popup()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			var appContent = new Grid() { Name = "test" };
+			var flyoutContent = new Grid()
+			{
+				Children =
+				{
+					new Button()
+				}
+			};
+
+			var flyout = new Flyout()
+			{
+				AllowFocusOnInteraction = false,
+				AllowFocusWhenDisabled = true,
+				Content = flyoutContent
+			};
+
+			var flyoutOwner = new Button()
+			{
+				Flyout = flyout
+			};
+
+			appContent.AddChild(flyoutOwner);
+
+			app.HostView.Children.Add(appContent);
+
+			appContent.Measure(new Size(20, 20));
+			appContent.Arrange(new Rect(0, 0, 20, 20));
+
+			flyout.ShowAt(flyoutOwner);
+
+			var popupPanel = flyout.GetPopupPanel();
+			var SUT = popupPanel.Popup;
+
+			Assert.AreEqual(false, SUT.AllowFocusOnInteraction);
+			Assert.AreEqual(true, SUT.AllowFocusWhenDisabled);
+
+			// Change values
+			flyout.AllowFocusOnInteraction = true;
+			flyout.AllowFocusWhenDisabled = false;
+
+			Assert.AreEqual(true, SUT.AllowFocusOnInteraction);
+			Assert.AreEqual(false, SUT.AllowFocusWhenDisabled);
+		}
+
+		[TestMethod]
 		public void When_Placement_Full()
 		{
 			var SUT = new Grid() { Name = "test" };

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
@@ -88,7 +88,7 @@ namespace Windows.UI.Xaml.Controls
 
 			flyout.SynchronizeNamescope();
 
-			if(args.OldValue is DependencyObject oldDO)
+			if (args.OldValue is DependencyObject oldDO)
 			{
 				oldDO.ClearValue(NameScope.NameScopeProperty);
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPresenter.cs
@@ -13,6 +13,28 @@ namespace Windows.UI.Xaml.Controls
 			DefaultStyleKey = typeof(FlyoutPresenter);
 		}
 
+		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
+		{
+			if (args.Property == AllowFocusOnInteractionProperty)
+			{
+				Content?.SetValue(AllowFocusOnInteractionProperty, AllowFocusOnInteraction);
+			}
+			else if (args.Property == AllowFocusWhenDisabledProperty)
+			{
+				Content?.SetValue(AllowFocusWhenDisabledProperty, AllowFocusWhenDisabled);
+			}
+
+			base.OnPropertyChanged2(args);
+		}
+
+		protected override void OnContentChanged(object oldValue, object newValue)
+		{
+			base.OnContentChanged(oldValue, newValue);
+
+			Content?.SetValue(AllowFocusOnInteractionProperty, AllowFocusOnInteraction);
+			Content?.SetValue(AllowFocusWhenDisabledProperty, AllowFocusWhenDisabled);
+		}
+
 		protected override void OnPointerPressed(PointerRoutedEventArgs args)
 		{
 			if (this.GetTemplateRoot() is FrameworkElement root && this.Parent is FlyoutBasePopupPanel panel)

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using Uno.UI;
 using Windows.Foundation;
 using Windows.UI.Xaml.Input;
-using Uno.Extensions;
-using Uno.UI.DataBinding;
 using Windows.UI.Xaml.Media;
-using Uno.UI;
 #if XAMARIN_IOS
 using CoreGraphics;
 using UIKit;
@@ -30,6 +25,17 @@ namespace Windows.UI.Xaml.Controls
 		/// Defines a custom layouter which overrides the default placement logic of the <see cref="PopupPanel"/>
 		/// </summary>
 		internal IDynamicPopupLayouter CustomLayouter { get; set; }
+
+		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
+		{
+			if (args.Property == AllowFocusOnInteractionProperty ||
+				args.Property == AllowFocusWhenDisabledProperty)
+			{
+				PropagateFocusProperties();
+			}
+
+			base.OnPropertyChanged2(args);
+		}
 
 		private protected override void OnUnloaded()
 		{
@@ -71,10 +77,13 @@ namespace Windows.UI.Xaml.Controls
 			{
 				provider.Store.ClearValue(provider.Store.DataContextProperty, DependencyPropertyValuePrecedences.Local);
 				provider.Store.ClearValue(provider.Store.TemplatedParentProperty, DependencyPropertyValuePrecedences.Local);
+				provider.Store.ClearValue(AllowFocusOnInteractionProperty, DependencyPropertyValuePrecedences.Local);
+				provider.Store.ClearValue(AllowFocusWhenDisabledProperty, DependencyPropertyValuePrecedences.Local);
 			}
 
 			UpdateDataContext(null);
 			UpdateTemplatedParent();
+			PropagateFocusProperties();
 
 			if (oldChild is FrameworkElement ocfe)
 			{
@@ -139,6 +148,15 @@ namespace Windows.UI.Xaml.Controls
 			if (Child is IDependencyObjectStoreProvider provider)
 			{
 				provider.Store.SetValue(provider.Store.TemplatedParentProperty, this.TemplatedParent, DependencyPropertyValuePrecedences.Local);
+			}
+		}
+
+		private void PropagateFocusProperties()
+		{
+			if (Child is IDependencyObjectStoreProvider provider)
+			{
+				provider.Store.SetValue(AllowFocusOnInteractionProperty, AllowFocusOnInteraction, DependencyPropertyValuePrecedences.Local);
+				provider.Store.SetValue(AllowFocusWhenDisabledProperty, AllowFocusWhenDisabled, DependencyPropertyValuePrecedences.Local);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -461,6 +461,8 @@ namespace Windows.UI.Xaml
 					var previousValue = GetValue(propertyDetails);
 					var previousPrecedence = GetCurrentHighestValuePrecedence(propertyDetails);
 
+					ApplyCoercion(actualInstanceAlias, propertyDetails, previousValue, value);
+
 					// Set even if they are different to make sure the value is now set on the right precedence
 					SetValueInternal(value, precedence, propertyDetails);
 
@@ -469,8 +471,6 @@ namespace Windows.UI.Xaml
 						// If a non-theme value is being set, clear any theme binding so it's not overwritten if the theme changes.
 						_resourceBindings?.ClearBinding(property, precedence);
 					}
-
-					ApplyCoercion(actualInstanceAlias, propertyDetails, previousValue, value);
 
 					// Value may or may not have changed based on the precedence
 					var newValue = GetValue(propertyDetails);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`ApplyCoercion` is called after `SetValueInternal`. This causes issues for example in case of `TextBox`, which calls `BeforeTextChanging` during coercion - in the event handler, the `TextBox.Text` would already return the newly set `Text` instead of the old one.


## What is the new behavior?

Coercion is performed before `SetValueInternal`.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
