### PR TITLE
fix: FileSavePicker should create target file on GTK and WPF

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileSavePickerExtension.cs
@@ -2,6 +2,7 @@
 
 using Gtk;
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Uno.UI.Runtime.Skia;
@@ -41,7 +42,11 @@ namespace Uno.Extensions.Storage.Pickers
 			StorageFile? file = null;
 			if (dialog.Run() == (int)ResponseType.Accept)
 			{
-				file = await StorageFile.GetFileFromPathAsync(dialog.Filename);
+				if (!File.Exists(dialog.Filename))
+				{
+					File.WriteAllText(dialog.Filename, "");
+				}
+				file = await StorageFile.GetFileFromPathAsync(dialog.Filename);				
 			}
 
 			dialog.Destroy();

--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileSavePickerExtension.cs
@@ -44,7 +44,7 @@ namespace Uno.Extensions.Storage.Pickers
 			{
 				if (!File.Exists(dialog.Filename))
 				{
-					File.WriteAllText(dialog.Filename, "");
+					File.Create(dialog.Filename).Dispose();
 				}
 				file = await StorageFile.GetFileFromPathAsync(dialog.Filename);				
 			}

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/Storage/Pickers/FileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/Storage/Pickers/FileSavePickerExtension.cs
@@ -55,7 +55,7 @@ namespace Uno.Extensions.Storage.Pickers
 			{
 				if (!File.Exists(saveFileDialog.FileName))
 				{
-					File.WriteAllText(saveFileDialog.FileName, "");
+					File.Create(saveFileDialog.FileName).Dispose();
 				}
 				return await StorageFile.GetFileFromPathAsync(saveFileDialog.FileName);
 			}

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/Storage/Pickers/FileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/Storage/Pickers/FileSavePickerExtension.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -52,6 +53,10 @@ namespace Uno.Extensions.Storage.Pickers
 
 			if (saveFileDialog.ShowDialog() == true)
 			{
+				if (!File.Exists(saveFileDialog.FileName))
+				{
+					File.WriteAllText(saveFileDialog.FileName, "");
+				}
 				return await StorageFile.GetFileFromPathAsync(saveFileDialog.FileName);
 			}
 			return null;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7783


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

File is not created when save picker selects a non-existing file.

## What is the new behavior?

File is created.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.