### PR TITLE
Fix `InfoBarPanel` namespace, update `InfoBar` to latest WinUI

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -4153,6 +4153,8 @@
 		  <Member fullName="Windows.UI.Composition.Desktop.DesktopWindowTarget" reason="Composition API relocation" />
 		  <Member fullName="Windows.UI.Composition.Core.CompositorController" reason="Composition API relocation" />
 		  <!-- END Composition relocation -->
+		  
+		  <Member fullName="Microsoft.UI.Xaml.Controls.InfoBarPanel" reason="InfoBarPanel has wrong namespace" />
 		</Types>
 		<Methods>
 			<Member
@@ -7458,6 +7460,9 @@
 				fullName="System.Void Windows.UI.Xaml.Controls.Primitives.CommandBarTemplateSettings..ctor(Windows.UI.Xaml.Controls.CommandBar commandBar)"
 				reason="API alignment" />
 
+			<Member
+				fullName="System.Void Microsoft.UI.Xaml.Controls.InfoBar.set_TemplateSettings(Microsoft.UI.Xaml.Controls.InfoBarTemplateSettings value)"
+				reason="Setter is not public in WinUI" />
 
 		  <!-- BEGIN .NET 6 BREAKING CHANGE -->
 		  <Member fullName="System.Void UIKit.UIViewExtensions.SetDimensions(UIKit.UIView view, System.Nullable`1&lt;System.nfloat&gt; width, System.Nullable`1&lt;System.nfloat&gt; height)" reason=".NET 6 RTM breaking change" />
@@ -8521,6 +8526,9 @@
 		  <Member fullName="System.nfloat Uno.UI.ViewHelper::MainScreenScale" reason=".NET 6 RTM breaking change" />
 		  <!-- END .NET 6 BREAKING CHANGE -->
 
+			<Member
+				fullName="Windows.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.InfoBarTemplateSettings::IconElementProperty"
+				reason="DPs should be properties" />
 		</Fields>
 		<Properties>
 			<Member

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/InfoBarTests/InfoBarPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/InfoBarTests/InfoBarPage.xaml
@@ -1,25 +1,27 @@
-﻿<Page
-    x:Class="UITests.Microsoft_UI_Xaml_Controls.InfoBarTests.InfoBarPage"
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- MUX Reference InfoBarPage.xaml, commit b424312 -->
+<local:TestPage
+    x:Class="MUXControlsTestApp.InfoBarPage"
+    x:Name="InfoBarTestPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.InfoBarTests"
+    xmlns:local="using:MUXControlsTestApp"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d not_win"
-	xmlns:not_win="http://uno.ui/not_win"
-	xmlns:controls="using:Microsoft.UI.Xaml.Controls"
-	xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    xmlns:contract5Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
+    mc:Ignorable="d">
 
-	<not_win:Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
-		<not_win:Grid.Resources>
-			<Style x:Name="CustomCloseButtonStyle" TargetType="Button" BasedOn="{StaticResource InfoBarCloseButtonStyle}">
-				<Style.Setters>
-					<Setter Property="Background" Value="Red"/>
-				</Style.Setters>
-			</Style>
-		</not_win:Grid.Resources>
-		<Grid>
+	<Page.Resources>
+		<Style x:Name="CustomCloseButtonStyle" TargetType="Button" BasedOn="{StaticResource InfoBarCloseButtonStyle}">
+			<Style.Setters>
+				<Setter Property="Background" Value="Red"/>
+			</Style.Setters>
+		</Style>
+	</Page.Resources>
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
+		<Grid x:Name="InfoBarParent">
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto"/>
 				<RowDefinition Height="*"/>
@@ -37,6 +39,7 @@
 
 			<Grid Grid.Row="1" Margin="0,20,0,0">
 				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="Auto"/>
 					<ColumnDefinition Width="Auto"/>
 					<ColumnDefinition Width="Auto"/>
 				</Grid.ColumnDefinitions>
@@ -62,10 +65,21 @@
 						<ComboBoxItem Content="None" />
 						<ComboBoxItem Content="Button" />
 						<ComboBoxItem Content="Hyperlink" />
+						<ComboBoxItem Content="RightAlignedButton" />
+						<ComboBoxItem Content="RightAlignedHyperlink" />
 					</ComboBox>
 
-					<Button Content="Set Foreground" Click="SetForegroundClick"/>
+					<Button x:Name="CollpaseActionButtonAsynchronouslyButton" Content="Collapse ActionButton async" Click="CollapseActionButtonAsynchronouslyClick"/>
+					<Button x:Name="DisableActionButtonAsynchronouslyButton" Content="Disable ActionButton async" Click="DisableActionButtonAsynchronouslyClick"/>
+					<Button x:Name="ResetActionButtonAsynchronouslyButton" Content="Reset ActionButton async" Click="ResetActionButtonAsynchronouslyClick"/>
 
+					<Button x:Name="AddInfoBarButton" Content="Add InfoBar" Click="AddInfoBarClick" IsEnabled="False"/>
+					<Button x:Name="RemoveInfoBarAsynchronouslyButton" Content="Remove InfoBar async" Click="RemoveInfoBarAsynchronouslyClick"/>
+
+					<Button Content="Set Foreground" Click="SetForegroundClick"/>
+				</StackPanel>
+
+				<StackPanel Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Left" Margin="20,0,0,0">
 					<CheckBox x:Name="IsOpenCheckBox" AutomationProperties.Name="IsOpenCheckBox" Content="IsOpen" IsChecked="{x:Bind TestInfoBar.IsOpen, Mode=TwoWay}"/>
 
 					<CheckBox x:Name="CancelCheckBox" AutomationProperties.Name="CancelCheckBox" Content="Cancel Close" />
