### PR TITLE
ci: Use C# 10 inside the Uno solution

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -68,23 +68,23 @@ jobs:
 
 - template: build/ci/.azure-devops-uap.yml
   parameters:
-    vmImage: '$(windowsHostedVMImage)'
+    vmImage: '$(windows2022HostedVMImage)'
 
 - template: build/ci/.azure-devops-unit-tests.yml
   parameters:
-    vmImage: '$(windowsHostedVMImage)'
+    vmImage: '$(windows2022HostedVMImage)'
 
 - template: build/ci/.azure-devops-skia-tests.yml
   parameters:
-    vmImage: '$(windowsHostedVMImage)'
+    vmImage: '$(windows2022HostedVMImage)'
 
 - template: build/ci/.azure-devops-docs.yml
   parameters:
-    vmImage: '$(windowsHostedVMImage)'
+    vmImage: '$(windows2022HostedVMImage)'
 
 - template: build/ci/.azure-devops-samplesapp-uitests-build.yml
   parameters:
-    vmImage: '$(windowsHostedVMImage)'
+    vmImage: '$(windows2022HostedVMImage)'
 
 - template: build/ci/.azure-devops-wasm-uitests.yml
   parameters:
@@ -117,7 +117,7 @@ jobs:
 
 - template: build/ci/.azure-devops-screenshot-compare.yml
   parameters:
-    vmImage: '$(windowsHostedVMImage)'
+    vmImage: '$(windows2022HostedVMImage)'
 
 - template: build/ci/.azure-devops-vs2022-vsix.yml
   parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -77,6 +77,7 @@ jobs:
 - template: build/ci/.azure-devops-skia-tests.yml
   parameters:
     vmImage: '$(windows2022HostedVMImage)'
+    poolName: '$(windowsScaledPool)'
 
 - template: build/ci/.azure-devops-docs.yml
   parameters:

--- a/build/android-uitest-build.sh
+++ b/build/android-uitest-build.sh
@@ -9,7 +9,7 @@ cd $BUILD_SOURCESDIRECTORY/build
 export IsUiAutomationMappingEnabled=true
 
 # build the sample and tests, while the emulator is starting
-msbuild /m /r /p:Configuration=$BUILDCONFIGURATION $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+mono '/Applications/Visual Studio.app/Contents/Resources/lib/monodevelop/bin/MSBuild/Current/bin/msbuild.dll' /m /r /p:Configuration=$BUILDCONFIGURATION $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
 
 mkdir -p $BUILD_ARTIFACTSTAGINGDIRECTORY/android
 cp $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Droid/bin/$BUILDCONFIGURATION/uno.platform.unosampleapp-Signed.apk $BUILD_ARTIFACTSTAGINGDIRECTORY/android

--- a/build/ci/.azure-devops-android-tests.yml
+++ b/build/ci/.azure-devops-android-tests.yml
@@ -209,6 +209,8 @@ jobs:
 
   - template: templates/optimize-roslyn-mono.yml
 
+  - template: templates/dotnet-install.yml
+
   - template: templates/ios-build-select-version.yml
     parameters:
       xCodeRoot: ${{ parameters.xCodeRoot }}

--- a/build/ci/.azure-devops-package-generic.yml
+++ b/build/ci/.azure-devops-package-generic.yml
@@ -53,6 +53,8 @@ jobs:
       packageType: runtime
       version: 2.2.x
 
+  - template: templates/dotnet-install.yml
+
   # Required for the Wasm uitests project
   - task: NodeTool@0
 

--- a/build/ci/.azure-devops-samplesapp-uitests-build.yml
+++ b/build/ci/.azure-devops-samplesapp-uitests-build.yml
@@ -23,6 +23,8 @@ jobs:
   - checkout: self
     clean: true
 
+  - template: templates/dotnet-install.yml
+
   - task: MSBuild@1
     displayName: 'Build UI Tests'
     inputs:

--- a/build/ci/.azure-devops-skia-tests.yml
+++ b/build/ci/.azure-devops-skia-tests.yml
@@ -1,11 +1,13 @@
 parameters:
   vmImage: ''
+  poolName: ''
 
 jobs:
 - job: Skia_Tests_Build
   displayName: 'Skia Samples App Build'
   timeoutInMinutes: 60
 
+  #pool: ${{ parameters.poolName }}
   pool:
     vmImage: ${{ parameters.vmImage }}
 
@@ -38,8 +40,9 @@ jobs:
   displayName: 'Skia Samples App Snapshot Tests'
   timeoutInMinutes: 60
 
-  pool:
-    vmImage: ${{ parameters.vmImage }}
+  pool: ${{ parameters.poolName }}
+  #pool:
+  #  vmImage: ${{ parameters.vmImage }}
 
   dependsOn: Skia_Tests_Build
 
@@ -69,8 +72,9 @@ jobs:
   displayName: 'Skia Samples App Runtime Tests'
   timeoutInMinutes: 30
 
