### PR TITLE
Don't call CloseAllPopups on Frame navigation

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -399,8 +399,6 @@ namespace Windows.UI.Xaml.Controls
 
 			Navigated?.Invoke(this, navigationEvent);
 
-			VisualTreeHelper.CloseAllPopups();
-
 			return true;
 		}
 


### PR DESCRIPTION
closes #7478 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When navigating within a Frame that is in a Popup, the Popup will be force closed

## What is the new behavior?

Popups will remain open while their inner Frame navigates

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
