### PR TITLE
Add support for `Description` property

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/NumberBoxTests/Given_NumberBox.Uno.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/NumberBoxTests/Given_NumberBox.Uno.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Drawing;
+using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
@@ -17,6 +18,17 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
 			_app.WaitForElement(headerContentTextBlock);
 
 			Assert.AreEqual("This is a NumberBox Header", headerContentTextBlock.GetDependencyPropertyValue("Text").ToString());
+		}
+
+		[Test]
+		[AutoRetry]
+		public void NumberBox_Description()
+		{
+			Run("UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests.NumberBox_Description", skipInitialScreenshot: true);
+
+			var numberBox = _app.WaitForElement("DescriptionNumberBox")[0];
+			using var screenshot = TakeScreenshot("NumberBox Description", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+			ImageAssert.HasColorAt(screenshot, numberBox.Rect.X + numberBox.Rect.Width / 2, numberBox.Rect.Y + numberBox.Rect.Height - 150, Color.Red);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
+{
+	[TestFixture]
+	public partial class AutoSuggestBoxTests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void PasswordBox_With_Description()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.AutoSuggestBoxTests.AutoSuggestBox_Description", skipInitialScreenshot: true);
+			var autoSuggestBox = _app.WaitForElement("DescriptionAutoSuggestBox")[0];
+			using var screenshot = TakeScreenshot("AutoSuggestBox Description", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+			ImageAssert.HasColorAt(screenshot, autoSuggestBox.Rect.X + autoSuggestBox.Rect.Width / 2, autoSuggestBox.Rect.Y + autoSuggestBox.Rect.Height - 150, Color.Red);
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
@@ -1,11 +1,8 @@
-﻿using NUnit.Framework;
-using SamplesApp.UITests.TestFramework;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
@@ -278,6 +275,16 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			Assert.AreEqual("Item:", text1, "item #4 should be now selected with ItemTemplate");
 			Assert.AreEqual("5", text2, "item #4 (value: 5) should be now selected with ItemTemplate");
 		});
+
+		[Test]
+		[AutoRetry]
+		public void ComboBox_With_Description()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Description", skipInitialScreenshot: true);
+			var comboBox = _app.WaitForElement("DescriptionComboBox")[0];			
+			using var screenshot = TakeScreenshot("ComboBox Description", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+			ImageAssert.HasColorAt(screenshot, comboBox.Rect.X + comboBox.Rect.Width / 2, comboBox.Rect.Y + comboBox.Rect.Height - 150, Color.Red);
+		}
 
 		public void ComboBoxTests_PlaceholderText_Impl(string targetName, int selectionIndex, Action<QueryEx> selectionValidation)
 		{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/DatePickerTests/UnoSamples_Tests.DatePicker.cs
@@ -329,5 +329,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.DatePickerTests
 
 			_app.FastTap("DismissButton");
 		}
+
+		[Test]
+		[AutoRetry]
+		public void CalendarDatePicker_With_Description()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.CalendarView.CalendarDatePicker_Description", skipInitialScreenshot: true);
+			var autoSuggestBox = _app.WaitForElement("DescriptionCalendarDatePicker")[0];
+			using var screenshot = TakeScreenshot("CalendarDatePicker Description", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+			ImageAssert.HasColorAt(screenshot, autoSuggestBox.Rect.X + autoSuggestBox.Rect.Width / 2, autoSuggestBox.Rect.Y + autoSuggestBox.Rect.Height - 150, Color.Red);
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -869,5 +869,25 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 				_app.WaitForText(marked, Text, timeout: TimeSpan.FromSeconds(20));
 			}
 		}
+
+		[Test]
+		[AutoRetry]
+		public void TextBox_With_Description()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_Description", skipInitialScreenshot: true);
+			var textBox = _app.WaitForElement("DescriptionTextBox")[0];
+			using var screenshot = TakeScreenshot("TextBox Description", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+			ImageAssert.HasColorAt(screenshot, textBox.Rect.X + textBox.Rect.Width / 2, textBox.Rect.Y + textBox.Rect.Height - 150, Color.Red);
+		}
+
+		[Test]
+		[AutoRetry]
+		public void PasswordBox_With_Description()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.TextBox.PasswordBox_Description", skipInitialScreenshot: true);
+			var passwordBox = _app.WaitForElement("DescriptionPasswordBox")[0];
+			using var screenshot = TakeScreenshot("PasswordBox Description", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+			ImageAssert.HasColorAt(screenshot, passwordBox.Rect.X + passwordBox.Rect.Width / 2, passwordBox.Rect.Y + passwordBox.Rect.Height - 150, Color.Red);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NumberBoxTests/NumberBox_Description.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NumberBoxTests/NumberBox_Description.xaml
@@ -1,0 +1,16 @@
+﻿<Page
+    x:Class="UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests.NumberBox_Description"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<NumberBox x:Name="DescriptionNumberBox">
+		<NumberBox.Description>
+			<Border Width="300" Height="300" Background="Red" />
+		</NumberBox.Description>
+	</NumberBox>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NumberBoxTests/NumberBox_Description.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NumberBoxTests/NumberBox_Description.xaml
@@ -5,12 +5,13 @@
     xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:mux="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<NumberBox x:Name="DescriptionNumberBox">
-		<NumberBox.Description>
+	<mux:NumberBox x:Name="DescriptionNumberBox">
+		<mux:NumberBox.Description>
 			<Border Width="300" Height="300" Background="Red" />
-		</NumberBox.Description>
-	</NumberBox>
+		</mux:NumberBox.Description>
+	</mux:NumberBox>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NumberBoxTests/NumberBox_Description.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NumberBoxTests/NumberBox_Description.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Microsoft_UI_Xaml_Controls.NumberBoxTests
+{
+	[Sample("NumberBox", "WinUI")]
+    public sealed partial class NumberBox_Description : Page
+    {
+        public NumberBox_Description()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1861,7 +1861,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Descripition.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Description.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -5677,8 +5677,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_DeleteButton_Automated.xaml.cs">
       <DependentUpon>TextBox_DeleteButton_Automated.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Descripition.xaml.cs">
-      <DependentUpon>TextBox_Descripition.xaml</DependentUpon>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Description.xaml.cs">
+      <DependentUpon>TextBox_Description.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Disabled.xaml.cs">
       <DependentUpon>TextBox_Disabled.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -181,6 +181,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NumberBoxTests\NumberBox_Description.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NumberBoxTests\NumberBox_ExpressionTest.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1037,6 +1041,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_Description.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_Icons.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1085,6 +1093,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarDatePicker_Description.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarDatePicker_Features.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1130,6 +1142,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_CornerRadius.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Description.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -1813,6 +1829,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\PasswordBox_Description.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\PasswordBox_Reveal_Scroll.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1838,6 +1858,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_DeleteButton_Automated.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Descripition.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -4500,6 +4524,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NumberBoxTests\MUX_Test.xaml.cs">
       <DependentUpon>MUX_Test.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NumberBoxTests\NumberBox_Description.xaml.cs">
+      <DependentUpon>NumberBox_Description.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NumberBoxTests\NumberBox_ExpressionTest.xaml.cs">
       <DependentUpon>NumberBox_ExpressionTest.xaml</DependentUpon>
     </Compile>
@@ -5077,6 +5104,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_BitmapIcon.xaml.cs">
       <DependentUpon>AutoSuggestBox_BitmapIcon.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_Description.xaml.cs">
+      <DependentUpon>AutoSuggestBox_Description.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_Icons.xaml.cs">
       <DependentUpon>AutoSuggestBox_Icons.xaml</DependentUpon>
     </Compile>
@@ -5110,6 +5140,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarDatePicker_Basics.xaml.cs">
       <DependentUpon>CalendarDatePicker_Basics.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarDatePicker_Description.xaml.cs">
+      <DependentUpon>CalendarDatePicker_Description.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarDatePicker_Features.xaml.cs">
       <DependentUpon>CalendarDatePicker_Features.xaml</DependentUpon>
@@ -5146,6 +5179,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_CornerRadius.xaml.cs">
       <DependentUpon>ComboBox_CornerRadius.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Description.xaml.cs">
+      <DependentUpon>ComboBox_Description.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Disabled.xaml.cs">
       <DependentUpon>ComboBox_Disabled.xaml</DependentUpon>
@@ -5617,6 +5653,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Visibility_Arrange.xaml.cs">
       <DependentUpon>TextBlock_Visibility_Arrange.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\PasswordBox_Description.xaml.cs">
+      <DependentUpon>PasswordBox_Description.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\PasswordBox_Reveal_Scroll.xaml.cs">
       <DependentUpon>PasswordBox_Reveal_Scroll.xaml</DependentUpon>
     </Compile>
@@ -5637,6 +5676,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_DeleteButton_Automated.xaml.cs">
       <DependentUpon>TextBox_DeleteButton_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Descripition.xaml.cs">
+      <DependentUpon>TextBox_Descripition.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Disabled.xaml.cs">
       <DependentUpon>TextBox_Disabled.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBox_Description.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBox_Description.xaml
@@ -1,0 +1,16 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.AutoSuggestBoxTests.AutoSuggestBox_Description"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.AutoSuggestBoxTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<AutoSuggestBox x:Name="DescriptionAutoSuggestBox">
+		<AutoSuggestBox.Description>
+			<Border Width="300" Height="300" Background="Red" />
+		</AutoSuggestBox.Description>
+	</AutoSuggestBox>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBox_Description.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBox_Description.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.AutoSuggestBoxTests
+{
+	[Sample("AutoSuggestBox")]
+    public sealed partial class AutoSuggestBox_Description : Page
+    {
+        public AutoSuggestBox_Description()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarDatePicker_Description.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarDatePicker_Description.xaml
@@ -1,0 +1,16 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.CalendarView.CalendarDatePicker_Description"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.CalendarView"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<CalendarDatePicker x:Name="DescriptionCalendarDatePicker">
+		<CalendarDatePicker.Description>
+			<Border Width="300" Height="300" Background="Red" />
+		</CalendarDatePicker.Description>
+	</CalendarDatePicker>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarDatePicker_Description.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarDatePicker_Description.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.CalendarView
+{
+	[Sample("Date Picking")]
+    public sealed partial class CalendarDatePicker_Description : Page
+    {
+        public CalendarDatePicker_Description()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Description.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Description.xaml
@@ -1,0 +1,16 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Description"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ComboBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<ComboBox x:Name="DescriptionComboBox">
+		<ComboBox.Description>
+			<Border Width="300" Height="300" Background="Red" />
+		</ComboBox.Description>
+	</ComboBox>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Description.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Description.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.ComboBox
+{
+	[Sample("ComboBox")]
+    public sealed partial class ComboBox_Description : Page
+    {
+        public ComboBox_Description()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Description.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Description.xaml
@@ -1,0 +1,16 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.PasswordBox_Description"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<PasswordBox x:Name="DescriptionPasswordBox">
+		<PasswordBox.Description>
+			<Border Width="300" Height="300" Background="Red" />
+		</PasswordBox.Description>
+	</PasswordBox>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Description.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/PasswordBox_Description.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBox
+{
+    [Sample("TextBox")]
+    public sealed partial class PasswordBox_Description : Page
+    {
+        public PasswordBox_Description()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Descripition.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Descripition.xaml
@@ -1,0 +1,16 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_Descripition"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<TextBox x:Name="DescriptionTextBox">
+		<TextBox.Description>
+			<Border Width="300" Height="300" Background="Red" />
+		</TextBox.Description>
+	</TextBox>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Descripition.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Descripition.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBox
+{
+	[Sample("TextBox")]
+    public sealed partial class TextBox_Descripition : Page
+    {
+        public TextBox_Descripition()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Description.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Description.xaml
@@ -1,5 +1,5 @@
 ﻿<Page
-    x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_Descripition"
+    x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_Description"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Description.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Description.xaml.cs
@@ -17,9 +17,9 @@ using Windows.UI.Xaml.Navigation;
 namespace UITests.Windows_UI_Xaml_Controls.TextBox
 {
 	[Sample("TextBox")]
-    public sealed partial class TextBox_Descripition : Page
+    public sealed partial class TextBox_Description : Page
     {
-        public TextBox_Descripition()
+        public TextBox_Description()
         {
             this.InitializeComponent();
         }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBox.cs
@@ -31,20 +31,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  object Description
-		{
-			get
-			{
-				return (object)this.GetValue(DescriptionProperty);
-			}
-			set
-			{
-				this.SetValue(DescriptionProperty, value);
-			}
-		}
-		#endif
+		// Skipping already declared property Description		
 		// Skipping already declared property AutoMaximizeSuggestionAreaProperty
 		// Skipping already declared property HeaderProperty
 		// Skipping already declared property IsSuggestionListOpenProperty
@@ -55,7 +42,7 @@ namespace Windows.UI.Xaml.Controls
 		// Skipping already declared property TextProperty
 		// Skipping already declared property UpdateTextOnSelectProperty
 		// Skipping already declared property QueryIconProperty
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
@@ -63,14 +50,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(Description), typeof(object), 
-			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
-			new FrameworkPropertyMetadata(default(object)));
-		#endif
+		// Skipping already declared property DescriptionProperty
 		// Skipping already declared method Windows.UI.Xaml.Controls.AutoSuggestBox.AutoSuggestBox()
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBox.AutoSuggestBox()
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBox.MaxSuggestionListHeight.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ComboBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ComboBox.cs
@@ -128,20 +128,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  object Description
-		{
-			get
-			{
-				return (object)this.GetValue(DescriptionProperty);
-			}
-			set
-			{
-				this.SetValue(DescriptionProperty, value);
-			}
-		}
-		#endif
+		// Skipping already declared property Description
 		// Skipping already declared property IsDropDownOpenProperty
 		// Skipping already declared property MaxDropDownHeightProperty
 		// Skipping already declared property HeaderProperty
@@ -172,14 +159,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(Description), typeof(object), 
-			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
-			new FrameworkPropertyMetadata(default(object)));
-		#endif
+		// Skipping already declared property DescriptionProperty		
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty IsEditableProperty { get; } = 

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
@@ -85,20 +85,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  object Description
-		{
-			get
-			{
-				return (object)this.GetValue(DescriptionProperty);
-			}
-			set
-			{
-				this.SetValue(DescriptionProperty, value);
-			}
-		}
-		#endif
+		// Skipping already declared property Description		
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool CanPasteClipboardContent
@@ -157,14 +144,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(Description), typeof(object), 
-			typeof(global::Windows.UI.Xaml.Controls.PasswordBox), 
-			new FrameworkPropertyMetadata(default(object)));
-		#endif
+		// Skipping already declared property DescriptionProperty
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionFlyoutProperty { get; } = 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.Properties.cs
@@ -149,7 +149,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		public new object Description
 		{
-			get => (object)GetValue(DescriptionProperty);
+			get => GetValue(DescriptionProperty);
 			set => SetValue(DescriptionProperty, value);
 		}
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.xaml
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.xaml
@@ -92,11 +92,12 @@
                             SelectionHighlightColor="{TemplateBinding SelectionHighlightColor}"
                             TextReadingOrder="{TemplateBinding TextReadingOrder}"
                             PreventKeyboardDisplayOnProgrammaticFocus="{TemplateBinding PreventKeyboardDisplayOnProgrammaticFocus}"
+							contract7Present:Description="{TemplateBinding Description}"
 								 />
                             <!--
 							UNO TODO
 							contract7Present:SelectionFlyout="{TemplateBinding SelectionFlyout}"
-                            contract7Present:Description="{TemplateBinding Description}"-->
+                            -->
 
                         <Popup x:Name="UpDownPopup"
                             Grid.Column="1"

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.Properties.cs
@@ -66,6 +66,12 @@ namespace Windows.UI.Xaml.Controls
 			set => this.SetValue(QueryIconProperty, value);
 		}
 
+		public object Description
+		{
+			get => this.GetValue(DescriptionProperty);
+			set => this.SetValue(DescriptionProperty, value);
+		}
+
 		public static global::Windows.UI.Xaml.DependencyProperty MaxSuggestionListHeightProperty { get; } =
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"MaxSuggestionListHeight", typeof(double),
@@ -134,6 +140,12 @@ namespace Windows.UI.Xaml.Controls
 			"QueryIcon", typeof(global::Windows.UI.Xaml.Controls.IconElement),
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.IconElement), propertyChangedCallback: (s, e) => (s as AutoSuggestBox)?.UpdateQueryButton()));
+
+		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } =
+			Windows.UI.Xaml.DependencyProperty.Register(
+				nameof(Description), typeof(object),
+				typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+				new FrameworkPropertyMetadata(default(object), propertyChangedCallback: (s, e) => (s as AutoSuggestBox)?.UpdateDescriptionVisibility(false)));
 
 		public event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxSuggestionChosenEventArgs> SuggestionChosen;
 		public event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxTextChangedEventArgs> TextChanged;

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.Properties.cs
@@ -66,7 +66,11 @@ namespace Windows.UI.Xaml.Controls
 			set => this.SetValue(QueryIconProperty, value);
 		}
 
-		public object Description
+		public 
+#if __IOS__ || __MACOS__
+		new
+#endif
+		object Description
 		{
 			get => this.GetValue(DescriptionProperty);
 			set => this.SetValue(DescriptionProperty, value);

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -55,6 +55,7 @@ namespace Windows.UI.Xaml.Controls
 
 			UpdateQueryButton();
 			UpdateTextBox();
+			UpdateDescriptionVisibility(true);
 
 			_textBoxBinding = new BindingPath("Text", null) { DataContext = _textBox, ValueChangedListener = this };
 
@@ -438,6 +439,21 @@ namespace Windows.UI.Xaml.Controls
 					Reason = tb._textChangeReason,
 					Owner = tb
 				});
+			}
+		}
+
+		private void UpdateDescriptionVisibility(bool initialization)
+		{
+			if (initialization && Description == null)
+			{
+				// Avoid loading DescriptionPresenter element in template if not needed.
+				return;
+			}
+
+			var descriptionPresenter = this.FindName("DescriptionPresenter") as ContentPresenter;
+			if (descriptionPresenter != null)
+			{
+				descriptionPresenter.Visibility = Description != null ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarDatePicker.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarDatePicker.Properties.cs
@@ -54,7 +54,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty DescriptionProperty { get; } = DependencyProperty.Register(
-			"Description", typeof(object), typeof(CalendarDatePicker), new FrameworkPropertyMetadata(default(object)));
+			"Description", typeof(object), typeof(CalendarDatePicker), new FrameworkPropertyMetadata(default(object), propertyChangedCallback: (s, e) => (s as CalendarDatePicker)?.UpdateDescriptionVisibility(false)));
 
 #if __IOS__ || __MACOS__
 		public new // .Description already exists on NSObject (both macOS & iOS)
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Controls
 #endif
 			object Description
 		{
-			get => (string)GetValue(DescriptionProperty);
+			get => GetValue(DescriptionProperty);
 			set => SetValue(DescriptionProperty, value);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/calendardatepicker_partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/calendardatepicker_partial.cs
@@ -134,7 +134,7 @@ namespace Windows.UI.Xaml.Controls
 					overlayMode = LightDismissOverlayMode;
 					((FlyoutBase)m_tpFlyout).LightDismissOverlayMode = overlayMode;
 				}
-			}
+			}						
 		}
 
 		protected override void OnApplyTemplate()
@@ -278,6 +278,9 @@ namespace Windows.UI.Xaml.Controls
 			FormatDate();
 
 			UpdateVisualState();
+
+			// TODO: Uno specific: This logic should later move to Control to match WinUI
+			UpdateDescriptionVisibility(true);
 
 			void OnFlyoutOpened(object sender, object eventArgs)
 			{
@@ -1103,6 +1106,21 @@ namespace Windows.UI.Xaml.Controls
 			if (m_tpDateText is {})
 			{
 				value = m_tpDateText.Text;
+			}
+		}
+
+		private void UpdateDescriptionVisibility(bool initialization)
+		{
+			if (initialization && Description == null)
+			{
+				// Avoid loading DescriptionPresenter element in template if not needed.
+				return;
+			}
+
+			var descriptionPresenter = this.FindName("DescriptionPresenter") as ContentPresenter;
+			if (descriptionPresenter != null)
+			{
+				descriptionPresenter.Visibility = Description != null ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/calendardatepicker_partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/calendardatepicker_partial.cs
@@ -134,7 +134,7 @@ namespace Windows.UI.Xaml.Controls
 					overlayMode = LightDismissOverlayMode;
 					((FlyoutBase)m_tpFlyout).LightDismissOverlayMode = overlayMode;
 				}
-			}						
+			}
 		}
 
 		protected override void OnApplyTemplate()

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -108,6 +108,7 @@ namespace Windows.UI.Xaml.Controls
 
 			UpdateHeaderVisibility();
 			UpdateContentPresenter();
