### PR TITLE
fix: Text selection on WASM

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Constants.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Constants.cs
@@ -9,7 +9,7 @@ namespace SamplesApp.UITests
 {
 	public partial class Constants
 	{
-		public const string WebAssemblyDefaultUri = "https://localhost:44309/";
+		public const string WebAssemblyDefaultUri = "http://localhost:55838/";
 		public const string iOSAppName = "uno.platform.uitestsample";
 		public const string AndroidAppName = "uno.platform.unosampleapp";
 		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -507,5 +507,35 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 				ImageAssert.AreEqual(snapshotTextHidden, r, snapshot, r);
 			}
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]
+		public void When_Text_Selection_Is_Enabled()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_IsTextSelectionEnabled");
+
+			var nonSelectableTextBlock = _app.WaitForElement("NonSelectableUnderscoreTextBlock").Single().Rect;
+			var selectableTextBlock = _app.WaitForElement("SelectableUnderscoreTextBlock").Single().Rect;
+
+			// Attempt selection
+			_app.DoubleTapCoordinates(nonSelectableTextBlock.CenterX, nonSelectableTextBlock.CenterY);
+
+			using (var nonSelectableScreenshot = TakeScreenshot("NonSelectableTextBlock", ignoreInSnapshotCompare: true))
+			{
+				ImageAssert.HasColorAt(nonSelectableScreenshot, nonSelectableTextBlock.CenterX, nonSelectableTextBlock.CenterY, Color.White);
+			}
+
+			// Click to ensure any selection is removed
+			_app.TapCoordinates(nonSelectableTextBlock.CenterX, nonSelectableTextBlock.CenterY);
+
+			// Attempt selection
+			_app.DoubleTapCoordinates(selectableTextBlock.CenterX, selectableTextBlock.CenterY);
+
+			using (var selectableScreenshot = TakeScreenshot("SelectableTextBlock", ignoreInSnapshotCompare: true))
+			{
+				ImageAssert.DoesNotHaveColorAt(selectableScreenshot, selectableTextBlock.CenterX, selectableTextBlock.CenterY, Color.White);
+			}
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_IsTextSelectionEnabled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_IsTextSelectionEnabled.xaml
@@ -8,6 +8,12 @@
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<StackPanel Spacing="15" Margin="10">
+		<TextBlock FontSize="15">Following underscore TextBlock cannot be selected:</TextBlock>
+		<TextBlock x:Name="NonSelectableUnderscoreTextBlock" FontSize="22" Foreground="Chocolate" IsTextSelectionEnabled="false" HorizontalAlignment="Left">____________</TextBlock>
+
+		<TextBlock FontSize="15">Following underscore TextBlock can be selected:</TextBlock>
+		<TextBlock x:Name="SelectableUnderscoreTextBlock" FontSize="22" Foreground="Chocolate" IsTextSelectionEnabled="true" HorizontalAlignment="Left">____________</TextBlock>
+		
 		<TextBlock FontSize="15">Following TextBlock with IsTextSelectionEnabled=false:</TextBlock>
 		<TextBlock FontSize="22" Foreground="Chocolate" IsTextSelectionEnabled="false">Try to select this.</TextBlock>
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -946,7 +946,7 @@ namespace Windows.UI.Xaml.Controls
 		internal override bool IsFocusable =>
 			/*IsActive() &&*/ //TODO Uno: No concept of IsActive in Uno yet.
 			IsVisible() &&
-			IsEnabled() && (IsTextSelectionEnabled || IsTabStop) &&
+			/*IsEnabled() &&*/ (IsTextSelectionEnabled || IsTabStop) &&
 			AreAllAncestorsVisible();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -730,6 +730,12 @@ namespace Windows.UI.Xaml.Controls
 				e.Handled = true;
 				// hyperlink.CompleteGesture(); No needs to complete the gesture as the TextBlock won't even receive the Pressed.
 			}
+			else if (sender is TextBlock textBlock && textBlock.IsTextSelectionEnabled)
+			{
+				// Selectable TextBlock should also handle pointer pressed to ensure
+				// RootVisual does not steal its focus.
+				e.Handled = true;
+			}
 		};
 
 		internal static readonly PointerEventHandler OnPointerReleased = (object sender, PointerRoutedEventArgs e) =>
