### PR TITLE
fix: Use SymbolThemeFontFamily instead of hard-coded Segoe MDL2 Assets

### DIFF
--- a/src/Uno.UI.FluentTheme/Resources/.editorconfig
+++ b/src/Uno.UI.FluentTheme/Resources/.editorconfig
@@ -1,0 +1,9 @@
+# Overrides our root .editorconfig to match https://github.com/microsoft/microsoft-ui-xaml/blob/fd22d7ff96871f58fec5d9b284eba02fe762c60e/.editorconfig#L120-L126
+
+[**.{xaml,xml}]
+indent_style = space
+indent_size = 4
+charset = utf-8-bom
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = crlf

--- a/src/Uno.UI.FluentTheme/Resources/Priority02/MenuFlyout_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/Resources/Priority02/MenuFlyout_themeresources.xaml
@@ -639,21 +639,21 @@
                             Grid.Column="0"
                             HorizontalAlignment="Left"
                             Margin="0">
-                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE8C1;" />
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8C1;" />
                         </Button>
                         <Button x:Name="LanguageSwitcherSettingsPenAndInkSettingsButton"
                             Background="{ThemeResource MenuFlyoutItemBackground}"
                             Grid.Column="1"
                             HorizontalAlignment="Center"
                             Margin="0">
-                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE713;" />
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE713;" />
                         </Button>
                         <Button x:Name="LanguageSwitcherSettingsHelpButton"
                             Background="{ThemeResource MenuFlyoutItemBackground}"
                             Grid.Column="2"
                             HorizontalAlignment="Right"
                             Margin="0">
-                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE9CE;" />
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE9CE;" />
                         </Button>
                     </Grid>
                  </ControlTemplate>

--- a/src/Uno.UI.FluentTheme/Resources/Priority06/RevealBrush_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/Resources/Priority06/RevealBrush_themeresources.xaml
@@ -2615,7 +2615,7 @@
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
               <ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" AutomationProperties.AccessibilityView="Raw" />
-              <TextBlock x:Name="ChevronTextBlock" Grid.Column="1" FontFamily="Segoe MDL2 Assets" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" Margin="6,0,0,0" AutomationProperties.AccessibilityView="Raw" />
+              <TextBlock x:Name="ChevronTextBlock" Grid.Column="1" FontFamily="{ThemeResource SymbolThemeFontFamily}" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" Margin="6,0,0,0" AutomationProperties.AccessibilityView="Raw" />
             </Grid>
           </Grid>
         </ControlTemplate>
@@ -2844,7 +2844,7 @@
             <Button x:Name="PrimaryButton" Grid.Column="0" Foreground="{TemplateBinding Foreground}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Command="{TemplateBinding Command}" CommandParameter="{TemplateBinding CommandParameter}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" Padding="{TemplateBinding Padding}" IsTabStop="False" AutomationProperties.AccessibilityView="Raw" />
             <Button x:Name="SecondaryButton" Grid.Column="2" Foreground="{TemplateBinding Foreground}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Padding="0,0,9,0" IsTabStop="False" AutomationProperties.AccessibilityView="Raw">
               <Button.Content>
-                <TextBlock FontFamily="Segoe MDL2 Assets" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" HorizontalAlignment="Right" AutomationProperties.AccessibilityView="Raw" />
+                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" HorizontalAlignment="Right" AutomationProperties.AccessibilityView="Raw" />
               </Button.Content>
             </Button>
           </Grid>

--- a/src/Uno.UI.FluentTheme/Resources/PriorityDefault/DropDownButton.xaml
+++ b/src/Uno.UI.FluentTheme/Resources/PriorityDefault/DropDownButton.xaml
@@ -107,7 +107,7 @@
                             <TextBlock
                                 x:Name="ChevronTextBlock"
                                 Grid.Column="1"
-                                FontFamily="Segoe MDL2 Assets"
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="12"
                                 Text="&#xE70D;"
                                 VerticalAlignment="Center"

