### PR TITLE
test: Adds Button_Events_Hover, Button_Events_Press, and Button_Event…

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1133,6 +1133,18 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Hover.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Press.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Release.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarDatePicker_Basics.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5292,8 +5304,18 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\Border_LinearGradientBrush.xaml.cs">
       <DependentUpon>Border_LinearGradientBrush.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\ButtonEventsViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Buttons_Native.xaml.cs">
       <DependentUpon>Buttons_Native.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Hover.xaml.cs">
+      <DependentUpon>Button_Events_Hover.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Press.xaml.cs">
+      <DependentUpon>Button_Events_Press.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Events_Release.xaml.cs">
+      <DependentUpon>Button_Events_Release.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarDatePicker_Basics.xaml.cs">
       <DependentUpon>CalendarDatePicker_Basics.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ButtonEventsViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ButtonEventsViewModel.cs
@@ -58,6 +58,12 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 			}
 		}
 
+		public void ResetCount()
+		{
+			_countValue = 0;
+			Count = _countValue.ToString();
+		}
+
 		public string TestTitle { get; }
 		public string ExpectedBehavior { get; }
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ButtonEventsViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ButtonEventsViewModel.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using UITests.Shared.Helpers;
+
+using Windows.UI.Xaml;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
+{
+	public class ButtonEventsViewModel
+	{
+		public ButtonEventsViewModel(Windows.UI.Xaml.Controls.Button testBtn, ButtonEventsDataViewModel dataViewModel)
+		{
+			TestBtn = testBtn;
+			DataViewModel = dataViewModel;
+		}
+		public Windows.UI.Xaml.Controls.Button TestBtn { get; }
+		public ButtonEventsDataViewModel DataViewModel { get; }
+	}
+
+	public class ButtonEventsDataViewModel : BindableBase
+	{
+		public ButtonEventsDataViewModel(string testTitle, string expectedBehavior, DispatcherTimer dispatcherTimer = null, Windows.UI.Xaml.Controls.Button testBtn = null)
+		{
+			TestTitle = testTitle;
+			ExpectedBehavior = expectedBehavior;
+			Count = _countValue.ToString();
+			_dispatcherTimer = dispatcherTimer;
+			_testBtn.SetTarget(testBtn);
+		}
+
+		private readonly System.WeakReference<Windows.UI.Xaml.Controls.Button> _testBtn = new System.WeakReference<Windows.UI.Xaml.Controls.Button>(null);
+
+		/// <summary>
+		/// Stops the DispatcherTimer (if any) and increments Count
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="args"></param>
+		public void IncrementCount(object sender, object args)
+		{
+			_dispatcherTimer?.Stop();
+			Count = (++_countValue).ToString();
+		}
+
+		private int _countValue;
+		private string _count;
+		public string Count
+		{
+			get => _count;
+			set
+			{
+				if (_count != value)
+				{
+					_count = value;
+					RaisePropertyChanged();
+				}
+			}
+		}
+
+		public string TestTitle { get; }
+		public string ExpectedBehavior { get; }
+
+		private DispatcherTimer _dispatcherTimer;
+
+		public void StartDispatcherTimer(object sender, object args)
+		{
+			_dispatcherTimer?.Start();
+		}
+
+		public void StopDispatcherTimer(object sender, object args)
+		{
+			_dispatcherTimer?.Stop();
+		}
+
+		public void TimerTick(object sender, object args)
+		{
+			if (_testBtn.TryGetTarget(out Windows.UI.Xaml.Controls.Button testBtn))
+			{
+				testBtn.ReleasePointerCaptures();
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml
@@ -1,0 +1,140 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Button.Button_Events_Hover"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:DefaultBindMode="OneWay"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<StackPanel Orientation="Horizontal"
+					HorizontalAlignment="Center"
+					Grid.ColumnSpan="2"
+					Margin="4">
+			<TextBlock FontWeight="Bold"
+					   Margin="0,0,4,0"
+					   Text="CURRENT TEST:" />
+			<TextBlock FontWeight="Bold"
+					   Margin="4,0,0,0"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.TestTitle}" />
+		</StackPanel>
+		<Button Content="Previous Event Test"
+				Command="{x:Bind PreviousEventCommand}"
+				Grid.Row="1"
+				Margin="4"
+				HorizontalAlignment="Center" />
+		<Button Content="Next Event Test"
+				Grid.Row="1"
+				Grid.Column="1"
+				Margin="4"
+				Command="{x:Bind NextEventCommand}"
+				HorizontalAlignment="Center" />
+		<Grid Grid.Row="2"
+			  Grid.ColumnSpan="2">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+
+			<TextBlock FontWeight="Bold"
+					   Margin="4"
+					   Grid.Column="2">Count</TextBlock>
+
+			<ContentControl Content="{x:Bind CurrentViewModel.TestBtn}"
+							MinWidth="100"
+							MinHeight="50"
+							VerticalContentAlignment="Stretch"
+							HorizontalContentAlignment="Stretch"
+							Margin="4"
+							Grid.Row="1"
+							Grid.Column="1" />
+			<TextBlock Grid.Row="1"
+					   Grid.Column="2"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.Count, Mode=OneWay}" />
+
+			<StackPanel Grid.Row="4"
+						Margin="4,8,4,4">
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="EXPECTED" />
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="BEHAVIOR" />
+			</StackPanel>
+			<TextBlock Grid.Row="4"
+					   Grid.Column="1"
+					   Grid.ColumnSpan="3"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,8,4,4"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.ExpectedBehavior}" />
+
+			<Border Background="BlueViolet"
+					x:Name="hitInvisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="False"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					x:Name="hitVisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="True"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					Opacity="0.5"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="2" />
+
+			<Border Background="BlueViolet"
+					Opacity="0.5"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="3" />
+
+			<TextBlock Grid.Row="2"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test visible (pointer doesn't pass through)
+			</TextBlock>
+			<TextBlock Grid.Row="3"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test NOT visible (pointer pass through)
+			</TextBlock>
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml
@@ -52,8 +52,8 @@
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto" MinHeight="40" />
 				<RowDefinition Height="Auto" MinHeight="40" />
-				<RowDefinition Height="Auto" />
-				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" MinHeight="60" />
+				<RowDefinition Height="Auto" MinHeight="60" />
 				<RowDefinition Height="*" />
 			</Grid.RowDefinitions>
 
@@ -62,11 +62,11 @@
 					   Grid.Column="2">Count</TextBlock>
 
 			<ContentControl Content="{x:Bind CurrentViewModel.TestBtn}"
-							MinWidth="100"
-							MinHeight="50"
+							MinWidth="180"
+							MinHeight="80"
 							VerticalContentAlignment="Stretch"
 							HorizontalContentAlignment="Stretch"
-							Margin="4"
+							Margin="4,0"
 							Grid.Row="1"
 							Grid.Column="1" />
 			<TextBlock Grid.Row="1"
@@ -92,8 +92,8 @@
 			<Border Background="BlueViolet"
 					x:Name="hitInvisibleZone"
 					Opacity="0.5"
-					Width="15"
-					Margin="20,0,0,0"
+					Width="60"
+					Margin="30,0,4,0"
 					HorizontalAlignment="Left"
 					IsHitTestVisible="False"
 					Grid.Column="1"
@@ -103,8 +103,8 @@
 			<Border Background="Gold"
 					x:Name="hitVisibleZone"
 					Opacity="0.5"
-					Width="15"
-					Margin="35,0,0,0"
+					Width="60"
+					Margin="60,0,4,0"
 					HorizontalAlignment="Left"
 					IsHitTestVisible="True"
 					Grid.Column="1"
@@ -113,24 +113,30 @@
 
 			<Border Background="Gold"
 					Opacity="0.5"
-					Margin="35,0,0,0"
+					Margin="60,0,4,0"
 					HorizontalAlignment="Stretch"
 					Grid.Column="1"
 					Grid.Row="2" />
 
 			<Border Background="BlueViolet"
 					Opacity="0.5"
-					Margin="20,0,0,0"
+					Margin="30,0,4,0"
 					HorizontalAlignment="Stretch"
 					Grid.Column="1"
 					Grid.Row="3" />
 
 			<TextBlock Grid.Row="2"
+					   VerticalAlignment="Center"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,0,0,0"
 					   Grid.Column="2"
 					   Grid.ColumnSpan="2">
 				Hit test visible (pointer doesn't pass through)
 			</TextBlock>
 			<TextBlock Grid.Row="3"
+					   VerticalAlignment="Center"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,0,0,0"
 					   Grid.Column="2"
 					   Grid.ColumnSpan="2">
 				Hit test NOT visible (pointer pass through)

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml.cs
@@ -69,18 +69,18 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 			testBtn.PointerReleased += dataViewModel.IncrementCount;
 			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
 
-			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds.");
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds, including beginning a touch within a button.");
 			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER ENTERED", ClickMode = clickMode };
+			testBtn.PointerEntered += dataViewModel.IncrementCount;
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
 			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
-			testBtn.PointerEntered += dataViewModel.IncrementCount;
 			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
 
-			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button's bounds.");
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button's bounds, including releasing a touch within the button.");
 			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER EXITED", ClickMode = clickMode };
+			testBtn.PointerExited += dataViewModel.IncrementCount;
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
 			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
-			testBtn.PointerExited += dataViewModel.IncrementCount;
 			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
 
 			var timer = new DispatcherTimer() { Interval = new System.TimeSpan(0, 0, 2) };
@@ -113,6 +113,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 		private void PreviousEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
 		{
 			_currentIndex = System.Math.Max(0, _currentIndex - 1);
+			CurrentViewModel?.DataViewModel.ResetCount();
 			CurrentViewModel = _viewModels[_currentIndex];
 			if (_currentIndex == 0)
 			{
@@ -126,6 +127,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 		private void NextEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
 		{
 			_currentIndex = System.Math.Min(_viewModels.Count - 1, _currentIndex + 1);
+			CurrentViewModel?.DataViewModel.ResetCount();
 			CurrentViewModel = _viewModels[_currentIndex];
 			if (_currentIndex == _viewModels.Count - 1)
 			{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml.cs
@@ -1,0 +1,162 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
+{
+
+	[SampleControlInfo("Button", "Button_Events_Hover", Description = "Button Event Tests for ClickMode.Hover"
+#if __WASM__
+		, IgnoreInSnapshotTests = true
+#endif
+		)]
+	public sealed partial class Button_Events_Hover : Page, System.ComponentModel.INotifyPropertyChanged
+	{
+		public Button_Events_Hover()
+		{
+			this.InitializeComponent();
+
+			PreviousEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				//Label = "Previous Event Test"
+			};
+			PreviousEventCommand.ExecuteRequested += PreviousEventCommand_ExecuteRequested;
+			PreviousEventCommand.CanExecuteRequested += PreviousEventCommand_CanExecuteRequested;
+
+			NextEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				//Label = "Next Event Test"
+			};
+			NextEventCommand.ExecuteRequested += NextEventCommand_ExecuteRequested;
+			NextEventCommand.CanExecuteRequested += NextEventCommand_CanExecuteRequested;
+
+			_viewModels = new System.Collections.Generic.List<ButtonEventsViewModel>();
+
+			var clickMode = ClickMode.Hover;
+
+			var dataViewModel = new ButtonEventsDataViewModel("Tapped", "On UWP, TAP will be raised when the pointer is both pressed and released over the button and the pointer didn't moved significantly while being pressed. For touch input, the release must occur within approximately 1 second after the press otherwise TAP will not be raised.");
+			var testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON TAP", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.Tapped += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Double Tapped", "On UWP, DOUBLE TAPPED will be raised on the PRESS right after a rapid press and release on the same control.For UWP the precise amount of time for the press and release depends on the Double-click speed setting in the Windows settings but is slightly less than 1 second at the setting that allows the most time to be considered a double click.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON DOUBLE TAPPED", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.DoubleTapped += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Click", "On UWP, CLICK will be raised when the pointer is moved over the button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON CLICK", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.Click += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Pressed", "On UWP, PRESSED will be raised when the pointer is pressed over the button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER PRESSED", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.PointerPressed += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Released", "On UWP, RELEASE will be raised when the pointer is released over the button. The pointer does not need to be pressed over the button, just released.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER RELEASED", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.PointerReleased += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER ENTERED", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.PointerEntered += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button's bounds.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER EXITED", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			testBtn.PointerExited += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			var timer = new DispatcherTimer() { Interval = new System.TimeSpan(0, 0, 2) };
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER CAPTURE LOST", ClickMode = clickMode };
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Capture Lost", "On UWP, CAPTURE LOST is never raised. Hover over the button for 2+ seconds then move off the button then press the button for 2+ seconds then release it to verify that it is not raised programmatically.", timer, testBtn);
+			timer.Tick += dataViewModel.TimerTick;
+			testBtn.Click += dataViewModel.StartDispatcherTimer;
+			testBtn.PointerReleased += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCanceled += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCaptureLost += dataViewModel.IncrementCount;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			CurrentViewModel = _viewModels[0];
+
+			Unloaded += (snd, evt) =>
+			{
+				var vms = _viewModels;
+				if (vms != null)
+				{
+					foreach (var item in vms)
+					{
+						item.DataViewModel.StopDispatcherTimer(null, null);
+					}
+				}
+			};
+		}
+
+		private void PreviousEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Max(0, _currentIndex - 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == 0)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			NextEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void PreviousEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex > 0;
+
+		private void NextEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Min(_viewModels.Count - 1, _currentIndex + 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == _viewModels.Count - 1)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			PreviousEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void NextEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex < _viewModels.Count - 1;
+
+		public Windows.UI.Xaml.Input.XamlUICommand PreviousEventCommand { get; set; }
+		public Windows.UI.Xaml.Input.XamlUICommand NextEventCommand { get; set; }
+
+		private ButtonEventsViewModel _currentViewModel;
+		public ButtonEventsViewModel CurrentViewModel
+		{
+			get => _currentViewModel;
+			set
+			{
+				if (_currentViewModel != value)
+				{
+					_currentViewModel = value;
+					RaisePropertyChanged();
+				}
+			}
+		}
+
+		private readonly System.Collections.Generic.List<ButtonEventsViewModel> _viewModels;
+		private int _currentIndex;
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		private void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null) => PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Hover.xaml.cs
@@ -34,7 +34,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 
 			var clickMode = ClickMode.Hover;
 
-			var dataViewModel = new ButtonEventsDataViewModel("Tapped", "On UWP, TAP will be raised when the pointer is both pressed and released over the button and the pointer didn't moved significantly while being pressed. For touch input, the release must occur within approximately 1 second after the press otherwise TAP will not be raised.");
+			var dataViewModel = new ButtonEventsDataViewModel("Tapped", "On UWP, TAP will be raised when the pointer is both pressed and released over the button and the pointer didn't moved significantly while being pressed. For touch and pen input, the release must occur within approximately 1 second after the press otherwise TAP will not be raised.");
 			var testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON TAP", ClickMode = clickMode };
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
 			testBtn.VerticalAlignment = VerticalAlignment.Stretch;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml
@@ -1,0 +1,142 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Button.Button_Events_Press"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:DefaultBindMode="OneWay"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<StackPanel Orientation="Horizontal"
+					HorizontalAlignment="Center"
+					Grid.ColumnSpan="2"
+					Margin="4">
+			<TextBlock FontWeight="Bold"
+					   Margin="0,0,4,0"
+					   Text="CURRENT TEST:" />
+			<TextBlock FontWeight="Bold"
+					   Margin="4,0,0,0"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.TestTitle}" />
+		</StackPanel>
+		<Button Content="Previous Event Test"
+				Command="{x:Bind PreviousEventCommand}"
+				FontWeight="Bold"
+				Grid.Row="1"
+				Margin="4"
+				HorizontalAlignment="Center" />
+		<Button Content="Next Event Test"
+				Command="{x:Bind NextEventCommand}"
+				FontWeight="Bold"
+				Grid.Row="1"
+				Grid.Column="1"
+				Margin="4"
+				HorizontalAlignment="Center" />
+		<Grid Grid.Row="2"
+			  Grid.ColumnSpan="2">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+
+			<TextBlock FontWeight="Bold"
+					   Margin="4"
+					   Grid.Column="2">Count</TextBlock>
+
+			<ContentControl Content="{x:Bind CurrentViewModel.TestBtn}"
+							MinWidth="100"
+							MinHeight="50"
+							VerticalContentAlignment="Stretch"
+							HorizontalContentAlignment="Stretch"
+							Margin="4"
+							Grid.Row="1"
+							Grid.Column="1" />
+			<TextBlock Grid.Row="1"
+					   Grid.Column="2"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.Count, Mode=OneWay}" />
+
+			<StackPanel Grid.Row="4"
+						Margin="4,8,4,4">
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="EXPECTED" />
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="BEHAVIOR" />
+			</StackPanel>
+			<TextBlock Grid.Row="4"
+					   Grid.Column="1"
+					   Grid.ColumnSpan="3"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,8,4,4"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.ExpectedBehavior}" />
+
+			<Border Background="BlueViolet"
+					x:Name="hitInvisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="False"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					x:Name="hitVisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="True"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					Opacity="0.5"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="2" />
+
+			<Border Background="BlueViolet"
+					Opacity="0.5"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="3" />
+
+			<TextBlock Grid.Row="2"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test visible (pointer doesn't pass through)
+			</TextBlock>
+			<TextBlock Grid.Row="3"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test NOT visible (pointer pass through)
+			</TextBlock>
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml
@@ -31,16 +31,14 @@
 		</StackPanel>
 		<Button Content="Previous Event Test"
 				Command="{x:Bind PreviousEventCommand}"
-				FontWeight="Bold"
 				Grid.Row="1"
 				Margin="4"
 				HorizontalAlignment="Center" />
 		<Button Content="Next Event Test"
-				Command="{x:Bind NextEventCommand}"
-				FontWeight="Bold"
 				Grid.Row="1"
 				Grid.Column="1"
 				Margin="4"
+				Command="{x:Bind NextEventCommand}"
 				HorizontalAlignment="Center" />
 		<Grid Grid.Row="2"
 			  Grid.ColumnSpan="2">
@@ -54,8 +52,8 @@
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto" MinHeight="40" />
 				<RowDefinition Height="Auto" MinHeight="40" />
-				<RowDefinition Height="Auto" />
-				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" MinHeight="60" />
+				<RowDefinition Height="Auto" MinHeight="60" />
 				<RowDefinition Height="*" />
 			</Grid.RowDefinitions>
 
@@ -64,11 +62,11 @@
 					   Grid.Column="2">Count</TextBlock>
 
 			<ContentControl Content="{x:Bind CurrentViewModel.TestBtn}"
-							MinWidth="100"
-							MinHeight="50"
+							MinWidth="180"
+							MinHeight="80"
 							VerticalContentAlignment="Stretch"
 							HorizontalContentAlignment="Stretch"
-							Margin="4"
+							Margin="4,0"
 							Grid.Row="1"
 							Grid.Column="1" />
 			<TextBlock Grid.Row="1"
@@ -94,8 +92,8 @@
 			<Border Background="BlueViolet"
 					x:Name="hitInvisibleZone"
 					Opacity="0.5"
-					Width="15"
-					Margin="20,0,0,0"
+					Width="60"
+					Margin="30,0,4,0"
 					HorizontalAlignment="Left"
 					IsHitTestVisible="False"
 					Grid.Column="1"
@@ -105,8 +103,8 @@
 			<Border Background="Gold"
 					x:Name="hitVisibleZone"
 					Opacity="0.5"
-					Width="15"
-					Margin="35,0,0,0"
+					Width="60"
+					Margin="60,0,4,0"
 					HorizontalAlignment="Left"
 					IsHitTestVisible="True"
 					Grid.Column="1"
@@ -115,24 +113,30 @@
 
 			<Border Background="Gold"
 					Opacity="0.5"
-					Margin="35,0,0,0"
+					Margin="60,0,4,0"
 					HorizontalAlignment="Stretch"
 					Grid.Column="1"
 					Grid.Row="2" />
 
 			<Border Background="BlueViolet"
 					Opacity="0.5"
-					Margin="20,0,0,0"
+					Margin="30,0,4,0"
 					HorizontalAlignment="Stretch"
 					Grid.Column="1"
 					Grid.Row="3" />
 
 			<TextBlock Grid.Row="2"
+					   VerticalAlignment="Center"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,0,0,0"
 					   Grid.Column="2"
 					   Grid.ColumnSpan="2">
 				Hit test visible (pointer doesn't pass through)
 			</TextBlock>
 			<TextBlock Grid.Row="3"
+					   VerticalAlignment="Center"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,0,0,0"
 					   Grid.Column="2"
 					   Grid.ColumnSpan="2">
 				Hit test NOT visible (pointer pass through)

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml.cs
@@ -60,21 +60,21 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
 			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
 
-			dataViewModel = new ButtonEventsDataViewModel("Pointer Released", "On UWP, POINTER RELEASED is NOT RAISED from a button when the pointer is a MOUSE but IS RAISED when the pointer is TOUCH input and the touch input is both pressed and released over the button and didn't move significantly while being pressed. The touch can be held for any amount of time.");
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Released", "On UWP, POINTER RELEASED is NOT RAISED from a button when the pointer is a MOUSE but IS RAISED when the pointer is TOUCH input and the touch input is both pressed and released over the button and didn't move significantly while being pressed. The touch must be held for at least a small bit of time before being released.");
 			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER RELEASED", ClickMode = clickMode };
 			testBtn.PointerReleased += dataViewModel.IncrementCount;
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
 			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
 			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
 
-			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds.");
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds, including beginning a touch within a button.");
 			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER ENTERED", ClickMode = clickMode };
 			testBtn.PointerEntered += dataViewModel.IncrementCount;
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
 			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
 			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
 
-			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button's bounds.");
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button's bounds, including releasing a touch within the button.");
 			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER EXITED", ClickMode = clickMode };
 			testBtn.PointerExited += dataViewModel.IncrementCount;
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
@@ -111,6 +111,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 		private void PreviousEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
 		{
 			_currentIndex = System.Math.Max(0, _currentIndex - 1);
+			CurrentViewModel?.DataViewModel.ResetCount();
 			CurrentViewModel = _viewModels[_currentIndex];
 			if (_currentIndex == 0)
 			{
@@ -124,6 +125,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 		private void NextEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
 		{
 			_currentIndex = System.Math.Min(_viewModels.Count - 1, _currentIndex + 1);
+			CurrentViewModel?.DataViewModel.ResetCount();
 			CurrentViewModel = _viewModels[_currentIndex];
 			if (_currentIndex == _viewModels.Count - 1)
 			{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Press.xaml.cs
@@ -1,0 +1,160 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
+{
+	[SampleControlInfo("Button", "Button_Events_Press", Description = "Button Event Tests for ClickMode.Press"
+#if __WASM__
+		, IgnoreInSnapshotTests = true
+#endif
+		)]
+	public sealed partial class Button_Events_Press : Page, System.ComponentModel.INotifyPropertyChanged
+	{
+		public Button_Events_Press()
+		{
+			this.InitializeComponent();
+
+			PreviousEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				Label = "Previous Event Test"
+			};
+			PreviousEventCommand.ExecuteRequested += PreviousEventCommand_ExecuteRequested;
+			PreviousEventCommand.CanExecuteRequested += PreviousEventCommand_CanExecuteRequested;
+
+			NextEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				Label = "Next Event Test"
+			};
+			NextEventCommand.ExecuteRequested += NextEventCommand_ExecuteRequested;
+			NextEventCommand.CanExecuteRequested += NextEventCommand_CanExecuteRequested;
+
+			_viewModels = new System.Collections.Generic.List<ButtonEventsViewModel>();
+
+			var clickMode = ClickMode.Press;
+			var dataViewModel = new ButtonEventsDataViewModel("Tapped", "On UWP, TAPPED will be raised when the pointer is both pressed and released over the button and the pointer didn't moved significantly while being pressed. For touch input, the release must occur within approximately 1 second after the press otherwise TAP will not be raised.");
+			var testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON TAPPED", ClickMode = clickMode };
+			testBtn.Tapped += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Double Tapped", "On UWP, DOUBLE TAPPED will be raised on the PRESS right after a rapid press and release on the same control. For UWP the precise amount of time for the press and release depends on the Double-click speed setting in the Windows settings but is slightly less than 1 second at the setting that allows the most time to be considered a double click.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON DOUBLE TAPPED", ClickMode = clickMode };
+			testBtn.DoubleTapped += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Click", "On UWP, CLICK will be raised when the pointer is pressed over the button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON CLICK", ClickMode = clickMode };
+			testBtn.Click += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Pressed", "On UWP, POINTER PRESSED is never raised from a button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER PRESSED", ClickMode = clickMode };
+			testBtn.PointerPressed += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Released", "On UWP, POINTER RELEASED is NOT RAISED from a button when the pointer is a MOUSE but IS RAISED when the pointer is TOUCH input and the touch input is both pressed and released over the button and didn't move significantly while being pressed. The touch can be held for any amount of time.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER RELEASED", ClickMode = clickMode };
+			testBtn.PointerReleased += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER ENTERED", ClickMode = clickMode };
+			testBtn.PointerEntered += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button's bounds.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER EXITED", ClickMode = clickMode };
+			testBtn.PointerExited += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			var timer = new DispatcherTimer() { Interval = new System.TimeSpan(0, 0, 2) };
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER CAPTURE LOST", ClickMode = clickMode };
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Capture Lost", "On UWP, CAPTURE LOST is raised when an event occurs that causes capture to change to another control or otherwise be released programmatically (press and hold the button for 2+ seconds to trigger this) or when the button is released, whichever occurs first. It will only be raised once regardless of the cause. The main difference between CAPTURE LOST and CLICK is that Click is only raised if the pointer is over the button when released while Capture Lost is raised regardless of the Pointer's location.", timer, testBtn);
+			timer.Tick += dataViewModel.TimerTick;
+			testBtn.Click += dataViewModel.StartDispatcherTimer;
+			testBtn.PointerReleased += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCanceled += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCaptureLost += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			CurrentViewModel = _viewModels[0];
+
+			Unloaded += (snd, evt) =>
+			{
+				var vms = _viewModels;
+				if (vms != null)
+				{
+					foreach (var item in vms)
+					{
+						item.DataViewModel.StopDispatcherTimer(null, null);
+					}
+				}
+			};
+		}
+
+		private void PreviousEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Max(0, _currentIndex - 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == 0)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			NextEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void PreviousEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex > 0;
+
+		private void NextEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Min(_viewModels.Count - 1, _currentIndex + 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == _viewModels.Count - 1)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			PreviousEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void NextEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex < _viewModels.Count - 1;
+
+		public Windows.UI.Xaml.Input.XamlUICommand PreviousEventCommand { get; set; }
+		public Windows.UI.Xaml.Input.XamlUICommand NextEventCommand { get; set; }
+
+		private ButtonEventsViewModel _currentViewModel;
+		public ButtonEventsViewModel CurrentViewModel
+		{
+			get => _currentViewModel;
+			set
+			{
+				if (_currentViewModel != value)
+				{
+					_currentViewModel = value;
+					RaisePropertyChanged();
+				}
+			}
+		}
+
+		private readonly System.Collections.Generic.List<ButtonEventsViewModel> _viewModels;
+		private int _currentIndex;
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		private void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null) => PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml
@@ -52,8 +52,8 @@
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto" MinHeight="40" />
 				<RowDefinition Height="Auto" MinHeight="40" />
-				<RowDefinition Height="Auto" />
-				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" MinHeight="60" />
+				<RowDefinition Height="Auto" MinHeight="60" />
 				<RowDefinition Height="*" />
 			</Grid.RowDefinitions>
 
@@ -62,11 +62,11 @@
 					   Grid.Column="2">Count</TextBlock>
 
 			<ContentControl Content="{x:Bind CurrentViewModel.TestBtn}"
-							MinWidth="100"
-							MinHeight="50"
+							MinWidth="180"
+							MinHeight="80"
 							VerticalContentAlignment="Stretch"
 							HorizontalContentAlignment="Stretch"
-							Margin="4"
+							Margin="4,0"
 							Grid.Row="1"
 							Grid.Column="1" />
 			<TextBlock Grid.Row="1"
@@ -92,8 +92,8 @@
 			<Border Background="BlueViolet"
 					x:Name="hitInvisibleZone"
 					Opacity="0.5"
-					Width="15"
-					Margin="20,0,0,0"
+					Width="60"
+					Margin="30,0,4,0"
 					HorizontalAlignment="Left"
 					IsHitTestVisible="False"
 					Grid.Column="1"
@@ -103,8 +103,8 @@
 			<Border Background="Gold"
 					x:Name="hitVisibleZone"
 					Opacity="0.5"
-					Width="15"
-					Margin="35,0,0,0"
+					Width="60"
+					Margin="60,0,4,0"
 					HorizontalAlignment="Left"
 					IsHitTestVisible="True"
 					Grid.Column="1"
@@ -113,24 +113,30 @@
 
 			<Border Background="Gold"
 					Opacity="0.5"
-					Margin="35,0,0,0"
+					Margin="60,0,4,0"
 					HorizontalAlignment="Stretch"
 					Grid.Column="1"
 					Grid.Row="2" />
 
 			<Border Background="BlueViolet"
 					Opacity="0.5"
-					Margin="20,0,0,0"
+					Margin="30,0,4,0"
 					HorizontalAlignment="Stretch"
 					Grid.Column="1"
 					Grid.Row="3" />
 
 			<TextBlock Grid.Row="2"
+					   VerticalAlignment="Center"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,0,0,0"
 					   Grid.Column="2"
 					   Grid.ColumnSpan="2">
 				Hit test visible (pointer doesn't pass through)
 			</TextBlock>
 			<TextBlock Grid.Row="3"
+					   VerticalAlignment="Center"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,0,0,0"
 					   Grid.Column="2"
 					   Grid.ColumnSpan="2">
 				Hit test NOT visible (pointer pass through)

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml
@@ -1,0 +1,140 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Button.Button_Events_Release"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:DefaultBindMode="OneWay"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<StackPanel Orientation="Horizontal"
+					HorizontalAlignment="Center"
+					Grid.ColumnSpan="2"
+					Margin="4">
+			<TextBlock FontWeight="Bold"
+					   Margin="0,0,4,0"
+					   Text="CURRENT TEST:" />
+			<TextBlock FontWeight="Bold"
+					   Margin="4,0,0,0"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.TestTitle}" />
+		</StackPanel>
+		<Button Content="Previous Event Test"
+				Command="{x:Bind PreviousEventCommand}"
+				Grid.Row="1"
+				Margin="4"
+				HorizontalAlignment="Center" />
+		<Button Content="Next Event Test"
+				Grid.Row="1"
+				Grid.Column="1"
+				Margin="4"
+				Command="{x:Bind NextEventCommand}"
+				HorizontalAlignment="Center" />
+		<Grid Grid.Row="2"
+			  Grid.ColumnSpan="2">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" MinHeight="40" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+
+			<TextBlock FontWeight="Bold"
+					   Margin="4"
+					   Grid.Column="2">Count</TextBlock>
+
+			<ContentControl Content="{x:Bind CurrentViewModel.TestBtn}"
+							MinWidth="100"
+							MinHeight="50"
+							VerticalContentAlignment="Stretch"
+							HorizontalContentAlignment="Stretch"
+							Margin="4"
+							Grid.Row="1"
+							Grid.Column="1" />
+			<TextBlock Grid.Row="1"
+					   Grid.Column="2"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.Count, Mode=OneWay}" />
+
+			<StackPanel Grid.Row="4"
+						Margin="4,8,4,4">
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="EXPECTED" />
+				<TextBlock Margin="0"
+						   FontWeight="Bold"
+						   Text="BEHAVIOR" />
+			</StackPanel>
+			<TextBlock Grid.Row="4"
+					   Grid.Column="1"
+					   Grid.ColumnSpan="3"
+					   TextWrapping="WrapWholeWords"
+					   Margin="4,8,4,4"
+					   Text="{x:Bind CurrentViewModel.DataViewModel.ExpectedBehavior}" />
+
+			<Border Background="BlueViolet"
+					x:Name="hitInvisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="False"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					x:Name="hitVisibleZone"
+					Opacity="0.5"
+					Width="15"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Left"
+					IsHitTestVisible="True"
+					Grid.Column="1"
+					Grid.Row="1"
+					Grid.RowSpan="3" />
+
+			<Border Background="Gold"
+					Opacity="0.5"
+					Margin="35,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="2" />
+
+			<Border Background="BlueViolet"
+					Opacity="0.5"
+					Margin="20,0,0,0"
+					HorizontalAlignment="Stretch"
+					Grid.Column="1"
+					Grid.Row="3" />
+
+			<TextBlock Grid.Row="2"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test visible (pointer doesn't pass through)
+			</TextBlock>
+			<TextBlock Grid.Row="3"
+					   Grid.Column="2"
+					   Grid.ColumnSpan="2">
+				Hit test NOT visible (pointer pass through)
+			</TextBlock>
+		</Grid>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml.cs
@@ -1,0 +1,161 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
+{
+	[SampleControlInfo("Button", "Button_Events_Release", Description = "Button Event Tests for ClickMode.Release"
+#if __WASM__
+		, IgnoreInSnapshotTests = true
+#endif
+		)]
+	public sealed partial class Button_Events_Release : Page, System.ComponentModel.INotifyPropertyChanged
+	{
+		public Button_Events_Release()
+		{
+			this.InitializeComponent();
+
+			PreviousEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				Label = "Previous Event Test"
+			};
+			PreviousEventCommand.ExecuteRequested += PreviousEventCommand_ExecuteRequested;
+			PreviousEventCommand.CanExecuteRequested += PreviousEventCommand_CanExecuteRequested;
+
+			NextEventCommand = new Windows.UI.Xaml.Input.XamlUICommand
+			{
+				Label = "Next Event Test"
+			};
+			NextEventCommand.ExecuteRequested += NextEventCommand_ExecuteRequested;
+			NextEventCommand.CanExecuteRequested += NextEventCommand_CanExecuteRequested;
+
+			_viewModels = new System.Collections.Generic.List<ButtonEventsViewModel>();
+
+			var clickMode = ClickMode.Release;
+
+			var dataViewModel = new ButtonEventsDataViewModel("Tapped", "On UWP, TAPPED will be raised when the pointer is both pressed and released over the button and the pointer didn't move significantly while being pressed.");
+			var testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON TAPPED", ClickMode = clickMode };
+			testBtn.Tapped += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Double Tapped", "On UWP, DOUBLE TAPPED will be raised on the PRESS right after a rapid press and release on the same control. For UWP the precise amount of time for the press and release depends on the Double-click speed setting in the Windows settings but is slightly less than 1 second at the setting that allows the most time to be considered a double click.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON DOUBLE TAPPED", ClickMode = clickMode };
+			testBtn.DoubleTapped += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Click", "On UWP, CLICK will be raised when the pointer is both pressed and released over the button. The pointer can go anywhere while pressed, as soon it's pressed and released over the control.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON CLICK", ClickMode = clickMode };
+			testBtn.Click += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Pressed", "On UWP, PRESSED is never raised from a button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER PRESSED", ClickMode = clickMode };
+			testBtn.PointerPressed += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Released", "On UWP, RELEASED is never raised from a button.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER RELEASED", ClickMode = clickMode };
+			testBtn.PointerReleased += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER ENTERED", ClickMode = clickMode };
+			testBtn.PointerEntered += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button zone.");
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER EXITED", ClickMode = clickMode };
+			testBtn.PointerExited += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			var timer = new DispatcherTimer() { Interval = new System.TimeSpan(0, 0, 2) };
+			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER CAPTURE LOST", ClickMode = clickMode };
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Capture Lost", "On UWP, CAPTURE LOST is only raised when the button is released (press and hold the button for 2+ seconds to verify that it is not raised programmatically). The main difference between CAPTURE LOST and CLICK is that Click is only raised if the pointer is over the button when released while Capture Lost is raised regardless of the Pointer's location.", timer, testBtn);
+			timer.Tick += dataViewModel.TimerTick;
+			testBtn.Click += dataViewModel.StartDispatcherTimer;
+			testBtn.PointerReleased += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCanceled += dataViewModel.StopDispatcherTimer;
+			testBtn.PointerCaptureLost += dataViewModel.IncrementCount;
+			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
+			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
+			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
+
+			CurrentViewModel = _viewModels[0];
+
+			Unloaded += (snd, evt) =>
+			{
+				var vms = _viewModels;
+				if (vms != null)
+				{
+					foreach (var item in vms)
+					{
+						item.DataViewModel.StopDispatcherTimer(null, null);
+					}
+				}
+			};
+		}
+
+		private void PreviousEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Max(0, _currentIndex - 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == 0)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			NextEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void PreviousEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex > 0;
+
+		private void NextEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
+		{
+			_currentIndex = System.Math.Min(_viewModels.Count - 1, _currentIndex + 1);
+			CurrentViewModel = _viewModels[_currentIndex];
+			if (_currentIndex == _viewModels.Count - 1)
+			{
+				sender.NotifyCanExecuteChanged();
+			}
+			PreviousEventCommand.NotifyCanExecuteChanged();
+		}
+
+		private void NextEventCommand_CanExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.CanExecuteRequestedEventArgs args) => args.CanExecute = _currentIndex < _viewModels.Count - 1;
+
+		public Windows.UI.Xaml.Input.XamlUICommand PreviousEventCommand { get; set; }
+		public Windows.UI.Xaml.Input.XamlUICommand NextEventCommand { get; set; }
+
+		private ButtonEventsViewModel _currentViewModel;
+		public ButtonEventsViewModel CurrentViewModel
+		{
+			get => _currentViewModel;
+			set
+			{
+				if (_currentViewModel != value)
+				{
+					_currentViewModel = value;
+					RaisePropertyChanged();
+				}
+			}
+		}
+
+		private readonly System.Collections.Generic.List<ButtonEventsViewModel> _viewModels;
+		private int _currentIndex;
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		private void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null) => PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Events_Release.xaml.cs
@@ -33,7 +33,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 
 			var clickMode = ClickMode.Release;
 
-			var dataViewModel = new ButtonEventsDataViewModel("Tapped", "On UWP, TAPPED will be raised when the pointer is both pressed and released over the button and the pointer didn't move significantly while being pressed.");
+			var dataViewModel = new ButtonEventsDataViewModel("Tapped", "On UWP, TAPPED will be raised when the pointer is both pressed and released over the button and the pointer didn't move significantly while being pressed. For touch input the touch must be released in less than a second in order for the event to be raised.");
 			var testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON TAPPED", ClickMode = clickMode };
 			testBtn.Tapped += dataViewModel.IncrementCount;
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
@@ -47,7 +47,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
 			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
 
-			dataViewModel = new ButtonEventsDataViewModel("Click", "On UWP, CLICK will be raised when the pointer is both pressed and released over the button. The pointer can go anywhere while pressed, as soon it's pressed and released over the control.");
+			dataViewModel = new ButtonEventsDataViewModel("Click", "On UWP, CLICK will be raised when the pointer is both pressed and released over the button. The pointer can go anywhere while pressed, as long as it's pressed and released over the control.");
 			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON CLICK", ClickMode = clickMode };
 			testBtn.Click += dataViewModel.IncrementCount;
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
@@ -61,21 +61,21 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
 			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
 
-			dataViewModel = new ButtonEventsDataViewModel("Pointer Released", "On UWP, RELEASED is never raised from a button.");
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Released", "On UWP, RELEASED is never raised from a button using a mouse. Using touch, it will be raised if a touch begins on the button, is held for at least a second, and is released without any substantial movement.");
 			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER RELEASED", ClickMode = clickMode };
 			testBtn.PointerReleased += dataViewModel.IncrementCount;
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
 			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
 			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
 
-			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds.");
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Entered", "On UWP, ENTERED is raised when the pointer is entering the button's bounds, including beginning a touch within a button.");
 			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER ENTERED", ClickMode = clickMode };
 			testBtn.PointerEntered += dataViewModel.IncrementCount;
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
 			testBtn.VerticalAlignment = VerticalAlignment.Stretch;
 			_viewModels.Add(new ButtonEventsViewModel(testBtn, dataViewModel));
 
-			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button zone.");
+			dataViewModel = new ButtonEventsDataViewModel("Pointer Exited", "On UWP, EXITED is raised when the pointer is leaving the button's bounds, including releasing a touch within the button.");
 			testBtn = new Windows.UI.Xaml.Controls.Button() { Content = "ON POINTER EXITED", ClickMode = clickMode };
 			testBtn.PointerExited += dataViewModel.IncrementCount;
 			testBtn.HorizontalAlignment = HorizontalAlignment.Stretch;
@@ -112,6 +112,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 		private void PreviousEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
 		{
 			_currentIndex = System.Math.Max(0, _currentIndex - 1);
+			CurrentViewModel?.DataViewModel.ResetCount();
 			CurrentViewModel = _viewModels[_currentIndex];
 			if (_currentIndex == 0)
 			{
@@ -125,6 +126,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
 		private void NextEventCommand_ExecuteRequested(Windows.UI.Xaml.Input.XamlUICommand sender, Windows.UI.Xaml.Input.ExecuteRequestedEventArgs args)
 		{
 			_currentIndex = System.Math.Min(_viewModels.Count - 1, _currentIndex + 1);
+			CurrentViewModel?.DataViewModel.ResetCount();
 			CurrentViewModel = _viewModels[_currentIndex];
 			if (_currentIndex == _viewModels.Count - 1)
 			{

--- a/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
@@ -44,18 +44,45 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		}
 
 		[TestMethod]
-		public void Tapped_Duration()
+		public void Tapped_Duration_Mouse()
 		{
 			var sut = new GestureRecognizer { GestureSettings = GestureSettings.Tap };
 			var taps = new List<TappedEventArgs>();
 			sut.Tapped += (snd, e) => taps.Add(e);
 
-			sut.ProcessDownEvent(25, 25);
+			sut.ProcessDownEvent(25, 25, device: PointerDeviceType.Mouse);
 			taps.Should().BeEmpty();
 
-			sut.CanBeDoubleTap(GetPoint(28, 28)).Should().BeFalse();
-			sut.ProcessUpEvent(27, 27, ts: long.MaxValue); // No matter the duration
-			taps.Should().BeEquivalentTo(Tap(25, 25));
+			sut.ProcessUpEvent(27, 27, device: PointerDeviceType.Mouse, ts: long.MaxValue); // No matter the duration for mouse
+			taps.Should().BeEquivalentTo(Tap(25, 25, device: PointerDeviceType.Mouse));
+		}
+
+		[TestMethod]
+		public void Tapped_Duration_Touch()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.Tap };
+			var taps = new List<TappedEventArgs>();
+			sut.Tapped += (snd, e) => taps.Add(e);
+
+			sut.ProcessDownEvent(25, 25, device: PointerDeviceType.Touch);
+			taps.Should().BeEmpty();
+
+			sut.ProcessUpEvent(27, 27, device: PointerDeviceType.Touch, ts: GestureRecognizer.HoldMinDelayTicks + 10);
+			taps.Should().BeEmpty();
+		}
+
+		[TestMethod]
+		public void Tapped_Duration_Pen()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.Tap };
+			var taps = new List<TappedEventArgs>();
+			sut.Tapped += (snd, e) => taps.Add(e);
+
+			sut.ProcessDownEvent(25, 25, device: PointerDeviceType.Pen);
+			taps.Should().BeEmpty();
+
+			sut.ProcessUpEvent(27, 27, device: PointerDeviceType.Pen, ts: GestureRecognizer.HoldMinDelayTicks + 10);
+			taps.Should().BeEmpty();
 		}
 
 		[TestMethod]
@@ -137,15 +164,14 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			var taps = new List<TappedEventArgs>();
 			sut.Tapped += (snd, e) => taps.Add(e);
 
-			sut.ProcessDownEvent(25, 25);
+			sut.ProcessDownEvent(25, 25, device: PointerDeviceType.Mouse);
 			taps.Should().BeEmpty();
 
-			sut.ProcessMoveEvent(26, 26);
-
+			sut.ProcessMoveEvent(26, 26, device: PointerDeviceType.Mouse);
 
 			sut.CanBeDoubleTap(GetPoint(28, 28)).Should().BeFalse();
-			sut.ProcessUpEvent(GetPoint(27, 27, ts: long.MaxValue)); // No matter the duration
-			taps.Should().BeEquivalentTo(Tap(25, 25));
+			sut.ProcessUpEvent(GetPoint(27, 27, device: PointerDeviceType.Mouse, ts: long.MaxValue)); // No matter the duration
+			taps.Should().BeEquivalentTo(Tap(25, 25, device: PointerDeviceType.Mouse));
 		}
 
 		[TestMethod]

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -314,6 +314,12 @@ namespace Windows.UI.Input
 					return false;
 				}
 
+				// For touch and pen, the release must occurs within a reasonable delay.
+				if (points.PointerType is not PointerDeviceType.Mouse && IsLongPress(points.Down, points.Up))
+				{
+					return false;
+				}
+
 				// For the pointer up, we check only the distance, as it's expected that the pressed button changed!
 				if (IsOutOfTapRange(points.Down.Position, points.Up.Position))
 				{


### PR DESCRIPTION
…s_Release tests to SamplesApp to test button conformance against UWP's behavior for the three ClickMode enumerators. These are useful for testing #7888

GitHub Issue (If applicable): closes #7888 

## PR Type

What kind of change does this PR introduce?

- Other... Please describe: SamplesApp tests

## What is the current behavior?

The Button_Events test doesn't test ClickMode.Hover and ClickMode.Press and its UI isn't designed for testing on Android and other small form-factor devices.

## What is the new behavior?

Button_Events still exists but now there are also Button_Events_Hover, Button_Events_Press, and Button_Events_Release that are configured to test each of the ClickMode enumerators with a UI designed to be usable on small form-factor devices. All are marked to not generate snapshots on WASM since WASM screenshots are (I believe) the only platfom that snapshots are currently tested on and snapshots would not reveal anything since the behavior requires mouse/touch input to test.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

It's associated with an issue but only provides tests for more easily testing the bugs reported in the issue; it doesn't provide any code changes other than adding the samples.

(This is the replacement for #7889 )

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