@@ -79,9 +93,11 @@
 					<CheckBox x:Name="CustomBackgroundCheckBox" AutomationProperties.Name="CustomBackgroundCheckBox" Content="Custom Background Color" Checked="CustomBackgroundChanged" Unchecked="CustomBackgroundChanged"/>
 
 					<CheckBox x:Name="CloseButtonStyleCheckBox" AutomationProperties.Name="CloseButtonStyleCheckBox" Content="Custom Close Button Style" Checked="CloseStyleChanged" Unchecked="CloseStyleChanged"/>
+
+					<CheckBox x:Name="RemoveActionButtonOnInvokeCheckBox" AutomationProperties.Name="RemoveActionButtonOnInvokeCheckBox" Content="Remove ActionButton on invoke"/>
 				</StackPanel>
 
-				<StackPanel Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Left" Margin="20,0,0,0">
+				<StackPanel Grid.Column="2" Orientation="Vertical" HorizontalAlignment="Left" Margin="20,0,0,0">
 					<TextBlock>Events:</TextBlock>
 					<ListBox x:Name="EventListBox" AutomationProperties.Name="EventListBox" MinWidth="150" MaxHeight="380">
 						<ListBox.Resources>
@@ -105,5 +121,5 @@
 				</StackPanel>
 			</Grid>
 		</Grid>
-	</not_win:Grid>
-</Page>
+	</Grid>
+</local:TestPage>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/InfoBarTests/InfoBarPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/InfoBarTests/InfoBarPage.xaml.cs
@@ -1,24 +1,38 @@
-﻿#pragma warning disable 105 // Disabled until the tree is migrate to WinUI
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference InfoBarPage.xaml.cs, commit b424312
 
 using System;
+using Windows.UI;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Controls;
-using Windows.UI;
-using Windows.UI.Xaml.Automation;
+
+using IconSource = Microsoft.UI.Xaml.Controls.IconSource;
+using SymbolIconSource = Microsoft.UI.Xaml.Controls.SymbolIconSource;
+
 using Uno.UI.Samples.Controls;
 
-namespace UITests.Microsoft_UI_Xaml_Controls.InfoBarTests
+namespace MUXControlsTestApp
 {
 	[Sample("InfoBar", "WinUI")]
-	public sealed partial class InfoBarPage : Page
+	public sealed partial class InfoBarPage : TestPage
 	{
+		private ButtonBase _actionButton = null;
+		private DispatcherTimer _timer = new DispatcherTimer();
+		private int _timerAction = 0;
+
 		public InfoBarPage()
 		{
 			this.InitializeComponent();
+
+			_timer.Interval = new TimeSpan(0, 0, 8 /*sec*/);
+			_timer.Tick += Timer_Tick;
 		}
-#if HAS_UNO
+
 		private void SeverityComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
 			string severityName = e.AddedItems[0].ToString();
@@ -48,6 +62,8 @@ namespace UITests.Microsoft_UI_Xaml_Controls.InfoBarTests
 		{
 			if (TestInfoBar == null) return;
 
+			DiscardActionButton();
+
 			if (ActionButtonComboBox.SelectedIndex == 0)
 			{
 				TestInfoBar.ActionButton = null;
@@ -56,14 +72,117 @@ namespace UITests.Microsoft_UI_Xaml_Controls.InfoBarTests
 			{
 				var button = new Button();
 				button.Content = "Action";
-				TestInfoBar.ActionButton = button;
+				button.Click += ActionButton_Click;
+				_actionButton = TestInfoBar.ActionButton = button;
 			}
 			else if (ActionButtonComboBox.SelectedIndex == 2)
 			{
 				var link = new HyperlinkButton();
 				link.NavigateUri = new Uri("http://www.microsoft.com/");
 				link.Content = "Informational link";
-				TestInfoBar.ActionButton = link;
+				link.Click += ActionButton_Click;
+				_actionButton = TestInfoBar.ActionButton = link;
+			}
+			else if (ActionButtonComboBox.SelectedIndex == 3)
+			{
+				var button = new Button();
+				button.Content = "Action";
+				button.HorizontalAlignment = HorizontalAlignment.Right;
+				button.Click += ActionButton_Click;
+				_actionButton = TestInfoBar.ActionButton = button;
+			}
+			else if (ActionButtonComboBox.SelectedIndex == 4)
+			{
+				var link = new HyperlinkButton();
+				link.NavigateUri = new Uri("http://www.microsoft.com/");
+				link.Content = "Informational link";
+				link.HorizontalAlignment = HorizontalAlignment.Right;
+				link.Click += ActionButton_Click;
+				_actionButton = TestInfoBar.ActionButton = link;
+			}
+
+			if (_actionButton != null)
+			{
+				// Workaround for GitHub Issue #4531.
+				_actionButton.TabIndex = 1;
+			}
+		}
+
+		private void ActionButton_Click(object sender, RoutedEventArgs e)
+		{
+			EventListBox.Items.Add("ActionButtonClick");
+
+			if (RemoveActionButtonOnInvokeCheckBox.IsChecked.Value)
+			{
+				ResetActionButtonProperty();
+			}
+		}
+
+		private void CollapseActionButtonProperty()
+		{
+			if (_actionButton != null)
+			{
+				_actionButton.Visibility = Visibility.Collapsed;
+			}
+		}
+
+		private void DisableActionButtonProperty()
+		{
+			if (_actionButton != null)
+			{
+				_actionButton.IsEnabled = false;
+			}
+		}
+
+		private void ResetActionButtonProperty()
+		{
+			ActionButtonComboBox.SelectedIndex = 0;
+		}
+
+		private void DiscardActionButton()
+		{
+			if (_actionButton != null)
+			{
+				_actionButton.Click -= ActionButton_Click;
+				_actionButton = null;
+			}
+		}
+
+		private void Timer_Tick(object sender, object e)
+		{
+			_timer.Stop();
+
+			switch (_timerAction)
+			{
+				case 0:
+					CollapseActionButtonProperty();
+					break;
+				case 1:
+					DisableActionButtonProperty();
+					break;
+				case 2:
+					ResetActionButtonProperty();
+					break;
+				case 3:
+					InfoBarParent.Children.Remove(TestInfoBar);
+					AddInfoBarButton.IsEnabled = true;
+					RemoveInfoBarAsynchronouslyButton.IsEnabled = false;
+					break;
+			}
+
+			switch (_timerAction)
+			{
+				case 0:
+				case 1:
+				case 2:
+					CollpaseActionButtonAsynchronouslyButton.IsEnabled = true;
+					DisableActionButtonAsynchronouslyButton.IsEnabled = true;
+					ResetActionButtonAsynchronouslyButton.IsEnabled = true;
+					RemoveInfoBarAsynchronouslyButton.IsEnabled = true;
+					break;
+				case 3:
+					AddInfoBarButton.IsEnabled = true;
+					break;
 			}
 		}
 
@@ -74,9 +193,9 @@ namespace UITests.Microsoft_UI_Xaml_Controls.InfoBarTests
 			switch (e.AddedItems[0].ToString())
 			{
 				case "Custom Icon":
-					Microsoft.UI.Xaml.Controls.SymbolIconSource symbolIcon = new Microsoft.UI.Xaml.Controls.SymbolIconSource();
+					SymbolIconSource symbolIcon = new SymbolIconSource();
 					symbolIcon.Symbol = Symbol.Pin;
-					TestInfoBar.IconSource = (Microsoft.UI.Xaml.Controls.IconSource)symbolIcon;
+					TestInfoBar.IconSource = (IconSource)symbolIcon;
 					break;
 
 				case "Default Icon":
@@ -109,6 +228,48 @@ namespace UITests.Microsoft_UI_Xaml_Controls.InfoBarTests
 		public void ClearButtonClick(object sender, object args)
 		{
 			EventListBox.Items.Clear();
+		}
+
+		private void CollapseActionButtonAsynchronouslyClick(object sender, object args)
+		{
+			StartAsynchronousAction(0);
+		}
+
+		private void DisableActionButtonAsynchronouslyClick(object sender, object args)
+		{
+			StartAsynchronousAction(1);
+		}
+
+		private void ResetActionButtonAsynchronouslyClick(object sender, object args)
+		{
+			StartAsynchronousAction(2);
+		}
+
+		private void AddInfoBarClick(object sender, object args)
+		{
+			InfoBarParent.Children.Insert(0, TestInfoBar);
+			AddInfoBarButton.IsEnabled = false;
+			CollpaseActionButtonAsynchronouslyButton.IsEnabled = true;
+			DisableActionButtonAsynchronouslyButton.IsEnabled = true;
+			ResetActionButtonAsynchronouslyButton.IsEnabled = true;
+			RemoveInfoBarAsynchronouslyButton.IsEnabled = true;
+		}
+
+		private void RemoveInfoBarAsynchronouslyClick(object sender, object args)
+		{
+			StartAsynchronousAction(3);
+		}
+
+		private void StartAsynchronousAction(int timerAction)
+		{
+			_timer.Start();
+			_timerAction = timerAction;
+
+			CollpaseActionButtonAsynchronouslyButton.IsEnabled = false;
+			DisableActionButtonAsynchronouslyButton.IsEnabled = false;
+			ResetActionButtonAsynchronouslyButton.IsEnabled = false;
+			AddInfoBarButton.IsEnabled = false;
+			RemoveInfoBarAsynchronouslyButton.IsEnabled = false;
 		}
 
 		public void SetForegroundClick(object sender, object args)
@@ -155,6 +316,5 @@ namespace UITests.Microsoft_UI_Xaml_Controls.InfoBarTests
 				TestInfoBar.Background = new SolidColorBrush(Colors.Transparent);
 			}
 		}
-#endif
 	}
 }