--- a/src/Uno.UI.FluentTheme/Resources/PriorityDefault/RatingControl.xaml
+++ b/src/Uno.UI.FluentTheme/Resources/PriorityDefault/RatingControl.xaml
@@ -9,7 +9,7 @@
         <!-- 9794813: retire these two properties as customisation points once all resource keys available -->
         <Setter Property="Foreground" Value="{ThemeResource RatingControlCaptionForeground}"/>
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}"/>
-        <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
+        <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}"/>
         <Setter Property="ItemInfo" Value="{ThemeResource MUX_RatingControlDefaultFontInfo}"/>
         <!-- IsFocusEngagementEnabled means the control has to be "engaged" with 
              using the A button before it actually receives key input from gamepad. -->

--- a/src/Uno.UI.FluentTheme/Resources/PriorityDefault/RatingControl_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/Resources/PriorityDefault/RatingControl_themeresources.xaml
@@ -49,7 +49,7 @@
             FontSize="32"
             Text="&#xE734;"
             AutomationProperties.AccessibilityView="Raw"
-            FontFamily="Segoe MDL2 Assets"/>
+            FontFamily="{ThemeResource SymbolThemeFontFamily}"/>
     </DataTemplate>
 
     <DataTemplate x:Key="ForegroundGlyphDefaultTemplate">
@@ -58,7 +58,7 @@
             FontSize="32"
             Text="&#xE735;"
             AutomationProperties.AccessibilityView="Raw"
-            FontFamily="Segoe MDL2 Assets"/>
+            FontFamily="{ThemeResource SymbolThemeFontFamily}"/>
     </DataTemplate>
 
     <DataTemplate x:Key="BackgroundImageDefaultTemplate">

--- a/src/Uno.UI.FluentTheme/Resources/PriorityDefault/SplitButton.xaml
+++ b/src/Uno.UI.FluentTheme/Resources/PriorityDefault/SplitButton.xaml
@@ -195,7 +195,7 @@
             <Button x:Name="PrimaryButton" Grid.Column="0" Foreground="{TemplateBinding Foreground}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="Transparent" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Command="{TemplateBinding Command}" CommandParameter="{TemplateBinding CommandParameter}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" Padding="{TemplateBinding Padding}" IsTabStop="False" AutomationProperties.AccessibilityView="Raw" />
             <Button x:Name="SecondaryButton" Grid.Column="2" Foreground="{TemplateBinding Foreground}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="Transparent" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Padding="0,0,9,0" IsTabStop="False" AutomationProperties.AccessibilityView="Raw">
               <Button.Content>
-                <TextBlock FontFamily="Segoe MDL2 Assets" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" HorizontalAlignment="Right" IsTextScaleFactorEnabled="False" AutomationProperties.AccessibilityView="Raw" />
+                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" HorizontalAlignment="Right" IsTextScaleFactorEnabled="False" AutomationProperties.AccessibilityView="Raw" />
               </Button.Content>
             </Button>
           </Grid>

--- a/src/Uno.UI.FluentTheme/themeresources.xaml
+++ b/src/Uno.UI.FluentTheme/themeresources.xaml
@@ -5320,13 +5320,13 @@
               <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Button x:Name="LanguageSwitcherSettingsLanguageSettingsButton" Background="{ThemeResource MenuFlyoutItemBackground}" Grid.Column="0" HorizontalAlignment="Left" Margin="0">
-              <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE8C1;" />
+              <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8C1;" />
             </Button>
             <Button x:Name="LanguageSwitcherSettingsPenAndInkSettingsButton" Background="{ThemeResource MenuFlyoutItemBackground}" Grid.Column="1" HorizontalAlignment="Center" Margin="0">
-              <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE713;" />
+              <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE713;" />
             </Button>
             <Button x:Name="LanguageSwitcherSettingsHelpButton" Background="{ThemeResource MenuFlyoutItemBackground}" Grid.Column="2" HorizontalAlignment="Right" Margin="0">
-              <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE9CE;" />
+              <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE9CE;" />
             </Button>
           </Grid>
         </ControlTemplate>
@@ -8493,7 +8493,7 @@
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
               <ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" AutomationProperties.AccessibilityView="Raw" />
