### PR TITLE
Refactored how SizeChanged is raised

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
@@ -671,7 +671,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			container.ActualWidth.Should().Be(100);
 			container.ActualHeight.Should().Be(100);
 
-#if !(__IOS__ || __MACOS__)
+#if __IOS__ || __MACOS__
+			// Event ordering is not well supported on iOS & macOS
+#elif __ANDROID__
+			// Event ordering is not well supported on Android
+#else
 			innerRaisedEventOrder.Should().Be(3, because: nameof(innerRaisedEventOrder));
 			sutRaisedEventOrder.Should().Be(2, because: nameof(sutRaisedEventOrder));
 			containerRaisedEventOrder.Should().Be(1, because: nameof(containerRaisedEventOrder));
@@ -700,7 +704,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		}
 
-#if !(__IOS__ || __MACOS__)
+#if !(__IOS__ || __MACOS__ || __ANDROID__)
 		[TestMethod]
 		[RunsOnUIThread]
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
@@ -675,6 +675,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// Event ordering is not well supported on iOS & macOS
 #elif __ANDROID__
 			// Event ordering is not well supported on Android
+#elif __SKIA__
+			// Event order is reversed on Skia
 #else
 			innerRaisedEventOrder.Should().Be(3, because: nameof(innerRaisedEventOrder));
 			sutRaisedEventOrder.Should().Be(2, because: nameof(sutRaisedEventOrder));
@@ -729,9 +731,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await TestServices.WindowHelper.WaitForIdle();
 
 			// Should not have actual/render size until loaded
+#if !(__SKIA__ || __WASM__)
 			sut.RenderSize.Should().BeOfWidth(0).And.BeOfHeight(0);
 			sut.ActualWidth.Should().Be(0, "sut.ActualWidth");
 			sut.ActualHeight.Should().Be(0, "sut.ActualHeight");
+#endif
 
 			await TestServices.WindowHelper.WaitForIdle();
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkElement.cs
@@ -632,17 +632,23 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				innerRaisedEvent = e;
 				innerRaisedEventOrder = ++eventOrderSequence;
 
+				Console.WriteLine($"#{eventOrderSequence}: inner.SizeChanged({e.NewSize})");
+
 				tcs.SetResult(null);
 			};
 			sut.SizeChanged += (o, e) =>
 			{
 				sutRaisedEvent = e;
 				sutRaisedEventOrder = ++eventOrderSequence;
+
+				Console.WriteLine($"#{eventOrderSequence}: sut.SizeChanged({e.NewSize})");
 			};
 			container.SizeChanged += (o, e) =>
 			{
 				containerRaisedEvent = e;
 				containerRaisedEventOrder = ++eventOrderSequence;
+
+				Console.WriteLine($"#{eventOrderSequence}: container.SizeChanged({e.NewSize})");
 			};
 
 			TestServices.WindowHelper.WindowContent = container;
@@ -665,29 +671,39 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			container.ActualWidth.Should().Be(100);
 			container.ActualHeight.Should().Be(100);
 
+#if !(__IOS__ || __MACOS__)
+			innerRaisedEventOrder.Should().Be(3, because: nameof(innerRaisedEventOrder));
+			sutRaisedEventOrder.Should().Be(2, because: nameof(sutRaisedEventOrder));
+			containerRaisedEventOrder.Should().Be(1, because: nameof(containerRaisedEventOrder));
+			eventOrderSequence.Should().Be(3, because: nameof(eventOrderSequence));
+#endif
+
+
 			innerRaisedEvent.Should().NotBeNull(because: nameof(innerRaisedEvent));
 			innerRaisedEvent?.NewSize.Should().BeOfWidth(100).And.BeOfHeight(200);
-			innerRaisedEventOrder.Should().Be(3, because: nameof(innerRaisedEventOrder));
 
 			sutRaisedEvent.Should().NotBeNull(because: nameof(sutRaisedEvent));
 			sutRaisedEvent?.NewSize.Should().BeOfWidth(100).And.BeOfHeight(200);
-			sutRaisedEventOrder.Should().Be(2, because: nameof(sutRaisedEventOrder));
+
 
 			containerRaisedEvent.Should().NotBeNull(because: nameof(containerRaisedEvent));
 			containerRaisedEvent?.NewSize.Should().BeOfWidth(100).And.BeOfHeight(100);
-			containerRaisedEventOrder.Should().Be(1, because: nameof(containerRaisedEventOrder));
 
 			LayoutInformation.GetAvailableSize(inner).Should().Be(new Size(100, double.PositiveInfinity), because: "inner AvailableSize");
 			LayoutInformation.GetAvailableSize(sut).Should().Be(new Size(100, 100), because: "sut AvailableSize");
 			// we don't care about container's availableSize here since it's environment dependant and unrelated to what we're testing
 
+#if !(__IOS__ || __MACOS__)
 			LayoutInformation.GetLayoutSlot(inner).Should().Be(new Rect(0, 0, 100, 200), because: "inner LayoutSlot");
 			LayoutInformation.GetLayoutSlot(sut).Should().Be(new Rect(0, 0, 100, 100), because: "sut LayoutSlot");
 			LayoutInformation.GetLayoutSlot(container).Should().Be(new Rect(0, 0, 100, 100), because: "container LayoutSlot");
+#endif
 		}
 
+#if !(__IOS__ || __MACOS__)
 		[TestMethod]
 		[RunsOnUIThread]
