### PR TITLE
fix(xLoad): [Android] Fix invalid x:Load reentrancy issue

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj
+++ b/src/Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj
@@ -68,4 +68,7 @@
 		</ItemGroup>
 	</Target>
 
+	<!-- VS2022 build issue -->
+	<Target Name="GetTargetPath" />
+
 </Project>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_Visibility_While_Materializing.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_Visibility_While_Materializing.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.When_xLoad_Visibility_While_Materializing"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<Grid>
+		<local:When_xLoad_Visibility_While_Materializing_Content
+			x:Name="item1"
+			x:FieldModifier="public"
+			x:Load="false"
+			Visibility="{x:Bind Model.IsVisible, Mode=OneWay, FallbackValue=false}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_Visibility_While_Materializing.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_Visibility_While_Materializing.xaml.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_Visibility_While_Materializing : UserControl
+	{
+		public When_xLoad_Visibility_While_Materializing()
+		{
+			Model = new Model();
+
+			Model.PropertyChanged += delegate {
+				FindName("item1");
+			};
+
+			this.InitializeComponent();
+		}
+
+		public Model Model { get; }
+	}
+
+	public class Model : System.ComponentModel.INotifyPropertyChanged
+	{
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		private bool _isVisible;
+
+		public bool IsVisible
+		{
+			get { return _isVisible; }
+			set
+			{
+				_isVisible = value;
+
+				PropertyChanged.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(IsVisible)));
+			}
+		}
+
+	}
+
+	public partial class When_xLoad_Visibility_While_Materializing_Content : UserControl
+	{
+		public When_xLoad_Visibility_While_Materializing_Content()
+		{
+			Instances++;
+		}
+
+		public static int Instances { get; set; }
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -10,6 +10,7 @@ using Windows.UI.Xaml.Controls;
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 {
 	[TestClass]
+	[RunsOnUIThread]
 	public class Given_xLoad
 	{
 		[TestMethod]
@@ -47,6 +48,24 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 			Assert.IsFalse((parent.Child as ElementStub).Load);
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_xLoad_Visibility_While_Materializing()
+		{
+			var SUT = new When_xLoad_Visibility_While_Materializing();
+
+			Assert.AreEqual(0, When_xLoad_Visibility_While_Materializing_Content.Instances);
+
+			TestServices.WindowHelper.WindowContent = SUT;
+
+			Assert.AreEqual(0, When_xLoad_Visibility_While_Materializing_Content.Instances);
+
+			SUT.Model.IsVisible = true;
+
+			Assert.AreEqual(1, When_xLoad_Visibility_While_Materializing_Content.Instances);
+		}
+
 	}
 }
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/6998

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

x:Load with Visibility binding does not fail with android.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
