### PR TITLE
`StartStopEventWrapper`

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/Helpers/Dpi/DpiHelper.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Helpers/Dpi/DpiHelper.cs
@@ -10,7 +10,7 @@ namespace Uno.UI.Runtime.Skia.Gtk.Helpers.Dpi;
 
 internal class DpiHelper
 {
-	private readonly StartStopEventWrapper<EventHandler> _dpiChangedWrapper;
+	private readonly StartStopDelegateWrapper<EventHandler> _dpiChangedWrapper;
 	private readonly UnoGtkWindow _window;
 
 	private float? _dpi;

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_StartStopEventWrapper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_StartStopEventWrapper.cs
@@ -13,14 +13,14 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 		[TestMethod]
 		public void When_Default_Event_Null()
 		{
-			var wrapper = new StartStopEventWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
+			var wrapper = new StartStopDelegateWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
 			Assert.IsNull(wrapper.Event);
 		}
 
 		[TestMethod]
 		public void When_Add_Handler_Event_Not_Null()
 		{
-			var wrapper = new StartStopEventWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
+			var wrapper = new StartStopDelegateWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
 			wrapper.AddHandler((s, e) => { });
 			Assert.IsNotNull(wrapper.Event);
 		}
@@ -31,7 +31,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 			void Handler(Accelerometer a, AccelerometerReadingChangedEventArgs e)
 			{
 			}
-			var wrapper = new StartStopEventWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
+			var wrapper = new StartStopDelegateWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
 			wrapper.AddHandler(Handler);
 			wrapper.RemoveHandler(Handler);
 			Assert.IsNull(wrapper.Event);
@@ -40,7 +40,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 		[TestMethod]
 		public void When_Remove_On_Empty()
 		{
-			var wrapper = new StartStopEventWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
+			var wrapper = new StartStopDelegateWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
 			wrapper.RemoveHandler((s, e) => { });
 			Assert.IsNull(wrapper.Event);
 		}
@@ -49,7 +49,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 		[TestMethod]
 		public void When_Remove_Nonexistent()
 		{
-			var wrapper = new StartStopEventWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
+			var wrapper = new StartStopDelegateWrapper<TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs>>(() => { }, () => { });
 			wrapper.AddHandler((s, e) => { });
 			wrapper.RemoveHandler((s, e) => { });
 			Assert.IsNotNull(wrapper.Event);
@@ -59,7 +59,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 		public void When_Single_Invoked()
 		{
 			var invoked = false;
-			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => { });
+			var wrapper = new StartStopDelegateWrapper<EventHandler<EventArgs>>(() => { }, () => { });
 			wrapper.AddHandler((s, e) => invoked = true);
 			Assert.IsFalse(invoked);
 			wrapper.Event?.Invoke(null, EventArgs.Empty);
@@ -71,7 +71,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 		{
 			var firstInvoked = false;
 			var secondInvoked = false;
-			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => { });
+			var wrapper = new StartStopDelegateWrapper<EventHandler<EventArgs>>(() => { }, () => { });
 			wrapper.AddHandler((s, e) => firstInvoked = true);
 			wrapper.AddHandler((s, e) => secondInvoked = true);
 			Assert.IsFalse(firstInvoked);
@@ -90,7 +90,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 				firstInvoked = true;
 			}
 			var secondInvoked = false;
-			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => { });
+			var wrapper = new StartStopDelegateWrapper<EventHandler<EventArgs>>(() => { }, () => { });
 			wrapper.AddHandler(FirstHandler);
 			wrapper.AddHandler((s, e) => secondInvoked = true);
 			Assert.IsFalse(firstInvoked);
@@ -105,7 +105,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 		public void When_First_Subscriber_OnFirst_Invoked()
 		{
 			var onFirst = false;
-			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => onFirst = true, () => { });
+			var wrapper = new StartStopDelegateWrapper<EventHandler<EventArgs>>(() => onFirst = true, () => { });
 			Assert.IsFalse(onFirst);
 			wrapper.AddHandler((s, e) => { });
 			Assert.IsTrue(onFirst);