-              <TextBlock x:Name="ChevronTextBlock" Grid.Column="1" FontFamily="Segoe MDL2 Assets" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" Margin="6,0,0,0" AutomationProperties.AccessibilityView="Raw" />
+              <TextBlock x:Name="ChevronTextBlock" Grid.Column="1" FontFamily="{ThemeResource SymbolThemeFontFamily}" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" Margin="6,0,0,0" AutomationProperties.AccessibilityView="Raw" />
             </Grid>
           </Grid>
         </ControlTemplate>
@@ -8722,7 +8722,7 @@
             <Button x:Name="PrimaryButton" Grid.Column="0" Foreground="{TemplateBinding Foreground}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Command="{TemplateBinding Command}" CommandParameter="{TemplateBinding CommandParameter}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" Padding="{TemplateBinding Padding}" IsTabStop="False" AutomationProperties.AccessibilityView="Raw" />
             <Button x:Name="SecondaryButton" Grid.Column="2" Foreground="{TemplateBinding Foreground}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Padding="0,0,9,0" IsTabStop="False" AutomationProperties.AccessibilityView="Raw">
               <Button.Content>
-                <TextBlock FontFamily="Segoe MDL2 Assets" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" HorizontalAlignment="Right" AutomationProperties.AccessibilityView="Raw" />
+                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" HorizontalAlignment="Right" AutomationProperties.AccessibilityView="Raw" />
               </Button.Content>
             </Button>
           </Grid>
@@ -14896,7 +14896,7 @@
               </Grid.ColumnDefinitions>
               <!-- Uno workaround: template-bind ContentTemplateSelector because it's not automatically propagated from the ContentControl -->
               <ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" AutomationProperties.AccessibilityView="Raw" />
-              <TextBlock x:Name="ChevronTextBlock" Grid.Column="1" FontFamily="Segoe MDL2 Assets" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" Margin="6,0,0,0" IsTextScaleFactorEnabled="False" AutomationProperties.AccessibilityView="Raw" />
+              <TextBlock x:Name="ChevronTextBlock" Grid.Column="1" FontFamily="{ThemeResource SymbolThemeFontFamily}" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" Margin="6,0,0,0" IsTextScaleFactorEnabled="False" AutomationProperties.AccessibilityView="Raw" />
             </Grid>
           </Grid>
         </ControlTemplate>
@@ -19388,7 +19388,7 @@
     <!-- 9794813: retire these two properties as customisation points once all resource keys available -->
     <Setter Property="Foreground" Value="{ThemeResource RatingControlCaptionForeground}" />
     <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
-    <Setter Property="FontFamily" Value="Segoe MDL2 Assets" />
+    <Setter Property="FontFamily" Value="{ThemeResource SymbolThemeFontFamily}" />
     <Setter Property="ItemInfo" Value="{ThemeResource MUX_RatingControlDefaultFontInfo}" />
     <!-- IsFocusEngagementEnabled means the control has to be "engaged" with 
              using the A button before it actually receives key input from gamepad. -->
@@ -19459,11 +19459,11 @@
   </Style>
   <DataTemplate x:Key="BackgroundGlyphDefaultTemplate">
     <!-- -8, -8 are to compensate for the default scale down, plus factoring in margins -->
-    <TextBlock Foreground="{ThemeResource RatingControlUnselectedForeground}" Margin="-8,-8,0,0" FontSize="32" Text="&#xE734;" AutomationProperties.AccessibilityView="Raw" FontFamily="Segoe MDL2 Assets" />
+    <TextBlock Foreground="{ThemeResource RatingControlUnselectedForeground}" Margin="-8,-8,0,0" FontSize="32" Text="&#xE734;" AutomationProperties.AccessibilityView="Raw" FontFamily="{ThemeResource SymbolThemeFontFamily}" />
   </DataTemplate>
   <DataTemplate x:Key="ForegroundGlyphDefaultTemplate">
     <!-- -8, -8 are to compensate for the default scale down, plus factoring in margins -->
