### PR TITLE
fix(dragdrop): Fix reordering items with multi-select in LV

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -111,7 +111,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
-		public void When_ReorderWithMultiSelectStartingFromASelectedItem_Down() => Test_ReorderMulti(2, 4);
+		public void When_ReorderWithMultiSelectStartingFromASelectedItem_Down() => Test_ReorderMulti(2, 4, expectedTo: 3);
 
 		[Test]
 		[AutoRetry]
@@ -126,7 +126,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
-		public void When_ReorderWithMultiSelectStartingFromASelectedItem_To_Last() => Test_ReorderMulti(2, 5);
+		public void When_ReorderWithMultiSelectStartingFromASelectedItem_To_Last() => Test_ReorderMulti(2, 5, expectedTo: 4);
 
 		private void Test_Reorder(int from, int to)
 		{
@@ -150,7 +150,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			Assert.IsTrue(op.GetDependencyPropertyValue<string>("Text").Contains("Move"));
 		}
 
-		private void Test_ReorderMulti(int from, int to)
+		private void Test_ReorderMulti(int from, int to, int? expectedTo = null)
 		{
 			Run("UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView", skipInitialScreenshot: true);
 
@@ -163,16 +163,17 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			var x = sutBounds.X + 50;
 			var srcY = Item(sutBounds, from);
 			var dstY = Item(sutBounds, to);
+			var expectedY = expectedTo is null ? dstY : Item(sutBounds, expectedTo.Value);
 
 			_app.TapCoordinates(x, Item(sutBounds, 4)); // We select the 4th item first, as it has to remain after the 2nd
 			_app.TapCoordinates(x, Item(sutBounds, 2));
 			_app.DragCoordinates(x, srcY, x, dstY);
 
 			var result = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
-			if (from is 2 or 4 || to is 2 or 4)
+			if (from is 2 or 4)
 			{
-				ImageAssert.HasColorAt(result, x, dstY, _items[2], tolerance: 10);
-				ImageAssert.HasColorAt(result, x, dstY + _itemHeight, _items[4], tolerance: 10);
+				ImageAssert.HasColorAt(result, x, expectedY, _items[2], tolerance: 10);
+				ImageAssert.HasColorAt(result, x, expectedY + _itemHeight, _items[4], tolerance: 10);
 			}
 			else
 			{

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -59,7 +59,76 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
 		public void When_Reorder_Last_To_First() => Test_Reorder(0, 5);
 
-		public void Test_Reorder(int from, int to)
+
+
+
+
+
+
+
+
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromAnUnselectedItem_Down() => Test_ReorderMulti(1, 3);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromAnUnselectedItem_Up() => Test_ReorderMulti(3, 1);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromAnUnselectedItem_First() => Test_ReorderMulti(0, 2);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromAnUnselectedItem_Last() => Test_ReorderMulti(5, 2);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromAnUnselectedItem_To_First() => Test_ReorderMulti(1, 0);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromAnUnselectedItem_To_Last() => Test_ReorderMulti(3, 5);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromAnUnselectedItem_First_To_Last() => Test_ReorderMulti(0, 5);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromAnUnselectedItem_Last_To_First() => Test_ReorderMulti(0, 5);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromASelectedItem_Down() => Test_ReorderMulti(2, 4);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromASelectedItem_Up() => Test_ReorderMulti(2, 1);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromASelectedItem_To_First() => Test_ReorderMulti(2, 0);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_ReorderWithMultiSelectStartingFromASelectedItem_To_Last() => Test_ReorderMulti(2, 5);
+
+		private void Test_Reorder(int from, int to)
 		{
 			Run("UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView", skipInitialScreenshot: true);
 
@@ -78,6 +147,37 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			var result = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 
 			ImageAssert.HasColorAt(result, x, dstY, _items[from], tolerance: 10);
+			Assert.IsTrue(op.GetDependencyPropertyValue<string>("Text").Contains("Move"));
+		}
+
+		private void Test_ReorderMulti(int from, int to)
+		{
+			Run("UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView", skipInitialScreenshot: true);
+
+			var sut = _app.Marked("SUT");
+			var op = _app.Marked("Operation");
+
+			_app.WaitForElement(sut);
+
+			var sutBounds = _app.Query(sut).Single().Rect;
+			var x = sutBounds.X + 50;
+			var srcY = Item(sutBounds, from);
+			var dstY = Item(sutBounds, to);
+
+			_app.TapCoordinates(x, Item(sutBounds, 4)); // We select the 4th item first, as it has to remain after the 2nd
+			_app.TapCoordinates(x, Item(sutBounds, 2));
+			_app.DragCoordinates(x, srcY, x, dstY);
+
+			var result = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+			if (from is 2 or 4 || to is 2 or 4)
+			{
+				ImageAssert.HasColorAt(result, x, dstY, _items[2], tolerance: 10);
+				ImageAssert.HasColorAt(result, x, dstY + _itemHeight, _items[4], tolerance: 10);
+			}
+			else
+			{
+				ImageAssert.HasColorAt(result, x, dstY, _items[from], tolerance: 10);
+			}
 			Assert.IsTrue(op.GetDependencyPropertyValue<string>("Text").Contains("Move"));
 		}
 	}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView.xaml
@@ -17,11 +17,14 @@
 			CanDragItems="True"
 			CanReorderItems="True"
 			AllowDrop="True"
+			SelectionMode="Multiple"
 			MinHeight="300"
 			x:Name="SUT">
 			<ListView.ItemTemplate>
 				<DataTemplate>
-					<Rectangle Fill="{Binding}" Width="300" Height="100" />
+					<Border Background="{Binding}" Width="300" Height="100">
+						<TextBlock Text="{Binding}" Foreground="Black" />
+					</Border>
 				</DataTemplate>
 			</ListView.ItemTemplate>
 		</ListView>

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -117,15 +117,15 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (ItemsControlFromItemContainer(sender) is ListViewBase that && that.CanDragItems)
 			{
-				var items = that.SelectionMode == ListViewSelectionMode.Multiple || that.SelectionMode == ListViewSelectionMode.Extended
-					? that.SelectedItems.ToList()
-					: new List<object>();
+				// The items contains all selected items ONLY if the draggedItem is selected.
 				var draggedItem = that.ItemFromContainer(sender);
-				if (draggedItem is { } && !items.Contains(draggedItem))
-				{
-					items.Add(draggedItem);
-				}
-
+				var items =
+					draggedItem is null ? new List<object>()
+					: (that.SelectionMode == ListViewSelectionMode.Multiple || that.SelectionMode == ListViewSelectionMode.Extended)
+						&& that.SelectedItems is { Count: > 0 } selected
+						&& selected.Contains(draggedItem)
+						? selected.ToList()
+						: new List<object>(1) { draggedItem };
 				var args = new DragItemsStartingEventArgs(innerArgs, items);
 
 				that.DragItemsStarting?.Invoke(that, args);
@@ -312,6 +312,9 @@ namespace Windows.UI.Xaml.Controls
 					}
 #endif
 				}
