### PR TITLE
docs: Made the headers consistent throughout the page

### DIFF
--- a/doc/articles/platform-specific-xaml.md
+++ b/doc/articles/platform-specific-xaml.md
@@ -22,7 +22,7 @@ For prefixes which will be excluded on Windows (e.g. `android`, `ios`), the actu
 
 ### Examples
 
-##### Example 1
+#### Example 1
 
 Using the following XAML:
 
@@ -135,6 +135,7 @@ Where:
  * 'Droid' represents Android
 
 ### XAML prefixes in cross-targeted libraries
+
 For Uno 3.0 and above, XAML prefixes behave differently in class libraries than when used directly in application code. Specifically, it isn't possible to distinguish Skia and Wasm in a library, since both platforms use the .NET Standard 2.0 target. The `wasm` and `skia` prefixes will always evaluate to false inside of a library.
 
 The prefix `netstdref` is available and will include the objects or properties in both Skia and Wasm build. A prefix `not_nestdref` can also be used to exclude them. Since Skia and Wasm are similar, it is often not necessary to make the distinction. 


### PR DESCRIPTION
Made the headers consistent throughout the page
- Changed the *Examples 1* header to be an h4 (the next level)
- Added a line break after *XAML prefixes in cross-targeted libraries*

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

Cleaned up the documentation.

## What is the new behavior?

Cleaned up the documentation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
