### PR TITLE
fix: Retry on detached DOM element

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -38,8 +39,30 @@ namespace SamplesApp.UITests.Runtime
 			var runTestCount = new QueryEx(q => AllQuery(q).Marked("runTestCount"));
 			var unitTestsControl = new QueryEx(q => AllQuery(q).Marked("UnitTestsRootControl"));
 
-			bool IsTestExecutionDone()
-				=> runningState.GetDependencyPropertyValue("Text")?.ToString().Equals("Finished", StringComparison.OrdinalIgnoreCase) ?? false;
+			async Task<bool> IsTestExecutionDone()
+			{
+				var sw = Stopwatch.StartNew();
+				Exception lastException = null;
+				do
+				{
+					try
+					{
+						return runningState.GetDependencyPropertyValue("Text")?.ToString().Equals("Finished", StringComparison.OrdinalIgnoreCase) ?? false;
+					}
+					catch (Exception e)
+					{
+						lastException = e;
+						Console.WriteLine($"IsTestExecutionDone failed with {e.Message}");
+					}
+
+					await Task.Delay(TimeSpan.FromSeconds(.5));
+
+					Console.WriteLine($"IsTestExecutionDone retrying");
+				}
+				while (sw.Elapsed < TimeSpan.FromSeconds(10));
+
+				throw lastException;
+			}
 
 			_app.WaitForElement(runButton);
 
@@ -59,13 +82,13 @@ namespace SamplesApp.UITests.Runtime
 
 				await Task.Delay(TimeSpan.FromSeconds(.5));
 
-				if (IsTestExecutionDone())
+				if (await IsTestExecutionDone())
 				{
 					break;
 				}
 			}
 
-			if (!IsTestExecutionDone())
+			if (!await IsTestExecutionDone())
 			{
 				Assert.Fail("A test run timed out");
 			}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes


## What is the new behavior?

Retry determining if tests ended, in case DOM elements get detached while being changed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
