### PR TITLE
fix: Fix lazy theme dictionary caching

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
@@ -876,6 +876,26 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		}
 
 		[TestMethod]
+		public void When_Lazy()
+		{
+			var dictionary = new ResourceDictionary();
+			var brush = new SolidColorBrush { Color = Colors.Red };
+			dictionary.TryGetValue("TestKey", out _);
+
+			dictionary.ThemeDictionaries.Add("Light", new WeakResourceInitializer(new Application(), o =>
+				new ResourceDictionary
+				{
+					["TestKey"] = new WeakResourceInitializer(o, _ => brush)
+				}));
+
+
+			// Make sure the cache is updated.
+			Assert.IsTrue(dictionary.TryGetValue("TestKey", out var testValue));
+			Assert.AreEqual(brush, testValue);
+
+		}
+
+		[TestMethod]
 		public void When_Resource_NotImplemented()
 		{
 			var initialCreationCount = SomeNotImplType.CreationAttempts;

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -249,6 +249,7 @@ namespace Windows.UI.Xaml
 			{
 				_hasUnmaterializedItems = true;
 				_values[resourceKey] = new LazyInitializer(ResourceResolver.CurrentScope, resourceInitializer);
+				ResourceDictionaryValueChange?.Invoke(this, EventArgs.Empty);
 			}
 			else
 			{


### PR DESCRIPTION
Helps porting latest NumberBox from WinUI.

cc @davidjohnoliver

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Invalid cached lazy theme resource is used

## What is the new behavior?

Cache is now invalidated properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
