### PR TITLE
feat: Per-monitor DPI scaling on Skia.WPF

### DIFF
--- a/src/SamplesApp/SamplesApp.Skia.WPF/SamplesApp.Skia.WPF.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.WPF/SamplesApp.Skia.WPF.csproj
@@ -18,6 +18,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<UseWPF>true</UseWPF>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net472'">

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Skia.WPF.Host/SkiaWpfHost.net6.vstemplate
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Skia.WPF.Host/SkiaWpfHost.net6.vstemplate
@@ -33,6 +33,7 @@
 	  <ProjectItem TargetFileName="App.xaml.cs" ReplaceParameters="true">App.xaml.cs</ProjectItem>
 	  <ProjectItem TargetFileName="MainWindow.xaml" ReplaceParameters="true">MainWindow.xaml</ProjectItem>
 	  <ProjectItem TargetFileName="MainWindow.xaml.cs" ReplaceParameters="true">MainWindow.xaml.cs</ProjectItem>
+	  <ProjectItem TargetFileName="app.manifest" ReplaceParameters="true">app.manifest</ProjectItem>
 	</Project>
   </TemplateContent>
 </VSTemplate>

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Skia.WPF.Host/UnoQuickStart.Skia.Wpf.Host.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Skia.WPF.Host/UnoQuickStart.Skia.Wpf.Host.csproj
@@ -5,6 +5,7 @@
 		<OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
 		<TargetFramework>net6.0-windows</TargetFramework>
 		<UseWPF>true</UseWPF>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Skia.WPF.Host/app.manifest
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Skia.WPF.Host/app.manifest
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="$ext_safeprojectname$.WPF.Host"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/UnoSolutionTemplate.net6.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/UnoSolutionTemplate.net6.csproj
@@ -101,6 +101,7 @@
     <None Include="Skia.WPF\Program.cs" />
     <None Include="Skia.WPF.Host\App.xaml.cs" />
     <None Include="Skia.WPF.Host\MainWindow.xaml.cs" />
+    <None Include="Skia.WPF.Host\app.manifest" />
     <None Include="Skia.WPF.Host\Properties\AssemblyInfo.cs" />
     <None Include="Skia.WPF.Host\Properties\Resources.Designer.cs" />
     <None Include="Skia.WPF.Host\Properties\Settings.Designer.cs" />

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.WPF.Host/SkiaWpfHost.vstemplate
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.WPF.Host/SkiaWpfHost.vstemplate
@@ -33,6 +33,7 @@
 	  <ProjectItem TargetFileName="App.xaml.cs" ReplaceParameters="true">App.xaml.cs</ProjectItem>
 	  <ProjectItem TargetFileName="MainWindow.xaml" ReplaceParameters="true">MainWindow.xaml</ProjectItem>
 	  <ProjectItem TargetFileName="MainWindow.xaml.cs" ReplaceParameters="true">MainWindow.xaml.cs</ProjectItem>
+	  <ProjectItem TargetFileName="app.manifest" ReplaceParameters="true">app.manifest</ProjectItem>
 	</Project>
   </TemplateContent>
 </VSTemplate>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.WPF.Host/UnoQuickStart.Skia.Wpf.Host.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.WPF.Host/UnoQuickStart.Skia.Wpf.Host.csproj
@@ -3,8 +3,9 @@
 	<PropertyGroup>
 		<OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
 		<OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6.0-windows</TargetFramework>
 		<UseWPF>true</UseWPF>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.WPF.Host/app.manifest
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.WPF.Host/app.manifest
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="$ext_safeprojectname$.WPF.Host"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/src/SolutionTemplate/UnoSolutionTemplate/UnoSolutionTemplate.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UnoSolutionTemplate.csproj
@@ -84,6 +84,7 @@
     <None Include="Skia.WPF\Program.cs" />
     <None Include="Skia.WPF.Host\App.xaml.cs" />
     <None Include="Skia.WPF.Host\MainWindow.xaml.cs" />
+    <None Include="Skia.WPF.Host\app.manifest" />
     <None Include="Skia.WPF.Host\Properties\AssemblyInfo.cs" />
     <None Include="Skia.WPF.Host\Properties\Resources.Designer.cs" />
     <None Include="Skia.WPF.Host\Properties\Settings.Designer.cs" />

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -53,6 +53,9 @@ namespace Uno.UI.Skia.Platform
 		private bool ignorePixelScaling;
 		private FocusManager? _focusManager;
 
+		private double _dpiScaleX;
+		private double _dpiScaleY;
+
 		static WpfHost()
 		{
 			DefaultStyleKeyProperty.OverrideMetadata(typeof(WpfHost), new WpfFrameworkPropertyMetadata(typeof(WpfHost)));
@@ -121,6 +124,10 @@ namespace Uno.UI.Skia.Platform
 			Windows.UI.Core.CoreDispatcher.DispatchOverride = d => dispatcher.BeginInvoke(d);
 			Windows.UI.Core.CoreDispatcher.HasThreadAccessOverride = dispatcher.CheckAccess;
 
+			var dpi = VisualTreeHelper.GetDpi(WpfApplication.Current.MainWindow);
+			_dpiScaleX = dpi.DpiScaleX;
+			_dpiScaleY = dpi.DpiScaleY;
+
 			WinUI.Application.Start(CreateApp, args);
 
 			WinUI.Window.InvalidateRender += () =>
@@ -132,6 +139,7 @@ namespace Uno.UI.Skia.Platform
 			WpfApplication.Current.Activated += Current_Activated;
 			WpfApplication.Current.Deactivated += Current_Deactivated;
 			WpfApplication.Current.MainWindow.StateChanged += MainWindow_StateChanged;
+			WpfApplication.Current.MainWindow.DpiChanged += MainWindow_DpiChanged;
 
 			Windows.Foundation.Size preferredWindowSize = ApplicationView.PreferredLaunchViewSize;
 			if (preferredWindowSize != Windows.Foundation.Size.Empty)
@@ -142,6 +150,12 @@ namespace Uno.UI.Skia.Platform
 
 			SizeChanged += WpfHost_SizeChanged;
 			Loaded += WpfHost_Loaded;
+		}
+
+		private void MainWindow_DpiChanged(object sender, DpiChangedEventArgs e)
+		{
+			_dpiScaleX = e.NewDpi.DpiScaleX;
+			_dpiScaleY = e.NewDpi.DpiScaleY;
 		}
 
 		public override void OnApplyTemplate()
@@ -226,9 +240,9 @@ namespace Uno.UI.Skia.Platform
 
 
 			int width, height;
-			var dpi = VisualTreeHelper.GetDpi(WpfApplication.Current.MainWindow);
-			double dpiScaleX = dpi.DpiScaleX;
-			double dpiScaleY = dpi.DpiScaleY;
+			
+			double dpiScaleX = _dpiScaleX;
+			double dpiScaleY = _dpiScaleY;
 			if (IgnorePixelScaling)
 			{
 				width = (int)ActualWidth;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7764

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Skia.WPF DPI scaling is not screen-aware.

## What is the new behavior?

Skia.WPF DPI scaling is screen aware and can update at runtime.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
