### PR TITLE
`TryReadJsFloat` fixed to handle values with decimal places

### DIFF
--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
@@ -134,7 +134,7 @@ namespace Windows.Graphics.Display
 		}
 
 		private static bool TryReadJsFloat(string property, out float value) =>
-			float.TryParse(WebAssemblyRuntime.InvokeJS(property), NumberStyles.Any, CultureInfo.InvariantCulture, out var value);
+			float.TryParse(WebAssemblyRuntime.InvokeJS(property), NumberStyles.Any, CultureInfo.InvariantCulture, out value);
 
 		private static string ReadJsString(string property) => WebAssemblyRuntime.InvokeJS(property);
 

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
@@ -134,7 +134,7 @@ namespace Windows.Graphics.Display
 		}
 
 		private static bool TryReadJsFloat(string property, out float value) =>
-			float.TryParse(WebAssemblyRuntime.InvokeJS(property), out value);
+			float.TryParse(WebAssemblyRuntime.InvokeJS(property), NumberStyles.Any, CultureInfo.InvariantCulture, out var value);
 
 		private static string ReadJsString(string property) => WebAssemblyRuntime.InvokeJS(property);
 

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
@@ -2,6 +2,7 @@
 using Uno;
 using Uno.Foundation;
 using System;
+using System.Globalization;
 
 namespace Windows.Graphics.Display
 {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7498

## PR Type

What kind of change does this PR introduce?
- [Bugfix] 
`TryReadJsFloat` is updated to correctly parse values with decimal places like 1.25


## What is the current behavior?
whenever `window.devicePixelRatio` is has decimal places the current parsing via `float.TryParse(WebAssemblyRuntime.InvokeJS(property), out value);` return 0


## What is the new behavior?
with the changes from this PR `window.devicePixelRatio` is correctly parsed and values like `1.25` are handled properly


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
easily testable by setting a different scale factor for the display
![image](https://user-images.githubusercontent.com/3210391/143020897-b9ee3911-edb7-4078-bef8-32172760a66b.png)


Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
