### PR TITLE
fix(pointers): Improve reliability of hold gesture

### DIFF
--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -58,7 +58,7 @@ namespace Windows.UI.Input
 				{
 					IsCompleted = true;
 				}
-				else
+				else if (SupportsHolding())
 				{
 					StartHoldingTimer();
 				}
@@ -248,38 +248,19 @@ namespace Windows.UI.Input
 
 			#region Holding timer
 			private bool SupportsHolding()
-			{
-				switch (PointerType)
+				=> PointerType switch
 				{
-					case PointerDeviceType.Mouse: return _settings.HasFlag(GestureSettings.HoldWithMouse);
-					default: return _settings.HasFlag(GestureSettings.Hold);
-				}
-			}
-
-			private bool NeedsHoldingTimer()
-			{
-				// When possible we don't start a timer for the Holding event, instead we rely on the fact that
-				// we get a lot of small moves due to the lack of precision of the capture device (pen and touch).
-				// Note: We rely on the same side effect for Drag detection (cf. Manipulation.IsBeginningOfDragManipulation).
-
-				switch (PointerType)
-				{
-					case PointerDeviceType.Mouse: return _settings.HasFlag(GestureSettings.HoldWithMouse);
-					case PointerDeviceType.Touch when DeviceHelper.IsSimulator: return true;
-					default: return false;
-				}
-			}
+					PointerDeviceType.Mouse => _settings.HasFlag(GestureSettings.HoldWithMouse),
+					_ => _settings.HasFlag(GestureSettings.Hold)
+				};
 
 			private void StartHoldingTimer()
 			{
-				if (NeedsHoldingTimer())
-				{
-					_holdingTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
-					_holdingTimer.Interval = TimeSpan.FromTicks(HoldMinDelayTicks);
-					_holdingTimer.State = this;
-					_holdingTimer.Tick += OnHoldingTimerTick;
-					_holdingTimer.Start();
-				}
+				_holdingTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+				_holdingTimer.Interval = TimeSpan.FromTicks(HoldMinDelayTicks);
+				_holdingTimer.State = this;
+				_holdingTimer.Tick += OnHoldingTimerTick;
+				_holdingTimer.Start();
 			}
 
 			private void StopHoldingTimer()


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/7130

## Fix
Improve reliability of hold gesture by always starting a timer on press when hold has been enabled.

## What is the current behavior?
We rely on the fact that we continuously receive events when holding for touch and pen pointers, due to lack of precision of those kind of inputs. But depending of the devices, this might cause some timing inconsistencies driving the gesture to be hard to get.

## What is the new behavior?
We always start a timer on pointer down if the `Hold` gesture has been enabled on the `GestureRecognizer`.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] **this specific change is not testable** ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
