### PR TITLE
fix: Handle scaling less than 100% on Wasm

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -81,6 +81,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		{
 			var scales = new List<ResolutionScale>()
 			{
+				(ResolutionScale)80,
 				ResolutionScale.Scale100Percent,
 				ResolutionScale.Scale150Percent,
 				ResolutionScale.Scale200Percent,

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.wasm.cs
@@ -126,6 +126,14 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 					var resolutionScale = scaleOverride == null ? (int)DisplayInformation.GetForCurrentView().ResolutionScale : (int)scaleOverride;
 
+					// On Windows, the minimum scale is 100%, however, on Wasm, we can have lower scales.
+					// This condition is to allow Wasm to use the .scale-100 image when the scale is < 100%
+					if (resolutionScale < 100)
+					{
+						resolutionScale = 100;
+					}
+
+
 					for (var i = KnownScales.Length - 1; i >= 0; i--)
 					{
 						var probeScale = KnownScales[i];


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6913

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On Wasm, when the browser is scaled to, for example, 90%, we don't pick the `.scale-100` resource.

## What is the new behavior?

Adjusted Wasm to pick the 100% scaled images for scaling less than 100%.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

The concept of < 100% resolutions doesn't seem to exist in UWP. Please let me know if you prefer a different behavior than what I did here.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