+			UpdateDescriptionVisibility(true);
 
 			if (_contentPresenter != null)
 			{
@@ -268,6 +269,37 @@ namespace Windows.UI.Xaml.Controls
 			if (_headerContentPresenter != null)
 			{
 				_headerContentPresenter.Visibility = headerVisibility;
+			}
+		}
+
+		public
+#if __IOS__ || __MACOS__
+		new
+#endif
+			object Description
+		{
+			get => this.GetValue(DescriptionProperty);
+			set => this.SetValue(DescriptionProperty, value);
+		}
+
+		public static DependencyProperty DescriptionProperty { get; } =
+			DependencyProperty.Register(
+				nameof(Description), typeof(object),
+				typeof(ComboBox),
+				new FrameworkPropertyMetadata(default(object), propertyChangedCallback: (s, e) => (s as ComboBox)?.UpdateDescriptionVisibility(false)));
+
+		private void UpdateDescriptionVisibility(bool initialization)
+		{
+			if (initialization && Description == null)
+			{
+				// Avoid loading DescriptionPresenter element in template if not needed.
+				return;
+			}
+
+			var descriptionPresenter = this.FindName("DescriptionPresenter") as ContentPresenter;
+			if (descriptionPresenter != null)
+			{
+				descriptionPresenter.Visibility = Description != null ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
@@ -32,6 +32,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnLoaded();
 			RegisterSetPasswordScope();
+			UpdateDescriptionVisibility(true);
 		}
 
 		private void RegisterSetPasswordScope()
@@ -121,6 +122,18 @@ namespace Windows.UI.Xaml.Controls
 		partial void OnPasswordChangedPartial(DependencyPropertyChangedEventArgs e);
 
 		#endregion
+
+		public new object Description
+		{
+			get => this.GetValue(DescriptionProperty);
+			set => this.SetValue(DescriptionProperty, value);
+		}
+
+		public static new global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } =
+			Windows.UI.Xaml.DependencyProperty.Register(
+				nameof(Description), typeof(object),
+				typeof(global::Windows.UI.Xaml.Controls.PasswordBox),
+				new FrameworkPropertyMetadata(default(object), propertyChangedCallback: (s, e) => (s as PasswordBox)?.UpdateDescriptionVisibility(false)));
 
 		protected override void OnTextChanged(DependencyPropertyChangedEventArgs e)
 		{
@@ -254,6 +267,21 @@ namespace Windows.UI.Xaml.Controls
 
 					VisualStateManager.GoToState(this, TextBoxConstants.ButtonCollapsedStateName, true);
 				}
