### PR TITLE
fix(xbind): x:bind may not be evaluated if x:Load is true during Loading

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -5611,6 +5611,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 												using (writer.BlockInvariant($"if (sender.IsMaterialized)"))
 												{
 													writer.AppendLineInvariant($"that.Bindings.UpdateResources();");
+
+													using (writer.BlockInvariant($"if (!that.IsLoaded)"))
+													{
+														// Refresh the bindings explicitly as the target is not yet loaded, but the
+														// x:Load value has already changed. In this case, the unloaded block registration below
+														// won't be called because the control was not loaded.
+														writer.AppendLineInvariant($"that.Bindings.Update();");
+													}
 												}
 											}
 										}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_Initial.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_Initial.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.When_xLoad_xBind_xLoad_Initial"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<Grid x:Name="topLevel" x:Load="{x:Bind IsLoad()}" x:FieldModifier="public">
+		<TextBlock x:Name="tb01" x:FieldModifier="public" Tag="{x:Bind Model.MyValue, Mode=OneWay}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_Initial.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_Initial.xaml.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_xBind_xLoad_Initial : UserControl
+	{
+		public When_xLoad_xBind_xLoad_Initial()
+		{
+			Model = new When_xLoad_xBind_xLoad_Initial_ViewModel();
+			this.InitializeComponent();
+		}
+
+		public bool IsLoad() => true;
+
+		public When_xLoad_xBind_xLoad_Initial_ViewModel Model {  get; set; }
+	}
+
+	public class When_xLoad_xBind_xLoad_Initial_ViewModel : System.ComponentModel.INotifyPropertyChanged
+	{
+		private int myValue = 1;
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		public int MyValue
+		{
+			get => myValue; set
+			{
+				myValue = value;
+
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs("MyValue"));
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -66,6 +66,23 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			Assert.AreEqual(1, When_xLoad_Visibility_While_Materializing_Content.Instances);
 		}
 
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_xLoad_xBind_xLoad_Initial()
+		{
+			var grid = new Grid();
+			TestServices.WindowHelper.WindowContent = grid;
+
+			var SUT = new When_xLoad_xBind_xLoad_Initial();
+			grid.Children.Add(SUT);
+
+			Assert.IsNotNull(SUT.tb01);
+			Assert.AreEqual(1, SUT.tb01.Tag);
+
+			SUT.Model.MyValue = 42;
+
+			Assert.AreEqual(42, SUT.tb01.Tag);
+		}
 	}
 }
 #endif

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_Initial.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_Initial.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_xLoad_xBind_xLoad_Initial"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<Grid x:Name="topLevel" x:Load="{x:Bind IsLoad()}" x:FieldModifier="public">
+		<TextBlock x:Name="tb01" x:FieldModifier="public" Tag="{x:Bind Model.MyValue, Mode=OneWay}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_Initial.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_Initial.xaml.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_xBind_xLoad_Initial : UserControl
+	{
+		public When_xLoad_xBind_xLoad_Initial()
+		{
+			Model = new When_xLoad_xBind_xLoad_Initial_ViewModel();
+			this.InitializeComponent();
+		}
+
+		public bool IsLoad() => true;
+
+		public When_xLoad_xBind_xLoad_Initial_ViewModel Model {  get; set; }
+	}
+
+	public class When_xLoad_xBind_xLoad_Initial_ViewModel : System.ComponentModel.INotifyPropertyChanged
+	{
+		private int myValue = 1;
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		public int MyValue
+		{
+			get => myValue; set
+			{
+				myValue = value;
+
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs("MyValue"));
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Uno.UI.Tests.Windows_UI_Xaml.Controls;
 using Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -1053,7 +1054,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 			var SUT = new Binding_xLoad_Setter();
 
 			SUT.ForceLoaded();
-
+			
 			Assert.IsNull(SUT.ellipse);
 			Assert.IsNotNull(SUT.square);
 			Assert.AreEqual(4, SUT.square.StrokeThickness);
@@ -1107,6 +1108,24 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 			AssertIsNullAsync(() => SUT.square);
 			Assert.AreEqual(4, SUT.ellipse.StrokeThickness);
 		}
+
+		[TestMethod]
+		public async Task When_xLoad_xBind_xLoad_Initial()
+		{
+			var grid = new Grid();
+			grid.ForceLoaded();
+
+			var SUT = new When_xLoad_xBind_xLoad_Initial();
+			grid.Children.Add(SUT);
+
+			Assert.IsNotNull(SUT.tb01);
+			Assert.AreEqual(1, SUT.tb01.Tag);
+
+			SUT.Model.MyValue = 42;
+
+			Assert.AreEqual(42, SUT.tb01.Tag);
+		}
+
 
 		[TestMethod]
 		public async Task When_Binding_xNull()


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/7161

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`x:Bind` evaluation is performed explicitly if the control being swapped is not yet loaded.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
