### PR TITLE
fix: support of SwipeControl nested in scrollable container

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Extensions/AppRectExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Extensions/AppRectExtensions.cs
@@ -4,16 +4,6 @@ namespace SamplesApp.UITests
 {
 	public static class AppRectExtensions
 	{
-		public static IAppRect ApplyScale(this IAppRect rect, float scale) =>
-			new AppRect(
-				x: rect.X * scale,
-				y: rect.Y * scale,
-				width: rect.Width * scale,
-				height: rect.Height * scale
-			);
-
-		public static IAppRect UnapplyScale(this IAppRect rect, float scale) => rect.ApplyScale(1f / scale);
-
 		public static IAppRect InflateBy(this IAppRect rect, float thickness) => rect.DeflateBy(-thickness);
 
 		public static IAppRect DeflateBy(this IAppRect rect, float thickness)

--- a/src/SamplesApp/SamplesApp.UITests/Extensions/AppScalingExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Extensions/AppScalingExtensions.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UITest;
+using Uno.UITest.Helpers.Queries;
+using Uno.UITests.Helpers;
+
+namespace SamplesApp.UITests.Extensions
+{
+	internal static class AppScalingExtensions
+	{
+		public static IAppRect LogicalToPhysicalPixels(this IAppRect rect, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return new AppRect(
+				x: rect.X * scale,
+				y: rect.Y * scale,
+				width: rect.Width * scale,
+				height: rect.Height * scale
+			);
+		}
+
+		public static IAppRect PhysicalToLogicalPixels(this IAppRect rect, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return new AppRect(
+				x: rect.X / scale,
+				y: rect.Y / scale,
+				width: rect.Width / scale,
+				height: rect.Height / scale
+			);
+		}
+
+		public static Point LogicalToPhysicalPixels(this Point point, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return new Point(
+				(int) (point.X * scale),
+				(int) (point.Y * scale)
+			);
+		}
+
+		public static Point PhysicalToLogicalPixels(this Point point, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return new Point(
+				(int)(point.X / scale),
+				(int)(point.Y / scale)
+			);
+		}
+
+		public static Size LogicalToPhysicalPixels(this Size size, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return new Size(
+				(int)(size.Width * scale),
+				(int)(size.Height * scale)
+			);
+		}
+
+		public static Size PhysicalToLogicalPixels(this Size size, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return new Size(
+				(int)(size.Width / scale),
+				(int)(size.Height / scale)
+			);
+		}
+
+		public static double LogicalToPhysicalPixels(this double pixels, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return pixels * scale;
+		}
+
+		public static double PhysicalToLogicalPixels(this double pixels, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return pixels / scale;
+		}
+
+		public static int LogicalToPhysicalPixels(this int pixels, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return (int)(pixels * scale);
+		}
+
+		public static int PhysicalToLogicalPixels(this int pixels, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return (int)(pixels / scale);
+		}
+
+		public static float LogicalToPhysicalPixels(this float pixels, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return pixels * scale;
+		}
+
+		public static float PhysicalToLogicalPixels(this float pixels, IApp app)
+		{
+			var scale = app.GetDisplayScreenScaling();
+
+			return pixels / scale;
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Extensions/QueryExtensions.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Extensions/QueryExtensions.cs
@@ -109,8 +109,8 @@ namespace SamplesApp.UITests
 			return AppInitializer.GetLocalPlatform() switch
 			{
 				Platform.Android => rect,
-				Platform.iOS => rect.ApplyScale(app.GetDisplayScreenScaling()),
-				Platform.Browser => rect.ApplyScale(app.GetDisplayScreenScaling()),
+				Platform.iOS => rect.LogicalToPhysicalPixels(app),
+				Platform.Browser => rect,
 				_ => throw new InvalidOperationException("Unknown current platform.")
 			};
 		}
@@ -119,12 +119,13 @@ namespace SamplesApp.UITests
 		{
 			return AppInitializer.GetLocalPlatform() switch
 			{
-				Platform.Android => rect.UnapplyScale(app.GetDisplayScreenScaling()),
+				Platform.Android => rect.PhysicalToLogicalPixels(app),
 				Platform.iOS => rect,
-				Platform.Browser => rect.UnapplyScale(app.GetDisplayScreenScaling()),
+				Platform.Browser => rect,
 				_ => throw new InvalidOperationException("Unknown current platform.")
 			};
 		}
+
 		public static void FastTap(this IApp app, string elementName)
 		{
 			var tapPosition = app.GetRect(elementName);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControlTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControlTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SamplesApp.UITests.Extensions;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest.Helpers.Queries;
 using Query = System.Func<Uno.UITest.IAppQuery, Uno.UITest.IAppQuery>;
@@ -55,6 +57,54 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.SwipeControlTests
 			result = output.GetDependencyPropertyValue<string>("Text");
 
 			Assert.AreEqual("Right_3", result);
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS | Platform.Android)]
+		public Task When_InListView()
+			=> When_InScrollableContainer("UITests.Windows_UI_Xaml_Controls.SwipeControlTests.SwipeControl_ListView");
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS | Platform.Android)]
+		public Task When_InScrollViewer()
+			=> When_InScrollableContainer("UITests.Windows_UI_Xaml_Controls.SwipeControlTests.SwipeControl_ScrollViewer");
+
+		private async Task When_InScrollableContainer(string testName)
+		{
+			QueryEx sut = new QueryEx(q => q.All().Marked("SUT"));
+			QueryEx output = new QueryEx(q => q.All().Marked("Output"));
+
+			Run(testName, skipInitialScreenshot: true);
+
+			var sutPhyRect = _app.GetPhysicalRect(sut);
+			var item2PhyPosition = new Point((int)sutPhyRect.X + 150, (int)sutPhyRect.Y + 150).LogicalToPhysicalPixels(_app);
+
+			// Validate initial state
+			var initial = TakeScreenshot("initial");
+			ImageAssert.HasColorAt(initial, item2PhyPosition.X, item2PhyPosition.Y, "#FFFFA52C");
+
+			// Execute left command on item 2
+			_app.DragCoordinates(item2PhyPosition.X, item2PhyPosition.Y, item2PhyPosition.X + 300.LogicalToPhysicalPixels(_app), item2PhyPosition.Y);
+			await Task.Delay(1000); // We cannot detect the animation ...
+
+			var swippedItem = output.GetDependencyPropertyValue<string>("Text");
+			Assert.AreEqual("#FFFFA52C", swippedItem);
+
+			// Scroll up
+			_app.DragCoordinates(sutPhyRect.CenterX, sutPhyRect.Bottom - 10.LogicalToPhysicalPixels(_app), sutPhyRect.CenterX, sutPhyRect.Y + 10.LogicalToPhysicalPixels(_app));
+
+			// Validate scrolled successfully
+			var postScroll = TakeScreenshot("after scroll");
+			ImageAssert.DoesNotHaveColorAt(postScroll, item2PhyPosition.X, item2PhyPosition.Y, "#FFFFA52C");
+
+			// Execute left command on item that is now at item 2 location
+			_app.DragCoordinates(item2PhyPosition.X, item2PhyPosition.Y, item2PhyPosition.X + 300.LogicalToPhysicalPixels(_app), item2PhyPosition.Y);
+			await Task.Delay(1000); // We cannot detect the animation ...
+
+			swippedItem = output.GetDependencyPropertyValue<string>("Text");
+			Assert.AreNotEqual("#FFFFA52C", swippedItem);
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1769,6 +1769,14 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SwipeControlTests\SwipeControl_ListView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SwipeControlTests\SwipeControl_ScrollViewer.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SymbolIconTests\SymbolIcon_Generic.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5629,6 +5637,12 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SwipeControlTests\SwipeControl_Automated.xaml.cs">
       <DependentUpon>SwipeControl_Automated.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SwipeControlTests\SwipeControl_ListView.xaml.cs">
+      <DependentUpon>SwipeControl_ListView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SwipeControlTests\SwipeControl_ScrollViewer.xaml.cs">
+      <DependentUpon>SwipeControl_ScrollViewer.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SwipeControlTests\TestCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\SymbolIconTests\SymbolIcon_Generic.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListViewMultiSelect.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListViewMultiSelect.xaml
@@ -1,0 +1,35 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListViewMultiSelect"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml.DragAndDrop"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		
+		<ListView 
+			CanDragItems="True"
+			CanReorderItems="True"
+			AllowDrop="True"
+			SelectionMode="Multiple"
+			MinHeight="300"
+			x:Name="SUT">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<Border Background="{Binding}" Width="300" Height="20">
+						<TextBlock Text="{Binding}" Foreground="Black" />
+					</Border>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+
+		<TextBlock x:Name="Operation" Text="--none--" Grid.Row="1" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListViewMultiSelect.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListViewMultiSelect.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml.DragAndDrop
+{
+	public sealed partial class DragDrop_ListViewMultiSelect : Page
+	{
+		public DragDrop_ListViewMultiSelect()
+		{
+			this.InitializeComponent();
+
+			SUT.ItemsSource = new ObservableCollection<string>
+			{
+				"#FFFF0018",
+				"#FFFFA52C",
+				"#FFFFFF41",
+				"#FF008018",
+				"#FF0000F9",
+				"#FF86007D",
+
+				"#CCFF0018",
+				"#CCFFA52C",
+				"#CCFFFF41",
+				"#CC008018",
+				"#CC0000F9",
+				"#CC86007D",
+
+				"#66FF0018",
+				"#66FFA52C",
+				"#66FFFF41",
+				"#66008018",
+				"#660000F9",
+				"#6686007D",
+
+				"#33FF0018",
+				"#33FFA52C",
+				"#33FFFF41",
+				"#33008018",
+				"#330000F9",
+				"#3386007D"
+			};
+
+			SUT.DragOver += (snd, e) =>
+			{
+				Operation.Text += e.AcceptedOperation.ToString();
+			};
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControl_ListView.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControl_ListView.xaml
@@ -1,0 +1,35 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.SwipeControlTests.SwipeControl_ListView"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.SwipeControlTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<ListView x:Name="SUT">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<SwipeControl Background="{Binding}" Width="300"  Height="100">
+						<SwipeControl.LeftItems>
+							<SwipeItems Mode="Execute">
+								<SwipeItem Text="Left_1" IconSource="{StaticResource Icon}" Invoked="ItemInvoked" />
+							</SwipeItems>
+						</SwipeControl.LeftItems>
+
+						<TextBlock Text="{Binding}" Foreground="Black" />
+					</SwipeControl>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+
+		<TextBlock x:Name="Output" Grid.Row="1"  Text="-- none --" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControl_ListView.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControl_ListView.xaml.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.SwipeControlTests
+{
+	[Sample("SwipeControl", "ListView")]
+	public sealed partial class SwipeControl_ListView : Page
+	{
+		public SwipeControl_ListView()
+		{
+			this.InitializeComponent();
+
+			SUT.ItemsSource = new []
+			{
+				"#FFFF0018",
+				"#FFFFA52C",
+				"#FFFFFF41",
+				"#FF008018",
+				"#FF0000F9",
+				"#FF86007D",
+
+				"#CCFF0018",
+				"#CCFFA52C",
+				"#CCFFFF41",
+				"#CC008018",
+				"#CC0000F9",
+				"#CC86007D",
+
+				"#66FF0018",
+				"#66FFA52C",
+				"#66FFFF41",
+				"#66008018",
+				"#660000F9",
+				"#6686007D",
+
+				"#33FF0018",
+				"#33FFA52C",
+				"#33FFFF41",
+				"#33008018",
+				"#330000F9",
+				"#3386007D"
+			};
+		}
+
+		private void ItemInvoked(SwipeItem sender, SwipeItemInvokedEventArgs args)
+		{
+			Output.Text = args.SwipeControl.DataContext?.ToString();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControl_ScrollViewer.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControl_ScrollViewer.xaml
@@ -1,0 +1,37 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.SwipeControlTests.SwipeControl_ScrollViewer"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.SwipeControlTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<ScrollViewer x:Name="SUT">
+			<ItemsControl x:Name="TheSecondSUT"  HorizontalAlignment="Left">
+				<ItemsControl.ItemTemplate>
+					<DataTemplate>
+						<SwipeControl Background="{Binding}" Width="300"  Height="100">
+							<SwipeControl.LeftItems>
+								<SwipeItems Mode="Execute">
+									<SwipeItem Text="Left_1" IconSource="{StaticResource Icon}" Invoked="ItemInvoked" />
+								</SwipeItems>
+							</SwipeControl.LeftItems>
+
+							<TextBlock Text="{Binding}" Foreground="Black" />
+						</SwipeControl>
+					</DataTemplate>
+				</ItemsControl.ItemTemplate>
+			</ItemsControl>
+		</ScrollViewer>
+
+		<TextBlock x:Name="Output" Grid.Row="1"  Text="-- none --" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControl_ScrollViewer.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControl_ScrollViewer.xaml.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.SwipeControlTests
+{
+	[Sample("SwipeControl", "ScrollViewer")]
+	public sealed partial class SwipeControl_ScrollViewer : Page
+	{
+		public SwipeControl_ScrollViewer()
+		{
+			this.InitializeComponent();
+
+			TheSecondSUT.ItemsSource = new[]
+			{
+				"#FFFF0018",
+				"#FFFFA52C",
+				"#FFFFFF41",
+				"#FF008018",
+				"#FF0000F9",
+				"#FF86007D",
+
+				"#CCFF0018",
+				"#CCFFA52C",
+				"#CCFFFF41",
+				"#CC008018",
+				"#CC0000F9",
+				"#CC86007D",
+
+				"#66FF0018",
+				"#66FFA52C",
+				"#66FFFF41",
+				"#66008018",
+				"#660000F9",
+				"#6686007D",
+
+				"#33FF0018",
+				"#33FFA52C",
+				"#33FFFF41",
+				"#33008018",
+				"#330000F9",
+				"#3386007D"
+			};
+		}
+
+		private void ItemInvoked(SwipeItem sender, SwipeItemInvokedEventArgs args)
+		{
+			Output.Text = args.SwipeControl.DataContext?.ToString();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.Android.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		public ScrollBarVisibility _horizontalScrollBarVisibility;
+		private ScrollBarVisibility _horizontalScrollBarVisibility;
 		public ScrollBarVisibility HorizontalScrollBarVisibility
 		{
 			get => _horizontalScrollBarVisibility;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -871,7 +871,7 @@ namespace Windows.UI.Xaml.Controls
 			=> (scrollable, visibility, mode, managedScrollbar) switch
 			{
 				(_, _, ScrollMode.Disabled, _) => ScrollBarVisibility.Disabled,
-				(0, ScrollBarVisibility.Auto, _, null) => ScrollBarVisibility.Disabled, // If scrollable is 0, the managed scrollbar won't be realized, we prefer to hide the native one until we are sure!
+				(0, ScrollBarVisibility.Auto, _, null) => ScrollBarVisibility.Hidden, // If scrollable is 0, the managed scrollbar won't be realized, we prefer to hide the native one until we are sure!
 				(_, _, _, null) when Uno.UI.Xaml.Controls.ScrollViewer.GetShouldFallBackToNativeScrollBars(this) => visibility,
 				(_, ScrollBarVisibility.Disabled, _, _) => ScrollBarVisibility.Disabled,
 				_ => ScrollBarVisibility.Hidden // If a managed scroll bar was set in the template, native scroll bar has to stay Hidden

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -871,7 +871,7 @@ namespace Windows.UI.Xaml.Controls
 			=> (scrollable, visibility, mode, managedScrollbar) switch
 			{
 				(_, _, ScrollMode.Disabled, _) => ScrollBarVisibility.Disabled,
-				(0, ScrollBarVisibility.Auto, _, null) => ScrollBarVisibility.Hidden, // If scrollable is 0, the managed scrollbar won't be realized, we prefer to hide the native one until we are sure!
+				(0, ScrollBarVisibility.Auto, _, null) => ScrollBarVisibility.Disabled, // If scrollable is 0, the managed scrollbar won't be realized, we prefer to hide the native one until we are sure!
 				(_, _, _, null) when Uno.UI.Xaml.Controls.ScrollViewer.GetShouldFallBackToNativeScrollBars(this) => visibility,
 				(_, ScrollBarVisibility.Disabled, _, _) => ScrollBarVisibility.Disabled,
 				_ => ScrollBarVisibility.Hidden // If a managed scroll bar was set in the template, native scroll bar has to stay Hidden


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/204

## Bugfix
Support of `SwipeControl` nested in scrollable container (`ScrollViewer` or native `ListView`)

## What is the current behavior?
When using native scroll bars, the `ScrollViewer` might report that it's can scroll horizontally. This drives our pointers engine on Android [to detect a conflicting gesture](https://github.com/unoplatform/uno/blob/f4ca959678fbea27e9ac810addeac851c00ffeb8/src/Uno.UI/UI/Xaml/UIElement.Pointers.Android.cs#L183) between the `SwipeControl` and `ScrollViewer` so it prevent the `ScrollViewer` to kick in **on any direction** (currently we cannot prevent scroll to start only on a given direction).

## What is the new behavior?
The `ScrollViewer` report `CanHorizontallyScroll = false` 

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
