### PR TITLE
docs: Fix bluetoothdevice documentation page

### DIFF
--- a/doc/articles/features/bluetoothdevice.md
+++ b/doc/articles/features/bluetoothdevice.md
@@ -4,7 +4,7 @@ The support for `Windows.Devices.Bluetooth` is not available at this point, but 
 
 ## Note for contributors of this Windows.Devices.Bluetooth
 	
-	To implement the `BluetoothDevice.GetDeviceSelectorFromClassOfDevice` method, you can use some of the information below.
+To implement the `BluetoothDevice.GetDeviceSelectorFromClassOfDevice` method, you can use some of the information below.
 
 This method should iterate all `ServiceCapabilities`, and use bits from it to construct part of query, and the method may look like:
 	


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Documentation content changes


## What is the current behavior?

- The page is in "Doc" folder instead of "doc" folder. On Unix-based systems, they are different and hence the page isn't published since the docfx.json file in "doc" won't pick up this file.
- A normal statement appears as a code block.


## What is the new behavior?

Fixed both.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
