### PR TITLE
fix: Handle types correctly in ResourceDictionary

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
@@ -47,6 +47,35 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		public void When_Simple_Add_And_Retrieve_Type_Key()
+		{
+			var rd = new ResourceDictionary();
+
+			// NOTE: Intentionally using a type outside of Uno.UI to prevent regressions if someone thought to use Type.GetType.
+			// See: https://stackoverflow.com/a/1825156/5108631
+			// Type.GetType(...) only works when the type is found in either mscorlib.dll or the currently executing assembly.
+			rd[typeof(Given_ResourceDictionary)] = nameof(When_Simple_Add_And_Retrieve_Type_Key);
+
+			var retrieved = rd[typeof(Given_ResourceDictionary)];
+
+			Assert.IsTrue(rd.ContainsKey(typeof(Given_ResourceDictionary)));
+			Assert.IsFalse(rd.ContainsKey("Uno.UI.Tests.Windows_UI_Xaml.Given_ResourceDictionary"));
+
+			Assert.AreEqual(nameof(When_Simple_Add_And_Retrieve_Type_Key), retrieved);
+
+			rd.TryGetValue(typeof(Given_ResourceDictionary), out var retrieved2);
+			Assert.AreEqual(nameof(When_Simple_Add_And_Retrieve_Type_Key), retrieved2);
+
+			var key = rd.Keys.Single();
+			Assert.AreEqual(typeof(Given_ResourceDictionary), key);
+
+			foreach (var kvp in rd)
+			{
+				Assert.AreEqual(typeof(Given_ResourceDictionary), kvp.Key);
+			}
+		}
+
+		[TestMethod]
 		public void When_Key_Not_Present()
 		{
 			var rd = new ResourceDictionary();

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -390,7 +390,7 @@ namespace Windows.UI.Xaml
 			=> _values.Keys.Select(k => ConvertKey(k)).ToList();
 
 		private static object ConvertKey(ResourceKey resourceKey)
-			=> resourceKey.IsType ? resourceKey.TypeKey : (object)resourceKey.Key;
+			=> resourceKey.TypeKey ?? (object)resourceKey.Key;
 
 		// TODO: this doesn't handle lazy initializers or aliases
 		public global::System.Collections.Generic.ICollection<object> Values => _values.Values;

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -387,10 +387,10 @@ namespace Windows.UI.Xaml
 		}
 
 		public global::System.Collections.Generic.ICollection<object> Keys
-			=> _values.Keys.Select(k => ConvertKey(k.Key)).ToList();
+			=> _values.Keys.Select(k => ConvertKey(k)).ToList();
 
 		private static object ConvertKey(ResourceKey resourceKey)
-			=> resourceKey.IsType ? Type.GetType(resourceKey.Key) : (object)resourceKey.Key;
+			=> resourceKey.IsType ? resourceKey.TypeKey : (object)resourceKey.Key;
 
 		// TODO: this doesn't handle lazy initializers or aliases
 		public global::System.Collections.Generic.ICollection<object> Values => _values.Values;
