### PR TITLE
fix(transformtovisual): Fix TransformToVisual on scrolled ScrollViewer

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -347,7 +347,10 @@ namespace Windows.UI.Xaml
 #if !UNO_HAS_MANAGED_SCROLL_PRESENTER
 				// On Skia, the Scrolling is managed by the ScrollContentPresenter (as UWP), which is flagged as IsScrollPort.
 				// Note: We should still add support for the zoom factor ... which is not yet supported on Skia.
-				if (elt is ScrollViewer sv)
+				if (elt is ScrollViewer sv
+					// Don't adjust for scroll offsets if it's the ScrollViewer itself calling TransformToVisual
+					&& elt != from
+				)
 				{
 					var zoom = sv.ZoomFactor;
 					if (zoom != 1)
@@ -367,7 +370,9 @@ namespace Windows.UI.Xaml
 				else
 #endif
 #if !__MACOS__ // On macOS the SCP is using RenderTransforms for scrolling which has already been included.
-				if (elt.IsScrollPort) // Custom scroller
+				if (elt.IsScrollPort
+					// Don't adjust for scroll offsets if it's the scroll port itself calling TransformToVisual, only for ancestors
+					&& elt != from) // Custom scroller
 				{
 					offsetX -= elt.ScrollOffsets.X;
 					offsetY -= elt.ScrollOffsets.Y;


### PR DESCRIPTION
When calling scrollViewer.TransformToVisual(), its scroll offsets were incorrectly being included in the returned transform, giving strange values.

This fix should improve the behaviour of VisibleBoundsPadding when used on elements nested inside a ScrollViewer.


<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
fixes https://github.com/unoplatform/nventive-private/issues/284