### PR TITLE
Fix effective viewport

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestEngineConfig.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestEngineConfig.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Linq;
+
+namespace Uno.UI.Samples.Tests
+{
+	public class UnitTestEngineConfig
+	{
+		public string[] Filters { get; set; }
+
+		public int Attempts { get; set; }
+
+		public bool IsConsoleOutputEnabled { get; set; }
+
+		public bool IsRunningIgnored { get; set; }
+	}
+}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.CustomConsoleOutput.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.CustomConsoleOutput.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace Uno.UI.Samples.Tests
+{
+	public sealed partial class UnitTestsControl
+	{
+		private class ConsoleOutputRecorder : IDisposable
+		{
+			private readonly TextWriterDuplicator _duplicator;
+			private readonly TextWriter _originalOutput;
+
+			private int _isDisposed;
+
+			public static ConsoleOutputRecorder Start()
+				=> new ConsoleOutputRecorder();
+
+			private ConsoleOutputRecorder()
+			{
+				_originalOutput = Console.Out;
+				_duplicator = new TextWriterDuplicator(_originalOutput);
+
+				Console.SetOut(_duplicator);
+			}
+
+			internal string GetContentAndReset()
+				=> _duplicator.GetContentAndReset();
+
+			/// <inheritdoc />
+			public void Dispose()
+			{
+				if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
+				{
+					GC.SuppressFinalize(this);
+					Console.SetOut(_originalOutput);
+				}
+			}
+
+			~ConsoleOutputRecorder()
+			{
+				Dispose();
+			}
+		}
+
+		private class TextWriterDuplicator : TextWriter
+		{
+			private readonly TextWriter _inner;
+			private readonly StringBuilder _accumulator = new StringBuilder();
+
+			public TextWriterDuplicator(TextWriter inner)
+			{
+				_inner = inner;
+			}
+
+			internal string GetContentAndReset()
+			{
+				var result = _accumulator.ToString();
+				Reset();
+				return result;
+			}
+
+			internal void Reset() => _accumulator.Clear();
+
+			public override Encoding Encoding { get; }
+
+			public override void Write(char value)
+			{
+				_inner.Write(value);
+				_accumulator.Append(value);
+			}
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -80,32 +80,12 @@ namespace Uno.UI.Samples.Tests
 		{
 			Interlocked.Exchange(ref _cts, new CancellationTokenSource())?.Cancel(); // cancel any previous CTS
 
-			var filter = testFilter.Text.Trim();
-			if (string.IsNullOrEmpty(filter))
-			{
-				filter = null;
-			}
-
+			var config = BuildConfig();
 			testResults.Children.Clear();
 
-			async Task DoRunTests()
-			{
-				try
-				{
-					await RunTests(_cts.Token, filter?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>());
-				}
-				finally
-				{
-					await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-					{
-						runButton.IsEnabled = true;
-						stopButton.IsEnabled = false;
-					});
-				}
-			}
-
-			_runner = Task.Run(DoRunTests);
+			_runner = Task.Run(() => RunTests(_cts.Token, config));
 		}
+
 
 		private void OnStopTests(object sender, RoutedEventArgs e)
 		{
@@ -333,6 +313,25 @@ namespace Uno.UI.Samples.Tests
 			return w.ToString();
 		}
 
+		private UnitTestEngineConfig BuildConfig()
+		{
+			var isConsoleOutput = consoleOutput.IsChecked ?? false;
+			var isRunningIgnored = runIgnored.IsChecked ?? false;
+			var attempts = (retry.IsChecked ?? true) ? _maxRepeatCount : 1;
+			var filter = testFilter.Text.Trim();
+			if (string.IsNullOrEmpty(filter))
+			{
+				filter = null;
+			}
+
+			return new UnitTestEngineConfig
+			{
+				Filters = filter?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>(),
+				IsConsoleOutputEnabled = isConsoleOutput,
+				IsRunningIgnored = isRunningIgnored,
+				Attempts = attempts,
+			};
+		}
 
 		private string GetTestResultIcon(TestResult testResult)
 		{
@@ -372,16 +371,6 @@ namespace Uno.UI.Samples.Tests
 		{
 			Interlocked.Exchange(ref _cts, new CancellationTokenSource())?.Cancel(); // cancel any previous CTS
 
-			var filter = testFilter.Text.Trim();
-			if (string.IsNullOrEmpty(filter))
-			{
-				filter = null;
-			}
-
-			var filters = filter != null ?
-				filter.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) :
-				Array.Empty<string>();
-
 			testResults.Children.Clear();
 
 			try
@@ -389,18 +378,9 @@ namespace Uno.UI.Samples.Tests
 				try
 				{
 					var testTypeInfo = BuildType(testClassInstance.GetType());
+					var engineConfig = BuildConfig();
 
-					var tests = FilterTests(testTypeInfo, filters);
-
-					if (tests.Length == 0)
-					{
-						return;
-					}
-
-					ReportTestClass(testTypeInfo.Type.GetTypeInfo());
-					_ = ReportMessage($"Running {tests.Length} test methods");
-
-					await ExecuteTestsForInstance(_cts.Token, testClassInstance, testTypeInfo.Tests, testTypeInfo);
+					await ExecuteTestsForInstance(_cts.Token, testClassInstance, testTypeInfo, engineConfig);
 				}
 				catch (Exception e)
 				{
@@ -420,7 +400,7 @@ namespace Uno.UI.Samples.Tests
 			}
 		}
 
-		private async Task RunTests(CancellationToken ct, string[] filters)
+		private async Task RunTests(CancellationToken ct, UnitTestEngineConfig config)
 		{
 			_currentRun = new TestRun();
 
@@ -432,21 +412,11 @@ namespace Uno.UI.Samples.Tests
 
 				_ = ReportMessage("Running tests...");
 
-				foreach (var type in testTypes.Where(t => t.Type != null))
+				foreach (var type in testTypes)
 				{
-					var tests = FilterTests(type, filters);
-
-					if (tests.Length == 0)
-					{
-						continue;
-					}
-
-					ReportTestClass(type.Type.GetTypeInfo());
-					_ = ReportMessage($"Running {tests.Length} test methods");
-
 					var instance = Activator.CreateInstance(type: type.Type);
 
-					await ExecuteTestsForInstance(ct, instance, tests, type);
+					await ExecuteTestsForInstance(ct, instance, type, config);
 				}
 
 				_ = ReportMessage("Tests finished running.", isRunning: false);
@@ -459,6 +429,14 @@ namespace Uno.UI.Samples.Tests
 				ReportTestResult("Runtime exception", TimeSpan.Zero, TestResult.Failed, e);
 				ReportTestsResults();
 			}
+			finally
+			{
+				await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+				{
+					runButton.IsEnabled = true;
+					stopButton.IsEnabled = false;
+				});
+			}
 
 			GenerateTestResults();
 		}
@@ -468,280 +446,235 @@ namespace Uno.UI.Samples.Tests
 			var testClassNameContainsFilters = filters?.Any(f => testClassInfo.Type.FullName.Contains(f, StrComp)) ?? false;
 			return testClassInfo.Tests
 				.Where(t => (filters?.None() ?? true)
-							|| testClassNameContainsFilters
-							|| filters.Any(f => t.DeclaringType.FullName.Contains(f, StrComp))
-							|| filters.Any(f => t.Name.Contains(f, StrComp)))
+					|| testClassNameContainsFilters
+					|| filters.Any(f => t.DeclaringType.FullName.Contains(f, StrComp))
+					|| filters.Any(f => t.Name.Contains(f, StrComp)))
 				.ToArray();