@@ -442,11 +442,11 @@ namespace Windows.UI.Xaml
 				var aliased = kvp.Value;
 				if (TryResolveAlias(ref aliased))
 				{
-					yield return new KeyValuePair<object, object>(ConvertKey(kvp.Key.Key), aliased);
+					yield return new KeyValuePair<object, object>(ConvertKey(kvp.Key), aliased);
 				}
 				else
 				{
-					yield return new KeyValuePair<object, object>(ConvertKey(kvp.Key.Key), kvp.Value);
+					yield return new KeyValuePair<object, object>(ConvertKey(kvp.Key), kvp.Value);
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/SpecializedResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/SpecializedResourceDictionary.cs
@@ -31,6 +31,7 @@ namespace Windows.UI.Xaml
 		public readonly struct ResourceKey
 		{
 			public readonly string Key;
+			public readonly Type TypeKey;
 			public readonly bool IsType;
 			public readonly uint HashCode;
 
@@ -41,6 +42,7 @@ namespace Windows.UI.Xaml
 			private ResourceKey(bool dummy)
 			{
 				Key = null;
+				TypeKey = null;
 				IsType = false;
 				HashCode = 0;
 			}
@@ -54,12 +56,14 @@ namespace Windows.UI.Xaml
 				if (key is string s)
 				{
 					Key = s;
+					TypeKey = null;
 					IsType = false;
 					HashCode = (uint)(s.GetHashCode() ^ IsType.GetHashCode());
 				}
 				else if (key is Type t)
 				{
 					Key = t.ToString();
+					TypeKey = t;
 					IsType = true;
 					HashCode = (uint)(t.GetHashCode() ^ IsType.GetHashCode());
 				}
@@ -72,6 +76,7 @@ namespace Windows.UI.Xaml
 				else
 				{
 					Key = key.ToString();
+					TypeKey = null;
 					IsType = false;
 					HashCode = (uint)(key.GetHashCode() ^ IsType.GetHashCode());
 				}
@@ -84,6 +89,7 @@ namespace Windows.UI.Xaml
 			public ResourceKey(string key)
 			{
 				Key = key;
+				TypeKey = null;
 				IsType = false;
 				HashCode = (uint)(key.GetHashCode() ^ IsType.GetHashCode());
 			}
@@ -95,6 +101,7 @@ namespace Windows.UI.Xaml
 			public ResourceKey(Type key)
 			{
 				Key = key.ToString();
+				TypeKey = key;
 				IsType = true;
 				HashCode = (uint)(key.GetHashCode() ^ IsType.GetHashCode());
 			}

--- a/src/Uno.UI/UI/Xaml/SpecializedResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/SpecializedResourceDictionary.cs
@@ -32,7 +32,6 @@ namespace Windows.UI.Xaml
 		{
 			public readonly string Key;
 			public readonly Type TypeKey;
-			public readonly bool IsType;
 			public readonly uint HashCode;
 
 			public static ResourceKey Empty { get; } = new ResourceKey(false);
@@ -43,7 +42,6 @@ namespace Windows.UI.Xaml
 			{
 				Key = null;
 				TypeKey = null;
-				IsType = false;
 				HashCode = 0;
 			}
 
@@ -57,15 +55,13 @@ namespace Windows.UI.Xaml
 				{
 					Key = s;
 					TypeKey = null;
-					IsType = false;
-					HashCode = (uint)(s.GetHashCode() ^ IsType.GetHashCode());
+					HashCode = (uint)(s.GetHashCode() ^ TypeKey?.GetHashCode() ?? 0);
 				}
 				else if (key is Type t)
 				{
 					Key = t.ToString();
 					TypeKey = t;
-					IsType = true;
-					HashCode = (uint)(t.GetHashCode() ^ IsType.GetHashCode());
+					HashCode = (uint)(t.GetHashCode() ^ TypeKey?.GetHashCode() ?? 0);
 				}
 				else if (key is ResourceKey)
 				{
@@ -77,8 +73,7 @@ namespace Windows.UI.Xaml
 				{
 					Key = key.ToString();
 					TypeKey = null;
-					IsType = false;
-					HashCode = (uint)(key.GetHashCode() ^ IsType.GetHashCode());
+					HashCode = (uint)(key.GetHashCode() ^ TypeKey?.GetHashCode() ?? 0);
 				}
 			}
 
@@ -90,8 +85,7 @@ namespace Windows.UI.Xaml
 			{
 				Key = key;
 				TypeKey = null;
-				IsType = false;
-				HashCode = (uint)(key.GetHashCode() ^ IsType.GetHashCode());
+				HashCode = (uint)(key.GetHashCode() ^ TypeKey?.GetHashCode() ?? 0);
 			}
 
 			/// <summary>
@@ -102,15 +96,14 @@ namespace Windows.UI.Xaml
 			{
 				Key = key.ToString();
 				TypeKey = key;
-				IsType = true;
-				HashCode = (uint)(key.GetHashCode() ^ IsType.GetHashCode());
+				HashCode = (uint)(key.GetHashCode() ^ TypeKey?.GetHashCode() ?? 0);
 			}
 
 			/// <summary>
 			/// Compares this instance with another ResourceKey instance
 			/// </summary>
 			public bool Equals(ResourceKey other)
-				=> IsType == other.IsType && Key == other.Key;
+				=> TypeKey == other.TypeKey && Key == other.Key;
 
 
 			public static implicit operator ResourceKey(string key)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7044

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Adding a resource with a System.Type key then retrieving it will result in a string being produced.

## What is the new behavior?

Correctly retrieve it as System.Type.

There was two issues here:

1. `ConvertKey(k.Key)`, this was resulting in an implicit conversion from string to `ResourceKey`, resulting in losing the information of the original `ResourceKey`.
2. Usage of `Type.GetType`, which only works in the current assembly or mscorlib (or System.Private.CoreLib).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information


Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
