### PR TITLE
Support non-default `xmlns` and `ConvertFromStringAttribute` in `XamlReader`

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/CreateFromString.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/CreateFromString.cs
@@ -1,0 +1,210 @@
+﻿using Windows.Foundation.Metadata;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
+{
+	public class CreateFromStringBase
+	{
+		public CreateFromStringBase(int value)
+		{
+			Value = value;
+		}
+
+		public int Value { get; set; }
+	}
+
+	[CreateFromString(MethodName = "??????")]
+	public class CreateFromStringInvalidMethodName : CreateFromStringBase
+	{
+		public CreateFromStringInvalidMethodName(int value) : base(value)
+		{
+		}
+	}
+
+	public partial class CreateFromStringInvalidMethodNameOwner : FrameworkElement
+	{
+		public CreateFromStringInvalidMethodName Test
+		{
+			get => (CreateFromStringInvalidMethodName)GetValue(TestProperty);
+			set => SetValue(TestProperty, value);
+		}
+
+		public static DependencyProperty TestProperty { get; } =
+			DependencyProperty.Register(nameof(Test), typeof(CreateFromStringInvalidMethodName), typeof(CreateFromStringInvalidMethodNameOwner), new PropertyMetadata(null));
+	}
+
+	[CreateFromString(MethodName = "ConversionMethod")]
+	public class CreateFromStringNonQualifiedMethodName : CreateFromStringBase
+	{
+		public CreateFromStringNonQualifiedMethodName(int value) : base(value)
+		{
+		}
+
+		public static CreateFromStringNonQualifiedMethodName ConversionMethod(string input)
+		{
+			return new CreateFromStringNonQualifiedMethodName(int.Parse(input) * 2);
+		}
+	}
+
+	public partial class CreateFromStringNonQualifiedMethodNameOwner : FrameworkElement
+	{
+		public CreateFromStringNonQualifiedMethodName Test
+		{
+			get => (CreateFromStringNonQualifiedMethodName)GetValue(TestProperty);
+			set => SetValue(TestProperty, value);
+		}
+
+		public static DependencyProperty TestProperty { get; } =
+			DependencyProperty.Register(nameof(Test), typeof(CreateFromStringNonQualifiedMethodName), typeof(CreateFromStringNonQualifiedMethodNameOwner), new PropertyMetadata(null));
+	}
+
+	[CreateFromString(MethodName = "Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests.CreateFromStringFullyQualifiedMethodName.ConversionMethod")]
+	public class CreateFromStringFullyQualifiedMethodName : CreateFromStringBase
+	{
+		public CreateFromStringFullyQualifiedMethodName(int value) : base(value)
+		{
+		}
+
+		public static CreateFromStringFullyQualifiedMethodName ConversionMethod(string input)
+		{
+			return new CreateFromStringFullyQualifiedMethodName(int.Parse(input) * 2);
+		}
+	}
+
+	public partial class CreateFromStringFullyQualifiedMethodNameOwner : FrameworkElement
+	{
+		public CreateFromStringFullyQualifiedMethodName Test
+		{
+			get => (CreateFromStringFullyQualifiedMethodName)GetValue(TestProperty);
+			set => SetValue(TestProperty, value);
+		}
+
+		public static DependencyProperty TestProperty { get; } =
+			DependencyProperty.Register(nameof(Test), typeof(CreateFromStringFullyQualifiedMethodName), typeof(CreateFromStringFullyQualifiedMethodNameOwner), new PropertyMetadata(null));
+	}
+
+	[CreateFromString(MethodName = "ConversionMethod")]
+	public class CreateFromStringNonStaticMethod : CreateFromStringBase
+	{
+		public CreateFromStringNonStaticMethod(int value) : base(value)
+		{
+		}
+
+		public CreateFromStringBase ConversionMethod(string input)
+		{
+			return new CreateFromStringNonStaticMethod(int.Parse(input) * 2);
+		}
+	}
+
+	public partial class CreateFromStringNonStaticMethodOwner : FrameworkElement
+	{
+		public CreateFromStringNonStaticMethod Test
+		{
+			get => (CreateFromStringNonStaticMethod)GetValue(TestProperty);
+			set => SetValue(TestProperty, value);
+		}
+
+		public static DependencyProperty TestProperty { get; } =
+			DependencyProperty.Register(nameof(Test), typeof(CreateFromStringNonStaticMethod), typeof(CreateFromStringNonStaticMethodOwner), new PropertyMetadata(null));
+	}
+
+	[CreateFromString(MethodName = "ConversionMethod")]
+	public class CreateFromStringPrivateStaticMethod : CreateFromStringBase
+	{
+		public CreateFromStringPrivateStaticMethod(int value) : base(value)
+		{
+		}
+
+		private static CreateFromStringPrivateStaticMethod ConversionMethod(string input)
+		{
+			return new CreateFromStringPrivateStaticMethod(int.Parse(input) * 2);
+		}
+	}
+
+	public partial class CreateFromStringPrivateStaticMethodOwner : FrameworkElement
+	{
+		public CreateFromStringPrivateStaticMethod Test
+		{
+			get => (CreateFromStringPrivateStaticMethod)GetValue(TestProperty);
+			set => SetValue(TestProperty, value);
+		}
+
+		public static DependencyProperty TestProperty { get; } =
+			DependencyProperty.Register(nameof(Test), typeof(CreateFromStringPrivateStaticMethod), typeof(CreateFromStringPrivateStaticMethodOwner), new PropertyMetadata(null));
+	}
+
+	[CreateFromString(MethodName = "ConversionMethod")]
+	public class CreateFromStringInternalStaticMethod : CreateFromStringBase
+	{
+		public CreateFromStringInternalStaticMethod(int value) : base(value)
+		{
+		}
+
+		public static CreateFromStringInternalStaticMethod ConversionMethod(string input)
+		{
+			return new CreateFromStringInternalStaticMethod(int.Parse(input) * 2);
+		}
+	}
+
+	public partial class CreateFromStringInternalStaticMethodOwner : FrameworkElement
+	{
+		public CreateFromStringInternalStaticMethod Test
+		{
+			get => (CreateFromStringInternalStaticMethod)GetValue(TestProperty);
+			set => SetValue(TestProperty, value);
+		}
+
+		public static DependencyProperty TestProperty { get; } =
+			DependencyProperty.Register(nameof(Test), typeof(CreateFromStringInternalStaticMethod), typeof(CreateFromStringInternalStaticMethodOwner), new PropertyMetadata(null));
+	}
+
+	[CreateFromString(MethodName = "ConversionMethod")]
+	public class CreateFromStringInvalidParameters : CreateFromStringBase
+	{
+		public CreateFromStringInvalidParameters(int value) : base(value)
+		{
+		}
+
+		public static CreateFromStringInvalidParameters ConversionMethod(string input, object args)
+		{
+			return new CreateFromStringInvalidParameters(int.Parse(input) * 2);
+		}
+	}
+
+	public partial class CreateFromStringInvalidParametersOwner : FrameworkElement
+	{
+		public CreateFromStringInvalidParameters Test
+		{
+			get => (CreateFromStringInvalidParameters)GetValue(TestProperty);
+			set => SetValue(TestProperty, value);
+		}
+
+		public static DependencyProperty TestProperty { get; } =
+			DependencyProperty.Register(nameof(Test), typeof(CreateFromStringInvalidParameters), typeof(CreateFromStringInvalidParametersOwner), new PropertyMetadata(null));
+	}
+
+	[CreateFromString(MethodName = "ConversionMethod")]
+	public class CreateFromStringInvalidReturnType : CreateFromStringBase
+	{
+		public CreateFromStringInvalidReturnType(int value) : base(value)
+		{
+		}
+
+		public static double ConversionMethod(string input)
+		{
+			return int.Parse(input) * 2.0;
+		}
+	}
+
+	public partial class CreateFromStringInvalidReturnTypeOwner : FrameworkElement
+	{
+		public CreateFromStringInvalidReturnType Test
+		{
+			get => (CreateFromStringInvalidReturnType)GetValue(TestProperty);
+			set => SetValue(TestProperty, value);
+		}
+
+		public static DependencyProperty TestProperty { get; } =
+			DependencyProperty.Register(nameof(Test), typeof(CreateFromStringInvalidReturnType), typeof(CreateFromStringInvalidReturnTypeOwner), new PropertyMetadata(null));
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -925,6 +925,86 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		}
 
 		[TestMethod]
+		public void When_Xmlns_Non_Default()
+		{
+			var xaml = "<NonDefaultXamlNamespace Test=\"42\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
+			var builder = Windows.UI.Xaml.Markup.XamlReader.Load(xaml);
+			if (builder is CreateFromStringFullyQualifiedMethodNameOwner owner)
+			{
+				Assert.AreEqual(42, owner.Test);
+			}
+		}
+
+		[TestMethod]
+		public void When_CreateFromString_Invalid_MethodName()
+		{
+			var xaml = "<CreateFromStringInvalidMethodNameOwner Test=\"8\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
+			Assert.ThrowsException<Uno.Xaml.XamlParseException>(() => Windows.UI.Xaml.Markup.XamlReader.Load(xaml));
+		}
+
+		[TestMethod]
+		public void When_CreateFromString_Non_Qualified_MethodName()
+		{
+			var xaml = "<CreateFromStringNonQualifiedMethodNameOwner Test=\"16\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
+			var builder = Windows.UI.Xaml.Markup.XamlReader.Load(xaml);
+			if (builder is CreateFromStringFullyQualifiedMethodNameOwner owner)
+			{
+				Assert.AreEqual(32, owner.Test.Value);
+			}
+		}
+
+		[TestMethod]
+		public void When_CreateFromString_Non_Static_Method()
+		{
+			var xaml = "<CreateFromStringNonStaticMethodOwner Test=\"4\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
+			Assert.ThrowsException<Uno.Xaml.XamlParseException>(() => Windows.UI.Xaml.Markup.XamlReader.Load(xaml));
+		}
+
+		[TestMethod]
+		public void When_CreateFromString_Private_Static_Method()
+		{
+			var xaml = "<CreateFromStringPrivateStaticMethodOwner Test=\"21\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
+			Assert.ThrowsException<Uno.Xaml.XamlParseException>(() => Windows.UI.Xaml.Markup.XamlReader.Load(xaml));
+		}
+
+		[TestMethod]
+		public void When_CreateFromString_Internal_Static_Method()
+		{
+			var xaml = "<CreateFromStringInternalStaticMethodOwner Test=\"42\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
+			var builder = Windows.UI.Xaml.Markup.XamlReader.Load(xaml);
+			if (builder is CreateFromStringFullyQualifiedMethodNameOwner owner)
+			{
+				Assert.AreEqual(84, owner.Test.Value);
+			}
+		}
+
+		[TestMethod]
+		public void When_CreateFromString_Invalid_Parameters()
+		{
+			var xaml = "<CreateFromStringInvalidParametersOwner Test=\"2\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
+			Assert.ThrowsException<Uno.Xaml.XamlParseException>(() => Windows.UI.Xaml.Markup.XamlReader.Load(xaml));
+		}
+
+		[TestMethod]
+		public void When_CreateFromString_Invalid_Return_Type()
+		{
+			var xaml = "<CreateFromStringInvalidReturnTypeOwner Test=\"1\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
+			// TODO: This should throw XamlParseException too
+			Assert.ThrowsException<ArgumentException>(() => Windows.UI.Xaml.Markup.XamlReader.Load(xaml));
+		}
+
+		[TestMethod]
+		public void When_CreateFromString_Fully_Qualified_MethodName()
+		{
+			var xaml = "<CreateFromStringFullyQualifiedMethodNameOwner Test=\"12\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
+			var builder = Windows.UI.Xaml.Markup.XamlReader.Load(xaml);
+			if (builder is CreateFromStringFullyQualifiedMethodNameOwner owner)
+			{
+				Assert.AreEqual(24, owner.Test.Value);
+			}
+		}
+		
+		[TestMethod]
 		public void When_xName_Reload()
 		{
 			var s = GetContent(nameof(When_xName_Reload));

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/NonDefaultXamlNamespace.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/NonDefaultXamlNamespace.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
+{
+	public partial class NonDefaultXamlNamespace : FrameworkElement
+    {
+		public int Test
+		{
+			get => (int)GetValue(TestProperty);
+			set => SetValue(TestProperty, value);
+		}
+
+		public static DependencyProperty TestProperty { get; } =
+			DependencyProperty.Register(nameof(Test), typeof(int), typeof(NonDefaultXamlNamespace), new PropertyMetadata(0));
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -1021,7 +1021,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 				{
 					try
 					{
-						return conversionMethod.Invoke(null, new object[] { memberValue });
+						return conversionMethod.Invoke(null, new object?[] { memberValue });
 					}
 					catch (Exception ex)
 					{

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -16,6 +16,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Text;
 using Windows.Foundation.Metadata;
+using Color = Windows.UI.Color;
 
 #if XAMARIN_ANDROID
 using _View = Android.Views.View;

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -1013,11 +1013,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 				{
 					var splitIndex = createFromString.MethodName.LastIndexOf(".");
 					var typeName = createFromString.MethodName.Substring(0, splitIndex);
-					sourceType = AppDomain.CurrentDomain
-						.GetAssemblies()
-						.Select(a => a.GetType(typeName))
-						.Trim()
-						.FirstOrDefault();
+					sourceType = TypeResolver.FindType(typeName);
 					methodName = createFromString.MethodName.Substring(splitIndex + 1);
 				}
 

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -405,7 +405,8 @@ namespace Windows.UI.Xaml.Markup.Reader
 				() => AppDomain.CurrentDomain
 					.GetAssemblies()
 					.Select(a =>
-						a.GetType(name)
+						a.GetType(name) ??
+						a.GetType(originalName)
 					)
 					.Trim()
 					.FirstOrDefault(),

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -22,14 +22,14 @@ namespace Windows.UI.Xaml.Markup.Reader
 			typeof(Size).Assembly,
 		};
 
-        private readonly Func<string?, Type?> _findType;
-        private readonly Func<Type, string, bool> _isAttachedProperty;
-        private readonly XamlFileDefinition FileDefinition;
-        private readonly Func<string, string, Type?> _findPropertyTypeByName;
-        private readonly Func<XamlMember, Type?> _findPropertyTypeByXamlMember;
-        private readonly Func<Type?, PropertyInfo?> _findContentProperty;
+		private readonly Func<string?, Type?> _findType;
+		private readonly Func<Type, string, bool> _isAttachedProperty;
+		private readonly XamlFileDefinition FileDefinition;
+		private readonly Func<string, string, Type?> _findPropertyTypeByName;
+		private readonly Func<XamlMember, Type?> _findPropertyTypeByXamlMember;
+		private readonly Func<Type?, PropertyInfo?> _findContentProperty;
 
-		public static ImmutableDictionary<string, string[]> KnownNamespaces { get; } 
+		public static ImmutableDictionary<string, string[]> KnownNamespaces { get; }
 			= new Dictionary<string, string[]>
 			{
 				{
@@ -44,68 +44,68 @@ namespace Windows.UI.Xaml.Markup.Reader
 				},
 			}.ToImmutableDictionary();
 
-        public XamlTypeResolver(XamlFileDefinition definition)
-        {
-            FileDefinition = definition;
-            _findType = SourceFindType;
-            _findType = _findType.AsMemoized();
-            _isAttachedProperty = Funcs.Create<Type, string, bool>(SourceIsAttachedProperty).AsLockedMemoized();
-            _findPropertyTypeByXamlMember = Funcs.Create<XamlMember, Type?>(SourceFindPropertyType).AsLockedMemoized();
-            _findPropertyTypeByName = Funcs.Create<string, string, Type?>(SourceFindPropertyType).AsLockedMemoized();
-            _findContentProperty = Funcs.Create<Type?, PropertyInfo?>(SourceFindContentProperty).AsLockedMemoized();
-        }
+		public XamlTypeResolver(XamlFileDefinition definition)
+		{
+			FileDefinition = definition;
+			_findType = SourceFindType;
+			_findType = _findType.AsMemoized();
+			_isAttachedProperty = Funcs.Create<Type, string, bool>(SourceIsAttachedProperty).AsLockedMemoized();
+			_findPropertyTypeByXamlMember = Funcs.Create<XamlMember, Type?>(SourceFindPropertyType).AsLockedMemoized();
+			_findPropertyTypeByName = Funcs.Create<string, string, Type?>(SourceFindPropertyType).AsLockedMemoized();
+			_findContentProperty = Funcs.Create<Type?, PropertyInfo?>(SourceFindContentProperty).AsLockedMemoized();
+		}
 
-        public bool IsAttachedProperty(XamlMemberDefinition member)
-        {
-            if (member.Member.DeclaringType != null)
-            {
-                var type = FindType(member.Member.DeclaringType);
+		public bool IsAttachedProperty(XamlMemberDefinition member)
+		{
+			if (member.Member.DeclaringType != null)
+			{
+				var type = FindType(member.Member.DeclaringType);
 
-                if (type != null)
-                {
-                    return _isAttachedProperty(type, member.Member.Name);
-                }
-            }
+				if (type != null)
+				{
+					return _isAttachedProperty(type, member.Member.Name);
+				}
+			}
 
-            return false;
-        }
+			return false;
+		}
 
-        public bool IsType(XamlType xamlType, XamlType baseType)
-        {
-            if (xamlType == baseType)
-            {
-                return true;
-            }
+		public bool IsType(XamlType xamlType, XamlType baseType)
+		{
+			if (xamlType == baseType)
+			{
+				return true;
+			}
 
-            if (baseType == null || xamlType == null)
-            {
-                return false;
-            }
+			if (baseType == null || xamlType == null)
+			{
+				return false;
+			}
 
-            var clrBaseType = _findType(baseType.Name);
+			var clrBaseType = _findType(baseType.Name);
 
-            if (clrBaseType != null)
-            {
-                return IsType(xamlType, clrBaseType.FullName);
-            }
-            else
-            {
-                return false;
-            }
-        }
+			if (clrBaseType != null)
+			{
+				return IsType(xamlType, clrBaseType.FullName);
+			}
+			else
+			{
+				return false;
+			}
+		}
 
-        /// <summary>
-        /// Determines if the provided member is an C# initializable list (where the collection already exists, and no set property is present)
-        /// </summary>
-        public bool IsInitializedCollection(PropertyInfo property)
-        {
-            if (property != null && IsInitializableProperty(property))
-            {
-                return IsCollectionOrListType(property.PropertyType);
-            }
+		/// <summary>
+		/// Determines if the provided member is an C# initializable list (where the collection already exists, and no set property is present)
+		/// </summary>
+		public bool IsInitializedCollection(PropertyInfo property)
+		{
+			if (property != null && IsInitializableProperty(property))
+			{
+				return IsCollectionOrListType(property.PropertyType);
+			}
 
-            return false;
-        }
+			return false;
+		}
 
 		public PropertyInfo? GetPropertyByName(XamlType declaringType, string propertyName, BindingFlags? flags = null)
 			=> GetPropertyByName(FindType(declaringType), propertyName, flags);
@@ -114,7 +114,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 			=> GetFieldByName(FindType(declaringType), propertyName, flags);
 
 		public PropertyInfo? FindContentProperty(Type? elementType)
-            => _findContentProperty(elementType);
+			=> _findContentProperty(elementType);
 
 		public PropertyInfo? GetPropertyByName(Type? type, string propertyName, BindingFlags? flags = null)
 			=> (flags != null
@@ -134,33 +134,33 @@ namespace Windows.UI.Xaml.Markup.Reader
 		private static EventInfo? GetEventByName(Type? type, string eventName)
 				=> type?.GetEvents().FirstOrDefault(p => p.Name == eventName);
 
-        private PropertyInfo? SourceFindContentProperty(Type? elementType)
-        {
-			if(elementType == null)
+		private PropertyInfo? SourceFindContentProperty(Type? elementType)
+		{
+			if (elementType == null)
 			{
 				return null;
 			}
 
-            var data = elementType
-                .GetCustomAttributes<ContentPropertyAttribute>()
-                .FirstOrDefault();
+			var data = elementType
+				.GetCustomAttributes<ContentPropertyAttribute>()
+				.FirstOrDefault();
 
-            if (data != null)
-            {
-                return GetPropertyByName(elementType, data.Name);
-            }
-            else
-            {
-                if (elementType.BaseType != typeof(object))
-                {
-                    return FindContentProperty(elementType.BaseType);
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
+			if (data != null)
+			{
+				return GetPropertyByName(elementType, data.Name);
+			}
+			else
+			{
+				if (elementType.BaseType != typeof(object))
+				{
+					return FindContentProperty(elementType.BaseType);
+				}
+				else
+				{
+					return null;
+				}
+			}
+		}
 
 		/// <summary>
 		/// Returns true if the property has an accessible public setter and has a parameterless constructor
@@ -213,9 +213,9 @@ namespace Windows.UI.Xaml.Markup.Reader
 		{
 			Type? currentType = type;
 
-			while(currentType != null && currentType != typeof(object))
+			while (currentType != null && currentType != typeof(object))
 			{
-				foreach(var property in currentType.GetProperties())
+				foreach (var property in currentType.GetProperties())
 				{
 					yield return property;
 				}
@@ -239,73 +239,73 @@ namespace Windows.UI.Xaml.Markup.Reader
 			}
 		}
 
-		private bool IsInitializableProperty(PropertyInfo property) 
-            => !(property.SetMethod?.IsPublic ?? false);
+		private bool IsInitializableProperty(PropertyInfo property)
+			=> !(property.SetMethod?.IsPublic ?? false);
 
-        public bool IsCollectionOrListType(Type type)
-        {
-            return IsImplementingInterface(type, typeof(global::System.Collections.ICollection)) ||
-                IsImplementingInterface(type, typeof(ICollection<>)) ||
-                IsImplementingInterface(type, typeof(global::System.Collections.IList)) ||
-                IsImplementingInterface(type, typeof(global::System.Collections.Generic.IList<>));
-        }
+		public bool IsCollectionOrListType(Type type)
+		{
+			return IsImplementingInterface(type, typeof(global::System.Collections.ICollection)) ||
+				IsImplementingInterface(type, typeof(ICollection<>)) ||
+				IsImplementingInterface(type, typeof(global::System.Collections.IList)) ||
+				IsImplementingInterface(type, typeof(global::System.Collections.Generic.IList<>));
+		}
 
-        private bool IsImplementingInterface(Type type, Type iface) => 
-            type
-                .Flatten(t => t.BaseType!)
-                .Any(t => t
-                    .GetInterfaces()
-                    .Any(i => 
-                        i == iface 
-                        || (i.IsGenericType && i.GetGenericTypeDefinition() == iface)
-                    )
-                );
+		private bool IsImplementingInterface(Type type, Type iface) =>
+			type
+				.Flatten(t => t.BaseType!)
+				.Any(t => t
+					.GetInterfaces()
+					.Any(i =>
+						i == iface
+						|| (i.IsGenericType && i.GetGenericTypeDefinition() == iface)
+					)
+				);
 
-        public bool IsType(XamlType xamlType, string? typeName)
-        {
-            var type = FindType(xamlType);
+		public bool IsType(XamlType xamlType, string? typeName)
+		{
+			var type = FindType(xamlType);
 
-            if (type != null)
-            {
-                do
-                {
-                    if (type.FullName == typeName)
-                    {
-                        return true;
-                    }
+			if (type != null)
+			{
+				do
+				{
+					if (type.FullName == typeName)
+					{
+						return true;
+					}
 
-                    type = type.BaseType;
+					type = type.BaseType;
 
-                    if (type == null)
-                    {
-                        break;
-                    }
+					if (type == null)
+					{
+						break;
+					}
 
-                } while (type.Name != "Object");
-            }
+				} while (type.Name != "Object");
+			}
 
-            return false;
-        }
+			return false;
+		}
 
-        public Type? FindType(string? name)
-        {
+		public Type? FindType(string? name)
+		{
 			if (name.IsNullOrWhiteSpace())
 			{
 				return null;
 			}
 
 			return _findType(name);
-        }
+		}
 
-        public Type? FindType(XamlType? type)
-        {
-            if (type != null)
-            {
-                var ns = FileDefinition.Namespaces.FirstOrDefault(n => n.Namespace == type.PreferredXamlNamespace);
-                var isKnownNamespace = ns?.Prefix?.HasValue() ?? false;
+		public Type? FindType(XamlType? type)
+		{
+			if (type != null)
+			{
+				var ns = FileDefinition.Namespaces.FirstOrDefault(n => n.Namespace == type.PreferredXamlNamespace);
+				var isKnownNamespace = ns?.Prefix?.HasValue() ?? false;
 
-                if (type.PreferredXamlNamespace == XamlConstants.XamlXmlNamespace)
-                {
+				if (type.PreferredXamlNamespace == XamlConstants.XamlXmlNamespace)
+				{
 					if (type.Name == "Bind")
 					{
 						return _findType(XamlConstants.Namespaces.Data + ".Binding");
@@ -314,21 +314,21 @@ namespace Windows.UI.Xaml.Markup.Reader
 					{
 						return systemType;
 					}
-                }
+				}
 
-                var fullName = isKnownNamespace ? ns?.Prefix + ":" + type.Name : type.Name;
+				var fullName = isKnownNamespace ? ns?.Prefix + ":" + type.Name : type.Name;
 
-                return _findType(fullName);
-            }
-            else
-            {
-                return null;
-            }
-        }
+				return _findType(fullName);
+			}
+			else
+			{
+				return null;
+			}
+		}
 
-        private Type? SourceFindType(string? name)
-        {
-			static string GetFullyQualifiedName(NamespaceDeclaration ns, string nonQualifiedName)
+		private Type? SourceFindType(string? name)
+		{
+			static string? GetFullyQualifiedName(NamespaceDeclaration? ns, string nonQualifiedName)
 			{
 				if (ns != null)
 				{
@@ -341,25 +341,27 @@ namespace Windows.UI.Xaml.Markup.Reader
 
 					return nsName + "." + nonQualifiedName;
 				}
+
+				return null;
 			}
 
-			if(name == null)
+			if (name == null)
 			{
 				return null;
 			}
 
-            var originalName = name;
+			var originalName = name;
 
-            if (name.Contains(":"))
-            {
-                var fields = name.Split(new[] { ':' });
+			if (name.Contains(":"))
+			{
+				var fields = name.Split(new[] { ':' });
 
-                var ns = FileDefinition.Namespaces.FirstOrDefault(n => n.Prefix == fields[0]);
+				var ns = FileDefinition.Namespaces.FirstOrDefault(n => n.Prefix == fields[0]);
 
 				name = GetFullyQualifiedName(ns, fields[1]);
-            }
-            else
-            {
+			}
+			else
+			{
 				var defaultXmlNamespaceDeclaration = FileDefinition
 						.Namespaces
 						.Where(n => n.Prefix.None())
@@ -367,11 +369,11 @@ namespace Windows.UI.Xaml.Markup.Reader
 
 				var defaultXmlNamespace = defaultXmlNamespaceDeclaration?.Namespace ?? "";
 
-                var clrNamespaces = KnownNamespaces.UnoGetValueOrDefault(defaultXmlNamespace, Array.Empty<string>());
+				var clrNamespaces = KnownNamespaces.UnoGetValueOrDefault(defaultXmlNamespace, Array.Empty<string>());
 
-                // Search first using the default namespace
-                foreach (var clrNamespace in clrNamespaces)
-                {
+				// Search first using the default namespace
+				foreach (var clrNamespace in clrNamespaces)
+				{
 					// This lookup is performed in the current assembly as it is the
 					// original behavior, and the Wasm AOT engine does not yet respect this
 					// behavior (because of Wasm missing stack walking feature)
@@ -384,16 +386,16 @@ namespace Windows.UI.Xaml.Markup.Reader
 							return type;
 						}
 					}
-                }
+				}
 
 				// The default namespace for the XAML snippet may be non-standard (starting with using: or clr-namespace:)
 				name = GetFullyQualifiedName(defaultXmlNamespaceDeclaration, name);
-            }
+			}
 
-            var resolvers = new Func<Type?>[] {
+			var resolvers = new Func<Type?>[] {
 
 				// As a full name
-				() => Type.GetType(name),
+				() => name != null ? Type.GetType(name) : null,
 
 				// As a partial name using the original type
 				() => Type.GetType(originalName),
@@ -405,138 +407,138 @@ namespace Windows.UI.Xaml.Markup.Reader
 				() => AppDomain.CurrentDomain
 					.GetAssemblies()
 					.Select(a =>
-						a.GetType(name) ??
+						(name != null ? a.GetType(name) : null) ??
 						a.GetType(originalName)
 					)
 					.Trim()
 					.FirstOrDefault(),
 			};
 
-            return resolvers
-                .Select(m => m())
-                .Trim()
-                .FirstOrDefault();
-        }
-        private static bool SourceIsAttachedProperty(Type type, string name)
-        {
+			return resolvers
+				.Select(m => m())
+				.Trim()
+				.FirstOrDefault();
+		}
+		private static bool SourceIsAttachedProperty(Type type, string name)
+		{
 			Type? currentType = type;
 
-            do
-            {
+			do
+			{
 				if (currentType == null)
 				{
 					return false;
 				}
 
 				var property = currentType.GetProperties().FirstOrDefault(p => p.Name == name);
-                var setMethod = currentType.GetMethods().FirstOrDefault(p => p.Name == "Set" + name);
+				var setMethod = currentType.GetMethods().FirstOrDefault(p => p.Name == "Set" + name);
 
-                if (property?.GetMethod?.IsStatic ?? false)
-                {
-                    return true;
-                }
+				if (property?.GetMethod?.IsStatic ?? false)
+				{
+					return true;
+				}
 
-                if (setMethod != null && setMethod.IsStatic)
-                {
-                    return true;
-                }
+				if (setMethod != null && setMethod.IsStatic)
+				{
+					return true;
+				}
 
 				currentType = currentType.BaseType;
 
-                if (type == null || type.Name == "Object")
-                {
-                    return false;
-                }
+				if (type == null || type.Name == "Object")
+				{
+					return false;
+				}
 
-            } while (true);
-        }
+			} while (true);
+		}
 
-        public Type? FindPropertyType(XamlMember xamlMember) => _findPropertyTypeByXamlMember(xamlMember);
+		public Type? FindPropertyType(XamlMember xamlMember) => _findPropertyTypeByXamlMember(xamlMember);
 
-        private Type? SourceFindPropertyType(XamlMember xamlMember)
-        {
-            // Search for the type the clr namespaces registered with the xml namespace
-            if (xamlMember.DeclaringType != null)
-            {
-                var clrNamespaces = KnownNamespaces.UnoGetValueOrDefault(xamlMember.DeclaringType.PreferredXamlNamespace, Array.Empty<string>());
+		private Type? SourceFindPropertyType(XamlMember xamlMember)
+		{
+			// Search for the type the clr namespaces registered with the xml namespace
+			if (xamlMember.DeclaringType != null)
+			{
+				var clrNamespaces = KnownNamespaces.UnoGetValueOrDefault(xamlMember.DeclaringType.PreferredXamlNamespace, Array.Empty<string>());
 
-                foreach (var clrNamespace in clrNamespaces)
-                {
-                    string declaringTypeName = xamlMember.DeclaringType.Name;
+				foreach (var clrNamespace in clrNamespaces)
+				{
+					string declaringTypeName = xamlMember.DeclaringType.Name;
 
-                    var propertyType = FindPropertyType(clrNamespace + "." + declaringTypeName, xamlMember.Name);
+					var propertyType = FindPropertyType(clrNamespace + "." + declaringTypeName, xamlMember.Name);
 
-                    if (propertyType != null)
-                    {
-                        return propertyType;
-                    }
-                }
-            }
+					if (propertyType != null)
+					{
+						return propertyType;
+					}
+				}
+			}
 
-            var type = FindType(xamlMember.DeclaringType);
+			var type = FindType(xamlMember.DeclaringType);
 
-            // If not, try to find the closest match using the name only.
-            return FindPropertyType(type?.FullName ?? "$$unknown", xamlMember.Name);
-        }
+			// If not, try to find the closest match using the name only.
+			return FindPropertyType(type?.FullName ?? "$$unknown", xamlMember.Name);
+		}
 
-        public Type? FindPropertyType(string ownerType, string propertyName) => _findPropertyTypeByName(ownerType, propertyName);
+		public Type? FindPropertyType(string ownerType, string propertyName) => _findPropertyTypeByName(ownerType, propertyName);
 
-        private Type? SourceFindPropertyType(string ownerType, string propertyName)
-        {
-            var type = FindType(ownerType);
+		private Type? SourceFindPropertyType(string ownerType, string propertyName)
+		{
+			var type = FindType(ownerType);
 
-            if (type != null)
-            {
-                do
-                {
-                    var resolvedType = type;
+			if (type != null)
+			{
+				do
+				{
+					var resolvedType = type;
 
-                    var property = resolvedType.GetProperties().FirstOrDefault(p => p.Name == propertyName);
-                    var setMethod = resolvedType.GetMethods().FirstOrDefault(p => p.Name == "Set" + propertyName);
+					var property = resolvedType.GetProperties().FirstOrDefault(p => p.Name == propertyName);
+					var setMethod = resolvedType.GetMethods().FirstOrDefault(p => p.Name == "Set" + propertyName);
 
-                    if (property != null)
-                    {
-                        //if (property.PropertyType.OriginalDefinition != null
-                        //    && property.PropertyType.OriginalDefinition?.ToDisplayString() == "System.Nullable<T>")
-                        //{
-                        //    //TODO
-                        //    return (property.Type as INamedTypeSymbol).TypeArguments.First() as INamedTypeSymbol;
-                        //}
-                        // else
-                        {
-                            return property.PropertyType;
-                        }
-                    }
-                    else
-                    {
-                        if (setMethod != null)
-                        {
-                            return setMethod.GetParameters().ElementAt(1).ParameterType;
-                        }
-                        else
-                        {
-                            var baseType = type.BaseType;
+					if (property != null)
+					{
+						//if (property.PropertyType.OriginalDefinition != null
+						//    && property.PropertyType.OriginalDefinition?.ToDisplayString() == "System.Nullable<T>")
+						//{
+						//    //TODO
+						//    return (property.Type as INamedTypeSymbol).TypeArguments.First() as INamedTypeSymbol;
+						//}
+						// else
+						{
+							return property.PropertyType;
+						}
+					}
+					else
+					{
+						if (setMethod != null)
+						{
+							return setMethod.GetParameters().ElementAt(1).ParameterType;
+						}
+						else
+						{
+							var baseType = type.BaseType;
 
-                            if (baseType == null)
-                            {
-                                baseType = type.BaseType;
-                            }
+							if (baseType == null)
+							{
+								baseType = type.BaseType;
+							}
 
-                            type = baseType;
+							type = baseType;
 
-                            if (type == null || type == typeof(object))
-                            {
-                                return null;
-                            }
-                        }
-                    }
-                } while (true);
-            }
-            else
-            {
-                return null;
-            }
-        }
+							if (type == null || type == typeof(object))
+							{
+								return null;
+							}
+						}
+					}
+				} while (true);
+			}
+			else
+			{
+				return null;
+			}
+		}
 
-    }
+	}
 }

--- a/src/Uno.UWP/Foundation/Metadata/CreateFromStringAttribute.cs
+++ b/src/Uno.UWP/Foundation/Metadata/CreateFromStringAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Windows.Foundation.Metadata;
+
+/// <summary>
+/// Creates a metadata object from a string.
+/// </summary>
+public partial class CreateFromStringAttribute : Attribute
+{
+	/// <summary>
+	/// Creates an instance of the attribute.
+	/// </summary>
+	public CreateFromStringAttribute() : base()
+	{
+	}
+
+	/// <summary>
+	/// Full name of the method performing conversion from string.
+	/// </summary>
+	public string MethodName;
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Foundation.Metadata/CreateFromStringAttribute.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Foundation.Metadata/CreateFromStringAttribute.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Foundation.Metadata
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CreateFromStringAttribute : global::System.Attribute
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public CreateFromStringAttribute() : base()
 		{
@@ -15,7 +15,7 @@ namespace Windows.Foundation.Metadata
 		}
 		#endif
 		// Forced skipping of method Windows.Foundation.Metadata.CreateFromStringAttribute.CreateFromStringAttribute()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		public  string MethodName;
 		#endif
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/7536

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

Not supported.

## What is the new behavior?

- When `XamlReader` loads XAML with non-default `xmlns` with "using:" or "clr-namespace:", it can handle it porperly.
- When string value of a property of type annotated with `ConvertFromStringAttribute` is read, it is properly handled in `XamlReader`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
