### PR TITLE
fix: Respect Opacity when rendering gradient brushes

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GradientBrushTests/LinearGradientBrush_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GradientBrushTests/LinearGradientBrush_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -34,6 +35,17 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GradientBrushTests
 			using var after = TakeScreenshot("After");
 
 			ImageAssert.AreNotEqual(before, after, screenRect);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void When_Opacity_Is_Specified()
+		{
+			Run("UITests.Windows_UI_Xaml_Media.GradientBrushTests.LinearGradientBrush_Opacity");
+
+			var grid = _app.Query("TestGrid").Single().Rect;
+			using var screenshot = TakeScreenshot(nameof(When_Opacity_Is_Specified));
+			ImageAssert.HasColorAt(screenshot, grid.CenterX, grid.CenterY, Color.FromArgb(255, 255, 128, 128));
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3597,6 +3597,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\GradientBrushTests\LinearGradientBrush_Opacity.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrushShapeStretchesAlignments.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6413,6 +6417,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\GradientBrushTests\GradientsPage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\GradientBrushTests\LinearGradientBrush_Change_Stops.xaml.cs">
       <DependentUpon>LinearGradientBrush_Change_Stops.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\GradientBrushTests\LinearGradientBrush_Opacity.xaml.cs">
+      <DependentUpon>LinearGradientBrush_Opacity.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrushShapeStretchesAlignments.xaml.cs">
       <DependentUpon>ImageBrushShapeStretchesAlignments.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/LinearGradientBrush_Opacity.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/LinearGradientBrush_Opacity.xaml
@@ -1,0 +1,22 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Media.GradientBrushTests.LinearGradientBrush_Opacity"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Media.GradientBrushTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid x:Name="TestGrid">
+		<Grid.Background>
+			<LinearGradientBrush StartPoint="0,0" EndPoint="1,1" Opacity="0.5">
+				<!-- Making it single color to easily test the opacity property -->
+				<GradientStop Color="Red" Offset="0.0" />
+				<GradientStop Color="Red" Offset="1.0" />
+			</LinearGradientBrush>
+		</Grid.Background>
+
+		<TextBlock FontSize="20" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/LinearGradientBrush_Opacity.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/LinearGradientBrush_Opacity.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Media.GradientBrushTests
+{
+	[Sample("GradientBrush")]
+    public sealed partial class LinearGradientBrush_Opacity : Page
+    {
+        public LinearGradientBrush_Opacity()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Media/RadialGradientBrush.Android.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Media/RadialGradientBrush.Android.cs
@@ -37,7 +37,7 @@ namespace Microsoft.UI.Xaml.Media
 				return null;
 			}
 
-			var colors = GradientStops.SelectToArray(s => ((Android.Graphics.Color)s.Color).ToArgb());
+			var colors = GradientStops.SelectToArray(s => ((Android.Graphics.Color)GetColorWithOpacity(s.Color)).ToArgb());
 			var locations = GradientStops.SelectToArray(s => (float)s.Offset);
 
 			var width = destinationRect.Width;

--- a/src/Uno.UI/Microsoft/UI/Xaml/Media/RadialGradientBrush.iOSmacOS.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Media/RadialGradientBrush.iOSmacOS.cs
@@ -21,7 +21,7 @@ namespace Microsoft.UI.Xaml.Media
 
 			var isRelative = MappingMode == BrushMappingMode.RelativeToBoundingBox;
 
-			var colors = GradientStops.SelectToArray(gs => (CGColor)gs.Color);
+			var colors = GradientStops.SelectToArray(gs => (CGColor)GetColorWithOpacity(gs.Color));
 			var locations = GradientStops.SelectToArray(gs => new nfloat(gs.Offset));
 
 			var layer = new RadialGradientLayer(colors, locations, center, radius, isRelative);

--- a/src/Uno.UI/UI/Xaml/Media/LinearGradientBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/LinearGradientBrush.Android.cs
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Media
 				return null;
 			}
 
-			var colors = GradientStops.SelectToList(s => ((Android.Graphics.Color)s.Color).ToArgb());
+			var colors = GradientStops.SelectToList(s => ((Android.Graphics.Color)GetColorWithOpacity(s.Color)).ToArgb());
 			var locations = GradientStops.SelectToList(s => (float)s.Offset);
 
 			if (GradientStops.Count == 1)

--- a/src/Uno.UI/UI/Xaml/Media/LinearGradientBrush.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/LinearGradientBrush.iOSmacOS.cs
@@ -16,7 +16,7 @@ namespace Windows.UI.Xaml.Media
 		{
 			var gradientLayer = new CAGradientLayer
 			{
-				Colors = GradientStops.SelectToArray(gs => (CGColor)gs.Color),
+				Colors = GradientStops.SelectToArray(gs => (CGColor)GetColorWithOpacity(gs.Color)),
 				Locations = GradientStops.SelectToArray(gs => new NSNumber(gs.Offset))
 			};
 			var transform = RelativeTransform;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1448

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Opacity isn't respected.

## What is the new behavior?

It's now respected.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