-		}
-
-		private class CustomConsoleOutput : TextWriter
-		{
-			private readonly TextWriter _previousOutput;
-			private readonly List<char> _accumulator = new List<char>();
-
-			public CustomConsoleOutput(TextWriter previousOutput)
-			{
-				_previousOutput = previousOutput;
-			}
-
-			internal string GetContentAndReset()
-			{
-				var result = new string(_accumulator.ToArray());
-				Reset();
-				return result;
-			}
-
-			internal void Reset() => _accumulator.Clear();
-
-			public override Encoding Encoding { get; }
-
-			public override void Write(char value)
-			{
-				_previousOutput.Write(value);
-				_accumulator.Add(value);
-			}
 		}
 
 		private async Task ExecuteTestsForInstance(
 			CancellationToken ct,
 			object instance,
-			MethodInfo[] tests,
-			UnitTestClassInfo testClassInfo)
+			UnitTestClassInfo testClassInfo,
+			UnitTestEngineConfig config)
 		{
-			IDisposable consoleRegistration = default;
-			CustomConsoleOutput testConsoleOutput = default;
+			using var consoleRecorder = config.IsConsoleOutputEnabled
+				? ConsoleOutputRecorder.Start()
+				: default;
 
-			bool isConsoleOutput = false;
-			bool isRunningIgnored = false;
-
-			await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+			var tests = FilterTests(testClassInfo, config.Filters);
+			if (tests.None())
 			{
-				isConsoleOutput = consoleOutput.IsChecked ?? false;
-				isRunningIgnored = runIgnored.IsChecked ?? false;
-			});
-
-			if (isConsoleOutput)
-			{
-				var previousOutput = Console.Out;
-
-				testConsoleOutput = new CustomConsoleOutput(previousOutput);
-
-				consoleRegistration = Disposable.Create(() => Console.SetOut(previousOutput));
-
-				Console.SetOut(testConsoleOutput);
+				return;
 			}
 
-			try
+			ReportTestClass(testClassInfo.Type.GetTypeInfo());
+			_ = ReportMessage($"Running {tests.Length} test methods");
+
+			foreach (var testMethod in tests)
 			{
-				var shouldRunIgnored = isRunningIgnored;
+				var testName = testMethod.Name;
 
-				foreach (var testMethod in tests)
+				if (IsIgnored(testMethod, out var ignoreMessage))
 				{
-					string testName = testMethod.Name;
-
-					if (IsIgnored(testMethod, out var ignoreMessage))
+					if (config.IsRunningIgnored)
 					{
-						if (shouldRunIgnored)
-						{
-							ignoreMessage = $"\n--> [Ignored] IS BYPASSED...";
-						}
-
-						_currentRun.Ignored++;
-						ReportTestResult(testName, TimeSpan.Zero, TestResult.Skipped, message: ignoreMessage);
-
-						if (!shouldRunIgnored)
-						{
-							continue;
-						}
+						ignoreMessage = $"\n--> [Ignored] IS BYPASSED...";
 					}
 
-					var runsOnUIThread =
-						HasCustomAttribute<RunsOnUIThreadAttribute>(testMethod) ||
-						HasCustomAttribute<RunsOnUIThreadAttribute>(testMethod.DeclaringType);
-					var requiresFullWindow =
-						HasCustomAttribute<RequiresFullWindowAttribute>(testMethod) ||
-						HasCustomAttribute<RequiresFullWindowAttribute>(testMethod.DeclaringType);
-					var expectedException = testMethod.GetCustomAttributes<ExpectedExceptionAttribute>()
-						.SingleOrDefault();
-					var dataRows = testMethod.GetCustomAttributes<DataRowAttribute>();
-					if (dataRows.Any())
+					_currentRun.Ignored++;
+					ReportTestResult(testName, TimeSpan.Zero, TestResult.Skipped, message: ignoreMessage);
+
+					if (!config.IsRunningIgnored)
 					{
-						foreach (var row in dataRows)
-						{
-							var d = row.Data;
-							await InvokeTestMethod(d);
-						}
+						continue;
 					}
-					else
+				}
+
+				var runsOnUIThread =
+					HasCustomAttribute<RunsOnUIThreadAttribute>(testMethod) ||
+					HasCustomAttribute<RunsOnUIThreadAttribute>(testMethod.DeclaringType);
+				var requiresFullWindow =
+					HasCustomAttribute<RequiresFullWindowAttribute>(testMethod) ||
+					HasCustomAttribute<RequiresFullWindowAttribute>(testMethod.DeclaringType);
+				var expectedException = testMethod
+					.GetCustomAttributes<ExpectedExceptionAttribute>()
+					.SingleOrDefault();
+				var dataRows = testMethod
+					.GetCustomAttributes<DataRowAttribute>()
+					.ToList();
+				if (dataRows.Any())
+				{
+					foreach (var row in dataRows)
 					{
-						await InvokeTestMethod(new object[0]);
+						var d = row.Data;
+						await InvokeTestMethod(d);
 					}
+				}
+				else
+				{
+					await InvokeTestMethod(Array.Empty<object>());
+				}
 
-					async Task InvokeTestMethod(object[] parameters)
+				async Task InvokeTestMethod(object[] parameters)
+				{
+					var fullTestName = $"{testName}({parameters.Select(p => p?.ToString() ?? "<null>").JoinBy(", ")})";
+
+					_currentRun.Run++;
+					_currentRun.CurrentRepeatCount = 0;
+
+					// We await this to make sure the UI is updated before running the test.
+					// This will help developpers to identify faulty tests when the app is crashing.
+					await ReportMessage($"Running test {fullTestName}");
+					ReportTestsResults();
+
+					var sw = new Stopwatch();
+					var canRetry = true;
+
+					while (canRetry)
 					{
-						var fullTestName =
-							$"{testName}({parameters.Select(p => p?.ToString() ?? "<null>").JoinBy(", ")})";
+						canRetry = false;
 
-						_currentRun.Run++;
-						_currentRun.CurrentRepeatCount = 0;
-
-						// We await this to make sure the UI is updated before running the test.
-						// This will help developpers to identify faulty tests when the app is crashing.
-						await ReportMessage($"Running test {fullTestName}");
-						ReportTestsResults();
-
-						var sw = new Stopwatch();
-						bool canRetry = true;
-
-						while (canRetry)
+						try
 						{
-							canRetry = false;
-
-							try
+							if (requiresFullWindow)
 							{
-								if (requiresFullWindow)
+								await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 								{
-									await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-									{
-										Private.Infrastructure.TestServices.WindowHelper.UseActualWindowRoot = true;
-										Private.Infrastructure.TestServices.WindowHelper.SaveOriginalWindowContent();
-									});
-								}
+									Private.Infrastructure.TestServices.WindowHelper.UseActualWindowRoot = true;
+									Private.Infrastructure.TestServices.WindowHelper.SaveOriginalWindowContent();
+								});
+							}
 
-								object returnValue = null;
-								if (runsOnUIThread)
-								{
-									await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-									{
-										sw.Start();
-										testClassInfo.Initialize?.Invoke(instance, new object[0]);
-										returnValue = testMethod.Invoke(instance, parameters);
-										sw.Stop();
-									});
-								}
-								else
+							object returnValue = null;
+							if (runsOnUIThread)
+							{
+								await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 								{
 									sw.Start();
 									testClassInfo.Initialize?.Invoke(instance, new object[0]);
 									returnValue = testMethod.Invoke(instance, parameters);
 									sw.Stop();
+								});
+							}
+							else
+							{
+								sw.Start();
+								testClassInfo.Initialize?.Invoke(instance, new object[0]);
+								returnValue = testMethod.Invoke(instance, parameters);
+								sw.Stop();
+							}
+
+							if (testMethod.ReturnType == typeof(Task))
+							{
+								var task = (Task)returnValue;
+								var timeoutTask = Task.Delay(DefaultUnitTestTimeout);
+
+								var resultingTask = await Task.WhenAny(task, timeoutTask);
+
+								if (resultingTask == timeoutTask)
+								{
+									throw new TimeoutException(
+										$"Test execution timed out after {DefaultUnitTestTimeout}");
 								}
 
-								if (testMethod.ReturnType == typeof(Task))
+								if (resultingTask.Exception != null)
 								{
-									var task = (Task)returnValue;
-									var timeoutTask = Task.Delay(DefaultUnitTestTimeout);
-
-									var resultingTask = await Task.WhenAny(task, timeoutTask);
-
-									if (resultingTask == timeoutTask)
-									{
-										throw new TimeoutException(
-											$"Test execution timed out after {DefaultUnitTestTimeout}");
-									}
-
-									if (resultingTask.Exception != null)
-									{
-										throw resultingTask.Exception;
-									}
+									throw resultingTask.Exception;
 								}
+							}
 
