### PR TITLE
[GitHub] Add regression report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/regression-report.yml
+++ b/.github/ISSUE_TEMPLATE/regression-report.yml
@@ -1,0 +1,124 @@
+name: Regression Report
+description: Report a regression encountered while developing with Uno
+labels: [kind/regression, triage/untriaged, difficulty/tbd]
+body:
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: Describe how the issue manifests
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what the desired behavior should be.
+  - type: textarea
+    id: how-to-reproduce
+    attributes:
+      label: How to reproduce it (as minimally and precisely as possible)
+      description: |
+                    Please provide a **MINIMAL REPRO PROJECT** and the **STEPS TO REPRODUCE**
+
+                    To create a minimal reproduction project:
+
+                    - Create an Uno app through:
+                    - `dotnet new --install Uno.ProjectTemplates.Dotnet` and `dotnet new unoapp`
+                    - or through the [Visual Studio extension](https://platform.uno/docs/articles/get-started-vs.html)
+                    - Make sure to add the least code possible to demonstrate the issue
+                    - Keep all project heads, even if the platforms are seemingly not relevant to your issue
+                    - Remove all the `obj/bin` folders and zip the folder.
+                    - Attach the zip file to the issue
+
+                    If the issue is visible on WebAssembly and uses only XAML:
+
+                    - Visit https://playground.platform.uno
+                    - Add your code and data context as needed
+                    - Create a link and paste it here
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Workaround
+      description: Please provide steps to workaround this problem if possible
+  - type: dropdown
+    id: works-uwp-winui
+    attributes:
+      label: Works on UWP/WinUI
+      description: |
+                    To make sure this is an Uno Platform specific issue, try running your sample application on Windows using the UWP or WinUI project. If it does not work on Windows either, it may be a Windows issue or it may be a documentation issue.
+                    In this case, [open a discussion](https://github.com/unoplatform/uno/discussions) instead.
+      options:
+        - 'Yes'
+        - 'No'
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: NuGet package(s)
+      multiple: true
+      options:
+        - Uno.UI / Uno.UI.WebAssembly / Uno.UI.Skia
+        - Uno.WinUI / Uno.WinUI.WebAssembly / Uno.WinUI.Skia
+        - Uno.SourceGenerationTasks
+        - Uno.UI.RemoteControl / Uno.WinUI.RemoteControl
+        - Other
+
+  - type: textarea
+    id: version-with-issue
+    attributes:
+      label: Version with issue
+
+  - type: textarea
+    id: last-known-working-version
+    attributes:
+      label: Last known working version
+
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Affected platforms
+      multiple: true
+      options:
+        - iOS
+        - Android
+        - WebAssembly
+        - WebAssembly renderers for Xamarin.Forms
+        - macOS
+        - Skia (WPF)
+        - Skia (GTK on Linux/macOS/Windows)
+        - Skia (Tizen)
+        - Windows
+        - Build tasks
+        - Solution Templates
+
+  - type: dropdown
+    id: ide
+    attributes:
+      label: IDE
+      multiple: true
+      options:
+        - Visual Studio 2022
+        - Visual Studio 2019
+        - Visual Studio 2017
+        - Visual Studio for Mac
+        - Rider Windows
+        - Rider macOS
+        - Visual Studio Code
+
+  - type: input
+    id: ide-version
+    attributes:
+      label: IDE version
+
+  - type: textarea
+    id: plugins
+    attributes:
+      label: Relevant plugins
+      description: For example, ReSharper version X
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Anything else we need to know?
+      description: We would love to know of any friction, apart from knowledge, that prevented you from sending in a pull-request


### PR DESCRIPTION
GitHub Issue (If applicable): 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Other... GitHub issue template

## What is the current behavior?

No way to specifically report regressions.

## What is the new behavior?

New template for `kind/regression` with additional field for last working version and version with issue.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.