--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/InfoBar.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/InfoBar.xaml
@@ -1,4 +1,5 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- MUX Reference InfoBar_themeresources.xaml, commit 6cc8dbb-->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"

--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/InfoBar_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/InfoBar_themeresources.xaml
@@ -1,4 +1,5 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- MUX Reference InfoBar_themeresources.xaml, commit 775568c -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -56,24 +57,24 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Key="HighContrast">
-            <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
-            <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
-            <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
-            <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
+            <StaticResource x:Key="InfoBarErrorSeverityBackgroundBrush" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="InfoBarWarningSeverityBackgroundBrush" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="InfoBarSuccessSeverityBackgroundBrush" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="InfoBarInformationalSeverityBackgroundBrush" ResourceKey="SystemColorWindowColorBrush" />
 
-            <StaticResource x:Key="InfoBarErrorSeverityIconBackground" ResourceKey="SystemColorHighlightColor" />
-            <StaticResource x:Key="InfoBarWarningSeverityIconBackground" ResourceKey="SystemColorHighlightColor" />
-            <StaticResource x:Key="InfoBarSuccessSeverityIconBackground" ResourceKey="SystemColorHighlightColor" />
-            <StaticResource x:Key="InfoBarInformationalSeverityIconBackground" ResourceKey="SystemColorHighlightColor" />
+            <StaticResource x:Key="InfoBarErrorSeverityIconBackground" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="InfoBarWarningSeverityIconBackground" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="InfoBarSuccessSeverityIconBackground" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="InfoBarInformationalSeverityIconBackground" ResourceKey="SystemColorHighlightColorBrush" />
 
-            <StaticResource x:Key="InfoBarErrorSeverityIconForeground" ResourceKey="SystemColorHighlightTextColor" />
-            <StaticResource x:Key="InfoBarWarningSeverityIconForeground" ResourceKey="SystemColorHighlightTextColor" />
-            <StaticResource x:Key="InfoBarSuccessSeverityIconForeground" ResourceKey="SystemColorHighlightTextColor" />
-            <StaticResource x:Key="InfoBarInformationalSeverityIconForeground" ResourceKey="SystemColorHighlightTextColor" />
+            <StaticResource x:Key="InfoBarErrorSeverityIconForeground" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="InfoBarWarningSeverityIconForeground" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="InfoBarSuccessSeverityIconForeground" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <StaticResource x:Key="InfoBarInformationalSeverityIconForeground" ResourceKey="SystemColorHighlightTextColorBrush" />
 
