### PR TITLE
feat: Initial page focus on WASM using browser keyboard navigation

### DIFF
--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -124,6 +124,26 @@ namespace Windows.UI.Xaml.Input
 			}
 			else if (focused != null)
 			{
+				// Special handling for RootVisual - which is not focusable on managed side
+				// but is focusable on native side. The purpose of this trick is to allow
+				// us to recognize, that the page was focused by tabbing from the address bar
+				// and focusing the first focusable element on the page instead.
+				if (focused is RootVisual rootVisual)
+				{					
+					var firstFocusable = FocusManager.FindFirstFocusableElement(rootVisual);
+					if (firstFocusable is FrameworkElement frameworkElement)
+					{
+						if (_log.Value.IsEnabled(LogLevel.Debug))
+						{
+							_log.Value.LogDebug(
+								$"Root visual focused - caused by browser keyboard navigation to the page, " +
+								$"moving focus to actual first focusable element - {frameworkElement?.ToString() ?? "[null]"}.");
+						}
+						frameworkElement.Focus(FocusState.Keyboard);
+					}
+					return;
+				}
+
 				ProcessElementFocused(focused);
 			}
 			else

--- a/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
@@ -27,18 +27,22 @@ namespace Uno.UI.Xaml.Core
 		public RootVisual(CoreServices coreServices)
 		{
 			_coreServices = coreServices ?? throw new System.ArgumentNullException(nameof(coreServices));
-			//Uno specific - flag as VisualTreeRoot for interop with existing logic
+            //Uno specific - flag as VisualTreeRoot for interop with existing logic
 			IsVisualTreeRoot = true;
+#if __WASM__
+			//Uno WASM specific - set tabindex to 0 so the RootVisual is "native focusable"
+			SetAttribute("tabindex", "0");
+#endif
 
 			PointerPressed += RootVisual_PointerPressed;
 			PointerReleased += RootVisual_PointerReleased;
 			PointerCanceled += RootVisual_PointerCanceled;
 		}
 
-		/// <summary>
-		/// Gets or sets the Visual Tree.
-		/// </summary>
-		internal VisualTree? AssociatedVisualTree { get; set; }
+        /// <summary>
+        /// Gets or sets the Visual Tree.
+        /// </summary>
+        internal VisualTree? AssociatedVisualTree { get; set; }
 
 		internal PopupRoot? AssociatedPopupRoot =>
 			AssociatedVisualTree?.PopupRoot ?? this.GetContext().MainPopupRoot;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7742 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

When tabbing from address bar in browser, the root scroll viewer gets focused.

## What is the new behavior?

When tabbing from address bar in browser, the first actual focusable element is focused (based on the managed focus rules).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.