### PR TITLE
fix: Add missing `NavigationViewItemPresenter.InfoBadge` property

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.Properties.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX reference NavigationViewItem.properties.cpp, commit 8f1a682
+// MUX reference NavigationViewItem.properties.cpp, commit fd22d7f
 
 using System.Collections.Generic;
 using Windows.UI.Xaml;

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItemPresenter.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItemPresenter.Properties.cs
@@ -39,7 +39,6 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 		public static DependencyProperty InfoBadgeProperty { get; } =
 			DependencyProperty.Register(nameof(InfoBadge), typeof(InfoBadge), typeof(NavigationViewItemPresenter), new FrameworkPropertyMetadata(null));
 
-
 		/// <summary>
 		/// Gets the template settings.
 		/// </summary>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItemPresenter.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItemPresenter.Properties.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference NavigationViewItemPresenter.properties.cpp, commit 6bdf738
+// MUX Reference NavigationViewItemPresenter.properties.cpp, commit fd22d7f
 
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -23,6 +23,22 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 		/// </summary>
 		public static DependencyProperty IconProperty { get; } =
 			DependencyProperty.Register(nameof(Icon), typeof(IconElement), typeof(NavigationViewItemPresenter), new FrameworkPropertyMetadata(null));
+
+		/// <summary>
+		/// Gets or sets the info badge in a NavigationView item.
+		/// </summary>
+		public InfoBadge InfoBadge
+		{
+			get => (InfoBadge)GetValue(InfoBadgeProperty);
+			set => SetValue(InfoBadgeProperty, value);
+		}
+
+		/// <summary>
+		/// Identifies the InfoBadge dependency property.
+		/// </summary>
+		public static DependencyProperty InfoBadgeProperty { get; } =
+			DependencyProperty.Register(nameof(InfoBadge), typeof(InfoBadge), typeof(NavigationViewItemPresenter), new FrameworkPropertyMetadata(null));
+
 
 		/// <summary>
 		/// Gets the template settings.

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewTemplateSettings.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewTemplateSettings.Properties.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference NavigationViewItemPresenter.properties.cpp, commit 2343eed
+// MUX Reference NavigationViewTemplateSettings.properties.cpp, commit 991c831
 
 using Windows.UI.Xaml;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The property was missing, resulting in error in logs

## What is the new behavior?

No longer missing.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
