### PR TITLE
fix: [Skia] Fix layout when RevealBrush is used

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_RevealBrush.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_RevealBrush.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_RevealBrush
+	{
+		[TestMethod]
+		public async Task When_RevealBrush_Assigned()
+		{
+			// Basic smoke test - RevealBrush is currently unimplemented, but it shouldn't break the layout
+
+			var siblingBorder = new Border { Width = 43, Height = 22 };
+			var gridWithRevealBackground = new Grid
+			{
+				Width = 57,
+				Height = 34,
+				Background = new RevealBackgroundBrush() { Color = Colors.Brown, FallbackColor = Colors.Brown },
+			};
+			var parentSP = new StackPanel
+			{
+				Children =
+				{
+					gridWithRevealBackground,
+					siblingBorder
+				}
+			};
+
+			WindowHelper.WindowContent = parentSP;
+			await WindowHelper.WaitForLoaded(parentSP);
+
+			await WindowHelper.WaitForEqual(57, () => gridWithRevealBackground.ActualWidth);
+			Assert.AreEqual(34, gridWithRevealBackground.ActualHeight);
+
+			Assert.AreEqual(43, siblingBorder.ActualWidth);
+			Assert.AreEqual(22, siblingBorder.ActualHeight);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Brush.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.skia.cs
@@ -107,9 +107,9 @@ namespace Windows.UI.Xaml.Media
 			{
 				return AssignAndObserveAcrylicBrush(acrylicBrush, compositor, brushSetter);
 			}
-			else if (brush is XamlCompositionBrushBase xamlCompositionBrushBase)
+			else if (brush is XamlCompositionBrushBase unimplementedCompositionBrush)
 			{
-				return AssignAndObserveXamlCompositionBrush(xamlCompositionBrushBase, compositor, brushSetter);
+				return AssignAndObserveXamlCompositionBrush(unimplementedCompositionBrush, compositor, brushSetter);
 			}
 			else
 			{
@@ -245,17 +245,27 @@ namespace Windows.UI.Xaml.Media
 			return disposables;
 		}
 
+		/// <summary>
+		/// Apply fallback colour for unimplemented <see cref="XamlCompositionBrushBase"/> types. For implemented types a more specific method
+		/// should be supplied.
+		/// </summary>
 		private static IDisposable AssignAndObserveXamlCompositionBrush(XamlCompositionBrushBase brush, Compositor compositor, BrushSetterHandler brushSetter)
 		{
 			var disposables = new CompositeDisposable();
 
-			var compositionBrush = brush.CompositionBrush;
+			var compositionBrush = compositor.CreateColorBrush(brush.FallbackColorWithOpacity);
 
-			//brush.RegisterDisposablePropertyChangedCallback(
-			//	XamlCompositionBrushBase.CompositionBrushProperty,
-			//	(s, e) => brushSetter(((CompositionBrush)e.NewValue))
-			//)
-			//.DisposeWith(disposables);
+			brush.RegisterDisposablePropertyChangedCallback(
+				AcrylicBrush.FallbackColorProperty,
+				(s, colorArg) => compositionBrush.Color = brush.FallbackColorWithOpacity
+			)
+			.DisposeWith(disposables);
+
+			brush.RegisterDisposablePropertyChangedCallback(
+				AcrylicBrush.OpacityProperty,
+				(s, colorArg) => compositionBrush.Color = brush.FallbackColorWithOpacity
+			)
+			.DisposeWith(disposables);
 
 			brushSetter(compositionBrush);
 


### PR DESCRIPTION
Fall back on FallbackColor when RevealBrush is assigned, instead of trying to use unimplemented CompositionBrush property which throws an exception.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
fixes https://github.com/unoplatform/uno.ui.toolkit/issues/58