### PR TITLE
perf(memory): Remove `RegisterDefaultValueProvider` delegate in favor of `UIElement` cast

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DefaultValueProvider.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DefaultValueProvider.cs
@@ -15,20 +15,7 @@ namespace Uno.UI.Tests.DependencyPropertyTests
 		[TestMethod]
 		public void When_DefaultValueProvider_Registered_Provides_Value()
 		{
-			bool GetDefaultValue(DependencyProperty property, out object value)
-			{
-				if (property == DefaultValueProviderSample.TestProperty)
-				{
-					value = 3;
-					return true;
-				}
-
-				value = null;
-				return false;
-			}
-
 			var test = new DefaultValueProviderSample();
-			test.RegisterDefaultValueProvider(GetDefaultValue);
 
 			var value = test.GetPrecedenceSpecificValue(DefaultValueProviderSample.TestProperty, DependencyPropertyValuePrecedences.DefaultValue);
 			Assert.AreEqual(3, value);
@@ -37,20 +24,7 @@ namespace Uno.UI.Tests.DependencyPropertyTests
 		[TestMethod]
 		public void When_DefaultValueProvider_Registered_Other_Property_Not_Affected()
 		{
-			bool GetDefaultValue(DependencyProperty property, out object value)
-			{
-				if (property == DefaultValueProviderSample.TestProperty)
-				{
-					value = 3;
-					return true;
-				}
-
-				value = 42; // Set arbitrary to verify false has effect
-				return false;
-			}
-
 			var test = new DefaultValueProviderSample();
-			test.RegisterDefaultValueProvider(GetDefaultValue);
 
 			var value = test.GetPrecedenceSpecificValue(DefaultValueProviderSample.OtherProperty, DependencyPropertyValuePrecedences.DefaultValue);
 			Assert.AreEqual(0, value);
@@ -59,33 +33,7 @@ namespace Uno.UI.Tests.DependencyPropertyTests
 		[TestMethod]
 		public void When_DefaultValueProvider_Multiple_Registered_Overwrite()
 		{
-			bool GetDefaultValue(DependencyProperty property, out object value)
-			{
-				if (property == DefaultValueProviderSample.TestProperty)
-				{
-					value = 3;
-					return true;
-				}
-
-				value = null;
-				return false;
-			}
-
-			bool GetDefaultValue2(DependencyProperty property, out object value)
-			{
-				if (property == DefaultValueProviderSample.TestProperty)
-				{
-					value = 17;
-					return true;
-				}
-
-				value = null;
-				return false;
-			}
-
-			var test = new DefaultValueProviderSample();
-			test.RegisterDefaultValueProvider(GetDefaultValue);
-			test.RegisterDefaultValueProvider(GetDefaultValue2);
+			var test = new InheritedDefaultValueProviderSample();
 
 			var value = test.GetPrecedenceSpecificValue(DefaultValueProviderSample.TestProperty, DependencyPropertyValuePrecedences.DefaultValue);
 			Assert.AreEqual(17, value);
@@ -94,44 +42,57 @@ namespace Uno.UI.Tests.DependencyPropertyTests
 		[TestMethod]
 		public void When_DefaultValueProvider_Multiple_Registered_Unaffected()
 		{
-			bool GetDefaultValue(DependencyProperty property, out object value)
-			{
-				if (property == DefaultValueProviderSample.TestProperty)
-				{
-					value = 3;
-					return true;
-				}
-
-				value = null;
-				return false;
-			}
-
-			bool GetDefaultValue2(DependencyProperty property, out object value)
-			{
-				if (property == DefaultValueProviderSample.OtherProperty)
-				{
-					value = 17;
-					return true;
-				}
-
-				value = 42;
-				return false;
-			}
-
-			var test = new DefaultValueProviderSample();
-			test.RegisterDefaultValueProvider(GetDefaultValue);
-			test.RegisterDefaultValueProvider(GetDefaultValue2);
+			var test = new InheritedDefaultValueProviderSample2();
 
 			var value = test.GetPrecedenceSpecificValue(DefaultValueProviderSample.TestProperty, DependencyPropertyValuePrecedences.DefaultValue);
 			Assert.AreEqual(3, value); // GetDefaultValue should apply
 		}
 	}
 
-	internal partial class DefaultValueProviderSample : MockDependencyObject
+	internal partial class InheritedDefaultValueProviderSample : DefaultValueProviderSample
+	{
+		internal override bool GetDefaultValue2(DependencyProperty property, out object value)
+		{
+			if (property == DefaultValueProviderSample.TestProperty)
+			{
+				value = 17;
+				return true;
+			}
+
+			return base.GetDefaultValue2(property, out value);
+		}
+	}
+
+	internal partial class InheritedDefaultValueProviderSample2 : DefaultValueProviderSample
+	{
+		internal override bool GetDefaultValue2(DependencyProperty property, out object value)
+		{
+			if (property == DefaultValueProviderSample.OtherProperty)
+			{
+				value = 17;
+				return true;
+			}
+
+			return base.GetDefaultValue2(property, out value);
+		}
+	}
+
+	internal partial class DefaultValueProviderSample : UIElement
 	{
 		public DefaultValueProviderSample()
 		{
 			
+		}
+
+		internal override bool GetDefaultValue2(DependencyProperty property, out object value)
+		{
+			if (property == DefaultValueProviderSample.TestProperty)
+			{
+				value = 3;
+				return true;
+			}
+
+			return base.GetDefaultValue2(property, out value);
 		}
 
 		public int Test

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
@@ -1900,14 +1900,13 @@ namespace Uno.UI.Tests.BinderTests
 
 	}
 
-	partial class MyDependencyObjectWithDefaultValueOverride : DependencyObject
+	partial class MyDependencyObjectWithDefaultValueOverride : FrameworkElement
 	{
 		public MyDependencyObjectWithDefaultValueOverride()
 		{
-			this.RegisterDefaultValueProvider(OnProvideDefaultValue);
 		}
 
-		private bool OnProvideDefaultValue(DependencyProperty property, out object defaultValue)
+		internal override bool GetDefaultValue2(DependencyProperty property, out object defaultValue)
 		{
 			if (property == MyPropertyProperty)
 			{
@@ -1916,8 +1915,7 @@ namespace Uno.UI.Tests.BinderTests
 				return true;
 			}
 
-			defaultValue = null;
-			return false;
+			return base.GetDefaultValue2(property, out defaultValue);
 		}
 
 		public int MyProperty

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarDatePicker.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarDatePicker.Properties.cs
@@ -179,7 +179,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private const int DEFAULT_MIN_MAX_DATE_YEAR_OFFSET = 100;
 
-		private bool SetPropertyDefaultValue(DependencyProperty property, out object value)
+		internal override bool GetDefaultValue2(DependencyProperty property, out object value)
 		{
 			Calendar GetOrCreateGregorianCalendar()
 			{
@@ -241,8 +241,7 @@ namespace Windows.UI.Xaml.Controls
 				return true;
 			}
 
-			value = default;
-			return false;
+			return base.GetDefaultValue2(property, out value);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/calendardatepicker_partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/calendardatepicker_partial.cs
@@ -68,8 +68,6 @@ namespace Windows.UI.Xaml.Controls
 		{
 			DefaultStyleKey = typeof(CalendarDatePicker);
 
-			this.RegisterDefaultValueProvider(SetPropertyDefaultValue);
-
 			m_isYearDecadeViewDimensionRequested = false;
 			m_colsInYearDecadeView = 0;
 			m_rowsInYearDecadeView = 0;

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -180,8 +180,6 @@ namespace Windows.UI.Xaml.Controls
 
 		public DatePicker()
 		{
-			this.RegisterDefaultValueProvider(GetDefaultValue2);
-
 			m_numberOfYears = 0;
 			m_reactionToSelectionChangeAllowed = true;
 			m_isInitializing = true;
@@ -1012,7 +1010,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		// Gives the default values for our properties.
-		private bool GetDefaultValue2(
+		internal override bool GetDefaultValue2(
 			 DependencyProperty pDP,
 			 out object pValue)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.cs
@@ -20,8 +20,6 @@ namespace Windows.UI.Xaml.Controls
 		{
 			DefaultStyleKey = typeof(ToggleSwitch);
 
-			this.RegisterDefaultValueProvider(GetDefaultValue2);
-
 			//TODO Uno specific: Calling prepare state here, but should be called from DXamlCore.
 			PrepareState();
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs
@@ -219,7 +219,7 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		/// <param name="dependencyProperty"></param>
 		/// <param name="value"></param>
-		private bool GetDefaultValue2(DependencyProperty dependencyProperty, out object? value)
+		internal override bool GetDefaultValue2(DependencyProperty dependencyProperty, out object? value)
 		{
 			var core = DXamlCore.Current;
 			if (dependencyProperty == OnContentProperty)
@@ -234,8 +234,8 @@ namespace Windows.UI.Xaml.Controls
 				value = offString;
 				return true;
 			}
-			value = null;
-			return false;
+
+			return base.GetDefaultValue2(dependencyProperty, out value);
 		}
 
 		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)

--- a/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
@@ -444,9 +444,6 @@ namespace Windows.UI.Xaml
 			uielement?.InvalidateRender();
 		}
 
-		internal static void RegisterDefaultValueProvider(this IDependencyObjectStoreProvider storeProvider, DependencyObjectStore.DefaultValueProvider provider)
-			=> storeProvider.Store.RegisterDefaultValueProvider(provider);
-
 		/// <summary>
 		/// See <see cref="DependencyObjectStore.RegisterPropertyChangedCallbackStrong(ExplicitPropertyChangedCallback)"/> for more details
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -524,11 +524,6 @@ namespace Windows.UI.Xaml
 			_properties.SetSourceValue(propertyDetails, value);
 		}
 
-		internal void RegisterDefaultValueProvider(DefaultValueProvider provider)
-		{
-			_properties.RegisterDefaultValueProvider(provider);
-		}
-
 		/// <summary>
 		/// Subscribes to a dependency property changed handler
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -39,7 +39,6 @@ namespace Windows.UI.Xaml
 		private int _entriesLength;
 		private int _minId;
 		private int _maxId;
-		private List<DependencyObjectStore.DefaultValueProvider>? _defaultValueProviders = null;
 
 		private object? Owner => _hardOwnerReference ?? _ownerReference.Target;
 
@@ -194,18 +193,12 @@ namespace Windows.UI.Xaml
 
 		private bool TryResolveDefaultValueFromProviders(DependencyProperty property, out object? value)
 		{
-			if (_defaultValueProviders != null)
+			// Replicate the WinUI behavior of DependencyObject::GetDefaultValue2 specifically for UIElement.
+			if (Owner is UIElement uiElement)
 			{
-				for (int i = _defaultValueProviders.Count - 1; i >= 0; i--)
-				{
-					var provider = _defaultValueProviders[i];
-					if (provider.Invoke(property, out var resolvedValue))
-					{
-						value = resolvedValue;
-						return true;
-					}
-				}
+				return uiElement.GetDefaultValue2(property, out value);
 			}
+
 			value = null;
 			return false;
 		}
@@ -231,27 +224,6 @@ namespace Windows.UI.Xaml
 		}
 
 		internal DependencyPropertyDetails?[] GetAllDetails() => Entries;
-
-		/// <summary>
-		/// Adds a default value provider.
-		/// </summary>
-		/// <param name="provider">Default value provider.</param>
-		/// <remarks>
-		/// Providers which are registered later have higher priority.
-		/// E.g. when both a derived and base class register their own default
-		/// value provider in the constructor for the same property, the derived
-		/// class value is used.
-		/// </remarks>
-		public void RegisterDefaultValueProvider(DependencyObjectStore.DefaultValueProvider provider)
-		{
-			if (provider == null)
-			{
-				throw new ArgumentNullException(nameof(provider));
-			}
-
-			_defaultValueProviders ??= new List<DependencyObjectStore.DefaultValueProvider>(2);
-			_defaultValueProviders.Add(provider);
-		}
 
 		internal void TryEnableHardReferences()
 		{

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -75,12 +75,17 @@ namespace Windows.UI.Xaml
 
 		private void Initialize()
 		{
-			this.RegisterDefaultValueProvider(OnGetDefaultValue);
 		}
 
 		private protected virtual bool IsTabStopDefaultValue => false;
 
-		private bool OnGetDefaultValue(DependencyProperty property, out object defaultValue)
+		/// <summary>
+		/// Provide an instance-specific default value for the specified property
+		/// </summary>
+		/// <remarks>
+		/// In general, it is best do define the property default value using <see cref="PropertyMetadata"/>.
+		/// </remarks>
+		internal virtual bool GetDefaultValue2(DependencyProperty property, out object defaultValue)
 		{
 			if (property == KeyboardAcceleratorsProperty)
 			{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Uses method override instead of delegate invocation for performance and less allocations during UIElement instanciation.

Note that this change removes internal support for `DependencyObject.GetDefaultValue2`, though this is not used anywhere in Uno at this point. We'll add it back as needed through generated code.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