-  pool:
-    vmImage: ${{ parameters.vmImage }}
+  pool: ${{ parameters.poolName }}
+  #pool:
+  #  vmImage: ${{ parameters.vmImage }}
 
   dependsOn: Skia_Tests_Build
 

--- a/build/ci/.azure-devops-unit-tests.yml
+++ b/build/ci/.azure-devops-unit-tests.yml
@@ -20,8 +20,8 @@ jobs:
       # Preview:
       #   ADDITIONAL_FLAGS: '/p:LangVersion=preview /p:UnoUIUseRoslynSourceGenerators=true /p:MicrosoftNetCompilerVersionOverride=3.8.0-3.final'
 
-      CSharp9:
-        ADDITIONAL_FLAGS: '/p:LangVersion=9.0 /p:UnoUIUseRoslynSourceGenerators=true'
+      #CSharp9:
+      #  ADDITIONAL_FLAGS: '/p:LangVersion=9.0 /p:UnoUIUseRoslynSourceGenerators=true'
 
   variables:
     CombinedConfiguration: Release|Any CPU
@@ -40,6 +40,7 @@ jobs:
       nugetPackages: $(NUGET_PACKAGES)
 
   - template: templates/gitversion.yml
+  - template: templates/dotnet-install.yml
 
   - task: MSBuild@1
     inputs:

--- a/build/ci/.azure-devops-unit-tests.yml
+++ b/build/ci/.azure-devops-unit-tests.yml
@@ -57,8 +57,7 @@ jobs:
         !**\*Wasm.Test*.dll
         !**\*UITests.dll
         !**\*.RuntimeTests.dll
-      vstestLocationMethod: version
-      vsTestVersion: latest
+      vsTestVersion: toolsInstaller
       testRunTitle: $(Agent.JobName)
       testSelector: testAssemblies
       batchingBasedOnAgentsOption: customBatchSize

--- a/build/ci/.azure-devops-vs2022-vsix.yml
+++ b/build/ci/.azure-devops-vs2022-vsix.yml
@@ -24,8 +24,6 @@ jobs:
     displayName: Build 2022 VSIX
     inputs:
       solution: Build/Uno.UI.Build.csproj
-      msbuildLocationMethod: location
-      msbuildLocation: $(MSBUILDPREVIEWPATH)
       msbuildArguments: /r /m /t:Build2022VSIX "/p:CombinedConfiguration=$(CombinedConfiguration)" /detailedsummary /bl:$(build.artifactstagingdirectory)\build-$(GitVersion.FullSemVer)-generate-vsix2022.binlog
       clean: false
       restoreNugetPackages: false

--- a/build/ci/.azure-devops-vs2022-vsix.yml
+++ b/build/ci/.azure-devops-vs2022-vsix.yml
@@ -18,12 +18,6 @@ jobs:
   - checkout: self
     clean: true
 
-  - powershell: |
-      dotnet tool update -g dotnet-vs
-      $MSBUILDPREVIEWPATH="$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin"
-      Write-Host "##vso[task.setvariable variable=MSBUILDPREVIEWPATH;]$MSBUILDPREVIEWPATH"
-    displayName: Setup VS17 Path
-
   - template: templates/gitversion.yml
 
   - task: MSBuild@1

--- a/build/ci/.azure-devops-wasm-cs9-preview-validation.yml
+++ b/build/ci/.azure-devops-wasm-cs9-preview-validation.yml
@@ -3,7 +3,7 @@ parameters:
 
 jobs:
 - job: Wasm_cs9_Build
-  displayName: 'WebAssembly Build (C# 9.0 Compiler)'
+  displayName: 'WebAssembly Samples App Build'
   container: nv-bionic-wasm
 
   pool:
@@ -27,7 +27,7 @@ jobs:
   #   displayName: 'Build sample app (netstandard2.0)'
 
   - bash: |
-      dotnet msbuild /r /p:Configuration=Release /p:UnoTargetFrameworkOverride=netstandard2.0 /p:LangVersion=9.0 /p:UnoUIUseRoslynSourceGenerators=true src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj  /bl:$(build.artifactstagingdirectory)/build-cs9-preview-$(GitVersion.FullSemVer).binlog
+      dotnet msbuild /r /p:Configuration=Release /p:UnoTargetFrameworkOverride=netstandard2.0 /p:UnoUIUseRoslynSourceGenerators=true src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj  /bl:$(build.artifactstagingdirectory)/build-cs9-preview-$(GitVersion.FullSemVer).binlog
 
     displayName: 'Build sample app (netstandard2.0)'
 

--- a/build/ci/.azure-devops-wasm-uitests.yml
+++ b/build/ci/.azure-devops-wasm-uitests.yml
@@ -102,7 +102,7 @@ jobs:
       dotnet tool uninstall dotnet-serve --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
       dotnet tool install dotnet-serve --version 1.8.15 --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
       export PATH="$PATH:$BUILD_SOURCESDIRECTORY/build/tools"
-      dotnet serve -p 8000 -d "$BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/site-net5.0" &
+      $BUILD_SOURCESDIRECTORY/build/tools/dotnet-serve -p 8000 -d "$BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/site-net5.0" &
       cd $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Wasm.UITests
       npm install
       node app

