### PR TITLE
fix: `AutoSuggestBox` should keep focus when popup is opened

### DIFF
--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -21,3 +21,7 @@ This can be changed using `Uno.UI.FeatureConfiguration.Style.UseUWPDefaultStyles
 By default, Uno automatically enables accessibility text scaling on iOS and Android devices however to have more control an option has been added to disable text scaling. 
 
 Use `Uno.UI.FeatureConfiguration.Font.IgnoreTextScaleFactor` to control this. 
+
+## Popups
+
+In older versions of Uno Platforms, the `Popup.IsLightDismissEnabled` dependency property defaulted to `true`. In UWP/WinUI and Uno 4.1 and newer, it correctly defaults to `false`. If your code depended on the old behavior, you can set the `Uno.UI.FeatureConfiguration.Popup.EnableLightDismissByDefault` property to `true` to override this.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -5,6 +5,8 @@ using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
@@ -54,5 +56,45 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.IsSuggestionListOpen.Should().BeTrue();
 		}
 #endif
+
+		[TestMethod]
+		public async Task When_Typing_Should_Keep_Focus()
+		{
+			static void GettingFocus(object sender, GettingFocusEventArgs e)
+			{
+				if (e.NewFocusedElement is Popup)
+				{
+					Assert.Fail();
+				}
+			}
+			Button button = null;
+			try
+			{
+				var SUT = new AutoSuggestBox();
+				button = new Button();
+				var stack = new StackPanel()
+				{
+					Children =
+					{
+						button,
+						SUT
+					}
+				};
+				SUT.ItemsSource = new List<string>() { "ab", "abc", "abcde" };
+				WindowHelper.WindowContent = stack;
+				await WindowHelper.WaitForIdle();
+
+				SUT.Focus(FocusState.Programmatic);
+				FocusManager.GettingFocus += GettingFocus;
+				SUT.Text = "a";
+				await WindowHelper.WaitForIdle();				
+			}
+			finally
+			{
+				FocusManager.GettingFocus -= GettingFocus;
+				button?.Focus(FocusState.Programmatic); // Unfocus the AutoSuggestBox to ensure popup is closed.
+				await WindowHelper.WaitForIdle();
+			}
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives.PopupPages;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
 
@@ -54,6 +55,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 			}
 		}
 #endif
+
+		[TestMethod]
+		public void When_IsLightDismissEnabled_Default()
+		{
+			var popup = new Popup();
+			Assert.IsFalse(popup.IsLightDismissEnabled);
+		}
 
 		private static bool CanReach(DependencyObject startingElement, DependencyObject targetElement)
 		{

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -275,9 +275,9 @@ namespace Uno.UI
 
 			/// <summary>
 			/// By default, light dismiss is disabled in UWP/WinUI unless
-			/// IsLightDismissEnabled is explicitly set to true.
-			/// In earlier versions of Uno Platform this property defaulted
-			/// to true, which was incorrect behavior. If your code depends on this
+			/// <see cref="Windows.UI.Xaml.Controls.Primitives.Popup.IsLightDismissEnabled"/> is explicitly set to true.
+			/// In earlier versions of Uno Platform, this property defaulted
+			/// to true, which was an incorrect behavior. If your code depends on this
 			/// legacy behavior, use this property to override it.
 			/// </summary>
 			public static bool EnableLightDismissByDefault { get; set; } = false;

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -272,6 +272,15 @@ namespace Uno.UI
 			/// </summary>
 			public static bool UseNativePopup { get; set; } = true;
 #endif
+
+			/// <summary>
+			/// By default, light dismiss is disabled in UWP/WinUI unless
+			/// IsLightDismissEnabled is explicitly set to true.
+			/// In earlier versions of Uno Platform this property defaulted
+			/// to true, which was incorrect behavior. If your code depends on this
+			/// legacy behavior, use this property to override it.
+			/// </summary>
+			public static bool EnableLightDismissByDefault { get; set; } = false;
 		}
 
 		public static class ProgressRing

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -49,10 +49,16 @@ namespace Windows.UI.Xaml.Controls
 			_suggestionsList = GetTemplateChild("SuggestionsList") as ListView;
 			_queryButton = GetTemplateChild("QueryButton") as Button;
 
+			// Uno specific: If the user enabled the legacy behavior for popup light dismiss default
+			// we force it to false explicitly to make sure the AutoSuggestBox works correctly.
+			if(FeatureConfiguration.Popup.EnableLightDismissByDefault)
+			{
+				_popup.IsLightDismissEnabled = false;
+			}
+
 #if __ANDROID__
 			_popup.DisableFocus();
 #endif
-			_popup.IsLightDismissEnabled = true;
 
 			UpdateQueryButton();
 			UpdateTextBox();

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
@@ -76,13 +76,12 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		private bool GetDefaultValue(DependencyProperty dependencyProperty, out object value)
 		{
-			value = null;			
-
 			if (dependencyProperty == IsLightDismissEnabledProperty)
 			{
-				value = FeatureConfiguration.Popup.EnableLightDismissByDefault ? true : false;
+				value = FeatureConfiguration.Popup.EnableLightDismissByDefault;
 				return true;
 			}
+			value = null;			
 			return false;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
@@ -70,7 +70,20 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		public Popup()
 		{
+			this.RegisterDefaultValueProvider(GetDefaultValue);
 			Initialize();
+		}
+
+		private bool GetDefaultValue(DependencyProperty dependencyProperty, out object value)
+		{
+			value = null;			
+
+			if (dependencyProperty == IsLightDismissEnabledProperty)
+			{
+				value = FeatureConfiguration.Popup.EnableLightDismissByDefault ? true : false;
+				return true;
+			}
+			return false;
 		}
 
 		private void Initialize()

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
@@ -70,19 +70,17 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		public Popup()
 		{
-			this.RegisterDefaultValueProvider(GetDefaultValue);
 			Initialize();
 		}
 
-		private bool GetDefaultValue(DependencyProperty dependencyProperty, out object value)
+		internal override bool GetDefaultValue2(DependencyProperty property, out object defaultValue)
 		{
-			if (dependencyProperty == IsLightDismissEnabledProperty)
+			if (property == IsLightDismissEnabledProperty)
 			{
-				value = FeatureConfiguration.Popup.EnableLightDismissByDefault;
+				defaultValue = FeatureConfiguration.Popup.EnableLightDismissByDefault;
 				return true;
 			}
-			value = null;			
-			return false;
+			return base.GetDefaultValue2(property, out defaultValue);
 		}
 
 		private void Initialize()


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7675

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`AutoSuggestBox` loses focus when its popup opens because `IsLightDismissEnabled` defaults to `true` on Uno instead of `false` as in UWP (and `IsLightDismissEnabled` popups may capture focus when opened)


## What is the new behavior?

- `Popup.IsLightDismissEnabled` is now `false` by default to match UWP
- Added `FeatureConfiguration.Popup.EnableLightDismissByDefault` that allows turning the legacy behavior back on where needed
- Added tests to cover the default, and the text change behavior of `AutoSuggestBox`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.