### PR TITLE
Misc fixes for pointers

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -3964,6 +3964,11 @@
 				fullName="Windows.UI.Xaml.Media.Animation.KeyTime Windows.UI.Xaml.Media.Animation.ObjectKeyFrame.get_KeyTime()"
 				reason="False positive, still present, but accessible also through an internal interface" />
 		</Methods>
+		<Types>
+			<Member
+				fullName="Windows.UI.Core.ICoreWindowExtension"
+				reason="Internal interface" />
+		</Types>
 	</IgnoreSet>
 	<!--
 	Supported nodes (please keep at the bottom of this file):

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/CoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/CoreWindowExtension.cs
@@ -125,9 +125,9 @@ namespace Uno.UI.Runtime.Skia
 
 		public CoreCursor PointerCursor { get => new CoreCursor(CoreCursorType.Arrow, 0); set { } }
 
-		public void ReleasePointerCapture() { }
+		public void SetPointerCapture(PointerIdentifier pointer) { }
 
-		public void SetPointerCapture() { }
+		public void ReleasePointerCapture(PointerIdentifier pointer) { }
 
 		public void Dispose()
 		{

--- a/src/Uno.UI.Runtime.Skia.Tizen/TizenCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Tizen/TizenCoreWindowExtension.cs
@@ -62,13 +62,12 @@ namespace Uno.UI.Runtime.Skia
 		}
 
 		/// <inheritdoc />
-		public void ReleasePointerCapture()
-			=> this.Log().Warn("Pointer capture release is not supported on Tizen");
-
-		/// <inheritdoc />
-		public void SetPointerCapture()
+		public void SetPointerCapture(PointerIdentifier pointer)
 			=> this.Log().Warn("Pointer capture is not supported on Tizen");
 
+		/// <inheritdoc />
+		public void ReleasePointerCapture(PointerIdentifier pointer)
+			=> this.Log().Warn("Pointer capture release is not supported on Tizen");
 
 		private void SetupTapGesture()
 		{

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfCoreWindowExtension.cs
@@ -84,11 +84,11 @@ namespace Uno.UI.Skia.Platform
 			}
 		}
 
-		public void ReleasePointerCapture()
-			=> WpfHost.Current.ReleaseMouseCapture();
-
-		public void SetPointerCapture()
+		public void SetPointerCapture(PointerIdentifier pointer)
 			=> WpfHost.Current.CaptureMouse();
+
+		public void ReleasePointerCapture(PointerIdentifier pointer)
+			=> WpfHost.Current.ReleaseMouseCapture();
 
 		private static uint GetNextFrameId()
 			=> (uint)Interlocked.Increment(ref _currentFrameId);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -106,7 +106,6 @@ namespace Windows.UI.Xaml.Controls
 			// Touch scroll support
 			ManipulationMode = ManipulationModes.TranslateX | ManipulationModes.TranslateY; // Updated in PrepareTouchScroll!
 			ManipulationStarting += PrepareTouchScroll;
-			ManipulationStarted += BeginTouchScroll;
 			ManipulationDelta += UpdateTouchScroll;
 			ManipulationCompleted += CompleteTouchScroll;
 
