### PR TITLE
fix(Android): Fix NRE when TextBlock.FontFamily is null

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -1,9 +1,11 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
+using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -53,6 +55,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual("Where ", ((Run)inlines[0]).Text);
 			Assert.AreEqual("did", ((Run)((Italic)inlines[1]).Inlines.Single()).Text);
 			Assert.AreEqual(" my text go?", ((Run)inlines[2]).Text);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Null_FontFamily()
+		{
+			var SUT = new TextBlock { Text = "Some text", FontFamily = null };
+			WindowHelper.WindowContent = SUT;
+			SUT.Measure(new Size(1000, 1000));
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Extensions/FontHelper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Extensions/FontHelper.Android.cs
@@ -1,4 +1,6 @@
-﻿using Android.App;
+﻿#nullable enable
+
+using Android.App;
 using Android.Graphics;
 using System;
 using System.Collections.Generic;
@@ -20,9 +22,9 @@ namespace Windows.UI.Xaml
 		private static bool _assetsListed;
 		private static readonly string DefaultFontFamilyName = "sans-serif";
 
-		internal static Typeface FontFamilyToTypeFace(FontFamily fontFamily, FontWeight fontWeight, TypefaceStyle style = TypefaceStyle.Normal)
+		internal static Typeface? FontFamilyToTypeFace(FontFamily? fontFamily, FontWeight fontWeight, TypefaceStyle style = TypefaceStyle.Normal)
 		{  
-			var entry = new FontFamilyToTypeFaceDictionary.Entry(fontFamily.Source, fontWeight, style);
+			var entry = new FontFamilyToTypeFaceDictionary.Entry(fontFamily?.Source, fontWeight, style);
 			 
 			if (!_fontFamilyToTypeFaceDictionary.TryGetValue(entry , out var typeFace))
 			{
@@ -33,14 +35,14 @@ namespace Windows.UI.Xaml
 			return typeFace;
 		}
 
-		internal static Typeface InternalFontFamilyToTypeFace(FontFamily fontFamily, FontWeight fontWeight, TypefaceStyle style)
+		internal static Typeface? InternalFontFamilyToTypeFace(FontFamily? fontFamily, FontWeight fontWeight, TypefaceStyle style)
 		{
 			if (fontFamily?.Source == null || fontFamily.Equals(FontFamily.Default))
 			{
 				fontFamily = GetDefaultFontFamily(fontWeight);
 			}
 
-			Typeface typeface;
+			Typeface? typeface;
 
 			try
 			{
@@ -72,7 +74,7 @@ namespace Windows.UI.Xaml
 					{
 						typeface = Android.Graphics.Typeface.CreateFromAsset(Android.App.Application.Context.Assets, actualAsset);
 
-						if (style != typeface.Style)
+						if (style != typeface?.Style)
 						{
 							typeface = Typeface.Create(typeface, style);
 						}

--- a/src/Uno.UI/UI/Xaml/Extensions/FontHelper.Lookup.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Extensions/FontHelper.Lookup.Android.cs
@@ -1,4 +1,6 @@
-﻿using Android.App;
+﻿#nullable enable
+
+using Android.App;
 using Android.Graphics;
 using System;
 using System.Collections.Generic;
@@ -26,19 +28,19 @@ namespace Windows.UI.Xaml
 			{
 				private readonly int _hashCode;
 
-				public Entry(string fontFamily, FontWeight fontWeight, TypefaceStyle style)
+				public Entry(string? fontFamily, FontWeight fontWeight, TypefaceStyle style)
 				{
 					FontFamily = fontFamily;
 					FontWeight = fontWeight;
 					Style = style;
-					_hashCode = FontFamily.GetHashCode() ^ FontWeight.GetHashCode() ^ Style.GetHashCode();
+					_hashCode = (FontFamily?.GetHashCode() ?? 0) ^ FontWeight.GetHashCode() ^ Style.GetHashCode();
 				}
 
-				public string FontFamily { get; }
+				public string? FontFamily { get; }
 				public FontWeight FontWeight { get; }
 				public TypefaceStyle Style { get; }
 
-				public override bool Equals(object other)
+				public override bool Equals(object? other)
 				{
 					if (other is Entry otherEntry)
 					{
@@ -55,11 +57,11 @@ namespace Windows.UI.Xaml
 
 			private readonly HashtableEx _entries = new HashtableEx();
 
-			internal bool TryGetValue(Entry key, out Typeface result)
+			internal bool TryGetValue(Entry key, out Typeface? result)
 			{
 				if (_entries.TryGetValue(key, out var value))
 				{
-					result = (Typeface)value;
+					result = (Typeface?)value;
 					return true;
 				}
 
@@ -67,7 +69,7 @@ namespace Windows.UI.Xaml
 				return false;
 			}
 
-			internal void Add(Entry key, Typeface typeFace)
+			internal void Add(Entry key, Typeface? typeFace)
 				=> _entries.Add(key, typeFace);
 
 			internal void Clear()


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensure that a `null` TextBlock.FontFamily fallsback to the default system font

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