@@ -115,7 +115,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 		public void When_Multiple_Subscribers_OnFirst_Once()
 		{
 			var onFirstCounter = 0;
-			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => onFirstCounter++, () => { });
+			var wrapper = new StartStopDelegateWrapper<EventHandler<EventArgs>>(() => onFirstCounter++, () => { });
 			Assert.AreEqual(0, onFirstCounter);
 			wrapper.AddHandler((s, e) => { });
 			wrapper.AddHandler((s, e) => { });
@@ -134,7 +134,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 			}
 
 			var onFirstCounter = 0;
-			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => onFirstCounter++, () => { });
+			var wrapper = new StartStopDelegateWrapper<EventHandler<EventArgs>>(() => onFirstCounter++, () => { });
 			Assert.AreEqual(0, onFirstCounter);
 			wrapper.AddHandler(FirstSubscriber);
 			wrapper.AddHandler(SecondSubscriber);
@@ -153,7 +153,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 			{
 			}
 			var onLast = false;
-			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => onLast = true);
+			var wrapper = new StartStopDelegateWrapper<EventHandler<EventArgs>>(() => { }, () => onLast = true);
 			wrapper.AddHandler(FirstSubscriber);
 			Assert.IsFalse(onLast);
 			wrapper.RemoveHandler(FirstSubscriber);
@@ -171,7 +171,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 			{
 			}
 			var onLastCounter = 0;
-			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => onLastCounter++);
+			var wrapper = new StartStopDelegateWrapper<EventHandler<EventArgs>>(() => { }, () => onLastCounter++);
 			wrapper.AddHandler(FirstSubscriber);
 			wrapper.AddHandler(SecondSubscriber);
 			Assert.AreEqual(0, onLastCounter);
@@ -188,7 +188,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 			}
 
 			var onLastCounter = 0;
-			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => onLastCounter++);
+			var wrapper = new StartStopDelegateWrapper<EventHandler<EventArgs>>(() => { }, () => onLastCounter++);
 			wrapper.AddHandler(FirstSubscriber);
 			Assert.AreEqual(0, onLastCounter);
 			wrapper.RemoveHandler(FirstSubscriber);
@@ -208,7 +208,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 			}
 
 			var onLastCounter = 0;
-			var wrapper = new StartStopEventWrapper<EventHandler<EventArgs>>(() => { }, () => onLastCounter++);
+			var wrapper = new StartStopDelegateWrapper<EventHandler<EventArgs>>(() => { }, () => onLastCounter++);
 			wrapper.AddHandler(FirstSubscriber);
 			wrapper.AddHandler(SecondSubscriber);
 			Assert.AreEqual(0, onLastCounter);

--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -40,7 +40,7 @@ public sealed partial class Geolocator
 				_location = location;
 
 				BroadcastStatusChanged(PositionStatus.Ready);
-				_owner._positionChangedWrapper.Event?.Invoke(_owner, new PositionChangedEventArgs(location.ToGeoPosition()));
+				_owner._positionChangedWrapper.Invoke(_owner, new PositionChangedEventArgs(location.ToGeoPosition()));
 			}
 		}
 

--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.cs
@@ -19,8 +19,8 @@ namespace Windows.Devices.Geolocation
 		// Using ConcurrentDictionary as concurrent HashSet (https://stackoverflow.com/questions/18922985/concurrent-hashsett-in-net-framework), byte is throwaway
 		private static readonly ConcurrentDictionary<Geolocator, byte> _statusChangedSubscriptions = new ConcurrentDictionary<Geolocator, byte>();
 
-		private readonly StartStopEventWrapper<TypedEventHandler<Geolocator, StatusChangedEventArgs>> _statusChangedWrapper;
-		private readonly StartStopEventWrapper<TypedEventHandler<Geolocator, PositionChangedEventArgs>> _positionChangedWrapper;
+		private readonly StartStopTypedEventWrapper<Geolocator, StatusChangedEventArgs> _statusChangedWrapper;
+		private readonly StartStopTypedEventWrapper<Geolocator, PositionChangedEventArgs> _positionChangedWrapper;
 
 		private PositionAccuracy _desiredAccuracy = PositionAccuracy.Default;
 
