### PR TITLE
fix: Move Background in default app template to Page

### DIFF
--- a/doc/articles/controls/map-control-support.md
+++ b/doc/articles/controls/map-control-support.md
@@ -34,9 +34,10 @@ Here's a complete sample:
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:maps="using:Windows.UI.Xaml.Controls.Maps"
-	  mc:Ignorable="d">
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto" />
 			<RowDefinition Height="*" />

--- a/doc/articles/features/using-winui2.md
+++ b/doc/articles/features/using-winui2.md
@@ -40,9 +40,10 @@ The [WinUI 2 library](https://docs.microsoft.com/en-us/windows/apps/winui/winui2
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:winui="using:Microsoft.UI.Xaml.Controls"
-        mc:Ignorable="d">
+        mc:Ignorable="d"
+        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid>
             <winui:NumberBox />
         </Grid>
     </Page>

--- a/doc/articles/getting-started-tutorial-1.md
+++ b/doc/articles/getting-started-tutorial-1.md
@@ -35,7 +35,7 @@ Also, you will learn how to run your applications on all platforms supported by 
 
 5. Add a `StackPanel` around your `TextBlock`
     ```xml
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <StackPanel>
             <TextBlock Text="Hello World" Margin="20" FontSize="30" />
         </StackPanel>
@@ -44,7 +44,7 @@ Also, you will learn how to run your applications on all platforms supported by 
 
 6. Add a `Slider`
     ```xml
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <StackPanel>
             <TextBlock Text="Hello World" Margin="20" FontSize="30" />
             <Slider x:Name="slider"/>
@@ -54,7 +54,7 @@ Also, you will learn how to run your applications on all platforms supported by 
 
 7. Bind the `Text` value of your `TextBlock` to the value of the `Slider`
     ```xml
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <StackPanel>
             <TextBlock Text="{Binding Value, ElementName=slider}" Margin="20" FontSize="30" />
             <Slider x:Name="slider"/>

--- a/doc/articles/getting-started-tutorial-2.md
+++ b/doc/articles/getting-started-tutorial-2.md
@@ -257,7 +257,7 @@ The tutorial walks you through creating a cross platform application with Uno Pl
 1. Now we will update the Grid so that we define 6 rows with a small spacing between the rows to add a little padding between the row elements.
 
     ```xml
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" RowSpacing="8">
+    <Grid>
       <Grid.RowDefinitions>
         <RowDefinition Height="Auto" />
         <RowDefinition Height="Auto" />

--- a/doc/articles/guides/silverlight-migration/03-review-app-startup.md
+++ b/doc/articles/guides/silverlight-migration/03-review-app-startup.md
@@ -105,9 +105,10 @@ In order to better align with the behavior of the Silverlight version of the app
         xmlns:local="using:TimeEntryUno"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d">
+        mc:Ignorable="d"
+        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid>
             <TextBlock Text="Hello, world!" Margin="20" FontSize="30" />
         </Grid>
     </Page>
@@ -124,9 +125,10 @@ In order to better align with the behavior of the Silverlight version of the app
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-        mc:Ignorable="d">
+        mc:Ignorable="d"
+        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid>
             <TextBlock Text="Hello, world!" Margin="20" FontSize="30" />
         </Grid>
     </Page>
@@ -135,7 +137,7 @@ In order to better align with the behavior of the Silverlight version of the app
 1. To add the navigation controls. replace `<Grid>..</Grid>` with the following:
 
     ```xml
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <muxc:NavigationView x:Name="NavView" PaneDisplayMode="Top" IsSettingsVisible="False"
                         IsBackEnabled="{Binding ElementName=ContentFrame, Path=CanGoBack}">
             <muxc:NavigationView.MenuItems>

--- a/doc/articles/guides/status-bar-theme-color.md
+++ b/doc/articles/guides/status-bar-theme-color.md
@@ -11,7 +11,7 @@ The complete sample code can be found here: [StatusBarThemeColor](https://github
 2. In `MainPage.xaml`, add a `<CommandBar>`:
     > On iOS, the status bar color cannot be set directly, so it is done via through a `CommandBar` placed in the page. You could also use any XAML element like `<Grid>` or `<Border>` to achieve a similar effect, if your application doesn't use navigation or doesn't use native navigation. This is because the page content can go under the status bar. In fact, you usually have to add padding to avoid that (see next step).
     ```xml
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -34,8 +34,7 @@ The complete sample code can be found here: [StatusBarThemeColor](https://github
           xmlns:toolkit="using:Uno.UI.Toolkit"
           ...>
 
-        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-              toolkit:VisibleBoundsPadding.PaddingMask="Top">
+        <Grid toolkit:VisibleBoundsPadding.PaddingMask="Top">
     ```
 4. In `MainPage.xaml.cs`, expose the `MyCommandBar` which will be referenced in a later step:
     ```cs

--- a/doc/articles/howto-consume-webservices.md
+++ b/doc/articles/howto-consume-webservices.md
@@ -913,14 +913,14 @@ In this task you will create the XAML for the UI and implement the bindings for 
         xmlns:viewmodels="using:TheCatApiClient.Shared.Models.ViewModels" 
         xmlns:datamodels="using:TheCatApiClient.Shared.Models.DataModels"
         xmlns:toolkit="using:Uno.UI.Toolkit"
-        mc:Ignorable="d">
+        mc:Ignorable="d"
+        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
         <Page.DataContext>
             <viewmodels:MainViewModel x:Name="ViewModel" />
         </Page.DataContext>
 
-        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-            toolkit:VisibleBoundsPadding.PaddingMask="All">
+        <Grid toolkit:VisibleBoundsPadding.PaddingMask="All">
             <Grid Padding="12">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -1040,14 +1040,14 @@ In this task you will create the XAML for the UI and implement the bindings for 
         xmlns:viewmodels="using:TheCatApiClient.Shared.Models.ViewModels" 
         xmlns:datamodels="using:TheCatApiClient.Shared.Models.DataModels"
         xmlns:toolkit="using:Uno.UI.Toolkit"
-        mc:Ignorable="d">
+        mc:Ignorable="d"
+        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
         <Page.DataContext>
             <viewmodels:MainViewModel x:Name="ViewModel" />
         </Page.DataContext>
 
-        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-            Margin="12">
+        <Grid Margin="12">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>

--- a/doc/articles/interop/wasm-javascript-3.md
+++ b/doc/articles/interop/wasm-javascript-3.md
@@ -144,9 +144,10 @@ An easy way to achieve this is to add JavaScript code to load the CSS file direc
        xmlns:local="using:FlatpickrDemo"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-       mc:Ignorable="d">
+       mc:Ignorable="d"
+       Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
    
-       <StackPanel Spacing="10" Padding="20" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+       <StackPanel Spacing="10" Padding="20">
          <TextBlock FontSize="15">
    		   Is Picker opened: <Run FontSize="20" FontWeight="Bold" Text="{Binding IsPickerOpened, ElementName=picker}" />
             <LineBreak />Picked Date/Time: <Run FontSize="20" FontWeight="Bold" Text="{Binding SelectedDateTime, ElementName=picker}" />
@@ -243,9 +244,11 @@ Background = new SolidColorBrush(Colors.Transparent);
 ```
 
 ### `TextBlock` content is not visible in browsers with the dark theme
-`TextBlock` defaults the text color as White correctly but `StackPanel` background needs to be set correctly.
+`TextBlock` defaults the text color as White correctly but `Page` background needs to be set correctly.
 ```
-<StackPanel Spacing="10" Padding="20" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+<Page 
+    ...
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 ```
 
 ## 🔬 Going further

--- a/doc/articles/native-styles.md
+++ b/doc/articles/native-styles.md
@@ -80,9 +80,10 @@ For example, to use native styling on a single `CheckBox` in XAML:
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:not_win="http://uno.ui/not_win"
-	  mc:Ignorable="d not_win">
+	  mc:Ignorable="d not_win"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Grid>
 		<!--This check box will use a platform-native style on Android and iOS-->
 		<CheckBox IsChecked="{Binding OptionSelected}"
 				  not_win:Style="{StaticResource NativeDefaultCheckBox}" />

--- a/doc/articles/native-views.md
+++ b/doc/articles/native-views.md
@@ -14,8 +14,7 @@ An example:
 	  xmlns:android="http://uno.ui/android"
 	  mc:Ignorable="d android">
 
-	<StackPanel Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-				Margin="0,30,0,0">
+	<StackPanel Margin="0,30,0,0">
 		<TextBlock Text="Rating" />
 		<android:Grid Background="Beige"
 					  Width="200">

--- a/doc/articles/native-views.md
+++ b/doc/articles/native-views.md
@@ -10,6 +10,7 @@ An example:
 
 ```xml
       ...
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  xmlns:android="http://uno.ui/android"
 	  mc:Ignorable="d android">

--- a/doc/blog/201907-SkiaSharp-for-wasm-support.md
+++ b/doc/blog/201907-SkiaSharp-for-wasm-support.md
@@ -12,7 +12,7 @@ Inside of the `Uno.SkiaSharp.Views` package you'll find support for the [SKXamlC
 
 XAML:
 ```xml
-<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+<Grid>
     <skia:SKXamlCanvas x:Name="test" PaintSurface="OnPaintSurface" />
 </Grid>
 ```

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Shared/MainPage.xaml
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Shared/MainPage.xaml
@@ -5,9 +5,10 @@
     xmlns:local="using:$ext_safeprojectname$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"    
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-		<TextBlock Text="Hello, world!" Margin="20" FontSize="30" />
+    <Grid>
+      <TextBlock Text="Hello, world!" Margin="20" FontSize="30" />
     </Grid>
 </Page>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Shared/MainPage.xaml
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Shared/MainPage.xaml
@@ -5,9 +5,10 @@
     xmlns:local="using:$ext_safeprojectname$"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-		<TextBlock Text="Hello, world!" Margin="20" FontSize="30" />
+    <Grid>
+      <TextBlock Text="Hello, world!" Margin="20" FontSize="30" />
     </Grid>
 </Page>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7102

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`Background` is set on `Grid` in default `MainPage.xaml`

## What is the new behavior?

`Background` is set on `Page`. Documentation updated too.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
