### PR TITLE
fix(wasm): geometry not receiving pointer events

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_GeometryGroup_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/HitTest_GeometryGroup_Tests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Input
+{
+	[TestFixture]
+	public partial class HitTest_GeometryGroup_Tests : SampleControlUITestBase
+	{
+		private const string _sample = "UITests.Windows_UI_Input.PointersTests.HitTest_GeometryGroup";
+
+		[Test] [AutoRetry] public void When_HollowCircle2()
+		{
+			Run(_sample);
+
+			var element = "HollowCircle2";
+
+			// tap on the hollow circle at the center of 12-o-clock position
+			var rect = _app.WaitForElement(element).Single().Rect;
+			var target = new PointF(
+				rect.CenterX,
+				rect.Bottom - rect.Height * (7f/8f)
+			);
+			_app.TapCoordinates(target.X, target.Y);
+
+			var result = _app.Marked("LastPressed").GetDependencyPropertyValue<string>("Text");
+			var resultSrc = _app.Marked("LastPressedSrc").GetDependencyPropertyValue<string>("Text");
+
+			result.Should().Be(element);
+			resultSrc.Should().Be(element);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -601,6 +601,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_GeometryGroup.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_Image.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4733,6 +4737,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Enability.xaml.cs">
       <DependentUpon>Enability.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_GeometryGroup.xaml.cs">
+      <DependentUpon>HitTest_GeometryGroup.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\HitTest_Image.xaml.cs">
       <DependentUpon>HitTest_Image.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_GeometryGroup.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_GeometryGroup.xaml
@@ -1,0 +1,59 @@
+﻿<Page x:Class="UITests.Windows_UI_Input.PointersTests.HitTest_GeometryGroup"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Windows_UI_Input.PointersTests"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<Grid Grid.Row="0"
+			  x:Name="TestCasePanel">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition  Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+			</Grid.ColumnDefinitions>
+  
+			<Path Grid.Column="0"
+				  x:Name="HollowCircle1"
+				  Fill="SkyBlue"
+				  Height="100" Width="100">
+				<Path.Data>
+					<GeometryGroup FillRule="EvenOdd">
+						<EllipseGeometry Center="50,50" RadiusX="50" RadiusY="50" />
+						<EllipseGeometry Center="50,50" RadiusX="25" RadiusY="25" />
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+			<Path Grid.Column="1"
+				  x:Name="HollowCircle2"
+				  Fill="SkyBlue"
+				  Height="100" Width="100">
+				<Path.Data>
+					<GeometryGroup FillRule="EvenOdd">
+						<EllipseGeometry Center="50,50" RadiusX="50" RadiusY="50" />
+						<EllipseGeometry Center="50,50" RadiusX="25" RadiusY="25" />
+					</GeometryGroup>
+				</Path.Data>
+			</Path>
+		</Grid>
+
+		<StackPanel Grid.Row="1" Orientation="Horizontal">
+			<TextBlock Text="Last pressed: " />
+			<TextBlock x:Name="LastPressed" Text="__none__" />
+			<TextBlock Text=" (src: " />
+			<TextBlock x:Name="LastPressedSrc" Text="__none__" />
+			<TextBlock Text=") - Last hovered: " />
+			<TextBlock x:Name="LastHovered" Text="__none__" />
+			<TextBlock Text=" (src: " />
+			<TextBlock x:Name="LastHoveredSrc" Text="__none__" />
+			<TextBlock Text=")" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_GeometryGroup.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/HitTest_GeometryGroup.xaml.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Windows.UI.Xaml.Shapes;
+using Uno.UI.Samples.Controls;
+using Uno.Extensions;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Input.PointersTests
+{
+	[Sample("Pointers", "GeometryGroup")]
+	public sealed partial class HitTest_GeometryGroup : Page
+	{
+		public HitTest_GeometryGroup()
+		{
+			this.InitializeComponent();
+			RegisterPointerEvents();
+
+			Loaded += (s, e) =>
+			{
+				_ = this.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, async () =>
+				{
+					// this needs to be added on SizeChanged or on a delay
+					HollowCircle2.Data = GenerateHollowCircle(new Size(100, 100));
+				});
+			};
+		}
+
+		private GeometryGroup GenerateHollowCircle(Size size)
+		{
+			var center = new Point(size.Width / 2, size.Height / 2);
+			var radius = Math.Min(size.Width,  size.Height) / 2;
+			var radius2 = radius * (1.0 / 2.0);
+
+			return new GeometryGroup().Apply(x => x.Children.AddRange(new EllipseGeometry[]
+			{
+				new EllipseGeometry { Center = center, RadiusX = radius, RadiusY = radius },
+				new EllipseGeometry { Center = center, RadiusX = radius2, RadiusY = radius2 },
+			}));
+		}
+
+		private void RegisterPointerEvents()
+		{
+			foreach (var elt in GetElements())
+			{
+				elt.PointerPressed += (snd, e) =>
+				{
+					e.Handled = true;
+					LastPressed.Text = elt.Name;
+					LastPressedSrc.Text = (e.OriginalSource as FrameworkElement)?.Name ?? "-unknown-";
+				};
+				elt.PointerMoved += (snd, e) =>
+				{
+					e.Handled = true;
+					LastHovered.Text = elt.Name;
+					LastHoveredSrc.Text = (e.OriginalSource as FrameworkElement)?.Name ?? "-unknown-";
+				};
+			}
+		}
+
+		private IEnumerable<FrameworkElement> GetElements()
+		{
+			yield return HollowCircle1;
+			yield return HollowCircle2;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -308,7 +308,8 @@ namespace Windows.UI.Xaml
 			}
 
 			// If we're not locally hit-test visible, visible, or enabled, we should be collapsed. Our children will be collapsed as well.
-			if (!IsLoaded || !IsHitTestVisible || Visibility != Visibility.Visible || !IsEnabledOverride())
+			// SvgElements are an exception here since they won't be loaded.
+			if (!(IsLoaded || HtmlTagIsSvg) || !IsHitTestVisible || Visibility != Visibility.Visible || !IsEnabledOverride())
 			{
 				return HitTestability.Collapsed;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`Path` whose `.Data` is injected later are unable to receive pointer events.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.