### PR TITLE
fix: Remove net5.0 nuget override target option for skia/wasm

### DIFF
--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -22,7 +22,6 @@
           xamarinios10 (iOS) - Uno.UI-iOS-only.slnf
           MonoAndroid11.0 (Android 11.0) - Uno.UI-Android-only.slnf
           netstandard2.0 (WebAssembly, Skia) - Uno.UI-Wasm-only.slnf, Uno.UI-Skia-only.slnf
-          net5.0 (WebAssembly, Skia) - Uno.UI-Wasm-only.slnf, Uno.UI-Skia-only.slnf
           net6.0-ios (.NET 6 iOS) - Uno.UI-net6-only.slnf
           net6.0-android (.NET 6 Android) - Uno.UI-net6-only.slnf
           net6.0-maccatalyst (.NET 6 macOS Catalyst) - Uno.UI-net6-only.slnf


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The netstd 2.0 override needs to be used for debugging, net5 does not work properly. This will be adjusted when going to net6.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
