### PR TITLE
fix(Border): Allow null BorderBrush to be set and implement BackgroundSizing

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FrameworkElementTests/UnoSamples_Test_FrameworkElement.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FrameworkElementTests/UnoSamples_Test_FrameworkElement.cs
@@ -57,7 +57,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FrameworkElementTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Browser, Platform.Android)] // Not supported on iOS & Skia yet.
+		[ActivePlatforms(Platform.Browser, Platform.Android, Platform.iOS)] // Not supported on Skia yet.
 		public void FrameworkElement_BackgroundSizing()
 		{
 			Run("UITests.Windows_UI_Xaml.FrameworkElementTests.DynamicBackgroundSizing");


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/294

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

![2021-10-12_01-59-39-PM](https://user-images.githubusercontent.com/4793020/137006332-6ead7ebc-0349-4838-9ba0-6c6805ae5fd9.png)



## What is the new behavior?

![2021-10-12_02-00-56-PM](https://user-images.githubusercontent.com/4793020/137006377-21c1b86f-aad6-4a59-8c82-1bba564d48ac.png)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