@@ -238,6 +237,12 @@ namespace Windows.UI.Xaml.Controls
 
 		private void PrepareTouchScroll(object sender, ManipulationStartingRoutedEventArgs e)
 		{
+			if (e.Pointer.Type != PointerDeviceType.Touch)
+			{
+				e.Mode = ManipulationModes.None;
+				return;
+			}
+
 			if (!CanVerticallyScroll || ExtentHeight <= 0)
 			{
 				e.Mode &= ~ManipulationModes.TranslateY;
@@ -246,15 +251,6 @@ namespace Windows.UI.Xaml.Controls
 			if (!CanHorizontallyScroll || ExtentWidth <= 0)
 			{
 				e.Mode &= ~ManipulationModes.TranslateX;
-			}
-		}
-
-		private void BeginTouchScroll(object sender, ManipulationStartedRoutedEventArgs e)
-		{
-			if (e.PointerDeviceType != PointerDeviceType.Touch)
-			{
-				e.Complete();
-				return;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -804,7 +804,7 @@ namespace Windows.UI.Xaml.Controls
 				that.CompleteGesture();
 
 				// On UWP we don't get any CaptureLost, so make sure to manually release the capture silently
-				that.ReleasePointerCapture(e.Pointer, muteEvent: true);
+				that.ReleasePointerCapture(e.Pointer.UniqueId, muteEvent: true);
 
 				// KNOWN ISSUE:
 				// On UWP the 'click' event is raised **after** the PointerReleased ... but deferring the event on the Dispatcher

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using Windows.ApplicationModel.DataTransfer.DragDrop;
 using Windows.ApplicationModel.DataTransfer.DragDrop.Core;
+using Windows.Devices.Input;
 using Uno;
 using Uno.UI.Xaml.Input;
 using Windows.System;
@@ -52,6 +53,7 @@ namespace Windows.UI.Xaml.Input
 		public override string ToString()
 			=> $"PointerRoutedEventArgs({Pointer}@{GetCurrentPoint(null).Position})";
 
+		PointerIdentifier CoreWindow.IPointerEventArgs.Pointer => Pointer.UniqueId;
 		long IDragEventSource.Id => Pointer.UniqueId;
 		uint IDragEventSource.FrameId => FrameId;
 

--- a/src/Uno.UI/UI/Xaml/UIElement.PointerCapture.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.PointerCapture.cs
@@ -23,7 +23,7 @@ namespace Windows.UI.Xaml
 		 */
 
 		[Flags]
-		private protected enum PointerCaptureKind : byte
+		internal enum PointerCaptureKind : byte
 		{
 			None = 0,
 
@@ -238,7 +238,7 @@ namespace Windows.UI.Xaml
 					// ** This is an IMPORTANT safety catch to prevent the application to become unresponsive **
 					Clear();
 
-					return false;
+					return true;
 				}
 				else if (_targets.TryGetValue(element, out var target))
 				{

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Managed.cs
@@ -290,7 +290,7 @@ namespace Windows.UI.Xaml
 				{
 					foreach (var target in capture.Targets)
 					{
-						target.Element.ReleasePointerCapture(capture.Pointer);
+						target.Element.ReleasePointerCapture(capture.Pointer.UniqueId, kinds: PointerCaptureKind.Any);
 					}
 				}
 			}
@@ -463,10 +463,10 @@ namespace Windows.UI.Xaml
 		#endregion
 
 		partial void CapturePointerNative(Pointer pointer)
-			=> CoreWindow.GetForCurrentThread()!.SetPointerCapture();
+			=> CoreWindow.GetForCurrentThread()!.SetPointerCapture(pointer.UniqueId);
 
 		partial void ReleasePointerNative(Pointer pointer)
-			=> CoreWindow.GetForCurrentThread()!.ReleasePointerCapture();
+			=> CoreWindow.GetForCurrentThread()!.ReleasePointerCapture(pointer.UniqueId);
 	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1,4 +1,11 @@
-﻿using System;
+﻿#if __WASM__ || __SKIA__
+// On iOS and Android, pointers are implicitly captured, so we will receive the "irrelevant" (i.e. !isOverOrCaptured)
+// pointer moves and we can use them for manipulation. But on WASM and SKIA we have to explicitly request to get those events
+// (expect on FF where they are also implicitly captured ... but we still capture them anyway).
+#define NEEDS_IMPLICIT_CAPTURE
+#endif
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -66,7 +73,7 @@ namespace Windows.UI.Xaml
 #endif
 		}
 
-		#region ManipulationMode (DP)
+				#region ManipulationMode (DP)
 		public static DependencyProperty ManipulationModeProperty { get; } = DependencyProperty.Register(
 			"ManipulationMode",
 			typeof(ManipulationModes),
@@ -94,9 +101,9 @@ namespace Windows.UI.Xaml
 			get => (ManipulationModes)this.GetValue(ManipulationModeProperty);
 			set => this.SetValue(ManipulationModeProperty, value);
 		}
-		#endregion
+				#endregion
 
-		#region CanDrag (DP)
+				#region CanDrag (DP)
 		public static DependencyProperty CanDragProperty { get; } = DependencyProperty.Register(
 			nameof(CanDrag),
 			typeof(bool),
@@ -119,9 +126,9 @@ namespace Windows.UI.Xaml
 			get => (bool)GetValue(CanDragProperty);
 			set => SetValue(CanDragProperty, value);
 		}
-		#endregion
+				#endregion
 
-		#region AllowDrop (DP)
+				#region AllowDrop (DP)
 		public static DependencyProperty AllowDropProperty { get; } = DependencyProperty.Register(
 			nameof(AllowDrop),
 			typeof(bool),
@@ -133,7 +140,7 @@ namespace Windows.UI.Xaml
 			get => (bool)GetValue(AllowDropProperty);
 			set => SetValue(AllowDropProperty, value);
 		}
-		#endregion
+				#endregion
 
 		private /* readonly but partial */ Lazy<GestureRecognizer> _gestures;
 
@@ -251,9 +258,9 @@ namespace Windows.UI.Xaml
 #endif
 		}
 
-		#region GestureRecognizer wire-up
+				#region GestureRecognizer wire-up
 
-		#region Event to RoutedEvent handler adapters
+				#region Event to RoutedEvent handler adapters
 		// Note: For the manipulation and gesture event args, the original source has to be the element that raise the event
 		//		 As those events are bubbling in managed only, the original source will be right one for all.
 
@@ -284,6 +291,14 @@ namespace Windows.UI.Xaml
 		private static readonly TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> OnRecognizerManipulationCompleted = (sender, args) =>
 		{
 			var that = (UIElement)sender.Owner;
+
+#if NEEDS_IMPLICIT_CAPTURE
+			foreach (var pointer in args.Pointers)
+			{
+				that.ReleasePointerCapture(pointer, muteEvent: true, PointerCaptureKind.Implicit);
+			}
+#endif
+
 			that.SafeRaiseEvent(ManipulationCompletedEvent, new ManipulationCompletedRoutedEventArgs(that, args));
 		};
 
@@ -317,7 +332,7 @@ namespace Windows.UI.Xaml
 			var that = (UIElement)sender.Owner;
 			that.OnDragStarting(args);
 		};
