### PR TITLE
fix(xBind): [Wasm] Fix invalid internal ElementStub state

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -47,6 +47,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			sut.IsLoad = false;
 
 			Assert.IsFalse((parent.Child as ElementStub).Load);
+
+			sut.IsLoad = true;
+
+			Assert.IsNotNull(sut.LoadBorder);
+			parent = sut.LoadBorder.Parent as Border;
+
+			sut.IsLoad = false;
+
+			Assert.IsFalse((parent.Child as ElementStub).Load);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/ElementStub.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
+using Uno.Extensions;
+using Uno.Logging;
 using Uno.UI;
 using Uno.UI.DataBinding;
 
@@ -177,6 +179,11 @@ namespace Windows.UI.Xaml
 
 		private void Materialize(bool isVisibilityChanged)
 		{
+			if(this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+			{
+				this.Log().Debug($"ElementStub.Materialize(isVibilityChanged: {isVisibilityChanged})");
+			}
+
 			if (_content == null && !_isMaterializing)
 			{
 #if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
@@ -203,15 +210,20 @@ namespace Windows.UI.Xaml
 #if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
 				}
 				finally
+#endif
 				{
 					_isMaterializing = false;
 				}
-#endif
 			}
 		}
 
 		private void Dematerialize()
 		{
+			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+			{
+				this.Log().Debug($"ElementStub.Dematerialize()");
+			}
+
 			if (_content != null)
 			{
 				var newView = SwapViews(oldView: (FrameworkElement)_content, newViewProvider: () => this as View);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7244

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Under webassembly, as try/finally blocks are removed, ElementStub is now properly maintaining its internal state to avoid update loops.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
