### PR TITLE
Ensure `IsApiContractAvailable` does not cache only one value for all requested versions

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Given_SharedHelpers.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Given_SharedHelpers.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿#if HAS_UNO
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.Helpers.WinUI;
 
 namespace Uno.UI.RuntimeTests.MUX;
@@ -32,3 +33,4 @@ public class Given_SharedHelpers
 		Assert.IsTrue(SharedHelpers.IsAPIContractVxAvailable(1));
 	}
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/MUX/Given_SharedHelpers.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Given_SharedHelpers.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Helpers.WinUI;
+
+namespace Uno.UI.RuntimeTests.MUX;
+
+[TestClass]
+public class Given_SharedHelpers
+{
+	[TestMethod]
+	public void When_Available_Contract_Requested()
+	{
+		Assert.IsTrue(SharedHelpers.IsAPIContractVxAvailable(1));
+	}
+
+	[TestMethod]
+	public void When_Unavailable_Contract_Requested()
+	{
+		Assert.IsFalse(SharedHelpers.IsAPIContractVxAvailable(1000));
+	}
+
+	[TestMethod]
+	public void When_Contract_Requested_In_Ascending_Order()
+	{
+		Assert.IsTrue(SharedHelpers.IsAPIContractVxAvailable(1));
+		Assert.IsFalse(SharedHelpers.IsAPIContractVxAvailable(1000));
+	}
+
+	[TestMethod]
+	public void When_Contract_Requested_In_Descending_Order()
+	{
+		Assert.IsFalse(SharedHelpers.IsAPIContractVxAvailable(1000));
+		Assert.IsTrue(SharedHelpers.IsAPIContractVxAvailable(1));
+	}
+}

--- a/src/Uno.UI/Helpers/WinUI/SharedHelpers.cs
+++ b/src/Uno.UI/Helpers/WinUI/SharedHelpers.cs
@@ -6,6 +6,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.Graphics.Display;
@@ -368,23 +369,25 @@ namespace Uno.UI.Helpers.WinUI
 			return s_IsIsLoadedAvailable.Value;
 		}
 
-		static bool isAPIContractVxAvailableInitialized = false;
-		static bool isAPIContractVxAvailable = false;
 		private static bool s_dynamicScrollbarsDirty = true;
 		private static bool s_dynamicScrollbars;
+		private static readonly Dictionary<ushort, bool> isApiContractVxAvailable = new Dictionary<ushort, bool>();
 
 		public static bool IsAPIContractVxAvailable(ushort apiVersion)
 		{
-			if (!isAPIContractVxAvailableInitialized)
+			// Uno specific: WinUI caches using static variables inside of a template function,
+			// which creates a separate cache for eache apiVersion value. Instead, we use a dictionary
+			// for the same functionality.
+			if (!isApiContractVxAvailable.TryGetValue(apiVersion, out var available))
 			{
-				isAPIContractVxAvailableInitialized = true;
-				isAPIContractVxAvailable =
+				available =
 					IsSystemDll() ?
 					true :
 					ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", apiVersion);
+				isApiContractVxAvailable[apiVersion] = available;
 			}
 
-			return isAPIContractVxAvailable;
+			return available;
 		}
 
 		// base helpers

--- a/src/Uno.UI/Helpers/WinUI/SharedHelpers.cs
+++ b/src/Uno.UI/Helpers/WinUI/SharedHelpers.cs
@@ -39,6 +39,11 @@ namespace Uno.UI.Helpers.WinUI
 		private static bool s_isMouseModeEnabledInitialized = false;
 		private static bool s_isMouseModeEnabled = false;
 
+		static SharedHelpers()
+		{
+			isApiContractVxAvailable = new Dictionary<ushort, bool>();
+		}
+
 		public static bool IsSystemDll() => false;
 
 		public static bool IsAnimationsEnabled()
@@ -371,7 +376,7 @@ namespace Uno.UI.Helpers.WinUI
 
 		private static bool s_dynamicScrollbarsDirty = true;
 		private static bool s_dynamicScrollbars;
-		private static readonly Dictionary<ushort, bool> isApiContractVxAvailable = new Dictionary<ushort, bool>();
+		private static readonly Dictionary<ushort, bool> isApiContractVxAvailable;
 
 		public static bool IsAPIContractVxAvailable(ushort apiVersion)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7513


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Orignal WinUI code caches the values using local static variables. However, as it is inside of a template function, compilation results in multiple copies of the function with separate cache values. Our code did not handle it this way.

## What is the new behavior?

Using static dictionary to cache the values. Added tests to prevent regressions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
