### PR TITLE
Support ItemsPresenter.MinHeight in ListView, fix TTV regression

### DIFF
--- a/src/Uno.UI.RuntimeTests/Extensions/FrameworkElementExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Extensions/FrameworkElementExtensions.cs
@@ -15,5 +15,11 @@ namespace Uno.UI.RuntimeTests.Extensions
 		/// </summary>
 		public static Rect GetOnScreenBounds(this FrameworkElement element)
 			=> element.TransformToVisual(null).TransformBounds(new Rect(0, 0, element.ActualWidth, element.ActualHeight));
+
+		/// <summary>
+		/// Get bounds of <paramref name="element"/> relative to <paramref name="relativeTo"/>.
+		/// </summary>
+		public static Rect GetRelativeBounds(this FrameworkElement element, FrameworkElement relativeTo)
+			=> element.TransformToVisual(relativeTo).TransformBounds(new Rect(0, 0, element.ActualWidth, element.ActualHeight));
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Helpers/TestsResourceHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/TestsResourceHelper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Disposables;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+namespace Uno.UI.RuntimeTests.Helpers
+{
+	internal static class TestsResourceHelper
+	{
+		private static TestsResources _testsResources;
+
+		/// <summary>
+		/// Get resource defined in TestsResources.xaml (templates, styles etc)
+		/// </summary>
+		public static T GetResource<T>(string resourceName)
+		{
+			_testsResources ??= new TestsResources();
+			return (T)_testsResources[resourceName];
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -1524,6 +1524,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+#if __WASM__
+		[Ignore] // https://github.com/unoplatform/uno/issues/7323
+#endif
 		public async Task When_Unequal_Size_Item_Removed()
 		{
 			var source = new ObservableCollection<ItemHeightViewModel>(

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -77,10 +77,20 @@ namespace Windows.UI.Xaml.Controls
 		private void OnPaddingChanged(Thickness oldValue, Thickness newValue)
 		{
 			this.InvalidateMeasure();
-			PropagatePadding();
+			PropagateLayoutValues();
 		}
 
 		#endregion
+
+		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
+		{
+			base.OnPropertyChanged2(args);
+
+			if (args.Property == FrameworkElement.MinHeightProperty || args.Property == FrameworkElement.MinWidthProperty)
+			{
+				PropagateLayoutValues();
+			}
+		}
 
 		/// <summary>
 		/// Indicates whether the ItemsPresenter is actually enclosed in the scrollable area of the 
@@ -132,7 +142,7 @@ namespace Windows.UI.Xaml.Controls
 				AddChild(_itemsPanel);
 #endif
 
-				PropagatePadding();
+				PropagateLayoutValues();
 			}
 
 			this.InvalidateMeasure();
@@ -152,13 +162,15 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		}
 
-		private void PropagatePadding()
+		private void PropagateLayoutValues()
 		{
 #if XAMARIN && !__MACOS__
 			var asListViewBase = _itemsPanel as NativeListViewBase;
 			if (asListViewBase != null)
 			{
 				asListViewBase.Padding = Padding;
+				asListViewBase.ItemsPresenterMinWidth = MinWidth;
+				asListViewBase.ItemsPresenterMinHeight = MinHeight;
 			}
 #endif
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.iOSAndroid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.iOSAndroid.cs
@@ -1,0 +1,14 @@
+﻿#if __IOS__ || __ANDROID__
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+
+namespace Windows.UI.Xaml.Controls
+{
+	partial class ItemsPresenter : ILayoutOptOut
+	{
+		public bool ShouldUseMinSize => !(_itemsPanel is NativeListViewBase);
+	}
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -530,6 +530,11 @@ namespace Windows.UI.Xaml.Controls
 				var childMaxWidth = frameworkElement.MaxWidth;
 				var childMinHeight = frameworkElement.MinHeight;
 				var childMinWidth = frameworkElement.MinWidth;
+				if (frameworkElement is ILayoutOptOut optOutElement && !optOutElement.ShouldUseMinSize)
+				{
+					childMinHeight = 0;
+					childMinWidth = 0;
+				}
 				var childWidth = frameworkElement.Width;
 				var childHeight = frameworkElement.Height;
 				var childMargin = frameworkElement.Margin;
@@ -537,8 +542,8 @@ namespace Windows.UI.Xaml.Controls
 				var hasChildWidth = !IsNaN(childWidth);
 				var hasChildMaxWidth = !IsInfinity(childMaxWidth) && !IsNaN(childMaxWidth);
 				var hasChildMaxHeight = !IsInfinity(childMaxHeight) && !IsNaN(childMaxHeight);
-				var hasChildMinWidth = childMinWidth > 0.0f;
-				var hasChildMinHeight = childMinHeight > 0.0f;
+				var hasChildMinWidth = childMinWidth > 0.0;
+				var hasChildMinHeight = childMinHeight > 0.0;
 
 				if (
 					childVerticalAlignment != VerticalAlignment.Stretch

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -750,6 +750,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				base.Frame = value;
 				UpdateContentViewFrame();
+				UpdateContentLayoutSlots(value);
 			}
 		}
 
@@ -766,6 +767,7 @@ namespace Windows.UI.Xaml.Controls
 				}
 				base.Bounds = value;
 				UpdateContentViewFrame();
+				UpdateContentLayoutSlots(Frame);
 			}
 		}
 
@@ -778,6 +780,20 @@ namespace Windows.UI.Xaml.Controls
 			if (ContentView != null)
 			{
 				ContentView.Frame = Bounds;
+			}
+		}
+
+		/// <summary>
+		/// Fakely propagate the applied Frame of this internal container as the LayoutSlot of the publicly visible container.
+		/// This is required for the UIElement.TransformToVisual to work properly.
+		/// </summary>
+		private void UpdateContentLayoutSlots(Rect frame)
+		{
+			var content = Content;
+			if (content != null)
+			{
+				LayoutInformation.SetLayoutSlot(content, frame);
+				content.LayoutSlotWithMarginsAndAlignments = frame;
 			}
 		}
 
