### PR TITLE
feat: Add support for multiple XamlReader types conversions

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -17,6 +17,7 @@ using FluentAssertions;
 using Windows.UI.Xaml.Controls.Primitives;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI;
+using Windows.UI;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 {
@@ -796,10 +797,23 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		}
 
 		[TestMethod]
-		public void When_Brush_And_StringColor()
+		public void When_Color_Thickness_GridLength_As_String()
 		{
-			var s = GetContent(nameof(When_Brush_And_StringColor));
+			var s = GetContent(nameof(When_Color_Thickness_GridLength_As_String));
 			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as ContentControl;
+
+			Assert.AreEqual(Windows.UI.Colors.Red, r.Resources["Color01"]);
+			Assert.AreEqual(Windows.UI.Colors.Blue, (r.Resources["scb01"] as SolidColorBrush).Color);
+			Assert.AreEqual(new Thickness(42), r.Resources["thickness"]);
+			Assert.AreEqual(new CornerRadius(42), r.Resources["cornerRadius"]);
+			Assert.AreEqual("TestFamily", (r.Resources["fontFamily"] as FontFamily).Source);
+			Assert.AreEqual(GridLength.FromString("42"), r.Resources["gridLength"]);
+			Assert.AreEqual(Windows.UI.Xaml.Media.Animation.KeyTime.FromTimeSpan(TimeSpan.Parse("1:2:3")), r.Resources["keyTime"]);
+			Assert.AreEqual(new Duration(TimeSpan.Parse("1:2:3")), r.Resources["duration"]);
+			Assert.AreEqual(Matrix.Identity, r.Resources["matrix"]);
+			Assert.AreEqual(Windows.UI.Text.FontWeights.Bold, r.Resources["fontWeight"]);
+
+			Assert.AreEqual(Windows.UI.Colors.Red, ((r.Content as Grid)?.Background as SolidColorBrush).Color);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_Brush_And_StringColor.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_Brush_And_StringColor.xamltest
@@ -1,5 +1,0 @@
-﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Name="testPage"
-             Width="42">
-</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_Color_Thickness_GridLength_As_String.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_Color_Thickness_GridLength_As_String.xamltest
@@ -1,0 +1,26 @@
+﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="testPage"
+             Width="42">
+  <UserControl.Resources>
+	  <Color x:Key="Color01">Red</Color>
+	  <SolidColorBrush x:Key="scb01">Blue</SolidColorBrush>
+	  <Thickness x:Key="thickness">42</Thickness>
+	  <CornerRadius x:Key="cornerRadius">42</CornerRadius>
+	  <FontFamily x:Key="fontFamily">TestFamily</FontFamily>
+	  <GridLength x:Key="gridLength">42</GridLength>
+	  <KeyTime x:Key="keyTime">1:2:3</KeyTime>
+	  <Duration x:Key="duration">1:2:3</Duration>
+	  <Matrix x:Key="matrix">1,0,0,1,0,0</Matrix>
+	  <FontWeight x:Key="fontWeight">Bold</FontWeight>
+  </UserControl.Resources>
+  <Grid>
+    <Grid.Background>
+      <SolidColorBrush>
+        <SolidColorBrush.Color>
+          <Color>Red</Color>
+        </SolidColorBrush.Color>
+      </SolidColorBrush>
+    </Grid.Background>
+  </Grid>
+</UserControl>

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlConstants.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlConstants.cs
@@ -23,6 +23,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 			public const string Primitives = Controls + ".Primitives";
 			public const string Text = RootWUINamespace + ".Text";
 			public const string Data = BaseXamlNamespace + ".Data";
+			public const string XamlText = BaseXamlNamespace + ".Text";
 			public const string Documents = BaseXamlNamespace + ".Documents";
 			public const string Media = BaseXamlNamespace + ".Media";
 			public const string MediaAnimation = BaseXamlNamespace + ".Media.Animation";
@@ -43,8 +44,9 @@ namespace Windows.UI.Xaml.Markup.Reader
 				MediaAnimation,
 				RootWUINamespace,
 				BaseXamlNamespace,
-				Data,
+				Text,
 				Documents,
+				XamlText,
 				"System",
 			};
 
