### PR TITLE
perf(Style): Implement `Style.IsSealed` to allow for flattened lists caching

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -30,7 +30,7 @@
 	<PackageReference Update="Uno.Wasm.Bootstrap.DevServer" Version="2.1.0" />
 	<PackageReference Update="xamarin.build.download" Version="0.10.0" PrivateAssets="all" />
 	<PackageReference Update="MSTest.TestAdapter" Version="2.2.8" />
-	<PackageReference Update="MSTest.TestFramework" Version="2.2.6" />
+	<PackageReference Update="MSTest.TestFramework" Version="2.2.8" />
 	<PackageReference Update="Uno.MonoAnalyzers" Version="1.0.0" PrivateAssets="all" />
 	<PackageReference Update="System.Memory" Version="4.5.4" />
 	<PackageReference Update="Uno.Wasm.WebSockets" Version="1.1.0" />

--- a/src/Uno.UI.Tests/App/App.xaml.cs
+++ b/src/Uno.UI.Tests/App/App.xaml.cs
@@ -63,7 +63,7 @@ namespace UnitTestsApp
 		/// <returns>The 'running' application.</returns>
 		public static App EnsureApplication()
 		{
-			if (Current == null)
+			if (Current is not App)
 			{
 				var application = new App();
 #if !NETFX_CORE

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_Style.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_Style.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Tests.App.Xaml;
+using Uno.UI.Tests.Helpers;
+using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_Style
+	{
+		[TestInitialize]
+		public void Init()
+		{
+			UnitTestsApp.App.EnsureApplication();
+		}
+
+		[TestMethod]
+		public void When_Sealed_Style_Add_Setter()
+		{
+			var SUT = new Style(typeof(Control));
+
+			SUT.Setters.Add(new Setter(Control.IsEnabledProperty, true));
+
+			SUT.Seal();
+
+			Assert.IsTrue(SUT.IsSealed);
+			Assert.IsTrue(SUT.Setters.IsSealed);
+			Assert.IsTrue(SUT.Setters[0].IsSealed);
+
+			Assert.ThrowsException<InvalidOperationException>(() => SUT.Setters.Add(new Setter(Control.IsHitTestVisibleProperty, true)));
+		}
+
+		[TestMethod]
+		public void When_Sealed_Style_Remove()
+		{
+			var SUT = new Style(typeof(Control));
+
+			SUT.Setters.Add(new Setter(Control.IsEnabledProperty, true));
+
+			SUT.Seal();
+
+			Assert.IsTrue(SUT.IsSealed);
+			Assert.IsTrue(SUT.Setters.IsSealed);
+			Assert.IsTrue(SUT.Setters[0].IsSealed);
+
+			SUT.Setters.Clear();
+		}
+
+		[TestMethod]
+		public void When_Sealed_Style_Setter_Update()
+		{
+			var SUT = new Style(typeof(Control));
+
+			Setter s;
+			SUT.Setters.Add(s = new Setter(Control.IsEnabledProperty, true));
+
+			SUT.Seal();
+
+			Assert.IsTrue(SUT.IsSealed);
+			Assert.IsTrue(SUT.Setters.IsSealed);
+			Assert.IsTrue(SUT.Setters[0].IsSealed);
+
+			Assert.ThrowsException<InvalidOperationException>(() => s.Value = null);
+		}
+
+		[TestMethod]
+		public void When_Sealed_Style_BasedOn_Sealed()
+		{
+			var SUT = new Style(typeof(Control));
+			SUT.Setters.Add(new Setter(Control.IsEnabledProperty, true));
+
+			var SUT2 = new Style(typeof(Control)) { BasedOn = SUT };
+			SUT2.Setters.Add(new Setter(Control.IsEnabledProperty, true));
+
+			SUT2.Seal();
+
+			Assert.IsTrue(SUT.IsSealed);
+			Assert.IsTrue(SUT.Setters.IsSealed);
+			Assert.IsTrue(SUT.Setters[0].IsSealed);
+
+			Assert.IsTrue(SUT2.IsSealed);
+			Assert.IsTrue(SUT2.Setters.IsSealed);
+			Assert.IsTrue(SUT2.Setters[0].IsSealed);
+		}
+
+		[TestMethod]
+		public void When_Sealed_Style_On_Apply()
+		{
+			var SUT = new Style(typeof(Control));
+			SUT.Setters.Add(new Setter(Control.IsEnabledProperty, true));
+
+			var SUT2 = new Style(typeof(Control)) { BasedOn = SUT };
+			SUT2.Setters.Add(new Setter(Control.IsEnabledProperty, true));
+
+			SUT2.Seal();
+
+			Control control = new();
+			control.Style = SUT2;
+
+			Assert.IsTrue(SUT.IsSealed);
+			Assert.IsTrue(SUT.Setters.IsSealed);
+			Assert.IsTrue(SUT.Setters[0].IsSealed);
+
+			Assert.IsTrue(SUT2.IsSealed);
+			Assert.IsTrue(SUT2.Setters.IsSealed);
+			Assert.IsTrue(SUT2.Setters[0].IsSealed);
+		}
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/SetterBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/SetterBase.cs
@@ -1,5 +1,7 @@
 #pragma warning disable 108 // new keyword hiding
 #pragma warning disable 114 // new keyword hiding
+using System;
+
 namespace Windows.UI.Xaml
 {
 	#if false || false || false || false || false || false || false
@@ -7,16 +9,5 @@ namespace Windows.UI.Xaml
 	#endif
 	public  partial class SetterBase : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  bool IsSealed
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool SetterBase.IsSealed is not implemented in Uno.");
-			}
-		}
-		#endif
-		// Forced skipping of method Windows.UI.Xaml.SetterBase.IsSealed.get
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/SetterBaseCollection.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/SetterBaseCollection.cs
@@ -7,17 +7,7 @@ namespace Windows.UI.Xaml
 	#endif
 	public  partial class SetterBaseCollection : global::System.Collections.Generic.IList<global::Windows.UI.Xaml.SetterBase>,global::System.Collections.Generic.IEnumerable<global::Windows.UI.Xaml.SetterBase>
 	{
-		// Skipping already declared property Size
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  bool IsSealed
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool SetterBaseCollection.IsSealed is not implemented in Uno.");
-			}
-		}
-		#endif
+
 		// Skipping already declared method Windows.UI.Xaml.SetterBaseCollection.SetterBaseCollection()
 		// Forced skipping of method Windows.UI.Xaml.SetterBaseCollection.SetterBaseCollection()
 		// Forced skipping of method Windows.UI.Xaml.SetterBaseCollection.IsSealed.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/Style.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/Style.cs
@@ -7,35 +7,5 @@ namespace Windows.UI.Xaml
 	#endif
 	public  partial class Style : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared property TargetType
-		// Skipping already declared property BasedOn
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  bool IsSealed
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool Style.IsSealed is not implemented in Uno.");
-			}
-		}
-		#endif
-		// Skipping already declared property Setters
-		// Skipping already declared method Windows.UI.Xaml.Style.Style(System.Type)
-		// Forced skipping of method Windows.UI.Xaml.Style.Style(System.Type)
-		// Skipping already declared method Windows.UI.Xaml.Style.Style()
-		// Forced skipping of method Windows.UI.Xaml.Style.Style()
-		// Forced skipping of method Windows.UI.Xaml.Style.IsSealed.get
-		// Forced skipping of method Windows.UI.Xaml.Style.Setters.get
-		// Forced skipping of method Windows.UI.Xaml.Style.TargetType.get
-		// Forced skipping of method Windows.UI.Xaml.Style.TargetType.set
-		// Forced skipping of method Windows.UI.Xaml.Style.BasedOn.get
-		// Forced skipping of method Windows.UI.Xaml.Style.BasedOn.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  void Seal()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Style", "void Style.Seal()");
-		}
-		#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs
@@ -92,11 +92,15 @@ namespace Windows.UI.Xaml
 
 		public bool IsReadOnly => ((ICollection<T>)_list).IsReadOnly;
 
