### PR TITLE
fix(xLoad): Adjust x:Load and x:Bind loading sequence

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -5611,21 +5611,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 												using (writer.BlockInvariant($"if (sender.IsMaterialized)"))
 												{
 													writer.AppendLineInvariant($"that.Bindings.UpdateResources();");
-
-													using (writer.BlockInvariant($"if (!that.IsLoaded)"))
-													{
-														// Refresh the bindings explicitly as the target is not yet loaded, but the
-														// x:Load value has already changed. In this case, the unloaded block registration below
-														// won't be called because the control was not loaded.
-														writer.AppendLineInvariant($"that.Bindings.Update();");
-													}
 												}
 											}
 										}
 
 										writer.AppendLineInvariant($"{closureName}.MaterializationChanged += {componentName}_update;");
 
-										using (writer.BlockInvariant($"void {componentName}_unloaded(object sender, RoutedEventArgs e)"))
+										using (writer.BlockInvariant($"void {componentName}_materializing(object sender)"))
 										{
 											// Refresh the bindings when the ElementStub is unloaded. This assumes that
 											// ElementStub will be unloaded **after** the stubbed control has been created
@@ -5633,7 +5625,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 											writer.AppendLineInvariant($"({componentName}_update_That.Target as {_className.className})?.Bindings.Update();");
 										}
 
-										writer.AppendLineInvariant($"{closureName}.Unloaded += {componentName}_unloaded;");
+										writer.AppendLineInvariant($"{closureName}.Materializing += {componentName}_materializing;");
 									}
 									else
 									{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_While_Loading.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_While_Loading.xaml
@@ -1,0 +1,13 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.When_xLoad_xBind_xLoad_While_Loading"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    x:DefaultBindMode="OneWay"
+    mc:Ignorable="d">
+
+	<Grid x:Name="topLevel" x:Load="{x:Bind IsLoad(MyIsLoaded)}" x:FieldModifier="public">
+		<TextBlock x:Name="tb01" x:FieldModifier="public" Tag="{x:Bind Model.MyValue, Mode=OneWay}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_While_Loading.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_xBind_xLoad_While_Loading.xaml.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_xBind_xLoad_While_Loading : UserControl
+	{
+		public When_xLoad_xBind_xLoad_While_Loading()
+		{
+			Model = new When_xLoad_xBind_xLoad_While_Loading_ViewModel();
+			this.InitializeComponent();
+
+			Loaded += When_xLoad_xBind_xLoad_While_Loading_Loaded;
+		}
+
+		private void When_xLoad_xBind_xLoad_While_Loading_Loaded(object sender, RoutedEventArgs e)
+		{
+			MyIsLoaded = true;
+		}
+
+		public bool IsLoad(bool load) => load;
+
+		public When_xLoad_xBind_xLoad_While_Loading_ViewModel Model {  get; set; }
+
+		public bool MyIsLoaded
+		{
+			get { return (bool)GetValue(MyIsLoadedProperty); }
+			set { SetValue(MyIsLoadedProperty, value); }
+		}
+
+		// Using a DependencyProperty as the backing store for MyIsLoaded.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyIsLoadedProperty =
+			DependencyProperty.Register("MyIsLoaded", typeof(bool), typeof(When_xLoad_xBind_xLoad_While_Loading), new PropertyMetadata(false));
+	}
+
+	public class When_xLoad_xBind_xLoad_While_Loading_ViewModel : System.ComponentModel.INotifyPropertyChanged
+	{
+		private int myValue = 1;
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		public int MyValue
+		{
+			get => myValue; set
+			{
+				myValue = value;
+
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs("MyValue"));
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -83,6 +83,24 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 			Assert.AreEqual(42, SUT.tb01.Tag);
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_xLoad_xBind_xLoad_While_Loading()
+		{
+			var grid = new Grid();
+			TestServices.WindowHelper.WindowContent = grid;
+
+			var SUT = new When_xLoad_xBind_xLoad_While_Loading();
+			grid.Children.Add(SUT);
+
+			Assert.IsNotNull(SUT.tb01);
+			Assert.AreEqual(1, SUT.tb01.Tag);
+
+			SUT.Model.MyValue = 42;
+
+			Assert.AreEqual(42, SUT.tb01.Tag);
+		}
 	}
 }
 #endif

--- a/src/Uno.UI/Mock/ElementStub.net.cs
+++ b/src/Uno.UI/Mock/ElementStub.net.cs
@@ -20,6 +20,8 @@ namespace Windows.UI.Xaml
 					var newView = (FrameworkElement)newViewProvider();
 					parentElement.RemoveChild(oldView);
 
+					RaiseMaterializing();
+
 					parentElement.AddChild(newView, currentPosition);
 
 					return newView;

--- a/src/Uno.UI/UI/Xaml/ElementStub.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.Android.cs
@@ -20,6 +20,8 @@ namespace Windows.UI.Xaml
 				var newView = newViewProvider();
 				parentViewGroup.RemoveViewAt(currentPosition.Value);
 
+				RaiseMaterializing();
+
 				var unoViewGroup = parentViewGroup as UnoViewGroup;
 
 				if (unoViewGroup != null)

--- a/src/Uno.UI/UI/Xaml/ElementStub.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.cs
@@ -64,6 +64,23 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		public event MaterializationChangedHandler MaterializationChanged;
 
+		/// <summary>
+		/// A delegate used to signal that the content is being materialized in <see cref="ElementStub.Materializing"/>
+		/// </summary>
+		/// <param name="sender">The instance being changed</param>
+		public delegate void MaterializingChangedHandler(ElementStub sender);
+
+		/// <summary>
+		/// An event raised when the materialized object of the <see cref="ElementStub"/> has changed.
+		/// </summary>
+		/// <remarks>
+		/// This event is only raised when the ElementStub is materializing its target (not
+		/// dematerializing), and is raised after the element stub has been removed from the
+		/// tree, but before the new target is added to the tree (so the x:Bind on loaded event
+		/// can be raised properly).
+		/// </remarks>
+		public event MaterializationChangedHandler Materializing;
+
 		public bool Load
 		{
 			get => (bool)GetValue(LoadProperty);
@@ -149,6 +166,14 @@ namespace Windows.UI.Xaml
 
 		public void Materialize()
 			=> Materialize(isVisibilityChanged: false);
+
+		private void RaiseMaterializing()
+		{
+			if (_isMaterializing)
+			{
+				Materializing?.Invoke(this);
+			}
+		}
 
 		private void Materialize(bool isVisibilityChanged)
 		{

--- a/src/Uno.UI/UI/Xaml/ElementStub.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.iOSmacOS.cs
@@ -25,6 +25,8 @@ namespace Windows.UI.Xaml
 				var currentSuperview = oldView?.Superview;
 				oldView?.RemoveFromSuperview();
 
+				RaiseMaterializing();
+
 #if __IOS__
 				currentSuperview?.InsertSubview(newContent, currentPosition);
 				return newContent;

--- a/src/Uno.UI/UI/Xaml/ElementStub.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.netstd.cs
@@ -20,6 +20,9 @@ namespace Windows.UI.Xaml
 					var newView = (FrameworkElement)newViewProvider();
 
 					parentElement.RemoveChild(oldView);
+
+					RaiseMaterializing();
+
 					parentElement.AddChild(newView, currentPosition);
 
 					return newView;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7189

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Changing the `x:Load` state during the `Loaded` event handler works properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
