### PR TITLE
feat: Add a FrameNavigationHelper to allow apps to access helper properties on Frame and its PackStackEntries

### DIFF
--- a/doc/articles/features/native-frame-nav.md
+++ b/doc/articles/features/native-frame-nav.md
@@ -37,6 +37,15 @@ The `Frame` also uses a custom presenter for its control template.
 On iOS, this presenter creates an `UINavigationController`, and keeps its states in sync with its `Frame`. It also creates a `UIViewController` for each `Page` that gets navigated.
 On iOS and on Android, it also manages the state of back button on the `CommandBar`, if it is presents on a `Page`.
 
+### Helpers
+There is a `FrameNavigationHelper` that is in place to expose useful properties and methods related to Frame-based navigation logic. It contains the following helper methods:
+
+Method|Return Type|Description
+-|-|-
+`GetCurrentEntry(Frame)`|`PageStackEntry`|Returns the PageStackEntry for the currently displayed Page within the given `frame`.
+`GetInstance(PageStackEntry)`|`Page`|Returns the actual Page instance of the given `entry`.
+`CreateNavigationEventArgs(...)`|`NavigationEventArgs`|Creates a new instance of `NavigationEventArgs`/>
+
 ## Platform Specifics
 - Android: Tapping the CommandBar's back button, system back button, or performing the sweep gesture will trigger `SystemNavigationService.BackRequested`. It's the responsibility of the application's navigation controller to eventually call `Frame.GoBack()`.
 - iOS: Tapping the back button automatically triggers a back navigation on the native `UINavigationController` (which is part of the native `Frame` implementation). The `Frame` will raise the `Navigated` event, and its state will automatically be updated to reflect the navigation. The navigation can't be intercepted or canceled.

--- a/src/Uno.UI/Helpers/FrameNavigationHelper.cs
+++ b/src/Uno.UI/Helpers/FrameNavigationHelper.cs
@@ -1,0 +1,49 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.Helpers
+{
+	/// <summary>
+	/// Helper to expose useful properties and methods related to Frame-based navigation logic.
+	/// </summary>
+	public static class FrameNavigationHelper
+	{
+		/// <summary>
+		/// Returns the <see cref="PageStackEntry"/> for the currently displayed <see cref="Page"/> within the given <paramref name="frame"/>.
+		/// </summary>
+		/// <param name="frame">The frame used for navigation</param>
+		/// /// <returns><see cref="PageStackEntry"/></returns>
+		public static PageStackEntry? GetCurrentEntry(Frame? frame) => frame?.CurrentEntry;
+
+		/// <summary>
+		/// Returns the actual <see cref="Page"/> instance of the given <paramref name="entry"/>.
+		/// </summary>
+		/// <param name="entry">The PageStackEntry from the Frame's BackStack.</param>
+		/// <returns><see cref="Page"/></returns>
+		public static Page? GetInstance(PageStackEntry? entry) => entry?.Instance;
+
+		/// <summary>
+		/// Creates a new instance of <see cref="NavigationEventArgs"/>
+		/// </summary>
+		/// <param name="content"></param>
+		/// <param name="navigationMode"></param>
+		/// <param name="navigationTransitionInfo"></param>
+		/// <param name="parameter"></param>
+		/// <param name="sourcePageType"></param>
+		/// <param name="uri"></param>
+		/// <returns><see cref="NavigationEventArgs"/></returns>
+		public static NavigationEventArgs CreateNavigationEventArgs(
+			object? content,
+			NavigationMode navigationMode,
+			NavigationTransitionInfo? navigationTransitionInfo,
+			object? parameter,
+			Type sourcePageType,
+			Uri? uri
+		) => new NavigationEventArgs(content, navigationMode, navigationTransitionInfo, parameter, sourcePageType, uri);
+	}
+}


### PR DESCRIPTION
Relevant to NavigationBar work

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Add a FrameNavigationHelper to expose:
- [`CurrentEntry` property on `Frame` ](https://github.com/unoplatform/uno/blob/e5febdcfd7321713dc20091b9bf0481a84636af6/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs#L45)
- [`Instance` property on `PageStackEntry`](https://github.com/unoplatform/uno/blob/e5febdcfd7321713dc20091b9bf0481a84636af6/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.cs#L48)
- [A creation method for `NavigationEventArgs`](https://github.com/unoplatform/uno/blob/e5febdcfd7321713dc20091b9bf0481a84636af6/src/Uno.UI/UI/Xaml/Navigation/NavigationEventArgs.cs#L10)

This is helpful when apps are defining their own Frame navigation logic. We can see how these are currently being used within the Uno `NativeFramePresenter` today. If an app were to implement their own NativeFramePresenter, these properties would be helpful to have available.

See usages:
- [Example 1](https://github.com/unoplatform/uno/blob/e5febdcfd7321713dc20091b9bf0481a84636af6/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs#L130-L136)
- [Example 2](https://github.com/unoplatform/uno/blob/e5febdcfd7321713dc20091b9bf0481a84636af6/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs#L363-L370)
- [Example 3](https://github.com/unoplatform/uno/blob/e5febdcfd7321713dc20091b9bf0481a84636af6/src/Uno.UI/NativeFramePresenter.Android.cs#L78)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
