### PR TITLE
fix(wasm): Image/AcrylicBrush.AssignAndObserveBrush exception

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -422,8 +422,12 @@ namespace Windows.UI.Xaml.Controls
 #endif
 			}
 
-			_foregroundChanged.Disposable =
-				Brush.AssignAndObserveBrush(Foreground, c => refreshForeground(), refreshForeground);
+			_foregroundChanged.Disposable = null;
+			if (Foreground?.SupportsAssignAndObserveBrush ?? false)
+			{
+				_foregroundChanged.Disposable =
+					Brush.AssignAndObserveBrush(Foreground, c => refreshForeground(), refreshForeground);
+			}
 
 			refreshForeground();
 		}

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
@@ -181,13 +181,17 @@ namespace Windows.UI.Xaml.Shapes
 #if LEGACY_SHAPE_MEASURE
 		protected virtual void OnFillChanged(Brush newValue)
 		{
-			_brushChanged.Disposable = Brush.AssignAndObserveBrush(newValue, _ =>
+			_brushChanged.Disposable = null;
+			if (newValue?.SupportsAssignAndObserveBrush ?? false)
+			{
+				_brushChanged.Disposable = Brush.AssignAndObserveBrush(newValue, _ =>
 #if __WASM__
-				OnFillUpdatedPartial()
+					OnFillUpdatedPartial()
 #else
-				RefreshShape(true)
+					RefreshShape(true)
 #endif
-			);
+				);
+			}
 
 			OnFillUpdated(newValue);
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
When an ImageBrush/AcrylicBrush is used for TextBlock.Foreground or Shape.Fill on wasm, this error happens:
> ImageBrush is ** not ** supported by the AssignAndObserveBrush. (Instead you have to use ImageBrush.Subscribe().

## What is the new behavior?
It should not happen anymore.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information