### PR TITLE
Flyout should return focus to previously focused element

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -14,6 +14,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 
@@ -457,6 +458,38 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var stackPanel = content as StackPanel;
 			Assert.AreEqual("My Data Context", (stackPanel.Children[0] as TextBlock).Text);
 #endif
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Flyout_Content_Takes_Focus()
+		{
+			var stackPanel = new StackPanel();
+			var button = new Button() { Content = "Flyout owner" };
+			stackPanel.Children.Add(button);
+			TestServices.WindowHelper.WindowContent = stackPanel;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var flyout = new Flyout();
+			var flyoutButton = new Button() { Content = "Flyout content" };
+			flyout.Content = flyoutButton;
+			FlyoutBase.SetAttachedFlyout(button, flyout);
+			button.Focus(FocusState.Pointer);
+
+			Assert.AreEqual(button, FocusManager.GetFocusedElement());
+
+			FlyoutBase.ShowAttachedFlyout(button);
+			flyoutButton.Focus(FocusState.Pointer);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreNotEqual(button, FocusManager.GetFocusedElement());
+
+			flyout.Hide();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(button, FocusManager.GetFocusedElement());
+
+			TestServices.WindowHelper.WindowContent = null;
 		}
 
 		private static void VerifyRelativeContentPosition(HorizontalPosition horizontalPosition, VerticalPosition verticalPosition, FrameworkElement content, double minimumTargetOffset, FrameworkElement target)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -18,6 +18,12 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 
+#if HAS_UNO
+using Popup = Windows.UI.Xaml.Controls.Popup;
+#else
+using Popup = Windows.UI.Xaml.Controls.Primitives.Popup;
+#endif
+
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
 	[TestClass]
@@ -488,6 +494,36 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await TestServices.WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(button, FocusManager.GetFocusedElement());
+
+			TestServices.WindowHelper.WindowContent = null;
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Flyout_Has_Focusable_Child()
+		{
+			var stackPanel = new StackPanel();
+			var button = new Button() { Content = "Flyout owner" };
+			stackPanel.Children.Add(button);
+			TestServices.WindowHelper.WindowContent = stackPanel;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var flyout = new Flyout();
+			var flyoutButton = new Button() { Content = "Flyout content" };
+			flyout.Content = flyoutButton;
+			FlyoutBase.SetAttachedFlyout(button, flyout);
+			button.Focus(FocusState.Pointer);
+
+			Assert.AreEqual(button, FocusManager.GetFocusedElement());
+
+			FlyoutBase.ShowAttachedFlyout(button);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var focused = FocusManager.GetFocusedElement();
+			Assert.IsInstanceOfType(focused, typeof(Popup));
+
+			flyout.Hide();
+			await TestServices.WindowHelper.WaitForIdle();
 
 			TestServices.WindowHelper.WindowContent = null;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -88,6 +88,14 @@ namespace Windows.UI.Xaml.Controls
 
 			if (_popup is PopupBase popup)
 			{
+				//TODO Uno specific: Ensures popup does not take focus when opened.
+				//This can be removed when the actual ComboBox code is fully ported
+				//from WinUI.
+				if (_popupBorder is { } border)
+				{
+					border.AllowFocusOnInteraction = false;
+				}
+
 				popup.CustomLayouter = new DropDownLayouter(this, popup);
 
 				popup.BindToEquivalentProperty(this, nameof(LightDismissOverlayMode));
@@ -406,6 +414,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnPointerReleased(args);
 
+			Focus(FocusState.Programmatic);
 			IsDropDownOpen = true;
 
 			// On UWP ComboBox does handle the released event.

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
@@ -26,6 +26,12 @@ namespace Windows.UI.Xaml.Controls
 		internal bool IsSubMenu { get; set; }
 
 		/// <summary>
+		/// In WinUI, Popup has IsTabStop set to true by default.
+		/// UWP does not include IsTabStop, but Popup is still focusable.
+		/// </summary>
+		private protected override bool IsTabStopDefaultValue => true;
+
+		/// <summary>
 		/// Returns true if the popup should show the light-dismiss overlay with its current configuration, false if not
 		/// </summary>
 		private bool ShouldShowLightDismissOverlay

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Uno.UI;
+using Uno.UI.DataBinding;
 using Uno.UI.Xaml.Core;
 using Windows.Foundation;
 using Windows.UI.Xaml.Input;
@@ -16,7 +17,7 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class PopupBase : FrameworkElement, IPopup
 	{
-		private WeakReference<UIElement> _lastFocusedElement = null;
+		private ManagedWeakReference _lastFocusedElement = null;
 		private FocusState _lastFocusState = FocusState.Unfocused;
 
 		private IDisposable _openPopupRegistration;
@@ -71,11 +72,11 @@ namespace Windows.UI.Xaml.Controls
 				{
 					// Store last focused element
 					var focusManager = VisualTree.GetFocusManagerForElement(this);
-					var focusedElement = focusManager.FocusedElement as UIElement;
-					var focusState = focusManager.GetRealFocusStateForFocusedElement();
+					var focusedElement = focusManager?.FocusedElement as UIElement;
+					var focusState = focusManager?.GetRealFocusStateForFocusedElement() ?? FocusState.Unfocused;
 					if (focusedElement != null && focusState != FocusState.Unfocused)
 					{
-						_lastFocusedElement = new WeakReference<UIElement>(focusedElement);
+						_lastFocusedElement = WeakReferencePool.RentWeakReference(this, focusedElement);
 						_lastFocusState = focusState;
 					}
 
@@ -94,7 +95,7 @@ namespace Windows.UI.Xaml.Controls
 
 				if (IsLightDismissEnabled)
 				{
-					if (_lastFocusedElement != null && _lastFocusedElement.TryGetTarget(out var target))
+					if (_lastFocusedElement != null && _lastFocusedElement.Target is UIElement target)
 					{
 						target.Focus(_lastFocusState);
 						_lastFocusedElement = null;

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -78,6 +78,12 @@ namespace Windows.UI.Xaml.Controls
 						_lastFocusedElement = new WeakReference<UIElement>(focusedElement);
 						_lastFocusState = focusState;
 					}
+
+					// Give the child focus if allowed
+					if (Child is FrameworkElement fw && fw.AllowFocusOnInteraction)
+					{
+						Focus(FocusState.Programmatic);
+					}
 				}
 
 				Opened?.Invoke(this, newIsOpen);
@@ -85,11 +91,14 @@ namespace Windows.UI.Xaml.Controls
 			else
 			{
 				_openPopupRegistration?.Dispose();
-				
-				if (_lastFocusedElement != null && _lastFocusedElement.TryGetTarget(out var target))
+
+				if (IsLightDismissEnabled)
 				{
-					target.Focus(_lastFocusState);
-					_lastFocusedElement = null;
+					if (_lastFocusedElement != null && _lastFocusedElement.TryGetTarget(out var target))
+					{
+						target.Focus(_lastFocusState);
+						_lastFocusedElement = null;
+					}
 				}
 
 				Closed?.Invoke(this, newIsOpen);


### PR DESCRIPTION
GitHub Issue (If applicable): partially #6852

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When a flyout gets focused and closes, no element is focused.

## What is the new behavior?

When flyout hides, focus is returned to previously focused element if it still exists.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
