### PR TITLE
fix: Move focus from page which is navigated away in `Frame`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
@@ -1,17 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Private.Infrastructure;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Input;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 {
@@ -119,7 +117,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			}
 			finally
 			{
-				TestServices.WindowHelper.WindowContent = null;
+				
 			}
 		}
 
@@ -149,7 +147,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			AssertHasFocus(innerControl);
 			Assert.AreEqual(FocusState.Unfocused, outerControl.FocusState);
 
-			TestServices.WindowHelper.WindowContent = null;
+			
 		}
 
 		[TestMethod]
@@ -174,13 +172,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			{
 				frame.Navigate(typeof(TwoButtonSecondPage));
 
-				await ((TwoButtonSecondPage)frame.Content).FinishedLoadingTask;
+				await WaitForLoadedEvent((TwoButtonSecondPage)frame.Content);
 				await TestServices.WindowHelper.WaitForIdle();
 			};
 
 			await AssertNavigationFocusSequence(expectedSequence, navigationAction);
 
-			TestServices.WindowHelper.WindowContent = null;
+			
 		}
 
 		[TestMethod]
@@ -194,7 +192,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			stackPanel.Children.Add(frame);
 			TestServices.WindowHelper.WindowContent = stackPanel;
 			frame.Navigate(typeof(TwoButtonFirstPage));
-			await ((TwoButtonFirstPage)frame.Content).FinishedLoadingTask;
+			await WaitForLoadedEvent((TwoButtonFirstPage)frame.Content);
 			((TwoButtonFirstPage)frame.Content).FocusFirst();
 
 			await TestServices.WindowHelper.WaitForIdle();
@@ -208,12 +206,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			{
 				frame.Navigate(typeof(TwoButtonSecondPage));
 
-				await ((TwoButtonSecondPage)frame.Content).FinishedLoadingTask;
+				await WaitForLoadedEvent((TwoButtonSecondPage)frame.Content);
 			};
 
-			await AssertNavigationFocusSequence(expectedSequence, navigationAction);
-
-			TestServices.WindowHelper.WindowContent = null;
+			await AssertNavigationFocusSequence(expectedSequence, navigationAction);			
 		}
 
 		[TestMethod]
@@ -227,8 +223,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			stackPanel.Children.Add(outerButton);
 			stackPanel.Children.Add(frame);
 			TestServices.WindowHelper.WindowContent = stackPanel;
+
+			await TestServices.WindowHelper.WaitForLoaded(stackPanel);
+
 			frame.Navigate(typeof(TwoButtonFirstPage));
-			await ((TwoButtonFirstPage)frame.Content).FinishedLoadingTask;
+			await WaitForLoadedEvent((TwoButtonFirstPage)frame.Content);
 			outerButton.Focus(FocusState.Programmatic);
 
 			await TestServices.WindowHelper.WaitForIdle();
@@ -242,12 +241,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			{
 				frame.Navigate(typeof(TwoButtonSecondPage));
 
-				await ((TwoButtonSecondPage)frame.Content).FinishedLoadingTask;
+				await WaitForLoadedEvent((TwoButtonSecondPage)frame.Content);
 			};
 
 			await AssertNavigationFocusSequence(expectedSequence, navigationAction);
-
-			TestServices.WindowHelper.WindowContent = null;
 		}
 
 		[TestMethod]
@@ -262,7 +259,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			stackPanel.Children.Add(new ToggleButton() { Name = "OuterButtonAfter" });
 			TestServices.WindowHelper.WindowContent = stackPanel;
 			frame.Navigate(typeof(TwoButtonFirstPage));
-			await ((TwoButtonFirstPage)frame.Content).FinishedLoadingTask;
+			await WaitForLoadedEvent((TwoButtonFirstPage)frame.Content);
 			((TwoButtonFirstPage)frame.Content).FocusFirst();
 
 			await TestServices.WindowHelper.WaitForIdle();
