### PR TITLE
test: Adds Button_Events_Hover, Button_Events_Press, and Button_Event…

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1109,6 +1109,18 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Hover.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Press.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Release.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarDatePicker_Basics.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5205,8 +5217,18 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\Border_LinearGradientBrush.xaml.cs">
       <DependentUpon>Border_LinearGradientBrush.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\ButtonEventsViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Buttons_Native.xaml.cs">
       <DependentUpon>Buttons_Native.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Hover.xaml.cs">
+      <DependentUpon>Button_Events_Hover.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Press.xaml.cs">
+      <DependentUpon>Button_Events_Press.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Release.xaml.cs">
+      <DependentUpon>Button_Events_Release.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarDatePicker_Basics.xaml.cs">
       <DependentUpon>CalendarDatePicker_Basics.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ButtonEventsViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ButtonEventsViewModel.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using UITests.Shared.Helpers;
+
+using Windows.UI.Xaml;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
+{
+	public class ButtonEventsViewModel
+	{
+		public ButtonEventsViewModel(Windows.UI.Xaml.Controls.Button testBtn, ButtonEventsDataViewModel dataViewModel)
+		{
+			TestBtn = testBtn;
+			DataViewModel = dataViewModel;
+		}
+		public Windows.UI.Xaml.Controls.Button TestBtn { get; }
+		public ButtonEventsDataViewModel DataViewModel { get; }
+	}
+
+	public class ButtonEventsDataViewModel : BindableBase
+	{
+		public ButtonEventsDataViewModel(string testTitle, string expectedBehavior, DispatcherTimer dispatcherTimer = null, Windows.UI.Xaml.Controls.Button testBtn = null)
+		{
+			TestTitle = testTitle;
+			ExpectedBehavior = expectedBehavior;
+			Count = _countValue.ToString();
+			_dispatcherTimer = dispatcherTimer;
+			_testBtn.SetTarget(testBtn);
+		}
+
+		private readonly System.WeakReference<Windows.UI.Xaml.Controls.Button> _testBtn = new System.WeakReference<Windows.UI.Xaml.Controls.Button>(null);
+
+		/// <summary>
+		/// Stops the DispatcherTimer (if any) and increments Count
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="args"></param>
+		public void IncrementCount(object sender, object args)
+		{
+			_dispatcherTimer?.Stop();
+			Count = (++_countValue).ToString();
+		}
+
+		private int _countValue;
+		private string _count;
+		public string Count
+		{
+			get => _count;
+			set
+			{
+				if (_count != value)
+				{
+					_count = value;
+					RaisePropertyChanged();
+				}
+			}
+		}
+
+		public string TestTitle { get; }
+		public string ExpectedBehavior { get; }
+
+		private DispatcherTimer _dispatcherTimer;
+
+		public void StartDispatcherTimer(object sender, object args)
+		{
+			_dispatcherTimer?.Start();
+		}
+
+		public void StopDispatcherTimer(object sender, object args)
+		{
+			_dispatcherTimer?.Stop();
+		}
+
+		public void TimerTick(object sender, object args)
+		{
+			if (_testBtn.TryGetTarget(out Windows.UI.Xaml.Controls.Button testBtn))
+			{
+				testBtn.ReleasePointerCaptures();
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml
@@ -1,0 +1,140 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Button.Button_Events_Hover"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:DefaultBindMode="OneWay"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<StackPanel Orientation="Horizontal"
+					HorizontalAlignment="Center"
+					Grid.ColumnSpan="2"
+					Margin="4">
+			<TextBlock FontWeight="Bold"
+					   Margin="0,0,4,0"
+					   Text="CURRENT TEST:" />
+			<TextBlock FontWeight="Bold"
+					   Margin="4,0,0,0"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.TestTitle}" />
+		</StackPanel>
+		<Button Content="Previous Event Test"
+				Command="{x:Bind PreviousEventCommand}"
+				Grid.Row="1"
+				Margin="4"
+				HorizontalAlignment="Center" />
+		<Button Content="Next Event Test"
+				Grid.Row="1"
+				Grid.Column="1"
+				Margin="4"
+				Command="{x:Bind NextEventCommand}"
+				HorizontalAlignment="Center" />
+		<Grid Grid.Row="2"
+			  Grid.ColumnSpan="2">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+
+			<TextBlock FontWeight="Bold"
+					   Margin="4"
+					   Grid.Column="2">Count</TextBlock>
+
+			<ContentControl Content="{x:Bind CurrentViewModel.TestBtn}"
+							MinWidth="100"
+							MinHeight="50"
+							VerticalContentAlignment="Stretch"
+							HorizontalContentAlignment="Stretch"
+							Margin="4"
+							Grid.Row="1"
+							Grid.Column="1" />
+			<TextBlock Grid.Row="1"
+					   Grid.Column="2"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.Count, Mode=OneWay}" />
+
+			<StackPanel Grid.Row="4"
+						Margin="4,8,4,4">
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="EXPECTED" />
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="BEHAVIOR" />
+			</StackPanel>
+			<TextBlock Grid.Row="4"
+					   Grid.Column="1"
+					   Grid.ColumnSpan="3"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,8,4,4"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.ExpectedBehavior}" />
+
+			<Border Background="BlueViolet"
+					x:Name="hitInvisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="False"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					x:Name="hitVisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="True"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					Opacity="0.5"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="2" />
+
+			<Border Background="BlueViolet"
+					Opacity="0.5"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="3" />
+
+			<TextBlock Grid.Row="2"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test visible (pointer doesn't pass through)
+			</TextBlock>
+			<TextBlock Grid.Row="3"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test NOT visible (pointer pass through)
+			</TextBlock>
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml.cs
@@ -1,0 +1,162 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
+{
+
+	[SampleControlInfo("Button", "Button_Events_Hover", Description = $"Button Event Tests for {nameof(ClickMode)}.{nameof(ClickMode.Hover)}"
+#if __WASM__
+		, IgnoreInSnapshotTests = true
+#endif
+		)]
+	public sealed partial class Button_Events_Hover : Page, System.ComponentModel.INotifyPropertyChanged
+	{
+		public Button_Events_Hover()
+		{
+			this.InitializeComponent();
+
+			PreviousEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				//Label = "Previous Event Test"
+			};
+			PreviousEventCommand.ExecuteRequested += PreviousEventCommand_ExecuteRequested;
+			PreviousEventCommand.CanExecuteRequested += PreviousEventCommand_CanExecuteRequested;
+
+			NextEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				//Label = "Next Event Test"
+			};
+			NextEventCommand.ExecuteRequested += NextEventCommand_ExecuteRequested;
+			NextEventCommand.CanExecuteRequested += NextEventCommand_CanExecuteRequested;
+
+			_viewModels = new System.Collections.Generic.List<ButtonEventsViewModel>();
+
+			var clickMode = ClickMode.Hover;
+
+			var dataViewModel = new ButtonEventsDataViewModel("Tapped", "On UWP, TAP will be raised when the pointer is both pressed and released over the button and the pointer didn't moved significantly while being pressed. For touch input, the release must occur within approximately 1 second after the press otherwise TAP will not be raised.");
+			var testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON TAP", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.Tapped += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Double Tapped", "On UWP, DOUBLE TAPPED will be raised on the PRESS right after a rapid press and release on the same control.For UWP the precise amount of time for the press and release depends on the Double-click speed setting in the Windows settings but is slightly less than 1 second at the setting that allows the most time to be considered a double click.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON DOUBLE TAPPED", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.DoubleTapped += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Click", "On UWP, CLICK will be raised when the pointer is moved over the button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON CLICK", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.Click += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Pressed", "On UWP, PRESSED will be raised when the pointer is pressed over the button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER PRESSED", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.PointerPressed += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Released", "On UWP, RELEASE will be raised when the pointer is released over the button. The pointer does not need to be pressed over the button, just released.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER RELEASED", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.PointerReleased += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER ENTERED", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.PointerEntered += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button's bounds.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER EXITED", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.PointerExited += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			var timer = new DispatcherTimer() { Interval = new System.TimeSpan(0, 0, 2) };
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER CAPTURE LOST", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Capture Lost", "On UWP, CAPTURE LOST is never raised. Hover over the button for 2+ seconds then move off the button then press the button for 2+ seconds then release it to verify that it is not raised programmatically.", timer, testBtn);
+			timer.Tick += dataViewModel.TimerTick;
+			testBtn.Click += dataViewModel.StartDispatcherTimer;
+			testBtn.PointerReleased += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCanceled += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCaptureLost += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			CurrentViewModel = _viewModels[0];
+
+			Unloaded += (snd, evt) =>
+			{
+				var vms = _viewModels;
+				if (vms != null)
+				{
+					foreach (var item in vms)
+					{
+						item.DataViewModel.StopDispatcherTimer(null, null);
+					}
+				}
+			};
+		}
+
+		private void PreviousEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Max(0, _currentIndex - 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == 0)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			NextEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void PreviousEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex > 0;
+
+		private void NextEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Min(_viewModels.Count - 1, _currentIndex + 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == _viewModels.Count - 1)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			PreviousEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void NextEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex < _viewModels.Count - 1;
+
+		public Windows.UI.Xaml.Input.XamlUICommand PreviousEventCommand { get; set; }
+		public Windows.UI.Xaml.Input.XamlUICommand NextEventCommand { get; set; }
+
+		private ButtonEventsViewModel _currentViewModel;
+		public ButtonEventsViewModel CurrentViewModel
+		{
+			get => _currentViewModel;
+			set
+			{
+				if (_currentViewModel != value)
+				{
+					_currentViewModel = value;
+					RaisePropertyChanged();
+				}
+			}
+		}
+
+		private readonly System.Collections.Generic.List<ButtonEventsViewModel> _viewModels;
+		private int _currentIndex;
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		private void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null) => PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml
@@ -1,0 +1,142 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Button.Button_Events_Press"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:DefaultBindMode="OneWay"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<StackPanel Orientation="Horizontal"
+					HorizontalAlignment="Center"
+					Grid.ColumnSpan="2"
+					Margin="4">
+			<TextBlock FontWeight="Bold"
+					   Margin="0,0,4,0"
+					   Text="CURRENT TEST:" />
+			<TextBlock FontWeight="Bold"
+					   Margin="4,0,0,0"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.TestTitle}" />
+		</StackPanel>
+		<Button Content="Previous Event Test"
+				Command="{x:Bind PreviousEventCommand}"
+				FontWeight="Bold"
+				Grid.Row="1"
+				Margin="4"
+				HorizontalAlignment="Center" />
+		<Button Content="Next Event Test"
+				Command="{x:Bind NextEventCommand}"
+				FontWeight="Bold"
+				Grid.Row="1"
+				Grid.Column="1"
+				Margin="4"
+				HorizontalAlignment="Center" />
+		<Grid Grid.Row="2"
+			  Grid.ColumnSpan="2">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+
+			<TextBlock FontWeight="Bold"
+					   Margin="4"
+					   Grid.Column="2">Count</TextBlock>
+
+			<ContentControl Content="{x:Bind CurrentViewModel.TestBtn}"
+							MinWidth="100"
+							MinHeight="50"
+							VerticalContentAlignment="Stretch"
+							HorizontalContentAlignment="Stretch"
+							Margin="4"
+							Grid.Row="1"
+							Grid.Column="1" />
+			<TextBlock Grid.Row="1"
+					   Grid.Column="2"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.Count, Mode=OneWay}" />
+
+			<StackPanel Grid.Row="4"
+						Margin="4,8,4,4">
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="EXPECTED" />
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="BEHAVIOR" />
+			</StackPanel>
+			<TextBlock Grid.Row="4"
+					   Grid.Column="1"
+					   Grid.ColumnSpan="3"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,8,4,4"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.ExpectedBehavior}" />
+
+			<Border Background="BlueViolet"
+					x:Name="hitInvisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="False"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					x:Name="hitVisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="True"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					Opacity="0.5"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="2" />
+
+			<Border Background="BlueViolet"
+					Opacity="0.5"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="3" />
+
+			<TextBlock Grid.Row="2"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test visible (pointer doesn't pass through)
+			</TextBlock>
+			<TextBlock Grid.Row="3"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test NOT visible (pointer pass through)
+			</TextBlock>
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml.cs
@@ -1,0 +1,160 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
+{
+	[SampleControlInfo("Button", "Button_Events_Press", Description = $"Button Event Tests for {nameof(ClickMode)}.{nameof(ClickMode.Press)}"
+#if __WASM__
+		, IgnoreInSnapshotTests = true
+#endif
+		)]
+	public sealed partial class Button_Events_Press : Page, System.ComponentModel.INotifyPropertyChanged
+	{
+		public Button_Events_Press()
+		{
+			this.InitializeComponent();
+
+			PreviousEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				Label = "Previous Event Test"
+			};
+			PreviousEventCommand.ExecuteRequested += PreviousEventCommand_ExecuteRequested;
+			PreviousEventCommand.CanExecuteRequested += PreviousEventCommand_CanExecuteRequested;
+
+			NextEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				Label = "Next Event Test"
+			};
+			NextEventCommand.ExecuteRequested += NextEventCommand_ExecuteRequested;
+			NextEventCommand.CanExecuteRequested += NextEventCommand_CanExecuteRequested;
+
+			_viewModels = new System.Collections.Generic.List<ButtonEventsViewModel>();
+
+			var clickMode = ClickMode.Press;
+			var dataViewModel = new ButtonEventsDataViewModel("Tapped", "On UWP, TAPPED will be raised when the pointer is both pressed and released over the button and the pointer didn't moved significantly while being pressed. For touch input, the release must occur within approximately 1 second after the press otherwise TAP will not be raised.");
+			var testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON TAPPED", ClickMode = clickMode };
+			testBtn.Tapped += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Double Tapped", "On UWP, DOUBLE TAPPED will be raised on the PRESS right after a rapid press and release on the same control. For UWP the precise amount of time for the press and release depends on the Double-click speed setting in the Windows settings but is slightly less than 1 second at the setting that allows the most time to be considered a double click.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON DOUBLE TAPPED", ClickMode = clickMode };
+			testBtn.DoubleTapped += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Click", "On UWP, CLICK will be raised when the pointer is pressed over the button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON CLICK", ClickMode = clickMode };
+			testBtn.Click += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Pressed", "On UWP, POINTER PRESSED is never raised from a button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER PRESSED", ClickMode = clickMode };
+			testBtn.PointerPressed += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Released", "On UWP, POINTER RELEASED is NOT RAISED from a button when the pointer is a MOUSE but IS RAISED when the pointer is TOUCH input and the touch input is both pressed and released over the button and didn't move significantly while being pressed. The touch can be held for any amount of time.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER RELEASED", ClickMode = clickMode };
+			testBtn.PointerReleased += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER ENTERED", ClickMode = clickMode };
+			testBtn.PointerEntered += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button's bounds.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER EXITED", ClickMode = clickMode };
+			testBtn.PointerExited += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			var timer = new DispatcherTimer() { Interval = new System.TimeSpan(0, 0, 2) };
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER CAPTURE LOST", ClickMode = clickMode };
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Capture Lost", "On UWP, CAPTURE LOST is raised when an event occurs that causes capture to change to another control or otherwise be released programmatically (press and hold the button for 2+ seconds to trigger this) or when the button is released, whichever occurs first. It will only be raised once regardless of the cause. The main difference between CAPTURE LOST and CLICK is that Click is only raised if the pointer is over the button when released while Capture Lost is raised regardless of the Pointer's location.", timer, testBtn);
+			timer.Tick += dataViewModel.TimerTick;
+			testBtn.Click += dataViewModel.StartDispatcherTimer;
+			testBtn.PointerReleased += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCanceled += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCaptureLost += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			CurrentViewModel = _viewModels[0];
+
+			Unloaded += (snd, evt) =>
+			{
+				var vms = _viewModels;
+				if (vms != null)
+				{
+					foreach (var item in vms)
+					{
+						item.DataViewModel.StopDispatcherTimer(null, null);
+					}
+				}
+			};
+		}
+
+		private void PreviousEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Max(0, _currentIndex - 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == 0)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			NextEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void PreviousEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex > 0;
+
+		private void NextEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Min(_viewModels.Count - 1, _currentIndex + 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == _viewModels.Count - 1)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			PreviousEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void NextEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex < _viewModels.Count - 1;
+
+		public Windows.UI.Xaml.Input.XamlUICommand PreviousEventCommand { get; set; }
+		public Windows.UI.Xaml.Input.XamlUICommand NextEventCommand { get; set; }
+
+		private ButtonEventsViewModel _currentViewModel;
+		public ButtonEventsViewModel CurrentViewModel
+		{
+			get => _currentViewModel;
+			set
+			{
+				if (_currentViewModel != value)
+				{
+					_currentViewModel = value;
+					RaisePropertyChanged();
+				}
+			}
+		}
+
+		private readonly System.Collections.Generic.List<ButtonEventsViewModel> _viewModels;
+		private int _currentIndex;
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		private void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null) => PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml
@@ -1,0 +1,140 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Button.Button_Events_Release"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:DefaultBindMode="OneWay"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<StackPanel Orientation="Horizontal"
+					HorizontalAlignment="Center"
+					Grid.ColumnSpan="2"
+					Margin="4">
+			<TextBlock FontWeight="Bold"
+					   Margin="0,0,4,0"
+					   Text="CURRENT TEST:" />
+			<TextBlock FontWeight="Bold"
+					   Margin="4,0,0,0"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.TestTitle}" />
+		</StackPanel>
+		<Button Content="Previous Event Test"
+				Command="{x:Bind PreviousEventCommand}"
+				Grid.Row="1"
+				Margin="4"
+				HorizontalAlignment="Center" />
+		<Button Content="Next Event Test"
+				Grid.Row="1"
+				Grid.Column="1"
+				Margin="4"
+				Command="{x:Bind NextEventCommand}"
+				HorizontalAlignment="Center" />
+		<Grid Grid.Row="2"
+			  Grid.ColumnSpan="2">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+
+			<TextBlock FontWeight="Bold"
+					   Margin="4"
+					   Grid.Column="2">Count</TextBlock>
+
+			<ContentControl Content="{x:Bind CurrentViewModel.TestBtn}"
+							MinWidth="100"
+							MinHeight="50"
+							VerticalContentAlignment="Stretch"
+							HorizontalContentAlignment="Stretch"
+							Margin="4"
+							Grid.Row="1"
+							Grid.Column="1" />
+			<TextBlock Grid.Row="1"
+					   Grid.Column="2"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.Count, Mode=OneWay}" />
+
+			<StackPanel Grid.Row="4"
+						Margin="4,8,4,4">
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="EXPECTED" />
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="BEHAVIOR" />
+			</StackPanel>
+			<TextBlock Grid.Row="4"
+					   Grid.Column="1"
+					   Grid.ColumnSpan="3"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,8,4,4"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.ExpectedBehavior}" />
+
+			<Border Background="BlueViolet"
+					x:Name="hitInvisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="False"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					x:Name="hitVisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="True"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					Opacity="0.5"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="2" />
+
+			<Border Background="BlueViolet"
+					Opacity="0.5"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="3" />
+
+			<TextBlock Grid.Row="2"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test visible (pointer doesn't pass through)
+			</TextBlock>
+			<TextBlock Grid.Row="3"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test NOT visible (pointer pass through)
+			</TextBlock>
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml.cs
@@ -1,0 +1,161 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
+{
+	[SampleControlInfo("Button", "Button_Events_Release", Description = $"Button Event Tests for {nameof(ClickMode)}.{nameof(ClickMode.Release)}"
+#if __WASM__
+		, IgnoreInSnapshotTests = true
+#endif
+		)]
+	public sealed partial class Button_Events_Release : Page, System.ComponentModel.INotifyPropertyChanged
+	{
+		public Button_Events_Release()
+		{
+			this.InitializeComponent();
+
+			PreviousEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				Label = "Previous Event Test"
+			};
+			PreviousEventCommand.ExecuteRequested += PreviousEventCommand_ExecuteRequested;
+			PreviousEventCommand.CanExecuteRequested += PreviousEventCommand_CanExecuteRequested;
+
+			NextEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				Label = "Next Event Test"
+			};
+			NextEventCommand.ExecuteRequested += NextEventCommand_ExecuteRequested;
+			NextEventCommand.CanExecuteRequested += NextEventCommand_CanExecuteRequested;
+
+			_viewModels = new System.Collections.Generic.List<ButtonEventsViewModel>();
+
+			var clickMode = ClickMode.Release;
+
+			var dataViewModel = new ButtonEventsDataViewModel("Tapped", "On UWP, TAPPED will be raised when the pointer is both pressed and released over the button and the pointer didn't move significantly while being pressed.");
+			var testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON TAPPED", ClickMode = clickMode };
+			testBtn.Tapped += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Double Tapped", "On UWP, DOUBLE TAPPED will be raised on the PRESS right after a rapid press and release on the same control. For UWP the precise amount of time for the press and release depends on the Double-click speed setting in the Windows settings but is slightly less than 1 second at the setting that allows the most time to be considered a double click.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON DOUBLE TAPPED", ClickMode = clickMode };
+			testBtn.DoubleTapped += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Click", "On UWP, CLICK will be raised when the pointer is both pressed and released over the button. The pointer can go anywhere while pressed, as soon it's pressed and released over the control.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON CLICK", ClickMode = clickMode };
+			testBtn.Click += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Pressed", "On UWP, PRESSED is never raised from a button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER PRESSED", ClickMode = clickMode };
+			testBtn.PointerPressed += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Released", "On UWP, RELEASED is never raised from a button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER RELEASED", ClickMode = clickMode };
+			testBtn.PointerReleased += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER ENTERED", ClickMode = clickMode };
+			testBtn.PointerEntered += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button zone.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER EXITED", ClickMode = clickMode };
+			testBtn.PointerExited += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			var timer = new DispatcherTimer() { Interval = new System.TimeSpan(0, 0, 2) };
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER CAPTURE LOST", ClickMode = clickMode };
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Capture Lost", "On UWP, CAPTURE LOST is only raised when the button is released (press and hold the button for 2+ seconds to verify that it is not raised programmatically). The main difference between CAPTURE LOST and CLICK is that Click is only raised if the pointer is over the button when released while Capture Lost is raised regardless of the Pointer's location.", timer, testBtn);
+			timer.Tick += dataViewModel.TimerTick;
+			testBtn.Click += dataViewModel.StartDispatcherTimer;
+			testBtn.PointerReleased += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCanceled += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCaptureLost += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			CurrentViewModel = _viewModels[0];
+
+			Unloaded += (snd, evt) =>
+			{
+				var vms = _viewModels;
+				if (vms != null)
+				{
+					foreach (var item in vms)
+					{
+						item.DataViewModel.StopDispatcherTimer(null, null);
+					}
+				}
+			};
+		}
+
+		private void PreviousEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Max(0, _currentIndex - 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == 0)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			NextEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void PreviousEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex > 0;
+
+		private void NextEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Min(_viewModels.Count - 1, _currentIndex + 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == _viewModels.Count - 1)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			PreviousEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void NextEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex < _viewModels.Count - 1;
+
+		public Windows.UI.Xaml.Input.XamlUICommand PreviousEventCommand { get; set; }
+		public Windows.UI.Xaml.Input.XamlUICommand NextEventCommand { get; set; }
+
+		private ButtonEventsViewModel _currentViewModel;
+		public ButtonEventsViewModel CurrentViewModel
+		{
+			get => _currentViewModel;
+			set
+			{
+				if (_currentViewModel != value)
+				{
+					_currentViewModel = value;
+					RaisePropertyChanged();
+				}
+			}
+		}
+
+		private readonly System.Collections.Generic.List<ButtonEventsViewModel> _viewModels;
+		private int _currentIndex;
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		private void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null) => PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+	}
+}


### PR DESCRIPTION
…s_Release tests to SamplesApp to test button conformance against UWP's behavior for the three ClickMode enumerators. These are useful for testing #7888

GitHub Issue (If applicable): #7888

## PR Type

What kind of change does this PR introduce?
- Other... Please describe: SamplesApp Tests

-->

## What is the current behavior?

The Button_Events test doesn't test ClickMode.Hover and ClickMode.Press and its UI isn't designed for testing on Android and other small form-factor devices

## What is the new behavior?

Button_Events still exists but now there are also Button_Events_Hover, Button_Events_Press, and Button_Events_Release that are configured to test each of the ClickMode enumerators with a UI designed to be usable on small form-factor devices. All are marked to not generate snapshots on WASM since WASM screenshots are (I believe) the only platfom that snapshots are currently tested on and snapshots would not reveal anything since the behavior requires mouse/touch input to test.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

It's associate with an issue but only provides tests for more easily testing the bugs reported in the issue; it doesn't provide any code changes other than adding the samples.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