@@ -936,5 +942,11 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		internal override bool CanHaveChildren() => true;
+
+		internal override bool IsFocusable =>
+			/*IsActive() &&*/ //TODO Uno: No concept of IsActive in Uno yet.
+			IsVisible() &&
+			IsEnabled() && (IsTextSelectionEnabled || IsTabStop) &&
+			AreAllAncestorsVisible();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -44,8 +44,6 @@ namespace Windows.UI.Xaml.Input
 
 			foreach (var parent in element.GetParents())
 			{
-				_log.Value.LogDebug($"Checking {parent}. TextBlock.IsFocusable: {(parent as TextBlock)?.IsFocusable == true}");
-
 				// Try to find the first focusable parent and set it as focused, otherwise just keep it for reference (GetFocusedElement())
 				if (parent is TextBlock textBlock && textBlock.IsFocusable)
 				{

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -19,6 +19,8 @@ namespace Windows.UI.Xaml.Input
 		/// </summary>
 		private static bool _isCallingFocusNative;
 
+		private static bool _skipNativeFocus;
+
 		internal static void ProcessControlFocused(Control control)
 		{
 			if (_log.Value.IsEnabled(LogLevel.Debug))
@@ -40,9 +42,28 @@ namespace Windows.UI.Xaml.Input
 				_log.Value.LogDebug($"{nameof(ProcessElementFocused)}() focusedElement={GetFocusedElement()}, element={element}, searching for focusable parent control");
 			}
 
-			// Try to find the first focusable parent and set it as focused, otherwise just keep it for reference (GetFocusedElement())
-			var ownerControl = element.GetParents().OfType<Control>().Where(control => control.IsFocusable).FirstOrDefault();
-			ProcessControlFocused(ownerControl);
+			foreach (var parent in element.GetParents())
+			{
+				_log.Value.LogDebug($"Checking {parent}. TextBlock.IsFocusable: {(parent as TextBlock)?.IsFocusable == true}");
+
+				// Try to find the first focusable parent and set it as focused, otherwise just keep it for reference (GetFocusedElement())
+				if (parent is TextBlock textBlock && textBlock.IsFocusable)
+				{
+					// Focusable TextBlock parent, we can move focus to it.
+					var focusManager = VisualTree.GetFocusManagerForElement(textBlock);
+
+					// We cannot call native focus here, as it would fail and would then blur focus immediately.
+					_skipNativeFocus = true;
+					focusManager?.UpdateFocus(new FocusMovement(textBlock, FocusNavigationDirection.None, FocusState.Pointer));
+					_skipNativeFocus = false;
+					break;
+				}
+				else if (parent is Control control && control.IsFocusable)
+				{
+					ProcessControlFocused(control);
+					break;
+				}
+			}
 		}
 
 		internal static bool FocusNative(UIElement element)
@@ -50,6 +71,12 @@ namespace Windows.UI.Xaml.Input
 			if (_log.Value.IsEnabled(LogLevel.Debug))
 			{
 				_log.Value.LogDebug($"{nameof(FocusNative)}(element: {element})");
+			}
+
+			if (_skipNativeFocus)
+			{
+				_log.Value.LogDebug($"{nameof(FocusNative)} skipping native focus");
+				return false;
 			}
 
 			if (element == null)

--- a/src/Uno.UI/UI/Xaml/UIElement.FocusMixins.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.FocusMixins.cs
@@ -148,9 +148,9 @@ namespace Windows.UI.Xaml
 
 		internal virtual bool IsFocusableForFocusEngagement() => false;
 
-		protected bool IsVisible() => Visibility == Visibility.Visible;
+		private protected bool IsVisible() => Visibility == Visibility.Visible;
 
-		protected bool IsEnabled()
+		private bool IsEnabled()
 		{
 			if (this is Control control)
 			{

--- a/src/Uno.UI/UI/Xaml/UIElement.FocusMixins.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.FocusMixins.cs
@@ -139,7 +139,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		internal bool IsFocusable =>
+		internal virtual bool IsFocusable =>
 					/*IsActive() &&*/ //TODO Uno: No concept of IsActive in Uno yet.
 					IsVisible() &&
 					(IsEnabled() || ((this as FrameworkElement)?.AllowFocusWhenDisabled == true)) &&
@@ -148,9 +148,9 @@ namespace Windows.UI.Xaml
 
 		internal virtual bool IsFocusableForFocusEngagement() => false;
 
-		private bool IsVisible() => Visibility == Visibility.Visible;
+		protected bool IsVisible() => Visibility == Visibility.Visible;
 
-		private bool IsEnabled()
+		protected bool IsEnabled()
 		{
 			if (this is Control control)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7068

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`TextBlock` selection is not working.

## What is the new behavior?

Working again.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.