### PR TITLE
fix: `IsTabStop` everywhere and `AllowFocusOnInteraction` on WASM

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -29,6 +29,7 @@ using Windows.UI.ViewManagement;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Logging;
+using Uno;
 
 #if !HAS_UNO
 using Uno.Logging;
@@ -466,6 +467,9 @@ namespace SamplesApp
 		{
 #if __IOS__
 			Uno.UI.FeatureConfiguration.CommandBar.AllowNativePresenterContent = true;
+#endif
+#if __IOS__ || __ANDROID__
+			WinRTFeatureConfiguration.Focus.EnableExperimentalKeyboardFocus = true;
 #endif
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerDirectionTests/UnoSamples_Tests.FocusManagerDirection.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerDirectionTests/UnoSamples_Tests.FocusManagerDirection.cs
@@ -32,7 +32,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.FocusManagerDirectionTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		public void FocusManager_FocusDirection_Next_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusTests.FocusManager_FocusDirection");
@@ -51,7 +50,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.FocusManagerDirectionTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		public void FocusManager_FocusDirection_Previous_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusTests.FocusManager_FocusDirection");
@@ -69,7 +67,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.FocusManagerDirectionTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		public void FocusManager_FocusDirection_Up_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusTests.FocusManager_FocusDirection");
@@ -87,7 +84,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.FocusManagerDirectionTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		public void FocusManager_FocusDirection_Down_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusTests.FocusManager_FocusDirection");
@@ -105,7 +101,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.FocusManagerDirectionTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		public void FocusManager_FocusDirection_Left_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusTests.FocusManager_FocusDirection");
@@ -123,7 +118,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.FocusManagerDirectionTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		public void FocusManager_FocusDirection_Right_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusTests.FocusManager_FocusDirection");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerTests/UnoSamples_Tests.FocusManager.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerTests/UnoSamples_Tests.FocusManager.cs
@@ -530,6 +530,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // WASM temporarily disabled due to #7820
 		public void FocusManager_GetFocusedElement_ComboBoxItem_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusTests.FocusManager_GetFocus_Automated");

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -57,6 +57,8 @@ namespace Uno.UI.Samples.Tests
 		private readonly TimeSpan DefaultUnitTestTimeout = TimeSpan.FromSeconds(60);
 #endif
 
+		private ApplicationView _applicationView;
+
 		private List<TestCase> _testCases = new List<TestCase>();
 		private TestRun _currentRun;
 
@@ -88,6 +90,8 @@ namespace Uno.UI.Samples.Tests
 			SampleChooserViewModel.Instance.SampleChanging += OnSampleChanging;
 			EnableConfigPersistence();
 			OverrideDebugProviderAsserts();
+
+			_applicationView = ApplicationView.GetForCurrentView();
 		}
 
 		private static void OverrideDebugProviderAsserts()
@@ -154,6 +158,7 @@ namespace Uno.UI.Samples.Tests
 				stopButton.IsEnabled = _cts != null && !_cts.IsCancellationRequested || !isRunning;
 				runningState.Text = isRunning ? "Running" : "Finished";
 				runStatus.Text = message;
+				_applicationView.Title = message;
 			}
 
 			await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, Setter);

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1917,6 +1917,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_IsTabStop.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Margin.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5761,6 +5765,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Formatting_Flicker.xaml.cs">
       <DependentUpon>TextBox_Formatting_Flicker.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_IsTabStop.xaml.cs">
+      <DependentUpon>TextBox_IsTabStop.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Margin.xaml.cs">
       <DependentUpon>TextBox_Margin.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FocusManager/FocusManager_GetFocus_Automated.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FocusManager/FocusManager_GetFocus_Automated.xaml
@@ -17,7 +17,7 @@
 		<Border Background="LightGray"
 						Margin="0,8,0,0">
 		  <TextBlock x:Name="TxtCurrentFocused"
-							   Text="FocusedElement"
+							   Text="&lt;none&gt;"
 							   FontSize="18"
 							   FontWeight="Bold"
 							   TextAlignment="Center"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsTabStop.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsTabStop.xaml
