### PR TITLE
fix: Fix TextBox/PasswordBox Foreground and add test for obscuring password

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PasswordBoxTests/PasswordBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PasswordBoxTests/PasswordBoxTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Drawing;
+using System.Linq;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PasswordBoxTests
+{
+	public partial class PasswordBoxTests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void PasswordShouldBeObscured()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.PasswordBoxTests.PasswordBoxPage");
+			var passwordBox = _app.Marked("redPasswordBox");
+			passwordBox.EnterText("         ");
+			using var screenshot = TakeScreenshot("Spaces typed in PasswordBox.");
+			ImageAssert.HasColorInRectangle(screenshot, _app.Query("redPasswordBox").Single().Rect.ToRectangle(), Color.Red);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1617,6 +1617,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\PasswordBoxTests\PasswordBoxPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\PersonPictureTests\PersonPicturePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5474,6 +5478,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\PageTests\Page_Update_Background.xaml.cs">
       <DependentUpon>Page_Update_Background.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\PasswordBoxTests\PasswordBoxPage.xaml.cs">
+      <DependentUpon>PasswordBoxPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\PersonPictureTests\PersonPicturePage.xaml.cs">
       <DependentUpon>PersonPicturePage.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/PasswordBoxTests/PasswordBoxPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/PasswordBoxTests/PasswordBoxPage.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.PasswordBoxTests.PasswordBoxPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.PasswordBoxTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel>
+		<PasswordBox x:Name="redPasswordBox" Foreground="Red" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/PasswordBoxTests/PasswordBoxPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/PasswordBoxTests/PasswordBoxPage.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.PasswordBoxTests
+{
+	[Sample("PasswordBox")]
+    public sealed partial class PasswordBoxPage : Page
+    {
+        public PasswordBoxPage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/PasswordBoxTests/PasswordBoxPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/PasswordBoxTests/PasswordBoxPage.xaml.cs
@@ -5,7 +5,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.PasswordBoxTests
 {
-	[Sample("PasswordBox")]
+	[Sample("TextBox")]
     public sealed partial class PasswordBoxPage : Page
     {
         public PasswordBoxPage()

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -219,6 +219,7 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 				var inputText = GetInputText();
 				_currentInputWidget = CreateInputWidget(acceptsReturn, isPassword, isPasswordVisible);
 				SetWidgetText(inputText ?? string.Empty);
+				SetForeground(textBox.Foreground);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7623

**Test wasn't validated locally due to issues with building the solution.**

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Test

## What is the current behavior?

- Foreground doesn't always take effect on Skia, depending on whether we had already created the widget or not.
- No test for the recently fixed bug about PasswordBox shows non-obscured text on Android.

## What is the new behavior?

- Set Foreground just after we create the widget.
- Test added


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
