### PR TITLE
fix(net6): Adjust versions for net6-winui templates

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/UnoWinUIQuickStart.Windows.Desktop/UnoWinUIQuickStart.Windows.Desktop.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/UnoWinUIQuickStart.Windows.Desktop/UnoWinUIQuickStart.Windows.Desktop.csproj
@@ -22,8 +22,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.16" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.16" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.22" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.22" />
 	</ItemGroup>
 
 	<Import Project="..\UnoWinUIQuickStart.Shared\UnoWinUIQuickStart.Shared.projitems" Label="Shared" />

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/UnoWinUIQuickStart.Windows.Package/UnoWinUIQuickStart.Windows.Package.wapproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/UnoWinUIQuickStart.Windows.Package/UnoWinUIQuickStart.Windows.Package.wapproj
@@ -67,16 +67,16 @@
 	<!--PackageReference.GeneratePathProperty does not support NUGET_PACKAGES env var...-->
 	<NuGetPackageRoot Condition="'$(NuGetPackageRoot)'==''">$(NUGET_PACKAGES)</NuGetPackageRoot>
 	<NuGetPackageRoot Condition="'$(NuGetPackageRoot)'==''">$(UserProfile)\.nuget\packages</NuGetPackageRoot>
-	<PkgMicrosoft_ProjectReunion Condition="'$(PkgMicrosoft_ProjectReunion)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.WindowsAppSDK', '1.0.0-experimental1'))</PkgMicrosoft_ProjectReunion>
-	<PkgMicrosoft_ProjectReunion Condition="!Exists($(PkgMicrosoft_ProjectReunion))">$(SolutionDir)packages\Microsoft.WindowsAppSDK.1.0.0-experimental1\</PkgMicrosoft_ProjectReunion>
-	<PkgMicrosoft_ProjectReunion_WinUI Condition="'$(PkgMicrosoft_ProjectReunion_WinUI)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.WindowsAppSDK.WinUI', '1.0.0-experimental1'))</PkgMicrosoft_ProjectReunion_WinUI>
-	<PkgMicrosoft_ProjectReunion_WinUI Condition="!Exists($(PkgMicrosoft_ProjectReunion_WinUI))">$(SolutionDir)packages\Microsoft.WindowsAppSDK.WinUI.1.0.0-experimental1\</PkgMicrosoft_ProjectReunion_WinUI>
+	<PkgMicrosoft_ProjectReunion Condition="'$(PkgMicrosoft_ProjectReunion)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.WindowsAppSDK', '1.0.0'))</PkgMicrosoft_ProjectReunion>
+	<PkgMicrosoft_ProjectReunion Condition="!Exists($(PkgMicrosoft_ProjectReunion))">$(SolutionDir)packages\Microsoft.WindowsAppSDK.1.0.0\</PkgMicrosoft_ProjectReunion>
+	<PkgMicrosoft_ProjectReunion_WinUI Condition="'$(PkgMicrosoft_ProjectReunion_WinUI)'==''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'Microsoft.WindowsAppSDK.WinUI', '1.0.0'))</PkgMicrosoft_ProjectReunion_WinUI>
+	<PkgMicrosoft_ProjectReunion_WinUI Condition="!Exists($(PkgMicrosoft_ProjectReunion_WinUI))">$(SolutionDir)packages\Microsoft.WindowsAppSDK.WinUI.1.0.0\</PkgMicrosoft_ProjectReunion_WinUI>
 	<Microsoft_ProjectReunion_AppXReference_props>$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_ProjectReunion)', 'build'))Microsoft.WindowsAppSDK.AppXReference.props</Microsoft_ProjectReunion_AppXReference_props>
 	<Microsoft_WinUI_AppX_targets>$([MSBuild]::NormalizeDirectory('$(PkgMicrosoft_ProjectReunion_WinUI)', 'build'))Microsoft.WinUI.AppX.targets</Microsoft_WinUI_AppX_targets>
 	<EntryPointProjectUniqueName>..\UnoWinUIQuickStart.Windows.Desktop\UnoWinUIQuickStart.Windows.Desktop.csproj</EntryPointProjectUniqueName>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Microsoft.WindowsAppSDK" Version="[1.0.0-experimental1]">
+	<PackageReference Include="Microsoft.WindowsAppSDK" Version="[1.0.0]">
 	  <IncludeAssets>build</IncludeAssets>
 	</PackageReference>
   </ItemGroup>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/UnoWinUIQuickStart.Windows.Desktop/UnoWinUIQuickStart.Windows.Desktop.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/UnoWinUIQuickStart.Windows.Desktop/UnoWinUIQuickStart.Windows.Desktop.csproj
@@ -22,8 +22,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.21" />
-		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.21" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.22" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.22" />
 	</ItemGroup>
 
 	<Import Project="..\UnoWinUIQuickStart.Shared\UnoWinUIQuickStart.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Bumps WinUI `winui-net6` and `winui` templates to use WinAppSDK 1.0 and latest sdk runtimes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
