### PR TITLE
fix: Avoid FocusManager usage before WASM app is fully initialized

### DIFF
--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -130,7 +130,9 @@ namespace Windows.UI.Xaml.Input
 			{
 				// This might occur if a non-Uno element receives focus
 				var focusManager = VisualTree.GetFocusManagerForElement(Window.Current.RootElement);
-				focusManager.ClearFocus();
+
+				// The focus manager may be null if JS raises focusin/blur before the app is initialized.
+				focusManager?.ClearFocus();
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7676, closes #7406

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`FocusManager` may be used before the app is initialized, which causes NRE.

## What is the new behavior?

Avoiding usage of `FocusManager` before the app is fully initialized.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.