-								var console = testConsoleOutput?.GetContentAndReset();
+							var console = consoleRecorder?.GetContentAndReset();
 
-								if (expectedException == null)
+							if (expectedException == null)
+							{
+								_currentRun.Succeeded++;
+								ReportTestResult(fullTestName, sw.Elapsed, TestResult.Passed, console: console);
+							}
+							else
+							{
+								_currentRun.Failed++;
+								ReportTestResult(fullTestName, sw.Elapsed, TestResult.Failed,
+									message: $"Test did not throw the excepted exception of type {expectedException.ExceptionType.Name}",
+									console: console);
+							}
+						}
+						catch (Exception e)
+						{
+							sw.Stop();
+
+							if (e is AggregateException agg)
+							{
+								e = agg.InnerExceptions.FirstOrDefault();
+							}
+
+							if (e is TargetInvocationException tie)
+							{
+								e = tie.InnerException;
+							}
+
+							var console = consoleRecorder?.GetContentAndReset();
+
+							if (e is AssertInconclusiveException inconclusiveException)
+							{
+								_currentRun.Ignored++;
+								ReportTestResult(fullTestName, sw.Elapsed, TestResult.Skipped, message: e.Message, console: console);
+							}
+							else if (expectedException == null || !expectedException.ExceptionType.IsInstanceOfType(e))
+							{
+								if (_currentRun.CurrentRepeatCount < config.Attempts - 1 && !Debugger.IsAttached)
 								{
-									_currentRun.Succeeded++;
-									ReportTestResult(fullTestName, sw.Elapsed, TestResult.Passed, console: console);
+									_currentRun.CurrentRepeatCount++;
+									canRetry = true;
+
+									RunCleanup(instance, testClassInfo, testName);
 								}
 								else
 								{
 									_currentRun.Failed++;
-									ReportTestResult(fullTestName, sw.Elapsed, TestResult.Failed,
-										message: $"Test did not throw the excepted exception of type {expectedException.ExceptionType.Name}",
-										console: console);
+									ReportTestResult(fullTestName, sw.Elapsed, TestResult.Failed, e, console: console);
 								}
 							}
-							catch (Exception e)
+							else
 							{
-								sw.Stop();
-
-								if (e is AggregateException agg)
-								{
-									e = agg.InnerExceptions.FirstOrDefault();
-								}
-
-								if (e is TargetInvocationException tie)
-								{
-									e = tie.InnerException;
-								}
-
-								var console = testConsoleOutput?.GetContentAndReset();
-
-								if (e is AssertInconclusiveException inconclusiveException)
-								{
-									_currentRun.Ignored++;
-									ReportTestResult(fullTestName, sw.Elapsed, TestResult.Skipped, message: e.Message, console: console);
-								}
-								else if (expectedException == null || !expectedException.ExceptionType.IsInstanceOfType(e))
-								{
-									if (_currentRun.CurrentRepeatCount < _maxRepeatCount && !Debugger.IsAttached)
-									{
-										_currentRun.CurrentRepeatCount++;
-										canRetry = true;
-
-										RunCleanup(instance, testClassInfo, testConsoleOutput, testName);
-									}
-									else
-									{
-										_currentRun.Failed++;
-										ReportTestResult(fullTestName, sw.Elapsed, TestResult.Failed, e, console: console);
-									}
-								}
-								else
-								{
-									_currentRun.Succeeded++;
-									ReportTestResult(fullTestName, sw.Elapsed, TestResult.Passed, e, console: console);
-								}
+								_currentRun.Succeeded++;
+								ReportTestResult(fullTestName, sw.Elapsed, TestResult.Passed, e, console: console);
 							}
-							finally
+						}
+						finally
+						{
+							if (requiresFullWindow)
 							{
-								if (requiresFullWindow)
+								await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 								{
-									await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-									{
-										Private.Infrastructure.TestServices.WindowHelper.RestoreOriginalWindowContent();
-										Private.Infrastructure.TestServices.WindowHelper.UseActualWindowRoot = false;
-									});
-								}
+									Private.Infrastructure.TestServices.WindowHelper.RestoreOriginalWindowContent();
+									Private.Infrastructure.TestServices.WindowHelper.UseActualWindowRoot = false;
+								});
 							}
 						}
 					}
+				}
 
-					RunCleanup(instance, testClassInfo, testConsoleOutput, testName);
+				RunCleanup(instance, testClassInfo, testName);
 
-					if (ct.IsCancellationRequested)
-					{
-						_ = ReportMessage("Stopped by user.", false);
-						return; // finish processing
-					}
+				if (ct.IsCancellationRequested)
+				{
+					_ = ReportMessage("Stopped by user.", false);
+					return; // finish processing
 				}
 			}
-			finally
-			{
-				consoleRegistration?.Dispose();
-			}
-		}
 
-		private void RunCleanup(object instance, UnitTestClassInfo testClassInfo, CustomConsoleOutput testConsoleOutput, string testName)
-		{
-			try
+			void RunCleanup(object instance, UnitTestClassInfo testClassInfo, string testName)
 			{
-				testClassInfo.Cleanup?.Invoke(instance, new object[0]);
-			}
-			catch (Exception e)
-			{
-				_currentRun.Failed++;
-				ReportTestResult(testName + " Cleanup", TimeSpan.Zero, TestResult.Failed, e, console: testConsoleOutput.GetContentAndReset());
+				try
+				{
+					testClassInfo.Cleanup?.Invoke(instance, new object[0]);
+				}
+				catch (Exception e)
+				{
+					_currentRun.Failed++;
+					ReportTestResult(testName + " Cleanup", TimeSpan.Zero, TestResult.Failed, e, console: consoleRecorder.GetContentAndReset());
+				}
 			}
 		}
 
@@ -780,7 +713,9 @@ namespace Uno.UI.Samples.Tests
 			return from type in types
 				   where type.GetTypeInfo().GetCustomAttribute(typeof(TestClassAttribute)) != null
 				   orderby type.Name
-				   select BuildType(type);
+				   let info = BuildType(type)
+				   where info.Type is {}
+				   select info;
 		}
 
 		private static UnitTestClassInfo BuildType(Type type)

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
@@ -21,24 +21,34 @@
 		</Grid.ColumnDefinitions>
 		<StackPanel Grid.Row="0">
 			<StackPanel Orientation="Horizontal" Spacing="4">
-				<Button x:Name="runButton"
-						not_skia:Content="▶️ Run"
-						skia:Content="Run"
-						Click="OnRunTests" />
-				<Button x:Name="stopButton"
-						IsEnabled="False"
-						not_skia:Content="⏹️ Stop"
-						skia:Content="Stop"
-						Click="OnStopTests" />
-				<TextBox x:Name="testFilter"
-						 PlaceholderText="Enter test filter here"
-						 Width="140" />
-				<ToggleButton x:Name="consoleOutput"
-						not_skia:Content="🖥️ Console Output"
-						skia:Content="Console Output" />
-				<ToggleButton x:Name="runIgnored"
-						not_skia:Content="🚫 Run [Ignore]"
-						skia:Content="Run [Ignore]" />
+				<Button
+					x:Name="runButton"
+					not_skia:Content="▶️ Run"
+					skia:Content="Run"
+					Click="OnRunTests" />
+				<Button
+					x:Name="stopButton"
+					IsEnabled="False"
+					not_skia:Content="⏹️ Stop"
+					skia:Content="Stop"
+					Click="OnStopTests" />
+				<TextBox
+					x:Name="testFilter"
+					PlaceholderText="Enter test filter here"
+					Width="140" />
+				<ToggleButton
+					x:Name="consoleOutput"
+					not_skia:Content="🖥️ Console Output"
+					skia:Content="Console Output" />
+				<ToggleButton
+					x:Name="runIgnored"
+					not_skia:Content="🚫 Run [Ignore]"
+					skia:Content="Run [Ignore]" />
+				<ToggleButton
+					x:Name="retry"
+					IsChecked="True"
+					not_skia:Content="➰ Auto retry"
+					skia:Content="Auto retry" />
 			</StackPanel>
 
 			<StackPanel Orientation="Horizontal">

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.Shared.projitems
@@ -49,7 +49,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Helper\ThicknessHelper2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UnitTest\TestCase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UnitTest\TestRun.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\UnitTest\UnitTestEngineConfig.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UnitTest\UnitTestsControl.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\UnitTest\UnitTestsControl.CustomConsoleOutput.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UnitTest\UnitTestTypeInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -100,7 +100,23 @@ namespace Windows.Foundation
 
 		public bool IsEmpty => Empty.Equals(this);
 
