### PR TITLE
Docs: Missing UseCors in SignalR docs

### DIFF
--- a/doc/articles/signalr.md
+++ b/doc/articles/signalr.md
@@ -32,9 +32,11 @@ public void ConfigureServices(IServiceCollection services)
             );
         }
 ```
-In your `Configure` method, add your `Hubs` endpoint
+In your `Configure` method, add your CORS policy and `Hubs` endpoint
 
 ``` csharp
+  app.UseCors("CorsPolicy");
+
   app.UseEndpoints(endpoints =>
             {
                 endpoints.MapRazorPages();
@@ -42,4 +44,4 @@ In your `Configure` method, add your `Hubs` endpoint
             });
 ```
 
-You now have a SignalR service you can use with your Uno application! 
+You now have a SignalR service that you can use with your Uno application!


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5460

https://github.com/unoplatform/uno/issues/5460

## PR Type

What kind of change does this PR introduce?
- Documentation content changes

## What is the current behavior?

SignalR docs are missing a call to app.UseCors in Startup class.


## What is the new behavior?

app.UseCors added to Startup class in SignalR docs.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

n/a

Internal Issue (If applicable):
n/a