@@ -918,6 +934,11 @@ namespace Windows.UI.Xaml.Controls
 			if (Content != null)
 			{
 				Layouter.ArrangeChild(Content, new Rect(0, 0, (float)size.Width, (float)size.Height));
+
+				// The item has to be arranged relative to this internal container (at 0,0),
+				// but doing this the LayoutSlot[WithMargins] has been updated, 
+				// so we fakely re-inject the relative position of the item in its parent.
+				UpdateContentLayoutSlots(Frame);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -21,6 +21,7 @@ using Uno.UI;
 using Uno.Logging;
 using Uno.UI.Extensions;
 using Microsoft.Extensions.Logging;
+using Uno.UI.UI.Xaml.Controls.Layouter;
 
 #if XAMARIN_IOS_UNIFIED
 using Foundation;
@@ -655,7 +656,7 @@ namespace Windows.UI.Xaml.Controls
 	/// <summary>
 	/// A hidden root item that allows the reuse of ContentControl features.
 	/// </summary>
-	internal class ListViewBaseInternalContainer : UICollectionViewCell
+	internal class ListViewBaseInternalContainer : UICollectionViewCell, ISetLayoutSlots
 	{
 		/// <summary>
 		/// Native constructor, do not use explicitly.

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.cs
@@ -66,6 +66,30 @@ namespace Windows.UI.Xaml.Controls
 		{
 			return ((IScrollSnapPointsInfo)NativeLayout).GetRegularSnapPoints(orientation, alignment, out offset);
 		}
+
+		internal double ItemsPresenterMinWidth
+		{
+			get => NativeLayout?.ItemsPresenterMinWidth ?? double.NaN;
+			set
+			{
+				if (NativeLayout != null)
+				{
+					NativeLayout.ItemsPresenterMinWidth = value;
+				}
+			}
+		}
+
+		internal double ItemsPresenterMinHeight
+		{
+			get => NativeLayout?.ItemsPresenterMinHeight ?? double.NaN;
+			set
+			{
+				if (NativeLayout != null)
+				{
+					NativeLayout.ItemsPresenterMinHeight = value;
+				}
+			}
+		}
 	}
 }
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -142,6 +142,30 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		private double _itemsPresenterMinWidth;
+		internal double ItemsPresenterMinWidth
+		{
+			get => _itemsPresenterMinWidth;
+			set
+			{
+				_itemsPresenterMinWidth = value;
+				RequestLayout();
+			}
+		}
+
+		private double itemsPresenterMinHeight;
+		internal double ItemsPresenterMinHeight
+		{
+			get => itemsPresenterMinHeight;
+			set
+			{
+				itemsPresenterMinHeight = value;
+				RequestLayout();
+			}
+		}
+
+		private int ItemsPresenterMinExtent => (int)ViewHelper.LogicalToPhysicalPixels(ScrollOrientation == Orientation.Vertical ? ItemsPresenterMinHeight : ItemsPresenterMinWidth);
+
 		private int InitialExtentPadding => (int)ViewHelper.LogicalToPhysicalPixels(ScrollOrientation == Orientation.Vertical ? Padding.Top : Padding.Left);
 		private int FinalExtentPadding => (int)ViewHelper.LogicalToPhysicalPixels(ScrollOrientation == Orientation.Vertical ? Padding.Bottom : Padding.Right);
 		private int InitialBreadthPadding => (int)ViewHelper.LogicalToPhysicalPixels(ScrollOrientation == Orientation.Vertical ? Padding.Left : Padding.Top);
@@ -731,7 +755,7 @@ namespace Windows.UI.Xaml.Controls
 				GetChildEndWithMargin(base.GetChildAt(FirstItemView + ItemViewCount - 1));
 			Debug.Assert(range > 0, "Must report a non-negative scroll range.");
 			Debug.Assert(remainingItems == 0 || range > Extent, "If any items are non-visible, the content range must be greater than the viewport extent.");
