### PR TITLE
Invalidate cached theme dictionary when theme dictionaries are added/removed

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
@@ -795,5 +795,84 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			Assert.IsTrue(resources.ContainsKey("TestKey"));
 			Assert.AreEqual(resources["TestKey"], "Test123");
 		}
+
+		[TestMethod]
+		public void When_Theme_Dictionary_Is_Cached_Then_Add_And_Clear_Theme()
+		{
+			var dictionary = new ResourceDictionary();
+			dictionary.TryGetValue("TestKey", out _); // This causes _activeThemeDictionary to be cached.
+
+			var lightTheme = new ResourceDictionary();
+			lightTheme.Add("TestKey", "TestValue");
+			dictionary.ThemeDictionaries.Add("Light", lightTheme); // Cached value is no longer valid due to adding theme.
+
+			// Make sure the cache is updated.
+			Assert.IsTrue(dictionary.TryGetValue("TestKey", out var testValue));
+			Assert.AreEqual("TestValue", testValue);
+
+			dictionary.ThemeDictionaries.Clear(); // Cached value is no longer valid due to clearing themes.
+
+			Assert.IsFalse(dictionary.TryGetValue("TestKey", out _));
+		}
+
+		[TestMethod]
+		public void When_Theme_Dictionary_Is_Cached_Then_Add_And_Remove_Theme()
+		{
+			var dictionary = new ResourceDictionary();
+			dictionary.TryGetValue("TestKey", out _); // This causes _activeThemeDictionary to be cached.
+
+			var lightTheme = new ResourceDictionary();
+			lightTheme.Add("TestKey", "TestValue");
+			dictionary.ThemeDictionaries.Add("Light", lightTheme); // Cached value is no longer valid due to adding theme.
+
+			// Make sure the cache is updated.
+			Assert.IsTrue(dictionary.TryGetValue("TestKey", out var testValue));
+			Assert.AreEqual("TestValue", testValue);
+
+			Assert.IsTrue(dictionary.ThemeDictionaries.Remove("Light")); // Cached value is no longer valid due to removing theme.
+
+			Assert.IsFalse(dictionary.TryGetValue("TestKey", out _));
+		}
+
+
+		[TestMethod]
+		public void When_Default_Theme_Dictionary_Is_Cached()
+		{
+			var defaultDictionary = new ResourceDictionary();
+			defaultDictionary.Add("TestKey", "TestValueFromDefaultDictionary");
+
+			var dictionary = new ResourceDictionary();
+			dictionary.ThemeDictionaries.Add("Default", defaultDictionary);
+			Assert.IsTrue(dictionary.TryGetValue("TestKey", out var testValue));
+			Assert.AreEqual("TestValueFromDefaultDictionary", testValue);
+
+			var lightDictionary = new ResourceDictionary();
+			lightDictionary.Add("TestKey", "TestValueFromLightDictionary");
+			dictionary.ThemeDictionaries.Add("Light", lightDictionary);
+			Assert.IsTrue(dictionary.TryGetValue("TestKey", out testValue));
+			Assert.AreEqual("TestValueFromLightDictionary", testValue);
+		}
+
+		[TestMethod]
+		public void When_Default_Theme_Dictionary_Should_Be_Used_After_Removing_Active_Theme()
+		{
+			var lightDictionary = new ResourceDictionary();
+			lightDictionary.Add("TestKey", "TestValueFromLightDictionary");
+
+			var dictionary = new ResourceDictionary();
+			dictionary.ThemeDictionaries.Add("Light", lightDictionary);
+			Assert.IsTrue(dictionary.TryGetValue("TestKey", out var testValue));
+			Assert.AreEqual("TestValueFromLightDictionary", testValue);
+
+			var defaultDictionary = new ResourceDictionary();
+			defaultDictionary.Add("TestKey", "TestValueFromDefaultDictionary");
+			dictionary.ThemeDictionaries.Add("Default", defaultDictionary);
+			dictionary.ThemeDictionaries.Remove("Light");
+			Assert.IsTrue(dictionary.TryGetValue("TestKey", out testValue));
+			Assert.AreEqual("TestValueFromDefaultDictionary", testValue);
+
+			dictionary.ThemeDictionaries.Remove("Default");
+			Assert.IsFalse(dictionary.TryGetValue("TestKey", out _));
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -24,26 +24,7 @@ namespace Windows.UI.Xaml
 		/// <summary>
 		/// This event is fired when a key that has value of type <see cref="ResourceDictionary"/> is added or changed in the current <see cref="ResourceDictionary" />
 		/// </summary>
-		private event EventHandler<ResourceDictionaryChangedEventArgs> ResourceDictionaryValueChange;
-
-		private class ResourceDictionaryChangedEventArgs
-		{
-			public ResourceDictionaryChangedEventArgs(object changedKey, ResourceDictionary newValue)
-			{
-				ChangedKey = changedKey;
-				NewValue = newValue;
-			}
-
-			/// <summary>
-			/// The key that was added or removed. This can be null if the dictionary is cleared, meaning all keys are removed.
-			/// </summary>
-			public object ChangedKey { get; }
-
-			/// <summary>
-			/// The <see cref="ResourceDictionary" /> that was added. This can be null if the theme was removed.
-			/// </summary>
-			public ResourceDictionary NewValue { get; }
-		}
+		private event EventHandler ResourceDictionaryValueChange;
 
 		/// <summary>
 		/// If true, there may be lazily-set values in the dictionary that need to be initialized.
@@ -143,7 +124,7 @@ namespace Windows.UI.Xaml
 			var keyToRemove = new ResourceKey(key);
 			if (_values.Remove(keyToRemove))
 			{
-				ResourceDictionaryValueChange?.Invoke(this, new ResourceDictionaryChangedEventArgs(keyToRemove, null));
+				ResourceDictionaryValueChange?.Invoke(this, EventArgs.Empty);
 				return true;
 			}
 
@@ -155,7 +136,7 @@ namespace Windows.UI.Xaml
 		public void Clear()
 		{
 			_values.Clear();
-			ResourceDictionaryValueChange?.Invoke(this, new ResourceDictionaryChangedEventArgs(null, null));
+			ResourceDictionaryValueChange?.Invoke(this, EventArgs.Empty);
 		}
 
 		public void Add(object key, object value) => Set(new ResourceKey(key), value, throwIfPresent: true);
@@ -272,9 +253,9 @@ namespace Windows.UI.Xaml
 			else
 			{
 				_values[resourceKey] = value;
-				if (value is ResourceDictionary addedOrChangedResourceDictionary)
+				if (value is ResourceDictionary)
 				{
-					ResourceDictionaryValueChange?.Invoke(this, new ResourceDictionaryChangedEventArgs(resourceKey, addedOrChangedResourceDictionary));
+					ResourceDictionaryValueChange?.Invoke(this, EventArgs.Empty);
 				}
 			}
 		}
@@ -301,9 +282,9 @@ namespace Windows.UI.Xaml
 				{
 					value = newValue;
 					_values[key] = newValue; // If Initializer threw an exception this will push null, to avoid running buggy initialization again and again (and avoid surfacing initializer to consumer code)
-					if (newValue is ResourceDictionary addedOrChangedResourceDictionary)
+					if (newValue is ResourceDictionary)
 					{
-						ResourceDictionaryValueChange?.Invoke(this, new ResourceDictionaryChangedEventArgs(key, addedOrChangedResourceDictionary));
+						ResourceDictionaryValueChange?.Invoke(this, EventArgs.Empty);
 					}
 					ResourceResolver.PopScope();
 				}


### PR DESCRIPTION
GitHub Issue (If applicable): Part of #7123

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Cached value doesn't get properly updated when needed.

## What is the new behavior?

Update cached value properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
