### PR TITLE
fix: Fix PasswordBox on Android not obscuring password

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -228,14 +228,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (_textBoxView != null)
 			{
-				if (FeatureConfiguration.TextBox.UseLegacyInputScope)
-				{
-					_textBoxView.InputType = types;
-				}
-				else
-				{
-					_textBoxView.SetRawInputType(types);
-				}
+				_textBoxView.InputType = types;
+				_textBoxView.SetRawInputType(types);
 
 				if (!types.HasPasswordFlag())
 				{


### PR DESCRIPTION
GitHub Issue (If applicable): #7623

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

PasswordBox not working properly on Android.


## What is the new behavior?

Should be working.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
