### PR TITLE
Improve reliability of D&D extension

### DIFF
--- a/src/Uno.Foundation.Runtime.WebAssembly/Interop/TSInteropMarshaller.wasm.cs
+++ b/src/Uno.Foundation.Runtime.WebAssembly/Interop/TSInteropMarshaller.wasm.cs
@@ -132,7 +132,13 @@ namespace Uno.Foundation.Interop
 			}
 			catch (Exception e)
 			{
-				value.Dispose();
+				try
+				{
+					value.Dispose();
+				}
+				// If the allocation failed, the dispose will most likely also fail,
+				// but we want to propagate the real exception of the allocation!
+				catch (Exception) { }
 
 				if (_logger.Value.IsEnabled(LogLevel.Error))
 				{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
@@ -9,6 +9,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 	[TestClass]
 	public class Given_Window
 	{
+#if !WINDOWS_UWP
 		[TestMethod]
 		[RunsOnUIThread]
 		public void When_CreateNewWindow()
@@ -16,5 +17,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			// This used to crash on wasm which was trying to create a second D&D extension
 			var sut = new Window();
 		}
+#endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_Window
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public void When_CreateNewWindow()
+		{
+			// This used to crash on wasm which was trying to create a second D&D extension
+			var sut = new Window();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Application.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Application.wasm.cs
@@ -45,7 +45,7 @@ namespace Windows.UI.Xaml
 
 			global::Uno.Foundation.Extensibility.ApiExtensibility.Register(
 				typeof(global::Windows.ApplicationModel.DataTransfer.DragDrop.Core.IDragDropExtension),
-				o => new global::Windows.ApplicationModel.DataTransfer.DragDrop.Core.DragDropExtension());
+				o => global::Windows.ApplicationModel.DataTransfer.DragDrop.Core.DragDropExtension.GetForCurrentView());
 
 			CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.Normal, Initialize);
 


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/7091

## Enhancement
Improve reliability of D&DExtension on wasm

## What is the current behavior?
Crashes if your try to create a new Window as it tries to create a second instance of D&DExtension .... which is not allowed

## What is the new behavior?
Re-use the same instance

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
