### PR TITLE
fix: Workaround absolute position issue

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using FluentAssertions;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest;
@@ -205,6 +206,21 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		public void Manipulation_WhenInScrollViewerAndManipulationTranslateYAndTranslateY_ThenManipulate()
 			=> TestManipulationInScroller("SetTranslateY", TranslateY, AssertFullManipulationSequence);
+
+		[Test]
+		[AutoRetry]
+		public void Manipulation_PositionShouldBeRelativeToControlBeingDragged()
+		{
+			Run("UITests.Shared.Windows_UI_Input.GestureRecognizerTests.ManipulationPosition");
+
+			var borderRect = _app.WaitForElement("SourceBorder").Single().Rect;
+			_app.DragCoordinates(
+				fromX: borderRect.CenterX,
+				fromY: borderRect.CenterY,
+				toX: borderRect.X,
+				toY: borderRect.Y);
+			_app.Marked("Result").GetDependencyPropertyValue("Text").Should().Be("ManipulationCompleted: 0.0, 0.0");
+		}
 
 		private void Diagonal(IAppRect target, IAppRect scroller)
 			=> _app.DragCoordinates(target.X + 5, target.Bottom - 5, scroller.Right - 20, scroller.Y + 10);

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -365,7 +365,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-      <Page Include="$(MSBuildThisFileDirectory)Windows_Devices\GeolocatorTests.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)Windows_Devices\GeolocatorTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -534,6 +534,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\ManipulationEvents.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\ManipulationPosition.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -4660,6 +4664,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\ManipulationEvents.xaml.cs">
       <DependentUpon>ManipulationEvents.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\ManipulationPosition.xaml.cs">
+      <DependentUpon>ManipulationPosition.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\GestureRecognizerTests\Manipulation_Basics.xaml.cs">
       <DependentUpon>Manipulation_Basics.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/ManipulationPosition.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/ManipulationPosition.xaml
