### PR TITLE
fix(dragdrop): Reordering item out of LV items bounds

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -52,17 +52,17 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_Reorder_To_Last_2() => Test_Reorder(3, 6 /* out of range */, expectedTo: 5);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
 		public void When_Reorder_First_To_Last() => Test_Reorder(0, 5);
 
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
 		public void When_Reorder_Last_To_First() => Test_Reorder(0, 5);
-
-
-
-
-
 
 
 
@@ -128,7 +128,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
 		public void When_ReorderWithMultiSelectStartingFromASelectedItem_To_Last() => Test_ReorderMulti(2, 5, expectedTo: 4);
 
-		private void Test_Reorder(int from, int to)
+		private void Test_Reorder(int from, int to, int? expectedTo = null)
 		{
 			Run("UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView", skipInitialScreenshot: true);
 
@@ -141,12 +141,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			var x = sutBounds.X + 50;
 			var srcY = Item(sutBounds, from);
 			var dstY = Item(sutBounds, to);
+			var expectedY = expectedTo is null ? dstY : Item(sutBounds, expectedTo.Value);
 
 			_app.DragCoordinates(x, srcY, x, dstY);
 
 			var result = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 
-			ImageAssert.HasColorAt(result, x, dstY, _items[from], tolerance: 10);
+			ImageAssert.HasColorAt(result, x, expectedY, _items[from], tolerance: 10);
 			Assert.IsTrue(op.GetDependencyPropertyValue<string>("Text").Contains("Move"));
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -64,10 +64,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
 		public void When_Reorder_Last_To_First() => Test_Reorder(0, 5);
 
-
-
-
-
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
@@ -128,6 +124,26 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
 		public void When_ReorderWithMultiSelectStartingFromASelectedItem_To_Last() => Test_ReorderMulti(2, 5, expectedTo: 4);
 
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_Reorder_OnTopPadding() => Test_ReorderWithPadding(null, 5, 0);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_Reorder_OnBottomPadding() => Test_ReorderWithPadding(null, -5, 5);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_Reorder_OnLeftPadding() => Test_ReorderWithPadding(5, null, 1);
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_Reorder_OnRightPadding() => Test_ReorderWithPadding(-5, null, 4);
+
 		private void Test_Reorder(int from, int to, int? expectedTo = null)
 		{
 			Run("UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView", skipInitialScreenshot: true);
@@ -181,6 +197,45 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 				ImageAssert.HasColorAt(result, x, dstY, _items[from], tolerance: 10);
 			}
 			Assert.IsTrue(op.GetDependencyPropertyValue<string>("Text").Contains("Move"));
+		}
+
+		private void Test_ReorderWithPadding(float? relativeX, float? relativeY, int expectedTo)
+		{
+			Run("UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView_WithPadding", skipInitialScreenshot: true);
+
+			var sut = _app.Marked("SUT");
+			var result = _app.Marked("Result");
+
+			_app.WaitForElement(sut);
+
+			const int itemSize = 50;
+			const int movedItem = 3; // 4th item
+
+			var sutBounds = _app.Query(sut).Single().Rect;
+			var srcX = sutBounds.X + 50 /* Left padding */ + 100 /* Over element */;
+			var srcY = sutBounds.Y + 50 /* Top padding */ + itemSize * movedItem;
+			var dstX = relativeX.HasValue
+				? (relativeX.Value >= 0 ? sutBounds.X + relativeX.Value : sutBounds.Right + relativeX.Value)
+				: srcX;
+			var dstY  = relativeY.HasValue
+				? (relativeY.Value >= 0 ? sutBounds.Y + relativeY.Value : sutBounds.Bottom + relativeY.Value)
+				: sutBounds.Y + 50 + itemSize * expectedTo;
+			
+			_app.DragCoordinates(srcX, srcY, dstX, dstY);
+
+			var expectedOrder = GetExpected();
+			var actualOrder = result.GetDependencyPropertyValue<string>("Text");
+
+			Assert.AreEqual(expectedOrder, actualOrder);
+
+			string GetExpected()
+			{
+				var items = _items.ToList();
+				items.RemoveAt(movedItem);
+				items.Insert(expectedTo, _items[movedItem]);
+
+				return string.Join(";", items);
+			}
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -127,22 +127,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
-		public void When_Reorder_OnTopPadding() => Test_ReorderWithPadding(null, 5, 0);
+		public void When_Reorder_OnTopPadding() => Test_ReorderWithPadding(null, 25, 0);
 
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
-		public void When_Reorder_OnBottomPadding() => Test_ReorderWithPadding(null, -5, 5);
+		public void When_Reorder_OnBottomPadding() => Test_ReorderWithPadding(null, -25, 5);
 
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
-		public void When_Reorder_OnLeftPadding() => Test_ReorderWithPadding(5, null, 1);
+		public void When_Reorder_OnLeftPadding() => Test_ReorderWithPadding(25, null, 1);
 
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
-		public void When_Reorder_OnRightPadding() => Test_ReorderWithPadding(-5, null, 4);
+		public void When_Reorder_OnRightPadding() => Test_ReorderWithPadding(-25, null, 4);
 
 		private void Test_Reorder(int from, int to, int? expectedTo = null)
 		{
@@ -209,7 +209,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			_app.WaitForElement(sut);
 
 			const int itemSize = 50;
-			const int movedItem = 3; // 4th item
+			const int movedItem = 4; // 4th item
 
 			var sutBounds = _app.Query(sut).Single().Rect;
 			var srcX = sutBounds.X + 50 /* Left padding */ + 100 /* Over element */;
@@ -219,7 +219,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 				: srcX;
 			var dstY  = relativeY.HasValue
 				? (relativeY.Value >= 0 ? sutBounds.Y + relativeY.Value : sutBounds.Bottom + relativeY.Value)
-				: sutBounds.Y + 50 + itemSize * expectedTo;
+				: sutBounds.Y + 50 + itemSize * (expectedTo + 1) + 25;
 			
 			_app.DragCoordinates(srcX, srcY, dstX, dstY);
 
@@ -231,8 +231,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			string GetExpected()
 			{
 				var items = _items.ToList();
-				items.RemoveAt(movedItem);
-				items.Insert(expectedTo, _items[movedItem]);
+				items.RemoveAt(movedItem - 1);
+				items.Insert(expectedTo, _items[movedItem - 1]);
 
 				return string.Join(";", items);
 			}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -132,16 +132,19 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		[Ignore("https://github.com/unoplatform/Uno.UITest/pull/35")]
 		public void When_Reorder_OnBottomPadding() => Test_ReorderWithPadding(null, -25, 5);
 
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		[Ignore("https://github.com/unoplatform/Uno.UITest/pull/35")]
 		public void When_Reorder_OnLeftPadding() => Test_ReorderWithPadding(25, null, 1);
 
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		[Ignore("https://github.com/unoplatform/Uno.UITest/pull/35")]
 		public void When_Reorder_OnRightPadding() => Test_ReorderWithPadding(-25, null, 4);
 
 		private void Test_Reorder(int from, int to, int? expectedTo = null)

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -793,6 +793,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_ListView_WithPadding.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_Nested.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4966,6 +4970,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_ListView_Custom_States.xaml.cs">
       <DependentUpon>DragDrop_ListView_Custom_States.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_ListView_WithPadding.xaml.cs">
+      <DependentUpon>DragDrop_ListView_WithPadding.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_Nested.xaml.cs">
       <DependentUpon>DragDrop_Nested.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView_WithPadding.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView_WithPadding.xaml
@@ -1,0 +1,40 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView_WithPadding"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.DragAndDrop"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<ListView
+			x:Name="SUT"
+			CanDragItems="True"
+			CanReorderItems="True"
+			AllowDrop="True"
+			SelectionMode="None"
+			MinHeight="300"
+			Padding="50"
+			Margin="50"
+			BorderBrush="DarkGray"
+			BorderThickness="2"
+			Background="Gray">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<Border Background="{Binding}" Width="300" Height="50">
+						<TextBlock Text="{Binding}" Foreground="Black" />
+					</Border>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+
+		<TextBlock x:Name="Result" Text="--none--" Grid.Row="1" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView_WithPadding.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView_WithPadding.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Android.Gms.Common.Util;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml.DragAndDrop
+{
+	[Sample("DragAndDrop", "ListView",
+		Description = "This automated tests validate that items reordering in ListView which has padding is working properly, including when dragging over that padding.",
+		IgnoreInSnapshotTests = true)]
+	public sealed partial class DragDrop_ListView_WithPadding : Page
+	{
+		public DragDrop_ListView_WithPadding()
+		{
+			this.InitializeComponent();
+
+			var source = new ObservableCollection<string>
+			{
+				"#FF0018",
+				"#FFA52C",
+				"#FFFF41",
+				"#008018",
+				"#0000F9",
+				"#86007D"
+			};
+
+			source.CollectionChanged += (snd, e) => Dump();
+
+			SUT.ItemsSource = source;
+			Dump();
+
+			void Dump()
+				=> Result.Text = string.Join(";", source);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView_WithPadding.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView_WithPadding.xaml.cs
@@ -2,7 +2,6 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using Windows.UI.Xaml.Controls;
-using Android.Gms.Common.Util;
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Windows_UI_Xaml.DragAndDrop

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
@@ -74,7 +74,7 @@ namespace Windows.UI.Xaml.Shapes
 				_currentState = newState;
 			}
 
-			return newState.BoundsPath;
+			return newState.BoundsPath; // Will be null if not updated !!!
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -192,7 +192,7 @@ namespace Windows.UI.Xaml.Controls
 			var container = dragEventArgs.DataView.FindRawData(ReorderContainerFormatId) as FrameworkElement; // TODO: This might have changed/been recycled if scrolled 
 			if (that is null || src is null || item is null || container is null || src != that)
 			{
-				dragEventArgs.Log().Warn("Invalid reorder event.");
+				if (dragEventArgs.Log().IsEnabled(LogLevel.Warning)) dragEventArgs.Log().Warn("Invalid reorder event.");
 				dragEventArgs.AcceptedOperation = DataPackageOperation.None;
 
 				return;
@@ -222,7 +222,7 @@ namespace Windows.UI.Xaml.Controls
 			var src = dragEventArgs.DataView.FindRawData(ReorderOwnerFormatId) as ListView;
 			if (that is null || src != that)
 			{
-				dragEventArgs.Log().Warn("Invalid reorder event.");
+				if (dragEventArgs.Log().IsEnabled(LogLevel.Warning)) dragEventArgs.Log().Warn("Invalid reorder event.");
 
 				return;
 			}
@@ -242,7 +242,7 @@ namespace Windows.UI.Xaml.Controls
 			var container = dragEventArgs.DataView.FindRawData(ReorderContainerFormatId) as FrameworkElement; // TODO: This might have changed/been recycled if scrolled 
 			if (that is null || src is null || item is null || container is null || src != that)
 			{
-				dragEventArgs.Log().Warn("Invalid reorder event.");
+				if (dragEventArgs.Log().IsEnabled(LogLevel.Warning)) dragEventArgs.Log().Warn("Invalid reorder event.");
 
 				return;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Stub.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Stub.cs
@@ -18,6 +18,8 @@ namespace Windows.UI.Xaml.Controls
 		internal void UpdateReorderingItem(Point location, FrameworkElement element, object item) { }
 
 		internal Uno.UI.IndexPath? CompleteReorderingItem(FrameworkElement element, object item) => null;
+
+		internal void CleanupReordering() { }
 	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -1597,7 +1597,7 @@ namespace Windows.UI.Xaml.Controls
 					var distance = ((Rect)layoutAttributes.Frame).GetDistance(adjustedPoint);
 					if (distance == 0)
 					{
-						// Fats path: we found the element that is under the element
+						// Fast path: we found the element that is under the element
 						return layoutAttributes;
 					}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -1062,6 +1062,13 @@ namespace Windows.UI.Xaml.Controls
 			LightRefresh();
 		}
 
+		internal void CleanupReordering()
+		{
+			_pendingReorder = null;
+
+			LightRefresh();
+		}
+
 		internal Uno.UI.IndexPath? CompleteReorderingItem(FrameworkElement element, object item)
 		{
 			var updatedIndex = default(Uno.UI.IndexPath?);

--- a/src/Uno.UI/UI/Xaml/DragDrop/DropUITarget.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DropUITarget.cs
@@ -15,6 +15,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
+using Uno.UI.Extensions;
 
 namespace Windows.UI.Xaml
 {
@@ -61,18 +62,19 @@ namespace Windows.UI.Xaml
 				var target = await UpdateTarget(dragInfo, dragUIOverride, ct);
 				if (!target.HasValue)
 				{
+					dragUIOverride.Clear(); // For safety only, this should have already de done in the 'UpdateTarget' if needed.
 					return DataPackageOperation.None;
 				}
 
 				var (element, args) = target.Value;
-				element.RaiseDragEnterOrOver(args);
+				(args.OriginalSource as UIElement)!.RaiseDragEnterOrOver(args);
 
 				if (args.Deferral is { } deferral)
 				{
 					await deferral.Completed(ct);
 				}
 
-				UpdateState(args);
+				UpdateState(element, args);
 
 				return args.AcceptedOperation;
 			});
@@ -108,8 +110,8 @@ namespace Windows.UI.Xaml
 					return DataPackageOperation.None;
 				}
 
-				var (element, args) = target.Value;
-				element.RaiseDrop(args);
+				(_, var args) = target.Value;
+				(args.OriginalSource as UIElement)!.RaiseDrop(args);
 
 				if (args.Deferral is { } deferral)
 				{
@@ -119,7 +121,7 @@ namespace Windows.UI.Xaml
 				return args.AcceptedOperation;
 			});
 
-		private async Task<(UIElement element, global::Windows.UI.Xaml.DragEventArgs args)?> UpdateTarget(
+		private async Task<(UIElement dropTarget, global::Windows.UI.Xaml.DragEventArgs args)?> UpdateTarget(
 			CoreDragInfo dragInfo,
 			CoreDragUIOverride? dragUIOverride,
 			CancellationToken ct)
@@ -150,15 +152,29 @@ namespace Windows.UI.Xaml
 				{
 					await deferral.Completed(ct);
 				}
+
+				// Note: We don't clear the 'dragUIOverride' here as even if we are leaving some UI elements,
+				//		 the 'dropTarget' (computed below) might still be the same.
 			}
 
 			if (target.element is null)
 			{
+				// When we don't find any target, we should make sure to reset the uiOverride data
+				// as it's the same instance which is re-used by the DragOperation (like UWP).
+				dragUIOverride?.Clear();
+
 				return null;
 			}
 
+			// We search here for the real drop target in order to properly associate the 'state' to the element that effectively allows the drop,
+			// so we won't reset 'state' and clear 'dragUiOverride' when we are only moving from a nested element to another of the same 'dropTarget'.
+			// (like from a LVItem to another one from the same LV).
+			var dropTarget = target.element.FindFirstParent<UIElement>(elt => elt.AllowDrop, includeCurrent: true);
+			global::System.Diagnostics.Debug.Assert(dropTarget is not null);
+			dropTarget ??= target.element; // Safety only!
+
 			DragEventArgs args;
-			if (target.element is {} && _pendingDropTargets.TryGetValue(target.element, out var state))
+			if (_pendingDropTargets.TryGetValue(dropTarget, out var state))
 			{
 				args = new DragEventArgs(target.element!, dragInfo, state.uiOverride)
 				{
@@ -167,15 +183,20 @@ namespace Windows.UI.Xaml
 			}
 			else
 			{
+				// When we reach a new target UI element, we should make sure to reset the uiOverride data
+				// as it's the same instance which is re-used by the DragOperation (like UWP).
+				// It's the responsibility to the new 'target.element', to configure the whole UI override.
+				dragUIOverride?.Clear();
+
 				args = new DragEventArgs(target.element!, dragInfo, new DragUIOverride(dragUIOverride ?? new CoreDragUIOverride()));
 			}
 
-			return (target.element!, args);
+			return (dropTarget, args);
 		}
 
-		private void UpdateState(DragEventArgs args)
+		private void UpdateState(UIElement dropTarget, DragEventArgs args)
 		{
-			_pendingDropTargets[(UIElement)args.OriginalSource] = (args.DragUIOverride, args.AcceptedOperation);
+			_pendingDropTargets[dropTarget] = (args.DragUIOverride, args.AcceptedOperation);
 		}
 	}
 }

--- a/src/Uno.UWP/Extensions/RectExtensions.cs
+++ b/src/Uno.UWP/Extensions/RectExtensions.cs
@@ -54,5 +54,23 @@ namespace Uno.Extensions
 			rect.Intersect(other);
 			return !rect.IsEmpty;
 		}