+			}
+		}
+
+		private void UpdateDescriptionVisibility(bool initialization)
+		{
+			if (initialization && Description == null)
+			{
+				// Avoid loading DescriptionPresenter element in template if not needed.
+				return;
+			}
+
+			var descriptionPresenter = this.FindName("DescriptionPresenter") as ContentPresenter;
+			if (descriptionPresenter != null)
+			{
+				descriptionPresenter.Visibility = Description != null ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -113,7 +113,7 @@ namespace Windows.UI.Xaml.Controls
 			OnFocusStateChanged((FocusState)FocusStateProperty.GetMetadata(GetType()).DefaultValue, FocusState, initial: true);
 			OnVerticalContentAlignmentChanged(VerticalAlignment.Top, VerticalContentAlignment);
 			OnTextCharacterCasingChanged(CreateInitialValueChangerEventArgs(CharacterCasingProperty, CharacterCasingProperty.GetMetadata(GetType()).DefaultValue, CharacterCasing));
-			OnDescriptionChanged(CreateInitialValueChangerEventArgs(DescriptionProperty, DescriptionProperty.GetMetadata(GetType()).DefaultValue, Description));
+			UpdateDescriptionVisibility(true);
 			var buttonRef = _deleteButton?.GetTarget();
 
 			if (buttonRef != null)
@@ -313,44 +313,33 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		object Description
 		{
-			get => (object)this.GetValue(DescriptionProperty);
-			set
-			{
-				this.SetValue(DescriptionProperty, value);
-			}
+			get => this.GetValue(DescriptionProperty);
+			set => this.SetValue(DescriptionProperty, value);
 		}
 
 		public static DependencyProperty DescriptionProperty { get; } =
 			DependencyProperty.Register(
-				"Description",
+				nameof(Description),
 				typeof(object),
 				typeof(TextBox),
 				new FrameworkPropertyMetadata(
 					defaultValue: null,
-					propertyChangedCallback: (s, e) => ((TextBox)s)?.OnDescriptionChanged(e)
+					propertyChangedCallback: (s, e) => ((TextBox)s)?.UpdateDescriptionVisibility(false)
 				)
 			);
 
-		private void OnDescriptionChanged(DependencyPropertyChangedEventArgs args)
+		private void UpdateDescriptionVisibility(bool initialization)
 		{
-			ContentPresenter descriptionPresenter = this.FindName("DescriptionPresenter") as ContentPresenter;
+			if (initialization && Description == null)
+			{
+				// Avoid loading DescriptionPresenter element in template if not needed.
+				return;
+			}
+
+			var descriptionPresenter = this.FindName("DescriptionPresenter") as ContentPresenter;
 			if (descriptionPresenter != null)
 			{
-				if (args.NewValue != null)
-				{
-					if (args.NewValue is string s && string.IsNullOrWhiteSpace(s))
-					{
-						descriptionPresenter.Visibility = Visibility.Collapsed;
-					}
-					else
-					{
-						descriptionPresenter.Visibility = Visibility.Visible;
-					}
-				}
-				else
-				{
-					descriptionPresenter.Visibility = Visibility.Collapsed;
-				}
+				descriptionPresenter.Visibility = Description != null ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
 		#endregion

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -553,6 +553,7 @@
 						<Grid.RowDefinitions>
 							<RowDefinition Height="Auto" />
 							<RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
 						</Grid.RowDefinitions>
 						<Grid.ColumnDefinitions>
 							<ColumnDefinition Width="*" />
@@ -767,6 +768,13 @@
 										   HorizontalAlignment="Right"
 										   VerticalAlignment="Center"
 										   AutomationProperties.AccessibilityView="Raw" />
+						<ContentPresenter x:Name="DescriptionPresenter"
+										   Grid.Row="2"
+										   Grid.Column="0"
+										   Grid.ColumnSpan="2"
+										   Foreground="{ThemeResource SystemControlDescriptionTextForegroundBrush}"
+										   Content="{TemplateBinding Description}"
+										   x:Load="False"/>
 						<Popup x:Name="Popup">
 							<Border x:Name="PopupBorder"
 									Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
@@ -4428,6 +4436,7 @@
 						<Grid.RowDefinitions>
 							<RowDefinition Height="Auto" />
 							<RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
 						</Grid.RowDefinitions>
 						<Border x:Name="BackgroundElement"
 								Grid.Row="1"
@@ -4486,6 +4495,14 @@
 								FontSize="{TemplateBinding FontSize}"
 								VerticalAlignment="Stretch"
 								MinWidth="34" />
+						<ContentPresenter x:Name="DescriptionPresenter"
+                            Grid.Row="2"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="2"
+                            Content="{TemplateBinding Description}"
+                            Foreground="{ThemeResource SystemControlDescriptionTextForegroundBrush}"
+                            AutomationProperties.AccessibilityView="Raw"
+                            x:Load="False"/>
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -6029,6 +6046,7 @@
 						<Grid.RowDefinitions>
 							<RowDefinition Height="Auto" />
 							<RowDefinition Height="*" />
+							<RowDefinition Height="Auto" />
 						</Grid.RowDefinitions>
 						<Border x:Name="BorderElement"
 							Grid.Row="1"
@@ -6093,7 +6111,13 @@
 							Width="{TemplateBinding Height}"
 							VerticalAlignment="Stretch"
 							AutomationProperties.AccessibilityView="Raw"/>
-
+                        <ContentPresenter x:Name="DescriptionPresenter"
+                            Grid.Row="2"
+                            Grid.ColumnSpan="3"
+                            Content="{TemplateBinding Description}"
+                            x:Load="False"
+                            Foreground="{ThemeResource SystemControlDescriptionTextForegroundBrush}"
+                            AutomationProperties.AccessibilityView="Raw" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -6123,6 +6147,7 @@
 							PlaceholderText="{TemplateBinding PlaceholderText}"
 							Header="{TemplateBinding Header}"
 							Width="{TemplateBinding Width}"
+                            Description="{TemplateBinding Description}"
 							ScrollViewer.BringIntoViewOnFocusChange="False"
 							Canvas.ZIndex="0"
 							Margin="0"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7641

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`Description` not fully supported on all controls that have it.

## What is the new behavior?

- `Description` supported on all controls which have it
- Added UI tests for `Description`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
