### PR TITLE
fix: Duration cast in Fluent theme

### DIFF
--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/Priority01/Common_themeresources_any.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/Priority01/Common_themeresources_any.xaml
@@ -705,4 +705,9 @@
     <x:String x:Key="ControlFastAnimationAfterDuration">00:00:00.168</x:String>
     <x:String x:Key="ControlFasterAnimationDuration">00:00:00.083</x:String>
 
+    <!-- Uno specific: Custom resources using Duration type explicitly to avoid cast issues caused by #7168. -->
+    <x:Duration x:Key="UnoControlNormalAnimationDuration">00:00:00.250</x:Duration>
+    <x:Duration x:Key="UnoControlFastAnimationDuration">00:00:00.167</x:Duration>
+    <x:Duration x:Key="UnoControlFastAnimationAfterDuration">00:00:00.168</x:Duration>
+    <x:Duration x:Key="UnoControlFasterAnimationDuration">00:00:00.083</x:Duration>
 </ResourceDictionary>

--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/CommandBarFlyout_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/CommandBarFlyout_themeresources.xaml
@@ -1,4 +1,5 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Uno specific: All occurrences of GeneratedDuration="{StaticResource ...}" use a custom resource to avoid issues caused by #7168 -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -839,16 +840,16 @@
                                  so we'll include dummy empty storyboards to get CommandBar to do what we want. -->
                             <VisualStateGroup x:Name="DisplayModeStates">
                                 <VisualStateGroup.Transitions>
-                                    <VisualTransition From="CompactClosed" To="CompactOpenUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="CompactClosed" To="CompactOpenUp" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard />
                                     </VisualTransition>
-                                    <VisualTransition From="CompactOpenUp" To="CompactClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="CompactOpenUp" To="CompactClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard />
                                     </VisualTransition>
-                                    <VisualTransition From="CompactClosed" To="CompactOpenDown" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="CompactClosed" To="CompactOpenDown" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard />
                                     </VisualTransition>
-                                    <VisualTransition From="CompactOpenDown" To="CompactClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="CompactOpenDown" To="CompactClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard />
                                     </VisualTransition>
                                 </VisualStateGroup.Transitions>
@@ -858,7 +859,7 @@
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="ExpansionStates">
                                 <VisualStateGroup.Transitions>
-                                    <VisualTransition From="Collapsed" To="ExpandedUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="Collapsed" To="ExpandedUp" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard x:Name="CollapsedToExpandedUp">
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Width">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" />
@@ -902,7 +903,7 @@
                                             </ObjectAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="ExpandedUp" To="Collapsed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="ExpandedUp" To="Collapsed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard x:Name="ExpandedUpToCollapsed" FillBehavior="Stop">
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Width">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" />
@@ -935,7 +936,7 @@
                                             </ObjectAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="Collapsed" To="ExpandedDown" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="Collapsed" To="ExpandedDown" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard x:Name="CollapsedToExpandedDown">
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Width">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" />
@@ -976,7 +977,7 @@
                                             </ObjectAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="ExpandedDown" To="Collapsed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="ExpandedDown" To="Collapsed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard x:Name="ExpandedDownToCollapsed" FillBehavior="Stop">
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Width">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" />
@@ -1050,7 +1051,7 @@
                             </VisualStateGroup>
                             <VisualStateGroup>
                                 <VisualStateGroup.Transitions>
-                                    <VisualTransition From="Default" To="ExpandedUpWithPrimaryCommands" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="Default" To="ExpandedUpWithPrimaryCommands" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SecondaryItemsControl" Storyboard.TargetProperty="BorderThickness">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarFlyoutBorderUpThemeThickness}" />
@@ -1078,7 +1079,7 @@
                                             </contract7Present:ObjectAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="Default" To="ExpandedDownWithPrimaryCommands" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="Default" To="ExpandedDownWithPrimaryCommands" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SecondaryItemsControl" Storyboard.TargetProperty="BorderThickness">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarFlyoutBorderDownThemeThickness}" />
@@ -1106,7 +1107,7 @@
                                             </contract7Present:ObjectAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="ExpandedUpWithPrimaryCommands" To="Default" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="ExpandedUpWithPrimaryCommands" To="Default" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SecondaryItemsControl" Storyboard.TargetProperty="BorderThickness">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarFlyoutBorderUpThemeThickness}" />
@@ -1142,7 +1143,7 @@
                                             </contract7Present:ObjectAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="ExpandedDownWithPrimaryCommands" To="Default" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="ExpandedDownWithPrimaryCommands" To="Default" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SecondaryItemsControl" Storyboard.TargetProperty="BorderThickness">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarFlyoutBorderDownThemeThickness}" />

--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/CommandBar_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/CommandBar_themeresources.xaml
@@ -1,4 +1,5 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Uno specific: All occurrences of GeneratedDuration="{StaticResource ...}" use a custom resource to avoid issues caused by #7168 -->
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:contract4Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,4)"
   xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,6)"
