### PR TITLE
fix(pointers): Make sure to never raise pointer entered/exited on parents

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/NestedHandling_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/NestedHandling_Tests.cs
@@ -26,5 +26,21 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			var result = _app.Marked("_result").GetDependencyPropertyValue("Text");
 			result.Should().Be("Pressed SUCCESS | Released SUCCESS");
 		}
+
+		[Test]
+		[AutoRetry]
+		public void When_Nested_Then_EnterAndExitedDoesNotBubble()
+		{
+			Run(_sample);
+
+			_app.FastTap("_nested");
+			_app.FastTap("_exitResult"); // Forces the pointer to move somewhere else on WASM to get the exit
+
+			var enterResult = _app.Marked("_enterResult").GetDependencyPropertyValue("Text");
+			enterResult.Should().Be("SUCCESS");
+
+			var exitResult = _app.Marked("_exitResult").GetDependencyPropertyValue("Text");
+			exitResult.Should().Be("SUCCESS");
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/NestedHandling.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/NestedHandling.xaml
@@ -16,7 +16,13 @@
 		</Border>
 
 		<StackPanel Orientation="Horizontal">
-			<TextBlock Text="Result: " />
+			<TextBlock Text="Entered result: " />
+			<TextBlock Text="**not run**" x:Name="_enterResult" />
+
+			<TextBlock Text="Exited result: " />
+			<TextBlock Text="**not run**" x:Name="_exitResult" />
+
+			<TextBlock Text="Pressed/Release result: " />
 			<TextBlock Text="**not run**" x:Name="_result" />
 		</StackPanel>
 	</Grid>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/NestedHandling.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/NestedHandling.xaml.cs
@@ -55,6 +55,30 @@ namespace UITests.Windows_UI_Input.PointersTests
 			_container.PointerPressed += (snd, e) => _result.Text = "Pressed FAIL";
 			_container.PointerMoved += (snd, e) => nestedMoveCount++;
 			_container.PointerReleased += (snd, e) => _result.Text += $" | Released {(nestedMoveCount == containerMoveCount ? "SUCCESS" : "FAIL")}";
+
+
+			_container.AddHandler(
+				PointerEnteredEvent,
+				new PointerEventHandler((snd, e) =>
+				{
+					if (e.OriginalSource != _container)
+					{
+						_enterResult.Text = "FAILED";
+					}
+				}),
+				handledEventsToo: true);
+			_nested.PointerEntered += (snd, e) => _enterResult.Text = "SUCCESS";
+			_container.AddHandler(
+				PointerExitedEvent,
+				new PointerEventHandler((snd, e) =>
+				{
+					if (e.OriginalSource != _container)
+					{
+						_exitResult.Text = "FAILED";
+					}
+				}),
+				handledEventsToo: true);
+			_nested.PointerExited += (snd, e) => _exitResult.Text = "SUCCESS";
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -748,6 +748,8 @@ namespace Windows.UI.Xaml
 			{
 				case RoutedEventFlag.PointerEntered:
 					OnPointerEnter(ptArgs, BubblingContext.OnManagedBubbling);
+					// Entered and Exited are never bubbling, we bubble them only for internal state updates, but event should not be raised
+					bubblingMode = BubblingMode.IgnoreElement;
 					break;
 				case RoutedEventFlag.PointerPressed:
 					OnPointerDown(ptArgs, BubblingContext.OnManagedBubbling);
@@ -760,6 +762,8 @@ namespace Windows.UI.Xaml
 					break;
 				case RoutedEventFlag.PointerExited:
 					OnPointerExited(ptArgs, BubblingContext.OnManagedBubbling);
+					// Entered and Exited are never bubbling, we bubble them only for internal state updates, but event should not be raised
+					bubblingMode = BubblingMode.IgnoreElement;
 					break;
 				case RoutedEventFlag.PointerCanceled:
 					OnPointerCancel(ptArgs, BubblingContext.OnManagedBubbling);

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml
 		// https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent
 		// https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent
 
-#region Native event registration handling
+		#region Native event registration handling
 		partial void OnGestureRecognizerInitialized(GestureRecognizer recognizer)
 		{
 			// When a gesture recognizer is initialized, we subscribe to pointer events in order to feed it.
@@ -107,15 +107,9 @@ namespace Windows.UI.Xaml
 					break;
 			}
 		}
-#endregion
+		#endregion
 
-#region Native event dispatch
-		// Note for Enter and Leave:
-		//	canBubble: true is actually not true.
-		//	When we subscribe to pointer enter in a window, we don't receive pointer enter for each sub-views!
-		//	But the web-browser will actually behave like WinUI for pointerenter and pointerleave, so here by setting it to true,
-		//	we just ensure that the managed code won't try to bubble it by its own.
-		//	However, if the event is Handled in managed, it will then bubble while it should not! https://github.com/unoplatform/uno/issues/3007
+		#region Native event dispatch
 		// Note about the HtmlEventDispatchResult:
 		//	For pointer events we never want to prevent the default behavior.
 		//	Especially for wheel where preventing the default would break scrolling.
@@ -253,9 +247,9 @@ namespace Windows.UI.Xaml
 
 			return type;
 		}
-#endregion
+		#endregion
 
-#region Capture
+		#region Capture
 		partial void OnManipulationModeChanged(ManipulationModes _, ManipulationModes newMode)
 			=> SetStyle("touch-action", newMode == ManipulationModes.None ? "none" : "auto");
 
@@ -280,9 +274,9 @@ namespace Windows.UI.Xaml
 				SetStyle("touch-action", "auto");
 			}
 		}
-#endregion
+		#endregion
 
-#region HitTestVisibility
+		#region HitTestVisibility
 		internal void UpdateHitTest()
 		{
 			this.CoerceValue(HitTestVisibilityProperty);
@@ -370,7 +364,7 @@ namespace Windows.UI.Xaml
 			this.ClearValue(HitTestVisibilityProperty);
 		}
 
-#endregion
+		#endregion
 
 		// TODO: This should be marshaled instead of being parsed! https://github.com/unoplatform/uno/issues/2116
 		private struct NativePointerEventArgs


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/3007

## Bugfix
Make sure to never raise pointer entered/exited on parents

## What is the current behavior?
When flagged as handled, the enter/exit events are bubbling in managed code. During that process handlers that are registered with the `handledEventsToo` flag are invoked.

## What is the new behavior?
On each element, we make sure to mute local event when receiving a a such event.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
