### PR TITLE
feat: more detailed GeoLocator UI test

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -16,8 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
-		<AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-		<AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\SamplesApp.Shared\Strings</ResourcesDirectory>
     <AndroidUseAapt2>true</AndroidUseAapt2>

--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -16,6 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\SamplesApp.Shared\Strings</ResourcesDirectory>

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/GeolocatorTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/GeolocatorTests.xaml
@@ -23,6 +23,8 @@
 			</TextBlock>
 
 			<TextBox Margin="0,12,0,0" Header="Desired accuracy in meters" Text="{Binding DesiredAccuracyInMeters, Mode=TwoWay}" />
+			<TimePicker Name="uiMaxCacheTime" ClockIdentifier="24HourClock" Header="Max cache time (mm:ss)" SelectedTime="{Binding maximumAge, Mode=TwoWay}" />
+			<TimePicker Name="uiTimeout" ClockIdentifier="24HourClock" Header="Timeout (mm:ss)" SelectedTime="{Binding timeout, Mode=TwoWay}" />
 
 			<Button Margin="0,12,0,0" Command="{Binding GetGeopositionCommand}">Get geoposition</Button>
 			<local:GeopositionDisplayControl Geoposition="{x:Bind ViewModel.Geoposition, Mode=OneWay}" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #
related: #2536, #5349
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Current test checks only GetGeopositionAsync(), without timeout and maximumAge parameters.

## What is the new behavior?
Test can check also timeout and maximumAge parameters


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
 This modified test can prove that current implementation of  GetGeopositionAsync(maximumAge, timeout) for Android platform is erroneously (it ignores both parameteras), and maybe this test would be reminder of promise about "fast track" for #2536 (promise given in July 2021).

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