-    <TextBlock Margin="-8,-8,0,0" FontSize="32" Text="&#xE735;" AutomationProperties.AccessibilityView="Raw" FontFamily="Segoe MDL2 Assets" />
+    <TextBlock Margin="-8,-8,0,0" FontSize="32" Text="&#xE735;" AutomationProperties.AccessibilityView="Raw" FontFamily="{ThemeResource SymbolThemeFontFamily}" />
   </DataTemplate>
   <DataTemplate x:Key="BackgroundImageDefaultTemplate">
     <Image Margin="-8,-8,0,0" AutomationProperties.AccessibilityView="Raw" />
@@ -20521,7 +20521,7 @@
             <Button x:Name="PrimaryButton" Grid.Column="0" Foreground="{TemplateBinding Foreground}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="Transparent" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Command="{TemplateBinding Command}" CommandParameter="{TemplateBinding CommandParameter}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" Padding="{TemplateBinding Padding}" IsTabStop="False" AutomationProperties.AccessibilityView="Raw" />
             <Button x:Name="SecondaryButton" Grid.Column="2" Foreground="{TemplateBinding Foreground}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="Transparent" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Padding="0,0,9,0" IsTabStop="False" AutomationProperties.AccessibilityView="Raw">
               <Button.Content>
-                <TextBlock FontFamily="Segoe MDL2 Assets" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" HorizontalAlignment="Right" IsTextScaleFactorEnabled="False" AutomationProperties.AccessibilityView="Raw" />
+                <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" FontSize="12" Text="&#xE70D;" VerticalAlignment="Center" HorizontalAlignment="Right" IsTextScaleFactorEnabled="False" AutomationProperties.AccessibilityView="Raw" />
               </Button.Content>
             </Button>
           </Grid>

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/SplitButtonTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/SplitButtonTests.cs
@@ -24,6 +24,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 
 using SplitButton = Microsoft.UI.Xaml.Controls.SplitButton;
 using ToggleSplitButton = Microsoft.UI.Xaml.Controls.ToggleSplitButton;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI.Xaml.Media;
+using Private.Infrastructure;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -81,6 +84,25 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 				bool isChecked = (bool)toggleSplitButton.GetValue(ToggleSplitButton.IsCheckedProperty);
 				Verify.IsTrue(isChecked, "ToggleSplitButton is not checked");
 			});
+		}
+
+		[TestMethod]
+		[Description("Verifies that the TextBlock representing the Chevron glyph uses the correct font")]
+		public void VerifyFontFamilyForChevron()
+		{
+			SplitButton splitButton = null;
+			using (StyleHelper.UseFluentStyles())
+			{
+				RunOnUIThread.Execute(() =>
+				{
+					splitButton = new SplitButton();
+					TestServices.WindowHelper.WindowContent = splitButton;
+
+					var secondayButton = splitButton.GetTemplateChild("SecondaryButton");
+					var font = ((secondayButton as Button).Content as TextBlock).FontFamily;
+					Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
+				});
+			}
 		}
 	}
 

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/SplitButtonTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/SplitButtonTests.cs
@@ -27,6 +27,7 @@ using ToggleSplitButton = Microsoft.UI.Xaml.Controls.ToggleSplitButton;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI.Xaml.Media;
 using Private.Infrastructure;
+using Uno.UI.RuntimeTests;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -87,21 +88,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 		}
 
 		[TestMethod]
