### PR TITLE
Fixed a potential crash with GetBBox() on WASM

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Basics_Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Basics_Shapes_Tests.cs
@@ -769,7 +769,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			var xamlShape6 = _app.GetPhysicalRect("xamlShape6");
 			var deferredShape6 = _app.GetPhysicalRect("deferredShape6");
 
-			ImageAssert.HasColorAt(screensnot, xamlShape6.CenterX, xamlShape6.CenterY, Color.Yellow, tolerance:5);
+			ImageAssert.HasColorAt(screensnot, xamlShape6.CenterX, xamlShape6.CenterY, Color.Yellow, tolerance: 5);
 			ImageAssert.HasColorAt(screensnot, deferredShape6.CenterX, xamlShape6.CenterY, Color.Yellow, tolerance: 5);
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Basics_Shapes_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Shapes/Basics_Shapes_Tests.cs
@@ -755,5 +755,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Shapes
 			"Rectangle_Uniform_MinWidthSmall",
 			"Rectangle_Uniform_Unconstrained",
 		};
+
+		[Test]
+		[AutoRetry]
+		public void Validate_Offscreen_Shapes()
+		{
+			Run("UITests.Windows_UI_Xaml_Shapes.Offscreen_Shapes");
+
+			_app.WaitForElement("deferredShape6");
+
+			using var screensnot = TakeScreenshot("offscreen_shapes", ignoreInSnapshotCompare: true);
+
+			var xamlShape6 = _app.GetPhysicalRect("xamlShape6");
+			var deferredShape6 = _app.GetPhysicalRect("deferredShape6");
+
+			ImageAssert.HasColorAt(screensnot, xamlShape6.CenterX, xamlShape6.CenterY, Color.Yellow, tolerance:5);
+			ImageAssert.HasColorAt(screensnot, deferredShape6.CenterX, xamlShape6.CenterY, Color.Yellow, tolerance: 5);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3969,6 +3969,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Offscreen_Shapes.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PathStretchModes.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6622,6 +6626,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\MeasurePage.xaml.cs">
       <DependentUpon>MeasurePage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\Offscreen_Shapes.xaml.cs">
+      <DependentUpon>Offscreen_Shapes.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\PathStretchModes.xaml.cs">
       <DependentUpon>PathStretchModes.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Offscreen_Shapes.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Offscreen_Shapes.xaml
@@ -1,0 +1,48 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Shapes.Offscreen_Shapes"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Shapes"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid RowSpacing="6" ColumnSpacing="6" x:Name="grid">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="Auto" />
+			<ColumnDefinition Width="Auto" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<TextBlock FontSize="20" HorizontalAlignment="Center" Grid.Row="0" Grid.Column="1">XAML</TextBlock>
+		<TextBlock FontSize="20" HorizontalAlignment="Center" Grid.Row="0" Grid.Column="2" FontStyle="Italic">Deferred</TextBlock>
+
+		<TextBlock FontSize="20" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0">Ellipse</TextBlock>
+		<TextBlock FontSize="20" VerticalAlignment="Center" Grid.Row="2" Grid.Column="0">Line</TextBlock>
+		<TextBlock FontSize="20" VerticalAlignment="Center" Grid.Row="3" Grid.Column="0">Path</TextBlock>
+		<TextBlock FontSize="20" VerticalAlignment="Center" Grid.Row="4" Grid.Column="0">Polygon</TextBlock>
+		<TextBlock FontSize="20" VerticalAlignment="Center" Grid.Row="5" Grid.Column="0">Polyline</TextBlock>
+		<TextBlock FontSize="20" VerticalAlignment="Center" Grid.Row="6" Grid.Column="0">Rectangle</TextBlock>
+
+		<Ellipse Grid.Row="1" Grid.Column="1" Fill="Yellow" Stroke="Green" StrokeThickness="2" Width="60" Height="40" x:Name="xamlShape1" />
+		<Line Grid.Row="2" Grid.Column="1" Fill="Yellow" Stroke="Green" StrokeThickness="2" X2="60" Y2="30" x:Name="xamlShape2" />
+		<Path Grid.Row="3" Grid.Column="1" Fill="Yellow" Stroke="Green" StrokeThickness="2" Width="60" Height="40" x:Name="xamlShape3" Data="M0,0L60,40 0,40 60,0Z" />
+		<Polygon Grid.Row="4" Grid.Column="1" Fill="Yellow" Stroke="Green" StrokeThickness="2" Width="60" Height="40" x:Name="xamlShape4" Points="0,0 60,40 0,40" />
+		<Polyline Grid.Row="5" Grid.Column="1" Fill="Yellow" Stroke="Green" StrokeThickness="2" Width="60" Height="40" x:Name="xamlShape5" Points="0,0 60,40 20,30 50,10" />
+		<Rectangle Grid.Row="6" Grid.Column="1" Fill="Yellow" Stroke="Green" StrokeThickness="2" Width="60" Height="40" x:Name="xamlShape6" />
+
+		<TextBlock FontSize="20" Grid.Row="7" Grid.ColumnSpan="4" TextWrapping="Wrap"> The 2 columns should appear identical</TextBlock>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Offscreen_Shapes.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Offscreen_Shapes.xaml.cs
@@ -1,0 +1,129 @@
+﻿using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
+using Uno.Extensions;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Shapes
+{
+	[Sample("Shapes")]
+	public sealed partial class Offscreen_Shapes : Page
+	{
+		public Offscreen_Shapes()
+		{
+			this.InitializeComponent();
+
+			Loaded += OnLoaded;
+		}
+
+		private async void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			Loaded -= OnLoaded;
+
+			await Task.Delay(200);
+
+			var sw = xamlShape1.Width;
+			var sh = xamlShape1.Height;
+			var sf = xamlShape1.Fill;
+			var ss = xamlShape1.Stroke;
+			var sst = xamlShape1.StrokeThickness;
+
+			await SetShape(
+				1,
+				new Ellipse
+				{
+					Width = sw,
+					Height = sh,
+					Fill = sf,
+					Stroke = ss,
+					StrokeThickness = sst
+				});
+
+			await SetShape(
+				2,
+				new Line
+				{
+					Fill = sf,
+					Stroke = ss,
+					StrokeThickness = sst,
+					X2=xamlShape2.X2,
+					Y2=xamlShape2.Y2
+				});
+
+			var p = await SetShape(
+				3,
+				new Path
+				{
+					Width = sw,
+					Height = sh,
+					Fill = sf,
+					Stroke = ss,
+					StrokeThickness = sst,
+				});
+
+#if NETFX_CORE
+			var geometry = XamlReader.Load("<Geometry xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>M0,0L60,40 0,40 60,0Z</Geometry>") as Geometry;
+#else
+			var geometry = (Geometry)"M0,0L60,40 0,40 60,0Z";
+#endif
+			p.Data = geometry;
+
+			var polygon = await SetShape(
+				4,
+				new Polygon
+				{
+					Width = sw,
+					Height = sh,
+					Fill = sf,
+					Stroke = ss,
+					StrokeThickness = sst
+				});
+
+			polygon.Points.AddRange(xamlShape4.Points);
+
+			var polyline = await SetShape(
+				5,
+				new Polyline
+				{
+					Width = sw,
+					Height = sh,
+					Fill = sf,
+					Stroke = ss,
+					StrokeThickness = sst,
+				});
+
+			polyline.Points.AddRange(xamlShape5.Points);
+
+			await SetShape(
+				6,
+				new Rectangle
+				{
+					Width = sw,
+					Height = sh,
+					Fill = sf,
+					Stroke = ss,
+					StrokeThickness = sst
+				});
+
+			async Task<T> SetShape<T>(int row, T element)
+				where T : FrameworkElement
+			{
+				await Task.Yield();
+				element.Measure(new Size(100, 100));
+				element.Arrange(new Rect(0, 0, 200, 200));
+				await Task.Yield();
+				Grid.SetColumn(element, 2);
+				Grid.SetRow(element, row);
+				element.Name = $"deferredShape{row}";
+
+				grid.Children.Add(element);
+
+				return element;
+			}
+		}
+	}
+}

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -385,7 +385,7 @@ var Uno;
                                 //
                                 // If the image fails to load, setup the splashScreen anyways with the
                                 // proper sample.
