### PR TITLE
Align `IsInContact` and `IsInRange` pointer properties

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkCoreWindowExtension.cs
@@ -387,6 +387,8 @@ namespace Uno.UI.Runtime.Skia
 					break;
 			}
 
+			properties.IsInRange = true;
+
 			var pointerPoint = new Windows.UI.Input.PointerPoint(
 				frameId: time,
 				timestamp: time,

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -116,12 +116,12 @@ namespace Windows.UI.Xaml
 		//	Especially for wheel where preventing the default would break scrolling.
 		//	cf. remarks on HtmlEventDispatchResult.PreventDefault
 		private static HtmlEventDispatchResult DispatchNativePointerEnter(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerEnter(ToPointerArgs(target, args, isInContact: false))
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerEnter(ToPointerArgs(target, args, isInContact: null))
 				? HtmlEventDispatchResult.StopPropagation
 				: HtmlEventDispatchResult.Ok;
 
 		private static HtmlEventDispatchResult DispatchNativePointerLeave(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerExited(ToPointerArgs(target, args, isInContact: false))
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerExited(ToPointerArgs(target, args, isInContact: null))
 				? HtmlEventDispatchResult.StopPropagation
 				: HtmlEventDispatchResult.Ok;
 
@@ -131,12 +131,12 @@ namespace Windows.UI.Xaml
 				: HtmlEventDispatchResult.Ok;
 
 		private static HtmlEventDispatchResult DispatchNativePointerUp(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerUp(ToPointerArgs(target, args, isInContact: true))
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerUp(ToPointerArgs(target, args, isInContact: false))
 				? HtmlEventDispatchResult.StopPropagation
 				: HtmlEventDispatchResult.Ok;
 
 		private static HtmlEventDispatchResult DispatchNativePointerMove(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerMove(ToPointerArgs(target, args, isInContact: true))
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerMove(ToPointerArgs(target, args, isInContact: null))
 				? HtmlEventDispatchResult.StopPropagation
 				: HtmlEventDispatchResult.Ok;
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -116,12 +116,12 @@ namespace Windows.UI.Xaml
 		//	Especially for wheel where preventing the default would break scrolling.
 		//	cf. remarks on HtmlEventDispatchResult.PreventDefault
 		private static HtmlEventDispatchResult DispatchNativePointerEnter(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerEnter(ToPointerArgs(target, args, isInContact: null))
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerEnter(ToPointerArgs(target, args))
 				? HtmlEventDispatchResult.StopPropagation
 				: HtmlEventDispatchResult.Ok;
 
 		private static HtmlEventDispatchResult DispatchNativePointerLeave(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerExited(ToPointerArgs(target, args, isInContact: null))
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerExited(ToPointerArgs(target, args))
 				? HtmlEventDispatchResult.StopPropagation
 				: HtmlEventDispatchResult.Ok;
 
@@ -136,7 +136,7 @@ namespace Windows.UI.Xaml
 				: HtmlEventDispatchResult.Ok;
 
 		private static HtmlEventDispatchResult DispatchNativePointerMove(UIElement target, string eventPayload)
-			=> TryParse(eventPayload, out var args) && target.OnNativePointerMove(ToPointerArgs(target, args, isInContact: null))
+			=> TryParse(eventPayload, out var args) && target.OnNativePointerMove(ToPointerArgs(target, args))
 				? HtmlEventDispatchResult.StopPropagation
 				: HtmlEventDispatchResult.Ok;
 
@@ -202,7 +202,7 @@ namespace Windows.UI.Xaml
 		private static PointerRoutedEventArgs ToPointerArgs(
 			UIElement snd,
 			NativePointerEventArgs args,
-			bool? isInContact,
+			bool? isInContact = null,
 			(bool isHorizontalWheel, double delta) wheel = default)
 		{
 			var pointerId = (uint)args.pointerId;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7382

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- `IsInContact` is always `true` for WASM `PointerMoved`, false for `PointerEntered`/`Exited`
- `IsInRange` is `false` in GTK

## What is the new behavior?

- `IsInContact` on WASM based on the actual pressed state of the pointer
- `IsInRange` is `true` in GTK

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.