--- a/build/ci/.azure-devops-wasm-uitests.yml
+++ b/build/ci/.azure-devops-wasm-uitests.yml
@@ -96,8 +96,11 @@ jobs:
 
   - bash: |
       set -euo pipefail
+      set -x
       IFS=$'\n\t'
-      dotnet tool install dotnet-serve --version 1.8.15 --tool-path $BUILD_SOURCESDIRECTORY/build/tools
+      dotnet tool uninstall dotnet-serve -g || true
+      dotnet tool uninstall dotnet-serve --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
+      dotnet tool install dotnet-serve --version 1.8.15 --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
       export PATH="$PATH:$BUILD_SOURCESDIRECTORY/build/tools"
       dotnet serve -p 8000 -d "$BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/site-net5.0" &
       cd $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Wasm.UITests

--- a/build/ci/templates/dotnet-install.yml
+++ b/build/ci/templates/dotnet-install.yml
@@ -1,6 +1,12 @@
 steps:
 
   - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK 6.0.100'
+    inputs:
+      packageType: sdk
+      version: 6.0.100
+
+  - task: UseDotNet@2
     displayName: 'Use .NET Core SDK 5.0.400'
     inputs:
       packageType: sdk

--- a/build/ios-uitest-build.sh
+++ b/build/ios-uitest-build.sh
@@ -4,4 +4,4 @@ IFS=$'\n\t'
 
 cd $BUILD_SOURCESDIRECTORY
 
-msbuild /m /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
+mono '/Applications/Visual Studio.app/Contents/Resources/lib/monodevelop/bin/MSBuild/Current/bin/msbuild.dll' /m /r /p:Configuration=Release $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj

--- a/build/run-automated-uitests.sh
+++ b/build/run-automated-uitests.sh
@@ -49,7 +49,7 @@ fi
 mkdir -p $UNO_UITEST_SCREENSHOT_PATH
 
 ## The python server serves the current working directory, and may be changed by the nunit runner
-dotnet serve -p 8000 -d "$BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/site-$SITE_SUFFIX" &
+dotnet-serve -p 8000 -d "$BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/site-$SITE_SUFFIX" &
 
 ## Build the NUnit configuration file
 echo "--trace=Verbose" > $UNO_TESTS_RESPONSE_FILE

--- a/build/run-automated-uitests.sh
+++ b/build/run-automated-uitests.sh
@@ -7,7 +7,8 @@ cd $BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries
 npm i chromedriver@86.0.0
 npm i puppeteer@5.3.1
 
-# install dotnet serve
+# install dotnet serve / Remove as needed
+dotnet tool uninstall dotnet-serve || true
 dotnet tool install dotnet-serve --version 1.8.15 --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
 export PATH="$PATH:$BUILD_SOURCESDIRECTORY/build/tools"
 

--- a/build/run-automated-uitests.sh
+++ b/build/run-automated-uitests.sh
@@ -8,6 +8,7 @@ npm i chromedriver@86.0.0
 npm i puppeteer@5.3.1
 
 # install dotnet serve / Remove as needed
+dotnet tool uninstall dotnet-serve -g || true
 dotnet tool uninstall dotnet-serve --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
 dotnet tool install dotnet-serve --version 1.8.15 --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
 export PATH="$PATH:$BUILD_SOURCESDIRECTORY/build/tools"

--- a/build/run-automated-uitests.sh
+++ b/build/run-automated-uitests.sh
@@ -1,4 +1,5 @@
 ﻿#!/bin/bash
+set -x #echo on
 set -euo pipefail
 IFS=$'\n\t'
 

--- a/build/run-automated-uitests.sh
+++ b/build/run-automated-uitests.sh
@@ -8,7 +8,7 @@ npm i chromedriver@86.0.0
 npm i puppeteer@5.3.1
 
 # install dotnet serve / Remove as needed
-dotnet tool uninstall dotnet-serve || true
+dotnet tool uninstall dotnet-serve --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
 dotnet tool install dotnet-serve --version 1.8.15 --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
 export PATH="$PATH:$BUILD_SOURCESDIRECTORY/build/tools"
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -46,7 +46,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-	<LangVersion>8.0</LangVersion>
+	<LangVersion>9.0</LangVersion>
 
 	<!--
 	Use this property to use either the Uno.SourceGeneration framework, or Roslyn's C# 9.0 generators.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,44 +27,46 @@
 
     <DefaultLanguage>en-US</DefaultLanguage>
 
-	<UnoSourceGeneratorUseGenerationHost>true</UnoSourceGeneratorUseGenerationHost>
+    <UnoSourceGeneratorUseGenerationHost>true</UnoSourceGeneratorUseGenerationHost>
 
-	<!-- Disable generation controller to conserver CI server memory -->
-	<UnoSourceGeneratorUseGenerationController Condition="'$(CI_Build)'=='true'">false</UnoSourceGeneratorUseGenerationController>
+    <!-- Disable generation controller to conserver CI server memory -->
+    <UnoSourceGeneratorUseGenerationController Condition="'$(CI_Build)'=='true'">false</UnoSourceGeneratorUseGenerationController>
 
