### PR TITLE
perf(memory): Reduce `ConditionalDisposable` pressure

### DIFF
--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Disposables/Disposables/ConditionalDisposable.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Disposables/Disposables/ConditionalDisposable.cs
@@ -26,11 +26,10 @@ namespace Uno.Disposables
 	/// <summary>
 	/// A disposable that can call an action when a dependent object has been collected.
 	/// </summary>
-	internal class ConditionalDisposable : IDisposable
+	internal abstract class ConditionalDisposable : IDisposable
 	{
 		private static ConditionalWeakTable<object, List<IDisposable>> _registrations = new ConditionalWeakTable<object, List<IDisposable>>();
 
-		private readonly Action _action;
 		private bool _disposed;
 		private readonly WeakReference? _conditionSource;
 		private readonly List<IDisposable> _list;
@@ -43,12 +42,10 @@ namespace Uno.Disposables
 		/// Creates a <see cref="ConditionalDisposable"/> instance using 
 		/// <paramref name="target"/> as a reference for its lifetime.
 		/// </summary>
-		/// <param name="action">The action to be executed when target has been collected</param>
 		/// <param name="conditionSource">An optional secondary reference, used to avoid calling action if it has been collected</param>
 		/// <param name="target">The instance to use to keep the disposable alive</param>
-		public ConditionalDisposable(object target, Action action, WeakReference? conditionSource = null)
+		public ConditionalDisposable(object target, WeakReference? conditionSource = null)
 		{
-			_action = action;
 			_conditionSource = conditionSource;
 
 #if DEBUG
@@ -74,6 +71,8 @@ namespace Uno.Disposables
 			Dispose(true);
 		}
 
+		protected abstract void TargetFinalized();
+
 		private void Dispose(bool disposing)
 		{
 			if(disposing)
@@ -94,7 +93,7 @@ namespace Uno.Disposables
 					{
 						_disposed = true;
 
-						_action();
+						TargetFinalized();
 					}
 				}
 			}
@@ -105,5 +104,4 @@ namespace Uno.Disposables
 			Dispose(false);
 		}
 	}
-
 }

--- a/src/Uno.UI/AssemblyInfo.cs
+++ b/src/Uno.UI/AssemblyInfo.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Uno.UI.RuntimeTests")]
 [assembly: InternalsVisibleTo("Uno.UI.RuntimeTests.Wasm")]
 [assembly: InternalsVisibleTo("Uno.UI.RuntimeTests.Skia")]
+[assembly: InternalsVisibleTo("Uno.UI.Lottie")]
 [assembly: InternalsVisibleTo("SamplesApp")]
 [assembly: InternalsVisibleTo("SamplesApp.Droid")]
 [assembly: InternalsVisibleTo("SamplesApp.macOS")]

--- a/src/Uno.UI/UI/Xaml/Controls/DropDownButton/DropDownButton.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DropDownButton/DropDownButton.cs
@@ -27,9 +27,17 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnApplyTemplate();
 
-			this.RegisterDisposablePropertyChangedCallback(Button.FlyoutProperty, OnFlyoutPropertyChanged);
-
 			RegisterFlyoutEvents();
+		}
+
+		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
+		{
+			if (args.Property == Button.FlyoutProperty)
+			{
+				OnFlyoutPropertyChanged(this, args);
+			}
+
+			base.OnPropertyChanged2(args);
 		}
 
 		private void RegisterFlyoutEvents()

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/ColumnDefinition.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/ColumnDefinition.cs
@@ -15,11 +15,14 @@ namespace Windows.UI.Xaml.Controls
 		{
 			InitializeBinder();
 			IsAutoPropertyInheritanceEnabled = false;
+		}
 
-			this.RegisterDisposablePropertyChangedCallback((i, p, args) =>
-			{
-				InvalidateDefinition();
-			});
+		/// <remarks>
+		/// This method is called from the generated IDependencyObjectInternal.OnPropertyChanged2 method
+		/// </summary>
+		internal void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
+		{
+			InvalidateDefinition();
 		}
 
 		#region Width DependencyProperty

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/ColumnDefinition.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/ColumnDefinition.cs
@@ -17,9 +17,7 @@ namespace Windows.UI.Xaml.Controls
 			IsAutoPropertyInheritanceEnabled = false;
 		}
 
-		/// <remarks>
-		/// This method is called from the generated IDependencyObjectInternal.OnPropertyChanged2 method
-		/// </summary>
+		// This method is called from the generated IDependencyObjectInternal.OnPropertyChanged2 method
 		internal void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
 		{
 			InvalidateDefinition();

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/RowDefinition.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/RowDefinition.cs
@@ -16,9 +16,7 @@ namespace Windows.UI.Xaml.Controls
 			IsAutoPropertyInheritanceEnabled = false;
 		}
 
