### PR TITLE
feat: Point users to implemented versions of obsolete WUX controls

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/RatingControlAutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/RatingControlAutomationPeer.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Automation.Peers
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class RatingControlAutomationPeer : global::Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public RatingControlAutomationPeer( global::Windows.UI.Xaml.Controls.RatingControl owner) : base(owner)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingControl.cs
@@ -183,7 +183,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.RatingControl), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || false || false || false || false || false || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public RatingControl() : base()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SplitButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SplitButton.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SplitButton : global::Windows.UI.Xaml.Controls.ContentControl
@@ -73,7 +73,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.SplitButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public SplitButton() : base()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SplitButtonAutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SplitButtonAutomationPeer.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SplitButtonAutomationPeer : global::Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer,global::Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider,global::Windows.UI.Xaml.Automation.Provider.IInvokeProvider
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public SplitButtonAutomationPeer( global::Windows.UI.Xaml.Controls.SplitButton owner) : base(owner)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSplitButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSplitButton.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ToggleSplitButton : global::Windows.UI.Xaml.Controls.SplitButton
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public ToggleSplitButton() : base()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSplitButtonAutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSplitButtonAutomationPeer.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ToggleSplitButtonAutomationPeer : global::Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer,global::Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider,global::Windows.UI.Xaml.Automation.Provider.IToggleProvider
@@ -27,7 +27,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public ToggleSplitButtonAutomationPeer( global::Windows.UI.Xaml.Controls.ToggleSplitButton owner) : base(owner)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeView.cs
@@ -225,7 +225,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || false || false || false || false || false || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public TreeView() : base()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TwoPaneView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TwoPaneView.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TwoPaneView : global::Windows.UI.Xaml.Controls.Control
@@ -223,7 +223,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TwoPaneView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.TwoPaneViewWideModeConfiguration)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || false || false || false || false || false || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public TwoPaneView() : base()
 		{

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/RatingControlAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/RatingControlAutomationPeer.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Windows.UI.Xaml.Controls;
+
+namespace Windows.UI.Xaml.Automation.Peers;
+
+[Obsolete(
+	"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+	"Please use Microsoft.UI.Xaml.Controls.RatingControl instead.")]
+public partial class RatingControlAutomationPeer : FrameworkElementAutomationPeer
+{
+	public RatingControlAutomationPeer(RatingControl owner) : base(owner)
+	{
+		throw new NotImplementedException(
+			"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+			"Please use Microsoft.UI.Xaml.Controls.RatingControl instead.");
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Unsupported/RatingControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Unsupported/RatingControl.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Windows.UI.Xaml.Controls;
+
+[Obsolete(
+		"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+		"Please use Microsoft.UI.Xaml.Controls.RatingControl instead.")]
+public partial class RatingControl
+{
+	public RatingControl()
+	{
+		throw new NotImplementedException(
+			"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+			"Please use Microsoft.UI.Xaml.Controls.RatingControl instead.");
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Unsupported/SplitButton.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Unsupported/SplitButton.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Windows.UI.Xaml.Controls;
+
+[Obsolete(
+		"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+		"Please use Microsoft.UI.Xaml.Controls.SplitButton instead.")]
+public partial class SplitButton
+{
+	public SplitButton()
+	{
+		throw new NotImplementedException(
+			"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+			"Please use Microsoft.UI.Xaml.Controls.SplitButton instead.");
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Unsupported/SplitButtonAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Unsupported/SplitButtonAutomationPeer.cs
@@ -1,13 +1,13 @@
-﻿using System;
+using System;
 
 namespace Windows.UI.Xaml.Controls;
 
 [Obsolete(
 	"The Windows.UI.Xaml.Controls version of this control is not supported. " +
 	"Please use Microsoft.UI.Xaml.Controls.SplitButton instead.")]
-public partial class SplitButton
+public partial class SplitButtonAutomationPeer
 {
-	public SplitButton()
+	public SplitButtonAutomationPeer(SplitButton owner) : base(owner)
 	{
 		throw new NotImplementedException(
 			"The Windows.UI.Xaml.Controls version of this control is not supported. " +

--- a/src/Uno.UI/UI/Xaml/Controls/Unsupported/ToggleSplitButton.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Unsupported/ToggleSplitButton.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Windows.UI.Xaml.Controls;
+
+[Obsolete(
+		"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+		"Please use Microsoft.UI.Xaml.Controls.ToggleSplitButton instead.")]
+public partial class ToggleSplitButton
+{
+	public ToggleSplitButton()
+	{
+		throw new NotImplementedException(
+			"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+			"Please use Microsoft.UI.Xaml.Controls.ToggleSplitButton instead.");
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Unsupported/ToggleSplitButtonAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Unsupported/ToggleSplitButtonAutomationPeer.cs
@@ -1,13 +1,13 @@
-﻿using System;
+using System;
 
 namespace Windows.UI.Xaml.Controls;
 
 [Obsolete(
 	"The Windows.UI.Xaml.Controls version of this control is not supported. " +
 	"Please use Microsoft.UI.Xaml.Controls.ToggleSplitButton instead.")]
-public partial class ToggleSplitButton
+public partial class ToggleSplitButtonAutomationPeer
 {
-	public ToggleSplitButton()
+	public ToggleSplitButtonAutomationPeer(ToggleSplitButton owner) : base(owner)
 	{
 		throw new NotImplementedException(
 			"The Windows.UI.Xaml.Controls version of this control is not supported. " +

--- a/src/Uno.UI/UI/Xaml/Controls/Unsupported/TreeView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Unsupported/TreeView.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Windows.UI.Xaml.Controls;
+
+[Obsolete(
+		"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+		"Please use Microsoft.UI.Xaml.Controls.TreeView instead.")]
+public partial class TreeView
+{
+	public TreeView()
+	{
+		throw new NotImplementedException(
+			"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+			"Please use Microsoft.UI.Xaml.Controls.TreeView instead.");
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Unsupported/TwoPaneView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Unsupported/TwoPaneView.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Windows.UI.Xaml.Controls;
+
+[Obsolete(
+		"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+		"Please use Microsoft.UI.Xaml.Controls.TwoPaneView instead.")]
+public partial class TwoPaneView
+{	
+	public TwoPaneView()
+	{
+		throw new NotImplementedException(
+			"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+			"Please use Microsoft.UI.Xaml.Controls.TwoPaneView instead.");
+	}
+}

--- a/src/Uno.WinUIRevert/Program.cs
+++ b/src/Uno.WinUIRevert/Program.cs
@@ -74,7 +74,12 @@ namespace UnoWinUIRevert
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Icon\SymbolIconSource.cs"),
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Icon\PathIconSource.cs"),
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Icon\FontIconSource.cs"),
-				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Icon\IconSource.cs")
+				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Icon\IconSource.cs"),
+				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\RatingControl.cs"),
+				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\SplitButton.cs"),
+				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\ToggleSplitButton.cs"),
+				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\TreeView.cs"),
+				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\TwoPaneView.cs"),
 			};
 			DeleteFiles(duplicatedImplementations);
 

--- a/src/Uno.WinUIRevert/Program.cs
+++ b/src/Uno.WinUIRevert/Program.cs
@@ -76,8 +76,11 @@ namespace UnoWinUIRevert
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Icon\FontIconSource.cs"),
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Icon\IconSource.cs"),
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\RatingControl.cs"),
+				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Automation\Peers\RatingControlAutomationPeer.cs"),
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\SplitButton.cs"),
+				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\SplitButtonAutomationPeer.cs"),
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\ToggleSplitButton.cs"),
+				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\ToggleSplitButtonAutomationPeer.cs"),
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\TreeView.cs"),
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\TwoPaneView.cs"),
 			};


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7501, related to #3886

## PR Type

What kind of change does this PR introduce?

- Feature
- Documentation content changes

## What is the current behavior?

- WUX controls implemented in MUX namespace are not easily recognizable and they just fail to show up at runtime


## What is the new behavior?

- The controls throw a `NotImplementedException` with clear explanation to transition to MUX namespace
- Generated docs for "implemented-views" show the controls as "supported" which is more in line with reality


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
