### PR TITLE
test: Enable TimePicker tests

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
@@ -12,7 +12,6 @@ using Uno.UITest.Helpers.Queries;
 namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 {
 	[TestFixture]
-	[Ignore("One of this test is preventing CI to pass https://github.com/unoplatform/uno/issues/6668")]
 	public partial class TimePickerTests_Tests : SampleControlUITestBase
 	{
 		[Test]
@@ -189,7 +188,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 			TakeScreenshot("TimePicker - Flyout", ignoreInSnapshotCompare: true);
 
 			// Dismiss the flyout
-			_app.TapCoordinates(10, 10);
+			_app.TapCoordinates(30, 30);
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TimePickerTests/UnoSamples_Tests.TimePicker.cs
@@ -122,9 +122,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 			{
 				Assert.AreEqual("12:00:00", theTimePicker.GetDependencyPropertyValue("Time")?.ToString());
 			}
-
-			// Dismiss the flyout
-			_app.TapCoordinates(10, 10);
 		}
 
 		[Test]
@@ -140,14 +137,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 			var timePickerFlyout = theTimePicker.Child;
 
 			// Open flyout
-			theTimePicker.FastTap();
+			_app.FastTap("HourTextBlock");
 
 			//Assert
 			Assert.IsNotNull(theTimePicker.GetDependencyPropertyValue("DataContext"));
 			Assert.IsNotNull(timePickerFlyout.GetDependencyPropertyValue("DataContext"));
 
 			// Dismiss the flyout
-			_app.TapCoordinates(10, 10);
+			_app.TapCoordinates(30, 30);
 		}
 
 		[Test]
@@ -178,7 +175,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TimePickerTests
 		public void TimePicker_Flyout()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TimePicker.TimePicker_Flyout_Automated", skipInitialScreenshot: true);
-
 			var picker = _app.Marked("TestTimePicker");
 
 			_app.WaitForElement(picker);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6668, closes #7030

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Test

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

~~There is really weird behavior with some of these tests. Let's see if this change will do it for now, and I'll open a new issue shortly.~~

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
