### PR TITLE
fix: Add XAML source generator cancellation support

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -256,7 +256,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				var lastBinaryUpdateTime = _forceGeneration ? DateTime.MaxValue : GetLastBinaryUpdateTime();
 
 				var resourceKeys = GetResourceKeys();
-				var filesFull = new XamlFileParser(_excludeXamlNamespaces, _includeXamlNamespaces, _metadataHelper).ParseFiles(_xamlSourceFiles);
+				var filesFull = new XamlFileParser(_excludeXamlNamespaces, _includeXamlNamespaces, _metadataHelper)
+					.ParseFiles(_xamlSourceFiles, _generatorContext.CancellationToken);
 				var files = filesFull
 					.Trim()
 					.OrderBy(f => f.UniqueID)
@@ -276,6 +277,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					.ToArray();
 
 				var filesToProcess = filesQuery.AsParallel();
+
+#if NETSTANDARD2_0
+				filesToProcess = filesToProcess
+					.WithCancellation(_generatorContext.CancellationToken);
+#endif
 
 				if (Debugger.IsAttached)
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -278,10 +278,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				var filesToProcess = filesQuery.AsParallel();
 
-#if NETSTANDARD2_0
 				filesToProcess = filesToProcess
 					.WithCancellation(_generatorContext.CancellationToken);
-#endif
 
 				if (Debugger.IsAttached)
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
@@ -34,18 +34,19 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			this._metadataHelper = roslynMetadataHelper;
 		}
 
-		public XamlFileDefinition[] ParseFiles(string[] xamlSourceFiles)
+		public XamlFileDefinition[] ParseFiles(string[] xamlSourceFiles, System.Threading.CancellationToken cancellationToken)
 		{
 			var files = new List<XamlFileDefinition>();
 
 			return xamlSourceFiles
 				.AsParallel()
-				.Select(ParseFile)
+				.WithCancellation(cancellationToken)
+				.Select(f => ParseFile(f, cancellationToken))
 				.Where(f => f != null)
 				.ToArray()!;
 		}
 
-		private XamlFileDefinition? ParseFile(string file)
+		private XamlFileDefinition? ParseFile(string file, System.Threading.CancellationToken cancellationToken)
 		{
 			try
 			{
@@ -65,6 +66,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					if (reader.Read())
 					{
+						cancellationToken.ThrowIfCancellationRequested();
+
 						return Visit(reader, file);
 					}
 				}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

XAML Source generators running in a .NET 5/6 context are now honoring cancellation requests.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