-	<!-- Disable source link when not building on GitHub -->
+    <!-- Disable source link when not building on GitHub -->
     <SourceLinkEnabled Condition="'$(BUILD_REPOSITORY_PROVIDER)'!='GitHub'">false</SourceLinkEnabled>
-	<EmbedUntrackedSources Condition="'$(BUILD_REPOSITORY_PROVIDER)'=='GitHub'">true</EmbedUntrackedSources>
-	<Deterministic>true</Deterministic>
-	
-	<UNO_UWP_BUILD>true</UNO_UWP_BUILD>
-	<DefineConstants Condition="'$(UNO_UWP_BUILD)'!='true'">$(DefineConstants);HAS_UNO_WINUI</DefineConstants>
-	<DefineConstants Condition="$(UnoTargetFrameworkOverride.ToLowerInvariant().StartsWith('monoandroid')) OR $(UnoTargetFrameworkOverride.ToLowerInvariant().StartsWith('net6.0-android'))">$(DefineConstants);TARGET_FRAMEWORK_OVERRIDE_ANDROID</DefineConstants>
-	<DefineConstants Condition="$(UnoTargetFrameworkOverride.ToLowerInvariant().StartsWith('xamarinios'))  OR $(UnoTargetFrameworkOverride.ToLowerInvariant().StartsWith('net6.0-ios'))">$(DefineConstants);TARGET_FRAMEWORK_OVERRIDE_IOS</DefineConstants>
+    <EmbedUntrackedSources Condition="'$(BUILD_REPOSITORY_PROVIDER)'=='GitHub'">true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
+    
+    <UNO_UWP_BUILD>true</UNO_UWP_BUILD>
+    <DefineConstants Condition="'$(UNO_UWP_BUILD)'!='true'">$(DefineConstants);HAS_UNO_WINUI</DefineConstants>
+    <DefineConstants Condition="$(UnoTargetFrameworkOverride.ToLowerInvariant().StartsWith('monoandroid')) OR $(UnoTargetFrameworkOverride.ToLowerInvariant().StartsWith('net6.0-android'))">$(DefineConstants);TARGET_FRAMEWORK_OVERRIDE_ANDROID</DefineConstants>
+    <DefineConstants Condition="$(UnoTargetFrameworkOverride.ToLowerInvariant().StartsWith('xamarinios'))  OR $(UnoTargetFrameworkOverride.ToLowerInvariant().StartsWith('net6.0-ios'))">$(DefineConstants);TARGET_FRAMEWORK_OVERRIDE_IOS</DefineConstants>
 
-	<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+
+    <MicrosoftNetCompilerVersionOverride>4.0.0-6.final</MicrosoftNetCompilerVersionOverride>
   </PropertyGroup>
 
   <PropertyGroup>
-	<LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
 
-	<!--
-	Use this property to use either the Uno.SourceGeneration framework, or Roslyn's C# 9.0 generators.
-	If UnoUIUseRoslynSourceGenerators is not defined, the environment defines if Roslyn is used or not, see
-	Uno.UI.SourceGenerators.props for more details. Note that Roslyn generators required VS 16.8 Pre 3 or later.
-	-->
-	<UnoUIUseRoslynSourceGenerators>false</UnoUIUseRoslynSourceGenerators>
+    <!--
+    Use this property to use either the Uno.SourceGeneration framework, or Roslyn's C# 9.0 generators.
+    If UnoUIUseRoslynSourceGenerators is not defined, the environment defines if Roslyn is used or not, see
+    Uno.UI.SourceGenerators.props for more details. Note that Roslyn generators required VS 16.8 Pre 3 or later.
+    -->
+    <UnoUIUseRoslynSourceGenerators>false</UnoUIUseRoslynSourceGenerators>
 
-	<!--
-	Force the compilation using Roslyn Generators to avoid type nuget
-	restore issues in the lottie project when building on .NET 5+
-	-->
-	<UnoUIUseRoslynSourceGenerators Condition="'$(MSBuildRuntimeType)'=='Core'">true</UnoUIUseRoslynSourceGenerators>
+    <!--
+    Force the compilation using Roslyn Generators to avoid type nuget
+    restore issues in the lottie project when building on .NET 5+
+    -->
+    <UnoUIUseRoslynSourceGenerators Condition="'$(MSBuildRuntimeType)'=='Core'">true</UnoUIUseRoslynSourceGenerators>
   
-	<!--
-	Force the compilation using Roslyn Generators on net6.0 and later
-	-->
-	<UnoUIUseRoslynSourceGenerators Condition="$(TargetFramework.StartsWith('net6'))">true</UnoUIUseRoslynSourceGenerators>
+    <!--
+    Force the compilation using Roslyn Generators on net6.0 and later
+    -->
+    <UnoUIUseRoslynSourceGenerators Condition="$(TargetFramework.StartsWith('net6'))">true</UnoUIUseRoslynSourceGenerators>
   </PropertyGroup>
 
   <!--
