### PR TITLE
fix: Add font fallback support to Skia

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1713,6 +1713,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Font_Fallback_Support.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Different_Font_Size.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5500,6 +5504,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockButton\Simple_TextBlockButton.xaml.cs">
       <DependentUpon>Simple_TextBlockButton.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Font_Fallback_Support.xaml.cs">
+      <DependentUpon>Font_Fallback_Support.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Different_Font_Size.xaml.cs">
       <DependentUpon>SimpleText_MaxLines_Different_Font_Size.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Font_Fallback_Support.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Font_Fallback_Support.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.TextBlockControl.Font_Fallback_Support"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBlockControl"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel>
+		<TextBlock Text="Sample Text - 示例文本" FontWeight="Bold" FontSize="40" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Font_Fallback_Support.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Font_Fallback_Support.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBlockControl
+{
+    [Sample("TextBlockControl")]
+    public sealed partial class Font_Fallback_Support : Page
+    {
+        public Font_Fallback_Support()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/SkiaTextLine.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/SkiaTextLine.skia.cs
@@ -1,0 +1,70 @@
+﻿#nullable enable
+
+using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.UI.Composition
+{
+	/// <summary>
+	/// Because Skia doesn't support fallback fonts for specific parts of text, we manually handle that in this class.
+	/// </summary>
+	internal class SkiaTextLine
+	{
+		private readonly List<(string Text, SKTypeface? Font)> _parts = new List<(string Text, SKTypeface? Font)>();
+		public IReadOnlyCollection<(string Text, SKTypeface? Font)> TextParts => _parts.AsReadOnly();
+
+		public SkiaTextLine(string text, SKTypeface? font, Func<string, SKFontStyleWeight, SKFontStyleWidth, SKFontStyleSlant, SKTypeface> getTypeFace)
+		{
+			if (text is null)
+			{
+				throw new ArgumentNullException(nameof(text));
+			}
+
+			if (text.Length == 0)
+			{
+				_parts.Add((text, font));
+				return;
+			}
+
+			var builder = new StringBuilder(capacity: text.Length);
+			builder.Append(text[0]);
+			SKTypeface? lastValidFont = GetFontForCharacter(text[0], font, getTypeFace);
+			for (var i = 1; i < text.Length; i++)
+			{
+				var character = text[i];
+				var currentFont = GetFontForCharacter(character, font, getTypeFace);
+				if (lastValidFont != currentFont)
+				{
+					_parts.Add((builder.ToString(), lastValidFont));
+					builder.Clear();
+					lastValidFont = currentFont;
+				}
+
+				builder.Append(character);
+			}
+
+			if (builder.Length > 0)
+			{
+				_parts.Add((builder.ToString(), lastValidFont));
+			}
+		}
+
+		private static SKTypeface? GetFontForCharacter(char character, SKTypeface? font, Func<string, SKFontStyleWeight, SKFontStyleWidth, SKFontStyleSlant, SKTypeface> getTypeFace)
+		{
+			if (font?.ContainsGlyph(character) ?? true)
+			{
+				return font;
+			}
+
+			var fontForCharacter = SKFontManager.Default.MatchCharacter(character);
+			if (fontForCharacter is null)
+			{
+				return font;
+			}
+
+			return getTypeFace(fontForCharacter.FamilyName, (SKFontStyleWeight)font.FontWeight, (SKFontStyleWidth)font.FontStyle.Width, font.FontSlant);
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6973

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

By default, Skia (unlike Android/Wasm (iOS/macOS not confirmed), doesn't support fallback fonts when the specified font doesn't contain a given character.

## What is the new behavior?

The parts of the text that can't be rendered with the specified font will be rendered in a fallback font that supports that given character.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
