### PR TITLE
Fix ScrollViewer's ControlTemplate content not unreferenced while recycling

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -546,9 +546,9 @@ namespace Uno.UI.Samples.Tests
 			var testClassNameContainsFilters = filters?.Any(f => testClassInfo.Type.FullName.Contains(f, StrComp)) ?? false;
 			return testClassInfo.Tests
 				.Where(t => (filters?.None() ?? true)
-					|| testClassNameContainsFilters
-					|| filters.Any(f => t.DeclaringType.FullName.Contains(f, StrComp))
-					|| filters.Any(f => t.Name.Contains(f, StrComp)))
+					    || testClassNameContainsFilters
+					    || filters.Any(f => t.DeclaringType.FullName.Contains(f, StrComp))
+					    || filters.Any(f => t.Name.Contains(f, StrComp)))
 				.ToArray();
 		}
 
@@ -828,7 +828,6 @@ namespace Uno.UI.Samples.Tests
 				select type;
 
 			var types = GetType().GetTypeInfo().Assembly.GetTypes().Concat(testAssembliesTypes);
-			var ts = types.Select(t => t.FullName).ToArray();
 
 			return from type in types
 				   where type.GetTypeInfo().GetCustomAttribute(typeof(TestClassAttribute)) != null

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ContentDialog_Leak.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ContentDialog_Leak.xaml
@@ -1,0 +1,41 @@
+﻿<ContentDialog
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.ContentDialog_Leak">
+
+	<StackPanel>
+		<ScrollViewer>
+			<StackPanel>
+				<TextBox />
+				<TextBox />
+				<TextBox />
+				<TextBox />
+				<TextBox />
+				<TextBox />
+			</StackPanel>
+
+		</ScrollViewer>
+		<TextBox />
+		<TextBox />
+		<ScrollViewer>
+			<StackPanel>
+				<TextBox />
+				<ScrollViewer />
+				<TextBox />
+				<ScrollViewer />
+				<TextBox />
+				<ScrollViewer />
+				<TextBox />
+				<ScrollViewer />
+				<TextBox />
+				<ScrollViewer />
+				<TextBox />
+				<ScrollViewer />
+			</StackPanel>
+		</ScrollViewer>
+	</StackPanel>
+
+</ContentDialog>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ContentDialog_Leak.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ContentDialog_Leak.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public partial class ContentDialog_Leak : ContentDialog
+	{
+		public ContentDialog_Leak()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -50,7 +50,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(typeof(ListView), 15)]
 		[DataRow(typeof(ProgressRing), 15)]
 		[DataRow(typeof(Pivot), 15)]
-		// [DataRow(typeof(ScrollBar), 15)] https://github.com/unoplatform/uno/issues/7331
+		[DataRow(typeof(ScrollBar), 15)] // https://github.com/unoplatform/uno/issues/7331
 		[DataRow(typeof(Slider), 15)]
 		[DataRow(typeof(SymbolIcon), 15)]
 		[DataRow(typeof(Viewbox), 15)]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -68,6 +68,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow("Uno.UI.Samples.Content.UITests.ButtonTestsControl.Buttons", 15)]
 		[DataRow("UITests.Windows_UI_Xaml.xLoadTests.xLoad_Test_For_Leak", 15)]
 		[DataRow("UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_LeakTest", 15)]
+		[DataRow("Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.ContentDialog_Leak", 15)]
 		public async Task When_Add_Remove(object controlTypeRaw, int count)
 		{
 #if TRACK_REFS

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -31,7 +31,7 @@
 		<Reference Include="System.Xml.Linq" />
 	</ItemGroup>
 
-	<Import Project="UnitTestsImport.props"/>
+	<Import Project="UnitTestsImport.props" />
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
 		<EmbeddedResource Include="LinkerDefinition.Wasm.xml">
@@ -101,7 +101,16 @@
 	</ItemGroup>
 	
 	<ItemGroup>
+	  <None Update="Tests\Windows_UI_Xaml\Controls\ContentDialog_Leak.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </None>
+	</ItemGroup>
+	
+	<ItemGroup>
 		<Page Update="Tests\Windows_UI_Xaml\Controls\Animation_Leak.xaml">
+		  <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+		</Page>
+		<Page Update="Tests\Windows_UI_Xaml\Controls\ContentDialog_Leak.xaml">
 		  <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
 		</Page>
 		<Page Update="Tests\Windows_UI_Xaml\Controls\xLoad_xBind.xaml">

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -136,7 +136,9 @@ namespace Windows.UI.Xaml.Controls
 					_popup.Child = null;
 					UpdateVisualState();
 					Closed?.Invoke(this, new ContentDialogClosedEventArgs(result));
-					_tcs.SetResult(result);
+
+					(var tcs, _tcs) = (_tcs, null);
+					DispatcherQueue.TryEnqueue(() => tcs?.TrySetResult(result));
 				}
 				_hiding = false;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.iOS.cs
@@ -166,6 +166,11 @@ namespace Windows.UI.Xaml.Controls
 				previousView.RemoveFromSuperview();
 			}
 