@@ -103,15 +105,15 @@
 	<_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.Skia.csproj</_AdjustedOutputProjects>
 	<_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.net6.csproj</_AdjustedOutputProjects>
 
-	<_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v1.Wasm.csproj</_AdjustedOutputProjects>
-	<_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v1.Skia.csproj</_AdjustedOutputProjects>
-	<_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v1.net6.csproj</_AdjustedOutputProjects>
+    <_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v1.Wasm.csproj</_AdjustedOutputProjects>
+    <_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v1.Skia.csproj</_AdjustedOutputProjects>
+    <_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v1.net6.csproj</_AdjustedOutputProjects>
 
-	<_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v2.Wasm.csproj</_AdjustedOutputProjects>
-	<_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v2.Skia.csproj</_AdjustedOutputProjects>
-	<_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v2.net6.csproj</_AdjustedOutputProjects>
+    <_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v2.Wasm.csproj</_AdjustedOutputProjects>
+    <_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v2.Skia.csproj</_AdjustedOutputProjects>
+    <_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.UI.FluentTheme.v2.net6.csproj</_AdjustedOutputProjects>
 
-	<_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.Xaml.net6.csproj</_AdjustedOutputProjects>
+    <_AdjustedOutputProjects>$(_AdjustedOutputProjects);Uno.Xaml.net6.csproj</_AdjustedOutputProjects>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -123,9 +125,9 @@
   </ItemGroup>
 
   <PropertyGroup Condition="$(_AdjustedOutputProjects.Contains('$(MSBuildProjectFile)'))">
-	<BaseOutputPath>bin\$(MSBuildProjectName)</BaseOutputPath>
-	<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-	<DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**</DefaultItemExcludes>
+    <BaseOutputPath>bin\$(MSBuildProjectName)</BaseOutputPath>
+    <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -134,24 +136,24 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)'=='net472' or '$(TargetFramework)'==''">
-	<!--
-	Include the reference assemblies to ensure that hard links don't use system files (workaround for same disk restriction)
-	Make sure to include on the versions that are needed to avoid growing the nuget cache unnecessarily.
-	-->
-	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.2" PrivateAssets="All" />
-	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" PrivateAssets="All" />
-	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2" PrivateAssets="All" />
+    <!--
+    Include the reference assemblies to ensure that hard links don't use system files (workaround for same disk restriction)
+    Make sure to include on the versions that are needed to avoid growing the nuget cache unnecessarily.
+    -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>
-	<IsMonoAndroid>false</IsMonoAndroid>
-	<IsMonoAndroid Condition="$(TargetFramework.ToLower().StartsWith('monoandroid')) or '$(TargetFramework)'=='net6.0-android'">true</IsMonoAndroid>
-	
-	<IsXamarinIOS>false</IsXamarinIOS>
-	<IsXamarinIOS Condition="$(TargetFramework.ToLower().StartsWith('xamarinios')) or '$(TargetFramework)'=='net6.0-ios'">true</IsXamarinIOS>
-	
-	<IsXamarinMac>false</IsXamarinMac>
-	<IsXamarinMac Condition="$(TargetFramework.ToLower().StartsWith('xamarinmac')) or '$(TargetFramework)'=='net6.0-macos'">true</IsXamarinMac>
+    <IsMonoAndroid>false</IsMonoAndroid>
+    <IsMonoAndroid Condition="$(TargetFramework.ToLower().StartsWith('monoandroid')) or '$(TargetFramework)'=='net6.0-android'">true</IsMonoAndroid>
+    
+    <IsXamarinIOS>false</IsXamarinIOS>
+    <IsXamarinIOS Condition="$(TargetFramework.ToLower().StartsWith('xamarinios')) or '$(TargetFramework)'=='net6.0-ios'">true</IsXamarinIOS>
+    
+    <IsXamarinMac>false</IsXamarinMac>
+    <IsXamarinMac Condition="$(TargetFramework.ToLower().StartsWith('xamarinmac')) or '$(TargetFramework)'=='net6.0-macos'">true</IsXamarinMac>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -161,10 +163,10 @@
 
   <PropertyGroup>
     <!--
-		This works around the fact that AndroidResgenFile is
-		automatically included as compiled file, even if AndroidUseIntermediateDesignerFile
-		is set to true.
-		-->
+        This works around the fact that AndroidResgenFile is
+        automatically included as compiled file, even if AndroidUseIntermediateDesignerFile
+        is set to true.
+        -->
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
   </PropertyGroup>
