### PR TITLE
fix: [GTK] Incorrect window ActualWidth and ActualHeight on WSL and Linux

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1001,6 +1001,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\WindowTests\Window_ContentIsFullyVisible.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\NoPhaseBinding_Large.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5085,6 +5089,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\XamlButtonWithClipping_Scrollable.xaml.cs">
       <DependentUpon>XamlButtonWithClipping_Scrollable.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\WindowTests\Window_ContentIsFullyVisible.xaml.cs">
+      <DependentUpon>Window_ContentIsFullyVisible.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\NoPhaseBinding_Large.xaml.cs">
       <DependentUpon>NoPhaseBinding_Large.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_ContentIsFullyVisible.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_ContentIsFullyVisible.xaml
@@ -1,0 +1,29 @@
+﻿<UserControl
+	x:Class="UITests.Windows_UI_Xaml.WindowTests.Window_ContentIsFullyVisible"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml.WindowTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel x:Name="Window_ContentIsFullyVisible_Content" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" BorderBrush="Orange" BorderThickness="1">
+		<!-- Uncomment the following lines and the contents of the SetDiagnosticInfoTextBlocksText method in the code-behind file for diagnostic information if there is a problem. A screenshot should show that this area, including the orange border, has the dimensions noted below as the Scaled ActualWidth and Scaled ActualHeight. If the dimensions do not match or the orange border is not fully visible, there is a problem with how the ActualWidth and ActualHeight values are being calculated internally. Note: If using an emulator, take a screenshot using the emulator's functionality. -->
+		<!--<TextBlock x:Name="ScaledActualWidthTextBlock"
+				   Margin="10" />
+		<TextBlock x:Name="ScaledActualHeightTextBlock"
+				   Margin="10" />
+		<TextBlock x:Name="LogicalDpiTextBlock"
+				   Margin="10" />
+		<TextBlock x:Name="RawPixelsPerViewPixelTextBlock"
+				   Margin="10" />
+		<TextBlock x:Name="ResolutionScaleTextBlock"
+				   Margin="10" />
+		<TextBlock x:Name="ActualWidthTextBlock"
+				   Margin="10" />
+		<TextBlock x:Name="ActualHeightTextBlock"
+				   Margin="10" />-->
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_ContentIsFullyVisible.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_ContentIsFullyVisible.xaml.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+
+using Uno.UI.Samples.Controls;
+
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.Graphics.Display;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml.WindowTests
+{
+	[Sample("Window", Description = "There should be a fully visible orange border.")]
+	public sealed partial class Window_ContentIsFullyVisible : UserControl
+	{
+		public Window_ContentIsFullyVisible()
+		{
+			this.InitializeComponent();
+			Window_ContentIsFullyVisible_Content.SizeChanged += Window_ContentIsFullyVisible_Content_SizeChanged;
+			SetDiagnosticInfoTextBlocksText();
+		}
+
+		private void Window_ContentIsFullyVisible_Content_SizeChanged(object sender, SizeChangedEventArgs args) => SetDiagnosticInfoTextBlocksText();
+
+		private void SetDiagnosticInfoTextBlocksText()
+		{
+			// Diagnostic information that's helpful if this test fails and you want to examine a screenshot to compare the reported size of the content versus its actual size. Remember to uncomment the TextBlocks in the Xaml file.
+
+			//DisplayInformation displayInformation = DisplayInformation.GetForCurrentView();
+			//ScaledActualWidthTextBlock.Text = $"Scaled {nameof(Window_ContentIsFullyVisible_Content.ActualWidth)} = {Window_ContentIsFullyVisible_Content.ActualWidth * displayInformation.RawPixelsPerViewPixel}";
+			//ScaledActualHeightTextBlock.Text = $"Scaled {nameof(Window_ContentIsFullyVisible_Content.ActualHeight)} = {Window_ContentIsFullyVisible_Content.ActualHeight * displayInformation.RawPixelsPerViewPixel}";
+			//LogicalDpiTextBlock.Text = $"{nameof(DisplayInformation.LogicalDpi)} = {displayInformation.LogicalDpi}";
+			//RawPixelsPerViewPixelTextBlock.Text = $"{nameof(DisplayInformation.RawPixelsPerViewPixel)} = {displayInformation.RawPixelsPerViewPixel}";
+			//ResolutionScaleTextBlock.Text = $"{nameof(DisplayInformation.ResolutionScale)} = {displayInformation.ResolutionScale}";
+			//ActualWidthTextBlock.Text = $"{nameof(Window_ContentIsFullyVisible_Content.ActualWidth)} = {Window_ContentIsFullyVisible_Content.ActualWidth}";
+			//ActualHeightTextBlock.Text = $"{nameof(Window_ContentIsFullyVisible_Content.ActualHeight)} = {Window_ContentIsFullyVisible_Content.ActualHeight}";
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -70,7 +70,7 @@ namespace Uno.UI.Runtime.Skia
 			_window = new Gtk.Window("Uno Host");
 			Size preferredWindowSize = ApplicationView.PreferredLaunchViewSize;
 			if (preferredWindowSize != Size.Empty)
-			{ 
+			{
 				_window.SetDefaultSize((int)preferredWindowSize.Width, (int)preferredWindowSize.Height);
 			}
 			else
@@ -121,16 +121,6 @@ namespace Uno.UI.Runtime.Skia
 			Windows.UI.Core.CoreDispatcher.DispatchOverride = Dispatch;
 			Windows.UI.Core.CoreDispatcher.HasThreadAccessOverride = () => _isDispatcherThread;
 
-			_window.Realized += (s, e) =>
-			{
-				WUX.Window.Current.OnNativeSizeChanged(new Windows.Foundation.Size(_window.AllocatedWidth, _window.AllocatedHeight));
-			};
-
-			_window.SizeAllocated += (s, e) =>
-			{
-				WUX.Window.Current.OnNativeSizeChanged(new Windows.Foundation.Size(e.Allocation.Width, e.Allocation.Height));
-			};
-
 			_window.WindowStateEvent += OnWindowStateChanged;
 
 			var overlay = new Overlay();
@@ -142,6 +132,16 @@ namespace Uno.UI.Runtime.Skia
 			overlay.AddOverlay(_fix);
 			_eventBox.Add(overlay);
 			_window.Add(_eventBox);
+
+			_area.Realized += (s, e) =>
+			{
+				WUX.Window.Current.OnNativeSizeChanged(new Windows.Foundation.Size(_area.AllocatedWidth, _area.AllocatedHeight));
+			};
+
+			_area.SizeAllocated += (s, e) =>
+			{
+				WUX.Window.Current.OnNativeSizeChanged(new Windows.Foundation.Size(e.Allocation.Width, e.Allocation.Height));
+			};
 
 			/* avoids double invokes at window level */
 			_area.AddEvents((int)GtkCoreWindowExtension.RequestedEvents);
@@ -166,7 +166,7 @@ namespace Uno.UI.Runtime.Skia
 			var winUIApplication = WUX.Application.Current;
 			var winUIWindow = WUX.Window.Current;
 			var newState = args.Event.NewWindowState;
-			var changedState = args.Event.ChangedMask;			
+			var changedState = args.Event.ChangedMask;
 
 			var isVisible =
 				!(newState.HasFlag(Gdk.WindowState.Withdrawn) ||


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5666 

[ScrollViewer ScrollBar not shown #5666](https://github.com/unoplatform/uno/issues/5666)
which is part of the larger epic
[Skia Rendering Backend Support #4309](https://github.com/unoplatform/uno/issues/4309)

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

In Skia.Gtk, the ActualWidth and ActualHeight of the window are set to the width and height values for the Gtk.Window.

When compiled and run on Windows using Gtk for Windows everything appears correct.

On WSL and Linux, likely specific to Wayland-based windowing, the values for the Gtk.Window's width and height includes the window's title bar and other non client area parts that are outside of the drawable area. This causes the Uno MainWindow to report and do layout, etc., using ActualWidth and ActualHeight values that are larger than they should be.

As a result, content that should be rendering inside the window instead renders past the right and bottom of the window resulting in things such as the scrollbars for the ScrollViewer control or the right and bottom part of the border in the SampleApp included in this pull request to appear to be missing.

## What is the new behavior?

The values for ActualWidth and ActualHeight are taken from the window's drawable area in GtkHost rather than using the window's width and height. Scrollbars for full-window ScrollViewers, full-window Borders, and anything else that is the size of or that is laid out to be on the right side or bottom of the window are now visible on WSL.

I am currently unable to test it on Linux but due to the nature of the change it should fix that as well.

The behavior of Skia.Gtk using Gtk for Windows remains identical to its previous behavior and the bug fix only affects Skia.Gtk so it does not change the behavior of any other platforms, tested and verified on UWP, Skia.Wpf, WASM, and Android.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit documentation template (for bug fixes / features)
- [x] Unit Tests and/or UI Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the automatic close keywords.
- [x] Commits must be following the Conventional Commits specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
I'm not sure if fixing rendering to be correct would be considered a breaking change. It's possible that someone has written code to work around this issue. If so, the result of this change would be that their application would most likely end up having empty space at the right side and bottom of the window rather than filling it. That is what would have happened to mine if I had decided to implement a workaround rather than create this fix.

The change won't cause code that compiles to fail to compile. It's possible that for some users the visual result would be as I described. It's highly unlikely that it would cause a program to crash at runtime unless someone wrote a work around and failed to write adequate error checking as part of it.

As such, I marked that this has no breaking changes. The migration path, if it is breaking, would be for affected users to remove their custom code that currently does rendering adjustment for Gtk.WSL, Gtk.Linux, and any other Gtk + Wayland/etc. combination and simply use the code they use for all other platforms they support since the behavior will now conform to the current behavior of all other platforms.

## Other information

<!-- Please provide any additional information if necessary -->
The UI test is in the SampleApp at: Window -> Window_ContentIsFullyVisible.

When testing, note that unlike with this fix where there is some padding between the edge of the window and the Border of the StackPanel, UWP renders the border right against the edge of the window. However, Skia.Gtk WSL, Skia.Gtk Gtk for Windows, Skia.Wpf, WASM, and Android, which are the platforms I tested this on, also have some amount of padding between the edge of their window/screen and the border. So while the behavior is different than UWP, it's different in the same way that all of those other platforms are different, and thus is unrelated to this bug fix.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
