### PR TITLE
fix(WPF): Also use WPF for net47

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
@@ -36,13 +36,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="PresentationFramework" />
-		<Reference Include="PresentationCore" />
-		<Reference Include="WindowsBase" />
-		<Reference Include="System.Xaml" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <ProjectReference Include="..\Uno.Foundation\Uno.Foundation.Skia.csproj" TreatAsPackageReference="false" PrivateAssets="all" />
 	  <ProjectReference Include="..\Uno.UI\Uno.UI.Skia.csproj" />
 	  <ProjectReference Include="..\Uno.UWP\Uno.Skia.csproj" TreatAsPackageReference="false" PrivateAssets="all" />

--- a/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
@@ -19,7 +19,7 @@
 		<PackageId Condition="'$(UNO_UWP_BUILD)'!='true'">Uno.WinUI.Runtime.Skia.Wpf</PackageId>
 	
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
-		<UseWPF Condition="'$(TargetFramework)'=='netcoreapp3.1' or '$(TargetFramework)'=='net5.0-windows'">true</UseWPF>
+		<UseWPF>true</UseWPF>
 
 		<!-- 9.0 to work around a VS 2019 build issue -->
 		<LangVersion>9.0</LangVersion>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6842

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix

## What is the current behavior?

`WpfHost` `xaml` styles are not included in .NET Framework assemblies.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

.NET Framework support seemed to have much less attention from Uno Platform maintainers long ago, since .NET Core 3.1 support [was added](https://github.com/unoplatform/uno/commit/e2d4eb209a5dece76eed28b0c01e8956ffe9f403). [At that time](https://github.com/unoplatform/uno/tree/4f02e17310a2af1d18bd7707aaa7ad4d00d6e60d/src/Uno.UI.Runtime.Skia.Wpf), there weren't much support for WPF, and no `xaml` files were used, and directly referencing WPF assemblies seemed enough for .NET Framework.

Way after .NET core support was the `TextBox` support, but at that time, nobody seemed to spare any thought for .NET Framework anymore, and while .NET Core builds and works properly, .NET Framework was left behind.

## What is the new behavior?

`WpfHost` `xaml` styles should be included in .NET Framework `Uno.UI.Runtime.Skia.Wpf` assemblies.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
