### PR TITLE
perf(timeline): Remove the use of events and disposables

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8645,6 +8645,12 @@
 			<Member
 				fullName="System.Void Uno.Media.StreamGeometryContext.BeginFigure(Windows.Foundation.Point startPoint, System.Boolean isFilled, System.Boolean isClosed)"
 				reason="isClosed paramater is not used and is misleading" />
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Media.Animation.Timeline.add_Completed(System.EventHandler`1&lt;System.Object&gt; value)"
+				reason="Incorrectly marked as removed because removed from an internal interface" />
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Media.Animation.Timeline.remove_Completed(System.EventHandler`1&lt;System.Object&gt; value)"
+				reason="Incorrectly marked as removed because removed from an internal interface" />
 		</Methods>
 	</IgnoreSet>
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ITimeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ITimeline.cs
@@ -19,7 +19,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		void SeekAlignedToLastTick(TimeSpan offset);
 		void SkipToFill();
 		void Deactivate();
-		event EventHandler<object> Completed;
-		event EventHandler<object> Failed;
+		void RegisterListener(ITimelineListener storyboard);
+		void UnregisterListener(ITimelineListener storyboard);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ITimelineListener.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ITimelineListener.cs
@@ -1,0 +1,8 @@
+﻿namespace Windows.UI.Xaml.Media.Animation
+{
+	internal interface ITimelineListener
+	{
+		void ChildCompleted(Timeline timeline);
+		void ChildFailed(Timeline timeline);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -16,12 +16,12 @@ namespace Windows.UI.Xaml.Media.Animation
 		private WeakReference<DependencyObject> _targetElement;
 		private BindingPath _propertyInfo;
 		private List<ITimelineListener> _timelineListeners = new();
-		private List<EventHandler<object>> _completedHandlers = new();
+		private List<EventHandler<object>> _completedHandlers;
 
 		public event EventHandler<object> Completed
 		{
-			add => _completedHandlers.Add(value);
-			remove => _completedHandlers.Remove(value);
+			add => (_completedHandlers ??= new()).Add(value);
+			remove => _completedHandlers?.Remove(value);
 		}
 
 		public Timeline()
@@ -102,9 +102,12 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		protected void OnCompleted()
 		{
-			for (int i = 0; i < _completedHandlers.Count; i++)
+			if (_completedHandlers != null)
 			{
-				_completedHandlers[i].Invoke(this, null);
+				for (int i = 0; i < _completedHandlers.Count; i++)
+				{
+					_completedHandlers[i].Invoke(this, null);
+				}
 			}
 
 			for (var i = 0; i < _timelineListeners.Count; i++)

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -16,6 +16,13 @@ namespace Windows.UI.Xaml.Media.Animation
 		private WeakReference<DependencyObject> _targetElement;
 		private BindingPath _propertyInfo;
 		private List<ITimelineListener> _timelineListeners = new();
+		private List<EventHandler<object>> _completedHandlers = new();
+
+		public event EventHandler<object> Completed
+		{
+			add => _completedHandlers.Add(value);
+			remove => _completedHandlers.Remove(value);
+		}
 
 		public Timeline()
 		{
@@ -87,8 +94,6 @@ namespace Windows.UI.Xaml.Media.Animation
 			DependencyProperty.Register("RepeatBehavior", typeof(RepeatBehavior), typeof(Timeline), new FrameworkPropertyMetadata(new RepeatBehavior()));
 
 
-		public event EventHandler<object> Completed;
-
 		void ITimeline.RegisterListener(ITimelineListener listener)
 			=> _timelineListeners.Add(listener);
 
@@ -97,7 +102,10 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		protected void OnCompleted()
 		{
-			Completed?.Invoke(this, null);
+			for (int i = 0; i < _completedHandlers.Count; i++)
+			{
+				_completedHandlers[i].Invoke(this, null);
+			}
 
 			for (var i = 0; i < _timelineListeners.Count; i++)
 			{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Code style update (formatting)

## What is the new behavior?

Removes the use of events and disposable to reduce the memory footprint when observing timeline events from a storyboard.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