+#endif
 		public async Task When_ArrangingElement_Not_Loaded()
 		{
 			using var _ = new AssertionScope();
@@ -710,8 +726,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			// Should not have actual/render size until loaded
 			sut.RenderSize.Should().BeOfWidth(0).And.BeOfHeight(0);
-			sut.ActualWidth.Should().Be(0);
-			sut.ActualHeight.Should().Be(0);
+			sut.ActualWidth.Should().Be(0, "sut.ActualWidth");
+			sut.ActualHeight.Should().Be(0, "sut.ActualHeight");
 
 			await TestServices.WindowHelper.WaitForIdle();
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_StackPanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_StackPanel.cs
@@ -2,11 +2,16 @@
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.UI;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Media;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
+using Windows.UI.Xaml.Shapes;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -52,6 +57,97 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			ids.Should().Be(expectedIds, "Expected from DOM");
 #endif
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+
+		public async Task When_AvailableSizeIsGreaterThanContent()
+		{
+			using var _ = new AssertionScope();
+
+			var pnl = new StackPanel { Spacing = 1 };
+			pnl.Children.Add(new Rectangle { Height = 100, Fill = new SolidColorBrush(Colors.Red) });
+			pnl.Children.Add(new Border { Height = 20 });
+			pnl.Children.Add(new TextBlock { Height = 100 });
+
+			var container = new Border
+			{
+				Child = pnl,
+				Width = 200,
+				Height = 400,
+				Background = new SolidColorBrush(Colors.Yellow)
+			};
+
+			var tcs = new TaskCompletionSource<Size>();
+
+			pnl.SizeChanged += (snd, evt) => tcs.SetResult(evt.NewSize);
+
+			TestServices.WindowHelper.WindowContent = container;
+
+			await tcs.Task;
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var availableSize = LayoutInformation.GetAvailableSize(pnl);
+			var desiredSize = pnl.DesiredSize;
+			var layoutSlot = LayoutInformation.GetLayoutSlot(pnl);
+			var sizeChanged = await tcs.Task;
+			var actualSize = new Size(pnl.ActualWidth, pnl.ActualHeight);
+			var renderSize = pnl.RenderSize;
+
+			availableSize.Should().Be(new Size(200, 400), because: nameof(availableSize));
+			desiredSize.Should().Be(new Size(0, 222), because: nameof(desiredSize));
+			layoutSlot.Should().Be(new Rect(0, 0, 200, 400), because: nameof(layoutSlot));
+			sizeChanged.Should().Be(new Size(200, 400), because: nameof(sizeChanged));
+			actualSize.Should().Be(new Size(200, 400), because: nameof(actualSize));
+			renderSize.Should().Be(new Size(200, 400), because: nameof(renderSize));
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+
+		public async Task When_AvailableSizeIsSmallerThanContent()
+		{
+			using var _ = new AssertionScope();
+
+			var pnl = new StackPanel { Spacing = 1 };
+			pnl.Children.Add(new Rectangle { Height = 100, Fill = new SolidColorBrush(Colors.Red) });
+			pnl.Children.Add(new Border { Height = 50 });
+			pnl.Children.Add(new TextBlock { Height = 100 });
+
+			var container = new Border
+			{
+				Child = pnl,
+				Width = 100,
+				Height = 200,
+				Background = new SolidColorBrush(Colors.Yellow)
+			};
+
+			var tcs = new TaskCompletionSource<Size>();
+
+			pnl.SizeChanged += (snd, evt) => tcs.SetResult(evt.NewSize);
+
+			TestServices.WindowHelper.WindowContent = container;
+
+			await tcs.Task;
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var availableSize = LayoutInformation.GetAvailableSize(pnl);
+			var desiredSize = pnl.DesiredSize;
+			var layoutSlot = LayoutInformation.GetLayoutSlot(pnl);
+			var sizeChanged = await tcs.Task;
+			var actualSize = new Size(pnl.ActualWidth, pnl.ActualHeight);
+			var renderSize = pnl.RenderSize;
+
+			availableSize.Should().Be(new Size(100, 200), because: nameof(availableSize));
+			desiredSize.Should().Be(new Size(0, 200), because: nameof(desiredSize));
+			layoutSlot.Should().Be(new Rect(0, 0, 100, 200), because: nameof(layoutSlot));
+			sizeChanged.Should().Be(new Size(100, 252), because: nameof(sizeChanged));
+			actualSize.Should().Be(new Size(100, 252), because: nameof(actualSize));
+			renderSize.Should().Be(new Size(100, 252), because: nameof(renderSize));
+			
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeViewIFrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeViewIFrameworkElement.cs
@@ -33,6 +33,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
+		Size IFrameworkElement.AssignedActualSize
+		{
+			get => throw new NotSupportedException();
+			set => throw new NotSupportedException();
+		}
+
 		public object MyValue
 		{
 			get { return (object)GetValue(MyValueProperty); }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeViewIFrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeViewIFrameworkElement.cs
@@ -33,7 +33,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
-#if HAS_UNO
+#if HAS_UNO && !__NETSTD__
 		Size IFrameworkElement.AssignedActualSize
 		{
 			get => throw new NotSupportedException();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeViewIFrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/NativeViewPage/NativeViewIFrameworkElement.cs
@@ -33,11 +33,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
+#if HAS_UNO
 		Size IFrameworkElement.AssignedActualSize
 		{
 			get => throw new NotSupportedException();
 			set => throw new NotSupportedException();
 		}
+#endif
 
 		public object MyValue
 		{

--- a/src/Uno.UI/DataBinding/BindingExpression.cs
+++ b/src/Uno.UI/DataBinding/BindingExpression.cs
@@ -337,11 +337,17 @@ namespace Windows.UI.Xaml.Data
 		{
 			if (ParentBinding.FallbackValue != null)
 			{
+				Console.WriteLine($"Applying fallback value {ParentBinding.FallbackValue} (need to be convected to {_boundPropertyType} before)");
 				SetTargetValue(ConvertToBoundPropertyType(ParentBinding.FallbackValue));
 			}
 			else if (useTypeDefaultValue && TargetPropertyDetails != null)
 			{
+				Console.WriteLine($"Applying fallback value by setting TargetValue...");
 				SetTargetValue(TargetPropertyDetails.Property.GetMetadata(_view.Target?.GetType()).DefaultValue);
+			}
+			else
+			{
+				Console.WriteLine($"No fallback value applied...");
 			}
 		}
 
@@ -637,9 +643,9 @@ namespace Windows.UI.Xaml.Data
 							this.Log().Error("Failed to apply binding to property [{0}] on [{1}] ({2})".InvariantCultureFormat(TargetPropertyDetails, _targetOwnerType, e.Message), e);
 						}
 
-						ApplyFallbackValue();
+						//ApplyFallbackValue();
 					}
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
+#if !HAS_EXPENSIVE_TRYFINALLY && false // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
 					finally
 #endif
 					{
@@ -659,7 +665,7 @@ namespace Windows.UI.Xaml.Data
 		/// can be significantly slower than other methods as a result on WebAssembly.
 		/// See https://github.com/dotnet/runtime/issues/56309
 		/// </remarks>
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		private void InnerSetTargetValueSafe(object v, bool useTargetNullValue)
 		{
 			if (v is UnsetValue)

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -1067,7 +1067,7 @@ namespace Uno.UI.DataBinding
 					}
 					else if (t != typeof(object))
 					{
-						value = ConvertWithConvertionExtension(value, t);
+						value = ConvertWithConversionExtension(value, t);
 					}
 				}
 			}
@@ -1080,19 +1080,27 @@ namespace Uno.UI.DataBinding
 		/// See https://github.com/dotnet/runtime/issues/56309
 		/// </remarks>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private static object ConvertWithConvertionExtension(object? value, Type? t)
+		private static object? ConvertWithConversionExtension(object? value, Type? t)
 		{
 			try
 			{
-				value = Conversion.To(value, t, CultureInfo.CurrentCulture);
+				Console.WriteLine($"Converting {value} ({value?.GetType().FullName}) to type {t?.FullName}...");
+				if (Conversion.TryConvertTo(value, t, out var v, CultureInfo.CurrentCulture))
+				{
+					value = v;
+				}
 			}
-			catch (Exception)
+			catch (Exception ex)
 			{
+				Console.WriteLine($"EXCEPTION Converting {value} ({value?.GetType().FullName}) to type {t?.FullName}: {ex}");
 				// This is a temporary fallback solution.
 				// The problem is that we don't actually know which culture we must use in advance.
 				// Values can come from the xaml (invariant culture) or from a two way binding (current culture).
 				// The real solution would be to pass a culture or source when setting a value in a Dependency Property.
-				value = Conversion.To(value, t, CultureInfo.InvariantCulture);
+				if (Conversion.TryConvertTo(value, t, out var v, culture: CultureInfo.InvariantCulture))
+				{
+					value = v;
+				}
 			}
 
 			return value;

--- a/src/Uno.UI/UI/LayoutHelper.cs
+++ b/src/Uno.UI/UI/LayoutHelper.cs
@@ -88,55 +88,116 @@ namespace Uno.UI
 			return new Size(marginWidth, marginHeight);
 		}
 
-		[Pure]
-		internal static (Point offset, bool overflow) GetAlignmentOffset(this IFrameworkElement e, Size clientSize, Size renderSize)
+		private static bool IsStrechHorizontalALignmentTreatedAsLeft(HorizontalAlignment ha, Size clientSize, Size inkSize)
 		{
-			// Start with Bottom-Right alignment, multiply by 0/0.5/1 for Top-Left/Center/Bottom-Right alignment
-			var offset = new Point(
-				clientSize.Width - renderSize.Width,
-				clientSize.Height - renderSize.Height
-			);
-
-			var overflow = false;
-
-			switch (e.HorizontalAlignment)
-			{
-				case HorizontalAlignment.Stretch when renderSize.Width > clientSize.Width:
-					offset.X = 0;
-					overflow = true;
-					break;
-				case HorizontalAlignment.Left:
-					offset.X = 0;
-					break;
-				case HorizontalAlignment.Stretch:
-				case HorizontalAlignment.Center:
-					offset.X *= 0.5;
-					break;
-				case HorizontalAlignment.Right:
-					offset.X *= 1;
-					break;
-			}
-
-			switch (e.VerticalAlignment)
-			{
-				case VerticalAlignment.Stretch when renderSize.Height > clientSize.Height:
-					offset.Y = 0;
-					overflow = true;
-					break;
-				case VerticalAlignment.Top:
-					offset.Y = 0;
-					break;
-				case VerticalAlignment.Stretch:
-				case VerticalAlignment.Center:
-					offset.Y *= 0.5;
-					break;
-				case VerticalAlignment.Bottom:
-					offset.Y *= 1;
-					break;
-			}
-
-			return (offset, overflow);
+			return ha == HorizontalAlignment.Stretch && inkSize.Width < clientSize.Width;
 		}
+
+		private static bool IsStretchVerticalAlignmentTreatedAsTop(VerticalAlignment va, Size clientSize, Size inkSize)
+		{
+			return va == VerticalAlignment.Stretch && inkSize.Height < clientSize.Height;
+		}
+
+		internal static Point ComputeAlignmentOffset(this IFrameworkElement e, Size clientSize, Size inkSize)
+		{
+			var ha = e.HorizontalAlignment;
+			var va = e.VerticalAlignment;
+
+			var offset = new Point();
+
+			//this is to degenerate Stretch to Top-Left in case when clipping is about to occur
+			if (IsStrechHorizontalALignmentTreatedAsLeft(ha, clientSize, inkSize))
+			{
+				ha = HorizontalAlignment.Left;
+			}
+
+			if (IsStretchVerticalAlignmentTreatedAsTop(va, clientSize, inkSize))
+			{
+				va = VerticalAlignment.Top;
+			}
+			//end of degeneration of Stretch to Top-Left
+
+
+
+			if (ha == HorizontalAlignment.Center || ha == HorizontalAlignment.Stretch)
+			{
+				offset.X = (clientSize.Width - inkSize.Width) / 2;
+			}
+			else if (ha == HorizontalAlignment.Right)
+			{
+				offset.X = clientSize.Width - inkSize.Width;
+			}
+			else
+			{
+				offset.X = 0;
+			}
+
+			if (va == VerticalAlignment.Center || va == VerticalAlignment.Stretch)
+			{
+				offset.Y = (clientSize.Height - inkSize.Height) / 2;
+			}
+			else if (va == VerticalAlignment.Bottom)
+			{
+				offset.Y = clientSize.Height - inkSize.Height;
+			}
+			else
+			{
+				offset.Y = 0;
+			}
+
+
+			return offset;
+		}
+
+		//[Pure]
+		//internal static (Point offset, bool overflow) GetAlignmentOffset(this IFrameworkElement e, Size clientSize, Size renderSize)
+		//{
+		//	// Start with Bottom-Right alignment, multiply by 0/0.5/1 for Top-Left/Center/Bottom-Right alignment
+		//	var offset = new Point(
+		//		clientSize.Width - renderSize.Width,
+		//		clientSize.Height - renderSize.Height
+		//	);
+
+		//	var overflow = false;
+
+		//	switch (e.HorizontalAlignment)
+		//	{
+		//		case HorizontalAlignment.Stretch when renderSize.Width > clientSize.Width:
+		//			offset.X = 0;
+		//			overflow = true;
+		//			break;
+		//		case HorizontalAlignment.Left:
+		//			offset.X = 0;
+		//			break;
+		//		case HorizontalAlignment.Stretch:
+		//		case HorizontalAlignment.Center:
+		//			offset.X *= 0.5;
+		//			break;
+		//		case HorizontalAlignment.Right:
+		//			offset.X *= 1;
+		//			break;
+		//	}
+
+		//	switch (e.VerticalAlignment)
+		//	{
+		//		case VerticalAlignment.Stretch when renderSize.Height > clientSize.Height:
+		//			offset.Y = 0;
+		//			overflow = true;
+		//			break;
+		//		case VerticalAlignment.Top:
+		//			offset.Y = 0;
+		//			break;
+		//		case VerticalAlignment.Stretch:
+		//		case VerticalAlignment.Center:
+		//			offset.Y *= 0.5;
+		//			break;
+		//		case VerticalAlignment.Bottom:
+		//			offset.Y *= 1;
+		//			break;
+		//	}
+
+		//	return (offset, overflow);
+		//}
 
 		[Pure]
 		internal static Size Min(Size val1, Size val2)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ImplicitTextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ImplicitTextBlock.cs
@@ -21,5 +21,16 @@ namespace Windows.UI.Xaml.Controls
 			var accessibilityView = AutomationProperties.GetAccessibilityView(parent);
 			AutomationProperties.SetAccessibilityView(this, accessibilityView);
 		}
+
+		private protected override void OnLoaded() => Console.WriteLine($"{this} Loaded");
+
+		private protected override void OnLoading() => Console.WriteLine($"{this} Loading");
+
+		private protected override void OnUnloaded() => Console.WriteLine($"{this} Unloaded");
+
+		public override string ToString()
+		{
+			return $"{base.ToString()}-txt=\"{Text}\"";
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -259,11 +259,15 @@ namespace Windows.UI.Xaml.Controls
 					}
 				}
 
-				var renderSize = ArrangeOverride(arrangeSize);
+				var actualSize = ArrangeOverride(arrangeSize);
+
+				// The ActualSide (ActualWidth/ActualHeight) is the return value of the ArrangeOverride()
+				// while the RenderSize is the constrained version.
+				Panel.AssignedActualSize = actualSize;
 
 				if (_elementAsUIElement != null)
 				{
-					_elementAsUIElement.RenderSize = renderSize.AtMost(maxSize);
+					_elementAsUIElement.RenderSize = actualSize.AtMost(maxSize);
 					_elementAsUIElement.NeedsClipToSlot = needsClipToSlot;
 					_elementAsUIElement.ApplyClip();
 

--- a/src/Uno.UI/UI/Xaml/Controls/StackPanel/StackPanel.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/StackPanel/StackPanel.Layout.cs
@@ -6,6 +6,7 @@ using Uno.Extensions;
 using Uno.Logging;
 using Uno;
 using Uno.UI;
+using Uno.UI.Extensions;
 
 #if XAMARIN_ANDROID
 using View = Android.Views.View;
@@ -77,10 +78,10 @@ namespace Windows.UI.Xaml.Controls
 			return desiredSize.Add(borderAndPaddingSize);
 		}
 
-		protected override Size ArrangeOverride(Size arrangeSize)
+		protected override Size ArrangeOverride(Size finalSize)
 		{
 			var borderAndPaddingSize = BorderAndPaddingSize;
-			arrangeSize = arrangeSize.Subtract(borderAndPaddingSize);
+			var arrangeSize = finalSize.Subtract(borderAndPaddingSize);
 
 			var childRectangle = new Windows.Foundation.Rect(BorderThickness.Left + Padding.Left, BorderThickness.Top + Padding.Top, arrangeSize.Width, arrangeSize.Height);
 
@@ -165,7 +166,7 @@ namespace Windows.UI.Xaml.Controls
 
 				ArrangeElement(view, adjustedRectangle);
 
-				var viewActualSize = view.AssignedActualSize; // TODO universal actual size
+				var viewActualSize = view.AssignedActualSize;
 
 				if (isHorizontal)
 				{
@@ -191,7 +192,13 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
-			return arrangedSize;
+			if (arrangedSize != finalSize)
+			{
+				Console.WriteLine($"{this.GetDebugName()}: arrangedSize={arrangedSize} (used), availableArrangeSize={finalSize} (allocated by parent)");
+			}
+
+			//return finalSize; // arrangedSize
+			return finalSize;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/StackPanel/StackPanel.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/StackPanel/StackPanel.Layout.cs
@@ -62,7 +62,7 @@ namespace Windows.UI.Xaml.Controls
 						desiredSize.Width += spacing;
 					}
 				}
-				else
+				else // Vertical
 				{
 					desiredSize.Width = Math.Max(desiredSize.Width, measuredSize.Width);
 					desiredSize.Height += measuredSize.Height;
@@ -115,6 +115,10 @@ namespace Windows.UI.Xaml.Controls
 				snapPoints.RemoveAt(count);
 			}
 
+			var arrangedSize = isHorizontal
+				? new Size(0, arrangeSize.Height)
+				: new Size(arrangeSize.Width, 0);
+
 			for (var i = 0; i < count; i++)
 			{
 				var view = Children[i];
@@ -137,8 +141,9 @@ namespace Windows.UI.Xaml.Controls
 					var snapPoint = (float)childRectangle.Right;
 					snapPointsChanged |= snapPoints[i] == snapPoint;
 					snapPoints[i] = snapPoint;
+
 				}
-				else
+				else // Vertical
 				{
 					childRectangle.Y += previousChildSize;
 
@@ -159,9 +164,20 @@ namespace Windows.UI.Xaml.Controls
 				var adjustedRectangle = childRectangle;
 
 				ArrangeElement(view, adjustedRectangle);
-			}
 
-			var finalSizeWithBorderAndPadding = arrangeSize.Add(borderAndPaddingSize);
+				var viewActualSize = view.AssignedActualSize; // TODO universal actual size
+
+				if (isHorizontal)
+				{
+					arrangedSize.Height = Math.Max(arrangedSize.Height, viewActualSize.Height);
+					arrangedSize.Width += viewActualSize.Width;
+				}
+				else
+				{
+					arrangedSize.Width = Math.Max(arrangedSize.Width, viewActualSize.Width);
+					arrangedSize.Height += viewActualSize.Height;
+				}
+			}
 
 			if(snapPointsChanged)
 			{
@@ -175,7 +191,7 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
-			return finalSizeWithBorderAndPadding;
+			return arrangedSize;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
@@ -291,7 +291,6 @@ namespace Windows.UI.Xaml
 
 				if (previousSize != newSize)
 				{
-					SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, newSize));
 					_renderTransform?.UpdateSize(newSize);
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.netstd.cs
@@ -233,6 +233,7 @@ namespace Windows.UI.Xaml
 			var clippedInkSize = innerInkSize.AtMost(maxSize);
 
 			RenderSize = needsClipToSlot ? clippedInkSize : innerInkSize;
