### PR TITLE
fix: fixes TextBox cursor color for Android 29+

### DIFF
--- a/build/run-api-sync-tool.cmd
+++ b/build/run-api-sync-tool.cmd
@@ -1,0 +1,8 @@
+@echo off
+echo Make sure that :
+echo - This script runs on Windows and in a Developer Command Prompt for Visual Studio (2019 or 2022)
+echo - crosstargeting_override.props is not defininig UnoTargetFrameworkOverride
+echo - This script is run from the build folder (not src/build)
+pause
+msbuild Uno.UI.Build.csproj "/p:CombinedConfiguration=Release|AnyCPU;BUILD_BUILDNUMBER=test_test_8888" /m /t:RunAPISyncTool /clp:PerformanceSummary;Summary /bl
+pause

--- a/doc/articles/contributing/guidelines/implementing-a-new winui-winrt-feature.md
+++ b/doc/articles/contributing/guidelines/implementing-a-new winui-winrt-feature.md
@@ -1,0 +1,31 @@
+## Guidelines for implementing a new WinUI/WinRT API
+
+Implementing a new WinUI/WinRT API generally requires to:
+- Find the generated API source file (e.g. `src\Uno.UWP\Generated\3.0.0.0\Windows.Data.Pdf\PdfDocument.cs`)
+- Copy the file to the non-generated location (e.g. `src\Uno.UWP\Data.Pdf\PdfDocument.cs`)
+- Keep only the members that need to be implemented in the non-generated location
+- Remove (completely or partially depending on the platforms) the implemented members in the generated file
+
+If your API implementation is for a specific platform:
+- You can use a platform suffix in the source file name (`PdfDocument.android.cs`) so the file is built only for this platform
+- Remove the parts that relate to your platform in the `NotImplemented` attribute:
+    ```
+    #if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+	public  global::Windows.Data.Pdf.PdfPageDimensions Dimensions
+	{
+	#endif
+    ```
+    becomes
+    ```
+    #if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+	public  global::Windows.Data.Pdf.PdfPageDimensions Dimensions
+	{
+	#endif
+    ```
+    when implemented for Android only.
+
+When implementing a feature, try to place as much code as possible in a common source file (a non-suffixed file), so that it is reused across platforms. Make sure to follow [partial classes coding guidelines](code-style.md).
+
+Note that the generated files may be overriden at any point, and placing custom code (aside from changing the `NotImplemented` values) will be overwritten.

--- a/doc/articles/contributing/guidelines/implementing-a-new winui-winrt-feature.md
+++ b/doc/articles/contributing/guidelines/implementing-a-new winui-winrt-feature.md
@@ -7,9 +7,9 @@ Implementing a new WinUI/WinRT API generally requires to:
 - Remove (completely or partially depending on the platforms) the implemented members in the generated file
 
 If your API implementation is for a specific platform:
-- You can use a platform suffix in the source file name (`PdfDocument.android.cs`) so the file is built only for this platform
+- You can use a platform suffix in the source file name (`PdfDocument.Android.cs`) so the file is built only for this platform
 - Remove the parts that relate to your platform in the `NotImplemented` attribute:
-    ```
+    ```csharp
     #if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	public  global::Windows.Data.Pdf.PdfPageDimensions Dimensions
