### PR TITLE
fix: Align PrimaryLanguageOverride behavior with UWP

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_ApplicationLanguages.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_ApplicationLanguages.cs
@@ -1,38 +1,31 @@
-﻿using System.Globalization;
-using System.Linq;
-using Windows.Globalization;
+﻿using Windows.Globalization;
 using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Storage;
 
-namespace Uno.UI.RuntimeTests.Tests.Windows_Globalization
+namespace Uno.UI.RuntimeTests.Tests.Windows_Globalization;
+
+[TestClass]
+public class Given_ApplicationLanguages
 {
-	[TestClass]
-	public class Given_ApplicationLanguages
+	[TestCleanup]
+	public void CleanUp()
 	{
-		[TestCleanup]
-		public void CleanUp()
-		{
-			ApplicationLanguages.PrimaryLanguageOverride = null;
-		}
+		ApplicationLanguages.PrimaryLanguageOverride = string.Empty;
+	}
 
-		[TestMethod]
-		public void Test_Chinese_With_Script_Subtag()
-		{
-			ApplicationLanguages.PrimaryLanguageOverride = "zh-Hans-CN";
+	[TestMethod]
+	public void Test_Chinese_With_Script_Subtag()
+	{
+		ApplicationLanguages.PrimaryLanguageOverride = "zh-Hans-CN";
+		ApplicationLanguages.Languages[0].Should().Be("zh-Hans-CN");
+		ApplicationData.Current.LocalSettings.Values["__Uno.PrimaryLanguageOverride"].Should().Be("zh-Hans-CN");
+	}
 
-			ApplicationLanguages.Languages[0].Should().Be("zh-Hans-CN");
-			CultureInfo.CurrentCulture.Name.Should().BeOneOf("zh-CN", "zh-Hans-CN");
-			CultureInfo.CurrentUICulture.Name.Should().BeOneOf("zh-CN", "zh-Hans-CN");
-		}
-
-		[TestMethod]
-		public void Test_French_With_Script_Subtag()
-		{
-			ApplicationLanguages.PrimaryLanguageOverride = "fr-Latn-CA";
-
-			ApplicationLanguages.Languages[0].Should().Be("fr-Latn-CA");
-			CultureInfo.CurrentCulture.Name.Should().BeOneOf("fr-CA", "fr-Latn-CA");
-			CultureInfo.CurrentUICulture.Name.Should().BeOneOf("fr-CA", "fr-Latn-CA");
-		}
+	[TestMethod]
+	public void Test_French_With_Script_Subtag()
+	{
+		ApplicationLanguages.PrimaryLanguageOverride = "fr-Latn-CA";
+		ApplicationLanguages.Languages[0].Should().Be("fr-Latn-CA");
+		ApplicationData.Current.LocalSettings.Values["__Uno.PrimaryLanguageOverride"].Should().Be("fr-Latn-CA");
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -123,8 +123,19 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		private static IDisposable SetAmbiantLanguage(string language)
 		{
 			var previousLanguage = ApplicationLanguages.PrimaryLanguageOverride;
+			var currentCulture = CultureInfo.CurrentCulture;
+			var currentUICulture = CultureInfo.CurrentUICulture;
+			var defaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentCulture;
+			var defaultThreadCurrentUICulture = CultureInfo.DefaultThreadCurrentUICulture;
 			ApplicationLanguages.PrimaryLanguageOverride = language;
-			return Disposable.Create(() => ApplicationLanguages.PrimaryLanguageOverride = previousLanguage);
+			return Disposable.Create(() =>
+			{
+				ApplicationLanguages.PrimaryLanguageOverride = previousLanguage;
+				CultureInfo.CurrentCulture = currentCulture;
+				CultureInfo.CurrentUICulture = currentUICulture;
+				CultureInfo.DefaultThreadCurrentCulture = defaultThreadCurrentCulture;
+				CultureInfo.DefaultThreadCurrentUICulture = defaultThreadCurrentUICulture;
+			});
 		}
 
 		private static void CheckDateTimeTextBlockPartPosition(DatePicker datePicker, string id, int expectedColumn)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !WINDOWS_UWP
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -151,3 +152,4 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 	}
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -128,6 +128,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var defaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentCulture;
 			var defaultThreadCurrentUICulture = CultureInfo.DefaultThreadCurrentUICulture;
 			ApplicationLanguages.PrimaryLanguageOverride = language;
+			ApplicationLanguages.Initialize();
 			return Disposable.Create(() =>
 			{
 				ApplicationLanguages.PrimaryLanguageOverride = previousLanguage;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -129,7 +129,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var defaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentCulture;
 			var defaultThreadCurrentUICulture = CultureInfo.DefaultThreadCurrentUICulture;
 			ApplicationLanguages.PrimaryLanguageOverride = language;
-			ApplicationLanguages.Initialize();
+			ApplicationLanguages.ApplyCulture();
 			return Disposable.Create(() =>
 			{
 				ApplicationLanguages.PrimaryLanguageOverride = previousLanguage;

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Uno;
 using Uno.UI;
 using Uno.Diagnostics.Eventing;
@@ -8,6 +9,7 @@ using Windows.Foundation.Metadata;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel;
+using Windows.Globalization;
 using Uno.Helpers.Theming;
 using Windows.UI.ViewManagement;
 using Uno.Extensions;
@@ -247,6 +249,7 @@ namespace Windows.UI.Xaml
 
 		public static void Start(global::Windows.UI.Xaml.ApplicationInitializationCallback callback)
 		{
+			ApplicationLanguages.Initialize();
 			StartPartial(callback);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -249,7 +249,7 @@ namespace Windows.UI.Xaml
 
 		public static void Start(global::Windows.UI.Xaml.ApplicationInitializationCallback callback)
 		{
-			ApplicationLanguages.Initialize();
+			ApplicationLanguages.ApplyCulture();
 			StartPartial(callback);
 		}
 

--- a/src/Uno.UWP/Globalization/ApplicationLanguages.cs
+++ b/src/Uno.UWP/Globalization/ApplicationLanguages.cs
@@ -14,6 +14,14 @@ namespace Windows.Globalization
 
 		static ApplicationLanguages()
 		{
+#if !NET461
+			if (ApplicationData.Current.LocalSettings.Values.TryGetValue(PrimaryLanguageOverrideSettingKey, out var savedValue)
+				&& savedValue is string stringSavedValue)
+			{
+				_primaryLanguageOverride = stringSavedValue;
+			}
+#endif
+
 			ApplyLanguages();
 		}
 
@@ -24,7 +32,9 @@ namespace Windows.Globalization
 			{
 				var culture = CreateCulture(primaryLanguageOverride);
 				CultureInfo.CurrentCulture = culture;
+				CultureInfo.DefaultThreadCurrentCulture = culture;
 				CultureInfo.CurrentUICulture = culture;
+				CultureInfo.DefaultThreadCurrentUICulture = culture;
 			}
 		}
 
@@ -32,13 +42,6 @@ namespace Windows.Globalization
 		{
 			get
 			{
-				if (_primaryLanguageOverride.Length == 0 &&
-					ApplicationData.Current.LocalSettings.Values.TryGetValue(PrimaryLanguageOverrideSettingKey, out var savedValue) &&
-					savedValue is string stringSavedValue)
-				{
-					_primaryLanguageOverride = stringSavedValue;
-				}
-
 				return _primaryLanguageOverride;
 			}
 			set

--- a/src/Uno.UWP/Globalization/ApplicationLanguages.cs
+++ b/src/Uno.UWP/Globalization/ApplicationLanguages.cs
@@ -87,7 +87,9 @@ namespace Windows.Globalization
 					ApplyCulture();
 				}
 
+#if !NET461
 				ApplicationData.Current.LocalSettings.Values[PrimaryLanguageOverrideSettingKey] = _primaryLanguageOverride;
+#endif
 			}
 		}
 

--- a/src/Uno.UWP/Globalization/ApplicationLanguages.cs
+++ b/src/Uno.UWP/Globalization/ApplicationLanguages.cs
@@ -12,7 +12,10 @@ namespace Windows.Globalization
 	public static partial class ApplicationLanguages
 	{
 		private static string _primaryLanguageOverride = string.Empty;
+
+#if !NET461
 		private const string PrimaryLanguageOverrideSettingKey = "__Uno.PrimaryLanguageOverride";
+#endif
 
 		static ApplicationLanguages()
 		{

--- a/src/Uno.UWP/Globalization/ApplicationLanguages.cs
+++ b/src/Uno.UWP/Globalization/ApplicationLanguages.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Windows.Storage;
 using Uno.UI;
+using Uno;
 
 namespace Windows.Globalization
 {
@@ -52,6 +53,11 @@ namespace Windows.Globalization
 				}
 
 				_primaryLanguageOverride = value;
+				if (WinRTFeatureConfiguration.ApplicationLanguages.UseLegacyPrimaryLanguageOverride)
+				{
+					Initialize();
+				}
+
 				ApplyLanguages();
 
 				ApplicationData.Current.LocalSettings.Values[PrimaryLanguageOverrideSettingKey] = _primaryLanguageOverride;

--- a/src/Uno.UWP/WinRTFeatureConfiguration.cs
+++ b/src/Uno.UWP/WinRTFeatureConfiguration.cs
@@ -14,5 +14,15 @@ namespace Uno
 		{
 			GestureRecognizer.RestoreDefaults();
 		}
+
+		public static class ApplicationLanguages
+		{
+			/// <summary>
+			/// <see cref="Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride"/> used to take effect (by changing current culture) during its setter.
+			/// On Windows, changing this property only takes effect after restarting the application. We changed the default behavior as a breaking change to match Windows.
+			/// Set this property to true to get the old behavior.
+			/// </summary>
+			public static bool UseLegacyPrimaryLanguageOverride { get; set; }
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6880, partial improvement to #11257

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- `PrimaryLanguageOverride` default value is null
- `PrimaryLanguageOverride` setter allows null
- `PrimaryLanguageOverride` not persisted.

## What is the new behavior?

- Default value is now string.Empty matching UWP
- Null isn't allowed.
- Value is persisted (not sure if UWP does it the same way)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
