### PR TITLE
fix(HitTest): Check for Clip property for ClippingBounds

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
@@ -363,7 +363,9 @@ namespace Windows.UI.Xaml.Media
 			// The maximum region where the current element and its children might draw themselves
 			// TODO: Get the real clipping rect! For now we assume no clipping.
 			// This is expressed in element coordinate space.
-			var clippingBounds = Rect.Infinite;
+			// For some controls imported from WinUI, such as NavigationView, 
+			// the Clip property may be significant. 
+			var clippingBounds = element.Clip?.Bounds ?? Rect.Infinite;
 
 			// The region where the current element draws itself.
 			// Be aware that children might be out of this rendering bounds if no clipping defined. TODO: .Intersect(clippingBounds)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7157

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix


<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

`VisualTreeHelper.HitTest` [ignores Clip](https://github.com/unoplatform/uno/blob/e5febdcfd7321713dc20091b9bf0481a84636af6/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs#L363-L367) completely, assumes that Clip is **always** null, and always use an Infinite `Rect` for `HitTest`ing. This may cause problems with some translated `WinUI` controls, such as in #7157.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

`VisualTreeHelper.HitTest` uses `Clip?.Bounds` when it is non-null.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
