### PR TITLE
fix: Use wss for RemoteControlClient when on https

### DIFF
--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Uno.Extensions;
+using Uno.Foundation;
 using Uno.Foundation.Logging;
 using Uno.UI.RemoteControl.Helpers;
 using Uno.UI.RemoteControl.HotReload;
@@ -74,6 +75,7 @@ namespace Uno.UI.RemoteControl
 		{
 			try
 			{
+				var isHttps = WebAssemblyRuntime.InvokeJS("window.location.protocol == 'https:'").ToLower() == "true";
 				async Task<(Uri endPoint, WebSocket socket)> Connect(string endpoint, int port, CancellationToken ct)
 				{
 					var s = new ClientWebSocket();
@@ -109,6 +111,10 @@ namespace Uno.UI.RemoteControl
 						}
 						else
 						{
+							if (isHttps)
+							{
+								return new Uri($"wss://{endpoint}:{port}/rc");
+							}
 							return new Uri($"ws://{endpoint}:{port}/rc");
 						}
 					}

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -75,7 +75,11 @@ namespace Uno.UI.RemoteControl
 		{
 			try
 			{
+#if __WASM__
 				var isHttps = WebAssemblyRuntime.InvokeJS("window.location.protocol == 'https:'").ToLower() == "true";
+#else
+				const bool isHttps = false;
+#endif
 				async Task<(Uri endPoint, WebSocket socket)> Connect(string endpoint, int port, CancellationToken ct)
 				{
 					var s = new ClientWebSocket();
@@ -111,11 +115,8 @@ namespace Uno.UI.RemoteControl
 						}
 						else
 						{
-							if (isHttps)
-							{
-								return new Uri($"wss://{endpoint}:{port}/rc");
-							}
-							return new Uri($"ws://{endpoint}:{port}/rc");
+							var scheme = isHttps ? "wss" : "ws";
+							return new Uri($"{scheme}://{endpoint}:{port}/rc");
 						}
 					}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When on https: only wss: connections are allowed, but we try to perform ws: connections

## What is the new behavior?

Uses wss: when https: is used.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
