### PR TITLE
fix(listview): [Android] Fix drag-to-reorder not applying

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -68,7 +68,7 @@ namespace Windows.UI.Xaml.Controls
 					items.ForEach(ClearContainerForDragDrop);
 				}
 			}
-		} 
+		}
 		#endregion
 
 		private void PrepareContainerForDragDrop(UIElement itemContainer)
@@ -134,7 +134,7 @@ namespace Windows.UI.Xaml.Controls
 
 				// The ListView must have both CanReorderItems and AllowDrop flags set to allow re-ordering (UWP)
 				// We also do not allow re-ordering if we where not able to find the item (as it has to be hidden in the view) (Uno only)
-				if (that.CanReorderItems && that.AllowDrop && draggedItem is {})
+				if (that.CanReorderItems && that.AllowDrop && draggedItem is { })
 				{
 					args.Data.SetData(ReorderOwnerFormatId, that);
 					args.Data.SetData(ReorderItemFormatId, draggedItem);
@@ -176,6 +176,10 @@ namespace Windows.UI.Xaml.Controls
 
 					that.DragItemsCompleted?.Invoke(that, args);
 				}
+
+				// Normally this will have been done by OnReorderCompleted, but sometimes OnReorderCompleted may not be called
+				// (eg if drag was released outside bounds of list)
+				that.CleanupReordering();
 			}
 		}
 
@@ -294,7 +298,7 @@ namespace Windows.UI.Xaml.Controls
 						// If we've moved items down, we have to take in consideration that the updatedIndex
 						// is already assuming that the item has been removed, so it's offsetted by 1.
 						newIndex--;
-					} 
+					}
 #endif
 				}
 
@@ -341,8 +345,15 @@ namespace Windows.UI.Xaml.Controls
 		private void UpdateReordering(Point location, FrameworkElement draggedContainer, object draggedItem)
 			=> VirtualizingPanel?.GetLayouter().UpdateReorderingItem(location, draggedContainer, draggedItem);
 
-		Uno.UI.IndexPath? CompleteReordering(FrameworkElement draggedContainer, object draggedItem)
+		private Uno.UI.IndexPath? CompleteReordering(FrameworkElement draggedContainer, object draggedItem)
 			=> VirtualizingPanel?.GetLayouter().CompleteReorderingItem(draggedContainer, draggedItem);
+
+		private void CleanupReordering()
+#if __ANDROID__
+			=> VirtualizingPanel?.GetLayouter().CleanupReordering();
+#else
+		{ }
+#endif
 
 		#region Helpers
 		private static bool IsObservableCollection(object src)

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -2127,6 +2127,10 @@ namespace Windows.UI.Xaml.Controls
 
 		internal Uno.UI.IndexPath? CompleteReorderingItem(FrameworkElement element, object item)
 		{
+			// Ensure that _pendingReorder.index is set. This is necessary in case it was invalidated from UpdateReorderingItem() but the
+			// list was not yet remeasured, which can happen when dragging rapidly.
+			GetAndUpdateReorderingIndex();
+
 			var updatedIndex = default(Uno.UI.IndexPath?);
 			if (_pendingReorder?.index is { } index)
 			{


### PR DESCRIPTION
Fix bug where drag-to-reorder would sometimes not be applied if item was dragged quickly, specifically in the case were the timing of events runs DragOver (pointer moved) -> Drop (pointer up) -> measure+arrange.

Fix an additional bug where an exception would occur if an item was dragged very rapidly from one end of the list to the other.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): fixes https://github.com/unoplatform/nventive-private/issues/255
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
