### PR TITLE
feat: Support Dark theme in Samples app

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
@@ -53,6 +53,7 @@ namespace SampleControl.Presentation
 		private bool _isAnyContentVisible = false;
 		private bool _contentAttachedToWindow;
 		private bool _useFluentStyles;
+		private bool _useDarkTheme;
 		private object _contentPhone = null;
 		private string _searchTerm = "";
 
@@ -410,10 +411,25 @@ namespace SampleControl.Presentation
 					Application.Current.Resources.MergedDictionaries.Remove(_fluentResources);
 				}
 #if HAS_UNO
+				// Force the in app styles to reload
 				Application.Current.Resources?.UpdateThemeBindings();
 				Uno.UI.ResourceResolver.UpdateSystemThemeBindings();
 				Application.PropagateThemeChanged(Windows.UI.Xaml.Window.Current.Content);
 #endif
+				RaisePropertyChanged();
+			}
+		}
+
+		public bool UseDarkTheme
+		{
+			get => _useDarkTheme;
+			set
+			{
+				_useDarkTheme = value;
+				if (Windows.UI.Xaml.Window.Current.Content is FrameworkElement root)
+				{
+					root.RequestedTheme = _useDarkTheme ? ElementTheme.Dark : ElementTheme.Light;
+				}
 				RaisePropertyChanged();
 			}
 		}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -533,8 +533,7 @@
 							  Style="{x:Null}"/>
 					<!-- Dark theme check box -->
 					<CheckBox Grid.Column="9"
-							  IsChecked="{Binding UseDarkTheme, Mode=TwoWay}"
-							  Style="{x:Null}">
+							  IsChecked="{Binding UseDarkTheme, Mode=TwoWay}">
 						<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xEC46;" />
 					</CheckBox>
 				</Grid>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -49,7 +49,7 @@
 				<Setter Property="BorderThickness"
 						Value="0,0,0,1" />
 				<Setter Property="Background"
-						Value="{StaticResource Color08Brush}" />
+						Value="{StaticResource ApplicationPageBackgroundThemeBrush}" />
 				<Setter Property="Height"
 								Value="50" />
 			</Style>
@@ -252,7 +252,7 @@
 			</VisualStateGroup>
 		</VisualStateManager.VisualStateGroups>
 		<SplitView.Pane>
-			<Grid Background="{StaticResource Color08Brush}"
+			<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 				  BorderBrush="LightGray"
 				  BorderThickness="0,0,1,0"
 				  toolkit:VisibleBoundsPadding.PaddingMask="All">
@@ -339,7 +339,7 @@
 								ContentTemplate="{StaticResource SearchList}" />
 
 				<!--NAVIGATION BUTTONS-->
-				<Border Background="{StaticResource Color08Brush}"
+				<Border Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 						
 						BorderThickness="0,1,0,0"
 						BorderBrush="{StaticResource Color05Brush}"
@@ -431,6 +431,7 @@
 					<Grid.ColumnDefinitions>
 						<ColumnDefinition Width="50" />
 						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="Auto" />
 						<ColumnDefinition Width="Auto" />
 						<ColumnDefinition Width="Auto" />
 						<ColumnDefinition Width="Auto" />
@@ -530,6 +531,12 @@
 							  Grid.Column="8"
 							  IsChecked="{Binding UseFluentStyles, Mode=TwoWay}"
 							  Style="{x:Null}"/>
+					<!-- Dark theme check box -->
+					<CheckBox Grid.Column="9"
+							  IsChecked="{Binding UseDarkTheme, Mode=TwoWay}"
+							  Style="{x:Null}">
+						<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xEC46;" />
+					</CheckBox>
 				</Grid>
 
 				<!-- Sample Content -->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7196

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Not supported.

## What is the new behavior?

Basic support for dark theme in Samples app added,

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.