-			return range;
+			return Math.Max(range, ItemsPresenterMinExtent);
 		}
 
 		/// <summary>
@@ -1173,8 +1197,9 @@ namespace Windows.UI.Xaml.Controls
 			int maxPossibleDelta;
 			if (fillDirection == GeneratorDirection.Forward)
 			{
+				var contentEnd = Math.Max(GetContentEnd(), ItemsPresenterMinExtent - ContentOffset);
 				// If this value is negative, collection dimensions are larger than all children and we should not scroll
-				maxPossibleDelta = Math.Max(0, GetContentEnd() - Extent);
+				maxPossibleDelta = Math.Max(0, contentEnd - Extent);
 				// In the rare case that GetContentStart() is positive (see below), permit a positive value.
 				maxPossibleDelta = Math.Max(GetContentStart(), maxPossibleDelta);
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -135,6 +135,30 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		private double _itemsPresenterMinWidth;
+		internal double ItemsPresenterMinWidth
+		{
+			get => _itemsPresenterMinWidth;
+			set
+			{
+				_itemsPresenterMinWidth = value;
+				InvalidateLayout();
+			}
+		}
+
+		private double itemsPresenterMinHeight;
+		internal double ItemsPresenterMinHeight
+		{
+			get => itemsPresenterMinHeight;
+			set
+			{
+				itemsPresenterMinHeight = value;
+				InvalidateLayout();
+			}
+		}
+
+		private Size ItemsPresenterMinSize => new Size(ItemsPresenterMinWidth, ItemsPresenterMinHeight);
+
 		private double InitialExtentPadding => ScrollOrientation == Orientation.Vertical ? Padding.Top : Padding.Left;
 		private double FinalExtentPadding => ScrollOrientation == Orientation.Vertical ? Padding.Bottom : Padding.Right;
 		private double InitialBreadthPadding => ScrollOrientation == Orientation.Vertical ? Padding.Left : Padding.Top;
@@ -271,13 +295,15 @@ namespace Windows.UI.Xaml.Controls
 				{
 					if (ScrollOrientation == Orientation.Vertical)
 					{
-						return new CGSize(measured.Width, DynamicContentExtent);
+						measured = new CGSize(measured.Width, DynamicContentExtent);
 					}
 					else
 					{
-						return new CGSize(DynamicContentExtent, measured.Height);
+						measured = new CGSize(DynamicContentExtent, measured.Height);
 					}
 				}
+
+				measured = LayoutHelper.Max(measured, ItemsPresenterMinSize);
 				return measured;
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -64,7 +64,11 @@ namespace Windows.UI.Xaml
 
 					Rect finalRect;
 					var parent = Superview;
-					if (parent is UIElement || parent is ISetLayoutSlots)
+					if (parent is UIElement
+						|| parent is ISetLayoutSlots
+						// In the case of ListViewItem inside native list, its parent's parent is ListViewBaseInternalContainer
+						|| parent?.Superview is ISetLayoutSlots
+					)
 					{
 						finalRect = LayoutSlotWithMarginsAndAlignments;
 					}

--- a/src/Uno.UI/UI/Xaml/ILayoutOptOut.cs
+++ b/src/Uno.UI/UI/Xaml/ILayoutOptOut.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.UI.Xaml
+{
+	/// <summary>
+	/// Uno-specific interface that allows controls to specify that particular properties should be ignored by the shared layouting, eg for
+	/// compatibility when a native template is used.
+	/// </summary>
+	internal interface ILayoutOptOut
+	{
+		bool ShouldUseMinSize { get; }
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
@@ -162,6 +162,12 @@ namespace Windows.UI.Xaml
 
 						switch (parent)
 						{
+							case ListViewBaseInternalContainer listViewBaseInternalContainer:
+								// In the case of ListViewBaseInternalContainer, the first managed parent is normally ItemsPresenter. We omit
+								// the offset since it's incorporated separately via the layout slot propagated to ListViewItem + the scroll offset.
+								parentElement = listViewBaseInternalContainer.FindFirstParent<UIElement>();
+								return true;
+
 							case UIElement eltParent:
 								// We found a UIElement in the parent hierarchy, we compute the X/Y offset between the
 								// first parent 'view' and this 'elt', and return it.


### PR DESCRIPTION
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
Match Windows' behavior when ItemsPresenter.MinHeight (or MinWidth for horizontal-scrolling list) is set inside of a ListView or GridView. Since the ItemsPresenter is actually outside the scrollable container (NativeListViewBase), this is implemented by mapping the MinHeight value to the native layout calculated by VirtualizingPanelLayout.

This supports scenarios where a minimal scrollable extent, regardless of number of items, is desired.

Additionally fixes a regression on iOS when calling TransformToVisual from within a ListView.

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
closes https://github.com/unoplatform/nventive-private/issues/303