-		#endregion
+				#endregion
 
 		private GestureRecognizer CreateGestureRecognizer()
 		{
@@ -374,9 +389,9 @@ namespace Windows.UI.Xaml
 				this.Log().Error("Haptic feedback for drag failed", error);
 			}
 		}
-		#endregion
+				#endregion
 
-		#region Manipulations (recognizer settings / custom bubbling)
+				#region Manipulations (recognizer settings / custom bubbling)
 		partial void AddManipulationHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo)
 		{
 			if (handlersCount == 1)
@@ -431,9 +446,9 @@ namespace Windows.UI.Xaml
 			}
 			// Note: We do not need to alter the location of the events, on UWP they are always relative to the OriginalSource.
 		}
-		#endregion
+				#endregion
 
-		#region Gestures (recognizer settings / custom bubbling / early completion)
+				#region Gestures (recognizer settings / custom bubbling / early completion)
 		private bool _isGestureCompleted;
 
 		partial void AddGestureHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo)
@@ -504,9 +519,9 @@ namespace Windows.UI.Xaml
 				_gestures.Value.CompleteGesture();
 			}
 		}
-		#endregion
+				#endregion
 
-		#region Drag And Drop (recognizer settings / custom bubbling / drag starting event)
+				#region Drag And Drop (recognizer settings / custom bubbling / drag starting event)
 		private void UpdateDragAndDrop(bool isEnabled)
 		{
 			// Note: The drag and drop recognizer setting is only driven by the CanDrag,
@@ -697,7 +712,7 @@ namespace Windows.UI.Xaml
 				SafeRaiseEvent(DropEvent, args);
 			}
 		}
