### PR TITLE
fix(xamlreader): Load ThemeResources properly

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -27,7 +27,7 @@
 	<PackageReference Update="Uno.Wasm.Bootstrap.DevServer" Version="2.1.0" />
 	<PackageReference Update="xamarin.build.download" Version="0.10.0" PrivateAssets="all" />
 	<PackageReference Update="MSTest.TestAdapter" Version="2.2.6" />
-	<PackageReference Update="MSTest.TestFramework" Version="2.2.5-preview-20210605-01" />
+	<PackageReference Update="MSTest.TestFramework" Version="2.2.6" />
 	<PackageReference Update="Uno.MonoAnalyzers" Version="1.0.0" PrivateAssets="all" />
 	<PackageReference Update="System.Memory" Version="4.5.4" />
 	<PackageReference Update="Uno.Wasm.WebSockets" Version="1.1.0" />

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -241,6 +241,64 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		}
 
 		[TestMethod]
+		public void When_ThemeResource()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			if (app.Resources.ThemeDictionaries.TryGetValue("Light", out var themeDictionary)
+				&& themeDictionary is ResourceDictionary dictionary)
+			{
+				dictionary["StaticRow"] = 42;
+				dictionary["StaticWidth"] = 42.0;
+				dictionary["StaticHeight"] = 44.0;
+			}
+
+			var s = GetContent(nameof(When_ThemeResource));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			Assert.IsNotNull(r);
+
+			var panel = r.FindName("innerPanel") as StackPanel;
+			Assert.IsNotNull(panel);
+
+			Assert.AreEqual(42, Grid.GetRow(panel));
+			Assert.AreEqual(42.0, panel.Width);
+			Assert.AreEqual(44.0, panel.Height);
+
+			if (app.Resources.ThemeDictionaries.TryGetValue("Light", out var themeDictionary2)
+				&& themeDictionary is ResourceDictionary dictionary2)
+			{
+				dictionary2.Remove("StaticRow");
+				dictionary2.Remove("StaticWidth");
+				dictionary2.Remove("StaticHeight");
+			}
+		}
+
+		[TestMethod]
+		public void When_ThemeResource_Lazy()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			var s = GetContent(nameof(When_ThemeResource_Lazy));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			Assert.IsNotNull(r);
+
+			var panel = r.FindName("innerPanel") as StackPanel;
+			Assert.IsNotNull(panel);
+
+			Assert.AreEqual(0, Grid.GetRow(panel));
+			Assert.AreEqual(double.NaN, panel.Width);
+			Assert.AreEqual(double.NaN, panel.Height);
+
+			r.ForceLoaded();
+
+			Assert.AreEqual(42, Grid.GetRow(panel));
+			Assert.AreEqual(42.0, panel.Width);
+			Assert.AreEqual(44.0, panel.Height);
+		}
+
+		[TestMethod]
 		public void When_TextBlock_Basic()
 		{
 			var s = GetContent(nameof(When_TextBlock_Basic));
@@ -305,6 +363,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			var s = GetContent(nameof(When_Style_ControlTemplate));
 			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
 			Assert.IsNotNull(r);
+
+			r.ForceLoaded();
 
 			var innerContent = r.Content as ContentControl;
 			Assert.IsNotNull(innerContent);
@@ -586,6 +646,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		{
 			var s = GetContent(nameof(When_StaticResource_Style_And_Binding));
 			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			r.ForceLoaded();
 
 			Assert.IsTrue(r.Resources.ContainsKey("test"));
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ThemeResource.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ThemeResource.xamltest
@@ -1,0 +1,13 @@
+﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+			Name="rootPage"
+      mc:Ignorable="d">
+
+	<StackPanel x:Name="innerPanel" 
+				Width="{ThemeResource StaticWidth}"
+				Height="{ThemeResource StaticHeight}"
+				Grid.Row="{ThemeResource StaticRow}" />
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ThemeResource_Lazy.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ThemeResource_Lazy.xamltest
@@ -1,0 +1,19 @@
+﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+			Name="rootPage"
+      mc:Ignorable="d">
+  
+  <Page.Resources>
+	<x:Double x:Key="StaticWidth">42.0</x:Double>
+	<x:Double x:Key="StaticHeight">44.0</x:Double>
+	<x:Int32 x:Key="StaticRow">42</x:Int32>
+  </Page.Resources>
+
+	<StackPanel x:Name="innerPanel" 
+				Width="{ThemeResource StaticWidth}"
+				Height="{ThemeResource StaticHeight}"
+				Grid.Row="{ThemeResource StaticRow}" />
+</Page>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6639

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change ensures that `ThemeResource` instances are loaded through the common flow for resource loading, so that the values coming from actual theme dictionaries, and parent element lazy dictionaries are applied properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
