### PR TITLE
fix: Suppress `IsEnabled` for focus purposes when `Command.CanExecuteChanged` becomes `false`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_Button
+	{
+		[TestMethod]
+		public async Task When_Command_Executing_IsEnabled()
+		{
+			var command = new IsExecutingCommand(true);
+			await RunIsExecutingCommandCommon(command);
+		}
+
+		[TestMethod]
+		public async Task When_Command_Executing_With_Delay_IsEnabled()
+		{
+			var command = new IsExecutingCommand(false);
+			await RunIsExecutingCommandCommon(command);
+		}
+
+		[TestMethod]
+		public async Task When_Command_Never_Stops()
+		{
+			var command = new NeverEndingCommand();
+
+			var (firstButton, secondButton) = await CreateCommandFocusWindowContentAsync(command);
+
+			firstButton.Focus(FocusState.Programmatic);
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			command.Execute(null);
+
+			// Focus should stay on the button
+			Assert.AreNotEqual(FocusState.Unfocused, firstButton.FocusState);
+
+			secondButton.Focus(FocusState.Programmatic);
+
+			// The button cannot be refocused
+			Assert.IsFalse(firstButton.Focus(FocusState.Programmatic));
+		}
+
+		private async Task RunIsExecutingCommandCommon(IsExecutingCommand command)
+		{
+			void FocusManager_LosingFocus(object sender, LosingFocusEventArgs e)
+			{
+				Assert.Fail("The button should not lose focus when its command is executing");
+			}
+
+			try
+			{
+				var (firstButton, secondButton) = await CreateCommandFocusWindowContentAsync(command);
+
+				firstButton.Focus(FocusState.Programmatic);
+
+				await TestServices.WindowHelper.WaitForIdle();
+
+				FocusManager.LosingFocus += FocusManager_LosingFocus;
+
+				// Execute command to simulate work
+				await command.SimulateExecutionAsync();
+
+				// Focus should stay on the button
+				Assert.AreNotEqual(FocusState.Unfocused, firstButton.FocusState);
+			}
+			finally
+			{
+				FocusManager.LosingFocus -= FocusManager_LosingFocus;
+			}
+		}
+
+		private async Task<(Button firstButton, Button secondButton)> CreateCommandFocusWindowContentAsync(ICommand firstButtonCommand)
+		{
+			var firstButton = new Button()
+			{
+				Content = "Test button",
+				Command = firstButtonCommand
+			};
+			var secondButton = new Button()
+			{
+				Content = "Do not focus me!"
+			};
+
+			var stackPanel = new StackPanel()
+			{
+				Children =
+				{
+					firstButton,
+					secondButton,
+				}
+			};
+
+			TestServices.WindowHelper.WindowContent = stackPanel;
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			return (firstButton, secondButton);
+		}
+
+		public class IsExecutingCommand : ICommand
+		{
+			private readonly bool _synchronousCompletion;
+			private bool IsExecuting = false;
+
+			public IsExecutingCommand(bool synchronousCompletion)
+			{
+				_synchronousCompletion = synchronousCompletion;
+			}
+
+			public event EventHandler CanExecuteChanged;
+
+			public bool CanExecute(object parameter) => !IsExecuting;
+
+			public void Execute(object parameter)
+			{
+				// Intentionally blank, we care only about CanExecute behavior
+			}
+
+			public async Task SimulateExecutionAsync()
+			{
+				IsExecuting = true;
+				CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+				if (!_synchronousCompletion)
+				{
+					await Task.Delay(100);
+				}
+				IsExecuting = false;
+				CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+			}
+		}
+
+		public class NeverEndingCommand : ICommand
+		{
+			private bool _wasStarted = false;
+
+			public NeverEndingCommand()
+			{
+			}
+
+			public event EventHandler CanExecuteChanged;
+
+			public bool CanExecute(object parameter) => !_wasStarted;
+
+			public void Execute(object parameter)
+			{
+				_wasStarted = true;
+				CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -795,8 +795,11 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
+			// TODO Uno specific: Adding check for IsEnabledSuppressed here
+			// as we need to make sure that when a Command is executing, the control
+			// should not lose focus
 			bool shouldReevaluateFocus =
-				!IsEnabled && //!pControl->ParserOwnsParent()
+				!(IsEnabled || IsEnabledSuppressed) && //!pControl->ParserOwnsParent()
 				!AllowFocusWhenDisabled &&
 				// We just disabled this control, find if this control
 				//or one of its children had focus.

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -720,14 +720,19 @@ namespace Windows.UI.Xaml
 		}
 		#endregion
 
+		internal bool IsEnabledSuppressed => _suppressIsEnabled;
+
 		/// <summary>
 		/// Provides the ability to disable <see cref="IsEnabled"/> value changes, e.g. in the context of ICommand CanExecute.
 		/// </summary>
 		/// <param name="suppress">If true, <see cref="IsEnabled"/> will always be false</param>
 		private protected void SuppressIsEnabled(bool suppress)
 		{
-			_suppressIsEnabled = suppress;
-			this.CoerceValue(IsEnabledProperty);
+			if (_suppressIsEnabled != suppress)
+			{
+				_suppressIsEnabled = suppress;
+				this.CoerceValue(IsEnabledProperty);
+			}
 		}
 
 		private object CoerceIsEnabled(object baseValue)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/nventive-private/issues/309

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Previously when `CanExecute()` on `Command` bound to `ButtonBase` became `false` caused the control to lose focus.

## What is the new behavior?

No longer losing focus.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