@@ -60,6 +62,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 				MediaAnimation,
 				Shapes,
 				Text,
+				XamlText,
 			};
 		}
 

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -13,6 +13,9 @@ using Uno.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Documents;
+using Windows.UI;
+using Windows.Foundation;
+using Windows.UI.Text;
 
 #if XAMARIN_ANDROID
 using _View = Android.Views.View;
@@ -32,6 +35,21 @@ namespace Windows.UI.Xaml.Markup.Reader
 		private readonly Stack<Type> _styleTargetTypeStack = new Stack<Type>();
 		private Queue<Action> _postActions = new Queue<Action>();
 		private static readonly Regex _attachedPropertMatch = new Regex(@"(\(.*?\))");
+
+		private static Type[] _genericConvertibles = new []
+		{
+			typeof(Media.Brush),
+			typeof(Media.SolidColorBrush),
+			typeof(Color),
+			typeof(Thickness),
+			typeof(CornerRadius),
+			typeof(Media.FontFamily),
+			typeof(GridLength),
+			typeof(Media.Animation.KeyTime),
+			typeof(Duration),
+			typeof(Media.Matrix),
+			typeof(FontWeight),
+		};
 
 		public XamlObjectBuilder(XamlFileDefinition xamlFileDefinition)
 		{
@@ -110,9 +128,11 @@ namespace Windows.UI.Xaml.Markup.Reader
 			{
 				return stringValue;
 			}
-			else if (type == typeof(Media.Brush) && control.Members.Where(m => m.Member.Name == "_UnknownContent").FirstOrDefault()?.Value is string brushStringValue)
+			else if (
+				_genericConvertibles.Contains(type)
+				&& control.Members.Where(m => m.Member.Name == "_UnknownContent").FirstOrDefault()?.Value is string otherContentValue)
 			{
-				return XamlBindingHelper.ConvertValue(typeof(Media.Brush), brushStringValue);
+				return XamlBindingHelper.ConvertValue(type, otherContentValue);
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -8,14 +8,20 @@ using System.Text;
 using Uno;
 using Uno.Extensions;
 using Uno.Xaml;
+using Windows.UI;
+using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Markup.Reader
 {
-    internal class XamlTypeResolver
-    {
-		private readonly static Assembly _frameworkElementAssembly = typeof(FrameworkElement).Assembly;
+	internal class XamlTypeResolver
+	{
+		private readonly static Assembly[] _lookupAssemblies = new[]{
+			typeof(FrameworkElement).Assembly,
+			typeof(Color).Assembly,
+			typeof(Size).Assembly,
+		};
 
-        private readonly Func<string, Type> _findType;
+		private readonly Func<string, Type> _findType;
         private readonly Func<Type, string, bool> _isAttachedProperty;
         private readonly XamlFileDefinition FileDefinition;
         private readonly Func<string, string, Type> _findPropertyTypeByName;
@@ -330,12 +336,15 @@ namespace Windows.UI.Xaml.Markup.Reader
 					// This lookup is performed in the current assembly as it is the
 					// original behavior, and the Wasm AOT engine does not yet respect this
 					// behavior (because of Wasm missing stack walking feature)
-					var type = _frameworkElementAssembly.GetType(clrNamespace + "." + name);
+					foreach (var assembly in _lookupAssemblies)
+					{
+						var type = assembly.GetType(clrNamespace + "." + name);
 
-                    if (type != null)
-                    {
-                        return type;
-                    }
+						if (type != null)
+						{
+							return type;
+						}
+					}
                 }
             }
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

`XamlReader` Support for in Resources or explicit inlines for:
- Brush
- olidColorBrush
- Color
- Thickness
- CornerRadius
- Media.FontFamily
- GridLength
- Media.Animation.KeyTime
- Duration
- Matrix
- FontWeight

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