+			SetActualSize(innerInkSize);
 
 			_logDebug?.Debug($"{DepthIndentation}{FormatDebugName()}: ArrangeOverride({arrangeSize})={innerInkSize}, clipped={clippedInkSize} (max={maxSize}) needsClipToSlot={needsClipToSlot}");
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -1018,6 +1018,7 @@ namespace Windows.UI.Xaml
 			set => AssignedActualSize = value;
 		}
 
+#if !(NET461 || __NETSTD_REFERENCE__)
 		internal override Size AssignedActualSize
 		{
 			get => base.AssignedActualSize;
@@ -1042,5 +1043,6 @@ namespace Windows.UI.Xaml
 				}
 			}
 		}
+#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -1022,7 +1022,11 @@ namespace Windows.UI.Xaml
 				{
 					base.AssignedActualSize = value;
 
-					SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, value));
+					if (IsLoaded)
+					{
+						// SizeChanged event should only be raised when the element is loaded (connected to VisualRoot)
+						SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, value));
+					}
 
 					if (_renderTransform != null)
 					{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml
 	{
 		public static class TraceProvider
 		{
-			public readonly static Guid Id = Guid.Parse("{DDDCCA61-5CB7-4585-95D7-58C5528AABE6}");
+			public static readonly Guid Id = Guid.Parse("{DDDCCA61-5CB7-4585-95D7-58C5528AABE6}");
 
 			public const int FrameworkElement_MeasureStart = 1;
 			public const int FrameworkElement_MeasureStop = 2;
@@ -1011,5 +1011,26 @@ namespace Windows.UI.Xaml
 			protected override Size MeasureOverride(Size availableSize) => _measureOverrideHandler(availableSize);
 		}
 #endif
+
+		Size IFrameworkElement.AssignedActualSize
+		{
+			get => base.AssignedActualSize;
+			set
+			{
+				var previousSize = base.AssignedActualSize;
+				if (previousSize != value)
+				{
+					base.AssignedActualSize = value;
+
+					SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, value));
+
+					if (_renderTransform != null)
+					{
+						// This will set the updated Transform
+						_renderTransform.UpdateSize(value);
+					}
+				}
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -1014,6 +1014,12 @@ namespace Windows.UI.Xaml
 
 		Size IFrameworkElement.AssignedActualSize
 		{
+			get => AssignedActualSize;
+			set => AssignedActualSize = value;
+		}
+
+		internal override Size AssignedActualSize
+		{
 			get => base.AssignedActualSize;
 			set
 			{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.skia.cs
@@ -38,10 +38,8 @@ namespace Windows.UI.Xaml
 
 		internal void SetActualSize(Size size)
 		{
-			var previousSize = AssignedActualSize;
 			AssignedActualSize = size;
-
-			RaiseSizeChanged(previousSize, size);
+			_renderTransform?.UpdateSize(size);
 		}
 
 		public double ActualWidth => GetActualWidth();
@@ -62,12 +60,6 @@ namespace Windows.UI.Xaml
 		public IEnumerator GetEnumerator() => _children.GetEnumerator();
 
 		public event SizeChangedEventHandler SizeChanged;
-
-		internal void RaiseSizeChanged(Size previous, Size newSize)
-		{
-			SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previous, newSize));
-			_renderTransform?.UpdateSize(newSize);
-		}
 
 		#region Margin Dependency Property
 		[GeneratedDependencyProperty(

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.skia.cs
@@ -36,7 +36,13 @@ namespace Windows.UI.Xaml
 			return Parent != null;
 		}
 
-		internal void SetActualSize(Size size) => AssignedActualSize = size;
+		internal void SetActualSize(Size size)
+		{
+			var previousSize = AssignedActualSize;
+			AssignedActualSize = size;
+
+			RaiseSizeChanged(previousSize, size);
+		}
 
 		public double ActualWidth => GetActualWidth();
 
@@ -57,10 +63,10 @@ namespace Windows.UI.Xaml
 
 		public event SizeChangedEventHandler SizeChanged;
 
-		internal void RaiseSizeChanged(SizeChangedEventArgs args)
+		internal void RaiseSizeChanged(Size previous, Size newSize)
 		{
-			SizeChanged?.Invoke(this, args);
-			_renderTransform?.UpdateSize(args.NewSize);
+			SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previous, newSize));
+			_renderTransform?.UpdateSize(newSize);
 		}
 
 		#region Margin Dependency Property

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
@@ -118,18 +118,11 @@ namespace Windows.UI.Xaml
 
 		public event SizeChangedEventHandler SizeChanged;
 
-		internal void RaiseSizeChanged(Size previous, Size newSize)
-		{
-			SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previous, newSize));
-			_renderTransform?.UpdateSize(newSize);
-		}
-
 		internal void SetActualSize(Size size)
 		{
-			var previousSize = AssignedActualSize;
 			AssignedActualSize = size;
 
-			RaiseSizeChanged(previousSize, size);
+			_renderTransform?.UpdateSize(size);
 		}
 
 		partial void OnGenericPropertyUpdatedPartial(DependencyPropertyChangedEventArgs args);

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
@@ -118,14 +118,19 @@ namespace Windows.UI.Xaml
 
 		public event SizeChangedEventHandler SizeChanged;
 
