### PR TITLE
chore: Bump WinUI to 2.6.2 in template

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/UWP/UnoQuickStart.Uwp.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/UWP/UnoQuickStart.Uwp.csproj
@@ -10,7 +10,7 @@
 			-->
 			<Version>6.2.11</Version>
 		</PackageReference>
-		<PackageReference Include="Microsoft.UI.Xaml" Version="2.5.0" />
+		<PackageReference Include="Microsoft.UI.Xaml" Version="2.6.2" />
 		<PackageReference Include="Uno.Core" Version="2.4.0" />
 		<PackageReference Include="Uno.UI" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/src/SolutionTemplate/UnoSolutionTemplate/UWP/UnoQuickStart.Uwp.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UWP/UnoQuickStart.Uwp.csproj
@@ -10,7 +10,7 @@
 			-->
 			<Version>6.2.11</Version>
 		</PackageReference>
-		<PackageReference Include="Microsoft.UI.Xaml" Version="2.5.0" />
+		<PackageReference Include="Microsoft.UI.Xaml" Version="2.6.2" />
 		<PackageReference Include="Uno.Core" Version="2.4.0" />
 		<PackageReference Include="Uno.UI" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />


### PR DESCRIPTION
GitHub Issue (If applicable): N/A

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Other... template update

## What is the current behavior?

Uses WinUI 2.5


## What is the new behavior?

Use WinUI 2.6 to match design.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
