### PR TITLE
feat(reapply_theme): Added the ability to reapply application theme

### DIFF
--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -326,7 +326,7 @@ namespace Windows.UI.Xaml
 
 		internal void UpdateResourceBindingsForHotReload() => OnResourcesChanged(ResourceUpdateReason.HotReload);
 
-		private void OnRequestedThemeChanged() => OnResourcesChanged(ResourceUpdateReason.ThemeResource);
+		internal void OnRequestedThemeChanged() => OnResourcesChanged(ResourceUpdateReason.ThemeResource);
 
 		private void OnResourcesChanged(ResourceUpdateReason updateReason)
 		{

--- a/src/Uno.UI/UI/Xaml/ApplicationHelper.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationHelper.cs
@@ -36,6 +36,19 @@ namespace Uno.UI
 			}
 		}
 
+		/// <summary>
+		/// Force all {ThemeResource} declarations to reevaluate its bindings.
+		/// </summary>
+		/// <remarks>
+		/// This could be useful if you manually changed the bound values in global
+		/// themed dictionary and you want to reapply them without having to toggle
+		/// dark/light and producing annoying flickering to user.
+		/// 
+		/// Only applications with dynamic color schemes should use this.
+		/// </remarks>
+		public static void ReapplyApplicationTheme()
+			=> Application.Current.OnRequestedThemeChanged();
+
 		public static bool IsLoadableComponent(Uri resource)
 		{
 			return Application.Current.IsLoadableComponent(resource);


### PR DESCRIPTION

# Feature
Added the ability to reapply application theme to be used when the colors are manually changed in ResourceDictionary, to force the reevaluation of the ApplicationTheme without having to toggle.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