@@ -175,7 +177,7 @@
         <!-- Optional: Declare that the Repository URL can be published to NuSpec -->
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <!-- Optional: Embed source files that are not tracked by the source control manager to the PDB -->
-		<!-- Disabled because of https://github.com/mono/linker/issues/1409 -->
+        <!-- Disabled because of https://github.com/mono/linker/issues/1409 -->
         <EmbedUntrackedSources>false</EmbedUntrackedSources>
         <!-- Optional: Include PDB in the built .nupkg -->
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,8 +43,6 @@
     <DefineConstants Condition="$(UnoTargetFrameworkOverride.ToLowerInvariant().StartsWith('xamarinios'))  OR $(UnoTargetFrameworkOverride.ToLowerInvariant().StartsWith('net6.0-ios'))">$(DefineConstants);TARGET_FRAMEWORK_OVERRIDE_IOS</DefineConstants>
 
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-
-    <MicrosoftNetCompilerVersionOverride>4.0.0-6.final</MicrosoftNetCompilerVersionOverride>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -92,8 +92,8 @@
 	  macOS needs an explicit override of the current compiler when running under mono.
 	  On other targets, .NET 6.0's compiler takes precedence.
 	  -->
-	
-	  <MicrosoftNetCompilerVersionOverride Condition="'$(MSBuildRuntimeType)'!='Core' and $([MSBuild]::IsOSPlatform('OSX'))">4.0.1</MicrosoftNetCompilerVersionOverride>
+
+	  <MicrosoftNetCompilerVersionOverride Condition="'$(MSBuildRuntimeType)'!='Core' and ($([MSBuild]::IsOSPlatform('OSX') or '$(MSBuildVersion)' &lt; '17.0')">4.0.1</MicrosoftNetCompilerVersionOverride>
   </PropertyGroup>
 
   <!-- Import the override as the nuget tooling in VS is skipping ItemGroup conditions for legacy projects -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -92,7 +92,6 @@
 	  macOS needs an explicit override of the current compiler when running under mono.
 	  On other targets, .NET 6.0's compiler takes precedence.
 	  -->
-
 	  <MicrosoftNetCompilerVersionOverride Condition="'$(MSBuildRuntimeType)'!='Core' and ($([MSBuild]::IsOSPlatform('OSX')) or '$(MSBuildVersion)' &lt; '17.0')">4.0.1</MicrosoftNetCompilerVersionOverride>
   </PropertyGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -42,10 +42,10 @@
 	<PackageReference Update="Xamarin.DuoSdk" Version="0.0.3.4" />
 	<PackageReference Update="Xamarin.UITest" Version="3.0.15" />
 	<PackageReference Update="System.Numerics.Vectors" Version="4.5.0" />
-	<PackageReference Update="SkiaSharp.Views" Version="2.80.0" />
-	<PackageReference Update="SkiaSharp.Views.WPF" Version="2.80.0" />
-	<PackageReference Update="SkiaSharp" Version="2.80.0" />
-	<PackageReference Update="SkiaSharp.NativeAssets.Linux" Version="2.80.0" />
+	<PackageReference Update="SkiaSharp.Views" Version="2.80.3" />
+	<PackageReference Update="SkiaSharp.Views.WPF" Version="2.80.3" />
+	<PackageReference Update="SkiaSharp" Version="2.80.3" />
+	<PackageReference Update="SkiaSharp.NativeAssets.Linux" Version="2.80.3" />
 	<PackageReference Update="GtkSharp" Version="3.24.24.4" />
 	<PackageReference Update="System.Json" Version="4.7.1" />
 	<PackageReference Update="FluentAssertions" Version="5.10.3" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -87,6 +87,15 @@
 		 Text="The Uno.UI Solution cannot build with a space in the path. Consider changing to a path without spaces."/>
   </Target>
 
+  <PropertyGroup>
+	  <!--
+	  macOS needs an explicit override of the current compiler when running under mono.
+	  On other targets, .NET 6.0's compiler takes precedence.
+	  -->
+	
+	  <MicrosoftNetCompilerVersionOverride Condition="'$(MSBuildRuntimeType)'!='Core' and $([MSBuild]::IsOSPlatform('OSX'))">4.0.1</MicrosoftNetCompilerVersionOverride>
+  </PropertyGroup>
+
   <!-- Import the override as the nuget tooling in VS is skipping ItemGroup conditions for legacy projects -->
   <Import Project="roslyn-override.targets" Condition="'$(MicrosoftNetCompilerVersionOverride)'!=''"/>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -46,7 +46,7 @@
 	<PackageReference Update="SkiaSharp.Views.WPF" Version="2.80.3" />
 	<PackageReference Update="SkiaSharp" Version="2.80.3" />
 	<PackageReference Update="SkiaSharp.NativeAssets.Linux" Version="2.80.3" />
-	<PackageReference Update="GtkSharp" Version="3.24.24.4" />
+	<PackageReference Update="GtkSharp" Version="3.24.24.34" />
 	<PackageReference Update="System.Json" Version="4.7.1" />
 	<PackageReference Update="FluentAssertions" Version="5.10.3" />
 	<PackageReference Update="Microsoft.Extensions.Logging.Console" Version="5.0.0" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -93,7 +93,7 @@
 	  On other targets, .NET 6.0's compiler takes precedence.
 	  -->
 