+		/// <summary>
+		/// This indicates that this rect is equals to the <see cref="Infinite"/>.
+		/// Unlike the <see cref="IsFinite"/>, this **DOES NOT** indicates that the rect is infinite on at least one of its axis.
+		/// </summary>
 		internal bool IsInfinite => Infinite.Equals(this);
+
+		/// <summary>
+		/// This make sure that this rect does not have any infinite value on any of its axis.
+		/// </summary>
+		/// <remarks>This is **NOT** the opposite of <see cref="IsInfinite"/>.</remarks>
+		internal bool IsFinite => !double.IsInfinity(X) && !double.IsInfinity(Y) && !double.IsInfinity(Width) && !double.IsInfinity(Height);
+
+		/// <summary>
+		/// Indicates that this rect does not have any infinite or NaN on any on its axis.
+		/// (I.e. it's a valid rect for standard layouting logic)
+		/// </summary>
+		internal bool IsValid => IsFinite && !double.IsNaN(X) && !double.IsNaN(Y) && !double.IsNaN(Width) && !double.IsNaN(Height);
 
 		internal bool IsUniform => Math.Abs(Left - Top) < Epsilon && Math.Abs(Left - Right) < Epsilon && Math.Abs(Left - Bottom) < Epsilon;
 
@@ -146,7 +162,9 @@ namespace Windows.Foundation
 		public override string ToString() => (string)this;
 
 		internal string ToDebugString()
-			=> IsEmpty ? "--empty--" : FormattableString.Invariant($"{Size.ToDebugString()}@{Location.ToDebugString()}");
+			=> IsEmpty ? "--empty--"
+				: IsInfinite ? "--infinite--"
+				: FormattableString.Invariant($"{Width:F2}x{Height:F2}@{Location.ToDebugString()}");
 
 		/// <summary>
 		/// Provides the size of this rectangle.

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ScrollContentPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ScrollContentPresenter.cs
@@ -51,7 +51,7 @@ namespace Windows.UI.Xaml.Controls
 		#endif
 		// Skipping already declared property ExtentHeight
 		// Skipping already declared property ExtentWidth
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || false
+		#if __ANDROID__ || __IOS__ || NET461 || false || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  double HorizontalOffset
 		{
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || false
+		#if __ANDROID__ || __IOS__ || NET461 || false || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  double VerticalOffset
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -54,7 +54,7 @@ namespace Windows.UI.Xaml.Controls
 
 		internal Size _unclippedDesiredSize;
 
-		private UIElement _elementAsUIElement;
+		private readonly UIElement _elementAsUIElement;
 
 		public IFrameworkElement Panel { get; }
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollBar/ScrollBar.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollBar/ScrollBar.cs
@@ -1146,6 +1146,13 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			pMouseIndicatorLength = 0.0;
 			pTouchIndicatorLength = 0.0;
 
+			// Uno workaround: If the scrollbar is smaller than the min size of the thumb,
+			//		we will try to set the visibility collapsed and then request to 'HideThumb',
+			//		which will drive uno to fall in an infinite layout cycle.
+			//		We instead cache the value and apply it only at the end.
+			double? m_tpElementHorizontalThumbWidth = default, m_tpElementVerticalThumbHeight = default, m_tpElementHorizontalPanningThumbWidth = default, m_tpElementVerticalPanningThumbHeight = default;
+			Visibility? m_tpElementHorizontalThumbVisibility = default, m_tpElementVerticalThumbVisibility = default, m_tpElementHorizontalPanningThumbVisibility = default, m_tpElementVerticalPanningThumbVisibility = default;
+
 			if (!hideThumb)
 			{
 				double minSize = 0.0;
@@ -1159,8 +1166,9 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 				double actualSize;
 				double actualSizeMinusRepeatButtonsLength;
+
 				if (orientation == Orientation.Horizontal &&
-m_tpElementHorizontalThumb != null)
+					m_tpElementHorizontalThumb != null)
 				{
 					if (maximum - minimum != 0)
 					{
@@ -1177,8 +1185,8 @@ m_tpElementHorizontalThumb != null)
 					}
 					else
 					{
-						m_tpElementHorizontalThumb.Visibility = Visibility.Visible;
-						m_tpElementHorizontalThumb.Width = result;
+						m_tpElementHorizontalThumbVisibility = Visibility.Visible;
+						m_tpElementHorizontalThumbWidth = result;
 						mouseIndicatorLengthWasSet = true;
 					}
 				}
@@ -1200,8 +1208,8 @@ m_tpElementHorizontalThumb != null)
 					}
 					else
 					{
-						m_tpElementVerticalThumb.Visibility = Visibility.Visible;
-						m_tpElementVerticalThumb.Height = result;
+						m_tpElementVerticalThumbVisibility = Visibility.Visible;
+						m_tpElementVerticalThumbHeight = result;
 						mouseIndicatorLengthWasSet = true;
 					}
 				}
@@ -1233,8 +1241,8 @@ m_tpElementHorizontalThumb != null)
 					}
 					else
 					{
-						m_tpElementHorizontalPanningThumb.Visibility = Visibility.Visible;
-						m_tpElementHorizontalPanningThumb.Width = result;
+						m_tpElementHorizontalPanningThumbVisibility = Visibility.Visible;
+						m_tpElementHorizontalPanningThumbWidth = result;
 						touchIndicatorLengthWasSet = true;
 					}
 				}
@@ -1255,8 +1263,8 @@ m_tpElementHorizontalThumb != null)
 					}
 					else
 					{
-						m_tpElementVerticalPanningThumb.Visibility = Visibility.Visible;
-						m_tpElementVerticalPanningThumb.Height = result;
+						m_tpElementVerticalPanningThumbVisibility = Visibility.Visible;
+						m_tpElementVerticalPanningThumbHeight = result;
 						touchIndicatorLengthWasSet = true;
 					}
 				}
@@ -1286,6 +1294,17 @@ m_tpElementHorizontalThumb != null)
 				{
 					m_tpElementVerticalPanningThumb.Visibility = Visibility.Collapsed;
 				}
