### PR TITLE
perf(memory): Remove delegate for UIElement GestureRecognizer

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Android.cs
@@ -42,6 +42,10 @@ namespace Windows.UI.Xaml
 				=> _target.OnNativeMotionEvent(nativeEvent, view, true);
 		}
 
+		partial void InitializePointersPartial()
+		{
+			ArePointersEnabled = true;
+		}
 
 		partial void AddPointerHandler(RoutedEvent routedEvent, int handlersCount, object handler, bool handledEventsToo)
 		{
@@ -61,7 +65,7 @@ namespace Windows.UI.Xaml
 
 		protected sealed override bool OnNativeMotionEvent(MotionEvent nativeEvent, View originalSource, bool isInView)
 		{
-			if (IsPointersSuspended)
+			if (!ArePointersEnabled)
 			{
 				return false;
 			}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.iOS.cs
@@ -76,12 +76,14 @@ namespace Windows.UI.Xaml
 		{
 			MultipleTouchEnabled = true;
 			RegisterLoadActions(OnLoadedForPointers, OnUnloadedForPointers);
+
+			ArePointersEnabled = true;
 		}
 
 		#region Native touch handling (i.e. source of the pointer / gesture events)
 		public override void TouchesBegan(NSSet touches, UIEvent evt)
 		{
-			if (IsPointersSuspended)
+			if (!ArePointersEnabled)
 			{
 				return; // Will also prevent subsequents events
 			}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

Reduce UIElement memory pressure by removing an unnecessary `Lazy<T>` holding `GestureRecognizer`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