+		[RunsOnUIThread]
 		[Description("Verifies that the TextBlock representing the Chevron glyph uses the correct font")]
 		public void VerifyFontFamilyForChevron()
 		{
-			SplitButton splitButton = null;
 			using (StyleHelper.UseFluentStyles())
 			{
-				RunOnUIThread.Execute(() =>
-				{
-					splitButton = new SplitButton();
-					TestServices.WindowHelper.WindowContent = splitButton;
+				var splitButton = new SplitButton();
+				TestServices.WindowHelper.WindowContent = splitButton;
 
-					var secondayButton = splitButton.GetTemplateChild("SecondaryButton");
-					var font = ((secondayButton as Button).Content as TextBlock).FontFamily;
-					Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
-				});
+				var secondayButton = splitButton.GetTemplateChild("SecondaryButton");
+				var font = ((secondayButton as Button).Content as TextBlock).FontFamily;
+				Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
 			}
 		}
 	}

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ToggleSplitButton/ToggleSplitButtonTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ToggleSplitButton/ToggleSplitButtonTests.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests.Helpers;
+using MUXControlsTestApp.Utilities;
+using Private.Infrastructure;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Common;
+
+namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
+{
+	[TestClass]
+	public class ToggleSplitButtonTests
+	{
+		[TestMethod]
+		[Description("Verifies that the TextBlock representing the Chevron glyph uses the correct font")]
+		public void VerifyFontFamilyForChevron()
+		{
+			Microsoft.UI.Xaml.Controls.ToggleSplitButton toggleSplitButton = null;
+			using (StyleHelper.UseFluentStyles())
+			{
+				RunOnUIThread.Execute(() =>
+				{
+					toggleSplitButton = new Microsoft.UI.Xaml.Controls.ToggleSplitButton();
+					TestServices.WindowHelper.WindowContent = toggleSplitButton;
+
+					var secondayButton = toggleSplitButton.GetTemplateChild("SecondaryButton");
+					var font = ((secondayButton as Button).Content as TextBlock).FontFamily;
+					Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
+				});
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/MUX/Windows_UI_Xaml_Controls/DropDownButtonTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Windows_UI_Xaml_Controls/DropDownButtonTests.cs
@@ -1,0 +1,34 @@
+﻿using Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MUXControlsTestApp.Utilities;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
+{
+	[TestClass]
+	public class DropDownButtonTests
+	{
+		[TestMethod]
+		[Description("Verifies that the TextBlock representing the Chevron glyph uses the correct font")]
+		public void VerifyFontFamilyForChevron()
+		{
+			DropDownButton dropDownButton = null;
+			using (StyleHelper.UseFluentStyles())
+			{
+				RunOnUIThread.Execute(() =>
+				{
+					dropDownButton = new DropDownButton();
+					TestServices.WindowHelper.WindowContent = dropDownButton;
+
+					var chevronTextBlock = dropDownButton.GetTemplateChild("ChevronTextBlock") as TextBlock;
+					var font = chevronTextBlock.FontFamily;
+					Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
+				});
+			}
+		}
+
+	}
+}

--- a/src/Uno.UI.RuntimeTests/MUX/Windows_UI_Xaml_Controls/DropDownButtonTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Windows_UI_Xaml_Controls/DropDownButtonTests.cs
@@ -11,6 +11,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 	[TestClass]
 	public class DropDownButtonTests
 	{
+#if !WINDOWS_UWP // GetTemplateChild is protected in UWP while public in Uno.
 		[TestMethod]
 		[Description("Verifies that the TextBlock representing the Chevron glyph uses the correct font")]
 		public void VerifyFontFamilyForChevron()
@@ -29,6 +30,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 				});
 			}
 		}
-
+#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout_19h1_themeresources.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout_19h1_themeresources.xaml
@@ -102,21 +102,21 @@
                             Grid.Column="0"
                             HorizontalAlignment="Left"
                             Margin="0">
-                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE8C1;" />
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8C1;" />
                         </Button>
                         <Button x:Name="LanguageSwitcherSettingsPenAndInkSettingsButton"
                             Background="{ThemeResource MenuFlyoutItemBackground}"
                             Grid.Column="1"
                             HorizontalAlignment="Center"
                             Margin="0">
-                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE713;" />
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE713;" />
                         </Button>
                         <Button x:Name="LanguageSwitcherSettingsHelpButton"
                             Background="{ThemeResource MenuFlyoutItemBackground}"
                             Grid.Column="2"
                             HorizontalAlignment="Right"
                             Margin="0">
-                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE9CE;" />
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE9CE;" />
                         </Button>
                     </Grid>
                  </ControlTemplate>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6638

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Chevron glyph doesn't show correctly when using fluent theme.


## What is the new behavior?

Shows correctly.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
