### PR TITLE
fix: Remove blue tap highlight on mobile browsers

### DIFF
--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -7,6 +7,7 @@ body {
   height: 100%;
   width: 100%;
   overflow: hidden;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
 .uno-root-element {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7569


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Mobile browsers add a blue highlight on interactive elements when tapped.

## What is the new behavior?

Blue highlight removed.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.