@@ -1,0 +1,32 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Input.GestureRecognizerTests.ManipulationPosition"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Input.GestureRecognizerTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<StackPanel Grid.Row="0">
+			<TextBlock x:Name="Result" />
+		</StackPanel>
+
+		<Border Grid.Row="1"
+				Margin="16"
+				Padding="16">
+			<Border x:Name="SourceBorder"
+					BorderBrush="Black" BorderThickness="1" Background="SkyBlue"
+					ManipulationMode="System,TranslateX,TranslateY"
+					ManipulationStarted="Border_ManipulationStarted"
+					ManipulationDelta="Border_ManipulationDelta"
+					ManipulationCompleted="Border_ManipulationCompleted" />
+		</Border>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/ManipulationPosition.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/ManipulationPosition.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System.Runtime.CompilerServices;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
+{
+	[Sample("Gesture recognizer")]
+	public sealed partial class ManipulationPosition : Page
+    {
+        public ManipulationPosition()
+        {
+            this.InitializeComponent();
+        }
+
+		private void Border_ManipulationStarted(object sender, ManipulationStartedRoutedEventArgs e)
+		{
+			UpdateText(e.Position);
+		}
+
+		private void Border_ManipulationDelta(object sender, ManipulationDeltaRoutedEventArgs e)
+		{
+			UpdateText(e.Position);
+		}
+
+		private void Border_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
+		{
+			UpdateText(e.Position);
+		}
+
+		private void UpdateText(Point p, [CallerMemberName] string caller = null)
+		{
+			Result.Text = $"{caller.Substring("Border_".Length)}: {p.X:N1}, {p.Y:N1}";
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
@@ -721,7 +721,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			var rd = new ResourceDictionary();
 			rd.MergedDictionaries.Add(rdInner);
 
-			var brush = UI.Helpers.WinUI.SharedHelpers.FindResource("Grin", rd, null);
+			var brush = Uno.UI.Helpers.WinUI.SharedHelpers.FindResource("Grin", rd, null);
 
 			Assert.IsNotNull(brush);
 			Assert.AreEqual(Colors.DarkOliveGreen, (brush as SolidColorBrush).Color);

--- a/src/Uno.UI/UI/Xaml/Input/Internal/ManipulationEventArgsHelpers.cs
+++ b/src/Uno.UI/UI/Xaml/Input/Internal/ManipulationEventArgsHelpers.cs
@@ -1,0 +1,13 @@
+﻿using Windows.Foundation;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.UI.Xaml.Input.Internal
+{
+	internal static class ManipulationEventArgsHelpers
+	{
+		internal static Point MapPointRelativeTo(UIElement element, Point point)
+			=> element is null
+				? point
+				: element.TransformToVisual(null).Inverse.TransformPoint(point);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedRoutedEventArgs.cs
@@ -2,6 +2,7 @@ using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.UI.Input;
 using Uno.UI.Xaml.Input;
+using Uno.UI.UI.Xaml.Input.Internal;
 
 namespace Windows.UI.Xaml.Input
 {
@@ -16,7 +17,13 @@ namespace Windows.UI.Xaml.Input
 
 			Pointers = args.Pointers;
 			PointerDeviceType = args.PointerDeviceType;
-			Position = args.Position;
+
+			// ManipulationCompletedEventArgs.Position is absolute position. We want to
+			// have a relative point to the element being manipulated to match UWP
+			// NOTE: This is a workaround, and this scenario is still broken for some cases.
+			// See https://github.com/unoplatform/uno/issues/6964#issuecomment-913041138 for details.
+			Position = ManipulationEventArgsHelpers.MapPointRelativeTo(container, args.Position);
+
 			Cumulative = args.Cumulative;
 			Velocities = args.Velocities;
 			IsInertial = args.IsInertial;

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
@@ -2,6 +2,7 @@ using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.UI.Input;
 using Uno.UI.Xaml.Input;
+using Uno.UI.UI.Xaml.Input.Internal;
 
 namespace Windows.UI.Xaml.Input
 {
@@ -20,7 +21,13 @@ namespace Windows.UI.Xaml.Input
 
 			Pointers = args.Pointers;
 			PointerDeviceType = args.PointerDeviceType;
-			Position = args.Position;
+
+			// ManipulationCompletedEventArgs.Position is absolute position. We want to
+			// have a relative point to the element being manipulated to match UWP
+			// NOTE: This is a workaround, and this scenario is still broken for some cases.
+			// See https://github.com/unoplatform/uno/issues/6964#issuecomment-913041138 for details.
+			Position = ManipulationEventArgsHelpers.MapPointRelativeTo(container, args.Position);
+
 			Delta = args.Delta;
 			Cumulative = args.Cumulative;
 			Velocities = args.Velocities;

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartedRoutedEventArgs.cs
@@ -2,6 +2,8 @@ using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.UI.Input;
 using Uno.UI.Xaml.Input;
+using Uno.UI;
+using Uno.UI.UI.Xaml.Input.Internal;
 
 namespace Windows.UI.Xaml.Input
 {
@@ -20,7 +22,13 @@ namespace Windows.UI.Xaml.Input
 
 			Pointers = args.Pointers;
 			PointerDeviceType = args.PointerDeviceType;
-			Position = args.Position;
+
+			// ManipulationCompletedEventArgs.Position is absolute position. We want to
+			// have a relative point to the element being manipulated to match UWP
+			// NOTE: This is a workaround, and this scenario is still broken for some cases.
+			// See https://github.com/unoplatform/uno/issues/6964#issuecomment-913041138 for details.
+			Position = ManipulationEventArgsHelpers.MapPointRelativeTo(container, args.Position);
+
 			Cumulative = args.Cumulative;
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): WORKAROUND #6964 (not sure if it's good enough). Would love to fix the root issue if someone can provide some help :)

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Manipulation event args position is always absolute (relative to screen)

## What is the new behavior?

It's now relative to the control as UWP, except for when the app isn't at the same position as screen.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
