### PR TITLE
Reverted to "v1" template for ProgressBar because the "fluent v2" is causing animation problems.

### DIFF
--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/ProgressBar.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/ProgressBar.xaml
@@ -19,7 +19,7 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <contract7Present:Setter Property="CornerRadius" Value="{StaticResource ProgressBarCornerRadius}" />
         <Setter Property="Template">
-            <Setter.Value>
+            <!--<Setter.Value>
                 <ControlTemplate TargetType="local:ProgressBar">
 
                     <Grid x:Name="LayoutRoot">
@@ -272,6 +272,233 @@
                                         contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}"
                                         contract7NotPresent:RadiusX="{Binding Source={StaticResource ProgressBarCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
                                         contract7NotPresent:RadiusY="{Binding Source={StaticResource ProgressBarCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}">
+                                        <Rectangle.RenderTransform>
+                                            <CompositeTransform/>
+                                        </Rectangle.RenderTransform>
+                                    </Rectangle>
+                                </Grid>
+                            </Border>
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>-->
+            <Setter.Value>
+                <!-- This is a copy of "v1" template, a workaround as described here: https://github.com/unoplatform/uno/issues/7050#issuecomment-918467992 -->
+                <ControlTemplate TargetType="local:ProgressBar">
+
+                    <Grid x:Name="LayoutRoot">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+
+                                <VisualStateGroup.Transitions>
+                                    <VisualTransition From="Updating" To="Determinate">
+                                        <Storyboard>
+                                            <RepositionThemeAnimation TargetName="DeterminateProgressBarIndicator" FromHorizontalOffset="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.IndicatorLengthDelta}" />
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Paused" To="Determinate">
+                                        <Storyboard>
+                                            <DoubleAnimation
+                                                Storyboard.TargetName="DeterminateProgressBarIndicator"
+                                                Storyboard.TargetProperty="Opacity"
+                                                To="1"
+                                                Duration="0:0:0.25" />
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Error" To="Determinate">
+                                        <Storyboard>
+                                            <ColorAnimation
+                                                Storyboard.TargetName="DeterminateProgressBarIndicator"
+                                                Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)"
+                                                To="{TemplateBinding Foreground}"
+                                                Duration="0:0:0.25"/>
+                                            <ColorAnimation
+                                                Storyboard.TargetName="ProgressBarRoot"
+                                                Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
+                                                To="{TemplateBinding Background}"
+                                                Duration="0:0:0.25"/>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                    <VisualTransition From="Indeterminate" To="Determinate">
+                                        <Storyboard>
+                                            <Storyboard>
+                                                <FadeInThemeAnimation TargetName="IndeterminateProgressBarIndicator" />
+                                                <FadeInThemeAnimation TargetName="IndeterminateProgressBarIndicator2" />
+                                            </Storyboard>
+                                        </Storyboard>
+                                    </VisualTransition>
+                                </VisualStateGroup.Transitions>
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Determinate" />
+                                <VisualState x:Name="Updating" />
+                                <VisualState x:Name="Indeterminate">
+                                    <Storyboard RepeatBehavior="Forever">
+                                        <DoubleAnimationUsingKeyFrames
+                                            Storyboard.TargetName="IndeterminateProgressBarIndicator"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
+                                            <SplineDoubleKeyFrame KeyTime="0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationStartPosition}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                            <SplineDoubleKeyFrame KeyTime="0:0:1.5" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationEndPosition}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                            <SplineDoubleKeyFrame KeyTime="0:0:2" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationEndPosition}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames
+                                            Storyboard.TargetName="IndeterminateProgressBarIndicator2"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
+                                            <SplineDoubleKeyFrame KeyTime="0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationStartPosition2}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                            <SplineDoubleKeyFrame KeyTime="0:0:0.75" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationStartPosition2}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                            <SplineDoubleKeyFrame KeyTime="0:0:2" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationEndPosition2}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimation Storyboard.TargetName="IndeterminateProgressBarIndicator"
+                                            Storyboard.TargetProperty="Opacity"
+                                            To="1"
+                                            Duration="0" />
+                                        <DoubleAnimation Storyboard.TargetName="IndeterminateProgressBarIndicator2"
+                                            Storyboard.TargetProperty="Opacity"
+                                            To="1"
+                                            Duration="0" />
+                                        <FadeOutThemeAnimation TargetName="DeterminateProgressBarIndicator" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="IndeterminateError">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames
+                                            Storyboard.TargetName="IndeterminateProgressBarIndicator"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
+                                            <SplineDoubleKeyFrame KeyTime="0:0:1" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationEndPosition}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity" Storyboard.TargetName="IndeterminateProgressBarIndicator">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
+                                            <DiscreteDoubleKeyFrame KeyTime="0:0:1" Value="0" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames
+                                            Storyboard.TargetName="IndeterminateProgressBarIndicator2"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
+                                            <SplineDoubleKeyFrame KeyTime="0:0:1" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationEndPosition2}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                            <SplineDoubleKeyFrame KeyTime="0:0:1.5" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationStartPosition2}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                            <SplineDoubleKeyFrame KeyTime="0:0:2.5" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationMidPosition}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity" Storyboard.TargetName="IndeterminateProgressBarIndicator2">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
+                                            <DiscreteDoubleKeyFrame KeyTime="0:0:1" Value="0" />
+                                            <DiscreteDoubleKeyFrame KeyTime="0:0:1.51" Value="1" />
+                                            <DiscreteDoubleKeyFrame KeyTime="0:0:2.5" Value="1" />
+                                            <DiscreteDoubleKeyFrame KeyTime="0:0:3" Value="1" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <ColorAnimationUsingKeyFrames
+                                            Storyboard.TargetName="IndeterminateProgressBarIndicator2"
+                                            Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)">
+                                            <LinearColorKeyFrame Value="{ThemeResource SystemAccentColor}" KeyTime="0:0:2.75" />
+                                            <LinearColorKeyFrame Value="{ThemeResource SystemErrorTextColor}" KeyTime="0:0:3" />
+                                        </ColorAnimationUsingKeyFrames>
+                                        <ColorAnimationUsingKeyFrames
+                                            Storyboard.TargetName="ProgressBarRoot"
+                                            Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)">
+                                            <LinearColorKeyFrame Value="{ThemeResource SystemBaseLowColor}" KeyTime="0:0:2.75" />
+                                            <LinearColorKeyFrame Value="{StaticResource SystemControlErrorBackgroundColor}" KeyTime="0:0:3" />
+                                        </ColorAnimationUsingKeyFrames>
+                                        <FadeOutThemeAnimation TargetName="DeterminateProgressBarIndicator" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Error">
+                                    <Storyboard>
+                                        <ColorAnimation
+                                            Storyboard.TargetName="DeterminateProgressBarIndicator"
+                                            Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)"
+                                            To="{ThemeResource SystemErrorTextColor}"
+                                            Duration="0:0:0.25"/>
+                                        <ColorAnimation
+                                            Storyboard.TargetName="ProgressBarRoot"
+                                            Storyboard.TargetProperty="(Border.Background).(SolidColorBrush.Color)"
+                                            To="{StaticResource SystemControlErrorBackgroundColor}"
+                                            Duration="0:0:0.25"/>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="IndeterminatePaused">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames
+                                            Storyboard.TargetName="IndeterminateProgressBarIndicator"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
+                                            <SplineDoubleKeyFrame KeyTime="0:0:1" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationEndPosition}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity" Storyboard.TargetName="IndeterminateProgressBarIndicator">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
+                                            <DiscreteDoubleKeyFrame KeyTime="0:0:1" Value="0" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames
+                                            Storyboard.TargetName="IndeterminateProgressBarIndicator2"
+                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.TranslateX)">
+                                            <SplineDoubleKeyFrame KeyTime="0:0:1" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationEndPosition2}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                            <SplineDoubleKeyFrame KeyTime="0:0:1.5" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationStartPosition2}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                            <SplineDoubleKeyFrame KeyTime="0:0:2.5" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ContainerAnimationMidPosition}" KeySpline="0.4, 0.0, 0.6, 1.0" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity" Storyboard.TargetName="IndeterminateProgressBarIndicator2">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="1" />
+                                            <DiscreteDoubleKeyFrame KeyTime="0:0:1" Value="0" />
+                                            <DiscreteDoubleKeyFrame KeyTime="0:0:1.51" Value="1" />
+                                            <DiscreteDoubleKeyFrame KeyTime="0:0:2.5" Value="1" />
+                                            <DiscreteDoubleKeyFrame KeyTime="0:0:2.51" Value="{ThemeResource ProgressBarIndicatorPauseOpacity}" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <ColorAnimationUsingKeyFrames
+                                            Storyboard.TargetName="IndeterminateProgressBarIndicator2"
+                                            Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)">
+                                            <LinearColorKeyFrame Value="{ThemeResource SystemAccentColor}" KeyTime="0:0:2.5" />
+                                            <LinearColorKeyFrame Value="{ThemeResource SystemBaseMediumLowColor}" KeyTime="0:0:2.75" />
+                                        </ColorAnimationUsingKeyFrames>
+                                        <FadeOutThemeAnimation TargetName="DeterminateProgressBarIndicator" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Paused">
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames
+                                            Storyboard.TargetName="DeterminateProgressBarIndicator"
+                                            Storyboard.TargetProperty="Fill" >
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemBaseMediumLowColor}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <DoubleAnimation
+                                            Storyboard.TargetName="DeterminateProgressBarIndicator"
+                                            Storyboard.TargetProperty="Opacity"
+                                            To="{ThemeResource ProgressBarIndicatorPauseOpacity}"
+                                            Duration="0:0:0.25" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Border x:Name="ProgressBarRoot"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}">
+
+                            <Border Clip="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ClipRect}">
+                                <Grid>
+                                    <Rectangle x:Name="DeterminateProgressBarIndicator"
+                                        Margin="{TemplateBinding Padding}"
+                                        Fill="{TemplateBinding Foreground}"         
+                                        HorizontalAlignment="Left"
+                                        RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
+                                        RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}">
+                                    </Rectangle>
+
+                                    <Rectangle x:Name="IndeterminateProgressBarIndicator"
+                                        Margin="{TemplateBinding Padding}"
+                                        Fill="{TemplateBinding Foreground}"         
+                                        HorizontalAlignment="Left"
+                                        Opacity="0"
+                                        RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
+                                        RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}">
+                                        <Rectangle.RenderTransform>
+                                            <CompositeTransform/>
+                                        </Rectangle.RenderTransform>
+                                    </Rectangle>
+
+                                    <Rectangle x:Name="IndeterminateProgressBarIndicator2"
+                                        Margin="{TemplateBinding Padding}"
+                                        Fill="{TemplateBinding Foreground}"         
+                                        HorizontalAlignment="Left"
+                                        Opacity="0"
+                                        RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}"
+                                        RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}">
                                         <Rectangle.RenderTransform>
                                             <CompositeTransform/>
                                         </Rectangle.RenderTransform>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/7050

# Patch a workaround
The template for `<ProgressBar />` on FluentV2 were displaying weird animation when put on indeterminated mode.

It has been reverted to _fluent v1_ until the [animation system](https://github.com/unoplatform/uno/issues/3919) has been refactored.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
