### PR TITLE
fix(ItemsControl): Don't hold a strong reference on ItemsSource INCC/VectorChanged

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ContentDialog_Leak.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ContentDialog_Leak.xaml.cs
@@ -11,6 +11,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
 			InitializeComponent();
 		}
 
+
 		public async Task WaitForTestToComplete()
 		{
 			var t = ShowAsync();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ItemsControl_ItemsSource_Leak.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ItemsControl_ItemsSource_Leak.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.ItemsControl_ItemsSource_Leak">
+
+	<StackPanel>
+		<ItemsControl x:Name="control1" />
+		<ItemsControl x:Name="control2" />
+		<ItemsControl x:Name="control3" />
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ItemsControl_ItemsSource_Leak.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ItemsControl_ItemsSource_Leak.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public partial class ItemsControl_ItemsSource_Leak : UserControl, IExtendedLeakTest
+	{
+		private static ObservableCollection<string> _staticObservableCollection = new();
+		private static ObservableVector<string> _staticObservableVector = new();
+		private static CollectionViewSource _staticCollectionViewSource = new();
+
+		public ItemsControl_ItemsSource_Leak()
+		{
+			InitializeComponent();
+		}
+
+		public async Task WaitForTestToComplete()
+		{
+			control1.ItemsSource = _staticObservableCollection;
+			control2.ItemsSource = _staticObservableVector;
+			control3.ItemsSource = _staticCollectionViewSource;
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ItemsControl_ItemsSource_Leak.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ItemsControl_ItemsSource_Leak.xaml.cs
@@ -10,8 +10,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
 	public partial class ItemsControl_ItemsSource_Leak : UserControl, IExtendedLeakTest
 	{
 		private static ObservableCollection<string> _staticObservableCollection = new();
-		private static ObservableVector<string> _staticObservableVector = new();
 		private static CollectionViewSource _staticCollectionViewSource = new();
+
+#if HAS_UNO
+		private static ObservableVector<string> _staticObservableVector = new();
+#endif
 
 		public ItemsControl_ItemsSource_Leak()
 		{
@@ -21,8 +24,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
 		public async Task WaitForTestToComplete()
 		{
 			control1.ItemsSource = _staticObservableCollection;
-			control2.ItemsSource = _staticObservableVector;
 			control3.ItemsSource = _staticCollectionViewSource;
+
+#if HAS_UNO
+			control2.ItemsSource = _staticObservableVector;
+#endif
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -69,6 +69,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow("UITests.Windows_UI_Xaml.xLoadTests.xLoad_Test_For_Leak", 15)]
 		[DataRow("UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_LeakTest", 15)]
 		[DataRow("Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.Button_Command_Leak", 15)]
+		[DataRow("Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.ItemsControl_ItemsSource_Leak", 15)]
 #if !__WASM__ // Temporary disabled on WASM - https://github.com/unoplatform/uno/issues/7860
 		[DataRow("Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.ContentDialog_Leak", 15)]
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ItemCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemCollection.cs
@@ -197,36 +197,108 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else if (itemsSource is INotifyCollectionChanged existingObservable)
 			{
-				// This is a workaround for a bug with EventRegistrationTokenTable on Xamarin, where subscribing/unsubscribing to a class method directly won't 
-				// remove the handler.
-				NotifyCollectionChangedEventHandler handler = OnItemsSourceCollectionChanged;
-				_itemsSourceCollectionChangeDisposable.Disposable = Disposable.Create(() =>
-					existingObservable.CollectionChanged -= handler
-				);
-				existingObservable.CollectionChanged += handler;
+				ObserveCollectionChangedInner(existingObservable);
 			}
 			else if (itemsSource is IObservableVector<object> observableVector)
 			{
-				// This is a workaround for a bug with EventRegistrationTokenTable on Xamarin, where subscribing/unsubscribing to a class method directly won't 
-				// remove the handler.
-				VectorChangedEventHandler<object> handler = OnItemsSourceVectorChanged;
-				_itemsSourceCollectionChangeDisposable.Disposable = Disposable.Create(() =>
-					observableVector.VectorChanged -= handler
-				);
-				observableVector.VectorChanged += handler;
+				ObserveCollectionChangedInner(observableVector);
 			}
 			else if (itemsSource is IObservableVector genericObservableVector)
 			{
-				VectorChangedEventHandler handler = OnItemsSourceVectorChanged;
-				_itemsSourceCollectionChangeDisposable.Disposable = Disposable.Create(() =>
-					genericObservableVector.UntypedVectorChanged -= handler
-				);
-				genericObservableVector.UntypedVectorChanged += handler;
+				ObserveCollectionChangedInner(genericObservableVector);
 			}
 			else
 			{
 				_itemsSourceCollectionChangeDisposable.Disposable = null;
 			}
+		}
+
+		private void ObserveCollectionChangedInner(INotifyCollectionChanged existingObservable)
+		{
+			var thatRef = new WeakReference(this);
+
+			void handler(object s, NotifyCollectionChangedEventArgs e)
+			{
+				// Wrap the registered delegate to avoid creating a strong
+				// reference to this ItemsCollection. The ItemsCollection is holding
+				// a reference to the items source, so it won`t be collected
+				// unless unset.Note that this block is not extracted to a separate
+				// helper to avoid the cost of creating additional delegates.
+
+				if (thatRef.Target is ItemCollection that)
+				{
+					that.OnItemsSourceCollectionChanged(s, e);
+				}
+				else
+				{
+					existingObservable.CollectionChanged -= handler;
+				}
+			}
+
+			// This is a workaround for a bug with EventRegistrationTokenTable on Xamarin, where subscribing/unsubscribing to a class method directly won't 
+			// remove the handler.
+			_itemsSourceCollectionChangeDisposable.Disposable = Disposable.Create(() =>
+				existingObservable.CollectionChanged -= handler
+			);
+			existingObservable.CollectionChanged += handler;
+		}
+
+		private void ObserveCollectionChangedInner(IObservableVector<object> observableVector)
+		{
+			var thatRef = new WeakReference(this);
+
+			void handler(IObservableVector<object> s, IVectorChangedEventArgs e)
+			{
+				// Wrap the registered delegate to avoid creating a strong
+				// reference to this ItemsCollection.The ItemsCollection is holding
+				// a reference to the items source, so it won`t be collected
+				// unless unset.Note that this block is not extracted to a separate
+				// helper to avoid the cost of creating additional delegates.
+
+				if (thatRef.Target is ItemCollection that)
+				{
+					that.OnItemsSourceVectorChanged(s, e);
+				}
+				else
+				{
+					observableVector.VectorChanged -= handler;
+				}
+			}
+
+			// This is a workaround for a bug with EventRegistrationTokenTable on Xamarin, where subscribing/unsubscribing to a class method directly won't 
+			// remove the handler.
+			_itemsSourceCollectionChangeDisposable.Disposable = Disposable.Create(() =>
+				observableVector.VectorChanged -= handler
+			);
+			observableVector.VectorChanged += handler;
+		}
+
+		private void ObserveCollectionChangedInner(IObservableVector genericObservableVector)
+		{
+			var thatRef = new WeakReference(this);
+
+			void handler(object s, IVectorChangedEventArgs e)
+			{
+				// Wrap the registered delegate to avoid creating a strong
+				// reference to this ItemsCollection.The ItemsCollection is holding
+				// a reference to the items source, so it won`t be collected
+				// unless unset.Note that this block is not extracted to a separate
+				// helper to avoid the cost of creating additional delegates.
+
+				if (thatRef.Target is ItemCollection that)
+				{
+					that.OnItemsSourceVectorChanged(s, e);
+				}
+				else
+				{
+					genericObservableVector.UntypedVectorChanged -= handler;
+				}
+			}
+
+			_itemsSourceCollectionChangeDisposable.Disposable = Disposable.Create(() =>
+				genericObservableVector.UntypedVectorChanged -= handler
+			);
+			genericObservableVector.UntypedVectorChanged += handler;
 		}
 
 		private void OnItemsSourceVectorChanged(object sender, IVectorChangedEventArgs args)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`ItemsControl` does not create a strong reference to observable collections when set from `ItemsSource`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
