### PR TITLE
fix(ItemsControl): [Android] Adjust collection update reset for ComboBox

### DIFF
--- a/src/Uno.UI.Tests/Helpers/ObservableCollectionEx.cs
+++ b/src/Uno.UI.Tests/Helpers/ObservableCollectionEx.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Uno.UI.Tests.Helpers
+{
+	internal class ObservableCollectionEx<TType> : System.Collections.ObjectModel.ObservableCollection<TType>
+	{
+		private int _batchUpdateCount;
+
+		public IDisposable BatchUpdate()
+		{
+			++_batchUpdateCount;
+
+			return Uno.Disposables.Disposable.Create(Release);
+
+			void Release()
+			{
+				if (--_batchUpdateCount <= 0)
+				{
+					OnCollectionChanged(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(System.Collections.Specialized.NotifyCollectionChangedAction.Reset));
+				}
+			}
+		}
+
+		protected override void OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			if (_batchUpdateCount > 0)
+			{
+				return;
+			}
+
+			base.OnCollectionChanged(e);
+		}
+
+		public void Append(TType item) => Add(item);
+
+		public TType GetAt(int index) => this[index];
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ItemsControlTests/Given_ItemsControl.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ItemsControlTests/Given_ItemsControl.cs
@@ -367,6 +367,48 @@ namespace Uno.UI.Tests.ItemsControlTests
 			Assert.AreEqual(0, listView.Items.Count);
 		}
 
+		[TestMethod]
+		public async Task When_Collection_Reset()
+		{
+			var count = 0;
+			var panel = new StackPanel();
+
+			var SUT = new ItemsControl()
+			{
+				ItemsPanelRoot = panel,
+				ItemContainerStyle = BuildBasicContainerStyle(),
+				InternalItemsPanelRoot = panel,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					count++;
+					return new Border();
+				})
+			};
+			SUT.ApplyTemplate();
+
+			var c = new ObservableCollectionEx<string>();
+			c.Add("One");
+			c.Add("Two");
+			c.Add("Three");
+
+			SUT.ItemsSource = c;
+			Assert.AreEqual(count, 3);
+
+			Assert.AreEqual(SUT.Items.Count, 3);
+
+			using (c.BatchUpdate())
+			{
+				c.Add("Four");
+				c.Add("Five");
+			}
+
+			Assert.AreEqual(SUT.Items.Count, 5);
+			Assert.AreEqual(count, 5);
+			Assert.IsNotNull(SUT.ContainerFromItem("One"));
+			Assert.IsNotNull(SUT.ContainerFromItem("Four"));
+			Assert.IsNotNull(SUT.ContainerFromItem("Five"));
+		}
+
 		private Style BuildBasicContainerStyle() =>
 			new Style(typeof(Windows.UI.Xaml.Controls.ListViewItem))
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -639,7 +639,6 @@ namespace Windows.UI.Xaml.Controls
 
 			IsGrouping = (e.NewValue as ICollectionView)?.CollectionGroups != null;
 			Items.SetItemsSource(UnwrapItemsSource() as IEnumerable);
-			UpdateItems(null);
 			ObserveCollectionChanged();
 			TryObserveCollectionViewSource(e.NewValue);
 		}
@@ -918,8 +917,8 @@ namespace Windows.UI.Xaml.Controls
 					}
 
 					ItemsPanelRoot.Children.Clear();
-					RequestLayoutPartial();
-					return;
+
+					// Fall-through and materialize the call collection.
 				}
 				else if (args.Action == NotifyCollectionChangedAction.Remove
 					&& args.OldItems.Count == 1)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/7350

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

ComboBox/ListView updates through Collection changes reset event are displayed properly. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
