### PR TITLE
Avoid breaking on TaskCanceledException in ObjectAnimationUsingKeyFrames

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
@@ -253,8 +253,21 @@ namespace Windows.UI.Xaml.Media.Animation
 							CoreDispatcherPriority.Normal,
 							async ct =>
 							{
-								await Task.Delay(dueTime, ct);
-								update();
+								// TODO: Ensure the exception is handled in debug to avoid
+								// breaking here in Visual Studio.
+#if DEBUG
+								try
+								{
+#endif
+									await Task.Delay(dueTime, ct);
+									update();
+#if DEBUG
+								}
+								catch (TaskCanceledException)
+								{
+									// Ignored
+								}
+#endif
 							}
 						)
 					);


### PR DESCRIPTION
GitHub Issue (If applicable): -


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On Skia, VS always breaks on `TaskCanceledException` in `ObjectAnimationUsingKeyFrames`

## What is the new behavior?

In debug mode, the exception is caught and ignored.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.