@@ -1,0 +1,19 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_IsTabStop"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel>
+		<TextBlock Text="Currently focused element" />
+		<TextBlock FontWeight="Bold" x:Name="CurrentlyFocusedTextBlock" Text="NONE" />
+		<TextBox Text="This singleline TextBox should be focusable" x:Name="FocusableSingleLineTextBox" />
+		<TextBox Text="This singleline TextBox should not be focusable" x:Name="UnfocusableSingleLineTextBox" IsTabStop="False" />
+		<TextBox Text="This multiline TextBox should be focusable" x:Name="FocusableMultiLineTextBox" AcceptsReturn="True" Height="100" />
+		<TextBox Text="This multiline TextBox should not be focusable" x:Name="UnfocusableMultiLineTextBox" AcceptsReturn="True" Height="100" IsTabStop="False" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsTabStop.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsTabStop.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBox
+{
+	[Sample(Description = "When IsTabStop=False, given element should not be focusable by pointer nor keyboard")]
+	public sealed partial class TextBox_IsTabStop : Page
+	{
+		public TextBox_IsTabStop()
+		{
+			this.InitializeComponent();
+			FocusManager.GettingFocus += FocusManager_GettingFocus;
+			this.Unloaded += TextBox_IsTabStop_Unloaded;
+		}
+
+		private void FocusManager_GettingFocus(object sender, GettingFocusEventArgs args)
+		{
+			CurrentlyFocusedTextBlock.Text = (args.NewFocusedElement as FrameworkElement)?.Name ?? args.NewFocusedElement?.GetType()?.Name ?? "NONE";
+		}
+
+		private void TextBox_IsTabStop_Unloaded(object sender, RoutedEventArgs e)
+		{
+			FocusManager.GettingFocus -= FocusManager_GettingFocus;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -288,9 +288,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				args.Handled = true;
 			}
 
-#if !__WASM__
 			Focus(FocusState.Pointer);
-#endif
 
 			base.OnPointerPressed(args);
 			UpdateCommonStatesWithoutNeedsLayout(ManipulationUpdateKind.Begin);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxDelegate.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxDelegate.iOS.cs
@@ -28,8 +28,10 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		public override void EditingStarted(UITextView textView)
 		{
-			// Using FocusState.Pointer by default until need to distinguish between Pointer, Programmatic and Keyboard.
-			_textBox.GetTarget()?.Focus(FocusState.Pointer);
+			if (_textBox.GetTarget() is TextBox textBox && textBox.FocusState == FocusState.Unfocused)
+			{
+				textBox.Focus(FocusState.Pointer);
+			}
 		}
 
 		/// <summary>
@@ -40,8 +42,10 @@ namespace Windows.UI.Xaml.Controls
 			var bindableTextView = textView as MultilineTextBoxView;
 			bindableTextView?.OnTextChanged();
 
-			// TODO: Remove when Focus is implemented correctly
-			_textBox.GetTarget()?.Unfocus();
+			if (_textBox.GetTarget() is TextBox textBox && textBox.FocusState != FocusState.Unfocused)
+			{
+				textBox.Unfocus();
+			}
 		}
 
 		public override bool ShouldChangeText(UITextView textView, NSRange range, string text)
@@ -70,7 +74,7 @@ namespace Windows.UI.Xaml.Controls
 
 			return false;
 		}
