### PR TITLE
fix!: [WASM] Animations leaking and flooding the log

### DIFF
--- a/src/Uno.Foundation.Runtime.WebAssembly/AssemblyInfo.cs
+++ b/src/Uno.Foundation.Runtime.WebAssembly/AssemblyInfo.cs
@@ -4,6 +4,7 @@ using global::System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("Uno.UI")]
 [assembly: InternalsVisibleTo("Uno")]
+[assembly: InternalsVisibleTo("Uno.Foundation")]
 [assembly: InternalsVisibleTo("Uno.UI.Wasm")]
 [assembly: InternalsVisibleTo("Uno.Wasm")]
 [assembly: InternalsVisibleTo("Uno.UI.Tests")]

--- a/src/Uno.Foundation.Runtime.WebAssembly/Interop/JSObjectHandle.wasm.cs
+++ b/src/Uno.Foundation.Runtime.WebAssembly/Interop/JSObjectHandle.wasm.cs
@@ -40,7 +40,14 @@ namespace Uno.Foundation.Interop
 			_managedGcHandle = GCHandle.Alloc(this, GCHandleType.Weak);
 			_managedHandle = GCHandle.ToIntPtr(_managedGcHandle);
 			_jsHandle = _metadata.CreateNativeInstance(_managedHandle);
+
+			IsAlive = true;
 		}
+
+		/// <summary>
+		/// Indicates if the JS object that is referenced by this handled is still alive or not
+		/// </summary>
+		public bool IsAlive { get; private set; }
 
 		/// <summary>
 		/// Metadata about the marshaled object
@@ -56,7 +63,13 @@ namespace Uno.Foundation.Interop
 		/// <inheritdoc />
 		public void Dispose()
 		{
+			if (!IsAlive)
+			{
+				return;
+			}
+
 			_metadata.DestroyNativeInstance(_managedHandle, _jsHandle);
+			IsAlive = false;
 
 			GC.SuppressFinalize(this);
 		}

--- a/src/Uno.Foundation.Runtime.WebAssembly/Interop/Runtime.wasm.cs
+++ b/src/Uno.Foundation.Runtime.WebAssembly/Interop/Runtime.wasm.cs
@@ -302,8 +302,13 @@ namespace Uno.Foundation
 					{
 						if (!mappedParameters.TryGetValue(jsObject, out var parameterReference))
 						{
+							if (!jsObject.Handle.IsAlive)
+							{
+								throw new InvalidOperationException("JSObjectHandle is invalid.");
+							}
+
 							mappedParameters[jsObject] = parameterReference = $"__parameter_{i}";
-							commandBuilder.AppendLine($"var {parameterReference} = {jsObject.Handle.GetNativeInstance()};");
+							commandBuilder.AppendLine($"const {parameterReference} = {jsObject.Handle.GetNativeInstance()};");
 						}
 
 						parameters[i] = parameterReference;

--- a/src/Uno.Foundation/FoundationFeatureConfiguration.cs
+++ b/src/Uno.Foundation/FoundationFeatureConfiguration.cs
@@ -32,5 +32,19 @@ namespace Uno
 			[DefaultValue(_defaultAllowNegativeWidthHeight)]
 			public static bool AllowNegativeWidthHeight { get; set; } = _defaultAllowNegativeWidthHeight;
 		}
