### PR TITLE
perf(wasm): Place loaded/unloaded exception handling behind a flag

### DIFF
--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -213,6 +213,12 @@ namespace Uno.UI
 			/// Setting it to true avoids the use of costly JavaScript->C# interop.
 			/// </remarks>
 			public static bool WasmUseManagedLoadedUnloaded { get; set; } = true;
+
+			/// <summary>
+			/// When false, skips the FrameworkElement Loading/Loaded/Unloaded exception handling. This can be
+			/// disabled to improve application performance on WebAssembly. See See #7005 for additional details.
+			/// </summary>
+			public static bool HandleLoadUnloadExceptions { get; set; } = true;
 		}
 
 		public static class Image
@@ -245,7 +251,7 @@ namespace Uno.UI
 		public static class BindingExpression
 		{
 			/// <summary>
-			/// Skips the BindingExpression.SetTargetValue exception handling. Can be disabled to
+			/// When false, skips the BindingExpression.SetTargetValue exception handling. Can be disabled to
 			/// improve application performance on WebAssembly. See See #7005 for additional details.
 			/// </summary>
 			public static bool HandleSetTargetValueExceptions { get; set; } = true;

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.netstd.cs
@@ -29,21 +29,40 @@ namespace Windows.UI.Xaml
 			OnLoadingPartial();
 			ApplyCompiledBindings();
 
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
-			try
+			void InvokeLoading()
 			{
-#endif
 				// Raise event before invoking base in order to raise them top to bottom
 				OnLoading();
 				_loading?.Invoke(this, new RoutedEventArgs(this));
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
 			}
-			catch (Exception error)
+
+			if (FeatureConfiguration.FrameworkElement.HandleLoadUnloadExceptions)
 			{
-				_log.Error("OnElementLoading failed in FrameworkElement", error);
-				Application.Current.RaiseRecoverableUnhandledException(error);
+				/// <remarks>
+				/// This method contains or is called by a try/catch containing method and
+				/// can be significantly slower than other methods as a result on WebAssembly.
+				/// See https://github.com/dotnet/runtime/issues/56309
+				/// </remarks>
+				void InvokeLoadingWithTry()
+				{
+					try
+					{
+						InvokeLoading();
+					}
+					catch (Exception error)
+					{
+						_log.Error("OnElementLoading failed in FrameworkElement", error);
+						Application.Current.RaiseRecoverableUnhandledException(error);
+					}
+				}
+
+				InvokeLoadingWithTry();
 			}
-#endif
+			else
+			{
+				InvokeLoading();
+			}
+
 
 			OnPostLoading();
 		}
@@ -56,21 +75,39 @@ namespace Windows.UI.Xaml
 		{
 			OnLoadedPartial();
 
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
-			try
+			void InvokeLoaded()
 			{
-#endif
 				// Raise event before invoking base in order to raise them top to bottom
 				OnLoaded();
 				_loaded?.Invoke(this, new RoutedEventArgs(this));
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
 			}
-			catch (Exception error)
+
+			if (FeatureConfiguration.FrameworkElement.HandleLoadUnloadExceptions)
 			{
-				_log.Error("OnElementLoaded failed in FrameworkElement", error);
-				Application.Current.RaiseRecoverableUnhandledException(error);
+				/// <remarks>
+				/// This method contains or is called by a try/catch containing method and
+				/// can be significantly slower than other methods as a result on WebAssembly.
+				/// See https://github.com/dotnet/runtime/issues/56309
+				/// </remarks>
+				void InvokeLoadedWithTry()
+				{
+					try
+					{
+						InvokeLoaded();
+   					}
+					catch (Exception error)
+					{
+						_log.Error("OnElementLoaded failed in FrameworkElement", error);
+						Application.Current.RaiseRecoverableUnhandledException(error);
+					}
+				}
+
+				InvokeLoadedWithTry();
 			}
-#endif
+			else
+			{
+				InvokeLoaded();
+			}
 		}
 
 		partial void OnLoadedPartial();
@@ -78,23 +115,42 @@ namespace Windows.UI.Xaml
 
 		private protected sealed override void OnFwEltUnloaded()
 		{
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
-			try
+			void InvokeUnloaded()
 			{
-#endif
 				// Raise event after invoking base in order to raise them bottom to top
 				OnUnloaded();
 				_unloaded?.Invoke(this, new RoutedEventArgs(this));
 				OnUnloadedPartial();
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
 			}
-			catch (Exception error)
+
+			if (FeatureConfiguration.FrameworkElement.HandleLoadUnloadExceptions)
 			{
-				_log.Error("OnElementUnloaded failed in FrameworkElement", error);
-				Application.Current.RaiseRecoverableUnhandledException(error);
+				/// <remarks>
+				/// This method contains or is called by a try/catch containing method and
+				/// can be significantly slower than other methods as a result on WebAssembly.
+				/// See https://github.com/dotnet/runtime/issues/56309
+				/// </remarks>
+				void InvokeUnloadedWithTry()
+				{
+					try
+					{
+						InvokeUnloaded();
+					}
+					catch (Exception error)
+					{
+						_log.Error("OnElementUnloaded failed in FrameworkElement", error);
+						Application.Current.RaiseRecoverableUnhandledException(error);
+					}
+				}
+
+				InvokeUnloadedWithTry();
 			}
-#endif
+			else
+			{
+				InvokeUnloaded();
+			}
 		}
+
 		partial void OnUnloadedPartial();
 
 		private protected virtual void OnUnloaded() { }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- fix

## What is the new behavior?

Previous related changes in https://github.com/unoplatform/uno/pull/7079 changed the behavior significantly and using a flag will allow for gradual exceptions resolution on the app side.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
