### PR TITLE
fix: Fix support of the CustomVisualStateMamager

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateManager.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateManager.cs
@@ -234,6 +234,20 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests
 			}
 		}
 
+		[TestMethod]
+		public void When_CustomManager_Then_UseIt()
+		{
+			var (control, group) = Setup();
+			var vsm = new CustomManager();
+			VisualStateManager.SetCustomVisualStateManager((FrameworkElement)control.TemplatedRoot, vsm);
+
+			VisualStateManager.GoToState(control, "state1", true);
+			VisualStateManager.GoToState(control, "state2", true);
+
+			Assert.IsTrue(new[] { "state1", "state2" }.SequenceEqual(vsm.States));
+		}
+
+
 		private static (Control control, VisualStateGroup states) Setup()
 		{
 			var control = new Control { Name = "control", Tag = "initial", Template = new ControlTemplate(() => new Grid()) };
@@ -247,7 +261,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests
 		}
 
 		private static VisualState State(int id)
-			=> new VisualState
+			=> new()
 			{
 				Name = "state" + id,
 				Setters = {new Setter(new TargetPropertyPath("control", "Tag"), "state" + id)}
@@ -303,6 +317,18 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests
 			internal void Unset()
 			{
 				IsActive = false;
+			}
+		}
+
+		private class CustomManager : VisualStateManager
+		{
+			public List<string> States { get; } = new();
+
+			/// <inheritdoc />
+			protected override bool GoToStateCore(Control control, FrameworkElement templateRoot, string stateName, VisualStateGroup @group, VisualState state, bool useTransitions)
+			{
+				States.Add(stateName);
+				return base.GoToStateCore(control, templateRoot, stateName, @group, state, useTransitions);
 			}
 		}
 	}


### PR DESCRIPTION
## Bugfix
Fix support of the CustomVisualStateMamager

## What is the current behavior?
The custom VSM is resolved on the control itself

## What is the new behavior?
It's resolved on the template root of the control like on UWP

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
