### PR TITLE
`LinearGradientBrush` angle should be reflected in `EndPoint`

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -27,7 +27,7 @@
 	<PackageReference Update="Uno.Wasm.Bootstrap.DevServer" Version="2.1.0" />
 	<PackageReference Update="xamarin.build.download" Version="0.10.0" PrivateAssets="all" />
 	<PackageReference Update="MSTest.TestAdapter" Version="2.2.6" />
-	<PackageReference Update="MSTest.TestFramework" Version="2.2.5-preview-20210605-01" />
+	<PackageReference Update="MSTest.TestFramework" Version="2.2.6" />
 	<PackageReference Update="Uno.MonoAnalyzers" Version="1.0.0" PrivateAssets="all" />
 	<PackageReference Update="System.Memory" Version="4.5.4" />
 	<PackageReference Update="Uno.Wasm.WebSockets" Version="1.1.0" />

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Media/Given_LinearGradientBrush.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Media/Given_LinearGradientBrush.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+using Windows.UI.Xaml.Media;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Media
+{
+	[TestClass]
+	public class Given_LinearGradientBrush
+	{
+		private const float Delta = 0.001f;
+
+		[TestMethod]
+		public void When_DefaultConstructor()
+		{
+			var linear = new LinearGradientBrush();
+			AssertPointsAlmostEqual(new Point(), linear.StartPoint);
+			AssertPointsAlmostEqual(new Point(1, 1), linear.EndPoint);
+		}
+
+		[TestMethod]
+		public void When_ZeroAngle()
+		{
+			var linear = new LinearGradientBrush(new GradientStopCollection(), 0);
+			AssertPointsAlmostEqual(new Point(), linear.StartPoint);
+			AssertPointsAlmostEqual(new Point(1, 0), linear.EndPoint);
+		}
+
+		[TestMethod]
+		public void When_FullAngle()
+		{
+			var linear = new LinearGradientBrush(new GradientStopCollection(), 360);
+			AssertPointsAlmostEqual(new Point(), linear.StartPoint);
+			AssertPointsAlmostEqual(new Point(1, 0), linear.EndPoint);
+		}
+
+		[TestMethod]
+		public void When_ThreeTimesFullAngle()
+		{
+			var linear = new LinearGradientBrush(new GradientStopCollection(), 1080);
+			AssertPointsAlmostEqual(new Point(), linear.StartPoint);
+			AssertPointsAlmostEqual(new Point(1, 0), linear.EndPoint);
+		}
+
+		[TestMethod]
+		public void When_NegativeFullAngle()
+		{
+			var linear = new LinearGradientBrush(new GradientStopCollection(), -360);
+			AssertPointsAlmostEqual(new Point(), linear.StartPoint);
+			AssertPointsAlmostEqual(new Point(1, 0), linear.EndPoint);
+		}
+
+		[TestMethod]
+		public void When_HalfAngle()
+		{
+			var linear = new LinearGradientBrush(new GradientStopCollection(), 180);
+			AssertPointsAlmostEqual(new Point(), linear.StartPoint);
+			AssertPointsAlmostEqual(new Point(-1, 0), linear.EndPoint);
+		}
+
+		[TestMethod]
+		public void When_RightAngle()
+		{
+			var linear = new LinearGradientBrush(new GradientStopCollection(), 90);
+			AssertPointsAlmostEqual(new Point(), linear.StartPoint);
+			AssertPointsAlmostEqual(new Point(0, 1), linear.EndPoint);
+		}
+
+		[TestMethod]
+		public void When_NegativeRightAngle()
+		{
+			var linear = new LinearGradientBrush(new GradientStopCollection(), -90);
+			AssertPointsAlmostEqual(new Point(), linear.StartPoint);
+			AssertPointsAlmostEqual(new Point(0, -1), linear.EndPoint);
+		}
+
+		[TestMethod]
+		public void When_135Angle()
+		{
+			var linear = new LinearGradientBrush(new GradientStopCollection(), 135);
+			AssertPointsAlmostEqual(new Point(), linear.StartPoint);
+			AssertPointsAlmostEqual(new Point(-0.7071, 0.7071), linear.EndPoint);
+		}
+
+		[TestMethod]
+		public void When_ArbitraryAngle()
+		{
+			var linear = new LinearGradientBrush(new GradientStopCollection(), 78035);
+			AssertPointsAlmostEqual(new Point(), linear.StartPoint);
+			AssertPointsAlmostEqual(new Point(0.0871, -0.9961), linear.EndPoint);
+		}
+
+		private void AssertPointsAlmostEqual(Point expected, Point actual)
+		{
+			Assert.AreEqual(expected.X, actual.X, Delta);
+			Assert.AreEqual(expected.Y, actual.Y, Delta);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/LinearGradientBrush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/LinearGradientBrush.cs
@@ -1,5 +1,7 @@
 ﻿using Windows.UI.Xaml.Markup;
 using Windows.Foundation;
+using Uno.Extensions;
+using System;
 
 namespace Windows.UI.Xaml.Media
 {
@@ -14,6 +16,9 @@ namespace Windows.UI.Xaml.Media
 			double angle)
 		{
 			GradientStops = gradientStopCollection;
+
+			var rad = MathEx.ToRadians(angle);
+			EndPoint = new Point(Math.Cos(rad), Math.Sin(rad));
 		}
 
 		public Point StartPoint
@@ -23,7 +28,7 @@ namespace Windows.UI.Xaml.Media
 		}
 
 		public static DependencyProperty StartPointProperty { get ; } = DependencyProperty.Register(
-			"StartPoint",
+			nameof(StartPoint),
 			typeof(Point),
 			typeof(LinearGradientBrush),
 			new FrameworkPropertyMetadata(default(Point))
@@ -36,7 +41,7 @@ namespace Windows.UI.Xaml.Media
 		}
 
 		public static DependencyProperty EndPointProperty { get ; } = DependencyProperty.Register(
-			"EndPoint",
+			nameof(EndPoint),
 			typeof(Point),
 			typeof(LinearGradientBrush),
 			new FrameworkPropertyMetadata(new Point(1,1))


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6950

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Not reflected.

## What is the new behavior?

Reflected, matching UWP.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.