+
+		/// <summary>
+		/// Gets the shortest distance from the given point to the edges of rect.
+		/// If the rect <see cref="Rect.Contains"/> the point, then distance will be 0.
+		/// </summary>
+		internal static double GetDistance(this Rect rect, Point point)
+		{
+			// Note: cf. Contains comment to understand why we do 'point.X - rect.Width <= rect.X'
+
+			var dx = point.X >= rect.X && point.X - rect.Width <= rect.X
+				? 0 // Point is vertically aligned with rect
+				: Math.Min(Math.Abs(point.X - rect.X), Math.Abs(point.X - rect.Right));
+			var dy = point.Y >= rect.Y && point.Y - rect.Height <= rect.Y
+				? 0 // Point is horizontally aligned with rect
+				: Math.Min(Math.Abs(point.Y - rect.Y), Math.Abs(point.Y - rect.Bottom));
+
+			return Math.Sqrt(Math.Pow(dx, 2) + Math.Pow(dy, 2));
+		}
 	}
 }


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/329

## Bugfix
Reordering items before or after the bounds of items on the LV has no effect.

## What is the current behavior?
* When we leave the bounds of a drop target, we don't reset the `dragUIOverride` object, so the accepted operation (i.e. `None`) is not updated in the `DragView`.
* In a `ListView` when reordering items after the bounds of the last item, the accepted operation remains to `Move` (as expected)  but drop has no effect.

## What is the new behavior?
* On pointer move, if we are over a new drop target, or if we are not able to find a drop target, we clear the `dragUIOvwerride`
* If we are not able to find an item under the pointer when reordering items of a `ListView`, we are selecting the last one.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
