### PR TITLE
fix: TextBox positioning and selection on GTK

### DIFF
--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -143,7 +143,7 @@ jobs:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Snaphot_Tests_Group_02'
     JobDisplayName: 'iOS Snaphot Tests Group 02'
-    JobTimeoutInMinutes: 45
+    JobTimeoutInMinutes: 70
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: true
     UITEST_SNAPSHOTS_GROUP: 01

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -6,6 +6,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
+using Windows.UI.Xaml;
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -186,6 +187,79 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			textBox.Select(20, 5);
 			Assert.AreEqual(10, textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_SelectionStart_Set()
+		{
+			var textBox = new TextBox
+			{
+				Text = "0123456789"
+			};
+
+			var button = new Button()
+			{
+				Content = "Some button"
+			};
+
+			var stackPanel = new StackPanel()
+			{
+				Children =
+				{
+					textBox,
+					button
+				}
+			};
+
+			WindowHelper.WindowContent = stackPanel;
+			await WindowHelper.WaitForLoaded(textBox);
+
+			button.Focus(FocusState.Programmatic);
+
+			await WindowHelper.WaitForIdle();
+
+			textBox.SelectionStart = 3;
+
+			textBox.Focus(FocusState.Programmatic);
+			Assert.AreEqual(3, textBox.SelectionStart);
+		}
+
+		[TestMethod]
+		public async Task When_Focus_Changes_SelectionStart_Preserved()
+		{
+			var textBox = new TextBox
+			{
+				Text = "0123456789"
+			};
+
+			var button = new Button()
+			{
+				Content = "Some button"
+			};
+
+			var stackPanel = new StackPanel()
+			{
+				Children =
+				{
+					textBox,
+					button
+				}
+			};
+
+			WindowHelper.WindowContent = stackPanel;
+			await WindowHelper.WaitForLoaded(textBox);
+
+			textBox.Focus(FocusState.Programmatic);
+
+			await WindowHelper.WaitForIdle();
+
+			textBox.SelectionStart = 3;
+
+			button.Focus(FocusState.Programmatic);
+			Assert.AreEqual(3, textBox.SelectionStart);
+
+			textBox.Focus(FocusState.Programmatic);
+			Assert.AreEqual(3, textBox.SelectionStart);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -698,7 +698,10 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var oldValue = FocusState;
 			base.UpdateFocusState(focusState);
-			OnFocusStateChanged(oldValue, focusState, initial: false);
+			if (oldValue != focusState)
+			{
+				OnFocusStateChanged(oldValue, focusState, initial: false);
+			}
 		}
 
 		private void OnFocusStateChanged(FocusState oldValue, FocusState newValue, bool initial)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7644, closes #7643, closes #7209


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Input controls may attempt to add their native controls to UI multiple times in succession, causing critical errors in app log
- Select method causes focus on input fields, which causes issues for `NumberBox`
- Native overlay positioning is not working reliably on GTK


## What is the new behavior?

Fixed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.