@@ -276,12 +273,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			{
 				frame.Navigate(typeof(TwoButtonSecondPage));
 
-				await ((TwoButtonSecondPage)frame.Content).FinishedLoadingTask;
+				await WaitForLoadedEvent((TwoButtonSecondPage)frame.Content);
 			};
 
 			await AssertNavigationFocusSequence(expectedSequence, navigationAction);
-
-			TestServices.WindowHelper.WindowContent = null;
 		}
 
 		[TestMethod]
@@ -293,7 +288,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			TestServices.WindowHelper.WindowContent = frame;
 			frame.Navigate(typeof(TwoButtonFirstPage));
 			frame.Navigate(typeof(TwoButtonSecondPage));
-			await ((TwoButtonSecondPage)frame.Content).FinishedLoadingTask;
+			await WaitForLoadedEvent((TwoButtonSecondPage)frame.Content);
 			((TwoButtonSecondPage)frame.Content).FocusFirst();
 
 			await TestServices.WindowHelper.WaitForIdle();
@@ -308,13 +303,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			{
 				frame.GoBack();
 
-				await ((TwoButtonFirstPage)frame.Content).FinishedLoadingTask;
+				await WaitForLoadedEvent((TwoButtonFirstPage)frame.Content);
 				await TestServices.WindowHelper.WaitForIdle();
 			};
 
 			await AssertNavigationFocusSequence(expectedSequence, navigationAction);
-
-			TestServices.WindowHelper.WindowContent = null;
 		}
 
 		[TestMethod]
@@ -341,14 +334,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			Func<Task> navigationAction = async () =>
 			{
 				frame.GoBack();
-				await ((TwoButtonFirstPage)frame.Content).FinishedLoadingTask;
+				await WaitForLoadedEvent((TwoButtonFirstPage)frame.Content);
 
 				await TestServices.WindowHelper.WaitForIdle();
 			};
 
-			await AssertNavigationFocusSequence(expectedSequence, navigationAction);
-
-			TestServices.WindowHelper.WindowContent = null;
+			await AssertNavigationFocusSequence(expectedSequence, navigationAction);	
 		}
 
 		[TestMethod]
@@ -376,14 +367,17 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			Func<Task> navigationAction = async () =>
 			{
 				frame.GoBack();
-				await ((TwoButtonFirstPage)frame.Content).FinishedLoadingTask;
+				await WaitForLoadedEvent((TwoButtonFirstPage)frame.Content);
 
 				await TestServices.WindowHelper.WaitForIdle();
 			};
 
 			await AssertNavigationFocusSequence(expectedSequence, navigationAction);
+		}
 
-			TestServices.WindowHelper.WindowContent = null;
+		private async Task WaitForLoadedEvent(FocusNavigationPage page)
+		{
+			await TestServices.WindowHelper.WaitFor(() => page.LoadedEventFinished);
 		}
 
 		private async Task AssertNavigationFocusSequence(string[] expectedSequence, Func<Task> navigationSequence)
@@ -411,7 +405,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 				FocusManager.GettingFocus += FocusManager_GettingFocus;
 
 				await navigationSequence();
