### PR TITLE
fix: Ensure that AppBarToggleButton's base.OnPropertyChanged is called

### DIFF
--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
@@ -4591,6 +4591,59 @@ namespace Windows.UI.Tests.Enterprise
 			await TestServices.WindowHelper.WaitForIdle();
 		}
 
+		[TestMethod]
+		[Description("Validates that setting IsChecked on an AppBarToggleButton programatically will still result in the same visual effect")]
+		public async Task ValidateAppBarToggleButtonIsCheckedProgramatically()
+		{
+			TestCleanupWrapper cleanup;
+
+			CommandBar root = null;
+			AppBarToggleButton button = null;
+
+			await RunOnUIThread(() =>
+			{
+				root = (CommandBar)XamlReader.Load(@"
+					
+                            <CommandBar xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+                                <AppBarToggleButton x:Name=""button""/>
+                            </CommandBar>
+				");
+
+				button = (AppBarToggleButton)root.FindName("button");
+
+				SetWindowContent(root);
+			});
+			await WindowHelper.WaitForIdle();
+
+			await OpenCommandBar(root, OpenMethod.Programmatic);
+
+			await WindowHelper.WaitForIdle();
+
+			await RunOnUIThread(() =>
+			{
+				button = (AppBarToggleButton)root.FindName("button");
+			});
+
+			await RunOnUIThread(async () =>
+			{
+				VERIFY_IS_TRUE(await ControlHelper.IsInVisualState(button, "CommonStates", "Normal"));
+			});
+			await WindowHelper.WaitForIdle();
+
+			await RunOnUIThread(() =>
+			{
+				button.IsChecked = true;
+			});
+			await WindowHelper.WaitForIdle();
+
+			await RunOnUIThread(async () =>
+			{
+				VERIFY_IS_TRUE(await ControlHelper.IsInVisualState(button, "CommonStates", "Checked"));
+			});
+			await WindowHelper.WaitForIdle();
+		}
+
+
 		private async Task ValidateDynamicOverflowOrderWorker(CommandBar cmdBar, DynamicOverflowOrderTest orderTestCase)
 		{
 			await OpenCommandBar(cmdBar, OpenMethod.Programmatic);

--- a/src/Uno.UI/UI/Xaml/Controls/AppBar/AppBarToggleButton.Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AppBar/AppBarToggleButton.Partial.cs
@@ -101,6 +101,7 @@ namespace Windows.UI.Xaml.Controls
 
 		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
 		{
+			base.OnPropertyChanged2(args);
 			OnPropertyChanged(args);
 		}
 


### PR DESCRIPTION
closes 7703


## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Setting IsChecked programatically on an AppBarToggleButton does not change its VisualState

## What is the new behavior?

Setting IsChecked programatically on an AppBarToggleButton does change its VisualState


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