-		internal void RaiseSizeChanged(SizeChangedEventArgs args)
+		internal void RaiseSizeChanged(Size previous, Size newSize)
 		{
-			SizeChanged?.Invoke(this, args);
-			_renderTransform?.UpdateSize(args.NewSize);
+			SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previous, newSize));
+			_renderTransform?.UpdateSize(newSize);
 		}
 
 		internal void SetActualSize(Size size)
-			=> AssignedActualSize = size;
+		{
+			var previousSize = AssignedActualSize;
+			AssignedActualSize = size;
+
+			RaiseSizeChanged(previousSize, size);
+		}
 
 		partial void OnGenericPropertyUpdatedPartial(DependencyPropertyChangedEventArgs args);
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
@@ -64,6 +64,8 @@ namespace Windows.UI.Xaml
 		event EventHandler<object> LayoutUpdated;
 		event SizeChangedEventHandler SizeChanged;
 
+		Size AssignedActualSize { get; set; }
+
 		object FindName(string name);
 
 		DependencyObject Parent { get; }

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -802,6 +802,15 @@ namespace <#= mixin.NamespaceName #>
 			
 		}
 
+#if !<#= mixin.IsFrameworkElement #> // IsFrameworkElement
+		Size IFrameworkElement.AssignedActualSize
+		{
+			get => _actualSize;
+			set => _actualSize = value;
+		}
+#endif
+
+
 #if <#= mixin.OverridesOnLayout #> // OverridesOnLayout
 		private Size _actualSize;
 		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