+			while (Subviews.Length > 0)
+			{
+				Subviews[0].RemoveFromSuperview();
+			}
+
 			if (newView != null)
 			{
 				AddSubview(newView);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Native.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Native.cs
@@ -7,11 +7,30 @@ namespace Windows.UI.Xaml.Controls
 {
 	// This file only contains support of NativeScrollContentPresenter
 
-	partial class ScrollContentPresenter
+	partial class ScrollContentPresenter : IFrameworkTemplatePoolAware
 	{
 		internal INativeScrollContentPresenter Native { get; set; }
 
 		private object RealContent => Native?.Content;
+
+		public void OnTemplateRecycled()
+		{
+			if (TemplatedParent is null && Native is { })
+			{
+				Native.Content = null;
+				Native = null;
+			}
+		}
+
+		protected internal override void OnTemplatedParentChanged(DependencyPropertyChangedEventArgs e)
+		{
+			if (e.NewValue is null)
+			{
+				Native.Content = null;
+			}
+
+			base.OnTemplatedParentChanged(e);
+		}
 
 		#region SCP to Native SCP
 		public ScrollBarVisibility NativeHorizontalScrollBarVisibility

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -34,6 +34,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			InitializePartial();
 			RegisterAsScrollPort(this);
+
+			InitializeScrollContentPresenter();
 		}
 		partial void InitializePartial();
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -16,6 +16,7 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Core;
+using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Uno;
 using Uno.Extensions;
@@ -132,6 +133,14 @@ namespace Windows.UI.Xaml.Controls
 			Loaded += AttachScrollBars;
 			Unloaded += DetachScrollBars;
 			Unloaded += ResetScrollIndicator;
+
+			this.RegisterParentChangedCallback(this, (instance, key, args) =>
+			{
+				if (args.NewParent is null)
+				{
+					ClearContentTemplatedParent(Content);
+				}
+			});
 		}
 
 		partial void InitializePartial();
@@ -969,16 +978,19 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		#region Content and TemplatedParent forwarding to the ScrollContentPresenter
-		protected override void OnContentChanged(object oldValue, object newValue)
+		protected override void OnContentChanged(object? oldValue, object? newValue)
 		{
-			base.OnContentChanged(oldValue, newValue);
-
-			if (_presenter != null)
+			if (oldValue is { } && oldValue != newValue)
 			{
 				// remove the explicit templated parent propagation
 				// for the lack of TemplatedParentScope support
 				ClearContentTemplatedParent(oldValue);
+			}
 
+			base.OnContentChanged(oldValue, newValue);
+
+			if (_presenter != null)
+			{
 				ApplyScrollContentPresenterContent(newValue);
 			}
 
@@ -987,7 +999,7 @@ namespace Windows.UI.Xaml.Controls
 			_snapPointsInfo = newValue as IScrollSnapPointsInfo;
 		}
 
-		private void ApplyScrollContentPresenterContent(object content)
+		private void ApplyScrollContentPresenterContent(object? content)
 		{
 			// Stop the automatic propagation of the templated parent on the Content
 			// This prevents issues when the a ScrollViewer is hosted in a control template
@@ -1048,7 +1060,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private void ClearContentTemplatedParent(object oldContent)
+		private void ClearContentTemplatedParent(object? oldContent)
 		{
 			if (oldContent is IDependencyObjectStoreProvider provider)
 			{

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
@@ -27,7 +27,7 @@ namespace Windows.UI.Xaml
 	
 	public partial class FrameworkTemplate : DependencyObject
 	{
-		private readonly FrameworkTemplateBuilder? _viewFactory;
+		internal readonly FrameworkTemplateBuilder? _viewFactory;
 		private readonly int _hashCode;
 		private readonly ManagedWeakReference? _ownerRef;
 

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -249,6 +249,11 @@ namespace Windows.UI.Xaml
 					_trace.WriteEventActivity(TraceProvider.RecycleTemplate, EventOpcode.Send, new[] { instance.GetType().ToString() });
 				}
 
+				if (instance is IDependencyObjectStoreProvider provider)
+				{
+					provider.Store.Parent = null;
+					provider.Store.ClearValue(provider.Store.TemplatedParentProperty, DependencyPropertyValuePrecedences.Local);
+				}
 				PropagateOnTemplateReused(instance);
 
 				var item = instance as View;

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -320,10 +320,8 @@ namespace Windows.UI.Xaml
 			{
 				i++;
 				var pooledTemplate = kvp.Key;
-				if (template?.Equals(pooledTemplate) ?? false)
+				if ((template?.Equals(pooledTemplate) ?? false) && template._viewFactory is { } func)
 				{
-					var func = ((Func<View>)template);
-
 					return $"{i}({func.Method.DeclaringType}.{func.Method.Name})";
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/1592
Potentially fixes https://github.com/unoplatform/uno/issues/7380

# Bugfix
ScrollViewer's ControlTemplate content not unreferenced while recycling

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