@@ -33,11 +33,11 @@ namespace Windows.Devices.Geolocation
 		/// </summary>
 		public Geolocator()
 		{
-			_statusChangedWrapper = new StartStopEventWrapper<TypedEventHandler<Geolocator, StatusChangedEventArgs>>(
+			_statusChangedWrapper = new StartStopTypedEventWrapper<Geolocator, StatusChangedEventArgs>(
 				() => StartStatusChanged(),
 				() => StopStatusChanged(),
 				_syncLock);
-			_positionChangedWrapper = new StartStopEventWrapper<TypedEventHandler<Geolocator, PositionChangedEventArgs>>(
+			_positionChangedWrapper = new StartStopTypedEventWrapper<Geolocator, PositionChangedEventArgs>(
 				() => StartPositionChanged(),
 				() => StopPositionChanged(),
 				_syncLock);

--- a/src/Uno.UWP/Devices/Sensors/LightSensor.cs
+++ b/src/Uno.UWP/Devices/Sensors/LightSensor.cs
@@ -15,11 +15,11 @@ namespace Windows.Devices.Sensors
 	{
 		private readonly static Lazy<LightSensor?> _instance = new Lazy<LightSensor?>(() => TryCreateInstance());
 
-		private readonly StartStopEventWrapper<TypedEventHandler<LightSensor, LightSensorReadingChangedEventArgs>> _readingChangedWrapper;
+		private readonly StartStopTypedEventWrapper<LightSensor, LightSensorReadingChangedEventArgs> _readingChangedWrapper;
 
 		private LightSensor()
 		{
-			_readingChangedWrapper = new StartStopEventWrapper<TypedEventHandler<LightSensor, LightSensorReadingChangedEventArgs>>(
+			_readingChangedWrapper = new StartStopTypedEventWrapper<LightSensor, LightSensorReadingChangedEventArgs>(
 				StartReading, StopReading);
 		}
 

--- a/src/Uno.UWP/Devices/Sensors/ProximitySensor.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/ProximitySensor.Android.cs
@@ -14,7 +14,7 @@ namespace Windows.Devices.Sensors;
 
 public partial class ProximitySensor
 {
-	private readonly StartStopEventWrapper<TypedEventHandler<ProximitySensor, ProximitySensorReadingChangedEventArgs>> _readingChangedWrapper;
+	private readonly StartStopTypedEventWrapper<ProximitySensor, ProximitySensorReadingChangedEventArgs> _readingChangedWrapper;
 
 	private Sensor? _sensor;
 	private ProximitySensorListener? _listener;

--- a/src/Uno.UWP/Gaming/Input/Gamepad.cs
+++ b/src/Uno.UWP/Gaming/Input/Gamepad.cs
@@ -12,14 +12,14 @@ public partial class Gamepad : IGameController
 {
 	private static readonly object _syncLock = new object();
 
-	private static readonly StartStopEventWrapper<EventHandler<Gamepad>> _gamepadAddedWrapper;
-	private static readonly StartStopEventWrapper<EventHandler<Gamepad>> _gamepadRemovedWrapper;
+	private static readonly StartStopEventWrapper<Gamepad> _gamepadAddedWrapper;
+	private static readonly StartStopEventWrapper<Gamepad> _gamepadRemovedWrapper;
 
 	static Gamepad()
 	{
-		_gamepadAddedWrapper = new StartStopEventWrapper<EventHandler<Gamepad>>(
+		_gamepadAddedWrapper = new StartStopEventWrapper<Gamepad>(
 			StartGamepadAdded, EndGamepadAdded, _syncLock);
-		_gamepadRemovedWrapper = new StartStopEventWrapper<EventHandler<Gamepad>>(
+		_gamepadRemovedWrapper = new StartStopEventWrapper<Gamepad>(
 			StartGamepadRemoved, EndGamepadRemoved, _syncLock);
 	}
 

--- a/src/Uno.UWP/Helpers/StartStopDelegateWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopDelegateWrapper.cs
@@ -1,0 +1,74 @@
+﻿#nullable enable
+
+using System;
+
+namespace Uno.Helpers
+{
+	/// <summary>
+	/// Creates a wrapper around a generic event, which needs to be synchronized
+	/// and needs to run an action when first subscriber is added and when
+	/// last subscriber is removed. The operations executed when first subscriber
+	/// is added and last subscriber is removed will execute within
+	/// a synchronization lock, so please avoid blocking within the actions.
+	/// </summary>
+	internal class StartStopDelegateWrapper<TDelegate>
+		where TDelegate : Delegate
+	{
+		private readonly object _syncLock;
+		private readonly Action _onFirst;
+		private readonly Action _onLast;
+
+		/// <summary>
+		/// Creates a new instance of start-stop delegate wrapper.
+		/// </summary>
+		/// <param name="onFirst">Action to run when first subscriber is added.
+		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
+		/// <param name="onLast">Action to run when last subscriber is removed.
+		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
+		/// <param name="sharedLock">Optional shared object to lock on (when multiple events
+		/// rely on the same native platform operation.</param>
+		public StartStopDelegateWrapper(
+			Action onFirst,
+			Action onLast,
+			object? sharedLock = null)
+		{
+			_onFirst = onFirst;
+			_onLast = onLast;
+			_syncLock = sharedLock ?? new object();
+		}
+
+		public TDelegate? Event { get; private set; } = null;
+
+		public object SyncLock => _syncLock;
+
+		public void AddHandler(TDelegate handler)
+		{
+			lock (_syncLock)
+			{
+				var firstSubscriber = Event == null;
+				Event = (TDelegate)Delegate.Combine(Event, handler);
+				if (firstSubscriber)
+				{
+					_onFirst();
+				}
+			}
+		}
+
+		public void RemoveHandler(TDelegate handler)
+		{
+			lock (_syncLock)
+			{
+				if (Event != null)
+				{
+					Event = (TDelegate?)Delegate.Remove(Event, handler);
+					if (Event == null)
+					{
+						_onLast();
+					}
+				}
+			}
+		}
+
+		public bool IsActive => Event != null;
+	}
+}

--- a/src/Uno.UWP/Helpers/StartStopDelegateWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopDelegateWrapper.cs
@@ -2,73 +2,89 @@
 
 using System;
 
-namespace Uno.Helpers
+namespace Uno.Helpers;
+
+/// <summary>
+/// Creates a wrapper around a generic event, which needs to be synchronized
+/// and needs to run an action when first subscriber is added and when
+/// last subscriber is removed. The operations executed when first subscriber
+/// is added and last subscriber is removed will execute within
+/// a synchronization lock, so please avoid blocking within the actions.
+/// </summary>
+internal class StartStopDelegateWrapper<TDelegate>
+	where TDelegate : Delegate
 {
+	private readonly object _syncLock;
+	private readonly Action _onFirst;
+	private readonly Action _onLast;
+
 	/// <summary>
-	/// Creates a wrapper around a generic event, which needs to be synchronized
-	/// and needs to run an action when first subscriber is added and when
-	/// last subscriber is removed. The operations executed when first subscriber
-	/// is added and last subscriber is removed will execute within
-	/// a synchronization lock, so please avoid blocking within the actions.
+	/// Creates a new instance of start-stop delegate wrapper.
 	/// </summary>
-	internal class StartStopDelegateWrapper<TDelegate>
-		where TDelegate : Delegate
+	/// <param name="onFirst">Action to run when first subscriber is added.
+	/// This will run within a synchronization lock so it should not involve blocking operations.</param>
+	/// <param name="onLast">Action to run when last subscriber is removed.
+	/// This will run within a synchronization lock so it should not involve blocking operations.</param>
+	/// <param name="sharedLock">Optional shared object to lock on (when multiple events
+	/// rely on the same native platform operation.</param>
+	public StartStopDelegateWrapper(
+		Action onFirst,
+		Action onLast,
+		object? sharedLock = null)
 	{
-		private readonly object _syncLock;
-		private readonly Action _onFirst;
-		private readonly Action _onLast;
+		_onFirst = onFirst;
+		_onLast = onLast;
+		_syncLock = sharedLock ?? new object();
+	}
 
-		/// <summary>
-		/// Creates a new instance of start-stop delegate wrapper.
-		/// </summary>
-		/// <param name="onFirst">Action to run when first subscriber is added.
-		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
-		/// <param name="onLast">Action to run when last subscriber is removed.
-		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
-		/// <param name="sharedLock">Optional shared object to lock on (when multiple events
-		/// rely on the same native platform operation.</param>
-		public StartStopDelegateWrapper(
-			Action onFirst,
-			Action onLast,
-			object? sharedLock = null)
+	/// <summary>
+	/// Backing delegate.
+	/// </summary>
+	public TDelegate? Event { get; private set; }
+
+	/// <summary>
+	/// Indicates if there is at least one active subscription.
+	/// </summary>
+	public bool IsActive => Event != null;
+
+	/// <summary>
+	/// Synchronization lock.
+	/// </summary>
+	public object SyncLock => _syncLock;
+
+	/// <summary>
+	/// Adds a handler.
+	/// </summary>
+	/// <param name="handler">Handler.</param>
+	public void AddHandler(TDelegate handler)
+	{
+		lock (_syncLock)
 		{
-			_onFirst = onFirst;
-			_onLast = onLast;
-			_syncLock = sharedLock ?? new object();
-		}
-
-		public TDelegate? Event { get; private set; } = null;
-
-		public object SyncLock => _syncLock;
-
-		public void AddHandler(TDelegate handler)
-		{
-			lock (_syncLock)
+			var firstSubscriber = Event == null;
+			Event = (TDelegate)Delegate.Combine(Event, handler);
+			if (firstSubscriber)
 			{
-				var firstSubscriber = Event == null;
-				Event = (TDelegate)Delegate.Combine(Event, handler);
-				if (firstSubscriber)
+				_onFirst();
+			}
+		}
+	}
+
+	/// <summary>
+	/// Removes a handler.
+	/// </summary>
+	/// <param name="handler">Handler.</param>
+	public void RemoveHandler(TDelegate handler)
+	{
+		lock (_syncLock)
+		{
+			if (Event != null)
+			{
+				Event = (TDelegate?)Delegate.Remove(Event, handler);
+				if (Event == null)
 				{
-					_onFirst();
+					_onLast();
 				}
 			}
 		}
-
-		public void RemoveHandler(TDelegate handler)
-		{
-			lock (_syncLock)
-			{
-				if (Event != null)
-				{
-					Event = (TDelegate?)Delegate.Remove(Event, handler);
-					if (Event == null)
-					{
-						_onLast();
-					}
-				}
-			}
-		}
-
-		public bool IsActive => Event != null;
 	}
 }

--- a/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
@@ -5,7 +5,7 @@ using System;
 namespace Uno.Helpers;
 
 /// <summary>
-/// Start stop wrapper for EventHandler<T> events.
+/// Start stop wrapper for EventHandler`1 events.
 /// </summary>
 /// <typeparam name="TEventArgs">Event args type.</typeparam>
 internal class StartStopEventWrapper<TEventArgs> : StartStopDelegateWrapper<EventHandler<TEventArgs>>

--- a/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
@@ -70,5 +70,7 @@ namespace Uno.Helpers
 				}
 			}
 		}
+
+		public bool IsActive => Event != null;
 	}
 }

--- a/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopEventWrapper.cs
@@ -2,33 +2,32 @@
 
 using System;
 
-namespace Uno.Helpers
+namespace Uno.Helpers;
+
+/// <summary>
+/// Start stop wrapper for EventHandler<T> events.
+/// </summary>
+/// <typeparam name="TEventArgs">Event args type.</typeparam>
+internal class StartStopEventWrapper<TEventArgs> : StartStopDelegateWrapper<EventHandler<TEventArgs>>
 {
 	/// <summary>
-	/// Start stop wrapper for EventHandler<T> events.
+	/// Creates a new instance of start-stop event wrapper.
 	/// </summary>
-	/// <typeparam name="TEventArgs">Event args type.</typeparam>
-	internal class StartStopEventWrapper<TEventArgs> : StartStopDelegateWrapper<EventHandler<TEventArgs>>
+	/// <param name="onFirst">Action to run when first subscriber is added.
+	/// This will run within a synchronization lock so it should not involve blocking operations.</param>
+	/// <param name="onLast">Action to run when last subscriber is removed.
+	/// This will run within a synchronization lock so it should not involve blocking operations.</param>
+	/// <param name="sharedLock">Optional shared object to lock on (when multiple events
+	/// rely on the same native platform operation.</param>
+	public StartStopEventWrapper(Action onFirst, Action onLast, object? sharedLock = null) :
+		base(onFirst, onLast, sharedLock)
 	{
-		/// <summary>
-		/// Creates a new instance of start-stop event wrapper.
-		/// </summary>
-		/// <param name="onFirst">Action to run when first subscriber is added.
-		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
-		/// <param name="onLast">Action to run when last subscriber is removed.
-		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
-		/// <param name="sharedLock">Optional shared object to lock on (when multiple events
-		/// rely on the same native platform operation.</param>
-		public StartStopEventWrapper(Action onFirst, Action onLast, object? sharedLock = null) :
-			base(onFirst, onLast, sharedLock)
-		{
-		}
-
-		/// <summary>
-		/// Invokes the event.
-		/// </summary>
-		/// <param name="sender">Sender.</param>
-		/// <param name="args">Args.</param>
-		public void Invoke(object sender, TEventArgs args) => Event?.Invoke(sender, args);
 	}
+
+	/// <summary>
+	/// Invokes the event.
+	/// </summary>
+	/// <param name="sender">Sender.</param>
+	/// <param name="args">Args.</param>
+	public void Invoke(object sender, TEventArgs args) => Event?.Invoke(sender, args);
 }

--- a/src/Uno.UWP/Helpers/StartStopTypedEventWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopTypedEventWrapper.cs
@@ -6,9 +6,10 @@ using Windows.Foundation;
 namespace Uno.Helpers;
 
 /// <summary>
-/// Start stop wrapper for TypedEventHandler<T> events.
+/// Start stop wrapper for TypedEventHandler`2 events.
 /// </summary>
-/// <typeparam name="TEventArgs">Event args type.</typeparam>
+/// <typeparam name="TSender">Sender type.</typeparam>
+/// <typeparam name="TResult">Event args type.</typeparam>
 internal class StartStopTypedEventWrapper<TSender, TResult> : StartStopDelegateWrapper<TypedEventHandler<TSender, TResult>>
 {
 	/// <summary>

--- a/src/Uno.UWP/Helpers/StartStopTypedEventWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopTypedEventWrapper.cs
@@ -1,14 +1,15 @@
 ﻿#nullable enable
 
 using System;
+using Windows.Foundation;
 
 namespace Uno.Helpers
 {
 	/// <summary>
-	/// Start stop wrapper for EventHandler<T> events.
+	/// Start stop wrapper for TypedEventHandler<T> events.
 	/// </summary>
 	/// <typeparam name="TEventArgs">Event args type.</typeparam>
-	internal class StartStopEventWrapper<TEventArgs> : StartStopDelegateWrapper<EventHandler<TEventArgs>>
+	internal class StartStopTypedEventWrapper<TSender, TResult> : StartStopDelegateWrapper<TypedEventHandler<TSender, TResult>>
 	{
 		/// <summary>
 		/// Creates a new instance of start-stop event wrapper.
@@ -19,7 +20,7 @@ namespace Uno.Helpers
 		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
 		/// <param name="sharedLock">Optional shared object to lock on (when multiple events
 		/// rely on the same native platform operation.</param>
-		public StartStopEventWrapper(Action onFirst, Action onLast, object? sharedLock = null) :
+		public StartStopTypedEventWrapper(Action onFirst, Action onLast, object? sharedLock = null) :
 			base(onFirst, onLast, sharedLock)
 		{
 		}
@@ -29,6 +30,6 @@ namespace Uno.Helpers
 		/// </summary>
 		/// <param name="sender">Sender.</param>
 		/// <param name="args">Args.</param>
-		public void Invoke(object sender, TEventArgs args) => Event?.Invoke(sender, args);
+		public void Invoke(TSender sender, TResult args) => Event?.Invoke(sender, args);
 	}
 }

--- a/src/Uno.UWP/Helpers/StartStopTypedEventWrapper.cs
+++ b/src/Uno.UWP/Helpers/StartStopTypedEventWrapper.cs
@@ -3,33 +3,32 @@
 using System;
 using Windows.Foundation;
 
-namespace Uno.Helpers
+namespace Uno.Helpers;
+
+/// <summary>
+/// Start stop wrapper for TypedEventHandler<T> events.
+/// </summary>
+/// <typeparam name="TEventArgs">Event args type.</typeparam>
+internal class StartStopTypedEventWrapper<TSender, TResult> : StartStopDelegateWrapper<TypedEventHandler<TSender, TResult>>
 {
 	/// <summary>
-	/// Start stop wrapper for TypedEventHandler<T> events.
+	/// Creates a new instance of start-stop event wrapper.
 	/// </summary>
-	/// <typeparam name="TEventArgs">Event args type.</typeparam>
-	internal class StartStopTypedEventWrapper<TSender, TResult> : StartStopDelegateWrapper<TypedEventHandler<TSender, TResult>>
+	/// <param name="onFirst">Action to run when first subscriber is added.
+	/// This will run within a synchronization lock so it should not involve blocking operations.</param>
+	/// <param name="onLast">Action to run when last subscriber is removed.
+	/// This will run within a synchronization lock so it should not involve blocking operations.</param>
+	/// <param name="sharedLock">Optional shared object to lock on (when multiple events
+	/// rely on the same native platform operation.</param>
+	public StartStopTypedEventWrapper(Action onFirst, Action onLast, object? sharedLock = null) :
+		base(onFirst, onLast, sharedLock)
 	{
-		/// <summary>
-		/// Creates a new instance of start-stop event wrapper.
-		/// </summary>
-		/// <param name="onFirst">Action to run when first subscriber is added.
-		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
-		/// <param name="onLast">Action to run when last subscriber is removed.
-		/// This will run within a synchronization lock so it should not involve blocking operations.</param>
-		/// <param name="sharedLock">Optional shared object to lock on (when multiple events
-		/// rely on the same native platform operation.</param>
-		public StartStopTypedEventWrapper(Action onFirst, Action onLast, object? sharedLock = null) :
-			base(onFirst, onLast, sharedLock)
-		{
-		}
-
-		/// <summary>
-		/// Invokes the event.
-		/// </summary>
-		/// <param name="sender">Sender.</param>
-		/// <param name="args">Args.</param>
-		public void Invoke(TSender sender, TResult args) => Event?.Invoke(sender, args);
 	}
+
+	/// <summary>
+	/// Invokes the event.
+	/// </summary>
+	/// <param name="sender">Sender.</param>
+	/// <param name="args">Args.</param>
+	public void Invoke(TSender sender, TResult args) => Event?.Invoke(sender, args);
 }

--- a/src/Uno.UWP/Networking/Connectivity/NetworkInformation.cs
+++ b/src/Uno.UWP/Networking/Connectivity/NetworkInformation.cs
@@ -11,7 +11,7 @@ namespace Windows.Networking.Connectivity;
 /// </summary>
 public static partial class NetworkInformation
 {
-	private static StartStopEventWrapper<NetworkStatusChangedEventHandler> _networkStatusChanged;
+	private static StartStopDelegateWrapper<NetworkStatusChangedEventHandler> _networkStatusChanged;
 
 	static NetworkInformation()
 	{

--- a/src/Uno.UWP/System/Power/PowerManager.cs
+++ b/src/Uno.UWP/System/Power/PowerManager.cs
@@ -24,14 +24,14 @@ public static partial class PowerManager
 	private static EnergySaverStatus? _lastEnergySaverStatus;
 #endif
 
-	private readonly static StartStopEventWrapper<EventHandler<object>> _powerSupplyStatusChanged;
-	private readonly static StartStopEventWrapper<EventHandler<object>> _remainingChargePercentChanged;
-	private readonly static StartStopEventWrapper<EventHandler<object>> _batteryStatusChanged;
+	private readonly static StartStopEventWrapper<object> _powerSupplyStatusChanged;
+	private readonly static StartStopEventWrapper<object> _remainingChargePercentChanged;
+	private readonly static StartStopEventWrapper<object> _batteryStatusChanged;
 #if __WASM__
-	private readonly static StartStopEventWrapper<EventHandler<object>> _remainingDischargeTimeChanged;
+	private readonly static StartStopEventWrapper<object> _remainingDischargeTimeChanged;
 #endif
 #if !__WASM__
-	private readonly static StartStopEventWrapper<EventHandler<object>> _energySaverStatusChanged;
+	private readonly static StartStopEventWrapper<object> _energySaverStatusChanged;
 #endif
 
 	static PowerManager()


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Each sensor class has its own implementation of event start/stop management.


## What is the new behavior?

Using shared start/stop infrastructure, which is covered by tests.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.