### PR TITLE
feat: Improve Skia TextBoxView overlay positioning and sizing

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/UnoDrawingArea.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UnoDrawingArea.cs
@@ -6,6 +6,7 @@ using Uno.UI.Xaml.Core;
 using Windows.UI.Xaml.Input;
 using WUX = Windows.UI.Xaml;
 using Uno.Foundation.Logging;
+using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Runtime.Skia
 {
@@ -21,18 +22,24 @@ namespace Uno.UI.Runtime.Skia
 				+= () =>
 				{
 					// TODO Uno: Make this invalidation less often if possible.
-					InvalidateFocusVisual();
+					InvalidateOverlays();
 					Invalidate();
 				};
 		}
 
-		private void InvalidateFocusVisual()
+		private void InvalidateOverlays()
 		{
-			if (_focusManager == null)
-			{
-				_focusManager = VisualTree.GetFocusManagerForElement(Windows.UI.Xaml.Window.Current?.RootElement);
-			}
+			_focusManager ??= VisualTree.GetFocusManagerForElement(Windows.UI.Xaml.Window.Current?.RootElement);
 			_focusManager?.FocusRectManager?.RedrawFocusVisual();
+			if (_focusManager?.FocusedElement is TextBox textBox)
+			{
+				textBox.TextBoxView?.Extension?.InvalidateLayout();
+			}
+		}
+
+		private void InvalidateInputField()
+		{
+
 		}
 
 		private void Invalidate()

--- a/src/Uno.UI.Runtime.Skia.Gtk/UnoDrawingArea.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UnoDrawingArea.cs
@@ -37,11 +37,6 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private void InvalidateInputField()
-		{
-
-		}
-
 		private void Invalidate()
 			=> QueueDrawArea(0, 0, 10000, 10000);
 

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -18,8 +18,6 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 		private ContentControl? _contentElement;
 		private WpfTextViewTextBox? _currentInputWidget;
 
-		private readonly SerialDisposable _textBoxEventSubscriptions = new SerialDisposable();
-
 		public TextBoxViewExtension(TextBoxView owner)
 		{
 			_owner = owner ?? throw new ArgumentNullException(nameof(owner));
@@ -42,20 +40,10 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 			EnsureWidgetForAcceptsReturn();
 			textInputLayer.Children.Add(_currentInputWidget!);
 
-			textBox.SizeChanged += ContentElementSizeChanged;
-			textBox.LayoutUpdated += ContentElementLayoutUpdated;
-
-			_textBoxEventSubscriptions.Disposable = Disposable.Create(() =>
-			{
-				textBox.SizeChanged -= ContentElementSizeChanged;
-				textBox.LayoutUpdated -= ContentElementLayoutUpdated;
-			});
-
 			UpdateNativeView();
 			SetTextNative(textBox.Text);
 
-			UpdateSize();
-			UpdatePosition();
+			InvalidateLayout();
 
 			_currentInputWidget!.Focus();
 		}
@@ -68,7 +56,6 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 			}
 
 			_contentElement = null;
-			_textBoxEventSubscriptions.Disposable = null;
 
 			var textInputLayer = GetWindowTextInputLayer();
 			textInputLayer?.Children.Remove(_currentInputWidget);
@@ -98,6 +85,12 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 			_currentInputWidget.MaxLength = textBox.MaxLength;
 			_currentInputWidget.IsReadOnly = textBox.IsReadOnly;
 			_currentInputWidget.Foreground = textBox.Foreground.ToWpfBrush();
+		}
+
+		public void InvalidateLayout()
+		{
+			UpdateSize();
+			UpdatePosition();
 		}
 
 		public void UpdateSize()
@@ -161,18 +154,6 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 		}
 
 		private string? GetInputText() => _currentInputWidget?.Text;
-
-		private void ContentElementLayoutUpdated(object? sender, object e)
-		{
-			UpdateSize();
-			UpdatePosition();
-		}
-
-		private void ContentElementSizeChanged(object sender, Windows.UI.Xaml.SizeChangedEventArgs args)
-		{
-			UpdateSize();
-			UpdatePosition();
-		}
 
 		public void SetIsPassword(bool isPassword)
 		{

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -125,7 +125,7 @@ namespace Uno.UI.Skia.Platform
 
 			WinUI.Window.InvalidateRender += () =>
 			{
-				InvalidateFocusVisual();
+				InvalidateOverlays();
 				InvalidateVisual();
 			};
 
@@ -266,13 +266,14 @@ namespace Uno.UI.Skia.Platform
 			drawingContext.DrawImage(bitmap, new Rect(0, 0, ActualWidth, ActualHeight));
 		}
 
