### PR TITLE
Load Samples app Pages within Frame

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/Samples/UnitTests/UnitTestsPage.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/Samples/UnitTests/UnitTestsPage.xaml.cs
@@ -10,6 +10,7 @@ namespace SamplesApp.Samples.UnitTests
 		"Unit Tests",
 		Name = "Unit Tests Runner",
 		Description = "Test bench to run UI tests that does not require interaction (a.k.a. runtime tests)",
+		UsesFrame = false,
 		IgnoreInSnapshotTests = true)]
 	public sealed partial class UnitTestsPage : Page
 	{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.ClosedFigurePage.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.ClosedFigurePage.cs
@@ -25,7 +25,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 
 			using var screenshot = TakeScreenshot("Closed state");
 
-			ImageAssert.HasColorAt(screenshot, 50, 300, Color.Black);
+			ImageAssert.HasColorAt(screenshot, 25, 300, Color.Black);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.ClosedFigurePage.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GeometryTests/UnoSamples_Tests.ClosedFigurePage.cs
@@ -25,7 +25,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GeometryTests
 
 			using var screenshot = TakeScreenshot("Closed state");
 
-			ImageAssert.HasColorAt(screenshot, 25, 300, Color.Black);
+			ImageAssert.HasColorAt(screenshot, 50, 300, Color.Black);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -22,6 +22,7 @@ using Uno.UI.Samples.Tests;
 
 #if HAS_UNO
 using Uno.Foundation.Logging;
+using MUXControlsTestApp;
 #else
 using Microsoft.Extensions.Logging;
 using Uno.Logging;
@@ -689,7 +690,8 @@ namespace SampleControl.Presentation
 					Description = attribute.Description,
 					ControlType = type.AsType(),
 					IgnoreInSnapshotTests = attribute.IgnoreInSnapshotTests,
-					IsManualTest = attribute.IsManualTest
+					IsManualTest = attribute.IsManualTest,
+					UsesFrame = attribute.UsesFrame
 				};
 		}
 
@@ -847,7 +849,6 @@ description: {sample.Description}";
 			}
 		}
 
-
 		/// <summary>
 		/// This method receives a newContent and returns a newly built content. It also adds the content to the settings for the latest ran tests.
 		/// </summary>
@@ -859,10 +860,12 @@ description: {sample.Description}";
 			SampleChanging?.Invoke(this, EventArgs.Empty);
 
 			FrameworkElement container = null;
