### PR TITLE
fix: fixed autoreverse animation for Wasm

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.cs
@@ -10,9 +10,9 @@ namespace Windows.UI.Xaml.Media.Animation
 	partial class AnimatorFactory
 	{
 		/// <summary>
-		/// Creates the actual animator instance
+		/// Creates the actual animator instance, new parameter autoReverse
 		/// </summary>
-		internal static IValueAnimator Create<T>(Timeline timeline, T startingValue, T targetValue) where T : struct
+		internal static IValueAnimator Create<T>(Timeline timeline, T startingValue, T targetValue, bool autoReverse) where T : struct
 		{
 			if (startingValue is float startingFloat && targetValue is float targetFloat)
 			{
@@ -26,10 +26,20 @@ namespace Windows.UI.Xaml.Media.Animation
 
 			if (startingValue is ColorOffset startingColor && targetValue is ColorOffset targetColor)
 			{
-				return CreateColor(timeline, startingColor, targetColor);
+				if (autoReverse)
+					return CreateColor(timeline, targetColor, startingColor);
+				else
+					return CreateColor(timeline, startingColor, targetColor);
 			}
 
 			throw new NotSupportedException();
+		}
+		/// <summary>
+		/// Creates the actual animator instance
+		/// </summary>
+		internal static IValueAnimator Create<T>(Timeline timeline, T startingValue, T targetValue) where T : struct
+		{
+			return Create(timeline, startingValue, targetValue, false);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ColorAnimation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ColorAnimation.cs
@@ -50,6 +50,18 @@ namespace Windows.UI.Xaml.Media.Animation
 			}
 		}
 
+		public bool AutoReverse
+		{
+			get
+			{
+				return (bool)this.GetValue(AutoReverseProperty);
+			}
+			set
+			{
+				this.SetValue(AutoReverseProperty, value);
+			}
+		}
+
 		bool IAnimation<ColorOffset>.EnableDependentAnimation => EnableDependentAnimation;
 
 		public Color? By

--- a/src/Uno.UI/UI/Xaml/Media/Animation/IAnimation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/IAnimation.cs
@@ -16,6 +16,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		T? From { get; }
 		T? By { get; }
 		bool EnableDependentAnimation { get; }
+		bool AutoReverse { get; }
 		IEasingFunction EasingFunction { get; }
 		T Subtract(T minuend, T subtrahend);
 		T Add(T first, T second);


### PR DESCRIPTION
GitHub Issue: closes #6027

## PR Type
- Fix


## What is the current behavior?
When activating autoreverse the animation does not end the reverse transition on the Wasm platform


## What is the new behavior?
When activating autoreverse, the transition animation is completely terminated


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
