### PR TITLE
fix: Remove incompatible (and unused) `AdditionalFiles` containing binary files in VS 17.1 Preview 3

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -360,7 +360,6 @@
 	  <AdditionalFiles Include="@(ApplicationDefinition)" SourceItemGroup="ApplicationDefinition" />
 	  <AdditionalFiles Include="@(PRIResource)" SourceItemGroup="PRIResource" />
 	  <AdditionalFiles Include="@(TSBindingAssemblySource)" SourceItemGroup="TSBindingAssemblySource" />
-	  <AdditionalFiles Include="@(Analyzer)" SourceItemGroup="Analyzer" />
 
 	  <_AdditionalFilesCleanup Include="@(AdditionalFiles)" />
 	  <AdditionalFiles Remove="@(_AdditionalFilesCleanup)" />


### PR DESCRIPTION
GitHub Issue (If applicable): #7872 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Removes unused `AdditionalFiles` inclusion which fails the build following a restriction in Roslyn, where additional files cannot be binary.

This particular change was included most likely as the result of investigation of up-to-date checks, but is not used as part of any   `GeneratorExecutionContext.GetMSBuildItems()` invocation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