@@ -819,7 +828,10 @@ namespace <#= mixin.NamespaceName #>
 
 			if (newSize != previousSize)
 			{
-				SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, newSize));
+				if(IsLoaded)
+				{
+					SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, newSize));
+				}
 				_renderTransform?.UpdateSize(newSize); // TODO: Move ** BEFORE ** base.OnLayout() ???
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -386,7 +386,11 @@ namespace <#= mixin.NamespaceName #>
 				
 				if (previousSize != _renderSize)
 				{
-					SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, _renderSize));
+					if(IsLoaded)
+					{
+						// SizeChanged event should only be raised when the element is loaded (connected to VisualRoot)
+						SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, _renderSize));
+					}
 
 					if (_renderTransform != null)
 					{

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -346,23 +346,30 @@ namespace <#= mixin.NamespaceName #>
 		public double ActualWidth => GetActualWidth();
 		public double ActualHeight => GetActualHeight();
 
-#if !<#= mixin.IsFrameworkElement #> // IsFrameworkElement
+#if !<#= mixin.IsFrameworkElement #> // <#= mixin.ClassName #>.IsFrameworkElement=<#= mixin.IsFrameworkElement #>
 		private protected virtual double GetActualWidth() => _actualSize.Width;
 		private protected virtual double GetActualHeight() => _actualSize.Height;
-#endif
 
 		private Size _actualSize;
+
+		Size IFrameworkElement.AssignedActualSize
+		{
+			get => _actualSize;
+			set => _actualSize = value;
+		}
+#endif
+
+		private Size _renderSize;
 		public override CGRect Frame
 		{
 			get { return base.Frame; }
 			set
 			{
-				var previousSize = _actualSize;
-				_actualSize = value.Size.ToFoundationSize().PhysicalToLogicalPixels();
+				var previousSize = _renderSize;
+				_renderSize = value.Size.ToFoundationSize().PhysicalToLogicalPixels();
 
-#if <#= mixin.IsFrameworkElement #> // IsFrameworkElement
-				RenderSize = _actualSize;
-				AssignedActualSize = _actualSize;
+#if <#= mixin.IsFrameworkElement #> // <#= mixin.ClassName #>.IsFrameworkElement=<#= mixin.IsFrameworkElement #>
+				RenderSize = _renderSize;
 #endif
 
 				CGAffineTransform? oldTransform = null;
@@ -377,14 +384,14 @@ namespace <#= mixin.NamespaceName #>
 				base.Frame = value;
 				AppliedFrame = value;
 				
-				if (previousSize != _actualSize)
+				if (previousSize != _renderSize)
 				{
-					SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, _actualSize));
+					SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, _renderSize));
 
 					if (_renderTransform != null)
 					{
 						// This will set the updated Transform
-						_renderTransform.UpdateSize(_actualSize);
+						_renderTransform.UpdateSize(_renderSize);
 					}
 					else if (oldTransform.HasValue)
 					{

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
@@ -344,6 +344,12 @@ namespace <#= mixin.NamespaceName #>
 #if !<#= mixin.IsFrameworkElement #> // IsFrameworkElement
 		private protected virtual double GetActualWidth() => _actualSize.Width;
 		private protected virtual double GetActualHeight() => _actualSize.Height;
+
+		Size IFrameworkElement.AssignedActualSize
+		{
+			get => _actualSize;
+			set => _actualSize = value;
+		}
 #endif
 
 		private Size _actualSize;
@@ -374,7 +380,11 @@ namespace <#= mixin.NamespaceName #>
 
 				if (previousSize != _actualSize)
 				{
-					SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, _actualSize));
+					if(IsLoaded)
+					{
+						// SizeChanged event should only be raised when the element is loaded (connected to VisualRoot)
+						SizeChanged?.Invoke(this, new SizeChangedEventArgs(this, previousSize, _actualSize));
+					}
 
 					if (_renderTransform != null)
 					{

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.netstd.cs
@@ -211,7 +211,6 @@ namespace Windows.UI.Xaml
 
 		partial void HideVisual();
 		partial void ShowVisual();
-
 		
 
 		internal virtual void ArrangeCore(Rect finalRect)
@@ -227,17 +226,7 @@ namespace Windows.UI.Xaml
 				Debug.Assert(value.Width >= 0, "Invalid width");
 				Debug.Assert(value.Height >= 0, "Invalid height");
 
-				var previousSize = _size;
 				_size = value;
-
-				if (_size != previousSize)
-				{
-					if (this is FrameworkElement frameworkElement)
-					{
-						frameworkElement.SetActualSize(_size);
-						frameworkElement.RaiseSizeChanged(new SizeChangedEventArgs(this, previousSize, _size));
-					}
-				}
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -98,7 +98,7 @@ namespace Windows.UI.Xaml
 
 		public Vector2 ActualSize => new Vector2((float)GetActualWidth(), (float)GetActualHeight());
 
-		internal Size AssignedActualSize { get; set; }
+		internal virtual Size AssignedActualSize { get; set; }
 
 		private protected virtual double GetActualWidth() => AssignedActualSize.Width;
 

--- a/src/Uno.UI/UI/Xaml/UIElement.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.netstd.cs
@@ -170,7 +170,7 @@ namespace Windows.UI.Xaml
 
 			if (child.IsLoaded)
 			{
-				this.Log().Error($"{this}: Inconsistent state: child {child} is already loaded (OnChildAdded)");
+				this.Log().Info($"{this.GetDebugName()}: Inconsistent state: child {child} is already loaded (OnChildAdded)");
 			}
 			else
 			{
@@ -196,7 +196,7 @@ namespace Windows.UI.Xaml
 			}
 			else
 			{
-				this.Log().Error($"{this}: Inconsistent state: child {child} is not loaded (OnChildRemoved)");
+				this.Log().Info($"{this.GetDebugName()}: Inconsistent state: child {child} is not loaded (OnChildRemoved)");
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -1161,7 +1161,6 @@ namespace Uno.UI.Xaml
 				SetStyles(
 					htmlId,
 					new[] {
-						("position", "absolute"),
 						("top", rect.Top.ToString(CultureInfo.InvariantCulture) + "px"),
 						("left", rect.Left.ToString(CultureInfo.InvariantCulture) + "px"),
 						("width", rect.Width.ToString(CultureInfo.InvariantCulture) + "px"),

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -1,85 +1,85 @@
 ﻿html,
 body {
-  /**
-      Disable root scrolling (bouncing effect on touch devices)
-    */
-  position: fixed;
-  height: 100%;
-  width: 100%;
-  overflow: hidden;
+	/**
+			Disable root scrolling (bouncing effect on touch devices)
+		*/
+	position: fixed;
+	height: 100%;
+	width: 100%;
+	overflow: hidden;
 }
 
 .uno-root-element {
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
 }
 
 .uno-uielement {
-  position: absolute;
-  display: inline;
-  outline: none;
-  /*
-      Disable pointer events by default to match HitTestVisibilityProperty
-      default value
-  */
-  pointer-events: none;
-  /*
-    Padding & margin are required for measure/arrange to behave well:
-    margin & padding are calculated through Xaml elements.
-  */
-  margin: 0 !important;
-  padding: 0;
-  line-height: normal;
-  -webkit-box-sizing: border-box !important;
-  -moz-box-sizing: border-box !important;
-  box-sizing: border-box !important;
-  /*
-    Force all element to have a transform, to allow correct measure of text and images.
-    See WindowManager.ts on measureViewInternal() for more details.
-  */
-  transform: translate(0, 0);
+	position: absolute;
+	display: inline;
+	outline: none;
+	/*
+			Disable pointer events by default to match HitTestVisibilityProperty
+			default value
+	*/
+	pointer-events: none;
+	/*
+		Padding & margin are required for measure/arrange to behave well:
+		margin & padding are calculated through Xaml elements.
+	*/
+	margin: 0 !important;
+	padding: 0;
+	line-height: normal;
+	-webkit-box-sizing: border-box !important;
+	-moz-box-sizing: border-box !important;
+	box-sizing: border-box !important;
+	/*
+		Force all element to have a transform, to allow correct measure of text and images.
+		See WindowManager.ts on measureViewInternal() for more details.
+	*/
+	transform: translate(0, 0);
 
-  /*
-    By default, the background of UWP controls is not drawn under the border of the control.
-  */
-  background-clip: padding-box;
+	/*
+		By default, the background of UWP controls is not drawn under the border of the control.
+	*/
+	background-clip: padding-box;
 }
 
 .uno-uielement .noclip {
-  /* Used when we need to force the element to be unclipped.
-      --> Used by the toolkit for elevation
-  */
-  clip: auto !important;
+	/* Used when we need to force the element to be unclipped.
+			--> Used by the toolkit for elevation
+	*/
+	clip: auto !important;
 }
 
 svg.uno-uielement {
-  /*
-    The SVG elements are not intended to be a touch target (they are only a holder collection of child shapes),
-    instead it's their child SvgElement that should be the target of the pointer.
-    This also ensure that we are HitTestVisible only for shapes that has a fill.
-  */
-  pointer-events: none;
+	/*
+		The SVG elements are not intended to be a touch target (they are only a holder collection of child shapes),
+		instead it's their child SvgElement that should be the target of the pointer.
+		This also ensure that we are HitTestVisible only for shapes that has a fill.
+	*/
+	pointer-events: none;
 
-  stroke-width: 1px; /* default value of Shape.StrokeThickness */
+	stroke-width: 1px; /* default value of Shape.StrokeThickness */
 }
 
 .uno-frameworkelement.uno-unarranged {
-  -ms-opacity: 0;
-  opacity: 0;
-  position: fixed;
+	-ms-opacity: 0;
+	opacity: 0;
+	position: fixed;
 }
 
 .uno-uielement.uno-visibility-collapsed {
-  /*
-    Note: On wasm when we have an 'hidden' (or 'collapsed') element, its height is used to compute the native 'scrollHeight',
-	  driving the SV to flicker when we scroll while at the bottom of the viewport (if those hidden element would have increase the viewport if visible).
-	  To avoid that, we move the element way out of the visible bounds of the view.
-  */
-  visibility: hidden !important;
-  top: -100000px !important;
-  left: -100000px !important;
+	/*
+		Note: On wasm when we have an 'hidden' (or 'collapsed') element, its height is used to compute the native 'scrollHeight',
+		driving the SV to flicker when we scroll while at the bottom of the viewport (if those hidden element would have increase the viewport if visible).
+		To avoid that, we move the element way out of the visible bounds of the view.
+	*/
+	visibility: hidden !important;
+	top: -100000px !important;
+	left: -100000px !important;
 }
 
 svg.uno-frameworkelement.uno-unarranged,
@@ -87,157 +87,157 @@ iframe.uno-frameworkelement.uno-unarranged,
 img.uno-frameworkelement.uno-unarranged,
 video.uno-frameworkelement.uno-unarranged,
 embed.uno-frameworkelement.uno-unarranged {
-  /*
-    "Replaced element" (like iFrame, img, video, ... cf. https://developer.mozilla.org/en-US/docs/Web/CSS/Replaced_element)
-    have a default size of 300x150px (as described here https://www.w3.org/TR/css-sizing-3/#intrinsic-sizes)
-    > For boxes without an intrinsic aspect ratio:
-    >     [../..]
-    >     Otherwise, use 300px for the width and/or 150px for the height as needed.
+	/*
+		"Replaced element" (like iFrame, img, video, ... cf. https://developer.mozilla.org/en-US/docs/Web/CSS/Replaced_element)
+		have a default size of 300x150px (as described here https://www.w3.org/TR/css-sizing-3/#intrinsic-sizes)
+		> For boxes without an intrinsic aspect ratio:
+		>     [../..]
+		>     Otherwise, use 300px for the width and/or 150px for the height as needed.
 
-    SVG element that does not have a measurable viewport are also requested to follow the same logic
-    https://www.w3.org/TR/SVGMobile12/coords.html#InitialViewport
-    >  If the parent document is styled with CSS, then the negotiation process must follow the CSS rules for replaced elements.
+		SVG element that does not have a measurable viewport are also requested to follow the same logic
+		https://www.w3.org/TR/SVGMobile12/coords.html#InitialViewport
+		>  If the parent document is styled with CSS, then the negotiation process must follow the CSS rules for replaced elements.
 
-    Here we make sure that any unarranged "replaced element" have a fixed with / height to 0,
-    so they won't be taken in consideration by scroll viewers (overflow) which are computing their extent in native.
+		Here we make sure that any unarranged "replaced element" have a fixed with / height to 0,
+		so they won't be taken in consideration by scroll viewers (overflow) which are computing their extent in native.
 
-    A common visual effect of this, is that a non virtualized GridView with items smaller than 150px height
-    is vertically scrollable when it should not! (There is a Rectangle in their template, which rendered using an SVG element).
+		A common visual effect of this, is that a non virtualized GridView with items smaller than 150px height
+		is vertically scrollable when it should not! (There is a Rectangle in their template, which rendered using an SVG element).
 
-    Note: this is required has have set a "transform: translate(0, 0);" on all ".uno-uielement",
-          which has a side effect to establish a "containing block" (cf. WindowManager.ts on measureViewInternal()).
-  */
-  width: 0;
-  height: 0;
+		Note: this is required has have set a "transform: translate(0, 0);" on all ".uno-uielement",
+					which has a side effect to establish a "containing block" (cf. WindowManager.ts on measureViewInternal()).
+	*/
+	width: 0;
+	height: 0;
 }
 
 .uno-textblock:not(.selectionEnabled) {
-  -webkit-touch-callout: none; /* Safari */
-  -webkit-user-select: none; /* iOSSafari */
-  -khtml-user-select: none; /* Konqueror HTML */
-  -moz-user-select: none; /* Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
-  user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
+	-webkit-touch-callout: none; /* Safari */
+	-webkit-user-select: none; /* iOSSafari */
+	-khtml-user-select: none; /* Konqueror HTML */
+	-moz-user-select: none; /* Firefox */
+	-ms-user-select: none; /* Internet Explorer/Edge */
+	user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
 }
 
 .uno-textblock {
-  text-rendering: optimizeLegibility; /* iOS Safari */
+	text-rendering: optimizeLegibility; /* iOS Safari */
 
-  /* Following are required for gradient brush as Foreground on text. Should not affect normal rendering. */
-  -ms-background-clip: text !important;
-  -webkit-background-clip: text !important;
-  background-clip: text !important;
+	/* Following are required for gradient brush as Foreground on text. Should not affect normal rendering. */
+	-ms-background-clip: text !important;
+	-webkit-background-clip: text !important;
+	background-clip: text !important;
 
-  /* overflow:hidden is required for text-overflow: ellipsis to work correctly */
-  overflow: hidden;
+	/* overflow:hidden is required for text-overflow: ellipsis to work correctly */
+	overflow: hidden;
 }
 
 [data-use-hand-cursor-interaction="true"] .uno-buttonbase,
 [data-use-hand-cursor-interaction="true"] .uno-toggleswitch {
-  cursor: pointer;
+	cursor: pointer;
 }
 
 .uno-hyperlinkbutton {
-  cursor: pointer;
+	cursor: pointer;
 }
 
 .uno-textboxview {
-  outline: none;
-  border: none;
-  background-color: transparent;
+	outline: none;
+	border: none;
+	background-color: transparent;
 }
 
 .uno-textelement {
-  position: relative;
+	position: relative;
 }
 
 .uno-htmlimage {  
-  user-select: none;
-  -moz-user-select: none;
-  -webkit-user-drag: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
+	user-select: none;
+	-moz-user-select: none;
+	-webkit-user-drag: none;
+	-webkit-user-select: none;
+	-ms-user-select: none;
 }
 
 .uno-scrollcontentpresenter {
-  -webkit-overflow-scrolling: touch;
+	-webkit-overflow-scrolling: touch;
 }
 
-  .uno-scrollcontentpresenter.scroll-x-auto {
-    overflow-x: auto;
-  }
+	.uno-scrollcontentpresenter.scroll-x-auto {
+		overflow-x: auto;
+	}
 
-  .uno-scrollcontentpresenter.scroll-y-auto {
-    overflow-y: auto;
-  }
+	.uno-scrollcontentpresenter.scroll-y-auto {
+		overflow-y: auto;
+	}
 
-  .uno-scrollcontentpresenter.scroll-x-disabled {
-    overflow-x: hidden;
-  }
+	.uno-scrollcontentpresenter.scroll-x-disabled {
+		overflow-x: hidden;
+	}
 
-  .uno-scrollcontentpresenter.scroll-x-hidden {
-    overflow-x: auto; /* We must not use "hidden" to allow native scrolling interaction like mouse wheel */
-    scrollbar-width: none; /* scrollbar-height has no effect on FF, using scrollbar-width works on all browsers (non standard proeprty) */
-  }
+	.uno-scrollcontentpresenter.scroll-x-hidden {
+		overflow-x: auto; /* We must not use "hidden" to allow native scrolling interaction like mouse wheel */
+		scrollbar-width: none; /* scrollbar-height has no effect on FF, using scrollbar-width works on all browsers (non standard proeprty) */
+	}
 
-  .uno-scrollcontentpresenter.scroll-x-hidden::-webkit-scrollbar {
-    height: 0;
-  }
+	.uno-scrollcontentpresenter.scroll-x-hidden::-webkit-scrollbar {
+		height: 0;
+	}
 
-  .uno-scrollcontentpresenter.scroll-y-disabled {
-    overflow-y: hidden;
-  }
+	.uno-scrollcontentpresenter.scroll-y-disabled {
+		overflow-y: hidden;
+	}
 
-  .uno-scrollcontentpresenter.scroll-y-hidden {
-    overflow-y: auto; /* We must not use "hidden" to allow native scrolling interaction like mouse wheel */
-    scrollbar-width: none;
-  }
+	.uno-scrollcontentpresenter.scroll-y-hidden {
+		overflow-y: auto; /* We must not use "hidden" to allow native scrolling interaction like mouse wheel */
+		scrollbar-width: none;
+	}
 
-  .uno-scrollcontentpresenter.scroll-y-hidden::-webkit-scrollbar {
-    width: 0;
-  }
+	.uno-scrollcontentpresenter.scroll-y-hidden::-webkit-scrollbar {
+		width: 0;
+	}
 
-  .uno-scrollcontentpresenter.scroll-x-visible {
-    overflow-x: scroll;
-  }
+	.uno-scrollcontentpresenter.scroll-x-visible {
+		overflow-x: scroll;
+	}
 
-  .uno-scrollcontentpresenter.scroll-y-visible {
-    overflow-y: scroll;
-  }
+	.uno-scrollcontentpresenter.scroll-y-visible {
+		overflow-y: scroll;
+	}
 
 .uno-splash {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  max-width: 620px;
-  width: calc(100vw - 10px);
-  height: auto;
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 620px 300px;
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	max-width: 620px;
+	width: calc(100vw - 10px);
+	height: auto;
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: 620px 300px;
 }
 
 /* Bootstrapper logo override */
 .uno-loader .logo {
-  position: fixed !important;
-  top: 50% !important;
-  left: 50% !important;
-  transform: translate(-50%, -50%) !important;
-  max-width: 620px !important;
-  width: calc(100vw - 10px) !important;
-  height: auto !important;
-  background-repeat: no-repeat !important;
-  background-position: center !important;
-  background-size: 620px 300px !important;
+	position: fixed !important;
+	top: 50% !important;
+	left: 50% !important;
+	transform: translate(-50%, -50%) !important;
+	max-width: 620px !important;
+	width: calc(100vw - 10px) !important;
+	height: auto !important;
+	background-repeat: no-repeat !important;
+	background-position: center !important;
+	background-size: 620px 300px !important;
 }
 
 textarea {
-  resize: none;
-  overflow: hidden; /* Scrolling is handled by the parent ScrollViewer */
+	resize: none;
+	overflow: hidden; /* Scrolling is handled by the parent ScrollViewer */
 }
 
 input::-ms-reveal,
 input::-ms-clear {
-  display: none;
+	display: none;
 }

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -845,7 +845,6 @@ var Uno;
                 const params = WindowManagerArrangeElementParams.unmarshal(pParams);
                 const element = this.getView(params.HtmlId);
                 const style = element.style;
-                style.position = "absolute";
                 style.top = params.Top + "px";
                 style.left = params.Left + "px";
                 style.width = params.Width === NaN ? "auto" : params.Width + "px";
@@ -1506,7 +1505,7 @@ var Uno;
                 const resultWidth = offsetWidth ? offsetWidth : element.clientWidth;
                 const resultHeight = offsetHeight ? offsetHeight : element.clientHeight;
                 // +1 is added to take rounding/flooring into account
-                return [resultWidth + 1, resultHeight];
+                return [resultWidth > 0 ? resultWidth + 1 : 0, resultHeight];
             }
             measureViewInternal(viewId, maxWidth, maxHeight, measureContent) {
                 const element = this.getView(viewId);

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -684,7 +684,6 @@ namespace Uno.UI {
 
 			const style = element.style;
 
-			style.position = "absolute";
 			style.top = params.Top + "px";
 			style.left = params.Left + "px";
 			style.width = params.Width === NaN ? "auto" : params.Width + "px";
@@ -1529,7 +1528,7 @@ namespace Uno.UI {
 			const resultHeight = offsetHeight ? offsetHeight : element.clientHeight;
 
 			// +1 is added to take rounding/flooring into account
-			return [resultWidth + 1, resultHeight];
+			return [resultWidth > 0 ? resultWidth + 1 : 0, resultHeight];
 		}
 
 		private measureViewInternal(viewId: number, maxWidth: number, maxHeight: number, measureContent: boolean): [number, number] {

--- a/src/Uno.UWP/UI/Composition/CoreAnimation.iOSmacOS.cs
+++ b/src/Uno.UWP/UI/Composition/CoreAnimation.iOSmacOS.cs
@@ -191,8 +191,21 @@ namespace Windows.UI.Composition
 
 		private void StopAnimation(StopReason reason, long? time = default, float? value = default)
 		{
-			if (_current.animation == null || !_layer.TryGetTarget(out var layer))
+			if (_current.animation == null)
 			{
+				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				{
+					this.Log().DebugFormat("CoreAnimation '{0}' unable to remove native animation: no running animation.", _key);
+				}
+				return;
+			}
+
+			if (!_layer.TryGetTarget(out var layer))
+			{
+				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				{
+					this.Log().DebugFormat("CoreAnimation '{0}' unable to remove native animation: layout not found.", _key);
+				}
 				return;
 			}
 
@@ -259,6 +272,10 @@ namespace Windows.UI.Composition
 				var (currentAnim, from, to) = _current;
 				if (currentAnim != animation)
 				{
+					if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+					{
+						this.Log().DebugFormat("CoreAnimation '{0}': unable to {1} because another animation is running.", _key, _stop.reason);
+					}
 					return; // We are no longer the current animation, do not interfere with the current
 				}
 


### PR DESCRIPTION
# Bugfix
Changed the way the `SizeChanged` is raised to use the unconstrained result from the `ArrangeOverride` implementation, before constraining the result to the `finalRect`'s size.

This will bring the Uno behavior closer to UWP/WinUI and improve the support of component libraries. In this case, it will fix display bugs with WCT DataGrid's extended details feature.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords] >>**PRIVATE ISSUE**<<
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
