### PR TITLE
fix: Open suggestion list when focus, reflect text changes

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -13,6 +13,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 	[RunsOnUIThread]
 	public class Given_AutoSuggestBox
 	{
+#if !WINDOWS_UWP // GetTemplateChild is protected in UWP while public in Uno.
 		[TestMethod]
 		public async Task When_Text_Changed_Should_Reflect_In_DataTemplate_TextBox()
 		{
@@ -52,5 +53,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.Text = "a";
 			SUT.IsSuggestionListOpen.Should().BeTrue();
 		}
+#endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_AutoSuggestBox
+	{
+		[TestMethod]
+		public async Task When_Text_Changed_Should_Reflect_In_DataTemplate_TextBox()
+		{
+			var SUT = new AutoSuggestBox();
+			SUT.Text = "New text..";
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForIdle();
+			var textBox = (TextBox)SUT.GetTemplateChild("TextBox");
+			textBox.Text.Should().Be("New text..");
+		}
+
+		[TestMethod]
+		public async Task When_Text_Changed_And_Not_Focused_Should_Not_Open_Suggestion_List()
+		{
+			var SUT = new AutoSuggestBox();
+			SUT.ItemsSource = new List<string>() { "ab", "abc", "abcde" };
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForIdle();
+
+			var textBox = (TextBox)SUT.GetTemplateChild("TextBox");
+			textBox.IsFocused.Should().BeFalse();
+			SUT.Text = "a";
+			SUT.IsSuggestionListOpen.Should().BeFalse();
+		}
+
+		[TestMethod]
+		public async Task When_Text_Changed_And_Focused_Should_Open_Suggestion_List()
+		{
+			var SUT = new AutoSuggestBox();
+			SUT.ItemsSource = new List<string>() { "ab", "abc", "abcde" };
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForIdle();
+
+			var textBox = (TextBox)SUT.GetTemplateChild("TextBox");
+			SUT.Focus(FocusState.Programmatic);
+			textBox.IsFocused.Should().BeTrue();
+			SUT.Text = "a";
+			SUT.IsSuggestionListOpen.Should().BeTrue();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -53,6 +53,7 @@ namespace Windows.UI.Xaml.Controls
 #endif
 
 			UpdateQueryButton();
+			UpdateTextBox();
 
 			_textBoxBinding = new BindingPath("Text", null) { DataContext = _textBox, ValueChangedListener = this };
 
@@ -119,7 +120,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 					IsSuggestionListOpen = false;
 				}
-				else
+				else if (_textBox?.IsFocused ?? false)
 				{
 					IsSuggestionListOpen = true;
 					_suggestionsList.ItemsSource = GetItems();
@@ -283,6 +284,16 @@ namespace Windows.UI.Xaml.Controls
 			_queryButton.Visibility = QueryIcon == null ? Visibility.Collapsed : Visibility.Visible;
 		}
 
+		private void UpdateTextBox()
+		{
+			if (_textBox == null)
+			{
+				return;
+			}
+
+			_textBox.Text = Text;
+		}
+
 		private void OnSuggestionListItemClick(object sender, ItemClickEventArgs e)
 		{
 			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
@@ -413,6 +424,9 @@ namespace Windows.UI.Xaml.Controls
 
 			if (dependencyObject is AutoSuggestBox tb)
 			{
+				tb.UpdateTextBox();
+				tb.UpdateSuggestionList();
+
 				if (tb._textChangeReason == AutoSuggestionBoxTextChangeReason.UserInput)
 				{
 					tb.UpdateUserInput(newValue);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6321

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Changing `AutoSuggestBox.Text` doesn't propagate to the underlying `TextBox`
- Suggestion list is opened even if the control isn't focused.
- Suggestion list isn't opened on text change.

## What is the new behavior?

- Changing `AutoSuggestBox.Text` now propagates to the underlying `TextBox`
- Suggestion list is opened only if the control is focused.
- Suggest list is opened on text change (only when focused too).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