+
+#if __WASM__
+		public static class Runtime
+		{
+			/// <summary>
+			/// Indicates if exception thrown in javascript should be rethrown in managed code.
+			/// </summary>
+			public static bool RethrowNativeExceptions
+			{
+				get => WebAssembly.Runtime.RethrowNativeExceptions;
+				set => WebAssembly.Runtime.RethrowNativeExceptions = value;
+			}
+		}
+#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/CPUBoundAnimator.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/CPUBoundAnimator.cs
@@ -79,7 +79,10 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// <inheritdoc />
 		public void Pause()
 		{
-			CheckDisposed();
+			if (_isDisposed)
+			{
+				return;
+			}
 
 			IsRunning = false;
 			_elapsed.Stop();
@@ -103,7 +106,10 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// <inheritdoc />
 		public void Cancel()
 		{
-			CheckDisposed();
+			if (_isDisposed)
+			{
+				return;
+			}
 
 			IsRunning = false;
 			_elapsed.Stop();
@@ -211,8 +217,13 @@ namespace Windows.UI.Xaml.Media.Animation
 		}
 
 		/// <inheritdoc />
-		public void Dispose()
+		public virtual void Dispose()
 		{
+			if (_isDisposed)
+			{
+				return; // Avoid to invoke native stuff if animator has already been disposed
+			}
+
 			_isDisposed = true;
 
 			IsRunning = false;

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/RenderingLoopAnimator.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/RenderingLoopAnimator.wasm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using Uno.Foundation;
 using Uno.Foundation.Interop;
@@ -15,16 +16,56 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		public JSObjectHandle Handle { get; }
 
+		protected override void EnableFrameReporting()
+		{
+			if (Handle.IsAlive)
+			{
+				WebAssemblyRuntime.InvokeJSWithInterop($"{this}.EnableFrameReporting();");
+			}
+		}
 
-		protected override void EnableFrameReporting() => WebAssemblyRuntime.InvokeJSWithInterop($"{this}.EnableFrameReporting();");
+		protected override void DisableFrameReporting()
+		{
+			if (Handle.IsAlive)
+			{
+				WebAssemblyRuntime.InvokeJSWithInterop($"{this}.DisableFrameReporting();");
+			}
+		}
 
-		protected override void DisableFrameReporting() => WebAssemblyRuntime.InvokeJSWithInterop($"{this}.DisableFrameReporting();");
+		protected override void SetStartFrameDelay(long delayMs)
+		{
+			if (Handle.IsAlive)
+			{
+				WebAssemblyRuntime.InvokeJSWithInterop($"{this}.SetStartFrameDelay({delayMs});");
+			}
+		}
 
-		protected override void SetStartFrameDelay(long delayMs) => WebAssemblyRuntime.InvokeJSWithInterop($"{this}.SetStartFrameDelay({delayMs});");
-
-		protected override void SetAnimationFramesInterval() => WebAssemblyRuntime.InvokeJSWithInterop($"{this}.SetAnimationFramesInterval();");
+		protected override void SetAnimationFramesInterval()
+		{
+			if (Handle.IsAlive)
+			{
+				WebAssemblyRuntime.InvokeJSWithInterop($"{this}.SetAnimationFramesInterval();");
+			}
+		}
 
 		private void OnFrame() => OnFrame(null, null);
+
+		/// <inheritdoc />
+		public override void Dispose()
+		{
+			// WARNING: If the Dispose is invoked by the GC, it has most probably already disposed the Handle,
+			//			which means that we have already lost ability to dispose/stop the native object!
+
+			base.Dispose();
+			Handle.Dispose();
+
+			GC.SuppressFinalize(this);
+		}
+
+		~RenderingLoopAnimator()
+		{
+			Dispose();
+		}
 
 		private class Metadata : IJSObjectMetadata
 		{
@@ -36,18 +77,18 @@ namespace Windows.UI.Xaml.Media.Animation
 			public long CreateNativeInstance(IntPtr managedHandle)
 			{
 				var id = RenderingLoopAnimatorMetadataIdProvider.Next();
-				WebAssemblyRuntime.InvokeJS($"Windows.UI.Xaml.Media.Animation.RenderingLoopFloatAnimator.createInstance(\"{managedHandle}\", \"{id}\")");
+				WebAssemblyRuntime.InvokeJS($"Windows.UI.Xaml.Media.Animation.RenderingLoopAnimator.createInstance(\"{managedHandle}\", \"{id}\")");
 
 				return id;
 			}
 
 			/// <inheritdoc />
 			public string GetNativeInstance(IntPtr managedHandle, long jsHandle)
-				=> $"Windows.UI.Xaml.Media.Animation.RenderingLoopFloatAnimator.getInstance(\"{jsHandle}\")";
+				=> $"Windows.UI.Xaml.Media.Animation.RenderingLoopAnimator.getInstance(\"{jsHandle}\")";
 
 			/// <inheritdoc />
 			public void DestroyNativeInstance(IntPtr managedHandle, long jsHandle)
-				=> WebAssemblyRuntime.InvokeJS($"Windows.UI.Xaml.Media.Animation.RenderingLoopFloatAnimator.destroyInstance(\"{jsHandle}\")");
+				=> WebAssemblyRuntime.InvokeJS($"Windows.UI.Xaml.Media.Animation.RenderingLoopAnimator.destroyInstance(\"{jsHandle}\")");
 
 			/// <inheritdoc />
 			public object InvokeManaged(object instance, string method, string parameters)

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ColorAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ColorAnimationUsingKeyFrames.cs
@@ -94,8 +94,6 @@ namespace Windows.UI.Xaml.Media.Animation
 					PropertyInfo?.CloneShareableObjectsInPath();
 
 					_wasBeginScheduled = false;
-					_subscriptions.Clear(); //Dispose all and start a new
-
 					_activeDuration.Restart();
 					_replayCount = 1;
 
@@ -179,7 +177,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		void ITimeline.SkipToFill()
 		{
-			if (_currentAnimator != null && _currentAnimator.IsRunning)
+			if (_currentAnimator is { IsRunning: true })
 			{
 				_currentAnimator.Cancel();//Stop the animator if it is running
 				_startingValue = null;
@@ -192,7 +190,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		void ITimeline.Deactivate()
 		{
-			if (_currentAnimator != null && _currentAnimator.IsRunning)
+			if (_currentAnimator is { IsRunning: true })
 			{
 				_currentAnimator.Cancel();//Stop the animator if it is running
 				_startingValue = null;
@@ -213,7 +211,8 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// </summary>
 		private void Play()
 		{
-			InitializeAnimators();//Create the animator
+			_subscriptions.Clear(); // Dispose all and start a new
+			InitializeAnimators(); // Create the animator
 
 			if (!EnableDependentAnimation && this.GetIsDependantAnimation())
 			{ // Don't start the animator its a dependent animation
@@ -351,6 +350,8 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// </summary>
 		private void OnEnd()
 		{
+			_subscriptions.Clear();
+
 			// If the animation was GPU based, remove the animated value
 			if (NeedsRepeat(_activeDuration, _replayCount))
 			{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/DoubleAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/DoubleAnimationUsingKeyFrames.cs
@@ -13,7 +13,7 @@ namespace Windows.UI.Xaml.Media.Animation
 {
 	[ContentProperty(Name = "KeyFrames")]
 	public partial class DoubleAnimationUsingKeyFrames : Timeline, ITimeline
-    {
+	{
 		private readonly Stopwatch _activeDuration = new Stopwatch();
 		private int _replayCount = 1;
 		private double? _startingValue = null;
@@ -77,7 +77,6 @@ namespace Windows.UI.Xaml.Media.Animation
 						return; // nothing to do
 					}
 					_wasBeginScheduled = false;
-                    _subscriptions.Clear(); //Dispose all and start a new
 
 					_activeDuration.Restart();
 					_replayCount = 1;
@@ -157,7 +156,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		void ITimeline.SkipToFill()
 		{
-			if (_currentAnimator != null && _currentAnimator.IsRunning)
+			if (_currentAnimator is { IsRunning: true })
 			{
 				_currentAnimator.Cancel();//Stop the animator if it is running
 				_startingValue = null;
@@ -170,7 +169,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		void ITimeline.Deactivate()
 		{
-			if (_currentAnimator != null && _currentAnimator.IsRunning)
+			if (_currentAnimator is { IsRunning: true })
 			{
 				_currentAnimator.Cancel();//Stop the animator if it is running
 				_startingValue = null;
@@ -191,7 +190,8 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// </summary>
 		private void Play()
 		{
-			InitializeAnimators();//Create the animator
+			_subscriptions.Clear(); // Dispose all current animators
+			InitializeAnimators(); // Create the animator
 
 			if (!EnableDependentAnimation && this.GetIsDependantAnimation())
 			{ // Don't start the animator its a dependent animation
@@ -267,7 +267,7 @@ namespace Windows.UI.Xaml.Media.Animation
 					OnAnimatorEnd(i);
 				};
 				++index;
-            }
+			}
 		}
 
 		private void OnAnimatorEnd(int i)
@@ -288,7 +288,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			else
 			{
 				_currentAnimator = _animators[nextAnimatorIndex];
-                _currentAnimator.Start();
+				_currentAnimator.Start();
 			}
 		}
 
@@ -315,6 +315,8 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// </summary>
 		private void OnEnd()
 		{
+			_subscriptions.Clear(); // Dispose all current animators
+
 			// If the animation was GPU based, remove the animated value
 			if (NeedsRepeat(_activeDuration, _replayCount))
 			{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
@@ -183,7 +183,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 			public void SkipToFill()
 			{
-				if (_animator != null && _animator.IsRunning)
+				if (_animator is { IsRunning: true })
 				{
 					_animator.Cancel();//Stop the animator if it is running
 					_startingValue = null;
@@ -257,7 +257,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			{
 				if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 				{
-					this.Log().Debug("DoubleAnimation has ended.");
+					this.Log().Debug("TimeLine has ended.");
 				}
 
 				OnEnd();
@@ -275,7 +275,8 @@ namespace Windows.UI.Xaml.Media.Animation
 			/// </summary>
 			private void Play()
 			{
-				InitializeAnimator();//Create the animator
+				_animator?.Dispose();
+				InitializeAnimator(); // Create the animator
 
 				if (!EnableDependentAnimation && _owner.GetIsDependantAnimation())
 				{ // Don't start the animator its a dependent animation
@@ -330,6 +331,8 @@ namespace Windows.UI.Xaml.Media.Animation
 			/// </summary>
 			private void OnEnd()
 			{
+				_animator?.Dispose();
+
 				// If the animation was GPU based, remove the animated value
 				if (NeedsRepeat(_activeDuration, _replayCount))
 				{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -416,7 +416,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		~Timeline()
 		{
-			Dispose(true);
+			Dispose(false);
 		}
 	}
 }

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -1196,11 +1196,11 @@ declare namespace Windows.UI.Xaml {
     }
 }
 declare namespace Windows.UI.Xaml.Media.Animation {
-    class RenderingLoopFloatAnimator {
+    class RenderingLoopAnimator {
         private managedHandle;
         private static activeInstances;
         static createInstance(managedHandle: string, jsHandle: number): void;
-        static getInstance(jsHandle: number): RenderingLoopFloatAnimator;
+        static getInstance(jsHandle: number): RenderingLoopAnimator;
         static destroyInstance(jsHandle: number): void;
         private constructor();
         SetStartFrameDelay(delay: number): void;

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -4417,19 +4417,25 @@ var Windows;
             (function (Media) {
                 var Animation;
                 (function (Animation) {
-                    class RenderingLoopFloatAnimator {
+                    class RenderingLoopAnimator {
                         constructor(managedHandle) {
                             this.managedHandle = managedHandle;
                             this._isEnabled = false;
                         }
                         static createInstance(managedHandle, jsHandle) {
-                            RenderingLoopFloatAnimator.activeInstances[jsHandle] = new RenderingLoopFloatAnimator(managedHandle);
+                            RenderingLoopAnimator.activeInstances[jsHandle] = new RenderingLoopAnimator(managedHandle);
                         }
                         static getInstance(jsHandle) {
-                            return RenderingLoopFloatAnimator.activeInstances[jsHandle];
+                            return RenderingLoopAnimator.activeInstances[jsHandle];
                         }
                         static destroyInstance(jsHandle) {
-                            delete RenderingLoopFloatAnimator.activeInstances[jsHandle];
+                            var instance = RenderingLoopAnimator.getInstance(jsHandle);
+                            // If the JSObjectHandle is being disposed before the animator is stopped (GC collecting JSObjectHandle before the animator)
+                            // we won't be able to DisableFrameReporting anymore.
+                            if (instance) {
+                                instance.DisableFrameReporting();
+                            }
+                            delete RenderingLoopAnimator.activeInstances[jsHandle];
                         }
                         SetStartFrameDelay(delay) {
                             this.unscheduleFrame();
@@ -4484,8 +4490,8 @@ var Windows;
                             });
                         }
                     }
-                    RenderingLoopFloatAnimator.activeInstances = {};
-                    Animation.RenderingLoopFloatAnimator = RenderingLoopFloatAnimator;
+                    RenderingLoopAnimator.activeInstances = {};
+                    Animation.RenderingLoopAnimator = RenderingLoopAnimator;
                 })(Animation = Media.Animation || (Media.Animation = {}));
             })(Media = Xaml.Media || (Xaml.Media = {}));
         })(Xaml = UI.Xaml || (UI.Xaml = {}));

--- a/src/Uno.UI/ts/Windows/UI/Xaml/Animation/RenderingLoopAnimator.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/Animation/RenderingLoopAnimator.ts
@@ -1,17 +1,23 @@
 ﻿namespace Windows.UI.Xaml.Media.Animation {
-	export class RenderingLoopFloatAnimator {
-		private static activeInstances: { [jsHandle: number]: RenderingLoopFloatAnimator} = {};
+	export class RenderingLoopAnimator {
+		private static activeInstances: { [jsHandle: number]: RenderingLoopAnimator} = {};
 
 		public static createInstance(managedHandle: string, jsHandle: number) {
-			RenderingLoopFloatAnimator.activeInstances[jsHandle] = new RenderingLoopFloatAnimator(managedHandle);
+			RenderingLoopAnimator.activeInstances[jsHandle] = new RenderingLoopAnimator(managedHandle);
 		}
 
-		public static getInstance(jsHandle: number): RenderingLoopFloatAnimator {
-			return RenderingLoopFloatAnimator.activeInstances[jsHandle];
+		public static getInstance(jsHandle: number): RenderingLoopAnimator {
+			return RenderingLoopAnimator.activeInstances[jsHandle];
 		}
 
 		public static destroyInstance(jsHandle: number) {
-			delete RenderingLoopFloatAnimator.activeInstances[jsHandle];
+			var instance = RenderingLoopAnimator.getInstance(jsHandle);
+			// If the JSObjectHandle is being disposed before the animator is stopped (GC collecting JSObjectHandle before the animator)
+			// we won't be able to DisableFrameReporting anymore.
+			if (instance) {
+				instance.DisableFrameReporting();
+			}
+			delete RenderingLoopAnimator.activeInstances[jsHandle];
 		}
 
 		private constructor(private managedHandle: string) {


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/7726

## Bugfix
When memory is constrained, animations on wasm might remain active indefinitely and flood the log.

## What is the current behavior?
1. If the GC collects the `JsObjectHandle` of the `RenderingLoopAnimator` before the animator is being stopped/disposed, the animator cannot properly stop the native frame rendering, driving to log to be flooded by error messages.
2. Some animation are not disposing their animator until being re-started (or replayed).
3. Exceptions raised in JavaScript when using the internal `WebAssembly.Runtime.InvokeJS` are not re-thrown in managed code.

## What is the new behavior?
1. When the handle is being disposed, we make sure to also stop the frame rendering directly in JS.
2. Animations are disposing their animator right at the end of animation (theire going to be re-created if animation needs repeat)
3. Exception are not re-thrown by default (cf. Other information)

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ]~~ Contains **NO** breaking changes~~ It does! Cf. Other Information
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
```
                              ****************************
                              ** SILENT BREAKING CHANGE **
                              ****************************
```

**This PR introduces a breaking change:**
[Wasm] Exceptions raised in JavasScript are now being rethown by default in managed code.
You can disable this behavior by setting the `Uno.FoundationFeatureConfiguration.Runtime.RethrowNativeExceptions` config flag to `false`.