+
+				// When moving more than one item (multi-select), we keep their actual order in the list, no matter which one was dragged.
+				movedItems.Sort((it1, it2) => indexOf(it1).CompareTo(indexOf(it2)));
 
 				for (var i = 0; i < movedItems.Count; i++)
 				{

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -231,6 +231,12 @@ namespace Windows.UI.Xaml.Controls
 
 		private void PrepareTouchScroll(object sender, ManipulationStartingRoutedEventArgs e)
 		{
+			if (e.Container != this)
+			{
+				// This gesture is coming from a nested element, we just ignore it!
+				return;
+			}
+
 			if (e.Pointer.Type != PointerDeviceType.Touch)
 			{
 				e.Mode = ManipulationModes.None;
@@ -249,14 +255,22 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		private void UpdateTouchScroll(object sender, ManipulationDeltaRoutedEventArgs e)
-			=> Set(
+		{
+			if (e.Container != this) // No needs to check the pointer type, if the manip is local it's touch, otherwise it was cancelled in starting.
+			{
+				// This gesture is coming from a nested element, we just ignore it!
+				return;
+			}
+
+			Set(
 				horizontalOffset: HorizontalOffset - e.Delta.Translation.X,
 				verticalOffset: VerticalOffset - e.Delta.Translation.Y,
 				isIntermediate: true);
+		}
 
 		private void CompleteTouchScroll(object sender, ManipulationCompletedRoutedEventArgs e)
 		{
-			if ((PointerDeviceType)e.PointerDeviceType != PointerDeviceType.Touch)
+			if (e.Container != this || (PointerDeviceType)e.PointerDeviceType != PointerDeviceType.Touch)
 			{
 				return;
 			}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Managed.cs
@@ -362,7 +362,7 @@ namespace Windows.UI.Xaml
 					}
 					else
 					{
-						var explicitTarget = targets.Find(c => c.Kind == PointerCaptureKind.Explicit)!;
+						var explicitTarget = targets.Find(c => c.Kind.HasFlag(PointerCaptureKind.Explicit))!;
 
 						raise(explicitTarget.Element, routedArgs, BubblingContext.Bubble);
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -338,7 +338,7 @@ namespace Windows.UI.Xaml
 			var that = (UIElement)sender.Owner;
 			that.OnDragStarting(args);
 		};
-				#endregion
+		#endregion
 
 		private GestureRecognizer CreateGestureRecognizer()
 		{
@@ -395,7 +395,7 @@ namespace Windows.UI.Xaml
 				this.Log().Error("Haptic feedback for drag failed", error);
 			}
 		}
-				#endregion
+		#endregion
 		
 		#region Manipulations (recognizer settings / custom bubbling)
 		partial void AddManipulationHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo)
@@ -452,7 +452,7 @@ namespace Windows.UI.Xaml
 			}
 			// Note: We do not need to alter the location of the events, on UWP they are always relative to the OriginalSource.
 		}
-				#endregion
+		#endregion
 
 		#region Gestures (recognizer settings / custom bubbling / early completion)
 		private bool _isGestureCompleted;
@@ -905,7 +905,7 @@ namespace Windows.UI.Xaml
 				// so we should not use them for gesture recognition.
 				var isDragging = _gestures.Value.IsDragging;
 				_gestures.Value.ProcessUpEvent(args.GetCurrentPoint(this), !ctx.IsInternal || isOverOrCaptured);
-				if (isDragging)
+				if (isDragging && !ctx.IsInternal)
 				{
 					global::Windows.UI.Xaml.Window.Current.DragDrop.ProcessDropped(args);
 				}


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/326

## Bugfix
* Drag and drop support on skia
* Drag and drop in SV
* Ordering items with multi-select in LV

## What is the current behavior?
Items are re-ordered using the selection order when multiple items are selected instead of using the current order of items in source list.

## What is the new behavior?
We re-order dragged items before applying the reorder.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