-		/// <remarks>
-		/// This method is called from the generated IDependencyObjectInternal.OnPropertyChanged2 method
-		/// </summary>
+		// This method is called from the generated IDependencyObjectInternal.OnPropertyChanged2 method
 		internal void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
 		{
 			InvalidateDefinition();

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/RowDefinition.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/RowDefinition.cs
@@ -14,11 +14,14 @@ namespace Windows.UI.Xaml.Controls
 		{
 			InitializeBinder();
 			IsAutoPropertyInheritanceEnabled = false;
+		}
 
-			this.RegisterDisposablePropertyChangedCallback((i, p, args) =>
-			{
-				InvalidateDefinition();
-			});
+		/// <remarks>
+		/// This method is called from the generated IDependencyObjectInternal.OnPropertyChanged2 method
+		/// </summary>
+		internal void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
+		{
+			InvalidateDefinition();
 		}
 
 		#region Height DependencyProperty

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void InitializeScrollContentPresenter()
 		{
-			this.RegisterParentChangedCallback(this, OnParentChanged);
+			this.RegisterParentChangedCallbackStrong(this, OnParentChanged);
 		}
 
 		private void OnParentChanged(object instance, object key, DependencyObjectParentChangedEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -82,7 +82,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public TextBox()
 		{
-			this.RegisterParentChangedCallback(this, OnParentChanged);
+			this.RegisterParentChangedCallbackStrong(this, OnParentChanged);
 
 			DefaultStyleKey = typeof(TextBox);
 			SizeChanged += OnSizeChanged;

--- a/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
@@ -408,7 +408,7 @@ namespace Windows.UI.Xaml
 		/// <param name="handler">A callback to be called</param>
 		/// <returns>A disposable that cancels the subscription.</returns>
 		internal static void RegisterParentChangedCallbackStrong(this DependencyObject instance, object key, ParentChangedCallback handler)
-			=> GetStore(instance).RegisterParentChangedCallback(key, handler);
+			=> GetStore(instance).RegisterParentChangedCallbackStrong(key, handler);
 
 		/// <summary>
 		/// Determines if the specified dependency property is set.

--- a/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
@@ -401,6 +401,16 @@ namespace Windows.UI.Xaml
 		}
 
 		/// <summary>
+		/// Registers to parent changes.
+		/// </summary>
+		/// <param name="instance">The target dependency object</param>
+		/// <param name="key">A key to be passed to the callback parameter.</param>
+		/// <param name="handler">A callback to be called</param>
+		/// <returns>A disposable that cancels the subscription.</returns>
+		internal static void RegisterParentChangedCallbackStrong(this DependencyObject instance, object key, ParentChangedCallback handler)
+			=> GetStore(instance).RegisterParentChangedCallback(key, handler);
+
+		/// <summary>
 		/// Determines if the specified dependency property is set.
 		/// A property is set whenever a value (including null) is assigned to it.
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/IDependencyObjectInternal.cs
+++ b/src/Uno.UI/UI/Xaml/IDependencyObjectInternal.cs
@@ -1,0 +1,14 @@
+﻿namespace Windows.UI.Xaml
+{
+	/// <summary>
+	/// Internal implemenation for <see cref="DependencyObject"/>
+	/// </summary>
+	internal partial interface IDependencyObjectInternal
+	{
+		/// <summary>
+		/// Invoked on every <see cref="DependencyProperty"/> changes, automatically generated for every <see cref="DependencyObject"/> implementing type.
+		/// </summary>
+		/// <param name="args"></param>
+		void OnPropertyChanged2(DependencyPropertyChangedEventArgs args);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/StateTriggerBase.cs
+++ b/src/Uno.UI/UI/Xaml/StateTriggerBase.cs
@@ -15,7 +15,7 @@ namespace Windows.UI.Xaml
 
 			IsAutoPropertyInheritanceEnabled = false;
 
-			this.RegisterParentChangedCallback(
+			this.RegisterParentChangedCallbackStrong(
 				key: this,
 				handler: (instance, key, handler)
 					=> OnOwnerChanged()

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -651,11 +651,6 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		// This is part of the WinUI internal contract and is being invoked on each DP change
-		internal virtual void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
-		{
-		}
-
 		/// <summary>
 		/// Backing property for <see cref="LayoutInformation.GetAvailableSize(UIElement)"/>
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
@@ -44,7 +44,7 @@ namespace Windows.UI.Xaml
 			IsAutoPropertyInheritanceEnabled = false;
 			InitializeBinder();
 
-			this.RegisterParentChangedCallback(this, OnParentChanged);
+			this.RegisterParentChangedCallbackStrong(this, OnParentChanged);
 		}
 
 		public VisualState CurrentState => _current.state;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

- Remove indirect delegates created from `ConditionalDisposable`
- Use strong references for property changes registrations to avoid the creation of `ConditionalDisposable` instances
- If `RegisterPropertyChangedCallback` is used and is registered on self, don't use `DispatcherConditionalDisposable`
- Generate `OnPropertyChanged2` for all uno-internal DependencyObject to avoid delegates creation. DependencyObject now invokes this method through `IDependencyObjectInternal`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
