### PR TITLE
fix: Update text according to AcceptsReturn

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/TextBoxTests/Given_TextBox.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/TextBoxTests/Given_TextBox.cs
@@ -94,13 +94,13 @@ namespace Uno.UI.Tests.TextBoxTests
 			var textChangingCount = 0;
 			var beforeTextChangingCount = 0;
 			textBox.BeforeTextChanging += (tb, e) =>
-			  {
-				  beforeTextChangingCount++;
-				  if (e.NewText == "Papaya")
-				  {
-					  e.Cancel = true;
-				  }
-			  };
+			{
+				beforeTextChangingCount++;
+				if (e.NewText == "Papaya")
+				{
+					e.Cancel = true;
+				}
+			};
 			textBox.TextChanging += (tb, e) => textChangingCount++;
 			textBox.Text = "Chirimoya";
 			Assert.AreEqual("Chirimoya", textBox.Text);
@@ -114,6 +114,31 @@ namespace Uno.UI.Tests.TextBoxTests
 
 			textBox.Text = "Chirimoya";
 			Assert.AreEqual(2, beforeTextChangingCount);
+		}
+
+		[TestMethod]
+		public void When_Multi_Line_Text_And_Not_AcceptsReturn()
+		{
+			var textBox = new TextBox();
+			Assert.AreEqual(false, textBox.AcceptsReturn);
+			textBox.Text = "Hello\nWorld";
+			Assert.AreEqual("Hello", textBox.Text);
+
+			textBox.Text = "Hello\rWorld";
+			Assert.AreEqual("Hello", textBox.Text);
+		}
+
+		[TestMethod]
+		public void When_Multi_Line_Text_And_Not_AcceptsReturn_After_Text_Was_Set()
+		{
+			var textBox = new TextBox();
+
+			textBox.AcceptsReturn = true;
+			textBox.Text = "Hello\nWorld";
+			Assert.AreEqual("Hello\nWorld", textBox.Text);
+
+			textBox.AcceptsReturn = false;
+			Assert.AreEqual("Hello", textBox.Text);
 		}
 
 		public class MySource : System.ComponentModel.INotifyPropertyChanged

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -168,6 +168,20 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		private static string GetSingleLine(string value)
+		{
+			for (int i = 0; i < value.Length; i++)
+			{
+				var c = value[i];
+				if (c == '\r' || c == '\n')
+				{
+					return value.Substring(0, i);
+				}
+			}
+
+			return value;
+		}
+
 		public static DependencyProperty TextProperty { get; } =
 			DependencyProperty.Register(
 				"Text",
@@ -265,6 +279,11 @@ namespace Windows.UI.Xaml.Controls
 				return DependencyProperty.UnsetValue;
 			}
 
+			if (!AcceptsReturn)
+			{
+				baseString = GetSingleLine(baseString);
+			}
+
 			var args = new TextBoxBeforeTextChangingEventArgs(baseString);
 			BeforeTextChanging?.Invoke(this, args);
 			if (args.Cancel)
@@ -272,7 +291,7 @@ namespace Windows.UI.Xaml.Controls
 				return DependencyProperty.UnsetValue;
 			}
 
-			return baseValue;
+			return baseString;
 		}
 
 		#endregion
@@ -404,6 +423,16 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnAcceptsReturnChanged(DependencyPropertyChangedEventArgs e)
 		{
+			if (e.NewValue is false)
+			{
+				var text = Text;
+				var singleLineText = GetSingleLine(text);
+				if (text != singleLineText)
+				{
+					Text = singleLineText;
+				}
+			}
+
 			OnAcceptsReturnChangedPartial(e);
 			UpdateButtonStates();
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7296

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Text not trimmed to single line only when `AcceptsReturn` is false


## What is the new behavior?

Text is trimmed to single line only properly.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