+			}
+			else
+			{
+				if (m_tpElementHorizontalThumbWidth.HasValue) m_tpElementHorizontalThumb.Width = m_tpElementHorizontalThumbWidth.Value;
+				if (m_tpElementVerticalThumbHeight.HasValue) m_tpElementVerticalThumb.Height = m_tpElementVerticalThumbHeight.Value;
+				if (m_tpElementHorizontalPanningThumbWidth.HasValue) m_tpElementHorizontalPanningThumb.Width = m_tpElementHorizontalPanningThumbWidth.Value;
+				if (m_tpElementVerticalPanningThumbHeight.HasValue) m_tpElementVerticalPanningThumb.Height = m_tpElementVerticalPanningThumbHeight.Value;
+				if (m_tpElementHorizontalThumbVisibility.HasValue) m_tpElementHorizontalThumb.Visibility = m_tpElementHorizontalThumbVisibility.Value;
+				if (m_tpElementVerticalThumbVisibility.HasValue) m_tpElementVerticalThumb.Visibility = m_tpElementVerticalThumbVisibility.Value;
+				if (m_tpElementHorizontalPanningThumbVisibility.HasValue) m_tpElementHorizontalPanningThumb.Visibility = m_tpElementHorizontalPanningThumbVisibility.Value;
+				if (m_tpElementVerticalPanningThumbVisibility.HasValue) m_tpElementVerticalPanningThumb.Visibility = m_tpElementVerticalPanningThumbVisibility.Value;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -41,54 +41,35 @@ namespace Windows.UI.Xaml.Controls
 
 		private void TryRegisterEvents(ScrollBarVisibility visibility)
 		{
-
 			if (
 				!_eventsRegistered
 				&& (visibility == ScrollBarVisibility.Auto || visibility == ScrollBarVisibility.Visible))
 			{
-				// Those events are only needed when native scrollbars are used, in order to handle
-				// pointer events on the native scrolbars themselves. See HandlePointerEvent for
-				// more details.
+				// Those events are only needed when native scrollbars are used,
+				// in order to handle pointer events on the native scrollbars themselves.
+				// See HandlePointerEvent for more details.
 
 				_eventsRegistered = true;
 
-				PointerReleased += ScrollViewer_PointerReleased;
-				PointerPressed += ScrollViewer_PointerPressed;
-				PointerCanceled += ScrollContentPresenter_PointerCanceled;
-				PointerMoved += ScrollContentPresenter_PointerMoved;
-				PointerEntered += ScrollContentPresenter_PointerEntered;
-				PointerExited += ScrollContentPresenter_PointerExited;
-				PointerWheelChanged += ScrollContentPresenter_PointerWheelChanged;
+				PointerReleased += HandlePointerEvent;
+				PointerPressed += HandlePointerEvent;
+				PointerCanceled += HandlePointerEvent;
+				PointerMoved += HandlePointerEvent;
+				PointerEntered += HandlePointerEvent;
+				PointerExited += HandlePointerEvent;
+				PointerWheelChanged += HandlePointerEvent;
 			}
 		}
 
-		private void ScrollContentPresenter_PointerWheelChanged(object sender, Input.PointerRoutedEventArgs e)
-			=> HandlePointerEvent(e);
-
-		private void ScrollContentPresenter_PointerExited(object sender, Input.PointerRoutedEventArgs e)
-			=> HandlePointerEvent(e);
-
-		private void ScrollContentPresenter_PointerEntered(object sender, Input.PointerRoutedEventArgs e)
-			=> HandlePointerEvent(e);
-
-		private void ScrollContentPresenter_PointerMoved(object sender, Input.PointerRoutedEventArgs e)
-			=> HandlePointerEvent(e);
-
-		private void ScrollContentPresenter_PointerCanceled(object sender, Input.PointerRoutedEventArgs e)
-			=> HandlePointerEvent(e);
-
-		private void ScrollViewer_PointerPressed(object sender, Input.PointerRoutedEventArgs e)
-			=> HandlePointerEvent(e);
-
-		private void ScrollViewer_PointerReleased(object sender, Input.PointerRoutedEventArgs e)
-			=> HandlePointerEvent(e);
+		private static void HandlePointerEvent(object sender, Input.PointerRoutedEventArgs e)
+			=> ((ScrollContentPresenter)sender).HandlePointerEvent(e);
 
 		private void HandlePointerEvent(Input.PointerRoutedEventArgs e)
 		{
 			var (clientSize, offsetSize) = WindowManagerInterop.GetClientViewSize(HtmlId);
 
-			bool hasHorizontalScroll = (offsetSize.Height - clientSize.Height) > 0;
-			bool hasVerticalScroll = (offsetSize.Width - clientSize.Width) > 0;
+			var hasHorizontalScroll = (offsetSize.Height - clientSize.Height) > 0;
+			var hasVerticalScroll = (offsetSize.Width - clientSize.Width) > 0;
 
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{
@@ -131,6 +112,7 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 		}
+
 		private static readonly string[] HorizontalVisibilityClasses = { "scroll-x-auto", "scroll-x-disabled", "scroll-x-hidden", "scroll-x-visible" };
 
 		ScrollBarVisibility IScrollContentPresenter.HorizontalScrollBarVisibility { get => HorizontalScrollBarVisibility; set => HorizontalScrollBarVisibility = value; }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -37,6 +37,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public ScrollContentPresenter()
 		{
+			RegisterAsScrollPort(this);
 		}
 
 		private void TryRegisterEvents(ScrollBarVisibility visibility)
@@ -143,6 +144,10 @@ namespace Windows.UI.Xaml.Controls
 			set { }
 		}
 
+		public double HorizontalOffset { get; private set; }
+
+		public double VerticalOffset { get; private set; }
+
 		Size? IScrollContentPresenter.CustomContentExtent => null;
 
 		private protected override void OnLoaded()
@@ -248,11 +253,16 @@ namespace Windows.UI.Xaml.Controls
 			// (the SV updates mode is always sync when isIntermediate is false).
 			var isIntermediate = false;
 
-			(TemplatedParent as ScrollViewer)?.OnScrollInternal(
-				GetNativeHorizontalOffset(),
-				GetNativeVerticalOffset(),
-				isIntermediate
-			);
+			var horizontalOffset = GetNativeHorizontalOffset();
+			var verticalOffset = GetNativeVerticalOffset();
+
+			HorizontalOffset = horizontalOffset;
+			VerticalOffset = verticalOffset;
+
+			(TemplatedParent as ScrollViewer)?.OnScrollInternal(horizontalOffset, verticalOffset, isIntermediate);
+
+			ScrollOffsets = new Point(horizontalOffset, verticalOffset);
+			InvalidateViewport();
 		}
 
 		private double GetNativeHorizontalOffset()

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.MuxInternal.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.MuxInternal.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Windows.Foundation;
 using Windows.UI.Xaml.Automation.Peers;
 using DirectUI;
 using Uno.Disposables;
@@ -17,9 +18,29 @@ namespace Windows.UI.Xaml.Controls
 
 		internal bool m_templatedParentHandlesMouseButton;
 
+		// Indicates whether ScrollViewer should ignore mouse wheel scroll events (not zoom).
+		internal bool ArePointerWheelEventsIgnored { get; set; } = false;
+		internal bool IsInManipulation => IsInDirectManipulation || m_isInConstantVelocityPan;
+
+		/// <summary>
+		/// Gets or set whether the <see cref="ScrollViewer"/> will allow scrolling outside of the ScrollViewer's Child bound.
+		/// </summary>		
+		internal bool ForceChangeToCurrentView { get; set; } = false;
 		internal bool IsInDirectManipulation { get; }
 		internal bool TemplatedParentHandlesScrolling { get; set; }
 		internal Func<AutomationPeer>? AutomationPeerFactoryIndex { get; set; }
