### PR TITLE
fix(iOS): Time and Date Picker

### DIFF
--- a/doc/articles/controls/TimePicker.md
+++ b/doc/articles/controls/TimePicker.md
@@ -4,17 +4,17 @@
 
 TimePicker is use to select a specific time of the day in hour and minute (AM/PM).
 
-Button showing time open the time picker popup. 
+Button showing time open the time picker popup.
 Bind to the Time property of the control to set initial time.
 days, seconds and milliseconds of input timespan are ignored
 By default minute increment is set to 1
 if you assign a negative value or 0, it will use 1 minute increment
 if you assign a value over 30, it will use 30 minute increment
 While all increments under 30 minutes are valid, we recommend using 1,2,5,10,15,20,25,30 minute increment.
-If bound time is 2h03 and time increment is 5 than time picker initial pickable time will be 2h05 
-If bound time is 2h08 and time increment is 15 than time picker initial pickable time will be 2h15 
+If bound time is 2h03 and time increment is 5 than time picker initial pickable time will be 2h05
+If bound time is 2h08 and time increment is 15 than time picker initial pickable time will be 2h15
 Cancel button cancel the new time selection. You can also click outside the time picker to do the same.
-Done/OK button save the new selected time. 
+Done/OK button save the new selected time.
 
 ### Styles
 Time button style: TimePickerFlyoutButtonStyle
@@ -46,7 +46,7 @@ Some `ColorBrushes` are specific to **iOS** and could be changed by copying and 
 ```
 IOSTimePickerAcceptButtonForegroundBrush  Color="#055bb7"
 IOSTimePickerDismissButtonForegroundBrush  Color="#055bb7"
-IOSTimePickerHeaderBackgroundBrush  Color="{ThemeResource SystemListLowColor}" 
+IOSTimePickerHeaderBackgroundBrush  Color="{ThemeResource SystemListLowColor}"
 ```
 If you want to show a dimmed overlay underneath the picker, set the `TimePicker.LightDismissOverlayMode` property to `On`.
 
@@ -61,3 +61,6 @@ Since **iOS14** the native `TimePicker` changed the way it's presented. By defau
 ```csharp
 Uno.UI.FeatureConfiguration.TimePicker.UseLegacyStyle = true;
 ```
+
+> [!IMPORTANT]
+> This feature flag is required and will only affect iOS 14 devices. As of **iOS 15**, the preferred style for the DatePicker is again the one found in iOS13 and earlier.

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -561,7 +561,7 @@ namespace Uno.UI
 		{
 #if __IOS__
 			/// <summary>
-			/// Gets or set whether the DatePicker rendered matches the Legacy Style or not.
+			/// Gets or set whether the <see cref="Windows.UI.Xaml.Controls.DatePicker" /> rendered matches the Legacy Style or not.
 			/// </summary>
 			/// <remarks>
 			/// Important: This flag will only have an impact on iOS 14 devices

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -560,6 +560,12 @@ namespace Uno.UI
 		public static class DatePicker
 		{
 #if __IOS__
+			/// <summary>
+			/// Gets or set whether the DatePicker rendered matches the Legacy Style or not.
+			/// </summary>
+			/// <remarks>
+			/// Important: This flag will only have an impact on iOS 14 devices
+			/// </remarks>
 			public static bool UseLegacyStyle { get; set; } = false;
 #endif
 		}
@@ -567,6 +573,12 @@ namespace Uno.UI
 		public static class TimePicker
 		{
 #if __IOS__
+			/// <summary>
+			/// Gets or set whether the TimePicker rendered matches the Legacy Style or not.
+			/// </summary>
+			/// <remarks>
+			/// Important: This flag will only have an impact on iOS 14 devices
+			/// </remarks>
 			public static bool UseLegacyStyle { get; set; } = false;
 #endif
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.md
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.md
@@ -4,9 +4,9 @@
 
 DatePicker is use to select a specific date.
 
-*Button showing date open the date picker popup.
-*Bind to the Date property of the control to set initial time.
-*Done/OK button save the new selected date.
+* Button showing date open the date picker popup.
+* Bind to the Date property of the control to set initial time.
+* Done/OK button save the new selected date.
 
 ### Device-specific implementation quirks
 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.md
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.md
@@ -4,9 +4,9 @@
 
 DatePicker is use to select a specific date.
 
-*Button showing date open the date picker popup. 
+*Button showing date open the date picker popup.
 *Bind to the Date property of the control to set initial time.
-*Done/OK button save the new selected date. 
+*Done/OK button save the new selected date.
 
 ### Device-specific implementation quirks
 
@@ -35,3 +35,6 @@ Since **iOS14** the native `DatePicker` changed the way it's presented. By defau
 ```csharp
 Uno.UI.FeatureConfiguration.DatePicker.UseLegacyStyle = true;
 ```
+
+> [!IMPORTANT]
+> This feature flag is required and will only affect iOS 14 devices. As of **iOS 15**, the preferred style for the DatePicker is again the one found in iOS13 and earlier.

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -219,6 +219,14 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
+			//iOS 15 brought back the Dial Wheels for the Date Picker
+			if (UIDevice.CurrentDevice.CheckSystemVersion(15, 0))
+			{
+				_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
+
+				return;
+			}
+
 			if (UIDevice.CurrentDevice.CheckSystemVersion(13, 4))
 			{
 				_picker.PreferredDatePickerStyle = FeatureConfiguration.DatePicker.UseLegacyStyle

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -219,7 +219,6 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			//iOS 15 brought back the Dial Wheels for the Date Picker
 			if (UIDevice.CurrentDevice.CheckSystemVersion(15, 0))
 			{
 				_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -160,7 +160,6 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			//iOS 15 brought back the Dial Wheels for the Date Picker
 			if (UIDevice.CurrentDevice.CheckSystemVersion(15, 0))
 			{
 				_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -160,6 +160,14 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
+			//iOS 15 brought back the Dial Wheels for the Date Picker
+			if (UIDevice.CurrentDevice.CheckSystemVersion(15, 0))
+			{
+				_picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
+
+				return;
+			}
+
 			if (UIDevice.CurrentDevice.CheckSystemVersion(13, 4))
 			{
 				_picker.PreferredDatePickerStyle = FeatureConfiguration.TimePicker.UseLegacyStyle


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7589 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
As of iOS15, users are unable to update the initial value of the TimePicker

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
