### PR TITLE
[iOS] Fixed potential native animation not terminating

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/Animation_Leak.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/Animation_Leak.xaml
@@ -1,0 +1,12 @@
+﻿<Page
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.Animation_Leak">
+
+	<Grid>
+		<Rectangle x:Name="sut" Fill="Red" />
+	</Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/Animation_Leak.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/Animation_Leak.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public partial class Animation_Leak : Page
+	{
+		public Animation_Leak()
+		{
+			InitializeComponent();
+
+			// Launch a fade-out of the rectangle
+			var storyboard = new Storyboard();
+			var animation = new DoubleAnimation
+			{
+				To = 0,
+				Duration = new Duration(TimeSpan.FromSeconds(0.15)),
+				EasingFunction = new QuadraticEase { EasingMode = EasingMode.EaseInOut },
+			};
+
+			Storyboard.SetTarget(animation, sut);
+			Storyboard.SetTargetProperty(animation, "Opacity");
+
+			storyboard.Children.Add(animation);
+			storyboard.Begin();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -41,6 +41,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(typeof(XamlEvent_Leak_UserControl_xBind), 15)]
 		[DataRow(typeof(XamlEvent_Leak_UserControl_xBind_Event), 15)]
 		[DataRow(typeof(XamlEvent_Leak_TextBox), 15)]
+		[DataRow(typeof(Animation_Leak), 15)]
 		[DataRow(typeof(TextBox), 15)]
 		[DataRow(typeof(Button), 15)]
 		[DataRow(typeof(RadioButton), 15)]

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -113,10 +113,21 @@
 	</ItemGroup>
 	
 	<ItemGroup>
+	  <None Remove="Tests\Windows_UI_Xaml\Controls\Animation_Leak.xaml" />
+	</ItemGroup>
+	
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="Tests\Windows_UI_Xaml\Controls\Animation_Leak.xaml" />
+	</ItemGroup>
+	
+	<ItemGroup>
 		<Compile Include="Tests\Windows_UI_Xaml_Controls\HtmlElementAttributeTests\Given_HtmlElementAttribute.Wasm.cs" />
 	</ItemGroup>
 	
 	<ItemGroup>
+		<Page Update="Tests\Windows_UI_Xaml\Controls\Animation_Leak.xaml">
+		  <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+		</Page>
 		<Page Update="Tests\Windows_UI_Xaml\Controls\xLoad_xBind.xaml">
 			<SubType>Designer</SubType>
 		</Page>

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -113,14 +113,6 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <None Remove="Tests\Windows_UI_Xaml\Controls\Animation_Leak.xaml" />
-	</ItemGroup>
-	
-	<ItemGroup>
-	  <UpToDateCheckInput Remove="Tests\Windows_UI_Xaml\Controls\Animation_Leak.xaml" />
-	</ItemGroup>
-	
-	<ItemGroup>
 		<Compile Include="Tests\Windows_UI_Xaml_Controls\HtmlElementAttributeTests\Given_HtmlElementAttribute.Wasm.cs" />
 	</ItemGroup>
 	


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/nventive-private/issues/272

# Bugfix
Fixed a problematic case where a native animation can be _lost_ if the GC is run during the duration of the animation, preventing the animation from being removed and leaving the UI in an undetermined undesired state.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
