### PR TITLE
Dev/xygu/20211223/wasm flipview reset

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlipViewTests/FlipView_Tests.FlipView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlipViewTests/FlipView_Tests.FlipView.cs
@@ -14,53 +14,66 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlipViewTests
     [TestFixture]
     public partial class FlipView_Tests : SampleControlUITestBase
     {
+		// Green, Blue, Red, Fuchsia, Orange
+		const string ButtonColors = "#008000,#0000FF,#FF0000,#FF00FF,#FFA500";
+
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)]
 		public void FlipView_WithButtons_FlipForward()
 		{
-			Run("UITests.Windows_UI_Xaml_Controls.FlipView.FlipView_Buttons");
-
-			_app.WaitForElement("NextButtonHorizontal");
-
-			_app.WaitForElement("Button1");
-
-			_app.WaitForElement("NextButtonHorizontal");
-
-			// FlipView buttons are Collapsed by default.
-			var nextButton = _app.Marked("NextButtonHorizontal");			
-			nextButton.SetDependencyPropertyValue("Visibility", "Visible");
-
-			_app.FastTap("NextButtonHorizontal");
-
-			_app.WaitForElement("Button2");
+			FlipView_WithButtons_BtnNavTest(1, true);
 		}
 
 		[Test]
-		[AutoRetry]
+		[AutoRetry(tryCount: 1)]
 		[ActivePlatforms(Platform.Browser)]
 		public void FlipView_WithButtons_FlipBackward()
 		{
+			FlipView_WithButtons_BtnNavTest(0, true, false);
+		}
+
+		private void FlipView_WithButtons_BtnNavTest(int expectedIndex, params bool[] forwardNavigations)
+		{
 			Run("UITests.Windows_UI_Xaml_Controls.FlipView.FlipView_Buttons");
 
-			_app.WaitForElement("NextButtonHorizontal");
-
-			// FlipView buttons are Collapsed by default.
+			var flipview = _app.Marked("SUT");
 			var nextButton = _app.Marked("NextButtonHorizontal");
-			nextButton.SetDependencyPropertyValue("Visibility", "Visible");
+			var previousButton = _app.Marked("PreviousButtonHorizontal");
 
-			_app.FastTap("NextButtonHorizontal");
+			// using tap to ensure navigation buttons are visible, since we cant mouse-over
+			_app.WaitForElement(flipview);
+			_app.FastTap(flipview);
 
-			_app.WaitForElement("Button2");
+			// perform navigations
+			foreach (var navigation in forwardNavigations.Select((x, i) => new { Step = i, Forward = x }))
+			{
+				string GetCurrentNavigationContext() =>
+					$"step#{navigation.Step} of" + new string(forwardNavigations
+						.Select(x => x ? 'N' : 'P').ToArray())
+						.Insert(navigation.Step, "*");
 
-			_app.WaitForElement("PreviousButtonHorizontal");
+				// tap previous or next
+				var targetButton = navigation.Forward ? nextButton : previousButton;
+				_app.WaitForElement(targetButton, $"Timeout waiting for the {(navigation.Forward ? "next" : "previous")} button in {GetCurrentNavigationContext()}");
+				_app.FastTap(targetButton);
+			}
 
-			var backButton = _app.Marked("PreviousButtonHorizontal");
-			backButton.SetDependencyPropertyValue("Visibility", "Visible");
-			
-			_app.FastTap("PreviousButtonHorizontal");
+			var flipviewRect = _app.GetPhysicalRect(flipview);
+			var navigationContext = new string(forwardNavigations.Select(x => x ? 'N' : 'P').ToArray());
+			var previousButtonRect = _app.GetPhysicalRect(previousButton);
 
-			_app.WaitForElement("Button1");
+			// check for selection index && content
+			Assert.AreEqual(expectedIndex, flipview.GetDependencyPropertyValue<int>("SelectedIndex"));
+			using (var screenshot = TakeScreenshot($"Post_{navigationContext}_Navigation", ignoreInSnapshotCompare: true))
+			{
+				ImageAssert.HasColorAt(
+					screenshot,
+					flipviewRect.X + previousButtonRect.Width + 2,
+					flipviewRect.CenterY,
+					ButtonColors.Split(',').ElementAtOrDefault(expectedIndex) ?? throw new IndexOutOfRangeException($"{nameof(expectedIndex)} is out of range")
+				);
+			}
 		}
 
 		[Test]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
