### PR TITLE
feat: Support for `Canvas.ZIndex` on Skia

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1149,6 +1149,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Canvas\Grid_ZIndex.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Canvas\Measure_Children_In_Canvas.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5237,6 +5241,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Canvas\Canvas_ZIndex.xaml.cs">
       <DependentUpon>Canvas_ZIndex.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Canvas\Grid_ZIndex.xaml.cs">
+      <DependentUpon>Grid_ZIndex.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Canvas\Measure_Children_In_Canvas.xaml.cs">
       <DependentUpon>Measure_Children_In_Canvas.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Canvas/Grid_ZIndex.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Canvas/Grid_ZIndex.xaml
@@ -1,0 +1,47 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.Canvas.Grid_ZIndex"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.Canvas"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Margin="8" RowSpacing="8" ColumnSpacing="8">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="100" />
+			<RowDefinition Height="100" />
+			<RowDefinition Height="100" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="100" />
+			<ColumnDefinition Width="100" />
+		</Grid.ColumnDefinitions>
+		<Grid>
+			<Border x:Name="NoZIndexRed" Background="Red" />
+			<Border Margin="20" x:Name="NoZIndexBlue" Background="Green" />
+			<Border Margin="40" x:Name="NoZIndexGreen" Background="Blue" />
+		</Grid>
+		<Grid Grid.Column="1">
+			<Border Canvas.ZIndex="5" x:Name="AllZIndexGreen" Margin="20" Background="Green" />
+			<Border Canvas.ZIndex="10" x:Name="AllZIndexBlue" Margin="40" Background="Blue" />
+			<Border Canvas.ZIndex="0" x:Name="AllZIndexRed" Background="Red" />
+		</Grid>
+		<Grid Grid.Column="0" Grid.Row="1">
+			<Border x:Name="LowerZIndexGreen" Margin="20" Canvas.ZIndex="20" Background="Green" />
+			<Border x:Name="LowerZIndexRed" Background="Red" />
+			<Border x:Name="LowerZIndexBlue" Background="Blue" Canvas.ZIndex="40" Margin="40" />
+		</Grid>
+		<Grid Grid.Column="1" Grid.Row="1">
+			<Border Canvas.ZIndex="5" x:Name="MixedZIndexGreen" Margin="20" Background="Green" />
+			<Border Canvas.ZIndex="10" x:Name="MixedZIndexBlue" Margin="40" Background="Blue" />
+			<Border x:Name="MixedZIndexRed" Background="Red" />
+		</Grid>
+		<Grid Grid.Column="0" Grid.Row="2">
+			<Border Canvas.ZIndex="5" x:Name="NegativeZIndexBlue" Background="Blue" Margin="40" />
+			<Border Margin="20" x:Name="NegativeZIndexGreen" Background="Green" />
+			<Border Canvas.ZIndex="-5" x:Name="NegativeZIndexRed" Background="Red" />
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Canvas/Grid_ZIndex.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Canvas/Grid_ZIndex.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.Canvas
+{
+	[Sample(Description = "All 5 shapes should look the same - blue inside green inside red")]
+	public sealed partial class Grid_ZIndex : Page
+    {
+        public Grid_ZIndex()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI.Composition/Composition/Compositor.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Compositor.skia.cs
@@ -49,7 +49,7 @@ namespace Windows.UI.Composition
 
 			if (RootVisual != null)
 			{
-				foreach (var visual in RootVisual.Children)
+				foreach (var visual in RootVisual.GetChildrenInRenderOrder())
 				{
 					RenderVisual(surface, info, visual);
 				}
@@ -88,14 +88,14 @@ namespace Windows.UI.Composition
 				switch (visual)
 				{
 					case SpriteVisual spriteVisual:
-						foreach (var inner in spriteVisual.Children)
+						foreach (var inner in spriteVisual.GetChildrenInRenderOrder())
 						{
 							RenderVisual(surface, info, inner);
 						}
 						break;
 
 					case ContainerVisual containerVisual:
-						foreach (var inner in containerVisual.Children)
+						foreach (var inner in containerVisual.GetChildrenInRenderOrder())
 						{
 							RenderVisual(surface, info, inner);
 						}

--- a/src/Uno.UI.Composition/Composition/Compositor.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Compositor.skia.cs
@@ -1,11 +1,9 @@
 #nullable enable
 
-using SkiaSharp;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Numerics;
-using Windows.Services.Maps;
+using SkiaSharp;
 using Windows.UI.Core;
 
 namespace Windows.UI.Composition
@@ -49,9 +47,10 @@ namespace Windows.UI.Composition
 
 			if (RootVisual != null)
 			{
-				foreach (var visual in RootVisual.GetChildrenInRenderOrder())
+				var children = RootVisual.GetChildrenInRenderOrder();
+				for (var i = 0; i < children.Count; i++)
 				{
-					RenderVisual(surface, info, visual);
+					RenderVisual(surface, info, children[i]);
 				}
 			}
 		}
@@ -85,21 +84,13 @@ namespace Windows.UI.Composition
 
 				visual.Render(surface, info);
 
-				switch (visual)
+				if (visual is ContainerVisual containerVisual)
 				{
-					case SpriteVisual spriteVisual:
-						foreach (var inner in spriteVisual.GetChildrenInRenderOrder())
-						{
-							RenderVisual(surface, info, inner);
-						}
-						break;
-
-					case ContainerVisual containerVisual:
-						foreach (var inner in containerVisual.GetChildrenInRenderOrder())
-						{
-							RenderVisual(surface, info, inner);
-						}
-						break;
+					var children = containerVisual.GetChildrenInRenderOrder();
+					for (var i = 0; i < children.Count; i++)
+					{
+						RenderVisual(surface, info, children[i]);
+					}
 				}
 
 				surface.Canvas.Restore();
@@ -133,7 +124,7 @@ namespace Windows.UI.Composition
 						throw new InvalidOperationException($"Clipping with source {cpg.Path?.GeometrySource} is not supported");
 					}
 				}
-				else if(geometricClip.Geometry is null)
+				else if (geometricClip.Geometry is null)
 				{
 					// null is nop
 				}

--- a/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
@@ -12,14 +12,14 @@ public partial class ContainerVisual : Visual
 
 	internal bool IsChildrenRenderOrderDirty { get; set; }
 
-	internal IEnumerable<Visual> GetChildrenInRenderOrder()
+	internal IList<Visual> GetChildrenInRenderOrder()
 	{
 		if (IsChildrenRenderOrderDirty)
 		{
 			ResetRenderOrder();
 		}
 
-		return !_hasCustomRenderOrder ? Children : _childrenInRenderOrder;
+		return !_hasCustomRenderOrder ? Children.InnerList : _childrenInRenderOrder;
 	}
 
 	internal void ResetRenderOrder()

--- a/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
@@ -1,10 +1,40 @@
 #nullable enable
 
-using SkiaSharp;
+using System.Collections.Generic;
+using System.Linq;
 
-namespace Windows.UI.Composition
+namespace Windows.UI.Composition;
+
+public partial class ContainerVisual : Visual
 {
-	public partial class ContainerVisual : Visual
+	private List<Visual> _childrenInRenderOrder = new List<Visual>();
+	private bool _hasCustomRenderOrder = false;
+
+	internal bool IsChildrenRenderOrderDirty { get; set; }
+
+	internal IEnumerable<Visual> GetChildrenInRenderOrder()
 	{
+		if (IsChildrenRenderOrderDirty)
+		{
+			ResetRenderOrder();
+		}
+
+		return !_hasCustomRenderOrder ? Children : _childrenInRenderOrder;
+	}
+
+	internal void ResetRenderOrder()
+	{
+		_childrenInRenderOrder.Clear();
+		_hasCustomRenderOrder = false;
+		if (Children.Any(c => c.ZIndex != 0))
+		{
+			// We need to sort children in ZIndex order
+			foreach (var child in Children.OrderBy(c => c.ZIndex))
+			{
+				_childrenInRenderOrder.Add(child);
+			}
+			_hasCustomRenderOrder = true;
+		}
+		IsChildrenRenderOrderDirty = false;
 	}
 }

--- a/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Composition;
 
 public partial class ContainerVisual : Visual
 {
-	private List<Visual> _childrenInRenderOrder = new List<Visual>();
+	private List<Visual>? _childrenInRenderOrder;
 	private bool _hasCustomRenderOrder = false;
 
 	internal bool IsChildrenRenderOrderDirty { get; set; }
@@ -19,15 +19,16 @@ public partial class ContainerVisual : Visual
 			ResetRenderOrder();
 		}
 
-		return !_hasCustomRenderOrder ? Children.InnerList : _childrenInRenderOrder;
+		return !_hasCustomRenderOrder ? Children.InnerList : _childrenInRenderOrder!;
 	}
 
 	internal void ResetRenderOrder()
 	{
-		_childrenInRenderOrder.Clear();
+		_childrenInRenderOrder?.Clear();
 		_hasCustomRenderOrder = false;
 		if (Children.Any(c => c.ZIndex != 0))
 		{
+			_childrenInRenderOrder ??= new List<Visual>();
 			// We need to sort children in ZIndex order
 			foreach (var child in Children.OrderBy(c => c.ZIndex))
 			{

--- a/src/Uno.UI.Composition/Composition/Visual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.skia.cs
@@ -22,6 +22,8 @@ namespace Windows.UI.Composition
 
 		// Backing for scroll offsets
 		private Vector2 _anchorPoint = Vector2.Zero;
+		private int _zIndex;
+
 		public Vector2 AnchorPoint
 		{
 			get => _anchorPoint;
@@ -29,6 +31,22 @@ namespace Windows.UI.Composition
 			{
 				_anchorPoint = value;
 				Compositor.InvalidateRender();
+			}
+		}
+
+		internal int ZIndex
+		{
+			get => _zIndex;
+			set
+			{
+				if (_zIndex != value)
+				{
+					_zIndex = value;
+					if (Parent is ContainerVisual containerVisual)
+					{
+						containerVisual.IsChildrenRenderOrderDirty = true;
+					}
+				}
 			}
 		}
 	}

--- a/src/Uno.UI.Composition/Composition/VisualCollection.cs
+++ b/src/Uno.UI.Composition/Composition/VisualCollection.cs
@@ -21,6 +21,8 @@ namespace Windows.UI.Composition
 
 		public int Count => _visuals.Count;
 
+		internal IList<Visual> InnerList => _visuals;
+
 		public void InsertAbove(Visual newChild, Visual sibling)
 		{
 			var index = _visuals.IndexOf(sibling);

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.skia.cs
@@ -1,0 +1,9 @@
+﻿namespace Windows.UI.Xaml.Controls;
+
+public partial class Canvas
+{
+	static partial void OnZIndexChangedPartial(UIElement element, double? zindex)
+	{
+		element.Visual.ZIndex = (int)zindex;
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -40,6 +40,8 @@ namespace Windows.UI.Xaml
 			UpdateHitTest();
 		}
 
+		internal bool IsChildrenRenderOrderDirty { get; set; } = true;
+
 		partial void InitializeKeyboard();
 
 		private void OnPropertyChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
@@ -127,6 +129,7 @@ namespace Windows.UI.Xaml
 			}
 
 			OnChildAdded(child);
+			Visual.IsChildrenRenderOrderDirty = true;
 
 			InvalidateMeasure();
 		}
@@ -172,7 +175,11 @@ namespace Windows.UI.Xaml
 		private void InnerRemoveChild(UIElement child)
 		{
 			child.SetParent(null);
-			Visual?.Children.Remove(child.Visual);
+			if (Visual != null)
+			{
+				Visual.Children.Remove(child.Visual);
+				Visual.IsChildrenRenderOrderDirty = true;
+			}
 			OnChildRemoved(child);
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5644, part of #325

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Not supported.

## What is the new behavior?

`Canvas.ZIndex` is supported and applied irrespective of parent panel

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.