-	  <MicrosoftNetCompilerVersionOverride Condition="'$(MSBuildRuntimeType)'!='Core' and ($([MSBuild]::IsOSPlatform('OSX') or '$(MSBuildVersion)' &lt; '17.0')">4.0.1</MicrosoftNetCompilerVersionOverride>
+	  <MicrosoftNetCompilerVersionOverride Condition="'$(MSBuildRuntimeType)'!='Core' and ($([MSBuild]::IsOSPlatform('OSX')) or '$(MSBuildVersion)' &lt; '17.0')">4.0.1</MicrosoftNetCompilerVersionOverride>
   </PropertyGroup>
 
   <!-- Import the override as the nuget tooling in VS is skipping ItemGroup conditions for legacy projects -->

--- a/src/SamplesApp/SamplesApp.Skia.WPF/SamplesApp.Skia.WPF.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.WPF/SamplesApp.Skia.WPF.csproj
@@ -34,7 +34,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-		<PackageReference Include="SkiaSharp.Views.WPF" Version="2.80.2" />
+		<PackageReference Include="SkiaSharp.Views.WPF" Version="2.80.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.Tizen/UnoQuickStart.Skia.Tizen.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.Tizen/UnoQuickStart.Skia.Tizen.csproj
@@ -24,7 +24,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="SkiaSharp.Views" Version="2.80.4" />
+		<PackageReference Include="SkiaSharp.Views" Version="2.80.3" />
 		<PackageReference Include="Uno.UI.Skia.Tizen" Version="3.0.0-dev.1447" />
 		<PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.1447" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.Tizen/UnoQuickStart.Skia.Tizen.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.Tizen/UnoQuickStart.Skia.Tizen.csproj
@@ -24,7 +24,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-		<PackageReference Include="SkiaSharp.Views" Version="2.80.2" />
+		<PackageReference Include="SkiaSharp.Views" Version="2.80.4" />
 		<PackageReference Include="Uno.UI.Skia.Tizen" Version="3.0.0-dev.1447" />
 		<PackageReference Include="Uno.UI.RemoteControl" Version="3.0.0-dev.1447" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>

--- a/src/Uno.Foundation/AsyncAction.cs
+++ b/src/Uno.Foundation/AsyncAction.cs
@@ -6,79 +6,78 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 
-namespace Windows.Foundation
+namespace Windows.Foundation;
+
+internal class AsyncAction : IAsyncAction, IAsyncActionInternal
 {
-	internal class AsyncAction : IAsyncAction, IAsyncActionInternal
+	private CancellationTokenSource _cts = new CancellationTokenSource();
+	private AsyncActionCompletedHandler _onCompleted;
+	private Task _task;
+	private AsyncStatus _status;
+	private uint _id = 0;
+
+	public static AsyncAction FromTask(Func<CancellationToken, Task> taskBuilder) => new AsyncAction(taskBuilder);
+
+	private AsyncAction(Func<CancellationToken, Task> taskBuilder)
 	{
-		private CancellationTokenSource _cts = new CancellationTokenSource();
-		private AsyncActionCompletedHandler _onCompleted;
-		private Task _task;
-		private AsyncStatus _status;
-		private uint _id = 0;
-
-		public static AsyncAction FromTask(Func<CancellationToken, Task> taskBuilder) => new AsyncAction(taskBuilder);
-
-		private AsyncAction(Func<CancellationToken, Task> taskBuilder)
-		{
-			_task = BuildTaskAsync(taskBuilder);
-		}
-
-		private async Task BuildTaskAsync(Func<CancellationToken, Task> taskBuilder)
-		{
-			Status = AsyncStatus.Started;
-
-			try
-			{
-				await taskBuilder(_cts.Token);
-				Status = AsyncStatus.Completed;
-			}
-			catch (Exception e)
-			{
-				ErrorCode = e;
-				Status = AsyncStatus.Error;
-				throw;
-			}
-		}
-
-		public AsyncActionCompletedHandler Completed
-		{
-			get { return _onCompleted; }
-			set
-			{
-				_onCompleted = value;
-				if (Status != AsyncStatus.Started) { value?.Invoke(this, Status); }
-			}
-		}
-
-		public Exception ErrorCode { get; private set; }
-
-		public uint Id => _id;
-
-		public AsyncStatus Status
-		{
-			get { return _status; }
-			set
-			{
-				_status = value;
-				_onCompleted?.Invoke(this, AsyncStatus.Error);
-			}
-		}
-
-		public void Cancel()
-		{
-			_cts.Cancel();
-		}
-
-		public void Close()
-		{
-			_cts.Cancel();
-		}
-
-		public void GetResults()
-		{
-			_task.Wait();
-		}
-
-		public Task Task => _task;
+		_task = BuildTaskAsync(taskBuilder);
 	}
+
+	private async Task BuildTaskAsync(Func<CancellationToken, Task> taskBuilder)
+	{
+		Status = AsyncStatus.Started;
+
+		try
+		{
+			await taskBuilder(_cts.Token);
+			Status = AsyncStatus.Completed;
+		}
+		catch (Exception e)
+		{
+			ErrorCode = e;
+			Status = AsyncStatus.Error;
+			throw;
+		}
+	}
+
+	public AsyncActionCompletedHandler Completed
+	{
+		get { return _onCompleted; }
+		set
+		{
+			_onCompleted = value;
+			if (Status != AsyncStatus.Started) { value?.Invoke(this, Status); }
+		}
+	}
+
+	public Exception ErrorCode { get; private set; }
+
+	public uint Id => _id;
+
+	public AsyncStatus Status
+	{
+		get { return _status; }
+		set
+		{
+			_status = value;
+			_onCompleted?.Invoke(this, AsyncStatus.Error);
+		}
+	}
+
+	public void Cancel()
+	{
+		_cts.Cancel();
+	}
+
+	public void Close()
+	{
+		_cts.Cancel();
+	}
+
+	public void GetResults()
+	{
+		_task.Wait();
+	}
+
+	public Task Task => _task;
 }