-                                let canvas = document.createElement('canvas');
+                                let canvas = document.createElement("canvas");
                                 canvas.width = img.width;
                                 canvas.height = img.height;
                                 let ctx = canvas.getContext("2d");
@@ -411,7 +411,7 @@ var Uno;
                     const UNO_BOOTSTRAP_WEBAPP_BASE_PATH = config.environmentVariables["UNO_BOOTSTRAP_WEBAPP_BASE_PATH"] || "";
                     let fullImagePath = String(UnoAppManifest.splashScreenImage);
                     // If the splashScreenImage image already points to the app base path, use it, otherwise we build it.
-                    if (UNO_BOOTSTRAP_APP_BASE !== '' && fullImagePath.indexOf(UNO_BOOTSTRAP_APP_BASE) == -1) {
+                    if (UNO_BOOTSTRAP_APP_BASE !== "" && fullImagePath.indexOf(UNO_BOOTSTRAP_APP_BASE) == -1) {
                         fullImagePath = `${UNO_BOOTSTRAP_WEBAPP_BASE_PATH}${UNO_BOOTSTRAP_APP_BASE}/${UnoAppManifest.splashScreenImage}`;
                     }
                     img.src = fullImagePath;
@@ -463,7 +463,7 @@ var Uno;
                     return new URLSearchParams(window.location.search).toString();
                 }
                 else {
-                    const queryIndex = document.location.search.indexOf('?');
+                    const queryIndex = document.location.search.indexOf("?");
                     if (queryIndex !== -1) {
                         return document.location.search.substring(queryIndex + 1);
                     }
@@ -679,7 +679,7 @@ var Uno;
                 const element = this.getView(elementId);
                 for (const name in properties) {
                     if (properties.hasOwnProperty(name)) {
-                        var setVal = properties[name];
+                        const setVal = properties[name];
                         if (setVal === "true") {
                             element[name] = true;
                         }
@@ -700,7 +700,7 @@ var Uno;
                 const params = WindowManagerSetPropertyParams.unmarshal(pParams);
                 const element = this.getView(params.HtmlId);
                 for (let i = 0; i < params.Pairs_Length; i += 2) {
-                    var setVal = params.Pairs[i + 1];
+                    const setVal = params.Pairs[i + 1];
                     if (setVal === "true") {
                         element[params.Pairs[i]] = true;
                     }
@@ -927,7 +927,7 @@ var Uno;
             setElementTransformNative(pParams) {
                 const params = WindowManagerSetElementTransformParams.unmarshal(pParams);
                 const element = this.getView(params.HtmlId);
-                var style = element.style;
+                const style = element.style;
                 const matrix = `matrix(${params.M11},${params.M12},${params.M21},${params.M22},${params.M31},${params.M32})`;
                 style.transform = matrix;
                 this.setAsArranged(element);
@@ -1068,7 +1068,7 @@ var Uno;
                     // We achieve that by buffering it until the next few 'pointermove' on document for which we validate the new pointer location.
                     // It's common to get a move right after the leave with the same pointer's location,
                     // so we wait up to 3 pointer move before dropping the leave event.
-                    var attempt = 3;
+                    let attempt = 3;
                     WindowManager.current.ensurePendingLeaveEventProcessing();
                     WindowManager.current.processPendingLeaveEvent = (move) => {
                         if (!move.isOverDeep(element)) {
@@ -1197,9 +1197,9 @@ var Uno;
                 // defined in the browser settings. 
                 // https://stackoverflow.com/questions/20110224/what-is-the-height-of-a-line-in-a-wheel-event-deltamode-dom-delta-line
                 if (this._wheelLineSize == undefined) {
-                    const el = document.createElement('div');
-                    el.style.fontSize = 'initial';
-                    el.style.display = 'none';
+                    const el = document.createElement("div");
+                    el.style.fontSize = "initial";
+                    el.style.display = "none";
                     document.body.appendChild(el);
                     const fontSize = window.getComputedStyle(el).fontSize;
                     document.body.removeChild(el);
@@ -1441,7 +1441,7 @@ var Uno;
             getBBoxInternal(elementId) {
                 const element = this.getView(elementId);
                 let unconnectedRoot = null;
-                let cleanupUnconnectedRoot = (owner) => {
+                const cleanupUnconnectedRoot = (owner) => {
                     if (unconnectedRoot !== null) {
                         owner.removeChild(unconnectedRoot);
                     }
@@ -1450,6 +1450,7 @@ var Uno;
                     // On FireFox, the element needs to be connected to the DOM
                     // or the getBBox() will crash.
                     if (!element.isConnected) {
+                        unconnectedRoot = element;
                         while (unconnectedRoot.parentElement) {
                             // Need to find the top most "unconnected" parent
                             // of this element
@@ -1514,7 +1515,7 @@ var Uno;
                 let parentElement = null;
                 let parentElementWidthHeight = null;
                 let unconnectedRoot = null;
-                let cleanupUnconnectedRoot = (owner) => {
+                const cleanupUnconnectedRoot = (owner) => {
                     if (unconnectedRoot !== null) {
                         owner.removeChild(unconnectedRoot);
                     }
@@ -1541,14 +1542,14 @@ var Uno;
                         const inputElement = element;
                         cleanupUnconnectedRoot(this.containerElement);
                         // Create a temporary element that will contain the input's content
-                        var textOnlyElement = document.createElement("p");
+                        const textOnlyElement = document.createElement("p");
                         textOnlyElement.style.cssText = unconstrainedStyleCssText;
                         textOnlyElement.innerText = inputElement.value;
                         textOnlyElement.className = elementClasses;
                         unconnectedRoot = textOnlyElement;
                         this.containerElement.appendChild(unconnectedRoot);
-                        var textSize = this.measureElement(textOnlyElement);
-                        var inputSize = this.measureElement(element);
+                        const textSize = this.measureElement(textOnlyElement);
+                        const inputSize = this.measureElement(element);
                         // Take the width of the inner text, but keep the height of the input element.
                         return [textSize[0], inputSize[1]];
                     }
@@ -1556,7 +1557,7 @@ var Uno;
                         const inputElement = element;
                         cleanupUnconnectedRoot(this.containerElement);
                         // Create a temporary element that will contain the input's content
-                        var textOnlyElement = document.createElement("p");
+                        const textOnlyElement = document.createElement("p");
                         textOnlyElement.style.cssText = unconstrainedStyleCssText;
                         // If the input is null or empty, add a no-width character to force the paragraph to take up one line height
                         // The trailing new lines are going to be ignored for measure, so we also append no-width char at the end.
@@ -1564,10 +1565,10 @@ var Uno;
                         textOnlyElement.className = elementClasses; // Note: Here we will have the uno-textBoxView class name
                         unconnectedRoot = textOnlyElement;
                         this.containerElement.appendChild(unconnectedRoot);
-                        var textSize = this.measureElement(textOnlyElement);
+                        const textSize = this.measureElement(textOnlyElement);
                         // For TextAreas, take the width and height of the inner text
                         const width = Math.min(textSize[0], maxWidth);
-                        var height = Math.min(textSize[1], maxHeight);
+                        const height = Math.min(textSize[1], maxHeight);
                         return [width, height];
                     }
                     else {
@@ -1662,20 +1663,20 @@ var Uno;
                 const element = this.getView(viewId);
                 if (element.tagName.toUpperCase() === "IMG") {
                     const imgElement = element;
-                    var img = new Image();
+                    const img = new Image();
                     img.onload = buildMonochromeImage;
                     img.src = url;
                     function buildMonochromeImage() {
                         // create a colored version of img
-                        const c = document.createElement('canvas');
-                        const ctx = c.getContext('2d');
+                        const c = document.createElement("canvas");
+                        const ctx = c.getContext("2d");
                         c.width = img.width;
                         c.height = img.height;
                         ctx.drawImage(img, 0, 0);
-                        ctx.globalCompositeOperation = 'source-atop';
+                        ctx.globalCompositeOperation = "source-atop";
                         ctx.fillStyle = color;
                         ctx.fillRect(0, 0, img.width, img.height);
-                        ctx.globalCompositeOperation = 'source-over';
+                        ctx.globalCompositeOperation = "source-over";
                         imgElement.src = c.toDataURL();
                     }
                     return "ok";
@@ -1896,7 +1897,7 @@ var Uno;
                 return handle + "";
             }
             numberToCssColor(color) {
-                return "#" + color.toString(16).padStart(8, '0');
+                return "#" + color.toString(16).padStart(8, "0");
             }
             setCursor(cssCursor) {
                 const unoBody = document.getElementById(this.containerElementId);

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -84,7 +84,7 @@ namespace Uno.UI {
 							//
 							// If the image fails to load, setup the splashScreen anyways with the
 							// proper sample.
-							let canvas = document.createElement('canvas');
+							let canvas = document.createElement("canvas");
 							canvas.width = img.width;
 							canvas.height = img.height;
 							let ctx = canvas.getContext("2d");
@@ -114,7 +114,7 @@ namespace Uno.UI {
 				let fullImagePath = String(UnoAppManifest.splashScreenImage);
 
 				// If the splashScreenImage image already points to the app base path, use it, otherwise we build it.
-				if (UNO_BOOTSTRAP_APP_BASE !== '' && fullImagePath.indexOf(UNO_BOOTSTRAP_APP_BASE) == -1) {
+				if (UNO_BOOTSTRAP_APP_BASE !== "" && fullImagePath.indexOf(UNO_BOOTSTRAP_APP_BASE) == -1) {
 					fullImagePath = `${UNO_BOOTSTRAP_WEBAPP_BASE_PATH}${UNO_BOOTSTRAP_APP_BASE}/${UnoAppManifest.splashScreenImage}`;
 				}
 
@@ -208,7 +208,7 @@ namespace Uno.UI {
 				return new URLSearchParams(window.location.search).toString();
 			}
 			else {
-				const queryIndex = document.location.search.indexOf('?');
+				const queryIndex = document.location.search.indexOf("?");
 
 				if (queryIndex !== -1) {
 					return document.location.search.substring(queryIndex + 1);
@@ -481,7 +481,7 @@ namespace Uno.UI {
 
 			for (const name in properties) {
 				if (properties.hasOwnProperty(name)) {
-					var setVal = properties[name];
+					const setVal = properties[name];
 					if (setVal === "true") {
 						(element as any)[name] = true;
 					}
@@ -506,7 +506,7 @@ namespace Uno.UI {
 			const element = this.getView(params.HtmlId);
 
 			for (let i = 0; i < params.Pairs_Length; i += 2) {
-				var setVal = params.Pairs[i + 1];
+				const setVal = params.Pairs[i + 1];
 				if (setVal === "true") {
 					(element as any)[params.Pairs[i]] = true;
 				}
@@ -791,7 +791,7 @@ namespace Uno.UI {
 			const params = WindowManagerSetElementTransformParams.unmarshal(pParams);
 			const element = this.getView(params.HtmlId);
 
-			var style = element.style;
+			const style = element.style;
 
 			const matrix = `matrix(${params.M11},${params.M12},${params.M21},${params.M22},${params.M31},${params.M32})`;
 			style.transform = matrix;
@@ -970,7 +970,7 @@ namespace Uno.UI {
 
 				// It's common to get a move right after the leave with the same pointer's location,
 				// so we wait up to 3 pointer move before dropping the leave event.
-				var attempt = 3;
+				let attempt = 3;
 
 				WindowManager.current.ensurePendingLeaveEventProcessing();
 				WindowManager.current.processPendingLeaveEvent = (move: PointerEvent) => {
@@ -1124,9 +1124,9 @@ namespace Uno.UI {
 			// defined in the browser settings. 
 			// https://stackoverflow.com/questions/20110224/what-is-the-height-of-a-line-in-a-wheel-event-deltamode-dom-delta-line
 			if (this._wheelLineSize == undefined) {
-				const el = document.createElement('div');
-				el.style.fontSize = 'initial';
-				el.style.display = 'none';
+				const el = document.createElement("div");
+				el.style.fontSize = "initial";
+				el.style.display = "none";
 				document.body.appendChild(el);
 				const fontSize = window.getComputedStyle(el).fontSize;
 				document.body.removeChild(el);
@@ -1543,7 +1543,7 @@ namespace Uno.UI {
 			let parentElementWidthHeight: { width: string, height: string } = null;
 			let unconnectedRoot: HTMLElement = null;
 
-			let cleanupUnconnectedRoot = (owner: HTMLDivElement) => {
+			const cleanupUnconnectedRoot = (owner: HTMLDivElement) => {
 				if (unconnectedRoot !== null) {
 					owner.removeChild(unconnectedRoot);
 				}
@@ -1575,7 +1575,7 @@ namespace Uno.UI {
 					cleanupUnconnectedRoot(this.containerElement);
 
 					// Create a temporary element that will contain the input's content
-					var textOnlyElement = document.createElement("p") as HTMLParagraphElement;
+					const textOnlyElement = document.createElement("p") as HTMLParagraphElement;
 					textOnlyElement.style.cssText = unconstrainedStyleCssText;
 					textOnlyElement.innerText = inputElement.value;
 					textOnlyElement.className = elementClasses;
@@ -1583,8 +1583,8 @@ namespace Uno.UI {
 					unconnectedRoot = textOnlyElement;
 					this.containerElement.appendChild(unconnectedRoot);
 
-					var textSize = this.measureElement(textOnlyElement);
-					var inputSize = this.measureElement(element);
+					const textSize = this.measureElement(textOnlyElement);
+					const inputSize = this.measureElement(element);
 
 					// Take the width of the inner text, but keep the height of the input element.
 					return [textSize[0], inputSize[1]];
@@ -1594,7 +1594,7 @@ namespace Uno.UI {
 					cleanupUnconnectedRoot(this.containerElement);
 
 					// Create a temporary element that will contain the input's content
-					var textOnlyElement = document.createElement("p") as HTMLParagraphElement;
+					const textOnlyElement = document.createElement("p") as HTMLParagraphElement;
 					textOnlyElement.style.cssText = unconstrainedStyleCssText;
 
 					// If the input is null or empty, add a no-width character to force the paragraph to take up one line height
@@ -1605,11 +1605,11 @@ namespace Uno.UI {
 					unconnectedRoot = textOnlyElement;
 					this.containerElement.appendChild(unconnectedRoot);
 
-					var textSize = this.measureElement(textOnlyElement);
+					const textSize = this.measureElement(textOnlyElement);
 
 					// For TextAreas, take the width and height of the inner text
 					const width = Math.min(textSize[0], maxWidth);
-					var height = Math.min(textSize[1], maxHeight);
+					const height = Math.min(textSize[1], maxHeight);
 					return [width, height];
 				} else {
 					elementStyle.cssText = unconstrainedStyleCssText;
@@ -1728,24 +1728,24 @@ namespace Uno.UI {
 			if (element.tagName.toUpperCase() === "IMG") {
 
 				const imgElement = element as HTMLImageElement;
-				var img = new Image();
+				const img = new Image();
 				img.onload = buildMonochromeImage;
 				img.src = url;
 
 				function buildMonochromeImage() {
 
 					// create a colored version of img
-					const c = document.createElement('canvas');
-					const ctx = c.getContext('2d');
+					const c = document.createElement("canvas");
+					const ctx = c.getContext("2d");
 
 					c.width = img.width;
 					c.height = img.height;
 
 					ctx.drawImage(img, 0, 0);
-					ctx.globalCompositeOperation = 'source-atop';
+					ctx.globalCompositeOperation = "source-atop";
 					ctx.fillStyle = color;
 					ctx.fillRect(0, 0, img.width, img.height);
-					ctx.globalCompositeOperation = 'source-over';
+					ctx.globalCompositeOperation = "source-over";
 
 					imgElement.src = c.toDataURL();
 				}
@@ -2024,7 +2024,7 @@ namespace Uno.UI {
 		}
 
 		private numberToCssColor(color: number): string {
-			return "#" + color.toString(16).padStart(8, '0');
+			return "#" + color.toString(16).padStart(8, "0");
 		}
 
 		public setCursor(cssCursor: string): string {

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -1437,9 +1437,9 @@ namespace Uno.UI {
 		private getBBoxInternal(elementId: number): any {
 
 			const element = this.getView(elementId) as SVGGraphicsElement;
-			let unconnectedRoot: HTMLElement = null;
+			let unconnectedRoot: HTMLElement | SVGGraphicsElement = null;
 
-			let cleanupUnconnectedRoot = (owner: HTMLDivElement) => {
+			const cleanupUnconnectedRoot = (owner: HTMLDivElement) => {
 				if (unconnectedRoot !== null) {
 					owner.removeChild(unconnectedRoot);
 				}
@@ -1451,6 +1451,7 @@ namespace Uno.UI {
 				// or the getBBox() will crash.
 				if (!element.isConnected) {
 
+					unconnectedRoot = element;
 					while (unconnectedRoot.parentElement) {
 						// Need to find the top most "unconnected" parent
 						// of this element


### PR DESCRIPTION
# Bugfix
Offscreen `.Measure()` of shapes on WASM were leading to a crash.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
  (note: internal issue)
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