+
+		internal bool BringIntoViewport(Rect bounds,
+			bool skipDuringTouchContact,
+			bool skipAnimationWhileRunning,
+			bool animate)
+		{
+#if __WASM__
+			return ChangeView(bounds.X, bounds.Y, null, true);
+#else
+			return ChangeView(bounds.X, bounds.Y, null, !animate);
+#endif
+		}
 
 		internal void SetDirectManipulationStateChangeHandler(IDirectManipulationStateChangeHandler? handler)
 		{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.ViewportInfo.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.ViewportInfo.cs
@@ -1,0 +1,103 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using Windows.Foundation;
+using Uno.Extensions;
+
+namespace Windows.UI.Xaml
+{
+	// Internal interface used to allow communication between the real FrameworkElement
+	// and presenters that are only implementing the IFrameworkElement interface (cf. FrameworkElementMixins.tt).
+	// It must not be used anywhere else out of the file.
+	internal interface IFrameworkElement_EffectiveViewport
+	{
+		void InitializeEffectiveViewport();
+		IDisposable RequestViewportUpdates(IFrameworkElement_EffectiveViewport? child = null);
+		void OnParentViewportChanged(IFrameworkElement_EffectiveViewport parent, ViewportInfo viewport, bool isInitial = false);
+		void OnLayoutUpdated();
+	}
+
+	internal struct ViewportInfo : IEquatable<ViewportInfo>
+	{
+		public static ViewportInfo Empty { get; } = new ViewportInfo { Effective = Rect.Empty, Clip = Rect.Empty };
+
+		/// <summary>
+		/// The element used as reference coordinate space to express the values.
+		/// </summary>
+		public IFrameworkElement_EffectiveViewport? Reference;
+
+		/// <summary>
+		/// The public effective viewport
+		/// </summary>
+		public Rect Effective;
+
+		/// <summary>
+		/// The cumulative clipping applied by all parents scroll ports.
+		/// </summary>
+		public Rect Clip;
+
+		public ViewportInfo(IFrameworkElement_EffectiveViewport reference, Rect viewport)
+		{
+			Reference = reference;
+			Effective = Clip = viewport;
+		}
+
+		public ViewportInfo(IFrameworkElement_EffectiveViewport reference, Rect effective, Rect clip)
+		{
+			Reference = reference;
+			Effective = effective;
+			Clip = clip;
+		}
+
+		public ViewportInfo GetRelativeTo(IFrameworkElement_EffectiveViewport element)
+		{
+			Rect effective = Effective, clip = Clip;
+			if (element is UIElement uiElement && Reference is UIElement usuallyTheParentOfElement)
+			{
+				var parentToElement = UIElement.GetTransform(uiElement, usuallyTheParentOfElement).Inverse();
+
+				if (Effective.IsValid)
+				{
+					effective = parentToElement.Transform(Effective);
+				}
+
+				if (Clip.IsValid)
+				{
+					clip = parentToElement.Transform(Clip);
+				}
+			}
+
+			// If the Reference or the element is not a UIElement (native), we don't have any RenderTransform,
+			// and we assume that the 'element' is stretched in it's parent usually true except for ListView,
+			// but we won't even try to support that case.
+
+			return new ViewportInfo(element, effective, clip);
+		}
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"{Effective.ToDebugString()} (clip: {Clip.ToDebugString()})";
+
+		/// <inheritdoc />
+		public override int GetHashCode()
+			=> Effective.GetHashCode();
+
+		/// <inheritdoc />
+		public bool Equals(ViewportInfo other)
+			=> Equals(this, other);
+
+		/// <inheritdoc />
+		public override bool Equals(object obj)
+			=> obj is ViewportInfo vp && Equals(this, vp);
+
+		private static bool Equals(ViewportInfo left, ViewportInfo right)
+			=> left.Effective.Equals(right.Effective);
+
+		public static bool operator ==(ViewportInfo left, ViewportInfo right)
+			=> Equals(left, right);
+
+		public static bool operator !=(ViewportInfo left, ViewportInfo right)
+			=> !Equals(left, right);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
@@ -1,15 +1,17 @@
-﻿//#define TRACE_EFFECTIVE_VIEWPORT
+﻿#nullable enable
+
+#define TRACE_EFFECTIVE_VIEWPORT
 
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using Windows.Foundation;
 using Windows.UI.Xaml.Controls.Primitives;
 using Uno;
 using Uno.Disposables;
-using Uno.Extensions;
 using Uno.UI;
 using Uno.UI.Extensions;
 using _This = Windows.UI.Xaml.FrameworkElement;
@@ -21,29 +23,14 @@ using AppKit;
 
 namespace Windows.UI.Xaml
 {
-#if !TEMPLATED
-	// Internal interface used to allow communication between the real FrameworkElement
-	// and presenters that are only implementing the IFrameworkElement interface (cf. FrameworkElementMixins.tt).
-	// It must not be used anywhere else out of the file.
-	internal interface IFrameworkElement_EffectiveViewport
-	{
-		void InitializeEffectiveViewport();
-		IDisposable RequestViewportUpdates(IFrameworkElement_EffectiveViewport child = null);
-		void OnParentViewportChanged(IFrameworkElement_EffectiveViewport parent, Rect viewport, bool isInitial = false);
-		void OnLayoutUpdated();
-	}
-#endif
-
 	partial class FrameworkElement : IFrameworkElement_EffectiveViewport
 	{
-		private static RoutedEventHandler ReconfigureViewportPropagationOnLoad = (snd, e) => ((_This)snd).ReconfigureViewportPropagation();
-		private event TypedEventHandler<_This, EffectiveViewportChangedEventArgs> _effectiveViewportChanged;
+		private static readonly RoutedEventHandler ReconfigureViewportPropagationOnLoad = (snd, e) => ((_This)snd).ReconfigureViewportPropagation();
+		private event TypedEventHandler<_This, EffectiveViewportChangedEventArgs>? _effectiveViewportChanged;
 		private int _childrenInterestedInViewportUpdates;
-		private IDisposable _parentViewportUpdatesSubscription;
-		private Rect _parentViewport = Rect.Empty; // WARNING: Stored in parent's coordinates on iOS, use GetParentViewport()
-		private Rect _localViewport = Rect.Empty; // i.e. the applied clipping, Empty if not clipped
-		private Rect _lastEffectiveSlot = new Rect();
-		private Rect _lastEffectiveViewport = new Rect();
+		private IDisposable? _parentViewportUpdatesSubscription;
+		private ViewportInfo _parentViewport = ViewportInfo.Empty; // WARNING: Stored in parent's coordinates on iOS, use GetParentViewport()
+		private ViewportInfo _lastEffectiveViewport = new ViewportInfo();
 
 		public event TypedEventHandler<_This, EffectiveViewportChangedEventArgs> EffectiveViewportChanged
 		{
@@ -74,7 +61,7 @@ namespace Windows.UI.Xaml
 		/// <summary>
 		/// Make sure to request or disable effective viewport changes from the parent
 		/// </summary>
-		private void ReconfigureViewportPropagation(IFrameworkElement_EffectiveViewport child = null)
+		private void ReconfigureViewportPropagation(IFrameworkElement_EffectiveViewport? child = null)
 		{
 			if (IsLoaded && IsEffectiveViewportEnabled)
 			{
@@ -89,23 +76,25 @@ namespace Windows.UI.Xaml
 					}
 					else
 					{
-						// We are the root of the visual tree (maybe just temporarily),
-						// we update the effective viewport in order to initialize the _parentViewport of children.
+						global::System.Diagnostics.Debug.Assert(IsVisualTreeRoot);
+
+						// We are the root of the visual tree, we update the effective viewport
+						// in order to initialize the _parentViewport of children.
 						PropagateEffectiveViewportChange(isInitial: true);
 					}
 				}
-				else
+				else if (child != null)
 				{
 					TRACE_EFFECTIVE_VIEWPORT("New child requested viewport propagation which has already been enabled, forwarding current viewport to it.");
 
 					// We are already subscribed, the parent won't send any update (and our _parentViewport is expected to be up-to-date).
 					// But if this "reconfigure" was made for a new child (child != null), we have to initialize its own _parentViewport.
 
-					var slot = LayoutInformation.GetLayoutSlot(this); // a.k.a. the implicit viewport to use if none was defined by any parent (usually only few elements at the top of the tree)
+					//var slot = LayoutInformation.GetLayoutSlot(this); // a.k.a. the implicit viewport to use if none was defined by any parent (usually only few elements at the top of the tree)
 					var parentViewport = GetParentViewport();
-					var viewport = GetEffectiveViewport(parentViewport, slot);
+					var viewport = GetEffectiveViewport(parentViewport);
 
-					child?.OnParentViewportChanged(this, viewport, isInitial: true);
+					child.OnParentViewportChanged(this, viewport, isInitial: true);
 				}
 			}
 			else
@@ -117,7 +106,7 @@ namespace Windows.UI.Xaml
 					_parentViewportUpdatesSubscription.Dispose();
 					_parentViewportUpdatesSubscription = null;
 
-					_parentViewport = Rect.Empty;
+					_parentViewport = ViewportInfo.Empty;
 				}
 			}
 		}
@@ -126,7 +115,7 @@ namespace Windows.UI.Xaml
 		/// Used by a child of this element, in order to subscribe to viewport updates
 		/// (so the OnParentViewportChanged will be invoked on this given child)
 		/// </summary>
-		IDisposable IFrameworkElement_EffectiveViewport.RequestViewportUpdates(IFrameworkElement_EffectiveViewport child)
+		IDisposable IFrameworkElement_EffectiveViewport.RequestViewportUpdates(IFrameworkElement_EffectiveViewport? child)
 		{
 			global::System.Diagnostics.Debug.Assert(Uno.UI.Extensions.DependencyObjectExtensions.GetChildren(this).OfType<IFrameworkElement_EffectiveViewport>().Contains(child));
 
@@ -145,7 +134,7 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		void IFrameworkElement_EffectiveViewport.OnParentViewportChanged(
 			IFrameworkElement_EffectiveViewport parent, // We propagate the parent to avoid costly lookup
-			Rect viewport, // Be aware tht it might be empty ([+∞,+∞,-∞,-∞]) if not clipped
+			ViewportInfo viewport, // Be aware tht it might be empty ([+∞,+∞,-∞,-∞]) if not clipped
 			bool isInitial) // Indicates that this update is only intended to initiate the _parentViewport
 		{
 			if (!IsEffectiveViewportEnabled)
@@ -156,7 +145,8 @@ namespace Windows.UI.Xaml
 			}
 
 #if !__IOS__ // cf. GetParentViewport
-			viewport = ParentToLocalCoordinates(parent, viewport);
+			//viewport = ParentToLocalCoordinates(parent, viewport);
+			viewport = viewport.GetRelativeTo(this);
 #endif
 
 			if (!isInitial && viewport == _parentViewport)
@@ -169,6 +159,10 @@ namespace Windows.UI.Xaml
 		}
 
 #if IS_NATIVE_ELEMENT
+		private bool IsScrollPort { get; } = false;
+		private bool IsVisualTreeRoot { get; } = false;
+		private Windows.Foundation.Point ScrollOffsets { get; } = default;
+
 		// Native elements cannot be clipped (using Uno), so the _localViewport will always be an empty rect, and we only react to LayoutSlot updates
 		void IFrameworkElement_EffectiveViewport.OnLayoutUpdated()
 			=> PropagateEffectiveViewportChange();
@@ -177,82 +171,71 @@ namespace Windows.UI.Xaml
 
 		private protected sealed override void OnViewportUpdated(Rect viewport) // a.k.a. OnLayoutUpdated / OnClippingApplied
 		{
-			// Always keep it up-to-date, so if effective viewport is enable later, we will have a valid value.
-			_localViewport = viewport;
+			// The 'viewport' (a.k.a. the clipping) is actually not used to compute the EffectiveViewport ...
+			// except for element flagged as ScrollHost!
+			// For now we are using the LayoutSlot + ScrollOffsets (which is internal only!), but we should use that 'viewport'.
 
-			// Even if the viewport didn't changed, the LayoutSlot might have changed!
-			PropagateEffectiveViewportChange();
+			if (IsScrollPort || IsVisualTreeRoot)
+			{
+				PropagateEffectiveViewportChange();
+			}
 		}
 #endif
 
-		private Rect GetEffectiveViewport(Rect parentViewport, Rect slot)
+		private ViewportInfo GetEffectiveViewport(ViewportInfo parentViewport)
 		{
-			Rect viewport;
-			if (_localViewport.IsEmpty)
-			{
-				// The local element does not clips its children (the common case),
-				// so we only propagate the parent viewport (adjusted in the local coordinate space)
-				viewport = parentViewport;
-			}
-			else
-			{
-				// The local element is clipping its children, so it defines the "effective" viewport for it and its children.
-				// We however still have to consider the offsets applied by the parent (i.e. _parentViewport X and Y)
-				// and constraint the viewport to the parent's viewport size (i.e. _parentViewport Width and Height).
-				// Note: At this point as the _parentViewport is defined in local coordinate space,
-				//		 _parentViewport.X and Y are usually negative.
-				//		 If there isn't any parent that clipped us, then it will be empty [+∞,+∞,-∞,-∞],
-				//		 in that case make sure to ignore it (we assume that it's possible to be clipped only on one direction).
+			global::System.Diagnostics.Debug.Assert(parentViewport.Reference == this || parentViewport.Reference == null);
 
-				double x, y, width, height;
-				var parentWidth = parentViewport.Width.FiniteOrDefault(slot.Width);
-				if (_localViewport.Width < parentWidth)
+			if (IsVisualTreeRoot)
+			{
+				var slot = LayoutInformation.GetLayoutSlot(this);
+
+				return new ViewportInfo(this, slot, Rect.Infinite);
+			}
+
+			if (IsScrollPort)
+			{
+				var viewport = parentViewport.Clip;
+
+				// Pseudo intersect:
+				// A normal intersect would return `Empty` as soon as the `viewport` and the `scrollport` does not overlap,
+				// but on UWP the viewport is `Empty` only if the `viewport` is below the `scrollport` (for vertical scroll).
+				// It means for an item in a list which is not yet visible on load (while vertical offset is 0), its EffVP will be empty.
+				// Then when you scroll, its effVP will be something like [slot.Width,10 @ slot.X,slot.Y] when its first top 10px becomes visible.
+				// Then if you continue to scroll and the item goes above the 'scrollport', its effVP will be [slot.Width,slot.Height @ slot.X,slot.Y]
+				// while a normal intersect would be `Empty` (which is logic as the item is no longer visible at all,
+				// but it make sense to not request to not go back to empty so element won't unload its content when scrolling up)!
+				// However, nested scroll host has to do a real intersect.
+
+				if (viewport.Right <= 0
+					|| viewport.Bottom <= 0)
 				{
-					// The local element is clipping vertically
-					x = _localViewport.X;
-					width = _localViewport.Width;
+					return new ViewportInfo(this, Rect.Empty);
+				}
+
+				// TODO: We should constrains the clip only on axis on which we can scroll
+
+				// The visible window of the SCP
+				var scrollport = new Rect(
+					new Point(ScrollOffsets.X, ScrollOffsets.Y),
+					LayoutInformation.GetLayoutSlot(this).Size);
+
+				if (viewport.IsInfinite)
+				{
+					viewport = scrollport;
 				}
 				else
 				{
-					x = _localViewport.X + parentViewport.X.FiniteOrDefault(0);
-					width = Math.Min(_localViewport.Width, parentWidth);
+					viewport.Intersect(scrollport);
 				}
 
-				var parentHeight = parentViewport.Height.FiniteOrDefault(slot.Height);
-				if (_localViewport.Height < parentHeight)
-				{
-					// The local element is clipping vertically
-					y = _localViewport.Y;
-					height = _localViewport.Height;
-				}
-				else
-				{
-					y = _localViewport.Y + parentViewport.Y.FiniteOrDefault(0);
-					height = Math.Min(_localViewport.Height, parentHeight);
-				}
-
-				viewport = new Rect(x, y, width, height);
-
-#if !IS_NATIVE_ELEMENT && UNO_HAS_MANAGED_SCROLL_PRESENTER
-				// !IS_NATIVE_ELEMENT: Only true-UIElement can register as scroller
-				// UNO_HAS_MANAGED_SCROLL_PRESENTER: On iOS and Android, it's the ScrollViewer which is flagged as the "scroller",
-				//									 doing it here would add scroll offsets twice (parentviewport already constains them)
-
-				// This element is also acting as scroller, so we also have to apply the local scroll offsets.
-				// Note: Those offsets should probably be part of the _localViewport (Frame vs. Bounds),
-				//		 but for now we supports only the internal controls that are able to set the internal ScrollOffsets property.
-				if (IsScrollPort)
-				{
-					viewport.X += ScrollOffsets.X;
-					viewport.Y += ScrollOffsets.Y;
-				}
-#endif
+				return new ViewportInfo(this, viewport);
 			}
 
-			return viewport;
+			return parentViewport;
 		}
 
-		private Rect GetParentViewport()
+		private ViewportInfo GetParentViewport()
 #if __IOS__
 			// On iOS the Arrange is "async": When arranged an element only arranges its direct children (set their Frame)
 			// which then waits for their 'LayoutSubView' to arrange their own children.
@@ -265,24 +248,15 @@ namespace Windows.UI.Xaml
 			// we won't have a valid LayoutSlot (and LayoutSlotWithMarginsAndAlignment used in GetTransform).
 			//
 			// To avoid this we store the parentViewport in parent coordinates on iOS, and reconvert it every time.
-			=> ParentToLocalCoordinates(this.GetParent(), _parentViewport);
+			=> _parentViewport.GetRelativeTo(this);
 #else
 			=> _parentViewport;
-#endif
-
-		private Rect ParentToLocalCoordinates(object parent, Rect viewport)
-#if IS_NATIVE_ELEMENT // No RenderTransform on native elements
-			=> viewport;
-#else
-			=> !viewport.IsEmpty && parent is UIElement parentElt
-				? GetTransform(this, parentElt).Inverse().Transform(viewport)
-				: viewport;
 #endif
 
 		private void PropagateEffectiveViewportChange(
 			bool isInitial = false
 #if TRACE_EFFECTIVE_VIEWPORT
-			, [CallerMemberName] string caller = null) {
+			, [CallerMemberName] string? caller = null) {
 #else
 			)
 		{
@@ -294,34 +268,25 @@ namespace Windows.UI.Xaml
 				return;
 			}
 
-			var slot = LayoutInformation.GetLayoutSlot(this); // a.k.a. the implicit viewport to use if none was defined by any parent (usually only few elements at the top of the tree)
 			var parentViewport = GetParentViewport();
-			var viewport = GetEffectiveViewport(parentViewport, slot);
-
+			var viewport = GetEffectiveViewport(parentViewport);
 			var isViewportUpdate = _lastEffectiveViewport != viewport;
-			var isSlotUpdate = _lastEffectiveSlot != slot;
 
-			TRACE_EFFECTIVE_VIEWPORT($"viewport: {viewport.ToDebugString()} (updated: {isViewportUpdate}) "
-				+ $"| slot: {slot.ToDebugString()} (updated: {isSlotUpdate}) "
+			_lastEffectiveViewport = viewport;
+
+			TRACE_EFFECTIVE_VIEWPORT($"viewport: {viewport} (updated: {isViewportUpdate}) "
+				+ $"| slot: {LayoutInformation.GetLayoutSlot(this).ToDebugString()} "
 				+ $"| isInitial: {isInitial} "
-				+ $"| local: {_localViewport.ToDebugString()} "
-				+ $"| parent: {parentViewport.ToDebugString()} "
-#if IS_NATIVE_ELEMENT
-				+ $"| scroll: --none--(native) "
-#else
+				+ $"| parent: {parentViewport} "
 				+ $"| scroll: {(IsScrollPort ? $"{ScrollOffsets.ToDebugString()}" : "--none--")} "
-#endif
 				+ $"| reason: {caller} "
 				+ $"| children: {_childrenInterestedInViewportUpdates}");
 
-			_lastEffectiveViewport = viewport;
-			_lastEffectiveSlot = slot;
-
-			if (!isInitial && (isViewportUpdate || isSlotUpdate))
+			if (!isInitial && isViewportUpdate)
 			{
 				// Note: Here the viewport might have some infinite values (notably if we don't have any parent that clipped us).
 				//		 In that case we fallback to the LayoutSlot as we should not raise the event with infinite values.
-				_effectiveViewportChanged?.Invoke(this, new EffectiveViewportChangedEventArgs(viewport.FiniteOrDefault(slot)));
+				_effectiveViewportChanged?.Invoke(this, new EffectiveViewportChangedEventArgs(parentViewport.Effective));
 			}
 
 			if (_childrenInterestedInViewportUpdates > 0
@@ -353,11 +318,11 @@ namespace Windows.UI.Xaml
 		}
 #endif
 
-		[Conditional("TRACE_EFFECTIVE_VIEWPORT")]
+		//[Conditional("TRACE_EFFECTIVE_VIEWPORT")]
 		private void TRACE_EFFECTIVE_VIEWPORT(string text)
 		{
 #if TRACE_EFFECTIVE_VIEWPORT
-			Debug.Write($"{this.GetDebugIdentifier()} {text}\r\n");
+			Console.WriteLine($"{this.GetDebugIdentifier()} {text}");
 #endif
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
@@ -233,7 +233,11 @@ namespace Windows.UI.Xaml
 
 				viewport = new Rect(x, y, width, height);
 
-#if !IS_NATIVE_ELEMENT // Only true-UIElement can register as scroller.
+#if !IS_NATIVE_ELEMENT && UNO_HAS_MANAGED_SCROLL_PRESENTER
+				// !IS_NATIVE_ELEMENT: Only true-UIElement can register as scroller
+				// UNO_HAS_MANAGED_SCROLL_PRESENTER: On iOS and Android, it's the ScrollViewer which is flagged as the "scroller",
+				//									 doing it here would add scroll offsets twice (parentviewport already constains them)
+
 				// This element is also acting as scroller, so we also have to apply the local scroll offsets.
 				// Note: Those offsets should probably be part of the _localViewport (Frame vs. Bounds),
 				//		 but for now we supports only the internal controls that are able to set the internal ScrollOffsets property.
@@ -250,7 +254,7 @@ namespace Windows.UI.Xaml
 
 		private Rect GetParentViewport()
 #if __IOS__
-			// On iOS the Arrange is "async": When arranged an element only arrange its direct children (set their Frame)
+			// On iOS the Arrange is "async": When arranged an element only arranges its direct children (set their Frame)
 			// which then waits for their 'LayoutSubView' to arrange their own children.
 			//
 			// The issue is that after having arrange its children, the element will also apply its clipping,

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.netstd.cs
@@ -256,10 +256,7 @@ namespace Windows.UI.Xaml
 				var layoutFrame = new Rect(offset, clippedInkSize);
 
 				// Calculate clipped frame.
-				var clippedFrameWithParentOrigin =
-					layoutFrame
-						.IntersectWith(finalRect.DeflateBy(margin))
-					?? Rect.Empty;
+				var clippedFrameWithParentOrigin = layoutFrame.IntersectWith(finalRect.DeflateBy(margin)) ?? Rect.Empty;
 
 				// Rebase the origin of the clipped frame to layout
 				var clippedFrame = new Rect(

--- a/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
@@ -387,7 +387,7 @@ namespace Windows.UI.Xaml.Media
 				renderingBounds = parentToElement.Transform(renderingBounds);
 			}
 
-#if !UNO_HAS_MANAGED_SCROLL_PRESENTER
+#if !UNO_HAS_MANAGED_SCROLL_PRESENTER && !__WASM__
 			// On Skia, the Scrolling is managed by the ScrollContentPresenter (as UWP), which is flagged as IsScrollPort.
 			// Note: We should still add support for the zoom factor ... which is not yet supported on Skia.
 			if (element is ScrollViewer sv)
@@ -408,7 +408,7 @@ namespace Windows.UI.Xaml.Media
 			else
 #endif
 #if !__MACOS__ // On macOS the SCP is using RenderTransforms for scrolling which has already been included.
-			if (element.IsScrollPort)
+			if (element.IsScrollPort) // Managed SCP or custom scroller
 			{
 				posRelToElement.X += element.ScrollOffsets.X;
 				posRelToElement.Y += element.ScrollOffsets.Y;

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -343,7 +343,7 @@ namespace Windows.UI.Xaml
 					offsetY = layoutSlot.Y;
 				}
 
-#if !UNO_HAS_MANAGED_SCROLL_PRESENTER
+#if !UNO_HAS_MANAGED_SCROLL_PRESENTER && !__WASM__
 				// On Skia, the Scrolling is managed by the ScrollContentPresenter (as UWP), which is flagged as IsScrollPort.
 				// Note: We should still add support for the zoom factor ... which is not yet supported on Skia.
 				if (elt is ScrollViewer sv)
@@ -366,7 +366,7 @@ namespace Windows.UI.Xaml
 				else
 #endif
 #if !__MACOS__ // On macOS the SCP is using RenderTransforms for scrolling which has already been included.
-				if (elt.IsScrollPort) // Custom scroller
+				if (elt.IsScrollPort) // Managed SCP or custom scroller
 				{
 					offsetX -= elt.ScrollOffsets.X;
 					offsetY -= elt.ScrollOffsets.Y;


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/6763

## Bugfix
The `EffectiveViewport` was not computed the same way as UWP

## What is the current behavior?
We are considering clipping on all elements while UWP consider clipping only of _scroll host_

## What is the new behavior?
Almost the same behavior as UWP

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
**Tests pending**