### PR TITLE
fix: Disable `VisibleBoundsPadding` on Windows/WinUI3

### DIFF
--- a/doc/articles/features/VisibleBoundsPadding.md
+++ b/doc/articles/features/VisibleBoundsPadding.md
@@ -42,9 +42,9 @@ Usage is as follows:
 </UserControl>
 ```
 
-#### Note: 
+#### Notes
 - This behavior applies the greater of the existing padding or the calculated padding set on the element it is attached to.
-
+- `VisibleBoundsPadding` on WinAppSDK/Desktop does not have any effect. It is present to allow for same-XAML across platforms.
 
 ## See it in action
 

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -29,6 +29,10 @@
 		<CommonOverridePackageId>Uno.UI</CommonOverridePackageId>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362.0'">
+		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
+	</PropertyGroup>
+
 	<!--Workaround to prevent build to fail because the project has too many dependencies when checking support libraries versions.
 	(Introduced with support libraries 28.0.0.1) -->
 	<PropertyGroup>

--- a/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
+++ b/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
@@ -83,6 +83,9 @@ namespace Uno.UI.Toolkit
 		{
 			get
 			{
+#if WINUI
+				return new();
+#else
 				var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
 				var bounds = Window.Current?.Bounds ?? Rect.Empty;
 				var result = new Thickness {
@@ -100,6 +103,7 @@ namespace Uno.UI.Toolkit
 #endif
 
 				return result;
+#endif
 			}
 		}
 
@@ -110,6 +114,9 @@ namespace Uno.UI.Toolkit
 		{
 			get
 			{
+#if WINUI
+				return new();
+#else
 				var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
 
 				if (Window.Current is Window window)
@@ -120,6 +127,7 @@ namespace Uno.UI.Toolkit
 				}
 
 				return visibleBounds;
+#endif
 			}
 		}
 
@@ -141,6 +149,9 @@ namespace Uno.UI.Toolkit
 
 		private static void OnIsPaddingMaskChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
+#if WINUI
+			// VisibleBoundsPadding is disabled for WinUI 3 and up as there's available API for bounds.
+#else
 			if (dependencyObject is FrameworkElement fe)
 			{
 				VisibleBoundsDetails.GetInstance(fe).OnIsPaddingMaskChanged((PaddingMask)args.OldValue, (PaddingMask)args.NewValue);
@@ -154,8 +165,10 @@ namespace Uno.UI.Toolkit
 				}
 #endif
 			}
+#endif
 		}
 
+#if !WINUI
 		/// <summary>
 		/// If false, ApplicationView.VisibleBounds and Window.Current.Bounds have different aspect ratios (eg portrait vs landscape) which 
 		/// might arise transiently when the screen orientation changes.
@@ -365,5 +378,6 @@ namespace Uno.UI.Toolkit
 					.TransformBounds(new Rect(0, 0, boundsOf.ActualWidth, boundsOf.ActualHeight));
 			}
 		}
+#endif
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`VisibileBoundsPadding` depends on the `Bounds` and `VisibleBounds` properties which are not available on WinAppSDK desktop APIs. The implementation now acts as a noop on WinUI 3.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
