### PR TITLE
Fix(Border): Adjust UI Test snapshots differences after changes for pull request 6898 (Related to Uno.Themes - #616)

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/Border_CornerRadius_BorderThickness.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/Border_CornerRadius_BorderThickness.xaml
@@ -15,13 +15,15 @@
 				  Width="200"
 				  Height="200"
 				  Background="White">
+				<!-- Using Red with 50% Opacity for the BorderBrush and Blue with 50% Opacity for the Background here -->
+				<!-- Easier to catch specific issues for the Background and Border that way compare to using opaque colors for this test -->
 				<Border Width="200"
 						Height="200"
 						x:Name="MyBorder"
 						BorderThickness="{x:Bind MyBorderThickness, Mode=TwoWay}"
 						CornerRadius="{x:Bind MyCornerRadius, Mode=TwoWay}"
-						BorderBrush="Red"
-						Background="Blue" />
+						BorderBrush="#80FF0000"
+						Background="#800000FF" />
 				<Border BorderBrush="Yellow"
 						x:Name="LeftTarget"
 						HorizontalAlignment="Left"


### PR DESCRIPTION
GitHub Issue: https://github.com/unoplatform/Uno.Themes/issues/616
Related to: https://github.com/unoplatform/uno/pull/6898


## PR Type

What kind of change does this PR introduce?

- Adjust UI Test snapshots differences

## What is the current behavior?

UI Test was updated but not the associated xaml for the test


## What is the new behavior?

Adjust UI Test snapshots differences after changes for pull request #6898 (Related to Uno.Themes - #616)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

