### PR TITLE
fix(menuflyout): Ensure MenuFlyout nested submenus stay on screen

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Extensions/QueryExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Extensions/QueryExtensions.cs
@@ -158,5 +158,21 @@ namespace SamplesApp.UITests
 			app.WaitForElement(element);
 			app.WaitForDependencyPropertyValue(element, "FocusState", "Pointer");
 		}
+
+		/// <summary>
+		/// Calls the <see cref="IApp.WaitForElement(string, string, TimeSpan?, TimeSpan?, TimeSpan?)"/> method with a timeout message that specifies
+		/// the element name, which is useful when multiple elements are waited upon in the same test.
+		/// </summary>
+		public static IAppResult[] WaitForElementWithMessage(this IApp app, string elementName, string additionalMessage = null)
+		{
+			var timeoutMessage = $"Timed out waiting for element '{elementName}'";
+
+			if (additionalMessage != null)
+			{
+				timeoutMessage = $"{timeoutMessage} - {additionalMessage}";
+			}
+
+			return app.WaitForElement(elementName, timeoutMessage: timeoutMessage);
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutTests.cs
@@ -253,27 +253,33 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 		[AutoRetry]
 		public void When_MenuFlyout_Nested_Clamped_To_Window()
 		{
-			Run("UITests.Shared.Windows_UI_Xaml_Controls.MenuFlyoutTests.MenuFlyout_Nested_5639");
+			Run("UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests.MenuFlyout_Nested_5639");
 
-			_app.WaitForElement("ButtonWithMenuFlyout");
+			_app.WaitForElementWithMessage("ButtonWithMenuFlyout");
 
 			var hostGridRect = _app.GetLogicalRect("HostGrid");
 
+			var runNo = 0;
 			TestPositioning();
 			TestPositioning(); // Should work second time
 
 			void TestPositioning()
 			{
+				runNo++;
+				TakeScreenshot($"Initial - opening {runNo}");
 				_app.FastTap("ButtonWithMenuFlyout");
-				_app.WaitForElement("NestedMenuItem");
+				_app.WaitForElementWithMessage("NestedMenuItem", $"opening {runNo}");
+				TakeScreenshot($"Outer flyout - opening {runNo}");
 				_app.FastTap("NestedMenuItem");
 
+				_app.WaitForElementWithMessage("LastSubitem", $"opening {runNo}");
+				TakeScreenshot($"Nested flyout - opening {runNo}");
 				var lastItemRect = _app.GetLogicalRect("LastSubitem");
 
 				// Item should be adjusted to within window
 				Assert.Less(lastItemRect.Bottom, hostGridRect.Bottom);
 
-				_app.FastTap("DummyTopButton"); // Dismiss flyout
+				_app.FastTap("LastSubitem"); // Dismiss flyout
 			}
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutTests.cs
@@ -248,5 +248,33 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
 			_app.FastTap(_app.Marked("testItem2"));
 			Assert.AreEqual("click: test2", result.GetText());
 		}
+
+		[Test]
+		[AutoRetry]
+		public void When_MenuFlyout_Nested_Clamped_To_Window()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.MenuFlyoutTests.MenuFlyout_Nested_5639");
+
+			_app.WaitForElement("ButtonWithMenuFlyout");
+
+			var hostGridRect = _app.GetLogicalRect("HostGrid");
+
+			TestPositioning();
+			TestPositioning(); // Should work second time
+
+			void TestPositioning()
+			{
+				_app.FastTap("ButtonWithMenuFlyout");
+				_app.WaitForElement("NestedMenuItem");
+				_app.FastTap("NestedMenuItem");
+
+				var lastItemRect = _app.GetLogicalRect("LastSubitem");
+
+				// Item should be adjusted to within window
+				Assert.Less(lastItemRect.Bottom, hostGridRect.Bottom);
+
+				_app.FastTap("DummyTopButton"); // Dismiss flyout
+			}
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1557,6 +1557,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyout_Nested_5639.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\UIElement_ContextFlyout.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5360,6 +5364,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyout_IosNative.xaml.cs">
       <DependentUpon>MenuFlyout_IosNative.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyout_Nested_5639.xaml.cs">
+      <DependentUpon>MenuFlyout_Nested_5639.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\UIElement_ContextFlyout.xaml.cs">
       <DependentUpon>UIElement_ContextFlyout.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_Nested_5639.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_Nested_5639.xaml
@@ -1,0 +1,39 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests.MenuFlyout_Nested_5639"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid x:Name="HostGrid">
+		<Button Content="Dummy"
+				x:Name="DummyTopButton"
+				VerticalAlignment="Top" />
+		<Button Content="Show menu"
+				x:Name="ButtonWithMenuFlyout"
+				VerticalAlignment="Bottom">
+			<Button.Flyout>
+				<MenuFlyout>
+					<MenuFlyoutItem Text="Item 1" />
+					<MenuFlyoutItem Text="Item 2" />
+					<MenuFlyoutItem Text="Item 3" />
+					<MenuFlyoutSubItem Text="Nested menu"
+									   x:Name="NestedMenuItem">
+						<MenuFlyoutItem Text="Subitem 1" />
+						<MenuFlyoutItem Text="Subitem 2" />
+						<MenuFlyoutItem Text="Subitem 3" />
+						<MenuFlyoutItem Text="Subitem 4" />
+						<MenuFlyoutItem Text="Subitem 5" />
+						<MenuFlyoutItem Text="Subitem 6" />
+						<MenuFlyoutItem Text="Subitem 7" />
+						<MenuFlyoutItem Text="Last subitem"
+										x:Name="LastSubitem" />
+					</MenuFlyoutSubItem>
+				</MenuFlyout>
+			</Button.Flyout>
+		</Button>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_Nested_5639.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_Nested_5639.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
+{
+	[Sample("MenuFlyout")]
+	public sealed partial class MenuFlyout_Nested_5639 : UserControl
+	{
+		public MenuFlyout_Nested_5639()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/CascadingMenuHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/CascadingMenuHelper.cs
@@ -53,6 +53,9 @@ namespace Windows.UI.Xaml.Controls
 		// This fallback is used if we fail to retrieve a value from the MenuShowDelay RegKey
 		const int DefaultMenuShowDelay = 400; // in milliseconds
 
+		// Uno-specific workaround (see comment below)
+		private Point? _lastTargetPoint;
+
 		public CascadingMenuHelper()
 		{
 			m_isPointerOver = false;
@@ -567,6 +570,13 @@ namespace Windows.UI.Xaml.Controls
 						}
 
 						ownerAsSubMenuOwner.OpenSubMenu(targetPoint);
+						if (_lastTargetPoint is { } lastTargetPoint)
+						{
+							// Uno-specific workaround: reapply the location calculated in OnPresenterSizeChanged(), since that one properly
+							// adjusts to keep submenu within screen bounds. (WinUI seemingly relies upon presenter.SizeChanged being raised
+							// every time submenu opens? On Uno it isn't.)
+							ownerAsSubMenuOwner.PositionSubMenu(lastTargetPoint);
+						}
 						ownerAsSubMenuOwner.RaiseAutomationPeerExpandCollapse(true /* isOpen */);
 						ElementSoundPlayer.RequestInteractionSoundForElement(ElementSoundKind.Invoke, ownerAsControl);
 					}
@@ -932,6 +942,7 @@ namespace Windows.UI.Xaml.Controls
 					}
 				}
 
+				_lastTargetPoint = targetPoint;
 				ownerAsSubMenuOwner.PositionSubMenu(targetPoint);
 			}
 		}


### PR DESCRIPTION
Fix bug where nested submenus could be shown offscreen on the 2nd and later times they appeared.

GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/5639 , fixes #6928 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

- Bugfix

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
