### PR TITLE
fix(listview): [Android] Fix calculations when ItemsPresenter.MinHeight set

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -1199,7 +1199,7 @@ namespace Windows.UI.Xaml.Controls
 			int maxPossibleDelta;
 			if (fillDirection == GeneratorDirection.Forward)
 			{
-				var contentEnd = Math.Max(GetContentEnd(), ItemsPresenterMinExtent - ContentOffset);
+				var contentEnd = GetContentEnd();
 				// If this value is negative, collection dimensions are larger than all children and we should not scroll
 				maxPossibleDelta = Math.Max(0, contentEnd - Extent);
 				// In the rare case that GetContentStart() is positive (see below), permit a positive value.
@@ -2375,9 +2375,14 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		/// <summary>
-		/// Return the farthest extent of all currently materialized content.
+		/// Return the farthest extent of all currently materialized content, including the extent of the notional 'panel' defined by the ItemsPresenter.
 		/// </summary>
-		private int GetContentEnd()
+		private int GetContentEnd() => Math.Max(GetItemsContentEnd(), ItemsPresenterMinExtent - ContentOffset);
+
+		/// <summary>
+		/// Return the farthest extent of all currently materialized content items. Most of the time <see cref="GetContentEnd"/> should be used instead.
+		/// </summary>
+		private int GetItemsContentEnd()
 		{
 			int contentEnd = GetLeadingGroup(GeneratorDirection.Forward)?.End ?? GetHeaderEnd();
 			if (FooterViewCount > 0)


### PR DESCRIPTION


Take the ItemsPresenter.MinHeight into account when calculating content extent in all contexts, not just scrolling. This fixes a bug where the scroll would be incorrectly reset by UpdateScrollPositionForPaddingChanges() when ItemsPresenter.MinHeight was set.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
fixes https://github.com/unoplatform/nventive-private/issues/323