### PR TITLE
Updated App.Resources to use MergedResources in app.xaml

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml
@@ -4,8 +4,13 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:$ext_safeprojectname$">
 	
-	<Application.Resources>
-		<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-	</Application.Resources>
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+                <!-- Place resources here -->
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
 
 </Application>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5988

https://github.com/unoplatform/uno/issues/5988

## PR Type

What kind of change does this PR introduce?
Solution Template Update

## What is the current behavior?

App.xaml places default resources as a root element in the Application.Resources element.

## What is the new behavior?

Changed app.xaml to use MergdDictionaries instead to simplify adding additional custom resources

## PR Checklist

Please check if your PR fulfills the following requirements:

- [NA ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [NA] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [NA] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.