### PR TITLE
fix: GridViewItems are not visible

### DIFF
--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/GridViewItem_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/GridViewItem_themeresources.xaml
@@ -63,7 +63,9 @@
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 
-    <Style TargetType="GridViewItem" BasedOn="{StaticResource DefaultGridViewItemStyle}" />
+    <!--UNO TODO: ListViewItemPresenter isn't supported https://github.com/unoplatform/uno/issues/1444 -->
+    <!-- <Style TargetType="GridViewItem" BasedOn="{StaticResource DefaultGridViewItemStyle}" /> -->
+    <Style TargetType="GridViewItem" BasedOn="{StaticResource GridViewItemExpanded}" />
 
     <Style x:Key="DefaultGridViewItemStyle" TargetType="GridViewItem">
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />

--- a/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
+++ b/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
@@ -9380,7 +9380,7 @@
       </Setter.Value>
     </Setter>
   </Style>
-  <Style TargetType="GridViewItem" BasedOn="{StaticResource DefaultGridViewItemStyle}" />
+  <Style TargetType="GridViewItem" BasedOn="{StaticResource GridViewItemExpanded}" />
   <Thickness x:Key="RichEditBoxTopHeaderMargin">0,0,0,8</Thickness>
   <Style TargetType="RichEditBox" BasedOn="{StaticResource DefaultRichEditBoxStyle}" />
   <Style x:Key="DefaultRichEditBoxStyle" TargetType="RichEditBox">


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7146 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`GridViewItems` are not visible.

## What is the new behavior?

Are visible again, reverted the WinUI 2.6 style using `ListViewItemPresenter` and using `GridViewItemExpanded` style instead.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.