### PR TITLE
fix(ItemsControl): [iOS] Invalid native insert sequence in UIElementCollection

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ItemsControl/ItemsControlTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ItemsControl/ItemsControlTests.cs
@@ -54,5 +54,25 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ItemsControl
 
 			_app.WaitForElement("UpdateItem02");
 		}
+
+		[Test]
+		[AutoRetry]
+		public void ItemsControl_AppendItem()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.ItemsControl.ItemsControl_AppendItem");
+
+			var theItemsControl = _app.Marked("theItemsControl");
+			_app.WaitForElement(theItemsControl);
+
+			var item01 = _app.WaitForElement("AppendItem01").FirstOrDefault();
+
+			_app.Tap("AppendContent01");
+
+			var item02 = _app.WaitForElement("AppendItem02").FirstOrDefault();
+
+
+			// This check validates that the native collection is properly manipulated
+			Assert.IsTrue(item01.Rect.CenterY < item02.Rect.CenterY);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1493,6 +1493,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ItemsControl\ItemsControl_AppendItem.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ItemsControl\ItemsControl_ItemContainerStyle.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5420,6 +5424,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\WriteableBitmap_MultiInvalidate.xaml.cs">
       <DependentUpon>WriteableBitmap_MultiInvalidate.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ItemsControl\ItemsControl_AppendItem.xaml.cs">
+      <DependentUpon>ItemsControl_AppendItem.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ItemsControl\ItemsControl_ItemContainerStyle.xaml.cs">
       <DependentUpon>ItemsControl_ItemContainerStyle.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ItemsControl/ItemsControl_AppendItem.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ItemsControl/ItemsControl_AppendItem.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.ItemsControl.ItemsControl_AppendItem"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ItemsControl"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<StackPanel>
+		<Button x:Name="AppendContent01" Click="{x:Bind OnAppendContent01}" Content="Append 01" />
+
+		<ItemsControl x:Name="theItemsControl">
+			<ItemsControl.ItemTemplate>
+				<DataTemplate>
+					<StackPanel>
+						<Button AutomationProperties.AutomationId="{Binding}"
+								Content="{Binding}" />
+					</StackPanel>
+				</DataTemplate>
+			</ItemsControl.ItemTemplate>
+		</ItemsControl>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ItemsControl/ItemsControl_AppendItem.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ItemsControl/ItemsControl_AppendItem.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.ItemsControl
+{
+	[Sample("ItemsControl")]
+	public sealed partial class ItemsControl_AppendItem : UserControl
+    {
+		private ObservableCollection<string> _collection;
+
+		public ItemsControl_AppendItem()
+        {
+            this.InitializeComponent();
+
+			_collection = new ObservableCollection<string>();
+
+			_collection.Add("AppendItem01");
+
+			theItemsControl.ItemsSource = _collection;
+		}
+
+		private void OnAppendContent01()
+		{
+			_collection.Add("AppendItem02");
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ItemsControlTests/Given_ItemsControl.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ItemsControlTests/Given_ItemsControl.cs
@@ -417,6 +417,46 @@ namespace Uno.UI.Tests.ItemsControlTests
 		}
 #endif
 
+		[TestMethod]
+		public async Task When_Collection_Append()
+		{
+			var count = 0;
+			var panel = new StackPanel();
+
+			var SUT = new ItemsControl()
+			{
+				ItemsPanelRoot = panel,
+				ItemContainerStyle = BuildBasicContainerStyle(),
+				InternalItemsPanelRoot = panel,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					count++;
+					return new Border();
+				})
+			};
+			SUT.ApplyTemplate();
+
+			var c = new ObservableCollection<string>();
+
+			SUT.ItemsSource = c;
+
+			c.Add("One");
+			Assert.AreEqual(count, 1);
+
+			c.Add("Two");
+			Assert.AreEqual(count, 2);
+
+			c.Add("Three");
+			Assert.AreEqual(count, 3);
+
+			Assert.AreEqual(SUT.Items.Count, 3);
+
+			c.Add("Four");
+
+			Assert.AreEqual(SUT.Items.Count, 4);
+			Assert.AreEqual(count, 4);
+		}
+
 		private Style BuildBasicContainerStyle() =>
 			new Style(typeof(Windows.UI.Xaml.Controls.ListViewItem))
 			{

--- a/src/Uno.UI/UI/Xaml/UIElementCollection.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementCollection.iOS.cs
@@ -25,7 +25,14 @@ namespace Windows.UI.Xaml.Controls
 
 		private void InsertCore(int index, UIElement item)
 		{
-			_owner.InsertSubview(item, index);
+			if (_owner.ChildrenShadow.Count == index)
+			{
+				_owner.AddSubview(item);
+			}
+			else
+			{
+				_owner.InsertSubview(item, index);
+			}
 		}
 
 		private UIElement RemoveAtCore(int index)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/nventive-private/issues/319

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes `UIElementCollection` to insert items at a specific location on iOS.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
