### PR TITLE
feat(perf): Improve perf of the ObjectAnimationUsingKeyFrame

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3954,6 +3954,17 @@
 				reason="Method not in UWP contract" />
 		</Properties>
 	</IgnoreSet>
+	
+	<IgnoreSet>
+		<Methods>
+			<Member
+				fullName="System.Object Windows.UI.Xaml.Media.Animation.ObjectKeyFrame.get_Value()"
+				reason="False positive, still present, but accessible also through an internal interface" />
+			<Member
+				fullName="Windows.UI.Xaml.Media.Animation.KeyTime Windows.UI.Xaml.Media.Animation.ObjectKeyFrame.get_KeyTime()"
+				reason="False positive, still present, but accessible also through an internal interface" />
+		</Methods>
+	</IgnoreSet>
 	<!--
 	Supported nodes (please keep at the bottom of this file):
 		<Types>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3955,7 +3955,7 @@
 		</Properties>
 	</IgnoreSet>
 	
-	<IgnoreSet>
+	<IgnoreSet baseVersion="3.10.7">
 		<Methods>
 			<Member
 				fullName="System.Object Windows.UI.Xaml.Media.Animation.ObjectKeyFrame.get_Value()"

--- a/src/Uno.UI/UI/Xaml/Media/Animation/IKeyFrame.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/IKeyFrame.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Linq;
+
+namespace Windows.UI.Xaml.Media.Animation
+{
+	internal interface IKeyFrame
+	{
+		public KeyTime KeyTime { get; }
+	}
+
+	internal interface IKeyFrame<out TValue> : IKeyFrame
+	{
+		public TValue Value { get; }
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameComparer.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameComparer.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Windows.UI.Xaml.Media.Animation
+{
+	internal class KeyFrameComparer : IComparer<IKeyFrame>
+	{
+		public static KeyFrameComparer Instance { get; } = new KeyFrameComparer();
+
+		private KeyFrameComparer()
+		{
+		}
+
+		/// <inheritdoc />
+		public int Compare(IKeyFrame x, IKeyFrame y)
+			=> ((IComparable<KeyTime>)x.KeyTime).CompareTo(y.KeyTime);
+	}
+
+	internal class KeyFrameComparer<TValue> : IComparer<IKeyFrame<TValue>>
+	{
+		public static KeyFrameComparer<TValue> Instance { get; } = new KeyFrameComparer<TValue>();
+
+		private KeyFrameComparer()
+		{
+		}
+
+		/// <inheritdoc />
+		public int Compare(IKeyFrame<TValue> x, IKeyFrame<TValue> y)
+			=> ((IComparable<KeyTime>)x.KeyTime).CompareTo(y.KeyTime);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameComparer.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameComparer.cs
@@ -15,8 +15,23 @@ namespace Windows.UI.Xaml.Media.Animation
 		}
 
 		/// <inheritdoc />
-		public int Compare(IKeyFrame x, IKeyFrame y)
-			=> ((IComparable<KeyTime>)x.KeyTime).CompareTo(y.KeyTime);
+		public int Compare(IKeyFrame? x, IKeyFrame? y)
+			=> CompareCore(x, y);
+
+		public static int CompareCore(IKeyFrame? x, IKeyFrame? y)
+		{
+			// We consider 'null' as always lower than other items
+			if (x is null)
+			{
+				return y is null ? 0 : int.MinValue;
+			}
+			else if (y is null)
+			{
+				return int.MaxValue;
+			}
+
+			return ((IComparable<KeyTime>)x.KeyTime).CompareTo(y.KeyTime);
+		}
 	}
 
 	internal class KeyFrameComparer<TValue> : IComparer<IKeyFrame<TValue>>
@@ -28,7 +43,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		}
 
 		/// <inheritdoc />
-		public int Compare(IKeyFrame<TValue> x, IKeyFrame<TValue> y)
-			=> ((IComparable<KeyTime>)x.KeyTime).CompareTo(y.KeyTime);
+		public int Compare(IKeyFrame<TValue>? x, IKeyFrame<TValue>? y)
+			=> KeyFrameComparer.CompareCore(x, y);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameScheduler.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameScheduler.cs
@@ -1,0 +1,259 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Windows.System;
+using Uno.Disposables;
+using Uno.Extensions;
+
+namespace Windows.UI.Xaml.Media.Animation
+{
+	internal class KeyFrameScheduler<TValue> : IDisposable
+	{
+		public delegate IDisposable? OnFrame(TValue current, IKeyFrame<TValue> frame, TimeSpan duration);
+
+		private readonly Stopwatch _watch = new Stopwatch();
+		private readonly OnFrame _onFrame;
+		private readonly Action<EndReason> _onCompleted;
+		private readonly TimeSpan? _beginTime;
+		private readonly TimeSpan? _duration;
+		private readonly List<IKeyFrame<TValue>> _frames;
+
+		private DispatcherQueueTimer? _timer;
+		private int _frameId = 0;
+		private SerialDisposable? _frameSubscription; // Lazy init only if needed (not used for the common discrete key frames)
+		private TimeSpan _seekOffset;
+
+		private int _state = States.NotRunning;
+
+		private static class States
+		{
+			public const int NotRunning = 0;
+			public const int Running = 1;
+			public const int Paused = 2;
+			public const int Ended = int.MaxValue; // a.k.a. Stoped / Disposed : This Scheduler can run frames only once!
+		}
+
+		public enum EndReason
+		{
+			/// <summary>
+			/// Reached the last frame and wait for the configured duration
+			/// </summary>
+			EndOfFrames,
+
+			/// <summary>
+			/// Stopped by the user
+			/// </summary>
+			Stopped,
+
+			/// <summary>
+			/// Aborted
+			/// </summary>
+			Disposed
+		}
+
+		public KeyFrameScheduler(
+			TimeSpan? beginTime,
+			TimeSpan? duration,
+			TValue initialValue,
+			IEnumerable<IKeyFrame<TValue>>? frames,
+			OnFrame onFrame,
+			Action<EndReason> onCompleted)
+		{
+			CurrentValue = initialValue;
+
+			frames ??= Enumerable.Empty<IKeyFrame<TValue>>();
+			frames = frames.Trim();
+			frames = duration.HasValue
+				? frames.Where(k => k != null && k.KeyTime.TimeSpan <= duration.Value)
+				: frames.Trim();
+
+			_frames = frames.ToList();
+			_frames.Sort(KeyFrameComparer<TValue>.Instance);
+
+			_beginTime = beginTime;
+			_duration = duration;
+			_onFrame = onFrame;
+			_onCompleted = onCompleted;
+		}
+
+		public TValue CurrentValue { get; private set; }
+
+		public TimeSpan Elapsed => _seekOffset + _watch.Elapsed;
+
+		public void Start()
+		{
+			if (Interlocked.CompareExchange(ref _state, States.Running, States.NotRunning) == States.NotRunning)
+			{
+				_watch.Restart();
+
+				var nextFrame = GetNextFrameDueIn();
+				if (nextFrame > TimeSpan.Zero)
+				{
+					ScheduleNextFrame(nextFrame);
+				}
+				else
+				{
+					RunNextFrame();
+				}
+			}
+		}
+
+		public void Pause()
+		{
+			if (Interlocked.CompareExchange(ref _state, States.Paused, States.Running) == States.Running)
+			{
+				_watch.Stop();
+				_timer?.Stop();
+			}
+		}
+
+		public void Resume()
+		{
+			if (Interlocked.CompareExchange(ref _state, States.Running, States.Paused) == States.Paused)
+			{
+				_watch.Start();
+
+				var nextFrame = GetNextFrameDueIn();
+				if (nextFrame > TimeSpan.Zero)
+				{
+					ScheduleNextFrame(nextFrame);
+				}
+				else
+				{
+					RunNextFrame();
+				}
+			}
+		}
+
+		public void Stop()
+		{
+			Complete(EndReason.Stopped);
+		}
+
+		public void Seek(TimeSpan offset)
+		{
+			if (_state == States.Ended)
+			{
+				return;
+			}
+
+			_seekOffset += offset;
+
+			// Search for the first last frame before the updated Elapsed
+			_frameId = 0;
+			for (var i = 0; i < _frames.Count; i++)
+			{
+				if (_frames[i].KeyTime.TimeSpan > Elapsed)
+				{
+					break;
+				}
+				_frameId = i;
+			}
+
+			// And request to apply it right now if running
+			if (_state == States.Running)
+			{
+				RunNextFrame();
+			}
+		}
+
+		private void ScheduleNextFrame(TimeSpan delay)
+		{
+			if (_timer is null)
+			{
+				_timer = _timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+				_timer.State = this;
+				_timer.Tick += RunNextFrame;
+			}
+
+			_timer.Interval = delay;
+			_timer.Start();
+		}
+
+		private static void RunNextFrame(DispatcherQueueTimer timer, object state)
+			=> ((KeyFrameScheduler<TValue>)state).RunNextFrame();
+
+		private void RunNextFrame()
+		{
+			_timer?.Stop();
+
+			if (_state != States.Running)
+			{
+				return;
+			}
+
+			if (++_frameId >= _frames.Count)
+			{
+				Complete(EndReason.EndOfFrames);
+				return;
+			}
+
+			var frame = _frames[_frameId]!; // ! We trim the collection in ctor
+			var duration = GetNextFrameDueIn(); // The duration of the current before moving to next frame
+
+			var oldValue = CurrentValue;
+			CurrentValue = frame.Value;
+
+			var frameSubscription = _onFrame(oldValue, frame, duration);
+			if (frameSubscription != null)
+			{
+				(_frameSubscription ??= new SerialDisposable()).Disposable = frameSubscription;
+			}
+
+			if (duration > TimeSpan.Zero)
+			{
+				ScheduleNextFrame(duration);
+			}
+			else
+			{
+				RunNextFrame();
+			}
+		}
+
+		/// <summary>
+		/// Gets the delay to wait before moving to the next frame
+		/// </summary>
+		private TimeSpan GetNextFrameDueIn()
+		{
+			var nextFrameId = _frameId + 1;
+			var nextFrameDueTime = nextFrameId < _frames.Count
+				? _frames[nextFrameId].KeyTime.TimeSpan
+				: _duration ?? TimeSpan.Zero;
+
+			if (_beginTime.HasValue)
+			{
+				nextFrameDueTime += _beginTime.Value;
+			}
+
+			return nextFrameDueTime - Elapsed;
+		}
+
+		private void Complete(EndReason reason)
+		{
+			if (_timer is { } timer)
+			{
+				timer.Stop(); // Safety only, should already have been stopped!
+				timer.State = null;
+				timer.Tick -= RunNextFrame;
+
+				_timer = null;
+			}
+
+			_watch.Stop();
+			_frameSubscription?.Dispose();
+
+			if (Interlocked.Exchange(ref _state, States.Ended) != States.Ended)
+			{
+				_onCompleted(reason);
+			}
+		}
+
+		/// <inheritdoc />
+		public void Dispose()
+			=> Complete(EndReason.Disposed);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameScheduler.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameScheduler.cs
@@ -66,7 +66,6 @@ namespace Windows.UI.Xaml.Media.Animation
 			CurrentValue = initialValue;
 
 			frames ??= Enumerable.Empty<IKeyFrame<TValue>>();
-			frames = frames.Trim();
 			frames = duration.HasValue
 				? frames.Where(k => k != null && k.KeyTime.TimeSpan <= duration.Value)
 				: frames.Trim();

--- a/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameScheduler.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameScheduler.cs
@@ -164,7 +164,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		{
 			if (_timer is null)
 			{
-				_timer = _timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+				_timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
 				_timer.State = this;
 				_timer.Tick += RunNextFrame;
 			}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameScheduler.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/KeyFrameScheduler.cs
@@ -23,7 +23,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		private readonly List<IKeyFrame<TValue>> _frames;
 
 		private DispatcherQueueTimer? _timer;
-		private int _frameId = 0;
+		private int _frameId = -1;
 		private SerialDisposable? _frameSubscription; // Lazy init only if needed (not used for the common discrete key frames)
 		private TimeSpan _seekOffset;
 
@@ -175,7 +175,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		}
 
 		private static void RunNextFrame(DispatcherQueueTimer timer, object state)
-			=> ((KeyFrameScheduler<TValue>)state).RunNextFrame();
+			=> ((KeyFrameScheduler<TValue>)timer.State).RunNextFrame();
 
 		private void RunNextFrame()
 		{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/KeyTime.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/KeyTime.cs
@@ -11,67 +11,52 @@ namespace Windows.UI.Xaml.Media.Animation
 		public TimeSpan TimeSpan { get; private set; }
 
 		public static KeyTime FromTimeSpan(TimeSpan timeSpan)
-		{
-			return new KeyTime() { TimeSpan = timeSpan };
-		}
+			=> new KeyTime() { TimeSpan = timeSpan };
 
 		public static implicit operator KeyTime(string timeSpan)
 			=> FromTimeSpan(TimeSpan.Parse(timeSpan));
 
-		public static bool operator ==(KeyTime t1, KeyTime t2)
-		{
-			return Equals(t1, t2);
-		}
-
-		public static bool operator !=(KeyTime t1, KeyTime t2)
-		{
-			return !Equals(t1, t2);
-		}
-
 		public static implicit operator KeyTime(TimeSpan timeSpan)
-		{
-			return FromTimeSpan(timeSpan);
-		}
+			=> FromTimeSpan(timeSpan);
 
-		#region Equality overrides
-
+		#region Equality
 		public override int GetHashCode()
-		{
-			return this.TimeSpan.GetHashCode();
-		}
+			=> TimeSpan.GetHashCode();
 
 		public override bool Equals(object obj)
-		{
-			if (obj is KeyTime)
-			{
-				return this.Equals((KeyTime)obj);
-			}
-
-			return false;
-		}
+			=> obj is KeyTime other && Equals(this, other);
 
 		public bool Equals(KeyTime other)
-		{
-			return KeyTime.Equals(this, other);
-		}
+			=> Equals(this, other);
 
 		public static bool Equals(KeyTime first, KeyTime second)
-		{
-			return first.TimeSpan.Equals(second.TimeSpan);
-		}
+			=> first.TimeSpan.Equals(second.TimeSpan);
 
+		public static bool operator ==(KeyTime t1, KeyTime t2)
+			=> Equals(t1, t2);
+
+		public static bool operator !=(KeyTime t1, KeyTime t2)
+			=> !Equals(t1, t2);
+		#endregion
+
+		#region Comparision
+		int IComparable<KeyTime>.CompareTo(KeyTime other)
+			=> TimeSpan.CompareTo(other.TimeSpan);
+
+		public static bool operator <(KeyTime keytime1, KeyTime keytime2)
+			=> keytime1.TimeSpan < keytime2.TimeSpan;
+
+		public static bool operator >(KeyTime keytime1, KeyTime keytime2)
+			=> keytime1.TimeSpan > keytime2.TimeSpan;
+
+		public static bool operator <=(KeyTime keytime1, KeyTime keytime2)
+			=> keytime1.TimeSpan <= keytime2.TimeSpan;
+
+		public static bool operator >=(KeyTime keytime1, KeyTime keytime2)
+			=> keytime1.TimeSpan >= keytime2.TimeSpan;
 		#endregion
 
 		public override string ToString()
-		{
-			return this.TimeSpan.ToXamlString(CultureInfo.InvariantCulture);
-		}
-
-		int IComparable<KeyTime>.CompareTo(KeyTime other) => TimeSpan.CompareTo(other.TimeSpan);
-
-		public static bool operator <(KeyTime keytime1, KeyTime keytime2) => keytime1.TimeSpan < keytime2.TimeSpan;
-		public static bool operator >(KeyTime keytime1, KeyTime keytime2) => keytime1.TimeSpan > keytime2.TimeSpan;
-		public static bool operator <=(KeyTime keytime1, KeyTime keytime2) => keytime1.TimeSpan <= keytime2.TimeSpan;
-		public static bool operator >=(KeyTime keytime1, KeyTime keytime2) => keytime1.TimeSpan >= keytime2.TimeSpan;
+			=> TimeSpan.ToXamlString(CultureInfo.InvariantCulture);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
@@ -12,8 +12,8 @@ using System.Threading.Tasks;
 
 namespace Windows.UI.Xaml.Media.Animation
 {
-    [ContentProperty(Name = "KeyFrames")]
-    public sealed partial class ObjectAnimationUsingKeyFrames : Timeline, ITimeline
+	[ContentProperty(Name = "KeyFrames")]
+	public sealed partial class ObjectAnimationUsingKeyFrames : Timeline, ITimeline
 	{
 		private readonly static IEventProvider _trace = Tracing.Get(TraceProvider.Id);
 		private EventActivity _traceActivity;
@@ -28,13 +28,8 @@ namespace Windows.UI.Xaml.Media.Animation
 			public const int Resume = 4;
 		}
 
-		// Initialize the field with zero capacity, as it may stay empty more often than it is being used.
-		private CompositeDisposable _scheduledFrames = new CompositeDisposable(0);
-        
-        private Stopwatch _watch = new Stopwatch();
-        private TimeSpan _elapsedTime;
-        
-        private int _replayCount;
+		private KeyFrameScheduler<object>? _frameScheduler;
+		private (int count, TimeSpan time) _playStatus;
 
 		public ObjectAnimationUsingKeyFrames()
 		{
@@ -55,9 +50,9 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// </remarks>
 		internal static DependencyProperty KeyFramesProperty { get; } =
 			DependencyProperty.Register(
-				name: "KeyFrames", 
-				propertyType: typeof(ObjectKeyFrameCollection), 
-				ownerType: typeof(ObjectAnimationUsingKeyFrames), 
+				name: "KeyFrames",
+				propertyType: typeof(ObjectKeyFrameCollection),
+				ownerType: typeof(ObjectAnimationUsingKeyFrames),
 				typeMetadata: new FrameworkPropertyMetadata(
 					defaultValue: null
 				)
@@ -95,13 +90,20 @@ namespace Windows.UI.Xaml.Media.Animation
 
 			Reset();
 
-			_watch.Start();
-            _replayCount = 1;
+			State = TimelineState.Active;
 
-            Play();
-        }
+			_playStatus = default;
+			_frameScheduler = new KeyFrameScheduler<object>(
+				BeginTime,
+				Duration.HasTimeSpan ? Duration.TimeSpan : default(TimeSpan?),
+				default,
+				KeyFrames,
+				OnFrame,
+				OnFramesEnd);
+			_frameScheduler.Start();
+		}
 
-        void ITimeline.Stop()
+		void ITimeline.Stop()
 		{
 			if (_trace.IsEnabled)
 			{
@@ -112,15 +114,19 @@ namespace Windows.UI.Xaml.Media.Animation
 				);
 			}
 
+			// We explicitly call the Stop of the _frameScheduler befire teh Reste dispose it,
+			// so the EndReason will stopped instead of Aborted
+			_frameScheduler?.Stop();
+
 			Reset();
 			ClearValue();
-        }
+		}
 
-        void ITimeline.Resume()
-        {
-            if (State != TimelineState.Paused)
-            {
-                return;
+		void ITimeline.Resume()
+		{
+			if (State != TimelineState.Paused)
+			{
+				return;
 			}
 
 			if (_trace.IsEnabled)
@@ -133,16 +139,15 @@ namespace Windows.UI.Xaml.Media.Animation
 			}
 
 			State = TimelineState.Active;
+			_frameScheduler!.Resume();
+		}
 
-            Play();
-        }
-
-        void ITimeline.Pause()
-        {
-            if (State == TimelineState.Paused)
-            {
-                return;
-            }
+		void ITimeline.Pause()
+		{
+			if (State != TimelineState.Active)
+			{
+				return;
+			}
 
 			if (_trace.IsEnabled)
 			{
@@ -153,44 +158,31 @@ namespace Windows.UI.Xaml.Media.Animation
 				);
 			}
 
-			State = TimelineState.Active;
-            _scheduledFrames.Clear();
+			State = TimelineState.Paused;
+			_frameScheduler!.Pause();
+		}
 
-            State = TimelineState.Paused;
+		void ITimeline.Seek(TimeSpan offset)
+		{
+			_frameScheduler?.Seek(offset);
+		}
 
-            _elapsedTime = _watch.Elapsed;
-			_watch.Stop();
-			_watch.Reset();
+		void ITimeline.SeekAlignedToLastTick(TimeSpan offset)
+		{
+			// Same as Seek
+			((ITimeline)this).Seek(offset);
+		}
 
-        }
-        void ITimeline.Seek(TimeSpan offset)
-        {
-            _elapsedTime = offset;
+		void ITimeline.SkipToFill()
+		{
+			// Set value to last keytime and set state to filling
+			_frameScheduler?.Dispose();
+			_frameScheduler = null;
 
-            if (State == TimelineState.Active)
-            {
-                var keyframe = KeyFrames.FirstOrDefault(f => f.KeyTime.TimeSpan >= offset);
-                this.SetValue(keyframe.Value);
-            }
-        }
+			var fillFrame = KeyFrames.OrderBy(k => k.KeyTime.TimeSpan).Last();
 
-        void ITimeline.SeekAlignedToLastTick(TimeSpan offset)
-        {
-            // Same as Seek
-            ((ITimeline)this).Seek(offset);
-        }
-
-        void ITimeline.SkipToFill()
-        {
-            // Set value to last keytime and set state to filling
-            _scheduledFrames.Clear();
-            _elapsedTime = KeyFrames.Max(k => k.KeyTime.TimeSpan);
-
-            var fillFrame = KeyFrames.First(k => k.KeyTime.TimeSpan == _elapsedTime);
-
-            SetValue(fillFrame.Value);
-            State = TimelineState.Stopped;
-
+			SetValue(fillFrame.Value);
+			State = TimelineState.Stopped;
 		}
 
 		void ITimeline.Deactivate()
@@ -202,152 +194,95 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// Brings the Timeline to its initial state
 		/// </summary>
 		private void Reset()
-        {
-            _scheduledFrames.Clear();
-            State = TimelineState.Stopped;
-            _elapsedTime = TimeSpan.Zero;
-			_watch.Stop();
-			_watch.Reset();
+		{
+			_frameScheduler?.Dispose();
+			_frameScheduler = null;
+
+			State = TimelineState.Stopped;
+		}
+
+		private IDisposable? OnFrame(object currentValue, IKeyFrame<object> frame, TimeSpan duration)
+		{
+			SetValue(frame.Value);
+			return null;
+		}
+
+		private void OnFramesEnd(KeyFrameScheduler<object>.EndReason endReason)
+		{
+			_playStatus = (_playStatus.count + 1, _playStatus.time + _frameScheduler!.Elapsed);
+
+			if (endReason != KeyFrameScheduler<object>.EndReason.EndOfFrames)
+			{
+				return;
+			}
+
+			if (RepeatBehavior.ShouldRepeat(_playStatus.time, _playStatus.count))
+			{
+				Replay();
+				return;
+			}
+
+			if (FillBehavior == FillBehavior.HoldEnd)//Two types of fill behaviors : HoldEnd - Keep displaying the last frame
+			{
+				Fill();
+			}
+			else// Stop - Put back the initial state
+			{
+				Reset();
+				ClearValue();
+			}
+
+			OnCompleted();
 		}
 
 		/// <summary>
-		/// Runs the Timeline, By Scheduling the KeyFrames
+		/// Fills the animation: the final frame is shown and left visible
 		/// </summary>
-		private void Play()
-        {
-            State = TimelineState.Active;
+		private void Fill()
+		{
+			var lastTime = KeyFrames.Max(k => k.KeyTime.TimeSpan);
+			var lastKeyFrame = KeyFrames.First(k => k.KeyTime.TimeSpan.Equals(lastTime));
 
-            var beginTime = BeginTime.GetValueOrDefault(TimeSpan.Zero);  //Delay before starting the animation
-            
-            var duration = TimeSpan.MaxValue;  //Duration, frames below this timespan ar not played    
-            if (Duration.HasTimeSpan)
-            {
-                duration = Duration.TimeSpan;
-            }
-            
-            var finalTime = KeyFrames
-                .Max(okf => okf.KeyTime.TimeSpan)
-                .Add(beginTime)
-                .Subtract(_elapsedTime);
-            //Final Time : the time of the last Keyframe
+			_frameScheduler?.Dispose();
+			_frameScheduler = null;
 
-            foreach (var keyFrame in this.KeyFrames.Where(k => k.KeyTime.TimeSpan <= duration))
-            {
-                var value = keyFrame.Value;
-                var dueTime = keyFrame.KeyTime.TimeSpan.Add(beginTime).Subtract(_elapsedTime);
+			State = TimelineState.Filling;
+			SetValue(lastKeyFrame.Value);
+		}
 
-				Action update = () =>
-				{
-					//When a frame is scheduled to run, the bool determines if it is the last frame
-					OnFrame(value, dueTime.Equals(finalTime));
-				};
+		/// <summary>
+		/// Replays the Timeline
+		/// </summary>
+		private void Replay()
+		{
+			_frameScheduler?.Dispose();
 
-				if (dueTime == TimeSpan.Zero)
-				{
-					update();
-				}
-				else
-				{
-					_scheduledFrames.Add(
-						CoreDispatcher.Main.RunAsync(
-							CoreDispatcherPriority.Normal,
-							async ct =>
-							{
-								await Task.Delay(dueTime, ct);
-								update();
-							}
-						)
-					);
-				}
-            }
-        }
-
-        /// <summary>
-        /// When a frame is scheduled to run
-        /// </summary>
-        /// <param name="value">The payload of the keyframe</param>
-        /// <param name="isLast">Is this the last frame?</param>
-        private void OnFrame(object value, bool isLast)
-        {
-            if (!isLast)
-            {
-                SetValue(value);
-                return;
-            }
-
-            if (NeedsRepeat())
-            {
-                Replay();
-                return;
-            }
-            
-            if (FillBehavior == FillBehavior.HoldEnd)//Two types of fill behaviors : HoldEnd - Keep displaying the last frame
-            {
-                Fill();
-            }
-            else// Stop - Put back the initial state
-            {
-                Reset();
-				ClearValue();
-            }
-
-            OnCompleted();
-        }
-
-        /// <summary>
-        /// Fills the animation: the final frame is shown and left visible
-        /// </summary>
-        private void Fill()
-        {
-            var lastTime = KeyFrames.Max(k => k.KeyTime.TimeSpan);
-            var lastKeyFrame = KeyFrames.First(k => k.KeyTime.TimeSpan.Equals(lastTime));
-
-            State = TimelineState.Filling;
-            _scheduledFrames.Clear();
-            _elapsedTime = _watch.Elapsed;
-            SetValue(lastKeyFrame.Value);
-        }
-
-        /// <summary>
-        /// Replays the Timeline
-        /// </summary>
-        private void Replay()
-        {
 			ClearValue();
-            _replayCount++;
-            _scheduledFrames.Clear();
-            _elapsedTime = TimeSpan.Zero;
-			_watch.Reset();
-			Play();
-        }
 
-        /// <summary>
-        /// Checks if the Timeline will repeat.
-        /// </summary>
-        /// <returns><c>true</c>, Repeat needed, <c>false</c> otherwise.</returns>
-        private bool NeedsRepeat()
-        {
-            var totalTime = _watch.Elapsed;
 
-            //3 types of repeat behavors,             
-            return (RepeatBehavior.Type == RepeatBehaviorType.Forever) // Forever: Will always repeat the TimeLine
-                || (RepeatBehavior.HasCount && RepeatBehavior.Count > _replayCount) // Count: Will repeat the TimeLine x times
-                || (RepeatBehavior.HasDuration && RepeatBehavior.Duration - totalTime > TimeSpan.Zero); // Duration: Will repeat the TimeLine for a given duration
-        }
+			_frameScheduler = new KeyFrameScheduler<object>(
+				BeginTime,
+				Duration.HasTimeSpan ? Duration.TimeSpan : default(TimeSpan?),
+				default,
+				KeyFrames,
+				OnFrame,
+				OnFramesEnd);
+			_frameScheduler.Start();
+		}
 
 		/// <summary>
 		/// Destroys the animation
 		/// </summary>
 		/// <param name="disposing"></param>
 		protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
+		{
+			base.Dispose(disposing);
 
-            if (_scheduledFrames != null)
-            {
-                _scheduledFrames.Dispose();
-                _scheduledFrames = null;
-            }
-        }
-    }
+			if (_frameScheduler != null)
+			{
+				_frameScheduler.Dispose();
+				_frameScheduler = null;
+			}
+		}
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
@@ -28,7 +28,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			public const int Resume = 4;
 		}
 
-		private KeyFrameScheduler<object>? _frameScheduler;
+		private KeyFrameScheduler<object> _frameScheduler;
 		private (int count, TimeSpan time) _playStatus;
 
 		public ObjectAnimationUsingKeyFrames()
@@ -201,7 +201,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			State = TimelineState.Stopped;
 		}
 
