### PR TITLE
fix: Avoid TextChanged loop in GTK

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -263,10 +263,18 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 			switch (_currentInputWidget)
 			{
 				case Entry entry:
-					entry.Text = text;
+					// Avoid setting same text (as it raises WidgetTextChanged on GTK).
+					if (entry.Text != text)
+					{
+						entry.Text = text;
+					}
 					break;
 				case TextView textView:
-					textView.Buffer.Text = text;
+					// Avoid setting same text (as it raises WidgetTextChanged on GTK).
+					if (textView.Buffer.Text != text)
+					{
+						textView.Buffer.Text = text;
+					}
 					break;
 			};
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Skia GTK multiline input is laggy

## What is the new behavior?

Avoiding text changed loop avoids this lag.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
