### PR TITLE
fix(calendar): Fix miscs scrolling issues

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_EffectiveViewport.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_EffectiveViewport.cs
@@ -1120,12 +1120,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				_root = root;
 				_leaf = leaf;
 
-				leaf.Loaded += ElementLoaded;
+				leaf.Loading += ElementLoading;
 			}
 
-			private void ElementLoaded(object sender, RoutedEventArgs e)
+			private void ElementLoading(FrameworkElement sender, object args)
 			{
-				_leaf.Loaded -= ElementLoaded;
+				_leaf.Loading -= ElementLoading;
 
 				Subscribe(sender);
 
@@ -1155,7 +1155,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 			public void Dispose()
 			{
-				_leaf.Loaded -= ElementLoaded;
+				_leaf.Loading -= ElementLoading;
 				foreach (var listener in _listeners.Values)
 				{
 					listener.Dispose();

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -239,15 +239,6 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnScroll(object sender, EventArgs args)
 		{
-			if (IsArrangeDirty && _pendingScrollTo.HasValue)
-			{
-				// When the native element of the SCP is becoming "valid" with a non 0 offset, it will raise a scroll event.
-				// But if we have a manual scroll request pending, we need to mute it and wait for the next layout updated.
-				return;
-			}
-
-			_pendingScrollTo = default;
-
 			// We don't have any information from the DOM 'scroll' event about the intermediate vs. final state.
 			// We could try to rely on the IsPointerPressed state to detect when the user is scrolling and use it.
 			// This would however not include scrolling due to the inertia which should also be flagged as intermediate.
@@ -261,6 +252,21 @@ namespace Windows.UI.Xaml.Controls
 
 			var horizontalOffset = GetNativeHorizontalOffset();
 			var verticalOffset = GetNativeVerticalOffset();
+
+			if (IsArrangeDirty
+				&& _pendingScrollTo is { } pending
+				&& (
+					pending.horizontal is { } hOffset && Math.Abs(horizontalOffset - hOffset) > 1
+					|| pending.vertical is { } vOffset && Math.Abs(verticalOffset - vOffset) > 1)
+				)
+			{
+				// When the native element of the SCP is becoming "valid" with a non 0 offset, it will raise a scroll event.
+				// But if we have a manual scroll request pending, we need to mute it and wait for the next layout updated.
+
+				return;
+			}
+
+			_pendingScrollTo = default;
 
 			HorizontalOffset = horizontalOffset;
 			VerticalOffset = verticalOffset;

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
@@ -74,6 +74,13 @@ namespace Windows.UI.Xaml
 		{
 			if (IsLoaded && IsEffectiveViewportEnabled)
 			{
+#if CHECK_LAYOUTED
+				if (IsLoaded)
+				{
+					_isLayouted = true;
+				}
+#endif
+
 				if (_parentViewportUpdatesSubscription == null)
 				{
 					TRACE_EFFECTIVE_VIEWPORT("Enabling effective viewport propagation.");

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
@@ -33,6 +33,7 @@ namespace Windows.UI.Xaml
 	{
 		private static readonly RoutedEventHandler ReconfigureViewportPropagationOnLoad = (snd, e) => ((_This)snd).ReconfigureViewportPropagation();
 		private event TypedEventHandler<_This, EffectiveViewportChangedEventArgs>? _effectiveViewportChanged;
+		private bool _hasNewHandler;
 		private int _childrenInterestedInViewportUpdates;
 		private IDisposable? _parentViewportUpdatesSubscription;
 		private ViewportInfo _parentViewport = ViewportInfo.Empty; // WARNING: Stored in parent's coordinates space, use GetParentViewport()
@@ -45,6 +46,7 @@ namespace Windows.UI.Xaml
 		{
 			add
 			{
+				_hasNewHandler = true;
 				_effectiveViewportChanged += value;
 				ReconfigureViewportPropagation(isInternal: true);
 			}
@@ -321,8 +323,14 @@ namespace Windows.UI.Xaml
 				+ $"| reason: {caller} "
 				+ $"| children: {_childrenInterestedInViewportUpdates}");
 
-			if (!isInternal && viewportUpdated) // We don't want to raise the event when we are only initializing the tree due to a new event handler
+			if (viewportUpdated
+				&& (
+					!isInternal // We don't want to raise the event when we are only initializing the tree due to a new event handler somewhere in sub tree
+					|| _hasNewHandler // but if we have a new local handler, we do need to raise the event!
+				))
 			{
+				_hasNewHandler = false;
+
 				// Note: The event only notify about the parentViewport (expressed in local coordinate space!),
 				//		 the "local effective viewport" is used only by our children.
 				_effectiveViewportChanged?.Invoke(this, new EffectiveViewportChangedEventArgs(parentViewport.Effective));


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/7355

## Bugfix
Fix miscs scrolling issues in `CalendarView` and `CalendarDatePicker`

## What is the current behavior?
* The `SV.ViewChanged` might be missed when scrolling has been requested before the SV is loaded
* When we subscribe to the `EVPChanged` event on an element that has already been layouted, the element remains flags `_isLayouted = false` driving the event to not being fired . That's the case when we re-open a `CalendarDatePicker`: scrolling does not update the EVP.

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] _Urgent commit, tests have to be added later_ ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