@@ -17,7 +17,7 @@ If your API implementation is for a specific platform:
 	#endif
     ```
     becomes
-    ```
+    ```csharp
     #if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 	public  global::Windows.Data.Pdf.PdfPageDimensions Dimensions

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -446,6 +446,8 @@
       href: contributing/guidelines/updating-dependencies.md
     - name: Guidelines for issue triage
       href: contributing/guidelines/issue-triage.md
+    - name: Guidelines for implementing a new WinUI/WinRT feature
+      href: contributing/guidelines/implementing-a-new winui-winrt-feature.md
     - name: Adding documentation
       href: uno-development/doc-on-docs.md
     - name: DocFX

--- a/doc/articles/uno-development/building-uno-ui.md
+++ b/doc/articles/uno-development/building-uno-ui.md
@@ -75,3 +75,18 @@ The versions used are centralized in the [Directory.Build.targets](https://githu
 locations where `<PackageReference />` are used.
 
 When updating the versions of nuget packages, make sure to update all the .nuspec files in the [Build folder](https://github.com/unoplatform/uno/tree/master/build).
+
+### Running the SyncGenerator tool
+
+Uno Platform uses a tool which synchronizes all WinRT and WinUI APIs with the type implementations already present in Uno. This ensures that all APIs are present for consumers of Uno, even if some are not implemented.
+
+The synchronization process takes the APIs provided by the WinMD files referenced by the `Uno.UWPSyncGenerator.Reference` project and generates stubbed classes for types in the `Generated` folders of Uno.UI, Uno.Foundation and Uno.WinRT projects. If the generated classes have been partially implemented in Uno (in the non-Generated folders), the tool will automatically skip those implemented methods.
+
+The tool needs to be run on Windows because of its dependency on the Windows SDK WinMD files.
+
+To run the synchronization tool:
+- Open a `Developer Command Prompt for Visual Studio` (2019 or 2022)
+- Go the the `uno\build` folder (not the `uno\src\build` folder)
+- Run the `run-api-sync-tool.cmd` script; make sure to follow the instructions
+
+Note that as of Uno 3.10, the tool is manually run for the UWP part of the build and automatically run as part of the CI during the WinUI part of the build.

--- a/doc/articles/uno-development/contributing-intro.md
+++ b/doc/articles/uno-development/contributing-intro.md
@@ -26,6 +26,10 @@ Whether you're fixing a bug or working on a new feature, [inspecting the visual 
 
 See [Uno's code conventions and common patterns here](../contributing/guidelines/code-style.md).
 
+## Implementing a new feature
+
+See how to implement a new [feature here](../contributing/guidelines/implementing-a-new winui-winrt-feature.md).
+
 ## Adding tests
 
 Uno's stability rests upon a comprehensive testing suite. A code contribution usually isn't complete without a test.

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -167,12 +167,36 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			_app.WaitForText(textBox2, "");
 		}
 
+		[Test]
+		[AutoRetry]
+		public void TextBox_DeleteButton_Depends_On_Width()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.Width_Affects_Delete_Button");
+
+			var initiallyLarge = _app.Marked("initiallyLarge");
+			var initiallySmall = _app.Marked("initiallySmall");
+
+			initiallyLarge.FastTap();
+			Assert.NotNull(FindDeleteButton(_app.Query(initiallyLarge).Single()));
+
+			initiallySmall.FastTap();
+			Assert.Null(FindDeleteButton(_app.Query(initiallySmall).Single()));
+
+			_app.Marked("makeSmallerBtn").FastTap();
+			initiallyLarge.FastTap();
+			Assert.Null(FindDeleteButton(_app.Query(initiallyLarge).Single()));
+
+			_app.Marked("makeBiggerBtn").FastTap();
+			initiallySmall.FastTap();
+			Assert.NotNull(FindDeleteButton(_app.Query(initiallySmall).Single()));
+		}
+
 		private Uno.UITest.IAppResult FindDeleteButton(Uno.UITest.IAppResult source)
 		{
 			var deleteButtons = _app.Marked("DeleteButton");
 			var appResult = _app.Query(deleteButtons).ToArray();
 			var deleteButton = appResult
-				.First(r =>
+				.FirstOrDefault(r =>
 					r.Rect.CenterX > source.Rect.X
 					&& r.Rect.CenterX < source.Rect.Right
 					&& r.Rect.CenterY > source.Rect.Y

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1801,6 +1801,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\Width_Affects_Delete_Button.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ThumbTests\Thumb_DragEvents.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5483,6 +5487,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\WASM_Multiline.xaml.cs">
       <DependentUpon>WASM_Multiline.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\Width_Affects_Delete_Button.xaml.cs">
+      <DependentUpon>Width_Affects_Delete_Button.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ThumbTests\Thumb_DragEvents.xaml.cs">
       <DependentUpon>Thumb_DragEvents.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Width_Affects_Delete_Button.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Width_Affects_Delete_Button.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.Width_Affects_Delete_Button"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <StackPanel>
+		<StackPanel Orientation="Horizontal">
+			<TextBox Text="A" Width="70" x:Name="initiallySmall"/>
+			<Button x:Name="makeBiggerBtn" Content="Make bigger" Click="MakeBiggerClick" />
+		</StackPanel>
+		<StackPanel Orientation="Horizontal">
+			<TextBox Text="A" Width="71" x:Name="initiallyLarge"/>
+			<Button x:Name="makeSmallerBtn" Content="Make smaller" Click="MakeSmallerClick" />
+		</StackPanel>
+		
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Width_Affects_Delete_Button.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Width_Affects_Delete_Button.xaml
@@ -11,11 +11,11 @@
 
     <StackPanel>
 		<StackPanel Orientation="Horizontal">
-			<TextBox Text="A" Width="70" x:Name="initiallySmall"/>
+			<TextBox Text="A" Width="70" FontSize="14" x:Name="initiallySmall"/>
 			<Button x:Name="makeBiggerBtn" Content="Make bigger" Click="MakeBiggerClick" />
 		</StackPanel>
 		<StackPanel Orientation="Horizontal">
-			<TextBox Text="A" Width="71" x:Name="initiallyLarge"/>
+			<TextBox Text="A" Width="71" FontSize="14" x:Name="initiallyLarge"/>
 			<Button x:Name="makeSmallerBtn" Content="Make smaller" Click="MakeSmallerClick" />
 		</StackPanel>
 		

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Width_Affects_Delete_Button.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/Width_Affects_Delete_Button.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
+{
+	[Sample]
+	public sealed partial class Width_Affects_Delete_Button : UserControl
+	{
+		public Width_Affects_Delete_Button()
+		{
+			this.InitializeComponent();
+		}
+
+		private void MakeSmallerClick(object sender, RoutedEventArgs args)
+		{
+			initiallyLarge.Width = 50;
+		}
+
+		private void MakeBiggerClick(object sender, RoutedEventArgs args)
+		{
+			initiallySmall.Width = 100;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -76,6 +76,12 @@ namespace Windows.UI.Xaml.Controls
 			this.RegisterParentChangedCallback(this, OnParentChanged);
 
 			DefaultStyleKey = typeof(TextBox);
+			SizeChanged += OnSizeChanged;
+		}
+
+		private void OnSizeChanged(object sender, SizeChangedEventArgs args)
+		{
+			UpdateButtonStates();
 		}
 
 		private void OnParentChanged(object instance, object key, DependencyObjectParentChangedEventArgs args) => UpdateFontPartial();
@@ -688,9 +694,7 @@ namespace Windows.UI.Xaml.Controls
 				this.Log().LogDebug(nameof(UpdateButtonStates));
 			}
 
-			if (CanShowButton && _isButtonEnabled
-			// TODO (https://github.com/unoplatform/uno/issues/683): && ActualWidth >= TDB / Note: We also have to invoke this method on SizeChanged
-			)
+			if (CanShowButton && _isButtonEnabled && ActualWidth > 70)
 			{
 				VisualStateManager.GoToState(this, TextBoxConstants.ButtonVisibleStateName, true);
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -694,6 +694,7 @@ namespace Windows.UI.Xaml.Controls
 				this.Log().LogDebug(nameof(UpdateButtonStates));
 			}
 
+			// Minimum width for TextBox with DeleteButton visible is 5em.
 			if (CanShowButton && _isButtonEnabled && ActualWidth > FontSize * 5)
 			{
 				VisualStateManager.GoToState(this, TextBoxConstants.ButtonVisibleStateName, true);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -694,7 +694,7 @@ namespace Windows.UI.Xaml.Controls
 				this.Log().LogDebug(nameof(UpdateButtonStates));
 			}
 
-			if (CanShowButton && _isButtonEnabled && ActualWidth > 70)
+			if (CanShowButton && _isButtonEnabled && ActualWidth > FontSize * 5)
 			{
 				VisualStateManager.GoToState(this, TextBoxConstants.ButtonVisibleStateName, true);
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
@@ -136,8 +136,11 @@ namespace Windows.UI.Xaml.Controls
 				}
 				var editText = new EditText(context);
 
-				_cursorDrawableResField = textViewClass.GetDeclaredField("mCursorDrawableRes");
-				_cursorDrawableResField.Accessible = true;
+				if ((int)Build.VERSION.SdkInt < 29)
+				{
+					_cursorDrawableResField = textViewClass.GetDeclaredField("mCursorDrawableRes");
+					_cursorDrawableResField.Accessible = true;
+				}
 
 				_editorField = textViewClass.GetDeclaredField("mEditor");
 				_editorField.Accessible = true;
@@ -146,11 +149,12 @@ namespace Windows.UI.Xaml.Controls
 				{
 					_cursorDrawableField = _editorField.Get(editText)?.Class.GetDeclaredField("mCursorDrawable");
 				}
-				else
+				else if((int)Build.VERSION.SdkInt == 28)
 				{
-					// set differently in Android P (API 28) and higher
+					// set differently in Android P (API 28)
 					_cursorDrawableField = _editorField.Get(editText)?.Class.GetDeclaredField("mDrawableForCursor");
 				}
+				// Android versions 29+ are handled directly through SetColorFilter API
 
 				if (_cursorDrawableField != null)
 				{
@@ -167,51 +171,67 @@ namespace Windows.UI.Xaml.Controls
 						PrepareFields(editText.Context);
 					}
 
-					if (_cursorDrawableField == null || _cursorDrawableResField == null || _editorField == null || PorterDuff.Mode.SrcIn == null)
+					if (PorterDuff.Mode.SrcIn == null)
+					{
+						editText.Log().WarnIfEnabled(() => "Failed to change the cursor color. Some devices don't support this.");
+						return;
+					}
+
+					if ((int)Build.VERSION.SdkInt >= 29)
+					{
+						var drawable = editText.TextCursorDrawable;
+						if (BlendMode.SrcAtop != null)
+						{
+							drawable?.SetColorFilter(new BlendModeColorFilter(color, BlendMode.SrcAtop));
+						}
+					}
+					else if (_cursorDrawableField == null || _cursorDrawableResField == null || _editorField == null || PorterDuff.Mode.SrcIn == null)
 					{
 						// PrepareFields() failed, give up now
 						editText.Log().WarnIfEnabled(() => "Failed to change the cursor color. Some devices don't support this.");
 						return;
 					}
-
-					var mCursorDrawableRes = _cursorDrawableResField.GetInt(editText);
-					var editor = _editorField.Get(editText);
+					else
+					{
+						var mCursorDrawableRes = _cursorDrawableResField.GetInt(editText);
+						var editor = _editorField.Get(editText);
 
 #if __ANDROID_28__
 #pragma warning disable 618 // SetColorFilter is deprecated
-					if ((int)Build.VERSION.SdkInt < 28) // 28 means BuildVersionCodes.P
-					{
-						var drawables = new Drawable[2];
-						drawables[0] = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
-						drawables[1] = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
-						drawables[0].SetColorFilter(color, PorterDuff.Mode.SrcIn);
-						drawables[1].SetColorFilter(color, PorterDuff.Mode.SrcIn);
-						_cursorDrawableField.Set(editor, drawables);
-					}
-					else
-					{
-						var drawable = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
-						drawable.SetColorFilter(color, PorterDuff.Mode.SrcIn);
-						_cursorDrawableField.Set(editor, drawable);
-					}
+						if ((int)Build.VERSION.SdkInt < 28) // 28 means BuildVersionCodes.P
+						{
+							var drawables = new Drawable[2];
+							drawables[0] = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
+							drawables[1] = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
+							drawables[0].SetColorFilter(color, PorterDuff.Mode.SrcIn);
+							drawables[1].SetColorFilter(color, PorterDuff.Mode.SrcIn);
+							_cursorDrawableField.Set(editor, drawables);
+						}
+						else
+						{
+							var drawable = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
+							drawable.SetColorFilter(color, PorterDuff.Mode.SrcIn);
+							_cursorDrawableField.Set(editor, drawable);
+						}
 #pragma warning restore 618 // SetColorFilter is deprecated
 #else
-					if ((int)Build.VERSION.SdkInt < 28) // 28 means BuildVersionCodes.P
-					{
-						var drawables = new Drawable[2];
-						drawables[0] = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
-						drawables[1] = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
-						drawables[0].SetColorFilter(new BlendModeColorFilterCompat(color, BlendModeCompat.SrcIn));
-						drawables[1].SetColorFilter(new BlendModeColorFilterCompat(color, BlendModeCompat.SrcIn));
-						_cursorDrawableField.Set(editor, drawables);
-					}
-					else
-					{
-						var drawable = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
-						drawable.SetColorFilter(new BlendModeColorFilterCompat(color, BlendModeCompat.SrcIn));
-						_cursorDrawableField.Set(editor, drawable);
-					}
+						if ((int)Build.VERSION.SdkInt < 28) // 28 means BuildVersionCodes.P
+						{
+							var drawables = new Drawable[2];
+							drawables[0] = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
+							drawables[1] = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
+							drawables[0].SetColorFilter(new BlendModeColorFilterCompat(color, BlendModeCompat.SrcIn));
+							drawables[1].SetColorFilter(new BlendModeColorFilterCompat(color, BlendModeCompat.SrcIn));
+							_cursorDrawableField.Set(editor, drawables);
+						}
+						else
+						{
+							var drawable = ContextCompat.GetDrawable(editText.Context, mCursorDrawableRes);
+							drawable.SetColorFilter(new BlendModeColorFilterCompat(color, BlendModeCompat.SrcIn));
+							_cursorDrawableField.Set(editor, drawable);
+						}
 #endif
+					}
 				}
 				catch (Exception)
 				{

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -139,19 +139,24 @@ namespace Uno.UWPSyncGenerator
 
 		private static void InitializeRoslyn()
 		{
-			var pi = new System.Diagnostics.ProcessStartInfo(
-				"cmd.exe",
-				@"/c ""C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"" -property installationPath"
-			)
-			{
-				RedirectStandardOutput = true,
-				UseShellExecute = false,
-				CreateNoWindow = true
-			};
+			var installPath = Environment.GetEnvironmentVariable("VSINSTALLDIR");
 
-			var process = System.Diagnostics.Process.Start(pi);
-			process.WaitForExit();
-			var installPath = process.StandardOutput.ReadToEnd().Split('\r').First();
+			if (string.IsNullOrEmpty(installPath))
+			{
+				var pi = new System.Diagnostics.ProcessStartInfo(
+					"cmd.exe",
+					@"/c ""C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"" -property installationPath"
+				)
+				{
+					RedirectStandardOutput = true,
+					UseShellExecute = false,
+					CreateNoWindow = true
+				};
+
+				var process = System.Diagnostics.Process.Start(pi);
+				process.WaitForExit();
+				installPath = process.StandardOutput.ReadToEnd().Split('\r').First();
+			}
 
 			SetupMSBuildLookupPath(installPath);
 		}


### PR DESCRIPTION
GitHub Issue: closes #6240

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
- Fix

## What is the current behavior?
Error changing cursor color in API 29+

## What is the new behavior?
Fix cursor color change for Android 29+

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

# Before 
![Android 10](https://user-images.githubusercontent.com/33006894/131189332-ebbcb9e6-bab5-4432-8ad2-18549ca9f555.png)

# After
![Android 11](https://user-images.githubusercontent.com/33006894/131189345-55b0ff77-6806-4b08-9bc3-34e7f15d891a.png)