-            <StaticResource x:Key="InfoBarTitleForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
-            <StaticResource x:Key="InfoBarMessageForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
-            <StaticResource x:Key="InfoBarHyperlinkButtonForeground" ResourceKey="SystemControlHyperlinkTextBrush" />
+            <StaticResource x:Key="InfoBarTitleForeground" ResourceKey="SystemColorWindowTextColorBrush" />
+            <StaticResource x:Key="InfoBarMessageForeground" ResourceKey="SystemColorWindowTextColorBrush" />
+            <StaticResource x:Key="InfoBarHyperlinkButtonForeground" ResourceKey="SystemColorHotlightColorBrush" />
 
             <StaticResource x:Key="InfoBarBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
             <Thickness x:Key="InfoBarBorderThickness">2</Thickness>

--- a/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
+++ b/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
@@ -4989,21 +4989,21 @@
       <SolidColorBrush x:Key="HyperlinkForeground" Color="{StaticResource SystemColorHotlightColor}" />
       <SolidColorBrush x:Key="HyperlinkForegroundPointerOver" Color="{StaticResource SystemColorWindowTextColor}" />
       <SolidColorBrush x:Key="HyperlinkForegroundPressed" Color="{StaticResource SystemColorHighlightColor}" />
-      <SolidColorBrush x:Key="InfoBarErrorSeverityBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
-      <SolidColorBrush x:Key="InfoBarWarningSeverityBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
-      <SolidColorBrush x:Key="InfoBarSuccessSeverityBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
-      <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
-      <StaticResource x:Key="InfoBarErrorSeverityIconBackground" ResourceKey="SystemColorHighlightColor" />
-      <StaticResource x:Key="InfoBarWarningSeverityIconBackground" ResourceKey="SystemColorHighlightColor" />
-      <StaticResource x:Key="InfoBarSuccessSeverityIconBackground" ResourceKey="SystemColorHighlightColor" />
-      <StaticResource x:Key="InfoBarInformationalSeverityIconBackground" ResourceKey="SystemColorHighlightColor" />
-      <StaticResource x:Key="InfoBarErrorSeverityIconForeground" ResourceKey="SystemColorHighlightTextColor" />
-      <StaticResource x:Key="InfoBarWarningSeverityIconForeground" ResourceKey="SystemColorHighlightTextColor" />
-      <StaticResource x:Key="InfoBarSuccessSeverityIconForeground" ResourceKey="SystemColorHighlightTextColor" />
-      <StaticResource x:Key="InfoBarInformationalSeverityIconForeground" ResourceKey="SystemColorHighlightTextColor" />
-      <StaticResource x:Key="InfoBarTitleForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
-      <StaticResource x:Key="InfoBarMessageForeground" ResourceKey="SystemControlForegroundBaseHighBrush" />
-      <StaticResource x:Key="InfoBarHyperlinkButtonForeground" ResourceKey="SystemControlHyperlinkTextBrush" />
+      <StaticResource x:Key="InfoBarErrorSeverityBackgroundBrush" ResourceKey="SystemColorWindowColorBrush" />
+      <StaticResource x:Key="InfoBarWarningSeverityBackgroundBrush" ResourceKey="SystemColorWindowColorBrush" />
+      <StaticResource x:Key="InfoBarSuccessSeverityBackgroundBrush" ResourceKey="SystemColorWindowColorBrush" />
+      <StaticResource x:Key="InfoBarInformationalSeverityBackgroundBrush" ResourceKey="SystemColorWindowColorBrush" />
+      <StaticResource x:Key="InfoBarErrorSeverityIconBackground" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="InfoBarWarningSeverityIconBackground" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="InfoBarSuccessSeverityIconBackground" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="InfoBarInformationalSeverityIconBackground" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="InfoBarErrorSeverityIconForeground" ResourceKey="SystemColorHighlightTextColorBrush" />
+      <StaticResource x:Key="InfoBarWarningSeverityIconForeground" ResourceKey="SystemColorHighlightTextColorBrush" />
+      <StaticResource x:Key="InfoBarSuccessSeverityIconForeground" ResourceKey="SystemColorHighlightTextColorBrush" />
+      <StaticResource x:Key="InfoBarInformationalSeverityIconForeground" ResourceKey="SystemColorHighlightTextColorBrush" />
+      <StaticResource x:Key="InfoBarTitleForeground" ResourceKey="SystemColorWindowTextColorBrush" />
+      <StaticResource x:Key="InfoBarMessageForeground" ResourceKey="SystemColorWindowTextColorBrush" />
+      <StaticResource x:Key="InfoBarHyperlinkButtonForeground" ResourceKey="SystemColorHotlightColorBrush" />
       <StaticResource x:Key="InfoBarBorderBrush" ResourceKey="SystemControlTransientBorderBrush" />
       <Thickness x:Key="InfoBarBorderThickness">2</Thickness>
       <StaticResource x:Key="ListViewItemBorderBackground" ResourceKey="SystemControlHighlightListAccentLowBrush" />

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBar.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBar.Properties.cs
@@ -11,135 +11,226 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class InfoBar
 	{
+		/// <summary>
+		/// Occurs after the close button is clicked in the InfoBar.
+		/// </summary>
 		public event TypedEventHandler<InfoBar, object> CloseButtonClick;
 
+		/// <summary>
+		/// Occurs just before the InfoBar begins to close.
+		/// </summary>
 		public event TypedEventHandler<InfoBar, InfoBarClosingEventArgs> Closing;
 
+		/// <summary>
+		/// Occurs after the InfoBar is closed.
+		/// </summary>
 		public event TypedEventHandler<InfoBar, InfoBarClosedEventArgs> Closed;
 
+		/// <summary>
+		/// Gets or sets the action button of the InfoBar.
+		/// </summary>
 		public ButtonBase ActionButton
 		{
 			get => (ButtonBase)GetValue(ActionButtonProperty);
 			set => SetValue(ActionButtonProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the ActionButton dependency property.
+		/// </summary>
 		public static DependencyProperty ActionButtonProperty { get; } =
 			DependencyProperty.Register(nameof(ActionButton), typeof(ButtonBase), typeof(InfoBar), new FrameworkPropertyMetadata(null));
 
+		/// <summary>
+		/// Gets or sets the command to invoke when the close button is clicked in the InfoBar.
+		/// </summary>
 		public ICommand CloseButtonCommand
 		{
 			get => (ICommand)GetValue(CloseButtonCommandProperty);
 			set => SetValue(CloseButtonCommandProperty, value);
 		}
 
+		/// <summary>
+		/// Gets or sets the parameter to pass to the command for the close button in the InfoBar.
+		/// </summary>
 		public static DependencyProperty CloseButtonCommandProperty { get; } =
 			DependencyProperty.Register(nameof(CloseButtonCommand), typeof(ICommand), typeof(InfoBar), new FrameworkPropertyMetadata(null));
 
+		/// <summary>
+		/// Identifies the CloseButtonCommandParameter dependency property.
+		/// </summary>
 		public object CloseButtonCommandParameter
 		{
 			get => (object)GetValue(CloseButtonCommandParameterProperty);
 			set => SetValue(CloseButtonCommandParameterProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the CloseButtonCommand dependency property.
+		/// </summary>
 		public static DependencyProperty CloseButtonCommandParameterProperty { get; } =
 			DependencyProperty.Register(nameof(CloseButtonCommandParameter), typeof(object), typeof(InfoBar), new FrameworkPropertyMetadata(null));
 
+		/// <summary>
+		/// Gets or sets the Style to apply to the close button in the InfoBar.
+		/// </summary>
 		public Style CloseButtonStyle
 		{
 			get => (Style)GetValue(CloseButtonStyleProperty);
 			set => SetValue(CloseButtonStyleProperty, value);
 		}
 
+		/// <summary>
+		/// Gets or sets the Style to apply to the close button in the InfoBar.
+		/// </summary>
 		public static DependencyProperty CloseButtonStyleProperty { get; } =
 			DependencyProperty.Register(nameof(CloseButtonStyle), typeof(Style), typeof(InfoBar), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.ValueDoesNotInheritDataContext));
 
+		/// <summary>
+		/// Gets or sets the XAML Content that is displayed below the title and message in the InfoBar.
+		/// </summary>
 		public object Content
 		{
 			get => (object)GetValue(ContentProperty);
 			set => SetValue(ContentProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the Content dependency property.
+		/// </summary>
 		public static DependencyProperty ContentProperty { get; } =
 			DependencyProperty.Register(nameof(Content), typeof(object), typeof(InfoBar), new FrameworkPropertyMetadata(null));
 
+		/// <summary>
+		/// Gets or sets the data template for the InfoBar.Content.
+		/// </summary>
 		public DataTemplate ContentTemplate
 		{
 			get => (DataTemplate)GetValue(ContentTemplateProperty);
 			set => SetValue(ContentTemplateProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the ContentTemplate dependency property.
+		/// </summary>
 		public static DependencyProperty ContentTemplateProperty { get; } =
 			DependencyProperty.Register(nameof(ContentTemplate), typeof(DataTemplate), typeof(InfoBar), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.ValueDoesNotInheritDataContext));
 
+		/// <summary>
+		/// Gets or sets the graphic content to appear alongside the title and message in the InfoBar.
+		/// </summary>
 		public IconSource IconSource
 		{
 			get => (IconSource)GetValue(IconSourceProperty);
 			set => SetValue(IconSourceProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the IconSource dependency property.
+		/// </summary>
 		public static DependencyProperty IconSourceProperty { get; } =
 			DependencyProperty.Register(nameof(IconSource), typeof(IconSource), typeof(InfoBar), new FrameworkPropertyMetadata(null, OnIconSourcePropertyChanged));
 
+		/// <summary>
+		/// Identifies the IconSource dependency property.
+		/// </summary>
 		public bool IsClosable
 		{
 			get => (bool)GetValue(IsClosableProperty);
 			set => SetValue(IsClosableProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the IsClosable dependency property.
+		/// </summary>
 		public static DependencyProperty IsClosableProperty { get; } =
 			DependencyProperty.Register(nameof(IsClosable), typeof(bool), typeof(InfoBar), new FrameworkPropertyMetadata(true, OnIsClosablePropertyChanged));
 
+		/// <summary>
+		/// Gets or sets a value that indicates whether the icon is visible in the InfoBar.
+		/// </summary>
 		public bool IsIconVisible
 		{
 			get => (bool)GetValue(IsIconVisibleProperty);
 			set => SetValue(IsIconVisibleProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the IsIconVisible dependency property.
+		/// </summary>
 		public static DependencyProperty IsIconVisibleProperty { get; } =
 			DependencyProperty.Register(nameof(IsIconVisible), typeof(bool), typeof(InfoBar), new FrameworkPropertyMetadata(true, OnIsIconVisiblePropertyChanged));
 
+		/// <summary>
+		/// Gets or sets a value that indicates whether the InfoBar is open.
+		/// </summary>
 		public bool IsOpen
 		{
 			get => (bool)GetValue(IsOpenProperty);
 			set => SetValue(IsOpenProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the IsOpen dependency property.
+		/// </summary>
 		public static DependencyProperty IsOpenProperty { get; } =
 			DependencyProperty.Register(nameof(IsOpen), typeof(bool), typeof(InfoBar), new FrameworkPropertyMetadata(false, OnIsOpenPropertyChanged));
 
+		/// <summary>
+		/// Gets or sets the message of the InfoBar.
+		/// </summary>
 		public string Message
 		{
 			get => (string)GetValue(MessageProperty);
 			set => SetValue(MessageProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the Message dependency property.
+		/// </summary>
 		public static DependencyProperty MessageProperty { get; } =
 			DependencyProperty.Register(nameof(Message), typeof(string), typeof(InfoBar), new FrameworkPropertyMetadata(null));
 
+		/// <summary>
+		/// Gets or sets the type of the InfoBar to apply consistent status color, icon,
+		/// and assistive technology settings dependent on the criticality of the notification.
+		/// </summary>
 		public InfoBarSeverity Severity
 		{
 			get => (InfoBarSeverity)GetValue(SeverityProperty);
 			set => SetValue(SeverityProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the Severity dependency property.
+		/// </summary>
 		public static DependencyProperty SeverityProperty { get; } =
 			DependencyProperty.Register(nameof(Severity), typeof(InfoBarSeverity), typeof(InfoBar), new FrameworkPropertyMetadata(InfoBarSeverity.Informational, OnSeverityPropertyChanged));
 
-		public InfoBarTemplateSettings TemplateSettings
-		{
-			get => (InfoBarTemplateSettings)GetValue(TemplateSettingsProperty);
-			set => SetValue(TemplateSettingsProperty, value);
-		}
+		/// <summary>
+		/// Provides calculated values that can be referenced as TemplatedParent sources when defining templates for an InfoBar.
+		/// Not intended for general use.
+		/// </summary>
+		public InfoBarTemplateSettings TemplateSettings => (InfoBarTemplateSettings)GetValue(TemplateSettingsProperty);
 
+		/// <summary>
+		/// Identifies the TemplateSettings dependency property.
+		/// </summary>
 		public static DependencyProperty TemplateSettingsProperty { get; } =
 			DependencyProperty.Register(nameof(TemplateSettings), typeof(InfoBarTemplateSettings), typeof(InfoBar), new FrameworkPropertyMetadata(null));
 
+		/// <summary>
+		/// Gets or sets the title of the InfoBar.
+		/// </summary>
 		public string Title
 		{
 			get => (string)GetValue(TitleProperty);
 			set => SetValue(TitleProperty, value);
 		}
 
+		/// <summary>
+		/// Identifies the Title dependency property.
+		/// </summary>
 		public static DependencyProperty TitleProperty { get; } =
 			DependencyProperty.Register(nameof(Title), typeof(string), typeof(InfoBar), new FrameworkPropertyMetadata(null));
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBar.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBar.cs
@@ -1,4 +1,6 @@
-﻿// MUX reference InfoBar.cpp, commit 1f7779d
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference InfoBar.cpp, commit 1f7779d
 
 #pragma warning disable 105 // remove when moving to WinUI tree
 
@@ -11,7 +13,14 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 
 namespace Microsoft.UI.Xaml.Controls
-{	
+{
+	/// <summary>
+	/// An InfoBar is an inline notification for essential app-wide messages.
+	/// The InfoBar will take up space in a layout and will not cover up other
+	/// content or float on top of it. It supports rich content (including titles,
+	/// messages, icons, and buttons) and can be configured to be user-dismissable
+	/// or persistent.
+	/// </summary>
 	[ContentProperty(Name = nameof(Content))]
 	public partial class InfoBar : Control
 	{
@@ -27,6 +36,9 @@ namespace Microsoft.UI.Xaml.Controls
 		private FrameworkElement m_standardIconTextBlock = null;
 		private InfoBarCloseReason m_lastCloseReason = InfoBarCloseReason.Programmatic;
 
+		/// <summary>
+		/// Initializes a new instance of the InfoBar class.
+		/// </summary>
 		public InfoBar()
 		{
 			//__RP_Marker_ClassById(RuntimeProfiler.ProfId_InfoBar);
@@ -205,7 +217,7 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		void UpdateSeverity()
+		private void UpdateSeverity()
 		{
 			var severityState = "Informational";
 
@@ -245,28 +257,28 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		void UpdateIconVisibility()
+		private void UpdateIconVisibility()
 		{
 			VisualStateManager.GoToState(this, IsIconVisible ? (IconSource != null ? "UserIconVisible" : "StandardIconVisible") : "NoIconVisible", false);
 		}
 
-		void UpdateCloseButton()
+		private void UpdateCloseButton()
 		{
 			VisualStateManager.GoToState(this, IsClosable ? "CloseButtonVisible" : "CloseButtonCollapsed", false);
 		}
 
-		void OnForegroundChanged(DependencyObject sender, DependencyProperty args)
+		private void OnForegroundChanged(DependencyObject sender, DependencyProperty args)
 		{
 			UpdateForeground();
 		}
 
-		void UpdateForeground()
+		private void UpdateForeground()
 		{
 			// If Foreground is set, then change Title and Message Foreground to match.
 			VisualStateManager.GoToState(this, ReadLocalValue(Control.ForegroundProperty) == DependencyProperty.UnsetValue ? "ForegroundNotSet" : "ForegroundSet", false);
 		}
 
-		string GetSeverityLevelResourceName(InfoBarSeverity severity)
+		private string GetSeverityLevelResourceName(InfoBarSeverity severity)
 		{
 			switch (severity)
 			{
@@ -277,7 +289,7 @@ namespace Microsoft.UI.Xaml.Controls
 			return "InfoBarSeverityInformationalName";
 		}
 
-		string GetIconSeverityLevelResourceName(InfoBarSeverity severity)
+		private string GetIconSeverityLevelResourceName(InfoBarSeverity severity)
 		{
 			switch (severity)
 			{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarAutomationPeer.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarAutomationPeer.cs
@@ -1,4 +1,6 @@
-﻿// MUX reference InfoBarAutomationPeer.cpp, commit 3125489
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference InfoBarAutomationPeer.cpp, commit 3125489
 
 using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Xaml;
@@ -6,8 +8,15 @@ using Windows.UI.Xaml.Automation.Peers;
 
 namespace Microsoft.UI.Xaml.Automation.Peers
 {
+	/// <summary>
+	/// Exposes InfoBar types to Microsoft UI Automation.
+	/// </summary>
 	public partial class InfoBarAutomationPeer : FrameworkElementAutomationPeer
 	{
+		/// <summary>
+		/// Initializes a new instance of the InfoBarAutomationPeer class.
+		/// </summary>
+		/// <param name="owner">The InfoBar control instance to create the peer for.</param>
 		public InfoBarAutomationPeer(InfoBar owner) : base(owner)
 		{
 		}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarCloseReason.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarCloseReason.cs
@@ -1,10 +1,22 @@
-﻿// MUX reference InfoBar.idl, commit 3125489
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference InfoBar.idl, commit 3125489
 
 namespace Microsoft.UI.Xaml.Controls
 {
+	/// <summary>
+	/// Defines constants that indicate the cause of the InfoBar closure.
+	/// </summary>
 	public enum InfoBarCloseReason
 	{
+		/// <summary>
+		/// The InfoBar was closed by the user clicking the close button.
+		/// </summary>
 		CloseButton = 0,
+
+		/// <summary>
+		/// The InfoBar was programmatically closed.
+		/// </summary>
 		Programmatic = 1
 	}
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarClosedEventArgs.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarClosedEventArgs.cs
@@ -1,12 +1,21 @@
-﻿// MUX reference InfoBar.idl, commit 3125489
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference InfoBar.idl, commit 3125489
 
 namespace Microsoft.UI.Xaml.Controls
 {
-    public partial class InfoBarClosedEventArgs
+	/// <summary>
+	/// Provides data for the InfoBar.Closed event.
+	/// </summary>
+	public partial class InfoBarClosedEventArgs
     {
 		internal InfoBarClosedEventArgs(InfoBarCloseReason reason) =>
 			Reason = reason;
 
+		/// <summary>
+		/// Gets a constant that specifies whether the cause of the Closed
+		/// event was due to user interaction (Close button click) or programmatic closure.
+		/// </summary>
 		public InfoBarCloseReason Reason { get; }
 	}
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarClosingEventArgs.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarClosingEventArgs.cs
@@ -1,14 +1,26 @@
-﻿// MUX reference InfoBar.idl, commit 3125489
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference InfoBar.idl, commit 3125489
 
 namespace Microsoft.UI.Xaml.Controls
 {
-    public partial class InfoBarClosingEventArgs
+	/// <summary>
+	/// Provides data for the InfoBar.Closing event.
+	/// </summary>
+	public partial class InfoBarClosingEventArgs
     {
 		internal InfoBarClosingEventArgs(InfoBarCloseReason reason) =>
 			Reason = reason;
 
+		/// <summary>
+		/// Gets a constant that specifies whether the cause of the Closing event
+		/// was due to user interaction (Close button click) or programmatic closure.
+		/// </summary>
 		public InfoBarCloseReason Reason { get; }
 
+		/// <summary>
+		/// Gets or sets a value that indicates whether the Closing event should be canceled in the InfoBar.
+		/// </summary>
 		public bool Cancel { get; set; } = false;
 	}
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarPanel.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarPanel.Properties.cs
@@ -1,40 +1,82 @@
-﻿// MUX reference InfoBarPanel.properties.cpp, commit 533c6b1
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference InfoBarPanel.properties.cpp, commit 533c6b1
 
 using Windows.UI.Xaml;
 
-namespace Microsoft.UI.Xaml.Controls
+namespace Microsoft.UI.Xaml.Controls.Primitives
 {
 	public partial class InfoBarPanel
 	{
+		/// <summary>
+		/// Gets the HorizontalOrientationMargin from an object.
+		/// </summary>
+		/// <param name="obj">The object that has an HorizontalOrientationMargin.</param>
+		/// <returns>The HorizontalOrientationMargin thickness.</returns>
 		public static Thickness GetHorizontalOrientationMargin(DependencyObject obj) => (Thickness)obj.GetValue(HorizontalOrientationMarginProperty);
 
+		/// <summary>
+		/// Sets the HorizontalOrientationMargin to an object.
+		/// </summary>
+		/// <param name="obj">The object that the HorizontalOrientationMargin value will be set to.</param>
+		/// <param name="value">The thickness of the HorizontalOrientationMargin.</param>
 		public static void SetHorizontalOrientationMargin(DependencyObject obj, Thickness value) => obj.SetValue(HorizontalOrientationMarginProperty, value);
 
+		/// <summary>
+		/// Gets the identifier for the HorizontalOrientationMargin dependency property.
+		/// </summary>
 		public static DependencyProperty HorizontalOrientationMarginProperty { get; } =
 			DependencyProperty.RegisterAttached("HorizontalOrientationMargin", typeof(Thickness), typeof(InfoBarPanel), new FrameworkPropertyMetadata(default(Thickness)));
 
+		/// <summary>
+		/// Gets and sets the distance between the edges of the InfoBarPanel
+		/// and its children when the panel is oriented horizontally.
+		/// </summary>
 		public Thickness HorizontalOrientationPadding
 		{
 			get => (Thickness)GetValue(HorizontalOrientationPaddingProperty);
 			set => SetValue(HorizontalOrientationPaddingProperty, value);
 		}
 
+		/// <summary>
+		/// Gets the identifier for the HorizontalOrientationPadding dependency property.
+		/// </summary>
 		public static DependencyProperty HorizontalOrientationPaddingProperty { get; } =
 			DependencyProperty.Register(nameof(HorizontalOrientationPadding), typeof(Thickness), typeof(InfoBarPanel), new FrameworkPropertyMetadata(default(Thickness)));
 
+		/// <summary>
+		/// Gets the VerticalOrientationMargin from an object.
+		/// </summary>
+		/// <param name="obj">The object that has a VerticalOrientationMargin.</param>
+		/// <returns>The VerticalOrientationMargin thickness.</returns>
 		public static Thickness GetVerticalOrientationMargin(DependencyObject obj) => (Thickness)obj.GetValue(VerticalOrientationMarginProperty);
 
+		/// <summary>
+		/// Sets the VerticalOrientationMargin to an object.
+		/// </summary>
+		/// <param name="obj">The object that the VerticalOrientationMargin value will be set to.</param>
+		/// <param name="value">The thickness of the VerticalOrientationMargin.</param>
 		public static void SetVerticalOrientationMargin(DependencyObject obj, Thickness value) => obj.SetValue(VerticalOrientationMarginProperty, value);
 
+		/// <summary>
+		/// Gets the identifier for the VerticalOrientationMargin dependency property.
+		/// </summary>
 		public static DependencyProperty VerticalOrientationMarginProperty { get; } =
 			DependencyProperty.RegisterAttached("VerticalOrientationMargin", typeof(Thickness), typeof(InfoBarPanel), new FrameworkPropertyMetadata(default(Thickness)));
 
+		/// <summary>
+		/// Gets and sets the distance between the edges of the InfoBarPanel
+		/// and its children when the panel is oriented vertically.
+		/// </summary>
 		public Thickness VerticalOrientationPadding
 		{
 			get => (Thickness)GetValue(VerticalOrientationPaddingProperty);
 			set => SetValue(VerticalOrientationPaddingProperty, value);
 		}
 
+		/// <summary>
+		/// Gets the identifier for the VerticalOrientationPadding dependency property.
+		/// </summary>
 		public static DependencyProperty VerticalOrientationPaddingProperty { get; } =
 			DependencyProperty.Register(nameof(VerticalOrientationPadding), typeof(Thickness), typeof(InfoBarPanel), new FrameworkPropertyMetadata(default(Thickness)));
 	}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarPanel.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarPanel.cs
@@ -1,15 +1,27 @@
-﻿// MUX reference InfoBarPanel.cpp, commit d67e625
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference InfoBarPanel.cpp, commit d67e625
 
 using System;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Microsoft.UI.Xaml.Controls
+namespace Microsoft.UI.Xaml.Controls.Primitives
 {
+	/// <summary>
+	/// Represents a panel that arranges its items horizontally if there is available space, otherwise vertically.
+	/// </summary>
 	public partial class InfoBarPanel : Panel
 	{
 		private bool m_isVertical = false;
+
+		/// <summary>
+		/// Initializes a new instance of the InfoBarPanel class.
+		/// </summary>
+		public InfoBarPanel()
+		{
+		}
 
 		protected override Size MeasureOverride(Size availableSize)
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarSeverity.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarSeverity.cs
@@ -1,12 +1,42 @@
-﻿// MUX reference InfoBar.idl, commit 3125489
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference InfoBar.idl, commit 3125489
 
 namespace Microsoft.UI.Xaml.Controls
 {
+	/// <summary>
+	/// Defines constants that indicate the criticality of the InfoBar that is shown.
+	/// </summary>
 	public enum InfoBarSeverity
 	{
+		/// <summary>
+		/// Communicates that the InfoBar is displaying general information that
+		/// requires the user's attention. For assistive technologies, they will
+		/// follow the behavior set in the Processing_All constant.
+		/// </summary>
 		Informational = 0,
+
+		/// <summary>
+		/// Communicates that the InfoBar is displaying information regarding
+		/// a long-running and/or background task that has completed successfully.
+		/// For assistive technologies, they will follow the behavior
+		/// set in the Processing_All constant.
+		/// </summary>
 		Success = 1,
+
+		/// <summary>
+		/// Communicates that the InfoBar is displaying information regarding
+		/// a condition that might cause a problem in the future. For assistive
+		/// technologies, they will follow the behavior
+		/// set in the NotificationProcessing_ImportantAll constant.
+		/// </summary>
 		Warning = 2,
+
+		/// <summary>
+		/// Communicates that the InfoBar is displaying information regarding an error
+		/// or problem that has occurred. For assistive technologies, they will follow
+		/// the behavior set in the NotificationProcessing_ImportantAll constant.
+		/// </summary>
 		Error = 3,
 	}
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarTemplateSettings.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarTemplateSettings.cs
@@ -1,23 +1,38 @@
-﻿// MUX reference InfoBarTemplateSettings.properties.cpp, commit 3125489
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference InfoBarTemplateSettings.properties.cpp, commit 3125489
 
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Xaml.Controls
 {
+	/// <summary>
+	/// Provides calculated values that can be referenced as TemplatedParent
+	/// sources when defining templates for an InfoBar.
+	/// </summary>
 	public partial class InfoBarTemplateSettings : DependencyObject
     {
+		/// <summary>
+		/// Initializes a new instance of the InfoBarTemplateSettings class.
+		/// </summary>
 		public InfoBarTemplateSettings()
 		{
 		}
 
+		/// <summary>
+		/// Gets the icon element.
+		/// </summary>
 		public IconElement IconElement
 		{
 			get => (IconElement)GetValue(IconElementProperty);
 			set => SetValue(IconElementProperty, value);
 		}
 
-		public static readonly DependencyProperty IconElementProperty =
+		/// <summary>
+		/// Identifies the InfoBarTemplateSettings.IconElement dependency property.
+		/// </summary>
+		public static DependencyProperty IconElementProperty { get; } =
 			DependencyProperty.Register(nameof(IconElement), typeof(IconElement), typeof(InfoBarTemplateSettings), new FrameworkPropertyMetadata(null));
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

- `InfoBarPanel` has wrong namespace
- `InfoBar` is not up to date

## What is the new behavior?

- `InfoBarPanel` now has correct namespace
- `InfoBar` is updated to latest WinUI sources
- All `InfoBar` properties and classes have documentation

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.