### PR TITLE
perf(TestComparer): Optimize GC memory allocation.

### DIFF
--- a/src/Uno.UI.TestComparer/Comparer/TestFilesComparer.cs
+++ b/src/Uno.UI.TestComparer/Comparer/TestFilesComparer.cs
@@ -261,20 +261,23 @@ namespace Uno.UI.TestComparer.Comparer
 		public static unsafe bool DiffImages(string a, string b, string diffPath)
 		{
 			uint changes = 0;
-			using var img1 = SKBitmap.Decode(@"\\?\" + a);
-			using var img2 = SKBitmap.Decode(@"\\?\" + b);
+			var la = @"\\?\" + a;
+			var lb = @"\\?\" + b;
+			var info1 = SKBitmap.DecodeBounds(la);
+			var info2 = SKBitmap.DecodeBounds(lb);
 
-			// Get Rgba8888 Piexels
-			var pixmap1 = GetPixels(img1);
-			var pixmap2 = GetPixels(img2);
-
-			// if have same size
-			if (pixmap1.Size == pixmap2.Size)
+			if (info1.Size == info2.Size)
 			{
+				using var img1 = SKBitmap.Decode(la, info1.WithColorType(SKColorType.Rgba8888));
+				using var img2 = SKBitmap.Decode(lb, info2.WithColorType(SKColorType.Rgba8888));
+
+				using var pixmap1 = img1.PeekPixels();
+				using var pixmap2 = img2.PeekPixels();
+
 				var bmp1Ptr = (byte*)pixmap1.GetPixels().ToPointer();
 				var bmp2Ptr = (byte*)pixmap2.GetPixels().ToPointer();
 				var width = pixmap1.Width;
-				var height = pixmap2.Height;
+				var height = pixmap1.Height;
 
 
 				for (var row = 0; row < height; row++)
@@ -305,22 +308,7 @@ namespace Uno.UI.TestComparer.Comparer
 				//TODO: throw warings?
 				Console.WriteLine($"\t{a} and {b} have differnt size");
 			}
-			pixmap1?.Dispose();
-			pixmap2?.Dispose();
 			return changes > 0;
-		}
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private static unsafe SKPixmap GetPixels(SKBitmap image)
-		{
-			var pixmap = image.PeekPixels();
-			// Adjust color if not Rgba8888
-			if (image.ColorType != SKColorType.Rgba8888)
-			{
-				using (var old = pixmap)
-					pixmap = old.WithColorType(SKColorType.Rgba8888);
-			}
-			return pixmap;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Uno.UI.TestComparer/Program.cs
+++ b/src/Uno.UI.TestComparer/Program.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows.Media.Imaging;
 using System.Xml;
 using Mono.Options;
 using Newtonsoft.Json;

--- a/src/Uno.UI.TestComparer/Uno.UI.TestComparer.csproj
+++ b/src/Uno.UI.TestComparer/Uno.UI.TestComparer.csproj
@@ -3,12 +3,13 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net472</TargetFramework>
-	  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-  </PropertyGroup>
-
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	</PropertyGroup>
+	
 	<ItemGroup>
-	  <None Remove="Properties\launchSettings.json" />
+		<None Remove="Properties\launchSettings.json" />
 	</ItemGroup>	
 
 	<ItemGroup>
@@ -20,18 +21,12 @@
 		<PackageReference Include="NUnit.Engine" Version="3.11.1" />
 		<PackageReference Include="Refit" Version="6.0.94" />
 		<PackageReference Include="Mono.Options" Version="6.6.0.161" />
+		<PackageReference Include="SkiaSharp" Version="2.88.0-preview.140" />
 		<PackageReference Include="System.IO.Compression" Version="4.3.0" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Folder Include="Properties\" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Reference Include="PresentationCore" />
-	  <Reference Include="PresentationFramework" />
-	  <Reference Include="System.Windows.Forms" />
-	  <Reference Include="WindowsBase" />
+		<Folder Include="Properties\" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #
```ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19042.1237 (20H2/October2020Update)
Intel Core i7-7700K CPU 4.20GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4400.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4400.0), X64 RyuJIT


```
|   Method |      data |     Mean |   Error |   StdDev |   Median |      Min |      Max | Ratio | RatioSD | Rank |     Gen 0 | Allocated native memory | Native memory leak |     Gen 1 |     Gen 2 |     Allocated |
|--------- |---------- |---------:|--------:|---------:|---------:|---------:|---------:|------:|--------:|-----:|----------:|------------------------:|-------------------:|----------:|----------:|--------------:|
| **Uno(WPF)** | **T (1).png** | **281.9 ms** | **5.57 ms** | **12.91 ms** | **277.5 ms** | **266.6 ms** | **319.9 ms** |  **1.00** |    **0.00** |    **3** | **2000.0000** |           **157,828,212 B** |      **156,796,952 B** | **1000.0000** | **1000.0000** | **179,190,840 B** |
|     Skia | T (1).png | 228.4 ms | 6.94 ms | 20.34 ms | 219.9 ms | 204.7 ms | 286.1 ms |  0.81 |    0.07 |    1 |         - |            45,256,907 B |                  - |         - |         - |       5,461 B |
|   OpenCV | T (1).png | 257.9 ms | 2.14 ms |  1.79 ms | 257.5 ms | 254.7 ms | 262.0 ms |  0.90 |    0.06 |    2 |         - |            45,280,772 B |                  - |         - |         - |             - |
|          |           |          |         |          |          |          |          |       |         |      |           |                         |                    |           |           |               |
| **Uno(WPF)** | **T (2).png** | **293.2 ms** | **5.99 ms** | **17.57 ms** | **288.8 ms** | **266.7 ms** | **337.9 ms** |  **1.00** |    **0.00** |    **3** | **1500.0000** |           **157,828,212 B** |      **156,796,952 B** |  **500.0000** |  **500.0000** | **179,182,372 B** |
|     Skia | T (2).png | 206.0 ms | 1.25 ms |  1.39 ms | 205.6 ms | 204.4 ms | 209.2 ms |  0.69 |    0.03 |    1 |         - |            45,256,907 B |                  - |         - |         - |       5,461 B |
|   OpenCV | T (2).png | 265.2 ms | 5.20 ms |  9.11 ms | 264.0 ms | 254.4 ms | 287.7 ms |  0.90 |    0.06 |    2 |         - |            45,280,772 B |                  - |         - |         - |             - |
|          |           |          |         |          |          |          |          |       |         |      |           |                         |                    |           |           |               |
| **Uno(WPF)** | **T (3).png** | **288.4 ms** | **5.27 ms** |  **8.80 ms** | **287.3 ms** | **274.3 ms** | **314.2 ms** |  **1.00** |    **0.00** |    **3** | **1500.0000** |           **157,828,084 B** |      **156,796,952 B** |  **500.0000** |  **500.0000** | **179,190,252 B** |
|     Skia | T (3).png | 206.8 ms | 1.37 ms |  1.07 ms | 206.9 ms | 204.5 ms | 208.6 ms |  0.73 |    0.02 |    1 |         - |            45,269,838 B |                  - |         - |         - |       5,461 B |
|   OpenCV | T (3).png | 274.4 ms | 1.61 ms |  1.34 ms | 274.5 ms | 271.0 ms | 276.6 ms |  0.96 |    0.03 |    2 |         - |            45,279,868 B |                  - |         - |         - |             - |
|          |           |          |         |          |          |          |          |       |         |      |           |                         |                    |           |           |               |
| **Uno(WPF)** | **T (4).png** | **273.6 ms** | **4.82 ms** |  **4.51 ms** | **274.4 ms** | **265.9 ms** | **282.3 ms** |  **1.00** |    **0.00** |    **3** | **1500.0000** |           **157,828,212 B** |      **156,796,952 B** |  **500.0000** |  **500.0000** | **179,182,372 B** |
|     Skia | T (4).png | 206.3 ms | 1.03 ms |  0.96 ms | 206.6 ms | 204.4 ms | 207.6 ms |  0.75 |    0.01 |    1 |         - |            45,256,907 B |                  - |         - |         - |       5,461 B |
|   OpenCV | T (4).png | 257.2 ms | 1.22 ms |  1.02 ms | 257.3 ms | 254.8 ms | 258.7 ms |  0.94 |    0.02 |    2 |         - |            45,280,772 B |                  - |         - |         - |             - |

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- Reduces pressure on the GC
- about 28 percent faster

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