@@ -142,7 +143,7 @@
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="DisplayModeStates">
                                 <contract8Present:VisualStateGroup.Transitions>
-                                    <VisualTransition From="CompactClosed" To="CompactOpenUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="CompactClosed" To="CompactOpenUp" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Background">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarBackgroundOpen}" />
@@ -185,7 +186,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="CompactOpenUp" To="CompactClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="CompactOpenUp" To="CompactClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />
@@ -217,7 +218,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="CompactClosed" To="CompactOpenDown" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="CompactClosed" To="CompactOpenDown" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Background">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarBackgroundOpen}" />
@@ -254,7 +255,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="CompactOpenDown" To="CompactClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="CompactOpenDown" To="CompactClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />
@@ -280,7 +281,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="MinimalClosed" To="MinimalOpenUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="MinimalClosed" To="MinimalOpenUp" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="Padding">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="14,11,14,0" />
@@ -328,7 +329,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="MinimalOpenUp" To="MinimalClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="MinimalOpenUp" To="MinimalClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="Padding">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="14,11,14,0" />
@@ -377,7 +378,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="MinimalClosed" To="MinimalOpenDown" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="MinimalClosed" To="MinimalOpenDown" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="Padding">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="14,11,14,0" />
@@ -416,7 +417,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="MinimalOpenDown" To="MinimalClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="MinimalOpenDown" To="MinimalClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="Padding">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="14,11,14,0" />
@@ -456,7 +457,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="HiddenClosed" To="HiddenOpenUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="HiddenClosed" To="HiddenOpenUp" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />
@@ -490,7 +491,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="HiddenOpenUp" To="HiddenClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="HiddenOpenUp" To="HiddenClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />
@@ -525,7 +526,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="HiddenClosed" To="HiddenOpenDown" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                                    <VisualTransition From="HiddenClosed" To="HiddenOpenDown" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />
@@ -550,7 +551,7 @@
                                             </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="HiddenOpenDown" To="HiddenClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                                    <VisualTransition From="HiddenOpenDown" To="HiddenClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                                         <Storyboard>
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />

--- a/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
+++ b/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
@@ -5675,6 +5675,10 @@
   <x:String x:Key="ControlFastAnimationDuration">00:00:00.167</x:String>
   <x:String x:Key="ControlFastAnimationAfterDuration">00:00:00.168</x:String>
   <x:String x:Key="ControlFasterAnimationDuration">00:00:00.083</x:String>
+  <x:Duration x:Key="UnoControlNormalAnimationDuration">00:00:00.250</x:Duration>
+  <x:Duration x:Key="UnoControlFastAnimationDuration">00:00:00.167</x:Duration>
+  <x:Duration x:Key="UnoControlFastAnimationAfterDuration">00:00:00.168</x:Duration>
+  <x:Duration x:Key="UnoControlFasterAnimationDuration">00:00:00.083</x:Duration>
   <primitives:CornerRadiusFilterConverter x:Key="TopCornerRadiusFilterConverter" Filter="Top" />
   <primitives:CornerRadiusFilterConverter x:Key="RightCornerRadiusFilterConverter" Filter="Right" />
   <primitives:CornerRadiusFilterConverter x:Key="BottomCornerRadiusFilterConverter" Filter="Bottom" />
@@ -13811,16 +13815,16 @@
                                  so we'll include dummy empty storyboards to get CommandBar to do what we want. -->
               <VisualStateGroup x:Name="DisplayModeStates">
                 <VisualStateGroup.Transitions>
-                  <VisualTransition From="CompactClosed" To="CompactOpenUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="CompactClosed" To="CompactOpenUp" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard />
                   </VisualTransition>
-                  <VisualTransition From="CompactOpenUp" To="CompactClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="CompactOpenUp" To="CompactClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard />
                   </VisualTransition>
-                  <VisualTransition From="CompactClosed" To="CompactOpenDown" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="CompactClosed" To="CompactOpenDown" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard />
                   </VisualTransition>
-                  <VisualTransition From="CompactOpenDown" To="CompactClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="CompactOpenDown" To="CompactClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard />
                   </VisualTransition>
                 </VisualStateGroup.Transitions>
@@ -13830,7 +13834,7 @@
               </VisualStateGroup>
               <VisualStateGroup x:Name="ExpansionStates">
                 <VisualStateGroup.Transitions>