-		private IDisposable? OnFrame(object currentValue, IKeyFrame<object> frame, TimeSpan duration)
+		private IDisposable OnFrame(object currentValue, IKeyFrame<object> frame, TimeSpan duration)
 		{
 			SetValue(frame.Value);
 			return null;

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ObjectKeyFrame.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ObjectKeyFrame.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Windows.UI.Xaml.Media.Animation
 {
-	public partial class ObjectKeyFrame : DependencyObject
+	public partial class ObjectKeyFrame : DependencyObject, IKeyFrame<object>
 	{
 		public ObjectKeyFrame()
 		{
@@ -15,11 +15,10 @@ namespace Windows.UI.Xaml.Media.Animation
 		#region KeyTime Dependency Property
 		public KeyTime KeyTime
 		{
-			get { return (KeyTime)this.GetValue(KeyTimeProperty); }
-			set { this.SetValue(KeyTimeProperty, value); }
+			get => (KeyTime)this.GetValue(KeyTimeProperty);
+			set => this.SetValue(KeyTimeProperty, value);
 		}
-		
-		// Using a DependencyProperty as the backing store for KeyTime.  This enables animation, styling, binding, etc...
+
 		public static DependencyProperty KeyTimeProperty { get ; } =
 			DependencyProperty.Register("KeyTime", typeof(KeyTime), typeof(ObjectKeyFrame), new FrameworkPropertyMetadata(null));
 		#endregion
@@ -27,11 +26,10 @@ namespace Windows.UI.Xaml.Media.Animation
 		#region Value Dependency Property
 		public object Value
 		{
-			get { return (object)this.GetValue(ValueProperty); }
-			set { this.SetValue(ValueProperty, value); }
+			get => (object)this.GetValue(ValueProperty);
+			set => this.SetValue(ValueProperty, value);
 		}
 
-		// Using a DependencyProperty as the backing store for Value.  This enables animation, styling, binding, etc...
 		public static DependencyProperty ValueProperty { get ; } =
 			DependencyProperty.Register("Value", typeof(object), typeof(ObjectKeyFrame), new FrameworkPropertyMetadata(null));
 		#endregion

--- a/src/Uno.UI/UI/Xaml/Media/Animation/RepeatBehaviorType.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/RepeatBehaviorType.cs
@@ -4,10 +4,10 @@ using System.Text;
 
 namespace Windows.UI.Xaml.Media.Animation
 {
-    public enum RepeatBehaviorType
-    {
+	public enum RepeatBehaviorType
+	{
 		Count = 0,
 		Duration = 1,
 		Forever = 2
-    }
+	}
 }


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/7072

## Performance
Improve perf of the `ObjectAnimationUsingKeyFrame`

## What is the current behavior?
All frames of the `ObjectAnimationUsingKeyFrame` are scheduled on start, and cancelled if the animation is stop before the end

## What is the new behavior?
Frames are scheduled one by one

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
