### PR TITLE
docs: update get-started.md

### DIFF
--- a/doc/articles/get-started.md
+++ b/doc/articles/get-started.md
@@ -76,4 +76,8 @@ You can use **Visual Studio for Mac**, **JetBrains Rider**, or **Visual Studio C
 |---------------------------------------------------|------------------------|---------|-----|-------------------|-------|-------|------------------|-----------------------|
 | [**VS Code**](get-started-vscode.md)              | ❌                    | ❌      | ❌  | ✔️                | ❌  | ✔️   | ✔️              | ❌                    |
 | [**Codespaces / Gitpod**](get-started-vscode.md)  | ❌                    | ❌      | ❌  | ✔️                | ❌  | ✔️   | ✔️              | ✔️                    |
-| [**JetBrains Rider**](get-started-rider.md)       | ❌                    | ✔️      | ❌  | ✔️                | ❌  | ✔️   | ✔️              | ❌                    |
+| [**JetBrains Rider**](get-started-rider.md)       | ❌                    | ❌†      | ❌  | ✔️                | ❌  | ✔️   | ✔️              | ❌                    |
+
+† Notes:
+
+* **Android** on Linux: Xamarin.Android does not natively support linux development. Rider has been capable of Android development on Linux in the past, but [previous directions are considered obsolete.](https://rider-support.jetbrains.com/hc/en-us/articles/360000557259--Obsolete-How-to-develop-Xamarin-Android-applications-on-Linux-with-Rider) As of this comment (3 Nov 2021) [Xamarin Android builds on linux fail](https://github.com/xamarin/xamarin-android).


### PR DESCRIPTION
docs: update status of Jetbrains Rider development for Android on linux. Keeps in line with changes to master/doc/articles/get-started-rider.md

GitHub Issue (If applicable): closes #

syncing docs with previous pull request Update get-started-rider.md #7429

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

documentation update


## What is the new behavior?

documentation update


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