-                  <VisualTransition From="Collapsed" To="ExpandedUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="Collapsed" To="ExpandedUp" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard x:Name="CollapsedToExpandedUp">
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Width">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" />
@@ -13874,7 +13878,7 @@
                       </ObjectAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="ExpandedUp" To="Collapsed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="ExpandedUp" To="Collapsed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard x:Name="ExpandedUpToCollapsed" FillBehavior="Stop">
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Width">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" />
@@ -13907,7 +13911,7 @@
                       </ObjectAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="Collapsed" To="ExpandedDown" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="Collapsed" To="ExpandedDown" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard x:Name="CollapsedToExpandedDown">
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Width">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" />
@@ -13948,7 +13952,7 @@
                       </ObjectAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="ExpandedDown" To="Collapsed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="ExpandedDown" To="Collapsed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard x:Name="ExpandedDownToCollapsed" FillBehavior="Stop">
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Width">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" />
@@ -14022,7 +14026,7 @@
               </VisualStateGroup>
               <VisualStateGroup>
                 <VisualStateGroup.Transitions>
-                  <VisualTransition From="Default" To="ExpandedUpWithPrimaryCommands" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="Default" To="ExpandedUpWithPrimaryCommands" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SecondaryItemsControl" Storyboard.TargetProperty="BorderThickness">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarFlyoutBorderUpThemeThickness}" />
@@ -14050,7 +14054,7 @@
                       </contract7Present:ObjectAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="Default" To="ExpandedDownWithPrimaryCommands" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="Default" To="ExpandedDownWithPrimaryCommands" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SecondaryItemsControl" Storyboard.TargetProperty="BorderThickness">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarFlyoutBorderDownThemeThickness}" />
@@ -14078,7 +14082,7 @@
                       </contract7Present:ObjectAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="ExpandedUpWithPrimaryCommands" To="Default" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="ExpandedUpWithPrimaryCommands" To="Default" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SecondaryItemsControl" Storyboard.TargetProperty="BorderThickness">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarFlyoutBorderUpThemeThickness}" />
@@ -14114,7 +14118,7 @@
                       </contract7Present:ObjectAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="ExpandedDownWithPrimaryCommands" To="Default" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="ExpandedDownWithPrimaryCommands" To="Default" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SecondaryItemsControl" Storyboard.TargetProperty="BorderThickness">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarFlyoutBorderDownThemeThickness}" />
@@ -14390,7 +14394,7 @@
               </VisualStateGroup>
               <VisualStateGroup x:Name="DisplayModeStates">
                 <contract8Present:VisualStateGroup.Transitions>
-                  <VisualTransition From="CompactClosed" To="CompactOpenUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="CompactClosed" To="CompactOpenUp" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Background">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarBackgroundOpen}" />
@@ -14433,7 +14437,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="CompactOpenUp" To="CompactClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="CompactOpenUp" To="CompactClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />
@@ -14465,7 +14469,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="CompactClosed" To="CompactOpenDown" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="CompactClosed" To="CompactOpenDown" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="Background">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{ThemeResource CommandBarBackgroundOpen}" />
@@ -14502,7 +14506,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="CompactOpenDown" To="CompactClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="CompactOpenDown" To="CompactClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />
@@ -14528,7 +14532,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="MinimalClosed" To="MinimalOpenUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="MinimalClosed" To="MinimalOpenUp" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="Padding">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="14,11,14,0" />
@@ -14576,7 +14580,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="MinimalOpenUp" To="MinimalClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="MinimalOpenUp" To="MinimalClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="Padding">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="14,11,14,0" />
@@ -14625,7 +14629,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="MinimalClosed" To="MinimalOpenDown" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="MinimalClosed" To="MinimalOpenDown" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="Padding">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="14,11,14,0" />
@@ -14664,7 +14668,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="MinimalOpenDown" To="MinimalClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="MinimalOpenDown" To="MinimalClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="Padding">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="14,11,14,0" />
@@ -14704,7 +14708,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="HiddenClosed" To="HiddenOpenUp" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="HiddenClosed" To="HiddenOpenUp" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />
@@ -14738,7 +14742,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="HiddenOpenUp" To="HiddenClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="HiddenOpenUp" To="HiddenClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />
@@ -14773,7 +14777,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="HiddenClosed" To="HiddenOpenDown" GeneratedDuration="{StaticResource ControlNormalAnimationDuration}">
+                  <VisualTransition From="HiddenClosed" To="HiddenOpenDown" GeneratedDuration="{StaticResource UnoControlNormalAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />
@@ -14798,7 +14802,7 @@
                       </DoubleAnimationUsingKeyFrames>
                     </Storyboard>
                   </VisualTransition>
-                  <VisualTransition From="HiddenOpenDown" To="HiddenClosed" GeneratedDuration="{StaticResource ControlFastAnimationDuration}">
+                  <VisualTransition From="HiddenOpenDown" To="HiddenClosed" GeneratedDuration="{StaticResource UnoControlFastAnimationDuration}">
                     <Storyboard>
                       <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MoreButton" Storyboard.TargetProperty="VerticalAlignment">
                         <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Stretch" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7169

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Fails

## What is the new behavior?

Instead of using `string` based resources the styles now use `Duration` typed resources in the problematic places


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