-			if (typeof(Page).IsAssignableFrom(newContent.ControlType))
-			{
-				// Content is a page, for MUX compatibility we use Frame to navigate to it.
-				// This ensures the Page.Frame property is not null.
+			
+			var frameRequested =
+				newContent.UsesFrame &&
+				typeof(Page).IsAssignableFrom(newContent.ControlType);
+			if (frameRequested)
+			{				
 				var frame = new Frame();
 				frame.Navigate(newContent.ControlType);
 				container = frame;

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -858,19 +858,31 @@ description: {sample.Description}";
 		{
 			SampleChanging?.Invoke(this, EventArgs.Empty);
 
-			//Activator is used here in order to generate the view and bind it directly with the proper view model
-			var control = Activator.CreateInstance(newContent.ControlType);
-
-			if (control is ContentControl controlAsContentControl && !(controlAsContentControl.Content is Uno.UI.Samples.Controls.SampleControl))
+			FrameworkElement container = null;
+			if (typeof(Page).IsAssignableFrom(newContent.ControlType))
 			{
-				control = new Uno.UI.Samples.Controls.SampleControl
-				{
-					Content = control,
-					SampleDescription = newContent.Description
-				};
+				// Content is a page, for MUX compatibility we use Frame to navigate to it.
+				// This ensures the Page.Frame property is not null.
+				var frame = new Frame();
+				frame.Navigate(newContent.ControlType);
+				container = frame;
 			}
+			else
+			{
+				//Activator is used here in order to generate the view and bind it directly with the proper view model
+				var control = Activator.CreateInstance(newContent.ControlType);
 
-			var container = new Border { Child = control as UIElement };
+				if (control is ContentControl controlAsContentControl && !(controlAsContentControl.Content is Uno.UI.Samples.Controls.SampleControl))
+				{
+					control = new Uno.UI.Samples.Controls.SampleControl
+					{
+						Content = control,
+						SampleDescription = newContent.Description
+					};
+				}
+
+				container = new Border { Child = control as UIElement };
+			}
 
 			if (newContent.ViewModelType != null)
 			{

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserContent.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserContent.cs
@@ -18,6 +18,7 @@ namespace SampleControl.Entities
 		public string Description { get; set; }
 		public bool IgnoreInSnapshotTests { get; internal set; }
 		public bool IsManualTest { get; internal set; }
+		public bool UsesFrame { get; internal set; }
 
 		bool _isFavorite;
 		public bool IsFavorite

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControlInfoAttribute.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControlInfoAttribute.cs
@@ -15,7 +15,8 @@ namespace Uno.UI.Samples.Controls
 			Type viewModelType = null,
 			bool ignoreInSnapshotTests = false,
 			string description = null,
-			bool isManualTest = false
+			bool isManualTest = false,
+			bool usesFrame = true
 		)
 			: base(category)
 		{
@@ -24,6 +25,7 @@ namespace Uno.UI.Samples.Controls
 			IgnoreInSnapshotTests = ignoreInSnapshotTests;
 			IsManualTest = isManualTest;
 			Description = description;
+			UsesFrame = usesFrame;
 		}
 
 	}
@@ -89,5 +91,11 @@ namespace Uno.UI.Samples.Controls
 		/// An optional description of the sample. A good practice is to explain the expected result of the sample.
 		/// </summary>
 		public string Description { get; set; }
+
+		/// <summary>
+		/// Set to true if the sample is navigated to using frame navigation.
+		/// </summary>
+		/// <remarks>Defaults to true.</remarks>
+		public bool UsesFrame { get; set; } = true;
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_Dimensions.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_Dimensions.xaml.cs
@@ -3,7 +3,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Toolkit
 {
-	[Sample]
+	[Sample(UsesFrame = false)]
 	public sealed partial class ElevatedView_Dimensions : Page
 	{
 		public ElevatedView_Dimensions()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownPlacement.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownPlacement.xaml.cs
@@ -5,7 +5,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 {
-	[SampleControlInfo("ComboBox")]
+	[SampleControlInfo("ComboBox", UsesFrame = false)]
 	public sealed partial class ComboBox_DropDownPlacement : Page
 	{
 		public ComboBox_DropDownPlacement()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Native_With_AppBarButton_With_Foreground.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_Native_With_AppBarButton_With_Foreground.xaml.cs
@@ -18,7 +18,7 @@ using Windows.UI.Xaml.Navigation;
 
 namespace UITests.Windows_UI_Xaml_Controls.CommandBar
 {
-	[Sample]
+	[Sample(UsesFrame = false)]
 	public sealed partial class CommandBar_Native_With_AppBarButton_With_Foreground : Page
 	{
 		public CommandBar_Native_With_AppBarButton_With_Foreground()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Geometry/ClosedFigurePage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Geometry/ClosedFigurePage.xaml.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace SamplesApp.Windows_UI_Xaml_Media.Geometry
 {
-	[SampleControlInfo("Geometry", "ClosedFigure")]
+	[Sample("Geometry", Name = "ClosedFigure", UsesFrame = false)]
 	public sealed partial class ClosedFigurePage : Page
     {
         public ClosedFigurePage()


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4684

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

SamplesApp `Page` samples are instantiated using `Activator`.

## What is the new behavior?

`Page` samples are navigated to using a `Frame`. This ensures their `Page.Frame` property is not `null` and `OnNavigatedTo` method is called.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.