-				
+
 				CollectionAssert.AreEqual(expectedSequence, actualSequence);
 
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
@@ -184,7 +184,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
-		[Ignore("This test only passes on Windows - see #7900")]
 		public async Task When_Page_Navigates_Focus_With_Outer_Before()
 		{
 			var stackPanel = new StackPanel();
@@ -252,7 +251,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
-		[Ignore("This test only passes on Windows - see #7900")]
 		public async Task When_Page_Navigates_Focus_With_Outer_After()
 		{
 			var stackPanel = new StackPanel();
@@ -320,7 +318,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
-		[Ignore("This test only passes on Windows - see #7900")]
 		public async Task When_Page_Navigate_Back_With_Outer_Before()
 		{
 			var stackPanel = new StackPanel();
@@ -355,7 +352,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
-		[Ignore("This test only passes on Windows - see #7900")]
 		public async Task When_Page_Navigate_Back_With_Outer_After()
 		{
 			var stackPanel = new StackPanel();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
@@ -160,6 +160,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			var frame = new Frame();
 			TestServices.WindowHelper.WindowContent = frame;
 			frame.Navigate(typeof(TwoButtonFirstPage));
+			((TwoButtonFirstPage)frame.Content).FocusFirst();
 
 			await TestServices.WindowHelper.WaitForIdle();
 
@@ -173,6 +174,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			{
 				frame.Navigate(typeof(TwoButtonSecondPage));
 
+				await ((TwoButtonSecondPage)frame.Content).FinishedLoadingTask;
 				await TestServices.WindowHelper.WaitForIdle();
 			};
 
@@ -285,7 +287,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
-		public async Task When_Page_Navigate_Back_Without_Outer_Wrapper()
+		public async Task When_Page_Navigates_Back_Without_Outer_Wrapper()
 		{
 			var frame = new Frame();
 			TestServices.WindowHelper.WindowContent = frame;
@@ -318,7 +320,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
-		public async Task When_Page_Navigate_Back_With_Outer_Before()
+		public async Task When_Page_Navigates_Back_With_Outer_Before()
 		{
 			var stackPanel = new StackPanel();
 			var frame = new Frame();
@@ -352,7 +354,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
-		public async Task When_Page_Navigate_Back_With_Outer_After()
+		public async Task When_Page_Navigates_Back_With_Outer_After()
 		{
 			var stackPanel = new StackPanel();
 			var frame = new Frame();
@@ -409,11 +411,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 				FocusManager.GettingFocus += FocusManager_GettingFocus;
 
 				await navigationSequence();
-
-				global::System.Diagnostics.Debug.WriteLine($"####");
-				global::System.Diagnostics.Debug.WriteLine($"Expected: {string.Join(",", expectedSequence)}");
-				global::System.Diagnostics.Debug.WriteLine($"Actual: {string.Join(",", actualSequence)}");
-
+				
 				CollectionAssert.AreEqual(expectedSequence, actualSequence);
 
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_FocusManager.cs
@@ -184,7 +184,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
-		public async Task When_Page_Navigates_Focus_With_Outer_Wrapper()
+		[Ignore("This test only passes on Windows - see #7900")]
+		public async Task When_Page_Navigates_Focus_With_Outer_Before()
 		{
 			var stackPanel = new StackPanel();
 			var frame = new Frame();
@@ -217,6 +218,75 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
+		public async Task When_Page_Navigates_Focus_Outside_Frame()
+		{
+			var stackPanel = new StackPanel();
+			var frame = new Frame();
+			var outerButton = new ToggleButton() { Name = "OuterButton" };
+			stackPanel.Children.Add(outerButton);
+			stackPanel.Children.Add(frame);
+			TestServices.WindowHelper.WindowContent = stackPanel;
+			frame.Navigate(typeof(TwoButtonFirstPage));
+			await ((TwoButtonFirstPage)frame.Content).FinishedLoadingTask;
+			outerButton.Focus(FocusState.Programmatic);
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Focus should stay on the outer button
+			var expectedSequence = new string[]
+			{
+			};
+
+			Func<Task> navigationAction = async () =>
+			{
+				frame.Navigate(typeof(TwoButtonSecondPage));
+
+				await ((TwoButtonSecondPage)frame.Content).FinishedLoadingTask;
+			};
+
+			await AssertNavigationFocusSequence(expectedSequence, navigationAction);
+
+			TestServices.WindowHelper.WindowContent = null;
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[RequiresFullWindow]
+		[Ignore("This test only passes on Windows - see #7900")]
+		public async Task When_Page_Navigates_Focus_With_Outer_After()
+		{
+			var stackPanel = new StackPanel();
+			var frame = new Frame();
+			stackPanel.Children.Add(new ToggleButton() { Name = "OuterButton" });
+			stackPanel.Children.Add(frame);
+			stackPanel.Children.Add(new ToggleButton() { Name = "OuterButtonAfter" });
+			TestServices.WindowHelper.WindowContent = stackPanel;
+			frame.Navigate(typeof(TwoButtonFirstPage));
+			await ((TwoButtonFirstPage)frame.Content).FinishedLoadingTask;
+			((TwoButtonFirstPage)frame.Content).FocusFirst();
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var expectedSequence = new string[]
+			{
+				"OuterButtonAfter"
+			};
+
+			Func<Task> navigationAction = async () =>
+			{
+				frame.Navigate(typeof(TwoButtonSecondPage));
+
+				await ((TwoButtonSecondPage)frame.Content).FinishedLoadingTask;
+			};
+
+			await AssertNavigationFocusSequence(expectedSequence, navigationAction);
+
+			TestServices.WindowHelper.WindowContent = null;
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[RequiresFullWindow]
 		public async Task When_Page_Navigate_Back_Without_Outer_Wrapper()
 		{
 			var frame = new Frame();
@@ -224,6 +294,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			frame.Navigate(typeof(TwoButtonFirstPage));
 			frame.Navigate(typeof(TwoButtonSecondPage));
 			await ((TwoButtonSecondPage)frame.Content).FinishedLoadingTask;
+			((TwoButtonSecondPage)frame.Content).FocusFirst();
 
 			await TestServices.WindowHelper.WaitForIdle();
 
@@ -249,7 +320,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
-		public async Task When_Page_Navigate_Back_With_Outer_Wrapper()
+		[Ignore("This test only passes on Windows - see #7900")]
+		public async Task When_Page_Navigate_Back_With_Outer_Before()
 		{
 			var stackPanel = new StackPanel();
 			var frame = new Frame();
@@ -265,6 +337,42 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 			var expectedSequence = new string[]
 			{
 				"OuterButton"
+			};
+
+			Func<Task> navigationAction = async () =>
+			{
+				frame.GoBack();
+				await ((TwoButtonFirstPage)frame.Content).FinishedLoadingTask;
+
+				await TestServices.WindowHelper.WaitForIdle();
+			};
+
+			await AssertNavigationFocusSequence(expectedSequence, navigationAction);
+
+			TestServices.WindowHelper.WindowContent = null;
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[RequiresFullWindow]
+		[Ignore("This test only passes on Windows - see #7900")]
+		public async Task When_Page_Navigate_Back_With_Outer_After()
+		{
+			var stackPanel = new StackPanel();
+			var frame = new Frame();
+			stackPanel.Children.Add(new ToggleButton() { Name = "OuterButton" });
+			stackPanel.Children.Add(frame);
+			stackPanel.Children.Add(new ToggleButton() { Name = "OuterButtonAfter" });
+			TestServices.WindowHelper.WindowContent = stackPanel;
+			frame.Navigate(typeof(TwoButtonFirstPage));
+			frame.Navigate(typeof(TwoButtonSecondPage));
+			((TwoButtonSecondPage)frame.Content).FocusFirst();
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var expectedSequence = new string[]
+			{
+				"OuterButtonAfter"
 			};
 
 			Func<Task> navigationAction = async () =>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/FocusNavigationPage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/FocusNavigationPage.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages
+{
+	public class FocusNavigationPage : Page
+	{
+		private TaskCompletionSource<object> _loadingTaskCompletionSource =
+			new TaskCompletionSource<object>();
+
+		public FocusNavigationPage()
+		{
+			Loaded += Page_Loaded;
+		}
+
+		private void Page_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+		{
+			_loadingTaskCompletionSource.SetResult(null);
+		}
+
+		public Task FinishedLoadingTask => _loadingTaskCompletionSource.Task;
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/FocusNavigationPage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/FocusNavigationPage.cs
@@ -11,6 +11,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages
 		public FocusNavigationPage()
 		{
 			Loaded += Page_Loaded;
+			Unloaded += Page_Unloaded;
+		}
+
+		private void Page_Unloaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+		{
+			_loadingTaskCompletionSource = new TaskCompletionSource<object>();
 		}
 
 		private void Page_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/FocusNavigationPage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/FocusNavigationPage.cs
@@ -5,26 +5,22 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages
 {
 	public partial class FocusNavigationPage : Page
 	{
-		private TaskCompletionSource<object> _loadingTaskCompletionSource =
-			new TaskCompletionSource<object>();
-
 		public FocusNavigationPage()
 		{
 			Loaded += Page_Loaded;
 			Unloaded += Page_Unloaded;
 		}
 
-		public Task FinishedLoadingTask => _loadingTaskCompletionSource.Task;
+		public bool LoadedEventFinished { get; private set; }
 
 		private void Page_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
 		{
-			_loadingTaskCompletionSource.SetResult(null);
+			LoadedEventFinished = true;
 		}
 
 		private void Page_Unloaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
 		{
-			// Reset loading task for next navigation
-			_loadingTaskCompletionSource = new TaskCompletionSource<object>();
+			LoadedEventFinished = false;
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/FocusNavigationPage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/FocusNavigationPage.cs
@@ -14,16 +14,17 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages
 			Unloaded += Page_Unloaded;
 		}
 
-		private void Page_Unloaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
-		{
-			_loadingTaskCompletionSource = new TaskCompletionSource<object>();
-		}
+		public Task FinishedLoadingTask => _loadingTaskCompletionSource.Task;
 
 		private void Page_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
 		{
 			_loadingTaskCompletionSource.SetResult(null);
 		}
 
-		public Task FinishedLoadingTask => _loadingTaskCompletionSource.Task;
+		private void Page_Unloaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+		{
+			// Reset loading task for next navigation
+			_loadingTaskCompletionSource = new TaskCompletionSource<object>();
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/FocusNavigationPage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/FocusNavigationPage.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages
 {
-	public class FocusNavigationPage : Page
+	public partial class FocusNavigationPage : Page
 	{
 		private TaskCompletionSource<object> _loadingTaskCompletionSource =
 			new TaskCompletionSource<object>();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/TwoButtonFirstPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/TwoButtonFirstPage.xaml
@@ -1,0 +1,15 @@
+﻿<local:FocusNavigationPage
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages.TwoButtonFirstPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel>
+		<Button x:Name="FirstPageFirstButton" Click="{x:Bind GoForward}">First</Button>
+		<Button x:Name="FirstPageSecondButton">Second</Button>
+	</StackPanel>
+</local:FocusNavigationPage>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/TwoButtonFirstPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/TwoButtonFirstPage.xaml.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages
+{
+	public sealed partial class TwoButtonFirstPage : FocusNavigationPage
+	{
+		public TwoButtonFirstPage()
+		{
+			InitializeComponent();
+		}
+
+		private void GoForward() => Frame.Navigate(typeof(TwoButtonFirstPage));
+
+		public void FocusFirst() =>
+			FirstPageFirstButton.Focus(Windows.UI.Xaml.FocusState.Programmatic);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/TwoButtonSecondPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/TwoButtonSecondPage.xaml
@@ -1,0 +1,15 @@
+﻿<local:FocusNavigationPage
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages.TwoButtonSecondPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+		<Button x:Name="SecondPageFirstButton" Click="{x:Bind GoBackward}">First</Button>
+		<Button x:Name="SecondPageSecondButton">Second</Button>
+	</StackPanel>
+</local:FocusNavigationPage>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/TwoButtonSecondPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/TwoButtonSecondPage.xaml.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages
+{
+	public sealed partial class TwoButtonSecondPage : FocusNavigationPage
+	{
+		public TwoButtonSecondPage()
+		{
+			InitializeComponent();
+		}
+
+		private void GoBackward() => Frame.GoBack();
+
+		public void FocusFirst() =>
+			SecondPageFirstButton.Focus(Windows.UI.Xaml.FocusState.Programmatic);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -99,25 +99,6 @@
 	<ItemGroup>
 		<Compile Include="Tests\Windows_UI_Xaml_Controls\HtmlElementAttributeTests\Given_HtmlElementAttribute.Wasm.cs" />
 	</ItemGroup>
-	
-	
-	<ItemGroup>
-		<Page Update="Tests\Windows_UI_Xaml\Controls\Animation_Leak.xaml">
-		  <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-		</Page>
-		<Page Update="Tests\Windows_UI_Xaml\Controls\ContentDialog_Leak.xaml">
-		  <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-		</Page>
-		<Page Update="Tests\Windows_UI_Xaml\Controls\xLoad_xBind.xaml">
-			<SubType>Designer</SubType>
-		</Page>
-		<Page Update="Tests\Windows_UI_Xaml_Input\TestPages\TwoButtonSecondPage.xaml">
-		  <SubType>Designer</SubType>
-		</Page>
-		<Page Update="Tests\Windows_UI_Xaml_Input\TestPages\TwoButtonFirstPage.xaml">
-		  <SubType>Designer</SubType>
-		</Page>
-	</ItemGroup>
 
 	<Import Project="..\SourceGenerators\Uno.UI.SourceGenerators\Content\Uno.UI.SourceGenerators.props" />
 	<Import Project="..\SourceGenerators\Uno.UI.Tasks\Content\Uno.UI.Tasks.targets" Condition="'$(SkipUnoResourceGeneration)' == '' " />

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -111,6 +111,12 @@
 		<Page Update="Tests\Windows_UI_Xaml\Controls\xLoad_xBind.xaml">
 			<SubType>Designer</SubType>
 		</Page>
+		<Page Update="Tests\Windows_UI_Xaml_Input\TestPages\TwoButtonSecondPage.xaml">
+		  <SubType>Designer</SubType>
+		</Page>
+		<Page Update="Tests\Windows_UI_Xaml_Input\TestPages\TwoButtonFirstPage.xaml">
+		  <SubType>Designer</SubType>
+		</Page>
 	</ItemGroup>
 
 	<Import Project="..\SourceGenerators\Uno.UI.SourceGenerators\Content\Uno.UI.SourceGenerators.props" />

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -12,6 +12,8 @@ using Uno;
 using Windows.UI.Xaml.Media;
 using Uno.UI;
 using System.Runtime.CompilerServices;
+using Windows.UI.Xaml.Input;
+using Uno.UI.Xaml.Core;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -355,6 +357,8 @@ namespace Windows.UI.Xaml.Controls
 				CurrentEntry.Instance = page;
 			}
 
+			UnfocusCurrentPage();
+
 			Content = CurrentEntry.Instance;
 
 			if (IsNavigationStackEnabled)
@@ -398,6 +402,8 @@ namespace Windows.UI.Xaml.Controls
 			CurrentEntry.Instance.OnNavigatedTo(navigationEvent);
 
 			Navigated?.Invoke(this, navigationEvent);
+
+			FocusCurrentPage();
 
 			return true;
 		}
@@ -455,6 +461,38 @@ namespace Windows.UI.Xaml.Controls
 						entry.SourcePageType,
 						null
 					));
+		}
+
+		private void UnfocusCurrentPage()
+		{
+			var focusManager = VisualTree.GetFocusManagerForElement(this);
+			if (focusManager?.FocusedElement is not { } focusedElement)
+			{
+				return;
+			}
+
+			var isWithinCurrentPage = focusedElement.GetParents().Any(p => p == this);
+			if (isWithinCurrentPage)
+			{
+				focusManager.ClearFocus();
+			}
+		}
+
+		private void FocusCurrentPage()
+		{
+			var focusManager = VisualTree.GetFocusManagerForElement(this);
+			if (focusManager is null)
+			{
+				return;
+			}
+
+			var focused = focusManager.FocusedElement;
+
+			if (focused is null && Content is Page page)
+			{
+				// Try to set focus on the page
+				page.TryInitialFocus();
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -461,15 +461,6 @@ namespace Windows.UI.Xaml.Controls
 					));
 		}
 
-		private IDisposable MarkCurrentPageLeaving()
-		{
-			if (Content is Page page)
-			{
-				return Disposable.Create(() => page.IsLeavingFrame = false);
-			}
-			return Disposable.Empty;
-		}
-
 		/// <summary>
 		/// In case the current page contains a focused element,
 		/// we need to move the focus out of the page.
@@ -502,7 +493,7 @@ namespace Windows.UI.Xaml.Controls
 				if (inCurrentPage)
 				{
 					// Set the focus on the next focusable element.
-					focusManager.SetFocusOnNextFocusableElement(FocusState, true);
+					focusManager.SetFocusOnNextFocusableElement(FocusState.Programmatic, true);
 
 					(focusedElement as Control)?.UpdateFocusState(FocusState.Unfocused);
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/Page/Page.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Page/Page.cs
@@ -91,5 +91,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			UpdateBorder();
 		}
+
+		internal bool IsLeavingFrame { get; set; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Page/Page.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Page/Page.cs
@@ -91,7 +91,5 @@ namespace Windows.UI.Xaml.Controls
 		{
 			UpdateBorder();
 		}
-
-		internal bool IsLeavingFrame { get; set; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Page/Page.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Page/Page.mux.cs
@@ -22,11 +22,6 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnLoaded();
 
-			TryInitialFocus();
-		}
-
-		public void TryInitialFocus()
-		{
 			var spCurrentFocusedElement = this.GetFocusedElement();
 
 			var focusManager = VisualTree.GetFocusManagerForElement(this);
@@ -55,7 +50,7 @@ namespace Windows.UI.Xaml.Controls
 					focusManager.InitialFocus = true;
 
 					TrySetFocusedElement(spFirstFocusableElementDO);
-					
+
 					focusManager.InitialFocus = false;
 				}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Page/Page.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Page/Page.mux.cs
@@ -22,6 +22,11 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnLoaded();
 
+			TryInitialFocus();
+		}
+
+		public void TryInitialFocus()
+		{
 			var spCurrentFocusedElement = this.GetFocusedElement();
 
 			var focusManager = VisualTree.GetFocusManagerForElement(this);

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -107,6 +107,8 @@ namespace Windows.UI.Xaml
 
 		internal Size AssignedActualSize { get; set; }
 
+		internal bool IsLeavingFrame { get; set; }
+
 		private protected virtual double GetActualWidth() => AssignedActualSize.Width;
 
 		private protected virtual double GetActualHeight() => AssignedActualSize.Height;

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -104,6 +104,13 @@ namespace Windows.UI.Xaml
 					return false;
 				}
 
+				// TODO Uno specific: IsLeaving is not yet implemented on visual tree level,
+				// so we check if the Page is being navigated away from here instead.
+				if (pNext is Page page && page.IsLeavingFrame) 
+				{
+					return false;
+				}
+
 				pElement = pNext;
 			}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -99,14 +99,14 @@ namespace Windows.UI.Xaml
 			{
 				var pNext = pElement.GetUIElementAdjustedParentInternal(true /*public parents only*/);
 
-				if (pNext != null && pNext.Visibility == Visibility.Collapsed)
+				if (pNext?.Visibility == Visibility.Collapsed)
 				{
 					return false;
 				}
 
 				// TODO Uno specific: IsLeaving is not yet implemented on visual tree level,
 				// so we check if the Page is being navigated away from here instead.
-				if (pNext is Page page && page.IsLeavingFrame) 
+				if (pNext?.IsLeavingFrame == true) 
 				{
 					return false;
 				}

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -4292,6 +4292,9 @@ var Windows;
                 static unSubscribePointerEvents(pParams) {
                     const params = Windows.UI.Xaml.NativePointerSubscriptionParams.unmarshal(pParams);
                     const element = WindowManager.current.getView(params.HtmlId);
+                    if (!element) {
+                        return;
+                    }
                     if (params.Events & NativePointerEvent.pointerenter) {
                         element.removeEventListener("pointerenter", Xaml.UIElement.onPointerEnterReceived);
                     }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/nventive-private/issues/313, partially #7900

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

-  In some cases focus can stay on page which is being navigated from.
- When navigating, focus may move frantically from element to element as they are being unloaded.


## What is the new behavior?

When page is navigated away, focus will move away from it directly to some outer element or `null`. When the next page is navigated to, the focus will in case of `null` move to this new page.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.