### PR TITLE
fix(dotnetnew): Remove invalid solution filters in `dotnet new unoapp`

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/Uno.ProjectTemplates.Dotnet.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/Uno.ProjectTemplates.Dotnet.csproj
@@ -120,28 +120,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Remove="content\unoapp-net6\NuGet.config" />
-	  <None Remove="content\unoapp-net6\UnoQuickStart-vsmac.slnf" />
-	  <None Remove="content\unoapp-winui-net6\UnoWinUIQuickStart-vsmac.slnf" />
-	  <None Remove="content\unoapp-winui\UnoWinUIQuickStart-vsmac.slnf" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <UpToDateCheckInput Remove="content\unoapp-net6\NuGet.config" />
-	  <UpToDateCheckInput Remove="content\unoapp-net6\UnoQuickStart-vsmac.slnf" />
-	  <UpToDateCheckInput Remove="content\unoapp-winui-net6\UnoWinUIQuickStart-vsmac.slnf" />
-	  <UpToDateCheckInput Remove="content\unoapp-winui\UnoWinUIQuickStart-vsmac.slnf" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <Content Update="content\unoapp-net6\UnoQuickStart-vsmac.slnf">
 	    <PackagePath>content\unoapp</PackagePath>
 	  </Content>
 	  <Content Update="content\unoapp-winui-net6\UnoWinUIQuickStart-vsmac.slnf">
-	    <PackagePath>content\unoapp</PackagePath>
+	    <PackagePath>content\unoapp-winui-net6</PackagePath>
 	  </Content>
 	  <Content Update="content\unoapp-winui\UnoWinUIQuickStart-vsmac.slnf">
-	    <PackagePath>content\unoapp</PackagePath>
+	    <PackagePath>content\unoapp-winui</PackagePath>
 	  </Content>
 	</ItemGroup>
 

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-net6/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-net6/.template.config/template.json
@@ -119,6 +119,12 @@
       "dataType": "bool",
       "defaultValue": "false",
       "description": "Adds the Visual Studio Code Debugging support files for WebAssembly"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
     }
   },
   "primaryOutputs": [
@@ -151,6 +157,19 @@
     {
       "condition": "skia-linux-fb",
       "path": "UnoQuickStart.Skia.Linux.FrameBuffer\\UnoQuickStart.Skia.Linux.FrameBuffer.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
     }
   ],
   "sources": [

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/.template.config/template.json
@@ -35,7 +35,7 @@
     "B445DF73-AC9E-4276-9FBA-7CB5AD5D2518",
     "3EA9E612-E717-4E55-9034-DE653429FEFD", // WPF
     "3EA9E612-E717-4E55-9034-C415CD62AF9A", // UWP
-    "2B1FDFB6-C93C-4CA1-A6AB-528C4B3654B9"  // UWP
+    "2B1FDFB6-C93C-4CA1-A6AB-528C4B3654B9" // UWP
   ],
   "symbols": {
     "guid1": {
@@ -136,6 +136,12 @@
       "dataType": "bool",
       "defaultValue": "false",
       "description": "Adds the Visual Studio Code Debugging support files for WebAssembly"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
     }
   },
   "primaryOutputs": [
@@ -218,6 +224,19 @@
           ]
         }
       ]
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
     }
   ]
 }

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/.template.config/template.json
@@ -148,6 +148,12 @@
       "dataType": "bool",
       "defaultValue": "false",
       "description": "Adds the Visual Studio Code Debugging support files for WebAssembly"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
     }
   },
   "primaryOutputs": [
@@ -250,6 +256,19 @@
           ]
         }
       ]
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
     }
   ]
 }

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.template.config/template.json
@@ -138,6 +138,12 @@
       "dataType": "bool",
       "defaultValue": "false",
       "description": "Adds the Visual Studio Code Debugging support files for WebAssembly"
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
     }
   },
   "primaryOutputs": [
@@ -252,6 +258,19 @@
           ]
         }
       ]
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
     }
   ]
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/7277

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

No more invalid solution filter in the dotnet-new app template

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