-		private void InvalidateFocusVisual()
+		private void InvalidateOverlays()
 		{
-			if (_focusManager == null)
-			{
-				_focusManager = VisualTree.GetFocusManagerForElement(Windows.UI.Xaml.Window.Current?.RootElement);
-			}
+			_focusManager ??= VisualTree.GetFocusManagerForElement(Windows.UI.Xaml.Window.Current?.RootElement);
 			_focusManager?.FocusRectManager?.RedrawFocusVisual();
+			if (_focusManager?.FocusedElement is TextBox textBox)
+			{
+				textBox.TextBoxView?.Extension?.InvalidateLayout();
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxExtension.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxExtension.skia.cs
@@ -11,6 +11,8 @@ namespace Uno.UI.Xaml.Controls.Extensions
 
 		void UpdateNativeView();
 
+		void InvalidateLayout();
+
 		void UpdateSize();
 
 		void UpdatePosition();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -5,44 +5,46 @@ namespace Windows.UI.Xaml.Controls
 	public partial class TextBox
 	{
 		private TextBoxView _textBoxView;
+
+		internal TextBoxView TextBoxView => _textBoxView;
 		
 		internal ContentControl ContentElement => _contentElement;
 
-		partial void OnForegroundColorChangedPartial(Brush newValue) => _textBoxView?.OnForegroundChanged(newValue);
+		partial void OnForegroundColorChangedPartial(Brush newValue) => TextBoxView?.OnForegroundChanged(newValue);
 
-		partial void OnMaxLengthChangedPartial(DependencyPropertyChangedEventArgs e) => _textBoxView?.UpdateMaxLength();
+		partial void OnMaxLengthChangedPartial(DependencyPropertyChangedEventArgs e) => TextBoxView?.UpdateMaxLength();
 
 		private void UpdateTextBoxView()
 		{
 			_textBoxView ??= new TextBoxView(this);
-			if (ContentElement != null && ContentElement.Content != _textBoxView.DisplayBlock)
+			if (ContentElement != null && ContentElement.Content != TextBoxView.DisplayBlock)
 			{
-				ContentElement.Content = _textBoxView.DisplayBlock;
+				ContentElement.Content = TextBoxView.DisplayBlock;
 			}
 		}
 
-		partial void OnFocusStateChangedPartial(FocusState focusState) => _textBoxView?.OnFocusStateChanged(focusState);
+		partial void OnFocusStateChangedPartial(FocusState focusState) => TextBoxView?.OnFocusStateChanged(focusState);
 
 		partial void SelectPartial(int start, int length)
 		{
-			_textBoxView?.Select(start, length);
+			TextBoxView?.Select(start, length);
 		}
 
 		partial void SelectAllPartial() => Select(0, Text.Length);
 
 		public int SelectionStart
 		{
-			get => _textBoxView?.GetSelectionStart() ?? 0;
+			get => TextBoxView?.GetSelectionStart() ?? 0;
 			set => Select(start: value, length: SelectionLength);
 		}
 
 		public int SelectionLength
 		{
-			get => _textBoxView?.GetSelectionLength() ?? 0;
+			get => TextBoxView?.GetSelectionLength() ?? 0;
 			set => Select(SelectionStart, value);
 		}
 
 
-		protected void SetIsPassword(bool isPassword) => _textBoxView?.SetIsPassword(isPassword);
+		protected void SetIsPassword(bool isPassword) => TextBoxView?.SetIsPassword(isPassword);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -33,6 +33,8 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		internal ITextBoxViewExtension Extension => _textBoxExtension;
+
 		public TextBox? TextBox
 		{
 			get
@@ -50,7 +52,6 @@ namespace Windows.UI.Xaml.Controls
 		internal int GetSelectionLength() => _textBoxExtension?.GetSelectionLength() ?? 0;
 
 		public TextBlock DisplayBlock { get; } = new TextBlock();
-
 
 		internal void SetTextNative(string text)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): related to #7514

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

See below


## What is the new behavior?

- Previously we were using LayoutChanged and SizeChanged, but that was not completely reliable. Now we do the invalidation before render, which is much more accurate
- To prevent unnecessary operations we short-circuit as soon as possible - only computing when a TextBoxView is actually focused


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
