### PR TITLE
fix(appbarbutton): icon color not changing with app theme

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/CommandBar/CommandBar.Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBar/CommandBar.Partial.cs
@@ -26,6 +26,7 @@ using Uno.UI.Extensions;
 using static Microsoft.UI.Xaml.Controls._Tracing;
 using Uno.UI.Xaml.Input;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml;
 using Popup = Windows.UI.Xaml.Controls.Primitives.Popup;
 using Uno.UI;
@@ -355,12 +356,33 @@ namespace Windows.UI.Xaml.Controls
 			UpdateVisualState();
 		}
 
-		//Begin Uno Only
+		#region Uno Only
+
 		private void OnOverflowPopupClosed(object? sender, object e)
 		{
 			IsOpen = false;
 		}
-		//End Uno Only
+
+#if __IOS__ || __ANDROID__
+		private static DependencyProperty NavigationCommandProperty = Uno.UI.ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "NavigationCommand");
+
+		internal override void UpdateThemeBindings(ResourceUpdateReason updateReason)
+		{
+			base.UpdateThemeBindings(updateReason);
+
+			// these commands are not part of visual tree, so we need to propagate it manually
+			var commands = new[] { PrimaryCommands, SecondaryCommands }
+				.Where(x => x != null)
+				.SelectMany(x => x)
+				.OfType<AppBarButton>()
+				.Prepend(this.GetValue(NavigationCommandProperty) as AppBarButton);
+			foreach (var command in commands)
+			{
+				command?.UpdateThemeBindings(updateReason);
+			}
+		}
+#endif
+		#endregion
 
 		protected override Size MeasureOverride(Size availableSize)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/nventive-private#304
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

Changing the app theme will now affect the AppBarButton icon's color if its Foreground has been set to a theme-dependent resource, which previously was not the case on iOS+Android.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
note: on android, `FeatureConfiguration.AppBarButton.EnableBitmapIconTint` needs to be set to `true` for `NavigationCommand` use to its icon's Foreground property
