### PR TITLE
Generate specific platforms for NotImplemented types

### DIFF
--- a/src/Uno.Foundation/Generated/2.0.0.0/Windows.Foundation.Collections/ValueSet.cs
+++ b/src/Uno.Foundation/Generated/2.0.0.0/Windows.Foundation.Collections/ValueSet.cs
@@ -3,7 +3,7 @@
 namespace Windows.Foundation.Collections
 {
 	#if false || false || NET461 || false || false || false || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461")]
 	#endif
 	public  partial class ValueSet : global::Windows.Foundation.Collections.IPropertySet,global::Windows.Foundation.Collections.IObservableMap<string, object>,global::System.Collections.Generic.IDictionary<string, object>,global::System.Collections.Generic.IEnumerable<global::System.Collections.Generic.KeyValuePair<string, object>>
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Provider/ISelectionItemProvider.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Provider/ISelectionItemProvider.cs
@@ -2,33 +2,17 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Automation.Provider
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface ISelectionItemProvider 
 	{
-		#if false
-		bool IsSelected
-		{
-			get;
-		}
-		#endif
-		#if false
-		global::Windows.UI.Xaml.Automation.Provider.IRawElementProviderSimple SelectionContainer
-		{
-			get;
-		}
-		#endif
+		// Skipping already declared property IsSelected
+		// Skipping already declared property SelectionContainer
 		// Forced skipping of method Windows.UI.Xaml.Automation.Provider.ISelectionItemProvider.IsSelected.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.Provider.ISelectionItemProvider.SelectionContainer.get
-		#if false
-		void AddToSelection();
-		#endif
-		#if false
-		void RemoveFromSelection();
-		#endif
-		#if false
-		void Select();
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Automation.Provider.ISelectionItemProvider.AddToSelection()
+		// Skipping already declared method Windows.UI.Xaml.Automation.Provider.ISelectionItemProvider.RemoveFromSelection()
+		// Skipping already declared method Windows.UI.Xaml.Automation.Provider.ISelectionItemProvider.Select()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/GridViewItemPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/GridViewItemPresenter.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls.Primitives
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class GridViewItemPresenter : global::Windows.UI.Xaml.Controls.ContentPresenter
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ListViewItemPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/ListViewItemPresenter.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls.Primitives
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class ListViewItemPresenter : global::Windows.UI.Xaml.Controls.ContentPresenter
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/SettingsFlyoutTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/SettingsFlyoutTemplateSettings.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls.Primitives
 {
 	#if __ANDROID__ || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__ANDROID__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class SettingsFlyoutTemplateSettings : global::Windows.UI.Xaml.DependencyObject
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/CommandBarOverflowPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/CommandBarOverflowPresenter.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class CommandBarOverflowPresenter : global::Windows.UI.Xaml.Controls.ItemsControl
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsWrapGrid.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsWrapGrid.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class ItemsWrapGrid : global::Windows.UI.Xaml.Controls.Panel
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaPlayerElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaPlayerElement.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || false || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class MediaPlayerElement : global::Windows.UI.Xaml.Controls.Control
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaTransportControls.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaTransportControls.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || false || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class MediaTransportControls : global::Windows.UI.Xaml.Controls.Control
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaTransportControlsHelper.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaTransportControlsHelper.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class MediaTransportControlsHelper 
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PathIcon.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PathIcon.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || false || false || false || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class PathIcon : global::Windows.UI.Xaml.Controls.IconElement
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SymbolIcon.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SymbolIcon.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class SymbolIcon : global::Windows.UI.Xaml.Controls.IconElement
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePicker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePicker.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || false || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class TimePicker : global::Windows.UI.Xaml.Controls.Control
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePickerFlyoutPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePickerFlyoutPresenter.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || NET461 || false || false || false || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461")]
 	#endif
 	public  partial class TimePickerFlyoutPresenter 
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSwitch.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSwitch.cs
@@ -42,27 +42,9 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSwitch.Toggled.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSwitch.Toggled.remove
 		// Skipping already declared method Windows.UI.Xaml.Controls.ToggleSwitch.OnToggled()
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		protected virtual void OnOnContentChanged( object oldContent,  object newContent)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.ToggleSwitch", "void ToggleSwitch.OnOnContentChanged(object oldContent, object newContent)");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		protected virtual void OnOffContentChanged( object oldContent,  object newContent)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.ToggleSwitch", "void ToggleSwitch.OnOffContentChanged(object oldContent, object newContent)");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		protected virtual void OnHeaderChanged( object oldContent,  object newContent)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.ToggleSwitch", "void ToggleSwitch.OnHeaderChanged(object oldContent, object newContent)");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.ToggleSwitch.OnOnContentChanged(object, object)
+		// Skipping already declared method Windows.UI.Xaml.Controls.ToggleSwitch.OnOffContentChanged(object, object)
+		// Skipping already declared method Windows.UI.Xaml.Controls.ToggleSwitch.OnHeaderChanged(object, object)
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSwitch.IsOnProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSwitch.HeaderProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSwitch.HeaderTemplateProperty.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Imaging/RenderTargetBitmap.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Imaging/RenderTargetBitmap.cs
@@ -2,78 +2,22 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Imaging
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class RenderTargetBitmap : global::Windows.UI.Xaml.Media.ImageSource
 	{
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  int PixelHeight
-		{
-			get
-			{
-				return (int)this.GetValue(PixelHeightProperty);
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  int PixelWidth
-		{
-			get
-			{
-				return (int)this.GetValue(PixelWidthProperty);
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty PixelHeightProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(PixelHeight), typeof(int), 
-			typeof(global::Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap), 
-			new FrameworkPropertyMetadata(default(int)));
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty PixelWidthProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(PixelWidth), typeof(int), 
-			typeof(global::Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap), 
-			new FrameworkPropertyMetadata(default(int)));
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public RenderTargetBitmap() 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap", "RenderTargetBitmap.RenderTargetBitmap()");
-		}
-		#endif
+		// Skipping already declared property PixelHeight
+		// Skipping already declared property PixelWidth
+		// Skipping already declared property PixelHeightProperty
+		// Skipping already declared property PixelWidthProperty
+		// Skipping already declared method Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap.RenderTargetBitmap()
 		// Forced skipping of method Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap.RenderTargetBitmap()
 		// Forced skipping of method Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap.PixelWidth.get
 		// Forced skipping of method Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap.PixelHeight.get
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.Foundation.IAsyncAction RenderAsync( global::Windows.UI.Xaml.UIElement element)
-		{
-			throw new global::System.NotImplementedException("The member IAsyncAction RenderTargetBitmap.RenderAsync(UIElement element) is not implemented in Uno.");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.Foundation.IAsyncAction RenderAsync( global::Windows.UI.Xaml.UIElement element,  int scaledWidth,  int scaledHeight)
-		{
-			throw new global::System.NotImplementedException("The member IAsyncAction RenderTargetBitmap.RenderAsync(UIElement element, int scaledWidth, int scaledHeight) is not implemented in Uno.");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Storage.Streams.IBuffer> GetPixelsAsync()
-		{
-			throw new global::System.NotImplementedException("The member IAsyncOperation<IBuffer> RenderTargetBitmap.GetPixelsAsync() is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap.RenderAsync(Windows.UI.Xaml.UIElement)
+		// Skipping already declared method Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap.RenderAsync(Windows.UI.Xaml.UIElement, int, int)
+		// Skipping already declared method Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap.GetPixelsAsync()
 		// Forced skipping of method Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap.PixelWidthProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap.PixelHeightProperty.get
 	}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/CompositionTarget.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/CompositionTarget.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Media
 {
 	#if false || false || NET461 || false || false || false || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__MACOS__")]
 	#endif
 	public  partial class CompositionTarget 
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/EllipseGeometry.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/EllipseGeometry.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Media
 {
 	#if __ANDROID__ || __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class EllipseGeometry : global::Windows.UI.Xaml.Media.Geometry
 	{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/LineGeometry.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/LineGeometry.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Xaml.Media
 {
 	#if __ANDROID__ || __IOS__ || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class LineGeometry : global::Windows.UI.Xaml.Media.Geometry
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Activation/IProtocolActivatedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Activation/IProtocolActivatedEventArgs.cs
@@ -3,7 +3,7 @@
 namespace Windows.ApplicationModel.Activation
 {
 	#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial interface IProtocolActivatedEventArgs : global::Windows.ApplicationModel.Activation.IActivatedEventArgs
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/BackgroundTaskDeferral.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/BackgroundTaskDeferral.cs
@@ -3,7 +3,7 @@
 namespace Windows.ApplicationModel.Background
 {
 	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class BackgroundTaskDeferral 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Calls/PhoneCallManager.cs
@@ -3,7 +3,7 @@
 namespace Windows.ApplicationModel.Calls
 {
 	#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class PhoneCallManager 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Chat/ChatMessageManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Chat/ChatMessageManager.cs
@@ -3,7 +3,7 @@
 namespace Windows.ApplicationModel.Chat
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class ChatMessageManager 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.DataTransfer/Clipboard.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.DataTransfer/Clipboard.cs
@@ -3,7 +3,7 @@
 namespace Windows.ApplicationModel.DataTransfer
 {
 	#if false || false || NET461 || false || false || false || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461")]
 	#endif
 	public  partial class Clipboard 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.DataTransfer/StandardDataFormats.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.DataTransfer/StandardDataFormats.cs
@@ -3,7 +3,7 @@
 namespace Windows.ApplicationModel.DataTransfer
 {
 	#if false || false || NET461 || false || false || false || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461")]
 	#endif
 	public  partial class StandardDataFormats 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Geolocation/Geolocator.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Geolocation/Geolocator.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Geolocation
 {
 	#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class Geolocator 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Lights/Lamp.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Lights/Lamp.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Lights
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class Lamp : global::System.IDisposable
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Midi/IMidiOutPort.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Midi/IMidiOutPort.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Midi
 {
 	#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial interface IMidiOutPort : global::System.IDisposable
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Radios/Radio.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Radios/Radio.cs
@@ -3,12 +3,12 @@
 namespace Windows.Devices.Radios
 {
 	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class Radio 
 	{
 		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Devices.Radios.RadioKind Kind
 		{
 			get
@@ -18,7 +18,7 @@ namespace Windows.Devices.Radios
 		}
 		#endif
 		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string Name
 		{
 			get
@@ -28,7 +28,7 @@ namespace Windows.Devices.Radios
 		}
 		#endif
 		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Devices.Radios.RadioState State
 		{
 			get
@@ -50,7 +50,7 @@ namespace Windows.Devices.Radios
 		// Forced skipping of method Windows.Devices.Radios.Radio.Name.get
 		// Forced skipping of method Windows.Devices.Radios.Radio.Kind.get
 		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyList<global::Windows.Devices.Radios.Radio>> GetRadiosAsync()
 		{
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IReadOnlyList<Radio>> Radio.GetRadiosAsync() is not implemented in Uno.");

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Accelerometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Accelerometer.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Sensors
 {
 	#if false || false || false || false || false || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class Accelerometer 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Barometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Barometer.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Sensors
 {
 	#if false || false || false || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class Barometer 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Gyrometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Gyrometer.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Sensors
 {
 	#if false || false || false || false || false || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class Gyrometer 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/HingeAngleReading.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/HingeAngleReading.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Sensors
 {
 	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class HingeAngleReading 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/HingeAngleSensor.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/HingeAngleSensor.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Sensors
 {
 	#if false || false || false || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class HingeAngleSensor 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/HingeAngleSensorReadingChangedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/HingeAngleSensorReadingChangedEventArgs.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Sensors
 {
 	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class HingeAngleSensorReadingChangedEventArgs 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Magnetometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Magnetometer.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Sensors
 {
 	#if false || false || false || false || false || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class Magnetometer 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Pedometer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Sensors/Pedometer.cs
@@ -3,7 +3,7 @@
 namespace Windows.Devices.Sensors
 {
 	#if false || false || false || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class Pedometer 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Globalization.NumberFormatting/NumeralSystemTranslator.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Globalization.NumberFormatting/NumeralSystemTranslator.cs
@@ -5,8 +5,19 @@ namespace Windows.Globalization.NumberFormatting
 	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
-	public partial class NumeralSystemTranslator
+	public  partial class NumeralSystemTranslator 
 	{
-
+		// Skipping already declared property NumeralSystem
+		// Skipping already declared property Languages
+		// Skipping already declared property ResolvedLanguage
+		// Skipping already declared method Windows.Globalization.NumberFormatting.NumeralSystemTranslator.NumeralSystemTranslator(System.Collections.Generic.IEnumerable<string>)
+		// Forced skipping of method Windows.Globalization.NumberFormatting.NumeralSystemTranslator.NumeralSystemTranslator(System.Collections.Generic.IEnumerable<string>)
+		// Skipping already declared method Windows.Globalization.NumberFormatting.NumeralSystemTranslator.NumeralSystemTranslator()
+		// Forced skipping of method Windows.Globalization.NumberFormatting.NumeralSystemTranslator.NumeralSystemTranslator()
+		// Forced skipping of method Windows.Globalization.NumberFormatting.NumeralSystemTranslator.Languages.get
+		// Forced skipping of method Windows.Globalization.NumberFormatting.NumeralSystemTranslator.ResolvedLanguage.get
+		// Forced skipping of method Windows.Globalization.NumberFormatting.NumeralSystemTranslator.NumeralSystem.get
+		// Forced skipping of method Windows.Globalization.NumberFormatting.NumeralSystemTranslator.NumeralSystem.set
+		// Skipping already declared method Windows.Globalization.NumberFormatting.NumeralSystemTranslator.TranslateNumerals(string)
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Core/MediaSource.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Core/MediaSource.cs
@@ -3,7 +3,7 @@
 namespace Windows.Media.Core
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class MediaSource : global::System.IDisposable,global::Windows.Media.Playback.IMediaPlaybackSource
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/IMediaPlaybackSource.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/IMediaPlaybackSource.cs
@@ -3,7 +3,7 @@
 namespace Windows.Media.Playback
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial interface IMediaPlaybackSource 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackItem.cs
@@ -3,7 +3,7 @@
 namespace Windows.Media.Playback
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class MediaPlaybackItem : global::Windows.Media.Playback.IMediaPlaybackSource
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackList.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackList.cs
@@ -3,7 +3,7 @@
 namespace Windows.Media.Playback
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class MediaPlaybackList : global::Windows.Media.Playback.IMediaPlaybackSource
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackSession.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackSession.cs
@@ -3,7 +3,7 @@
 namespace Windows.Media.Playback
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class MediaPlaybackSession 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlayer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlayer.cs
@@ -3,7 +3,7 @@
 namespace Windows.Media.Playback
 {
 	#if false || false || false || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class MediaPlayer : global::System.IDisposable
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlayerFailedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlayerFailedEventArgs.cs
@@ -3,7 +3,7 @@
 namespace Windows.Media.Playback
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class MediaPlayerFailedEventArgs 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.SpeechRecognition/SpeechRecognitionResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.SpeechRecognition/SpeechRecognitionResult.cs
@@ -3,7 +3,7 @@
 namespace Windows.Media.SpeechRecognition
 {
 	#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class SpeechRecognitionResult 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.SpeechRecognition/SpeechRecognizer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.SpeechRecognition/SpeechRecognizer.cs
@@ -3,7 +3,7 @@
 namespace Windows.Media.SpeechRecognition
 {
 	#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class SpeechRecognizer : global::System.IDisposable
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking.Connectivity/ConnectionCost.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking.Connectivity/ConnectionCost.cs
@@ -3,7 +3,7 @@
 namespace Windows.Networking.Connectivity
 {
 	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class ConnectionCost 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking.Connectivity/ConnectionProfile.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking.Connectivity/ConnectionProfile.cs
@@ -3,7 +3,7 @@
 namespace Windows.Networking.Connectivity
 {
 	#if false || false || NET461 || false || false || false || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461")]
 	#endif
 	public  partial class ConnectionProfile 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking.Connectivity/IPInformation.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking.Connectivity/IPInformation.cs
@@ -3,7 +3,7 @@
 namespace Windows.Networking.Connectivity
 {
 	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class IPInformation 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking.Connectivity/NetworkInformation.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking.Connectivity/NetworkInformation.cs
@@ -3,7 +3,7 @@
 namespace Windows.Networking.Connectivity
 {
 	#if false || false || NET461 || false || false || false || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461")]
 	#endif
 	public  partial class NetworkInformation 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking/HostName.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking/HostName.cs
@@ -3,7 +3,7 @@
 namespace Windows.Networking
 {
 	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class HostName : global::Windows.Foundation.IStringable
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Phone.Devices.Notification/VibrationDevice.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Phone.Devices.Notification/VibrationDevice.cs
@@ -3,7 +3,7 @@
 namespace Windows.Phone.Devices.Notification
 {
 	#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class VibrationDevice 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Maps/MapLocationFinder.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Maps/MapLocationFinder.cs
@@ -3,7 +3,7 @@
 namespace Windows.Services.Maps
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class MapLocationFinder 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/KnownFolders.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage/KnownFolders.cs
@@ -3,7 +3,7 @@
 namespace Windows.Storage
 {
 	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class KnownFolders 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Display/DisplayRequest.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Display/DisplayRequest.cs
@@ -3,7 +3,7 @@
 namespace Windows.System.Display
 {
 	#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class DisplayRequest 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Power/PowerManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Power/PowerManager.cs
@@ -3,7 +3,7 @@
 namespace Windows.System.Power
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class PowerManager 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Profile/AnalyticsVersionInfo.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Profile/AnalyticsVersionInfo.cs
@@ -3,7 +3,7 @@
 namespace Windows.System.Profile
 {
 	#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class AnalyticsVersionInfo 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.UserProfile/GlobalizationPreferences.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.UserProfile/GlobalizationPreferences.cs
@@ -3,7 +3,7 @@
 namespace Windows.System.UserProfile
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class GlobalizationPreferences 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System/MemoryManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System/MemoryManager.cs
@@ -3,7 +3,7 @@
 namespace Windows.System
 {
 	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class MemoryManager 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core.Preview/SystemNavigationCloseRequestedPreviewEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core.Preview/SystemNavigationCloseRequestedPreviewEventArgs.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Core.Preview
 {
 	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class SystemNavigationCloseRequestedPreviewEventArgs 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core.Preview/SystemNavigationManagerPreview.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core.Preview/SystemNavigationManagerPreview.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Core.Preview
 {
 	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 	#endif
 	public  partial class SystemNavigationManagerPreview 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Notifications/BadgeNotification.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Notifications/BadgeNotification.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Notifications
 {
 	#if __ANDROID__ || false || false || false || false || false || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__ANDROID__")]
 	#endif
 	public  partial class BadgeNotification 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Notifications/BadgeUpdateManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Notifications/BadgeUpdateManager.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Notifications
 {
 	#if __ANDROID__ || false || false || false || false || false || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__ANDROID__")]
 	#endif
 	public  partial class BadgeUpdateManager 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Notifications/BadgeUpdater.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Notifications/BadgeUpdater.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.Notifications
 {
 	#if __ANDROID__ || false || false || false || false || false || false
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("__ANDROID__")]
 	#endif
 	public  partial class BadgeUpdater 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.StartScreen/JumpListItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.StartScreen/JumpListItem.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.StartScreen
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class JumpListItem 
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.ViewManagement/StatusBar.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.ViewManagement/StatusBar.cs
@@ -3,7 +3,7 @@
 namespace Windows.UI.ViewManagement
 {
 	#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-	[global::Uno.NotImplemented]
+	[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	#endif
 	public  partial class StatusBar 
 	{

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -314,6 +314,16 @@ namespace Uno.UWPSyncGenerator
 				return defines.Where(d => !string.IsNullOrEmpty(d)).Select(d => $"\"{d}\"").JoinBy(", ");
 			}
 
+			public bool IsNotImplementedInAllPlatforms()
+				=> IsNotDefinedByUno(AndroidSymbol) &&
+					IsNotDefinedByUno(IOSSymbol) &&
+					IsNotDefinedByUno(net461ymbol) &&
+					IsNotDefinedByUno(WasmSymbol) &&
+					IsNotDefinedByUno(SkiaSymbol) &&
+					IsNotDefinedByUno(NetStdReferenceSymbol) &&
+					MacOSSymbol == null;
+
+
 			private static bool IsNotDefinedByUno(ISymbol symbol)
 			{
 				if (symbol == null) { return true; }
@@ -798,7 +808,7 @@ namespace Uno.UWPSyncGenerator
 			{
 				types.AppendIf(b);
 
-				var IMethodSymbol = type.GetMembers().OfType<IMethodSymbol>().First(m => m.Name == "Invoke");
+				var IMethodSymbol = type.GetMembers("Invoke").OfType<IMethodSymbol>().First();
 				var members = string.Join(", ", IMethodSymbol.Parameters.Select(p => $"{SanitizeType(p.Type)} {SanitizeParameter(p.Name)}"));
 
 				b.AppendLineInvariant($"public delegate {SanitizeType(IMethodSymbol.ReturnType)} {type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)}({members});");

--- a/src/Uno.UWPSyncGenerator/SyncGenerator.cs
+++ b/src/Uno.UWPSyncGenerator/SyncGenerator.cs
@@ -75,7 +75,21 @@ namespace Uno.UWPSyncGenerator
 				else
 				{
 					allSymbols.AppendIf(b);
-					b.AppendLineInvariant($"[global::Uno.NotImplemented]");
+
+					var notImplementedList = allSymbols.GenerateNotImplementedList();
+
+					// We're at a point where the generated code wasn't correct here, and the straightforward
+					// fix (to use GenerateNotImplementedList) causes a very large diff. So we special case
+					// the addition of the attribute without specific platforms in cases where it doesn't actually matter.
+					if (string.IsNullOrEmpty(notImplementedList) || allSymbols.IsNotImplementedInAllPlatforms())
+					{
+						b.AppendLineInvariant($"[global::Uno.NotImplemented]");
+					}
+					else
+					{
+						b.AppendLineInvariant($"[global::Uno.NotImplemented({allSymbols.GenerateNotImplementedList()})]");
+					}
+
 					b.AppendLineInvariant($"#endif");
 				}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4893

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

NotImplemented attribute doesn't have platforms when applied to a type.


## What is the new behavior?

Correctly generate platforms.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
