### PR TITLE
fix: [iOS] Do not clear text on next key stroke after reveal

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
@@ -18,7 +18,9 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private SinglelineTextBoxDelegate _delegate;
 		private readonly WeakReference<TextBox> _textBox;
-		private readonly SerialDisposable _foregroundChanged = new SerialDisposable();
+		private readonly SerialDisposable _foregroundChanged = new();
+
+		private string _restoreOnNextKeyStroke;
 
 		public SinglelineTextBoxView(TextBox textBox)
 		{
@@ -28,27 +30,52 @@ namespace Windows.UI.Xaml.Controls
 			Initialize();
 		}
 
-		private void OnEditingChanged(object sender, EventArgs e)
+		/// <inheritdoc />
+		public override bool SecureTextEntry
 		{
-			OnTextChanged();
+			get => base.SecureTextEntry;
+			set
+			{
+				if (base.SecureTextEntry != value)
+				{
+					if (value)
+					{
+						// When we enable the "secure" mode, iOS will auto-magically clear the value on next key stroke
+						// (Without invoking the "ShouldClear" nor any callback except "DidChangeSelection" multiple times).
+						// The only way is to keep ref of the current text and restore it on next text change (expected to be an empty string).
+						_restoreOnNextKeyStroke = base.Text;
+					}
+
+					base.SecureTextEntry = value;
+				}
+			}
 		}
 
 		public override string Text
 		{
-			get
-			{
-				return base.Text;
-			}
-
+			get => base.Text;
 			set
 			{
 				// The native control will ignore a value of null and retain an empty string. We coalesce the null to prevent a spurious empty string getting bounced back via two-way binding.
-				value = value ?? string.Empty;
+				value ??= string.Empty;
 				if (base.Text != value)
 				{
 					base.Text = value;
 					OnTextChanged();
 				}
+			}
+		}
+
+		private void OnEditingChanged(object sender, EventArgs e)
+		{
+			if (_restoreOnNextKeyStroke is { Length: > 0 } text)
+			{
+				base.Text = text + base.Text;
+				_restoreOnNextKeyStroke = default;
+			}
+			else
+			{
+				OnTextChanged();
 			}
 		}
 


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/7400

## Bugfix
Text is cleared on first key stroke after reveal

## What is the current behavior?
When we press the reveal button of a `PasswordBox` we toggle the `SecureTextEntry` flag on the native `UITextField`. Doing this, on next key-stroke the system we clear the current text before inserting the new text.

## What is the new behavior?
When we detect a such behavior, we manually restore the text before.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