+		private protected virtual void ValidateItem(T item) { }
+
 		public T this[int index]
 		{
 			get => _list[index];
 			set
 			{
+				ValidateItem(value);
+
 				var originalValue = _list[index];
 
 				if (!ReferenceEquals(originalValue, value))
@@ -118,6 +122,8 @@ namespace Windows.UI.Xaml
 
 		public void Insert(int index, T item)
 		{
+			ValidateItem(item);
+
 			EnsureNotLocked();
 
 			_list.Insert(index, item);
@@ -141,6 +147,8 @@ namespace Windows.UI.Xaml
 		public void Add(T item)
 		{
 			EnsureNotLocked();
+
+			ValidateItem(item);
 
 			_list.Add(item);
 

--- a/src/Uno.UI/UI/Xaml/Setter.cs
+++ b/src/Uno.UI/UI/Xaml/Setter.cs
@@ -31,6 +31,8 @@ namespace Windows.UI.Xaml
 		private readonly SetterValueProviderHandler? _valueProvider;
 		private object? _value;
 		private int _targetNameResolutionFailureCount;
+		private DependencyProperty? _property;
+		private TargetPropertyPath? _target;
 
 		public object? Value
 		{
@@ -43,19 +45,44 @@ namespace Windows.UI.Xaml
 
 				return _value;
 			}
-			set => _value = value;
+			set
+			{
+				ValidateIsSealed();
+
+				_value = value;
+			}
+		}
+
+		private void ValidateIsSealed()
+		{
+			if (IsSealed)
+			{
+				throw new InvalidOperationException($"The setter is sealed and cannot be modified");
+			}
 		}
 
 		public TargetPropertyPath? Target
 		{
-			get;
-			set;
+			get => _target;
+			set
+			{
+				ValidateIsSealed();
+				_target = value;
+			}
 		}
 
 		/// <summary>
 		/// The property being set by this setter
 		/// </summary>
-		public DependencyProperty? Property { get; set; }
+		public DependencyProperty? Property
+		{
+			get => _property;
+			set
+			{
+				ValidateIsSealed();
+				_property = value;
+			}
+		}
 
 		/// <summary>
 		/// The name of the ThemeResource applied to the value, if any, as an optimized key.

--- a/src/Uno.UI/UI/Xaml/SetterBase.cs
+++ b/src/Uno.UI/UI/Xaml/SetterBase.cs
@@ -28,6 +28,14 @@ namespace Windows.UI.Xaml
 		{
 			this.Log().Debug("SetterBase.DataContextChanged");
 		}
+
+		public bool IsSealed
+		{
+			get; private set;
+		}
+
+		internal void Seal()
+			=> IsSealed = true;
 	}
 }
 

--- a/src/Uno.UI/UI/Xaml/SetterBaseCollection.cs
+++ b/src/Uno.UI/UI/Xaml/SetterBaseCollection.cs
@@ -20,5 +20,30 @@ namespace Windows.UI.Xaml
 			: base(parent, isAutoPropertyInheritanceEnabled: false)
 		{
 		}
+
+		public bool IsSealed { get; private set; }
+
+		internal void Seal()
+			=> IsSealed = true;
+
+		private protected override void ValidateItem(SetterBase item)
+		{
+			base.ValidateItem(item);
+
+			if (IsSealed)
+			{
+				throw new InvalidOperationException($"The SetterBaseCollection is sealed and cannot be modified");
+			}
+		}
+
+		private protected override void OnAdded(SetterBase setterBase)
+		{
+			base.OnAdded(setterBase);
+
+			if(setterBase is Setter setter && setter.Target is null)
+			{
+				setterBase.Seal();
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Style/Style.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Style.cs
@@ -17,19 +17,19 @@ namespace Windows.UI.Xaml
 	{
 		private static Logger _logger = typeof(Style).Log();
 
-		private delegate void ApplyToHandler(DependencyObject instance);
-
 		public delegate Style StyleProviderHandler();
 
-		private readonly static Dictionary<Type, StyleProviderHandler> _lookup = new Dictionary<Type, StyleProviderHandler>(Uno.Core.Comparison.FastTypeComparer.Default);
-		private readonly static Dictionary<Type, Style> _defaultStyleCache = new Dictionary<Type, Style>(Uno.Core.Comparison.FastTypeComparer.Default);
-		private readonly static Dictionary<Type, StyleProviderHandler> _nativeLookup = new Dictionary<Type, StyleProviderHandler>(Uno.Core.Comparison.FastTypeComparer.Default);
-		private readonly static Dictionary<Type, Style> _nativeDefaultStyleCache = new Dictionary<Type, Style>(Uno.Core.Comparison.FastTypeComparer.Default);
+		private readonly static Dictionary<Type, StyleProviderHandler> _lookup = new(Uno.Core.Comparison.FastTypeComparer.Default);
+		private readonly static Dictionary<Type, Style> _defaultStyleCache = new(Uno.Core.Comparison.FastTypeComparer.Default);
+		private readonly static Dictionary<Type, StyleProviderHandler> _nativeLookup = new(Uno.Core.Comparison.FastTypeComparer.Default);
+		private readonly static Dictionary<Type, Style> _nativeDefaultStyleCache = new(Uno.Core.Comparison.FastTypeComparer.Default);
 
 		/// <summary>
 		/// The xaml scope in force at the time the Style was created.
 		/// </summary>
 		private readonly XamlScope _xamlScope;
+		private Dictionary<object, SetterBase>? _settersMap;
+		private SetterBase[]? _flattenedSetters;
 
 		public Style()
 		{
@@ -52,6 +52,19 @@ namespace Windows.UI.Xaml
 
 		public SetterBaseCollection Setters { get; } = new SetterBaseCollection();
 
+		public bool IsSealed
+		{
+			get; private set;
+		}
+
+		public void Seal()
+		{
+			IsSealed = true;
+			Setters.Seal();
+
+			BasedOn?.Seal();
+		}
+
 		internal void ApplyTo(DependencyObject o, DependencyPropertyValuePrecedences precedence)
 		{
 			if (o == null)
@@ -62,19 +75,20 @@ namespace Windows.UI.Xaml
 
 			var localPrecedenceDisposable = DependencyObjectExtensions.OverrideLocalPrecedence(o, precedence);
 
-			var flattenedSetters = CreateSetterMap();
+			EnsureSetterMap();
+
 #if !HAS_EXPENSIVE_TRYFINALLY
 			try
 #endif
 			{
 				ResourceResolver.PushNewScope(_xamlScope);
 
-				// This block is a manual enumeration to avoid the foreach pattern
-				// See https://github.com/dotnet/runtime/issues/56309 for details
-				var settersEnumerator = flattenedSetters.GetEnumerator();
-				while (settersEnumerator.MoveNext())
+				if (_flattenedSetters != null)
 				{
-					settersEnumerator.Current.Value(o);
+					for (var i = 0; i < _flattenedSetters.Length; i++)
+					{
+						_flattenedSetters[i].ApplyTo(o);
+					}
 				}
 
 				// Check tree for resource binding values, since some Setters may have set ThemeResource-backed values
@@ -95,8 +109,8 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		internal void ClearInvalidProperties(DependencyObject dependencyObject, Style incomingStyle, DependencyPropertyValuePrecedences precedence)
 		{
-			var oldSetters = CreateSetterMap();
-			var newSetters = incomingStyle?.CreateSetterMap();
+			var oldSetters = EnsureSetterMap();
+			var newSetters = incomingStyle?.EnsureSetterMap();
 			foreach (var kvp in oldSetters)
 			{
 				if (kvp.Key is DependencyProperty dp)
@@ -113,20 +127,27 @@ namespace Windows.UI.Xaml
 		/// Creates a flattened list of setter methods for the whole hierarchy of
 		/// styles.
 		/// </summary>
-		private IDictionary<object, ApplyToHandler> CreateSetterMap()
+		private IDictionary<object, SetterBase> EnsureSetterMap()
 		{
-			var map = new Dictionary<object, ApplyToHandler>();
+			if (_settersMap == null)
+			{
+				_settersMap = new Dictionary<object, SetterBase>();
 
-			EnumerateSetters(this, map);
+				EnumerateSetters(this, _settersMap);
 
-			return map;
+				_flattenedSetters = _settersMap.Values.ToArray();
+			}
+
+			return _settersMap;
 		}
 
 		/// <summary>
 		/// Enumerates all the styles for the complete hierarchy.
 		/// </summary>
-		private void EnumerateSetters(Style style, Dictionary<object, ApplyToHandler> map)
+		private static void EnumerateSetters(Style style, Dictionary<object, SetterBase> map)
 		{
+			style.Seal();
+
 			if (style.BasedOn != null)
 			{
 				EnumerateSetters(style.BasedOn, map);
@@ -134,19 +155,21 @@ namespace Windows.UI.Xaml
 
 			if (style.Setters != null)
 			{
-				foreach (var setter in style.Setters)
+				for (var i = 0; i < style.Setters.Count; i++)
 				{
+					var setter = style.Setters[i];
+
 					if (setter is Setter s)
 					{
 						if (s.Property == null)
 						{
 							throw new InvalidOperationException("Property must be set on Setter used in Style"); // TODO: We should also support Setter.Target inside Style https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.setter#remarks
 						}
-						map[s.Property] = setter.ApplyTo;
+						map[s.Property] = setter;
 					}
 					else if (setter is ICSharpPropertySetter propertySetter)
 					{
-						map[propertySetter.Property] = setter.ApplyTo;
+						map[propertySetter.Property] = setter;
 					}
 				}
 			}


### PR DESCRIPTION
Closes https://github.com/unoplatform/uno/issues/7577

## PR Type

What kind of change does this PR introduce?
- Performance

## What is the new behavior?

- Applying styles now relies on caching based on the use of `Style.IsSealed` which is set when a style is applied to a Control. 
- Setters enumeration now relies on an arrray instead of a dictionary
- Setters application does not use delegates anymore

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