-		#endregion
+				#endregion
 
 		partial void PrepareManagedPointerEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref BubblingMode bubblingMode)
 		{
@@ -728,14 +743,14 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		#region Partial API to raise pointer events and gesture recognition (OnNative***)
+				#region Partial API to raise pointer events and gesture recognition (OnNative***)
 		private bool OnNativePointerEnter(PointerRoutedEventArgs args, BubblingContext ctx = default) => OnPointerEnter(args);
 
 		private bool OnPointerEnter(PointerRoutedEventArgs args, BubblingContext ctx = default)
 		{
 			// We override the isOver for the relevancy check as we will update it right after.
 			var isOverOrCaptured = ValidateAndUpdateCapture(args, isOver: true);
-			var handledInManaged = SetOver(args, true, muteEvent: ctx.IsLocalOnly || !isOverOrCaptured);
+			var handledInManaged = SetOver(args, true, muteEvent: ctx.IsInternal || !isOverOrCaptured);
 
 			return handledInManaged;
 		}
@@ -750,9 +765,9 @@ namespace Windows.UI.Xaml
 			// it due to an invalid state. So here we make sure to not stay in an invalid state that would
 			// prevent any interaction with the application.
 			var isOverOrCaptured = ValidateAndUpdateCapture(args, isOver: true, forceRelease: true);
-			var handledInManaged = SetPressed(args, true, muteEvent: ctx.IsLocalOnly || !isOverOrCaptured);
+			var handledInManaged = SetPressed(args, true, muteEvent: ctx.IsInternal || !isOverOrCaptured);
 
-			if (PointerRoutedEventArgs.PlatformSupportsNativeBubbling && !ctx.IsLocalOnly && !isOverOrCaptured)
+			if (PointerRoutedEventArgs.PlatformSupportsNativeBubbling && !ctx.IsInternal && !isOverOrCaptured)
 			{
 				// This case is for safety only, it should not happen as we should never get a Pointer down while not
 				// on this UIElement, and no capture should prevent the dispatch as no parent should hold a capture at this point.
@@ -773,11 +788,8 @@ namespace Windows.UI.Xaml
 
 				recognizer.ProcessDownEvent(point);
 
-#if __WASM__ || __SKIA__
-				// On iOS and Android, pointers are implicitly captured, so we will receive the "irrelevant" (i.e. !isOverOrCaptured)
-				// pointer moves and we can use them for manipulation. But on WASM and SKIA we have to explicitly request to get those events
-				// (expect on FF where they are also implicitly captured ... but we still capture them anyway).
-				if (recognizer.PendingManipulation?.IsActive(point.PointerDevice.PointerDeviceType, point.PointerId) ?? false)
+#if NEEDS_IMPLICIT_CAPTURE
+				if (recognizer.PendingManipulation?.IsActive(point.Pointer) ?? false)
 				{
 					Capture(args.Pointer, PointerCaptureKind.Implicit, args);
 				}
@@ -825,7 +837,7 @@ namespace Windows.UI.Xaml
 			var handledInManaged = false;
 			var isOverOrCaptured = ValidateAndUpdateCapture(args);
 
-			if (!ctx.IsLocalOnly && isOverOrCaptured)
+			if (!ctx.IsInternal && isOverOrCaptured)
 			{
 				// If this pointer was wrongly dispatched here (out of the bounds and not captured),
 				// we don't raise the 'move' event
@@ -838,7 +850,7 @@ namespace Windows.UI.Xaml
 			{
 				// We need to process only events that were not handled by a child control,
 				// so we should not use them for gesture recognition.
-				_gestures.Value.ProcessMoveEvents(args.GetIntermediatePoints(this), !ctx.IsLocalOnly || isOverOrCaptured);
+				_gestures.Value.ProcessMoveEvents(args.GetIntermediatePoints(this), !ctx.IsInternal || isOverOrCaptured);
 				if (_gestures.Value.IsDragging)
 				{
 					global::Windows.UI.Xaml.Window.Current.DragDrop.ProcessMoved(args);
@@ -855,7 +867,7 @@ namespace Windows.UI.Xaml
 			var handledInManaged = false;
 			var isOverOrCaptured = ValidateAndUpdateCapture(args, out var isOver);
 
-			handledInManaged |= SetPressed(args, false, muteEvent: ctx.IsLocalOnly || !isOverOrCaptured);
+			handledInManaged |= SetPressed(args, false, muteEvent: ctx.IsInternal || !isOverOrCaptured);
 
 			// Note: We process the UpEvent between Release and Exited as the gestures like "Tap"
 			//		 are fired between those events.
@@ -865,7 +877,7 @@ namespace Windows.UI.Xaml
 				// if they are bubbling in managed it means that they where handled a child control,
 				// so we should not use them for gesture recognition.
 				var isDragging = _gestures.Value.IsDragging;
-				_gestures.Value.ProcessUpEvent(args.GetCurrentPoint(this), !ctx.IsLocalOnly || isOverOrCaptured);
+				_gestures.Value.ProcessUpEvent(args.GetCurrentPoint(this), !ctx.IsInternal || isOverOrCaptured);
 				if (isDragging)
 				{
 					global::Windows.UI.Xaml.Window.Current.DragDrop.ProcessDropped(args);
@@ -892,7 +904,7 @@ namespace Windows.UI.Xaml
 			var handledInManaged = false;
 			var isOverOrCaptured = ValidateAndUpdateCapture(args);
 
-			handledInManaged |= SetOver(args, false, muteEvent: ctx.IsLocalOnly || !isOverOrCaptured);
+			handledInManaged |= SetOver(args, false, muteEvent: ctx.IsInternal || !isOverOrCaptured);
 
 			if (_gestures.IsValueCreated && _gestures.Value.IsDragging)
 			{
@@ -954,7 +966,7 @@ namespace Windows.UI.Xaml
 			else
 			{
 				args.Handled = false;
-				handledInManaged |= !ctx.IsLocalOnly && RaisePointerEvent(PointerCanceledEvent, args);
+				handledInManaged |= !ctx.IsInternal && RaisePointerEvent(PointerCanceledEvent, args);
 				handledInManaged |= SetNotCaptured(args);
 			}
 
@@ -993,9 +1005,9 @@ namespace Windows.UI.Xaml
 				_pendingRaisedEvent = (null, null, null);
 			}
 		}
-#endregion
+		#endregion
 
-#region Pointer over state (Updated by the partial API OnNative***, should not be updated externaly)
+		#region Pointer over state (Updated by the partial API OnNative***, should not be updated externaly)
 		/// <summary>
 		/// Indicates if a pointer (no matter the pointer) is currently over the element (i.e. OverState)
 		/// WARNING: This might not be maintained for all controls, cf. remarks.
@@ -1042,9 +1054,9 @@ namespace Windows.UI.Xaml
 				return RaisePointerEvent(PointerExitedEvent, args);
 			}
 		}
-#endregion
+		#endregion
 
-#region Pointer pressed state (Updated by the partial API OnNative***, should not be updated externaly)
+		#region Pointer pressed state (Updated by the partial API OnNative***, should not be updated externaly)
 		private readonly HashSet<uint> _pressedPointers = new HashSet<uint>();
 
 		/// <summary>
@@ -1116,9 +1128,9 @@ namespace Windows.UI.Xaml
 		}
 
 		private void ClearPressed() => _pressedPointers.Clear();
-#endregion
+		#endregion
 
-#region Pointer capture state (Updated by the partial API OnNative***, should not be updated externaly)
+		#region Pointer capture state (Updated by the partial API OnNative***, should not be updated externaly)
 		/*
 		 * About pointer capture
 		 *
@@ -1132,7 +1144,7 @@ namespace Windows.UI.Xaml
 
 		private List<Pointer> _localExplicitCaptures;
 
-#region Capture public (and internal) API ==> This manages only Explicit captures
+		#region Capture public (and internal) API ==> This manages only Explicit captures
 		public static DependencyProperty PointerCapturesProperty { get; } = DependencyProperty.Register(
 			"PointerCaptures",
 			typeof(IReadOnlyList<Pointer>),
@@ -1162,7 +1174,8 @@ namespace Windows.UI.Xaml
 			return Capture(pointer, PointerCaptureKind.Explicit, _pendingRaisedEvent.args);
 		}
 
-		public void ReleasePointerCapture(Pointer value) => ReleasePointerCapture(value, muteEvent: false);
+		public void ReleasePointerCapture(Pointer value)
+			=> ReleasePointerCapture((value ?? throw new ArgumentNullException(nameof(value))).UniqueId, muteEvent: false);
 
 		/// <summary>
 		/// Release a pointer capture with the ability to not raise the <see cref="PointerCaptureLost"/> event (cf. Remarks)
@@ -1172,13 +1185,12 @@ namespace Windows.UI.Xaml
 		/// UWP does not raise a PointerCaptureLost. This method give the ability to easily follow this behavior without requiring
 		/// the control to track and handle the event.
 		/// </remarks>
-		/// <param name="value">The pointer to release.</param>
+		/// <param name="pointer">The pointer to release.</param>
 		/// <param name="muteEvent">Determines if the event should be raised or not.</param>
-		private protected void ReleasePointerCapture(Pointer value, bool muteEvent)
+		/// <param name="kinds">The kind of captures to release.</param>
+		internal void ReleasePointerCapture(PointerIdentifier pointer, bool muteEvent = false, PointerCaptureKind kinds = PointerCaptureKind.Explicit)
 		{
-			var pointer = value ?? throw new ArgumentNullException(nameof(value));
-
-			if (!Release(pointer, PointerCaptureKind.Explicit, muteEvent: muteEvent)
+			if (!Release(pointer, kinds, muteEvent: muteEvent)
 				&& this.Log().IsEnabled(LogLevel.Information))
 			{
 				this.Log().Info($"{this}: Cannot release pointer {pointer}: not captured by this control.");
@@ -1199,7 +1211,7 @@ namespace Windows.UI.Xaml
 
 			Release(PointerCaptureKind.Explicit);
 		}
-#endregion
+		#endregion
 
 		partial void CapturePointerNative(Pointer pointer);
 		partial void ReleasePointerNative(Pointer pointer);
@@ -1235,7 +1247,7 @@ namespace Windows.UI.Xaml
 
 		private bool SetNotCaptured(PointerRoutedEventArgs args, bool forceCaptureLostEvent = false)
 		{
-			if (Release(args.Pointer, PointerCaptureKind.Any, args))
+			if (Release(args.Pointer.UniqueId, PointerCaptureKind.Any, args))
 			{
 				return true;
 			}
@@ -1272,7 +1284,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private bool Release(Pointer pointer, PointerCaptureKind kinds, PointerRoutedEventArgs relatedArgs = null, bool muteEvent = false)
+		private bool Release(PointerIdentifier pointer, PointerCaptureKind kinds, PointerRoutedEventArgs relatedArgs = null, bool muteEvent = false)
 		{
 			return PointerCapture.TryGet(pointer, out var capture)
 				&& Release(capture, kinds, relatedArgs, muteEvent);
@@ -1298,9 +1310,9 @@ namespace Windows.UI.Xaml
 			relatedArgs.Handled = false;
 			return RaisePointerEvent(PointerCaptureLostEvent, relatedArgs);
 		}
-#endregion
+		#endregion
 
-#region Drag state (Updated by the RaiseDrag***, should not be updated externaly)
+		#region Drag state (Updated by the RaiseDrag***, should not be updated externaly)
 		private HashSet<long> _draggingOver;
 
 		/// <summary>
@@ -1332,6 +1344,6 @@ namespace Windows.UI.Xaml
 		{
 			_draggingOver?.Clear();
 		}
-#endregion
+		#endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -1,4 +1,5 @@
 ﻿// #define TRACE_ROUTED_EVENT_BUBBLING
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -817,11 +818,6 @@ namespace Windows.UI.Xaml
 			/// but the UIElement.RoutedEvent won't be raised in any way (public and internal handlers) and it won't be sent to Control.On`RoutedEvent`() neither.
 			/// </remarks>
 			public bool IsInternal { get; set; }
-
-			/// <summary>
-			/// Indicates that the associated event is an internal event that will not be propagated to parent (cf. <see cref="OnManagedBubbling"/>).
-			/// </summary>
-			public bool IsLocalOnly => IsInternal && Mode == BubblingMode.NoBubbling;
 
 			public BubblingContext WithMode(BubblingMode mode) => new BubblingContext
 			{

--- a/src/Uno.UWP/UI/Core/CoreWindow.Pointers.Managed.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.Pointers.Managed.cs
@@ -2,21 +2,13 @@
 #nullable enable
 
 using System;
+using Windows.Devices.Input;
 using Uno.Foundation;
 using Uno.Foundation.Extensibility;
 using Windows.Foundation;
 
 namespace Windows.UI.Core
 {
-	public interface ICoreWindowExtension
-	{
-		public CoreCursor PointerCursor { get; set; }
-
-		void ReleasePointerCapture();
-
-		void SetPointerCapture();
-	}
-
 	public partial class CoreWindow : ICoreWindowEvents
 	{
 		private ICoreWindowExtension? _coreWindowExtension;
@@ -52,10 +44,14 @@ namespace Windows.UI.Core
 		}
 
 		public void SetPointerCapture()
-			=> _coreWindowExtension?.SetPointerCapture();
+			=> _coreWindowExtension?.SetPointerCapture(LastPointerEvent?.Pointer ?? default);
+		internal void SetPointerCapture(PointerIdentifier pointer)
+			=> _coreWindowExtension?.SetPointerCapture(pointer);
 
 		public void ReleasePointerCapture()
-			=> _coreWindowExtension?.ReleasePointerCapture();
+			=> _coreWindowExtension?.ReleasePointerCapture(LastPointerEvent?.Pointer ?? default);
+		internal void ReleasePointerCapture(PointerIdentifier pointer)
+			=> _coreWindowExtension?.ReleasePointerCapture(pointer);
 
 		void ICoreWindowEvents.RaisePointerEntered(PointerEventArgs args)
 			=> PointerEntered?.Invoke(this, args);

--- a/src/Uno.UWP/UI/Core/CoreWindow.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using Windows.Devices.Input;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
 using Uno.UI.Core;
@@ -120,6 +121,8 @@ namespace Windows.UI.Core
 
 		internal interface IPointerEventArgs
 		{
+			PointerIdentifier Pointer { get; }
+
 			PointerPoint GetLocation(object? relativeTo);
 		}
 

--- a/src/Uno.UWP/UI/Core/CoreWindow.macOS.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.macOS.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using AppKit;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
+using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.Foundation.Metadata;
@@ -54,10 +55,10 @@ namespace Windows.UI.Core
 		}
 
 		/// <inheritdoc />
-		public void ReleasePointerCapture() { }
+		public void ReleasePointerCapture(PointerIdentifier pointer) { }
 
 		/// <inheritdoc />
-		public void SetPointerCapture() { }
+		public void SetPointerCapture(PointerIdentifier pointer) { }
 
 		private void RefreshCursor()
 		{

--- a/src/Uno.UWP/UI/Core/ICoreWindowExtension.cs
+++ b/src/Uno.UWP/UI/Core/ICoreWindowExtension.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Linq;
+using Windows.Devices.Input;
+
+namespace Windows.UI.Core
+{
+	internal interface ICoreWindowExtension
+	{
+		public CoreCursor PointerCursor { get; set; }
+
+		void ReleasePointerCapture(PointerIdentifier pointer);
+
+		void SetPointerCapture(PointerIdentifier pointer);
+	}
+}

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -9,6 +9,7 @@ using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.System;
 using Microsoft.Extensions.Logging;
+using Uno;
 using Uno.Logging;
 
 namespace Windows.UI.Input
@@ -264,6 +265,7 @@ namespace Windows.UI.Input
 				switch (PointerType)
 				{
 					case PointerDeviceType.Mouse: return _settings.HasFlag(GestureSettings.HoldWithMouse);
+					case PointerDeviceType.Touch when DeviceHelper.IsSimulator: return true;
 					default: return false;
 				}
 			}

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
@@ -77,7 +77,35 @@ namespace Windows.UI.Input
 			public bool IsRotateEnabled	  => _isRotateEnabled;
 			public bool IsScaleEnabled	  => _isScaleEnabled;
 
-			public Manipulation(GestureRecognizer recognizer, PointerPoint pointer1)
+			internal static void AddPointer(GestureRecognizer recognizer, PointerPoint pointer)
+			{
+				var current = recognizer._manipulation;
+				if (current != null)
+				{
+					if (current.TryAdd(pointer))
+					{
+						// The pending manipulation which can either handle the pointer, either is still active with another pointer,
+						// just ignore the new pointer.
+						return;
+					}
+
+					// The current manipulation should be discarded
+					current.Complete(); // Will removed 'current' from the 'recognizer._manipulation' field.
+				}
+
+				var manipulation = new Manipulation(recognizer, pointer);
+				if (manipulation._state == ManipulationState.Completed)
+				{
+					// The new manipulation has been cancelled in the ManipStarting handler, throw it away.
+					manipulation.Complete(); // Should not do anything, safety only
+				}
+				else
+				{
+					recognizer._manipulation = manipulation;
+				}
+			}
+
+			private Manipulation(GestureRecognizer recognizer, PointerPoint pointer1)
 			{
 				_recognizer = recognizer;
 				_deviceType = pointer1.PointerDevice.PointerDeviceType;
@@ -114,27 +142,29 @@ namespace Windows.UI.Input
 
 				if ((_settings & (GestureSettingsHelper.Manipulations | GestureSettingsHelper.DragAndDrop)) == 0)
 				{
+					// The manipulation has been cancelled (all possible manip has been removed)
+					// WARNING: The _gestureRecognizer._manipulation has not been set yet! We cannot invoke the Complete right now (cf. AddPointer)
+
 					_state = ManipulationState.Completed;
+					return;
 				}
-				else
-				{
-					_isDraggingEnable = (_settings & GestureSettings.Drag) != 0;
-					_isTranslateXEnabled = (_settings & (GestureSettings.ManipulationTranslateX | GestureSettings.ManipulationTranslateRailsX)) != 0;
-					_isTranslateYEnabled = (_settings & (GestureSettings.ManipulationTranslateY | GestureSettings.ManipulationTranslateRailsY)) != 0;
-					_isRotateEnabled = (_settings & GestureSettings.ManipulationRotate) != 0;
-					_isScaleEnabled = (_settings & GestureSettings.ManipulationScale) != 0;
-				}
+
+				_isDraggingEnable = (_settings & GestureSettings.Drag) != 0;
+				_isTranslateXEnabled = (_settings & (GestureSettings.ManipulationTranslateX | GestureSettings.ManipulationTranslateRailsX)) != 0;
+				_isTranslateYEnabled = (_settings & (GestureSettings.ManipulationTranslateY | GestureSettings.ManipulationTranslateRailsY)) != 0;
+				_isRotateEnabled = (_settings & GestureSettings.ManipulationRotate) != 0;
+				_isScaleEnabled = (_settings & GestureSettings.ManipulationScale) != 0;
 
 				_recognizer.ManipulationConfigured?.Invoke(_recognizer, this);
 				StartDragTimer();
 			}
 
-			public bool IsActive(PointerDeviceType type, uint id)
+			public bool IsActive(PointerIdentifier pointer)
 				=> _state != ManipulationState.Completed
-					&& _deviceType == type
-					&& _origins.ContainsPointer(id);
+					&& _deviceType == pointer.Type
+					&& _origins.ContainsPointer(pointer.Id);
 
-			public bool TryAdd(PointerPoint point)
+			private bool TryAdd(PointerPoint point)
 			{
 				if (point.Pointer == _origins.Pointer1.Pointer)
 				{
@@ -142,7 +172,7 @@ namespace Windows.UI.Input
 						"Invalid manipulation state: We are receiving a down for the second time for the same pointer!"
 						+ "This is however common when using iOS emulator with VNC where we might miss some pointer events "
 						+ "due to focus being stole by debugger, in that case you can safely ignore this message.");
-					return false; // Request to create a new manipualtion
+					return false; // Request to create a new manipulation
 				}
 				else if (_state >= ManipulationState.Inertia)
 				{
@@ -236,11 +266,16 @@ namespace Windows.UI.Input
 							new ManipulationCompletedEventArgs(_currents.Identifiers, position, cumulative, velocities, _state == ManipulationState.Inertia, _contacts.onStart, _contacts.current));
 						break;
 
-					default:
+					case ManipulationState.Starting:
 						_inertia?.Dispose();
 						_state = ManipulationState.Completed;
 
 						_recognizer.ManipulationAborted?.Invoke(_recognizer, this);
+						break;
+
+					default: // Safety only
+						_inertia?.Dispose();
+						_state = ManipulationState.Completed;
 						break;
 				}
 
@@ -524,6 +559,7 @@ namespace Windows.UI.Input
 			{
 				_dragHoldTimer?.Stop();
 			}
+
 			// For pen and mouse this only means down -> * moves out of tap range;
 			// For touch it means down -> * moves close to origin for DragUsingFingerMinDelayTicks -> * moves far from the origin 
 			private bool IsBeginningOfDragManipulation()

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -90,18 +90,10 @@ namespace Windows.UI.Input
 			}
 			_gestures[value.PointerId] = gesture;
 
-			// Create of update a Manipulation responsible to recognize multi-pointer and drag gestures
+			// Create or update a Manipulation responsible to recognize multi-pointer and drag gestures
 			if (_isManipulationOrDragEnabled)
 			{
-				if (_manipulation == null)
-				{
-					_manipulation = new Manipulation(this, value);
-				}
-				else if (!_manipulation.TryAdd(value))
-				{
-					_manipulation.Complete();
-					_manipulation = new Manipulation(this, value);
-				}
+				Manipulation.AddPointer(this, value);
 			}
 		}
 
@@ -191,8 +183,8 @@ namespace Windows.UI.Input
 
 		#region Manipulations
 		internal event TypedEventHandler<GestureRecognizer, ManipulationStartingEventArgs> ManipulationStarting; // This is not on the public API!
-		internal event TypedEventHandler<GestureRecognizer, Manipulation> ManipulationConfigured; // Right after the ManipulationStarting, once application has configured settings
-		internal event TypedEventHandler<GestureRecognizer, Manipulation> ManipulationAborted; // The manipulation has been aborted while in starting state
+		internal event TypedEventHandler<GestureRecognizer, Manipulation> ManipulationConfigured; // Right after the ManipulationStarting, once application has configured settings ** ONLY if not cancelled in starting **
+		internal event TypedEventHandler<GestureRecognizer, Manipulation> ManipulationAborted; // The manipulation has been aborted while in starting state ** ONLY if received a ManipulationConfigured **
 		public event TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> ManipulationCompleted;
 		public event TypedEventHandler<GestureRecognizer, ManipulationInertiaStartingEventArgs> ManipulationInertiaStarting;
 		public event TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> ManipulationStarted;

--- a/src/Uno.UWP/UI/Input/ManipulationCompletedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/ManipulationCompletedEventArgs.cs
@@ -31,7 +31,7 @@ namespace Windows.UI.Input
 		/// <summary>
 		/// Gets identifiers of all pointer that has been involved in that manipulation (cf. Remarks).
 		/// </summary>
-		/// <remarks> This collection might contains pointers that has been released. <see cref="CurrentContactCount"/> gives the actual number of active pointers.</remarks>
+		/// <remarks>This collection might contains pointers that has been released. <see cref="CurrentContactCount"/> gives the actual number of active pointers.</remarks>
 		/// <remarks>All pointers are expected to have the same <see cref="PointerIdentifier.Type"/>.</remarks>
 		internal PointerIdentifier[] Pointers { get; }
 

--- a/src/Uno.UWP/Uno/DeviceHelper.cs
+++ b/src/Uno.UWP/Uno/DeviceHelper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Uno
+{
+	internal static class DeviceHelper
+	{
+		internal static bool IsSimulator { get; } =
+#if __IOS__
+			ObjCRuntime.Runtime.Arch == ObjCRuntime.Arch.SIMULATOR;
+#else
+			false;
+#endif
+	}
+}


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/7198

## Bugfix / feature
Misc fixes for pointers

## What is the current behavior?
We have to double tap on buttons when they are nested in `ScrollViewer` on skia



## What is the new behavior?
* Managed `SCP` (Skia/MacOS) aborts drag manipulation in `MnaipulationStarting` when not a mouse (Avoids useless implicit captures)
* Manipulation cancelled in `ManipulationStarting` are properly cleaned-up (was staying active until next `PointerDown` causing some noise in the log)
* Implicit captures (Skia/MacOS) are properly released on `PointerReleased` (Only explicit captures was released)
* Implicit captures (Skia/MacOS) are released on `ManipulationCompleted` which might be much earlier than `PointerRelease` if manipulation is programmatically completed
* Native pointer capture is now supported on GTK
* Misc: Reduce number of exception raised by `RemoteControlClient`

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~ Internal interface `ICoreWindowExtension` has been flagged as `internal`
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
