### PR TITLE
fix(popup): not working after alt-tabbing

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1589,6 +1589,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyout_DroidAltTab.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyout_IosNative.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5456,6 +5460,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyoutItem_Hierarchy.xaml.cs">
       <DependentUpon>MenuFlyoutItem_Hierarchy.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyout_DroidAltTab.xaml.cs">
+      <DependentUpon>MenuFlyout_DroidAltTab.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyout_IosNative.xaml.cs">
       <DependentUpon>MenuFlyout_IosNative.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_DroidAltTab.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_DroidAltTab.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests.MenuFlyout_DroidAltTab"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:android="http://uno.ui/android"
+			 mc:Ignorable="d android"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+	<Grid>
+		<CommandBar Content="asd" Style="{StaticResource NativeDefaultCommandBar}">
+			<CommandBar.PrimaryCommands>
+				<AppBarButton Content="Here">
+					<AppBarButton.Flyout>
+						<MenuFlyout android:UseNativePopup="True">
+							<MenuFlyoutItem Text="asd1" />
+							<MenuFlyoutItem Text="asd2" />
+							<MenuFlyoutItem Text="asd3" />
+						</MenuFlyout>
+					</AppBarButton.Flyout>
+				</AppBarButton>
+			</CommandBar.PrimaryCommands>
+		</CommandBar>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_DroidAltTab.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyout_DroidAltTab.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests
+{
+	[Uno.UI.Samples.Controls.SampleControlInfo("MenuFlyout", nameof(MenuFlyout_DroidAltTab), description: Description, IsManualTest = true, IgnoreInSnapshotTests = true)]
+	public sealed partial class MenuFlyout_DroidAltTab : UserControl
+	{
+		private const string Description = "[ManualTest]: tap 'Here' to open popup, switch app/go to home and come back, tap `Here` and popup should still work.";
+
+		public MenuFlyout_DroidAltTab()
+		{
+			this.InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/nventive-private#306

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Once a popup has been initialized (when it is first shown) and you alt-tab out the app and comes back,
this popup can no longer be opened again:
> Java.Lang.RuntimeException: 'Unable to add window -- token null is not valid; is your activity running?'

## What is the new behavior?

It should work now.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

The `PopupWindow` was previously created using the current instance of AppBarButton as the context provider, 
however that provided context becomes stale once you alt-tab out and back to the app. 
Trying to show a popup on a, now, stale context will not work, hence the error:
> Java.Lang.RuntimeException: 'Unable to add window -- token null is not valid; is your activity running?'

Internal Issue (If applicable):
unoplatform/nventive-private#306