-        
+
 		public override bool ShouldEndEditing(UITextView textView)
 		{
 			var bindableTextView = textView as MultilineTextBoxView;
@@ -79,7 +83,13 @@ namespace Windows.UI.Xaml.Controls
 
 		public override bool ShouldBeginEditing(UITextView textView)
 		{
-			return !_textBox.GetTarget()?.IsReadOnly ?? false;
+			if (_textBox.GetTarget() is not TextBox textBox)
+			{
+				return false;
+			}
+
+			// Both IsReadOnly = true and IsTabStop = false can prevent editing
+			return !textBox.IsReadOnly && textBox.IsTabStop;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxDelegate.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxDelegate.iOS.cs
@@ -72,7 +72,13 @@ namespace Windows.UI.Xaml.Controls
 
 		public override bool ShouldBeginEditing(UITextField textField)
 		{
-			return !_textBox.GetTarget()?.IsReadOnly ?? false;
+			if (_textBox.GetTarget() is not TextBox textBox)
+			{
+				return false;
+			}
+
+			// Both IsReadOnly = true and IsTabStop = false can prevent editing
+			return !textBox.IsReadOnly && textBox.IsTabStop;
 		}
 
 		/// <summary>
@@ -80,8 +86,10 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		public override void EditingStarted(UITextField textField)
 		{
-			// Using FocusState.Pointer by default until need to distinguish between Pointer, Programmatic and Keyboard.
-			_textBox.GetTarget()?.Focus(FocusState.Pointer);
+			if (_textBox.GetTarget() is TextBox textBox && textBox.FocusState == FocusState.Unfocused)
+			{
+				textBox.Focus(FocusState.Pointer);
+			}
 		}
 
 		/// <summary>
@@ -89,8 +97,10 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		public override void EditingEnded(UITextField textField)
 		{
-			// TODO: Remove when Focus is implemented correctly
-			_textBox.GetTarget()?.Unfocus();
+			if (_textBox.GetTarget() is TextBox textBox && textBox.FocusState != FocusState.Unfocused)
+			{
+				textBox.Unfocus();
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -411,29 +411,37 @@ namespace Windows.UI.Xaml.Controls
 			return style;
 		}
 
-		partial void OnIsReadonlyChangedPartial(DependencyPropertyChangedEventArgs e)
+		partial void OnIsReadonlyChangedPartial(DependencyPropertyChangedEventArgs e) => UpdateTextBoxViewReadOnly();
+
+		partial void OnIsTabStopChangedPartial() => UpdateTextBoxViewReadOnly();
+
+		private void UpdateTextBoxViewReadOnly()
 		{
-			if (_textBoxView != null)
+			if (_textBoxView == null)
 			{
-				var isReadOnly = IsReadOnly;
+				return;
+			}
 
-				_textBoxView.Focusable = !isReadOnly;
-				_textBoxView.FocusableInTouchMode = !isReadOnly;
-				_textBoxView.Clickable = !isReadOnly;
-				_textBoxView.LongClickable = !isReadOnly;
-				_textBoxView.SetCursorVisible(!isReadOnly);
+			// Both IsReadOnly = true and IsTabStop = false make the control
+			// not receive any input.
+			var isReadOnly = IsReadOnly || !IsTabStop;
 
-				if (isReadOnly)
+			_textBoxView.Focusable = !isReadOnly;
+			_textBoxView.FocusableInTouchMode = !isReadOnly;
+			_textBoxView.Clickable = !isReadOnly;
+			_textBoxView.LongClickable = !isReadOnly;
+			_textBoxView.SetCursorVisible(!isReadOnly);
+
+			if (isReadOnly)
+			{
+				_listener = _textBoxView.KeyListener;
+				_textBoxView.KeyListener = null;
+			}
+			else
+			{
+				if (_listener != null)
 				{
-					_listener = _textBoxView.KeyListener;
-					_textBoxView.KeyListener = null;
-				}
-				else
-				{
-					if (_listener != null)
-					{
-						_textBoxView.KeyListener = _listener;
-					}
+					_textBoxView.KeyListener = _listener;
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -694,6 +694,14 @@ namespace Windows.UI.Xaml.Controls
 
 		#endregion
 
+		private protected override void OnIsTabStopChanged(bool oldValue, bool newValue)
+		{
+			base.OnIsTabStopChanged(oldValue, newValue);
+			OnIsTabStopChangedPartial();
+		}
+
+		partial void OnIsTabStopChangedPartial();
+
 		internal override void UpdateFocusState(FocusState focusState)
 		{
 			var oldValue = FocusState;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -8,7 +8,7 @@ namespace Windows.UI.Xaml.Controls
 	public partial class TextBox : Control
 	{
 		private TextBoxView _textBoxView;
-		
+
 		protected override bool IsDelegatingFocusToTemplateChild() => true; // _textBoxView
 		partial void OnDeleteButtonClickPartial() => FocusTextView();
 		internal bool FocusTextView() => FocusManager.FocusNative(_textBoxView);
@@ -79,7 +79,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void UpdateFontPartial()
 		{
-			if(_textBoxView == null)
+			if (_textBoxView == null)
 			{
 				return;
 			}
@@ -112,12 +112,14 @@ namespace Windows.UI.Xaml.Controls
 			ApplyEnabled(e.NewValue);
 		}
 
-		partial void OnIsReadonlyChangedPartial(DependencyPropertyChangedEventArgs e)
+		partial void OnIsReadonlyChangedPartial(DependencyPropertyChangedEventArgs e) => UpdateTextBoxViewIsReadOnly();
+
+		partial void OnIsTabStopChangedPartial() => UpdateTextBoxViewIsReadOnly();
+
+		private void UpdateTextBoxViewIsReadOnly()
 		{
-			if (e.NewValue is bool isReadonly)
-			{
-				ApplyIsReadonly(isReadonly);
-			}
+			var isReadOnly = IsReadOnly || !IsTabStop;
+			ApplyIsReadonly(isReadOnly);
 		}
 
 		partial void OnInputScopeChangedPartial(DependencyPropertyChangedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -118,8 +118,8 @@ namespace Windows.UI.Xaml.Controls
 
 		private void UpdateTextBoxViewIsReadOnly()
 		{
-			var isReadOnly = IsReadOnly || !IsTabStop;
-			ApplyIsReadonly(isReadOnly);
+			var isNativeReadOnly = IsReadOnly || !IsTabStop;
+			_textBoxView?.SetIsReadOnly(isNativeReadOnly);
 		}
 
 		partial void OnInputScopeChangedPartial(DependencyPropertyChangedEventArgs e)
@@ -131,8 +131,6 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		private void ApplyEnabled(bool? isEnabled = null) => _textBoxView?.SetEnabled(isEnabled ?? IsEnabled);
-
-		private void ApplyIsReadonly(bool? isReadOnly = null) => _textBoxView?.SetIsReadOnly(isReadOnly ?? IsReadOnly);
 
 		private void ApplyInputScope(InputScope scope) => _textBoxView?.SetInputScope(scope);
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
@@ -208,7 +208,10 @@ namespace Windows.UI.Xaml.Controls
 		{
 			UpdateCaretColor();
 
-			_textBox.GetTarget()?.Focus(FocusState.Pointer);
+			if (_textBox.GetTarget() is TextBox textBox && textBox.FocusState == FocusState.Unfocused)
+			{
+				textBox.Focus(FocusState.Pointer);
+			}
 
 			return base.BecomeFirstResponder();
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -18,6 +18,8 @@ namespace Windows.UI.Xaml.Controls
 		private readonly TextBox _textBox;
 		private readonly SerialDisposable _foregroundChanged = new SerialDisposable();
 
+		private bool _isReadOnly = false;
+
 		public Brush Foreground
 		{
 			get => (Brush)GetValue(ForegroundProperty);
@@ -125,6 +127,13 @@ namespace Windows.UI.Xaml.Controls
 
 		internal void SetIsReadOnly(bool isReadOnly)
 		{
+			if (_isReadOnly == isReadOnly)
+			{
+				// Avoid JS call if the actual value didn't change.
+				return;
+			}
+
+			_isReadOnly = isReadOnly;
 			if (isReadOnly)
 			{
 				SetAttribute("readonly", "readonly");

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -57,6 +57,13 @@ namespace Windows.UI.Xaml.Input
 					_skipNativeFocus = false;
 					break;
 				}
+				else if (
+					parent is FrameworkElement fe &&
+					(!fe.AllowFocusOnInteraction || !fe.IsTabStop))
+				{
+					// Stop propagating, this element does not want to receive focus.
+					break;
+				}
 				else if (parent is Control control && control.IsFocusable)
 				{
 					ProcessControlFocused(control);
@@ -87,7 +94,7 @@ namespace Windows.UI.Xaml.Input
 
 			if (focusManager?.InitialFocus == true)
 			{
-				 // Do not focus natively on initial focus so the soft keyboard is not opened
+				// Do not focus natively on initial focus so the soft keyboard is not opened
 				return false;
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2115, closes #6471


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- `IsTabStop` had weird behavior for input fields on most platforms
- `AllowFocusOnInteraction` did not work reliably on WASM

## What is the new behavior?

- `IsTabStop` is properly respected by input fields
- `AllowFocusOnInteraction = false` properly stops propagation of native focus on WASM


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.