--- a/src/Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj
+++ b/src/Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj
@@ -39,7 +39,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 	</ItemGroup>
 
-	<!-- -->
+	<!-- Fix for VS 2022 -->
 	<Target Name="GetTargetPath" />
 
 	<Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">

--- a/src/Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj
+++ b/src/Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj
@@ -39,6 +39,9 @@
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 	</ItemGroup>
 
+	<!-- -->
+	<Target Name="GetTargetPath" />
+
 	<Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
 		<PropertyGroup>
 			<_TargetNugetFolder>$(USERPROFILE)\.nuget\packages\Uno.UI.RemoteControl\$(UnoNugetOverrideVersion)\tools\rc</_TargetNugetFolder>

--- a/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
@@ -20,6 +20,9 @@
 	
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
 		<UseWPF Condition="'$(TargetFramework)'=='netcoreapp3.1' or '$(TargetFramework)'=='net5.0-windows'">true</UseWPF>
+
+		<!-- 9.0 to work around a VS 2019 build issue -->
+		<LangVersion>9.0</LangVersion>
 	</PropertyGroup>
 	
 	<ItemGroup>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -186,7 +186,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
-#if __ANDROID__
+#if __ANDROID__ || __IOS__
 		[Ignore]
 #endif
 		public async Task When_InvalidateDuringArrange_Then_GetReArranged()

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.layout.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.layout.cs
@@ -229,7 +229,7 @@ namespace Windows.UI.Xaml.Shapes
 
 		private protected Size MeasureAbsoluteShape(Size availableSize, NativePath? path)
 		{
-			if (path == null)
+			if (path! == null!)
 			{
 				return default;
 			}
@@ -342,7 +342,7 @@ namespace Windows.UI.Xaml.Shapes
 
 		private protected Size ArrangeAbsoluteShape(Size finalSize, NativePath? path, FillRule fillRule = FillRule.EvenOdd)
 		{
-			if (path == null)
+			if (path! == null!)
 			{
 				Render(null);
 				return default;

--- a/src/Uno.WinUIRevert/Uno.WinUIRevert.csproj
+++ b/src/Uno.WinUIRevert/Uno.WinUIRevert.csproj
@@ -4,8 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
 
-		<!-- Required for non-net6 CI build -->
-		<LangVersion>9.0</LangVersion>
+    <!-- Required for non-net6 CI build -->
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Uno.WinUIRevert/Uno.WinUIRevert.csproj
+++ b/src/Uno.WinUIRevert/Uno.WinUIRevert.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+
+		<!-- Required for non-net6 CI build -->
+		<LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/roslyn-override.targets
+++ b/src/roslyn-override.targets
@@ -4,13 +4,25 @@
   This file is imported from Directory.Build.props as the nuget tooling
   in VS is skipping ItemGroup conditions for legacy projects (iOS, Android, ...).
   -->
+  <Choose>
+	  <When Condition="'$(MicrosoftNetCompilerVersionOverride)'!=''">
+		<PropertyGroup>
+		  <!--
+		  Disable shared compilation for the override to take place
+		  https://github.com/dotnet/roslyn/blob/315c2e149ba7889b0937d872274c33fcbfe9af5f/src/NuGet/Microsoft.Net.Compilers/build/Microsoft.Net.Compilers.props#L36
+		  -->
+		  <UseSharedCompilation>false</UseSharedCompilation>
+		</PropertyGroup>
+		<ItemGroup>
 
-  <ItemGroup Condition="'$(MicrosoftNetCompilerVersionOverride)'!=''">
-	 <!--This override is used to validate the user of specific version of the C# Compiler--> 
-	<PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilerVersionOverride)">
-	  <PrivateAssets>all</PrivateAssets>
-	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-	</PackageReference>
-  </ItemGroup>
+		  <!--This override is used to validate the user of specific version of the C# Compiler-->
+		  <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilerVersionOverride)">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		  </PackageReference>
+		</ItemGroup>
+
+	  </When>
+  </Choose>
 
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

- Move to C# 10 for all Uno solution projects, including macOS ones
- Use .NET 6 wherever possible
- Use stable VS2022 for VSIX creation
- Use hosted pool for skia tests (latest hosted agents seem to introduce some memory corruption)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