@@ -15,8 +15,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 	public class Given_FlipView
 	{
 		[TestMethod]
-#if !__IOS__ && !__ANDROID__
-		[Ignore] // Test fails on Skia and WASM: https://github.com/unoplatform/uno/issues/7671
+#if !__IOS__ && !__ANDROID__ && !__WASM__
+		[Ignore] // Test fails on Skia: https://github.com/unoplatform/uno/issues/7671
 #endif
 		public async Task When_Observable_ItemsSource_And_Added()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/FlipView/FlipView.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/FlipView/FlipView.managed.cs
@@ -474,6 +474,11 @@ namespace Windows.UI.Xaml.Controls
 						m_tpScrollViewer.VerticalScrollMode = ScrollMode.Disabled;
 						m_tpScrollViewer.HorizontalScrollMode = ScrollMode.Enabled;
 					}
+#if HAS_UNO && __WASM__
+					// UNO workaround: the scrollability depends on both the ScrollMode and the ScrollBarVisibility, and by default the latter is Disabled.
+					m_tpScrollViewer.HorizontalScrollBarVisibility = m_tpScrollViewer.HorizontalScrollMode == ScrollMode.Enabled ? ScrollBarVisibility.Hidden : ScrollBarVisibility.Disabled;
+					m_tpScrollViewer.VerticalScrollBarVisibility = m_tpScrollViewer.VerticalScrollMode == ScrollMode.Enabled ? ScrollBarVisibility.Hidden : ScrollBarVisibility.Disabled;
+#endif
 
 					m_tpScrollViewer.SizeChanged += OnScrollingHostPartSizeChanged;
 
@@ -1516,6 +1521,9 @@ namespace Windows.UI.Xaml.Controls
 					m_tpScrollViewer?.UpdateLayout();
 
 					m_tpFixOffsetTimer?.Stop();
+
+					// UNO: force previous/next buttons' visibility to update immediately
+					UpdateVisualState();
 
 					//m_tpScrollViewer?.InvalidateScrollInfo();
 					// When the application is not being rendered, there is no need to animate

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -158,16 +158,6 @@ namespace Windows.UI.Xaml.Controls
 			{
 				var slotSize = size;
 
-#if __WASM__
-				if (CanVerticallyScroll || _forceChangeToCurrentView)
-				{
-					slotSize.Height = double.PositiveInfinity;
-				}
-				if (CanHorizontallyScroll || _forceChangeToCurrentView)
-				{
-					slotSize.Width = double.PositiveInfinity;
-				}
-#else
 				if (CanVerticallyScroll)
 				{
 					slotSize.Height = double.PositiveInfinity;
@@ -176,7 +166,6 @@ namespace Windows.UI.Xaml.Controls
 				{
 					slotSize.Width = double.PositiveInfinity;
 				}
-#endif
 
 				child.Measure(slotSize);
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -127,16 +127,18 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		private bool _canHorizontallyScroll;
 		public bool CanHorizontallyScroll
 		{
-			get => HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled || _forceChangeToCurrentView;
-			set { }
+			get => _canHorizontallyScroll || _forceChangeToCurrentView;
+			set => _canHorizontallyScroll = value;
 		}
 
+		private bool _canVerticallyScroll;
 		public bool CanVerticallyScroll
 		{
-			get => VerticalScrollBarVisibility != ScrollBarVisibility.Disabled || _forceChangeToCurrentView;
-			set { }
+			get => _canVerticallyScroll || _forceChangeToCurrentView;
+			set => _canVerticallyScroll = value;
 		}
 
 		public double HorizontalOffset { get; private set; }


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.toolkit.ui#57

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On wasm, FlipView would always resets selection back to index 0.

## What is the new behavior?

- FlipView selection can be changed and will not reset back to index 0.
- The next and previous buttons will show/hide immediately according to the relative position of selection.
- re-enabled Given_FlipView.When_Observable_ItemsSource_And_Added for wasm

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

The ScrollViewer's HV-ScrollBarVisibilities were left at Disabled causing the SV to deem itself not scrollable. After changing selection, on the next arrange pass, the SV::TrimOverscroll will be called to "adjust" the scroll position and in turn triggers FlipView::OnScrollViewerViewChanged that updates the index based on the scroll position.