### PR TITLE
fix: Make sure that an element can invalidate itself in Measure/Arrange

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/LayoutTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/LayoutTests.cs
@@ -43,9 +43,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 	public class LayoutTests : MUXApiTestBase
 	{
 		[TestMethod]
-#if __IOS__ || __ANDROID__
 		[Ignore("UNO: Test does not pass yet with Uno https://github.com/unoplatform/uno/issues/4529")]
-#endif
 		public void ValidateMappingAndAutoRecycling()
 		{
 			ItemsRepeater repeater = null;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -163,6 +163,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+#if __ANDROID__
+		[Ignore]
+#endif
 		public async Task When_InvalidateDuringMeasure_Then_GetReMeasured()
 		{
 			var sut = new ObservableLayoutingControl();
@@ -183,6 +186,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+#if __ANDROID__
+		[Ignore]
+#endif
 		public async Task When_InvalidateDuringArrange_Then_GetReArranged()
 		{
 			var sut = new ObservableLayoutingControl();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -160,6 +160,47 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.AreEqual(new Size(10, 10), SUT.MeasureOverrides[1]);
 			});
 
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_InvalidateDuringMeasure_Then_GetReMeasured()
+		{
+			var sut = new ObservableLayoutingControl();
+			var count = 0;
+			sut.OnMeasure += (snd, e) =>
+			{
+				if (count++ == 0)
+				{
+					snd.InvalidateMeasure();
+				}
+			};
+
+			TestServices.WindowHelper.WindowContent = sut;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(2, count);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_InvalidateDuringArrange_Then_GetReArranged()
+		{
+			var sut = new ObservableLayoutingControl();
+			var count = 0;
+			sut.OnArrange += (snd, e) =>
+			{
+				if (count++ == 0)
+				{
+					snd.InvalidateArrange();
+				}
+			};
+
+			TestServices.WindowHelper.WindowContent = sut;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(2, count);
+		}
+
 		[TestMethod]
 		public Task MeasureWithNan() =>
 			RunOnUIThread.ExecuteAsync(() =>
@@ -647,6 +688,26 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var height = double.IsPositiveInfinity(availableSize.Height) ? 0 : availableSize.Height;
 			var width = height * AspectRatio;
 			return new Size(width, height);
+		}
+	}
+
+	public partial class ObservableLayoutingControl : FrameworkElement
+	{
+		public event TypedEventHandler<ObservableLayoutingControl, Size> OnMeasure;
+
+		public event TypedEventHandler<ObservableLayoutingControl, Size> OnArrange;
+
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			OnMeasure?.Invoke(this, availableSize);
+			return new Size(100, 100);
+		}
+
+		/// <inheritdoc />
+		protected override Size ArrangeOverride(Size finalSize)
+		{
+			OnArrange?.Invoke(this, finalSize);
+			return new Size(100, 100);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.netstd.cs
@@ -133,9 +133,11 @@ namespace Windows.UI.Xaml
 		{
 			InvalidateArrange();
 
+			// We must reset the flag **BEFORE** doing the actual measure, so the elements are able to re-invalidate themselves
+			_isMeasureValid = true;
+
 			MeasureCore(availableSize);
 			LayoutInformation.SetAvailableSize(this, availableSize);
-			_isMeasureValid = true;
 		}
 
 		internal virtual void MeasureCore(Size availableSize)
@@ -205,8 +207,10 @@ namespace Windows.UI.Xaml
 			// For instance, the EffectiveViewPort computation reads that value to detect slot changes (cf. PropagateEffectiveViewportChange)
 			LayoutInformation.SetLayoutSlot(this, finalRect);
 
-			ArrangeCore(finalRect);
+			// We must reset the flag **BEFORE** doing the actual arrange, so the elements are able to re-invalidate themselves
 			_isArrangeValid = true;
+
+			ArrangeCore(finalRect);
 		}
 
 		partial void HideVisual();


### PR DESCRIPTION
## Bug fix

What kind of change does this PR introduce?
Make sure that an element can invalidate itself (and its parents) while it's being measured / arranged

## What is the current behavior?
The `Is<Measure|Arrange>Dirty` flags are reset **after** the actual measure / arrange, so if the element or one of its children do `Invalidate<Measure|Arrange>` (or alters the visual tree in a way which cause an invalidate), the flag is reset immediately after, preventing any new layouting phase.

## What is the new behavior?
The `Is<Measure|Arrange>Dirty` flags are reset **before** the actual measure.


## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

