### PR TITLE
fix: Avoid jumpy ScrollViewer visibility on Skia by avoiding rounding errors in `ScrollViewer`

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -746,7 +746,19 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			ScrollableHeight = Math.Max(ExtentHeight - ViewportHeight, 0);
+			// On Skia, the ExtentHeight can include a rounding error, which may cause
+			// unwanted ScrollBar to pop in and out of existence.
+			if (ScrollableHeight < 0.1)
+			{
+				ScrollableHeight = 0;
+			}
 			ScrollableWidth = Math.Max(ExtentWidth - ViewportWidth, 0);
+			// On Skia, the ExtentWidth can include a rounding error, which may cause
+			// unwanted ScrollBar to pop in and out of existence.
+			if (ScrollableWidth < 0.1)
+			{
+				ScrollableWidth = 0;
+			}
 
 			UpdateComputedVerticalScrollability(invalidate: false);
 			UpdateComputedHorizontalScrollability(invalidate: false);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7514


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

In Skia the `ScrollViewer` `ExtentHeight` and `ExtentWidth` are based on the `ActualHeight` and `ActualWidth` value of a child. For `TextBlock` there is a special case where these values match the `DesiredSize`, which may can contain values with rounding errors (e.g. 18.0013324). This then causes issues for `TextBox` for example, as `ExtentHeight` - `ViewPortHeight` will resurt in a very small number like `0.0013324`, which is however enough to make the `ScrollBar` visibility toggle between `Collapsed` and `Visible` and it can happen repeatedly.

## What is the new behavior?

We check whether the `Extent` - `Viewport` subtraction actually yields a significant value, otherwise we just zero it out.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
