### PR TITLE
Improved deferrals usage, `CoreApplication.Entered/LeavingBackground`

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8684,6 +8684,12 @@
 			<Member
 				fullName="System.Void Windows.UI.Core.Preview.SystemNavigationManagerPreview..ctor()"
 				reason="Not public in UWP" />
+			<Member
+				fullName="System.Void Windows.UI.Core.Preview.SystemNavigationCloseRequestedPreviewEventArgs..ctor()"
+				reason="Not public in UWP" />
+			<Member
+				fullName="System.Void Windows.UI.Core.Preview.SystemNavigationCloseRequestedPreviewEventArgs..ctor(System.Action`1&lt;Windows.UI.Core.Preview.SystemNavigationCloseRequestedPreviewEventArgs&gt; complete)"
+				reason="Should not be public" />
 		</Methods>
 	  	<Properties>
 	 	</Properties>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8681,6 +8681,9 @@
 			<Member
 				fullName="System.Boolean Windows.UI.Xaml.FrameworkElement.get_StretchAffectsMeasure()"
 				reason="False positive: added in an internal interface" />
+			<Member
+				fullName="System.Void Windows.UI.Core.Preview.SystemNavigationManagerPreview..ctor()"
+				reason="Not public in UWP" />
 		</Methods>
 	  	<Properties>
 	 	</Properties>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/CloseRequestedTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/CloseRequestedTests.xaml.cs
@@ -29,12 +29,12 @@ namespace UITests.Windows_UI_Core
 		private async void CloseRequestedTests_CloseRequested(object sender, SystemNavigationCloseRequestedPreviewEventArgs e)
 		{
 			var deferral = e.GetDeferral();
-			var dialog = new MessageDialog("Are you sure you want to exit?", "Exit");
-			var confirmCommand = new UICommand("Yes");
-			var cancelCommand = new UICommand("No");
-			dialog.Commands.Add(confirmCommand);
-			dialog.Commands.Add(cancelCommand);
-			if (await dialog.ShowAsync() == cancelCommand)
+			var dialog = new ContentDialog();
+			dialog.Title = "Exit";
+			dialog.Content = "Are you sure you want to exit?";
+			dialog.PrimaryButtonText = "Yes";
+			dialog.SecondaryButtonText = "No";
+			if (await dialog.ShowAsync() != ContentDialogResult.Primary)
 			{
 				//cancel close by handling the event
 				e.Handled = true;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml
@@ -14,6 +14,7 @@
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 		<StackPanel Padding="12" Spacing="8">
+			<ToggleSwitch IsOn="{x:Bind Model.SimulateDeferrals, Mode=TwoWay}" OnContent="Simulate deferrals" OffContent="Simulate deferrals" />
 			<TextBlock Text="CoreWindow activation state" />
 			<TextBlock FontSize="30" Text="{x:Bind Model.CoreWindowActivationState, Mode=OneWay}" />
 			<TextBlock Text="CoreWindow activation mode" />
@@ -23,6 +24,7 @@
 			<TextBlock Text="Last change" />
 			<TextBlock Text="{x:Bind Model.ChangeTime, Mode=OneWay}" />
 			<Button Command="{x:Bind Model.ClearHistoryCommand}"  Content="Clear event history" />
+			<Button Command="{x:Bind Model.CopyToClipboardCommand}"  Content="Copy to clipboard" />
 		</StackPanel>
 		<ListView Grid.Row="1" ItemsSource="{x:Bind Model.History, Mode=OneWay}" />
 	</Grid>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
@@ -4,10 +4,13 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Uno.Disposables;
 using Uno.UI.Samples.Controls;
 using Uno.UI.Samples.UITests.Helpers;
+using Windows.ApplicationModel.Core;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI.Core;
@@ -23,7 +26,7 @@ using XamlWindow = Windows.UI.Xaml.Window;
 
 namespace UITests.Windows_UI_Core
 {
-	[SampleControlInfo("Windows.UI.Core", viewModelType: typeof(WindowActivationViewModel))]
+	[SampleControlInfo("Windows.UI.Core", controlName: "Application/Window lifecycle events", viewModelType: typeof(WindowActivationViewModel), isManualTest: true)]
 	public sealed partial class WindowActivationTests : Page
 	{
 		public WindowActivationTests()
@@ -54,6 +57,12 @@ namespace UITests.Windows_UI_Core
 			XamlWindow.Current.VisibilityChanged += WindowVisibilityChanged;
 			Application.Current.EnteredBackground += AppEnteredBackground;
 			Application.Current.LeavingBackground += AppLeavingBackground;
+			CoreApplication.EnteredBackground += CoreApplicationEnteredBackground;
+			CoreApplication.LeavingBackground += CoreApplicationLeavingBackground;
+			Application.Current.Suspending += ApplicationSuspending;
+			Application.Current.Resuming += ApplicationResuming;
+			CoreApplication.Suspending += CoreApplicationResuming;
+			CoreApplication.Resuming += CoreApplicationResuming;
 
 			Disposables.Add(() =>
 			{
@@ -62,12 +71,20 @@ namespace UITests.Windows_UI_Core
 				XamlWindow.Current.VisibilityChanged -= WindowVisibilityChanged;
 				Application.Current.EnteredBackground -= AppEnteredBackground;
 				Application.Current.LeavingBackground -= AppLeavingBackground;
+				CoreApplication.EnteredBackground -= CoreApplicationEnteredBackground;
+				CoreApplication.LeavingBackground -= CoreApplicationLeavingBackground;
+				Application.Current.Suspending -= ApplicationSuspending;
+				Application.Current.Resuming -= ApplicationResuming;
+				CoreApplication.Suspending -= CoreApplicationResuming;
+				CoreApplication.Resuming -= CoreApplicationResuming;
 			});
-		}
+		}		
 
 		public ObservableCollection<string> History { get; } = new ObservableCollection<string>();
 
 		public ICommand ClearHistoryCommand => GetOrCreateCommand(() => History.Clear());
+
+		public ICommand CopyToClipboardCommand => GetOrCreateCommand(() => CopyToClipboard());
 
 		public CoreWindowActivationState? CoreWindowActivationState
 		{
@@ -88,6 +105,8 @@ namespace UITests.Windows_UI_Core
 				RaisePropertyChanged();
 			}
 		}
+
+		public bool SimulateDeferrals { get; set; }
 
 		public string WindowVisibility
 		{
@@ -135,14 +154,86 @@ namespace UITests.Windows_UI_Core
 		}
 
 
-		private void AppLeavingBackground(object sender, Windows.ApplicationModel.LeavingBackgroundEventArgs e)
+		private async void AppLeavingBackground(object sender, Windows.ApplicationModel.LeavingBackgroundEventArgs e)
 		{
-			AddHistory("Application.LeavingBackground");
+			AddHistory("Application.LeavingBackground started");
+			if (SimulateDeferrals)
+			{
+				var deferral = e.GetDeferral();
+				await Task.Delay(500);
+				deferral.Complete();
+			}
+			AddHistory("Application.LeavingBackground ended");
 		}
 
-		private void AppEnteredBackground(object sender, Windows.ApplicationModel.EnteredBackgroundEventArgs e)
+		private async void CoreApplicationLeavingBackground(object sender, Windows.ApplicationModel.LeavingBackgroundEventArgs e)
 		{
-			AddHistory("Application.EnteredBackground");
+			AddHistory("CoreApplication.LeavingBackground started");
+			if (SimulateDeferrals)
+			{
+				var deferral = e.GetDeferral();
+				await Task.Delay(500);
+				deferral.Complete();
+			}
+			AddHistory("CoreApplication.LeavingBackground ended");
+		}
+
+		private async void AppEnteredBackground(object sender, Windows.ApplicationModel.EnteredBackgroundEventArgs e)
+		{
+			AddHistory("Application.EnteredBackground started");
+			if (SimulateDeferrals)
+			{
+				var deferral = e.GetDeferral();
+				await Task.Delay(500);
+				deferral.Complete();
+			}
+			AddHistory("Application.EnteredBackground ended");
+		}
+
+		private async void CoreApplicationEnteredBackground(object sender, Windows.ApplicationModel.EnteredBackgroundEventArgs e)
+		{
+			AddHistory("CoreApplication.EnteredBackground started");
+			if (SimulateDeferrals)
+			{
+				var deferral = e.GetDeferral();
+				await Task.Delay(500);
+				deferral.Complete();
+			}
+			AddHistory("CoreApplication.EnteredBackground ended");
+		}
+
+		private void ApplicationResuming(object sender, object e)
+		{
+			AddHistory("Application.Resuming");
+		}
+
+		private void CoreApplicationResuming(object sender, object e)
+		{
+			AddHistory("CoreApplication.Resuming");
+		}
+
+		private async void CoreApplicationSuspending(object sender, Windows.ApplicationModel.SuspendingEventArgs e)
+		{
+			AddHistory("CoreApplication.Suspending started");
+			if (SimulateDeferrals)
+			{
+				var deferral = e.SuspendingOperation.GetDeferral();
+				await Task.Delay(500);
+				deferral.Complete();
+			}
+			AddHistory("CoreApplication.Suspending ended");
+		}
+
+		private async void ApplicationSuspending(object sender, Windows.ApplicationModel.SuspendingEventArgs e)
+		{
+			AddHistory("Application.Suspending started");
+			if (SimulateDeferrals)
+			{
+				var deferral = e.SuspendingOperation.GetDeferral();
+				await Task.Delay(500);
+				deferral.Complete();
+			}
+			AddHistory("Application.Suspending ended");
 		}
 
 		private void AddHistory(string eventName)
@@ -152,6 +243,13 @@ namespace UITests.Windows_UI_Core
 				$"{DateTime.Now.ToLongTimeString()} | {eventName} | State: {CoreWindowActivationState} " +
 				$"| Mode: {CoreWindow.GetForCurrentThread().ActivationMode} | Visibility: {XamlWindow.Current.Visible}";
 			History.Insert(0, historyItem);
+		}
+
+		private void CopyToClipboard()
+		{
+			var dataPackage = new DataPackage();
+			dataPackage.SetText(string.Join(Environment.NewLine, History));
+			Clipboard.SetContent(dataPackage);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/UI/Core/Preview/SystemNavigationManagerPreviewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/UI/Core/Preview/SystemNavigationManagerPreviewExtension.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+
+using Gtk;
+using Uno.UI.Core.Preview;
+
+namespace Uno.Extensions.UI.Core.Preview;
+
+public class SystemNavigationManagerPreviewExtension : ISystemNavigationManagerPreviewExtension
+{
+	private readonly Window _window;
+
+	public SystemNavigationManagerPreviewExtension(Gtk.Window window)
+	{
+		_window = window;
+	}
+
+	public void RequestNativeAppClose() => _window.Close();
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/UI/Core/Preview/SystemNavigationManagerPreviewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/UI/Core/Preview/SystemNavigationManagerPreviewExtension.cs
@@ -5,7 +5,7 @@ using Uno.UI.Core.Preview;
 
 namespace Uno.Extensions.UI.Core.Preview;
 
-public class SystemNavigationManagerPreviewExtension : ISystemNavigationManagerPreviewExtension
+internal class SystemNavigationManagerPreviewExtension : ISystemNavigationManagerPreviewExtension
 {
 	private readonly Window _window;
 

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -213,8 +213,7 @@ namespace Uno.UI.Runtime.Skia
 			{
 				if (isVisible)
 				{
-					winUIApplication?.RaiseLeavingBackground(null);
-					winUIWindow?.OnVisibilityChanged(true);
+					winUIApplication?.RaiseLeavingBackground(() => winUIWindow?.OnVisibilityChanged(true));					
 				}
 				else
 				{

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -1,31 +1,32 @@
 ﻿using System;
 using System.IO;
-using Windows.System;
-using Uno.Extensions;
-using Uno.Foundation.Extensibility;
-using Uno.Helpers.Theming;
-using Uno.UI.Runtime.Skia.GTK.Extensions.Helpers.Theming;
-using Windows.UI.Xaml;
-using WUX = Windows.UI.Xaml;
-using Uno.UI.Xaml.Controls.Extensions;
-using Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls;
 using Gtk;
-using Uno.UI.Runtime.Skia.GTK.Extensions.Helpers;
-using Uno.Extensions.System;
-using Uno.UI.Runtime.Skia.GTK.Extensions.System;
-using Uno.UI.Runtime.Skia.GTK.UI.Core;
-using Uno.Extensions.Storage.Pickers;
-using Windows.Storage.Pickers;
-using Windows.UI.ViewManagement;
-using Windows.Foundation;
 using Uno.ApplicationModel.DataTransfer;
-using Uno.UI.Runtime.Skia.GTK.Extensions.ApplicationModel.DataTransfer;
+using Uno.Extensions;
+using Uno.Extensions.Storage.Pickers;
+using Uno.Extensions.System;
+using Uno.Extensions.UI.Core.Preview;
+using Uno.Foundation.Extensibility;
 using Uno.Foundation.Logging;
-using Windows.System.Profile.Internal;
+using Uno.Helpers.Theming;
+using Uno.UI.Core.Preview;
+using Uno.UI.Runtime.Skia.GTK.Extensions.ApplicationModel.DataTransfer;
+using Uno.UI.Runtime.Skia.GTK.Extensions.Helpers;
+using Uno.UI.Runtime.Skia.GTK.Extensions.Helpers.Theming;
+using Uno.UI.Runtime.Skia.GTK.Extensions.System;
+using Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls;
 using Uno.UI.Runtime.Skia.GTK.System.Profile;
-using Uno.UI.Runtime.Skia.Helpers;
-using Uno.UI.Runtime.Skia.Helpers.Dpi;
+using Uno.UI.Runtime.Skia.GTK.UI.Core;
+using Uno.UI.Xaml.Controls.Extensions;
+using Windows.Foundation;
+using Windows.Storage.Pickers;
+using Windows.System.Profile.Internal;
+using Windows.UI.Core.Preview;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using UnoApplication = Windows.UI.Xaml.Application;
+using WUX = Windows.UI.Xaml;
 
 namespace Uno.UI.Runtime.Skia
 {
@@ -70,6 +71,7 @@ namespace Uno.UI.Runtime.Skia
 			ApiExtensibility.Register(typeof(IClipboardExtension), o => new ClipboardExtensions(o));
 			ApiExtensibility.Register<FileSavePicker>(typeof(IFileSavePickerExtension), o => new FileSavePickerExtension(o));
 			ApiExtensibility.Register(typeof(IAnalyticsInfoExtension), o => new AnalyticsInfoExtension());
+			ApiExtensibility.Register(typeof(ISystemNavigationManagerPreviewExtension), o => new SystemNavigationManagerPreviewExtension(_window));
 
 			_isDispatcherThread = true;
 			_window = new Gtk.Window("Uno Host");
@@ -91,10 +93,7 @@ namespace Uno.UI.Runtime.Skia
 				Cursors.Reload();
 			};
 
-			_window.DeleteEvent += delegate
-			{
-				Gtk.Application.Quit();
-			};
+			_window.DeleteEvent += WindowClosing;
 
 			void Dispatch(System.Action d)
 			{
@@ -166,6 +165,27 @@ namespace Uno.UI.Runtime.Skia
 			Gtk.Application.Run();
 		}
 
+		private void WindowClosing(object sender, DeleteEventArgs args)
+		{
+			var manager = SystemNavigationManagerPreview.GetForCurrentView();
+			if (!manager.HasConfirmedClose)
+			{
+				if (!manager.RequestAppClose())
+				{
+					// App closing was prevented, handle event
+					args.RetVal = true;
+					return;
+				}
+			}
+
+			// Closing should continue, perform suspension.
+			UnoApplication.Current.RaiseSuspending();
+
+			// All prerequisites passed, can safely close.
+			args.RetVal = false;
+			Gtk.Main.Quit();
+		}
+
 		private void OnWindowStateChanged(object o, WindowStateEventArgs args)
 		{
 			var winUIApplication = WUX.Application.Current;
@@ -193,13 +213,13 @@ namespace Uno.UI.Runtime.Skia
 			{
 				if (isVisible)
 				{
-					winUIApplication?.OnLeavingBackground();
+					winUIApplication?.RaiseLeavingBackground(null);
 					winUIWindow?.OnVisibilityChanged(true);
 				}
 				else
 				{
 					winUIWindow?.OnVisibilityChanged(false);
-					winUIApplication?.OnEnteredBackground();
+					winUIApplication?.RaiseEnteredBackground(null);
 				}
 			}
 

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Core/Preview/SystemNavigationManagerPreviewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Core/Preview/SystemNavigationManagerPreviewExtension.cs
@@ -1,0 +1,10 @@
+﻿using System.Windows;
+using Uno.UI.Core.Preview;
+
+namespace Uno.Extensions.UI.Core.Preview
+{
+	public class SystemNavigationManagerPreviewExtension : ISystemNavigationManagerPreviewExtension
+	{
+		public void RequestNativeAppClose() => Application.Current.MainWindow.Close();
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Core/Preview/SystemNavigationManagerPreviewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Core/Preview/SystemNavigationManagerPreviewExtension.cs
@@ -3,7 +3,7 @@ using Uno.UI.Core.Preview;
 
 namespace Uno.Extensions.UI.Core.Preview
 {
-	public class SystemNavigationManagerPreviewExtension : ISystemNavigationManagerPreviewExtension
+	internal class SystemNavigationManagerPreviewExtension : ISystemNavigationManagerPreviewExtension
 	{
 		public void RequestNativeAppClose() => Application.Current.MainWindow.Close();
 	}

--- a/src/Uno.UI/BaseActivity.Android.cs
+++ b/src/Uno.UI/BaseActivity.Android.cs
@@ -194,7 +194,7 @@ namespace Uno.UI
 		{
 			SetAsCurrent();
 
-			Windows.UI.Xaml.Application.Current?.OnLeavingBackground();
+			Windows.UI.Xaml.Application.Current?.RaiseLeavingBackground(null);
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
 		}
 
@@ -204,7 +204,7 @@ namespace Uno.UI
 		{
 			SetAsCurrent();			
 
-			Windows.UI.Xaml.Application.Current?.OnResuming();
+			Windows.UI.Xaml.Application.Current?.RaiseResuming();
 			Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.CodeActivated);
 		}
 
@@ -221,7 +221,7 @@ namespace Uno.UI
 			ResignCurrent();
 
 			Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.Deactivated);
-			Windows.UI.Xaml.Application.Current?.OnSuspending();
+			Windows.UI.Xaml.Application.Current?.RaiseSuspending();
 		}
 
 		partial void InnerStop()
@@ -229,7 +229,7 @@ namespace Uno.UI
 			ResignCurrent();
 
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
-			Windows.UI.Xaml.Application.Current?.OnEnteredBackground();
+			Windows.UI.Xaml.Application.Current?.RaiseEnteredBackground(null);
 		}
 
 		partial void InnerDestroy() => ResignCurrent();

--- a/src/Uno.UI/BaseActivity.Android.cs
+++ b/src/Uno.UI/BaseActivity.Android.cs
@@ -194,8 +194,10 @@ namespace Uno.UI
 		{
 			SetAsCurrent();
 
-			Windows.UI.Xaml.Application.Current?.RaiseLeavingBackground(null);
-			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
+			Windows.UI.Xaml.Application.Current?.RaiseLeavingBackground(() =>
+			{
+				Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
+			});
 		}
 
 		partial void InnerRestart() => SetAsCurrent();
@@ -220,8 +222,7 @@ namespace Uno.UI
 		{
 			ResignCurrent();
 
-			Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.Deactivated);
-			Windows.UI.Xaml.Application.Current?.RaiseSuspending();
+			Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.Deactivated);			
 		}
 
 		partial void InnerStop()
@@ -229,7 +230,7 @@ namespace Uno.UI
 			ResignCurrent();
 
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
-			Windows.UI.Xaml.Application.Current?.RaiseEnteredBackground(null);
+			Windows.UI.Xaml.Application.Current?.RaiseEnteredBackground(() => Windows.UI.Xaml.Application.Current?.RaiseSuspending());
 		}
 
 		partial void InnerDestroy() => ResignCurrent();

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -608,12 +608,12 @@ namespace Uno.UI.Controls
 			{
 				Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
 				Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.Deactivated);
-				Windows.UI.Xaml.Application.Current?.RaiseEnteredBackground();
+				Windows.UI.Xaml.Application.Current?.RaiseEnteredBackground(null);
 			}
 
 			public override void DidDeminiaturize(NSNotification notification)
 			{
-				Windows.UI.Xaml.Application.Current?.RaiseLeavingBackground();
+				Windows.UI.Xaml.Application.Current?.RaiseLeavingBackground(null);
 				Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
 				Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.CodeActivated);
 			}

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -608,12 +608,12 @@ namespace Uno.UI.Controls
 			{
 				Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
 				Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.Deactivated);
-				Windows.UI.Xaml.Application.Current?.OnEnteredBackground();
+				Windows.UI.Xaml.Application.Current?.RaiseEnteredBackground();
 			}
 
 			public override void DidDeminiaturize(NSNotification notification)
 			{
-				Windows.UI.Xaml.Application.Current?.OnLeavingBackground();
+				Windows.UI.Xaml.Application.Current?.RaiseLeavingBackground();
 				Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
 				Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.CodeActivated);
 			}

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -643,23 +643,20 @@ namespace Uno.UI.Controls
 				var manager = SystemNavigationManagerPreview.GetForCurrentView();
 				if (!manager.HasConfirmedClose)
 				{
-					manager.OnCloseRequested();
-					if (!manager.HasConfirmedClose)
-					{
-						// Close was either deferred or canceled synchronously.
+					if (!manager.RequestAppClose())
+                    {
 						return false;
-					}
+                    }
 				}
 
-				// closing should continue, perform suspension
-
+				// Closing should continue, perform suspension.
 				if (!Application.Current.Suspended)
 				{
-					Application.Current.OnSuspending();
+					Application.Current.RaiseSuspending();
 					return Application.Current.Suspended;
 				}
 
-				// all prerequisites passed, can safely close
+				// All prerequisites passed, can safely close.
 				return true;
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Application.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Android.cs
@@ -35,10 +35,8 @@ namespace Windows.UI.Xaml
 			Resuming?.Invoke(null, null);
 		}
 
-		partial void OnSuspendingPartial()
-		{
-			Suspending?.Invoke(this, new Windows.ApplicationModel.SuspendingEventArgs(new Windows.ApplicationModel.SuspendingOperation(DateTime.Now.AddSeconds(30))));
-		}
+		private SuspendingOperation CreateSuspendingOperation() =>
+			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(30), null);
 
 		public void Exit()
 		{

--- a/src/Uno.UI/UI/Xaml/Application.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Android.cs
@@ -3,6 +3,7 @@ using System;
 using Android.Content.Res;
 using Android.OS;
 using Uno.UI.Extensions;
+using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;

--- a/src/Uno.UI/UI/Xaml/Application.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Android.cs
@@ -36,8 +36,12 @@ namespace Windows.UI.Xaml
 			Resuming?.Invoke(null, null);
 		}
 
+		/// <remarks>
+		/// The 5 second timeout seems to be the safest timeout for suspension activities.
+		/// See - https://stackoverflow.com/a/3987733/732221
+		/// </remarks>
 		private SuspendingOperation CreateSuspendingOperation() =>
-			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(30), null);
+			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(5), null);
 
 		public void Exit()
 		{

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -320,7 +320,7 @@ namespace Windows.UI.Xaml
 			CoreApplication.RaiseSuspending(suspendingEventArgs);			
 			var completedSynchronously = suspendingOperation.DeferralManager.EventRaiseCompleted();
 
-#if !__IOS__ && !__ANDROID__ && !__MACOS__
+#if !__IOS__ && !__ANDROID__
 			// Asynchronous suspension is not supported on all targets, warn the user
 			if (!completedSynchronously && this.Log().IsEnabled(LogLevel.Warning))
 			{
@@ -331,7 +331,7 @@ namespace Windows.UI.Xaml
 #endif
 		}
 
-#if !__IOS__ && !__ANDROID__ && !__MACOS__
+#if !__IOS__ && !__ANDROID__
 		/// <summary>
 		/// On platforms which don't support asynchronous suspension we indicate that with immediate
 		/// deadline and warning in logs.

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -331,7 +331,7 @@ namespace Windows.UI.Xaml
 #endif
 		}
 
-#if !__IOS__ && !__ANDROID__
+#if !__IOS__ && !__ANDROID__ && !__MACOS__
 		/// <summary>
 		/// On platforms which don't support asynchronous suspension we indicate that with immediate
 		/// deadline and warning in logs.

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -274,7 +274,9 @@ namespace Windows.UI.Xaml
 			if (!_isInBackground)
 			{
 				_isInBackground = true;
-				EnteredBackground?.Invoke(this, new EnteredBackgroundEventArgs());
+				var enteredEventArgs = new EnteredBackgroundEventArgs(null);
+				EnteredBackground?.Invoke(this, enteredEventArgs);
+				enteredEventArgs.DeferralManager.EventRaiseCompleted();
 			}
 		}
 
@@ -283,7 +285,9 @@ namespace Windows.UI.Xaml
 			if (_isInBackground)
 			{
 				_isInBackground = false;
-				LeavingBackground?.Invoke(this, new LeavingBackgroundEventArgs());
+				var leavingEventArgs = new LeavingBackgroundEventArgs(null);
+				LeavingBackground?.Invoke(this, leavingEventArgs);
+				leavingEventArgs.DeferralManager.EventRaiseCompleted();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -274,10 +274,18 @@ namespace Windows.UI.Xaml
 			if (!_isInBackground)
 			{
 				_isInBackground = true;
-				var enteredEventArgs = new EnteredBackgroundEventArgs(null);
+				var enteredEventArgs = new EnteredBackgroundEventArgs(onComplete);
 				EnteredBackground?.Invoke(this, enteredEventArgs);
 				CoreApplication.RaiseEnteredBackground(enteredEventArgs);
-				enteredEventArgs.DeferralManager.EventRaiseCompleted();
+				var completedSynchronously = enteredEventArgs.DeferralManager.EventRaiseCompleted();
+
+				// Asynchronous suspension is not supported
+				if (!completedSynchronously && this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().LogWarning(
+						"Asynchronous entered background completion is not supported yet. " +
+						"Long running operations may be terminated prematurely.");
+				}
 			}
 			else
 			{
@@ -290,10 +298,18 @@ namespace Windows.UI.Xaml
 			if (_isInBackground)
 			{
 				_isInBackground = false;
-				var leavingEventArgs = new LeavingBackgroundEventArgs(null);
+				var leavingEventArgs = new LeavingBackgroundEventArgs(onComplete);
 				LeavingBackground?.Invoke(this, leavingEventArgs);
 				CoreApplication.RaiseLeavingBackground(leavingEventArgs);
-				leavingEventArgs.DeferralManager.EventRaiseCompleted();
+				var completedSynchronously = leavingEventArgs.DeferralManager.EventRaiseCompleted();
+
+				// Asynchronous suspension is not supported
+				if (!completedSynchronously && this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().LogWarning(
+						"Asynchronous leaving background completion is not supported yet. " +
+						"Application may resume before the operation completes.");
+				}
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/Application.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.iOS.cs
@@ -233,14 +233,20 @@ namespace Windows.UI.Xaml
 		private void OnEnteredBackground(NSNotification notification)
 		{
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
-			EnteredBackground?.Invoke(this, new EnteredBackgroundEventArgs());
+
+			var enteredBackgroundArgs = new EnteredBackgroundEventArgs(null);
+			EnteredBackground?.Invoke(this, enteredBackgroundArgs);
+			enteredBackgroundArgs.DeferralManager.EventRaiseCompleted();
 
 			OnSuspending();
 		}
 
 		private void OnLeavingBackground(NSNotification notification)
-		{			
-			LeavingBackground?.Invoke(this, new LeavingBackgroundEventArgs());
+		{
+			var leavingBackgroundArgs = new LeavingBackgroundEventArgs(null);
+			LeavingBackground?.Invoke(this, leavingBackgroundArgs);
+			leavingBackgroundArgs.DeferralManager.EventRaiseCompleted();
+
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Application.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.iOS.cs
@@ -129,14 +129,8 @@ namespace Windows.UI.Xaml
 			_preventSecondaryActivationHandling = false;
 		}
 
-		partial void OnSuspendingPartial()
-		{
-			var operation = new SuspendingOperation(DateTime.Now.AddSeconds(10));
-
-			Suspending?.Invoke(this, new SuspendingEventArgs(operation));
-
-			_suspended = true;
-		}
+		private SuspendinOperation CreateSuspendingOperation() =>
+			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(10), () => _suspended = true);
 
 		public override void WillEnterForeground(UIApplication application)
 			=> OnResuming();

--- a/src/Uno.UI/UI/Xaml/Application.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.iOS.cs
@@ -9,7 +9,6 @@ using ObjCRuntime;
 using Windows.Graphics.Display;
 using Uno.UI.Services;
 using Uno.Extensions;
-
 using Windows.UI.Core;
 using Uno.Foundation.Logging;
 

--- a/src/Uno.UI/UI/Xaml/Application.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.iOS.cs
@@ -129,7 +129,7 @@ namespace Windows.UI.Xaml
 			_preventSecondaryActivationHandling = false;
 		}
 
-		private SuspendinOperation CreateSuspendingOperation() =>
+		private SuspendingOperation CreateSuspendingOperation() =>
 			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(10), () => _suspended = true);
 
 		public override void WillEnterForeground(UIApplication application)
@@ -228,20 +228,13 @@ namespace Windows.UI.Xaml
 		{
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
 
-			var enteredBackgroundArgs = new EnteredBackgroundEventArgs(null);
-			EnteredBackground?.Invoke(this, enteredBackgroundArgs);
-			enteredBackgroundArgs.DeferralManager.EventRaiseCompleted();
-
-			OnSuspending();
+			RaiseEnteredBackground(() => RaiseSuspending());
 		}
 
 		private void OnLeavingBackground(NSNotification notification)
 		{
-			var leavingBackgroundArgs = new LeavingBackgroundEventArgs(null);
-			LeavingBackground?.Invoke(this, leavingBackgroundArgs);
-			leavingBackgroundArgs.DeferralManager.EventRaiseCompleted();
-
-			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
+			RaiseResuming();
+			RaiseLeavingBackground(() => Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true));
 		}
 
 		private void OnActivated(NSNotification notification)

--- a/src/Uno.UI/UI/Xaml/Application.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.iOS.cs
@@ -131,9 +131,6 @@ namespace Windows.UI.Xaml
 		private SuspendingOperation CreateSuspendingOperation() =>
 			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(10), () => _suspended = true);
 
-		public override void WillEnterForeground(UIApplication application)
-			=> OnResuming();
-
 		partial void OnResumingPartial()
 		{
 			if (_suspended)

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private SuspendinOperation CreateSuspendingOperation() =>
+		private SuspendingOperation CreateSuspendingOperation() =>
 			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(30), () =>
 			{
 				Suspended = true;
@@ -179,14 +179,19 @@ namespace Windows.UI.Xaml
 		private void OnEnteredBackground(NSNotification notification)
 		{
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
-			EnteredBackground?.Invoke(this, new EnteredBackgroundEventArgs());
+
+			var enteredBackgroundEventArgs = new EnteredBackgroundEventArgs(null);
+			EnteredBackground?.Invoke(this, enteredBackgroundEventArgs);
+			enteredBackgroundEventArgs.DeferralManager.EventRaiseCompleted();
 
 			OnSuspending();
 		}
 
 		private void OnLeavingBackground(NSNotification notification)
 		{
-			LeavingBackground?.Invoke(this, new LeavingBackgroundEventArgs());
+			var leavingBackgroundEventArgs = new LeavingBackgroundEventArgs(null);
+			LeavingBackground?.Invoke(this, leavingBackgroundEventArgs);
+			leavingBackgroundEventArgs.DeferralManager.EventRaiseCompleted();
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -91,18 +91,12 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		partial void OnSuspendingPartial()
-		{
-			var operation = new SuspendingOperation(DateTime.Now.AddSeconds(30), () =>
+		private SuspendinOperation CreateSuspendingOperation() =>
+			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(30), () =>
 			{
 				Suspended = true;
 				NSApplication.SharedApplication.KeyWindow.PerformClose(null);
 			});
-
-			Suspending?.Invoke(this, new SuspendingEventArgs(operation));
-
-			operation.EventRaiseCompleted();
-		}
 
 		/// <summary>
 		/// This method enables UI Tests to get the output path

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -95,7 +95,6 @@ namespace Windows.UI.Xaml
 			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(0), () =>
 			{
 				Suspended = true;
-				NSApplication.SharedApplication.KeyWindow.PerformClose(null);
 			});
 
 		/// <summary>
@@ -173,7 +172,7 @@ namespace Windows.UI.Xaml
 			NSNotificationCenter.DefaultCenter.AddObserver(NSApplication.ApplicationHiddenNotification, OnEnteredBackground);
 			NSNotificationCenter.DefaultCenter.AddObserver(NSApplication.ApplicationShownNotification, OnLeavingBackground);
 			NSNotificationCenter.DefaultCenter.AddObserver(NSApplication.ApplicationActivatedNotification, OnActivated);
-			NSNotificationCenter.DefaultCenter.AddObserver(NSApplication.ApplicationDeactivatedNotification, OnDeactivated);
+			NSNotificationCenter.DefaultCenter.AddObserver(NSApplication.ApplicationDeactivatedNotification, OnDeactivated);			
 		}
 
 		private void OnEnteredBackground(NSNotification notification)
@@ -181,15 +180,12 @@ namespace Windows.UI.Xaml
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
 
 			RaiseEnteredBackground(null);
-
-			RaiseSuspending();
 		}
 
 		private void OnLeavingBackground(NSNotification notification)
 		{
 			RaiseResuming();
-			RaiseLeavingBackground(null);
-			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
+			RaiseLeavingBackground(() => Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true));
 		}
 
 		private void OnActivated(NSNotification notification)

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -92,7 +92,7 @@ namespace Windows.UI.Xaml
 		}
 
 		private SuspendingOperation CreateSuspendingOperation() =>
-			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(30), () =>
+			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(0), () =>
 			{
 				Suspended = true;
 				NSApplication.SharedApplication.KeyWindow.PerformClose(null);
@@ -180,18 +180,15 @@ namespace Windows.UI.Xaml
 		{
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(false);
 
-			var enteredBackgroundEventArgs = new EnteredBackgroundEventArgs(null);
-			EnteredBackground?.Invoke(this, enteredBackgroundEventArgs);
-			enteredBackgroundEventArgs.DeferralManager.EventRaiseCompleted();
+			RaiseEnteredBackground(null);
 
-			OnSuspending();
+			RaiseSuspending();
 		}
 
 		private void OnLeavingBackground(NSNotification notification)
 		{
-			var leavingBackgroundEventArgs = new LeavingBackgroundEventArgs(null);
-			LeavingBackground?.Invoke(this, leavingBackgroundEventArgs);
-			leavingBackgroundEventArgs.DeferralManager.EventRaiseCompleted();
+			RaiseResuming();
+			RaiseLeavingBackground(null);
 			Windows.UI.Xaml.Window.Current?.OnVisibilityChanged(true);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Application.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Application.wasm.cs
@@ -66,7 +66,9 @@ namespace Windows.UI.Xaml
 			var window = Windows.UI.Xaml.Window.Current;
 			if (isVisible)
 			{
-				application?.LeavingBackground?.Invoke(application, new LeavingBackgroundEventArgs());
+				var leavingEventArgs = new LeavingBackgroundEventArgs(() => { });
+				application?.LeavingBackground?.Invoke(application, leavingEventArgs);
+				leavingEventArgs.DeferralManager.EventRaiseCompleted();
 				window?.OnVisibilityChanged(true);
 				window?.OnActivated(CoreWindowActivationState.CodeActivated);
 			}
@@ -74,7 +76,9 @@ namespace Windows.UI.Xaml
 			{
 				window?.OnActivated(CoreWindowActivationState.Deactivated);
 				window?.OnVisibilityChanged(false);
-				application?.EnteredBackground?.Invoke(application, new EnteredBackgroundEventArgs());
+				var enteredEventArgs = new EnteredBackgroundEventArgs(() => { });
+				application?.EnteredBackground?.Invoke(application, enteredEventArgs);
+				enteredEventArgs.DeferralManager.EventRaiseCompleted();
 			}
 
 			return 0;

--- a/src/Uno.UI/UI/Xaml/Application.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Application.wasm.cs
@@ -141,20 +141,6 @@ namespace Windows.UI.Xaml
 			Current?.OnSuspending();
 		}
 
-		partial void OnSuspendingPartial()
-		{
-			var completed = false;
-			var operation = new SuspendingOperation(DateTime.Now.AddSeconds(0), () => completed = true);
-
-			Suspending?.Invoke(this, new SuspendingEventArgs(operation));
-			operation.EventRaiseCompleted();
-
-			if (!completed && this.Log().IsEnabled(LogLevel.Warning))
-			{
-				this.Log().LogWarning($"This platform does not support asynchronous Suspending deferral. Code executed after the of the method called by Suspending may not get executed.");
-			}
-		}
-
 		private void ObserveApplicationVisibility()
 		{
 			WebAssemblyRuntime.InvokeJS("Windows.UI.Xaml.Application.observeVisibility()");

--- a/src/Uno.UI/UI/Xaml/Application.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Application.wasm.cs
@@ -66,19 +66,17 @@ namespace Windows.UI.Xaml
 			var window = Windows.UI.Xaml.Window.Current;
 			if (isVisible)
 			{
-				var leavingEventArgs = new LeavingBackgroundEventArgs(() => { });
-				application?.LeavingBackground?.Invoke(application, leavingEventArgs);
-				leavingEventArgs.DeferralManager.EventRaiseCompleted();
-				window?.OnVisibilityChanged(true);
-				window?.OnActivated(CoreWindowActivationState.CodeActivated);
+				application?.RaiseLeavingBackground(()=>
+				{
+					window?.OnVisibilityChanged(true);
+					window?.OnActivated(CoreWindowActivationState.CodeActivated);
+				});
 			}
 			else
 			{
 				window?.OnActivated(CoreWindowActivationState.Deactivated);
 				window?.OnVisibilityChanged(false);
-				var enteredEventArgs = new EnteredBackgroundEventArgs(() => { });
-				application?.EnteredBackground?.Invoke(application, enteredEventArgs);
-				enteredEventArgs.DeferralManager.EventRaiseCompleted();
+				application?.RaiseEnteredBackground(null);
 			}
 
 			return 0;

--- a/src/Uno.UI/UI/Xaml/Application.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Application.wasm.cs
@@ -138,7 +138,7 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		internal static void DispatchSuspending()
 		{
-			Current?.OnSuspending();
+			Current?.RaiseSuspending();
 		}
 
 		private void ObserveApplicationVisibility()

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -148,9 +148,9 @@ namespace Windows.UI.Xaml.Controls
 
 			Closing?.Invoke(this, closingArgs);
 
-			closingArgs.DeferralManager.EventRaiseCompleted();
+			var completedSynchronously = closingArgs.DeferralManager.EventRaiseCompleted();
 
-			return !closingArgs.Cancel;
+			return completedSynchronously && !closingArgs.Cancel;
 		}
 
 		protected override void OnApplyTemplate()

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -148,14 +148,7 @@ namespace Windows.UI.Xaml.Controls
 
 			Closing?.Invoke(this, closingArgs);
 
-			if (!closingArgs.IsDeferred)
-			{
-				Complete(closingArgs);
-			}
-			else
-			{
-				closingArgs.EventRaiseCompleted();
-			}
+			closingArgs.DeferralManager.EventRaiseCompleted();
 
 			return !closingArgs.Cancel;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialogClosingEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialogClosingEventArgs.cs
@@ -1,24 +1,38 @@
 using System;
 using Uno.Helpers;
 
-namespace Windows.UI.Xaml.Controls
+namespace Windows.UI.Xaml.Controls;
+
+/// <summary>
+/// Provides data for the closing event.
+/// </summary>
+public partial class ContentDialogClosingEventArgs
 {
-	public partial class ContentDialogClosingEventArgs
+	internal ContentDialogClosingEventArgs(Action<ContentDialogClosingEventArgs> complete, ContentDialogResult result)
 	{
-		internal ContentDialogClosingEventArgs(Action<ContentDialogClosingEventArgs> complete, ContentDialogResult result)
-		{
-			DeferralManager = new DeferralManager<ContentDialogClosingDeferral>(h => new ContentDialogClosingDeferral(h));
-			DeferralManager.Completed += (s, e) => complete(this);
+		DeferralManager = new(h => new ContentDialogClosingDeferral(h));
+		DeferralManager.Completed += (s, e) => complete(this);
 
-			Result = result;
-		}
-
-		internal DeferralManager<ContentDialogClosingDeferral> DeferralManager { get; }
-
-		public bool Cancel { get; set; }
-
-		public ContentDialogResult Result { get; }
-
-		public ContentDialogClosingDeferral GetDeferral() => DeferralManager.GetDeferral();
+		Result = result;
 	}
+
+	/// <summary>
+	/// Gets or sets a value that can cancel the closing of the dialog.
+	/// A true value for Cancel cancels the default behavior.
+	/// </summary>
+	public bool Cancel { get; set; }
+
+	/// <summary>
+	/// Gets the ContentDialogResult of the closing event.
+	/// </summary>
+	public ContentDialogResult Result { get; }
+
+	internal DeferralManager<ContentDialogClosingDeferral> DeferralManager { get; }
+
+	/// <summary>
+	/// Gets a ContentDialogClosingDeferral that the app
+	/// can use to respond asynchronously to the closing event.
+	/// </summary>
+	/// <returns>Deferral</returns>
+	public ContentDialogClosingDeferral GetDeferral() => DeferralManager.GetDeferral();
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialogClosingEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialogClosingEventArgs.cs
@@ -5,33 +5,20 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class ContentDialogClosingEventArgs
 	{
-		private DeferralManager<ContentDialogClosingDeferral> _deferralManager;
-		private readonly Action<ContentDialogClosingEventArgs> _complete;
-
 		internal ContentDialogClosingEventArgs(Action<ContentDialogClosingEventArgs> complete, ContentDialogResult result)
 		{
-			_complete = complete;
+			DeferralManager = new DeferralManager<ContentDialogClosingDeferral>(h => new ContentDialogClosingDeferral(h));
+			DeferralManager.Completed += (s, e) => complete(this);
 
 			Result = result;
 		}
 
-		internal bool IsDeferred => _deferralManager != null;
+		internal DeferralManager<ContentDialogClosingDeferral> DeferralManager { get; }
 
 		public bool Cancel { get; set; }
 
 		public ContentDialogResult Result { get; }
-		
-		public ContentDialogClosingDeferral GetDeferral()
-		{
-			if (_deferralManager == null)
-			{
-				_deferralManager = new DeferralManager<ContentDialogClosingDeferral>(h => new ContentDialogClosingDeferral(h));
-				_deferralManager.Completed += (s, e) => _complete(this);
-			}
 
-			return _deferralManager.GetDeferral();
-		}
-
-		internal void EventRaiseCompleted() => _deferralManager?.EventRaiseCompleted();
+		public ContentDialogClosingDeferral GetDeferral() => DeferralManager.GetDeferral();
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/Core/CoreApplication.cs
+++ b/src/Uno.UWP/ApplicationModel/Core/CoreApplication.cs
@@ -1,59 +1,85 @@
 #pragma warning disable 108 // new keyword hiding
 #pragma warning disable 114 // new keyword hiding
+
+using System;
 using System.Collections.Generic;
 using Uno.Helpers.Theming;
 
-namespace Windows.ApplicationModel.Core
+namespace Windows.ApplicationModel.Core;
+
+public partial class CoreApplication
 {
-	public  partial class CoreApplication 
+	private static CoreApplicationView _currentView;
+	private static List<CoreApplicationView> _views;
+
+	static CoreApplication()
 	{
-		private static CoreApplicationView _currentView;
-		private static List<CoreApplicationView> _views;
-
-		public static event global::System.EventHandler<object> Resuming;
-
-		public static event global::System.EventHandler<global::Windows.ApplicationModel.SuspendingEventArgs> Suspending;
-
-		static CoreApplication()
-		{
-			_currentView = new CoreApplicationView();
-		}
-
-		/// <summary>
-		/// Raises the <see cref="Resuming"/> event
-		/// </summary>
-		internal static void RaiseResuming()
-			=> Resuming?.Invoke(null, null);
-
-		/// <summary>
-		/// Raises the <see cref="Suspending"/> event
-		/// </summary>
-		internal static void RaiseSuspending(SuspendingEventArgs args)
-			=> Suspending?.Invoke(null, args);
-
-		public static CoreApplicationView GetCurrentView()
-			=> _currentView;
-
-		public static global::Windows.ApplicationModel.Core.CoreApplicationView MainView
-			=> _currentView;
-
-		public static IReadOnlyList<CoreApplicationView> Views
-		{
-			get
-			{
-				if(_views == null)
-				{
-					_views = new List<CoreApplicationView> { _currentView };
-				}
-
-				return _views;
-			}
-		}
-
-		/// <summary>
-		/// This property is kept in sync with the Application.RequestedTheme to enable
-		/// native UI elements in non Uno.UWP to resolve the currently set Application theme.
-		/// </summary>
-		internal static SystemTheme RequestedTheme { get; set; }
+		_currentView = new CoreApplicationView();
 	}
+
+	/// <summary>
+	/// Occurs when an app is resuming.
+	/// </summary>
+	public static event EventHandler<object> Resuming;
+
+	/// <summary>
+	/// Occurs when the app is suspending.
+	/// </summary>
+	public static event EventHandler<SuspendingEventArgs> Suspending;
+
+	/// <summary>
+	/// Fired when the app enters the running in the background state.
+	/// </summary>
+	public static event EventHandler<EnteredBackgroundEventArgs> EnteredBackground;
+
+	/// <summary>
+	/// Fired just before application UI becomes visible.
+	/// </summary>
+	public static event EventHandler<LeavingBackgroundEventArgs> LeavingBackground;
+
+	/// <summary>
+	/// Raises the <see cref="Resuming"/> event.
+	/// </summary>
+	internal static void OnResuming() => Resuming?.Invoke(null, null);
+
+	/// <summary>
+	/// Raises the <see cref="Suspending"/> event.
+	/// </summary>
+	/// <param name="args">Suspending event args.</param>
+	internal static void OnSuspending(SuspendingEventArgs args) => Suspending?.Invoke(null, args);
+
+	/// <summary>
+	/// Raises the <see cref="EnteredBackground"/> event.
+	/// </summary>
+	/// <param name="args">Entered background event args.</param>
+	internal static void OnEnteredBackground(EnteredBackgroundEventArgs args) => EnteredBackground?.Invoke(null, args);
+
+	/// <summary>
+	/// Raises the <see cref="LeavingBackground"/> event.
+	/// </summary>
+	/// <param name="args">Leaving background event args.</param>
+	internal static void OnLeavingBackground(LeavingBackgroundEventArgs args) => LeavingBackground?.Invoke(null, args);
+
+	public static CoreApplicationView GetCurrentView() => _currentView;
+
+	public static CoreApplicationView MainView => _currentView;
+
+	public static IReadOnlyList<CoreApplicationView> Views
+	{
+		get
+		{
+			if (_views == null)
+			{
+				_views = new List<CoreApplicationView> { _currentView };
+			}
+
+			return _views;
+		}
+	}
+
+	/// <summary>
+	/// This property is kept in sync with the Application.RequestedTheme to enable
+	/// native UI elements in non Uno.UWP to resolve the currently set Application theme.
+	/// </summary>
+	internal static SystemTheme RequestedTheme { get; set; }
 }

--- a/src/Uno.UWP/ApplicationModel/Core/CoreApplication.cs
+++ b/src/Uno.UWP/ApplicationModel/Core/CoreApplication.cs
@@ -40,25 +40,25 @@ public partial class CoreApplication
 	/// <summary>
 	/// Raises the <see cref="Resuming"/> event.
 	/// </summary>
-	internal static void OnResuming() => Resuming?.Invoke(null, null);
+	internal static void RaiseResuming() => Resuming?.Invoke(null, null);
 
 	/// <summary>
 	/// Raises the <see cref="Suspending"/> event.
 	/// </summary>
 	/// <param name="args">Suspending event args.</param>
-	internal static void OnSuspending(SuspendingEventArgs args) => Suspending?.Invoke(null, args);
+	internal static void RaiseSuspending(SuspendingEventArgs args) => Suspending?.Invoke(null, args);
 
 	/// <summary>
 	/// Raises the <see cref="EnteredBackground"/> event.
 	/// </summary>
 	/// <param name="args">Entered background event args.</param>
-	internal static void OnEnteredBackground(EnteredBackgroundEventArgs args) => EnteredBackground?.Invoke(null, args);
+	internal static void RaiseEnteredBackground(EnteredBackgroundEventArgs args) => EnteredBackground?.Invoke(null, args);
 
 	/// <summary>
 	/// Raises the <see cref="LeavingBackground"/> event.
 	/// </summary>
 	/// <param name="args">Leaving background event args.</param>
-	internal static void OnLeavingBackground(LeavingBackgroundEventArgs args) => LeavingBackground?.Invoke(null, args);
+	internal static void RaiseLeavingBackground(LeavingBackgroundEventArgs args) => LeavingBackground?.Invoke(null, args);
 
 	public static CoreApplicationView GetCurrentView() => _currentView;
 

--- a/src/Uno.UWP/ApplicationModel/Core/CoreApplication.cs
+++ b/src/Uno.UWP/ApplicationModel/Core/CoreApplication.cs
@@ -64,18 +64,7 @@ public partial class CoreApplication
 
 	public static CoreApplicationView MainView => _currentView;
 
-	public static IReadOnlyList<CoreApplicationView> Views
-	{
-		get
-		{
-			if (_views == null)
-			{
-				_views = new List<CoreApplicationView> { _currentView };
-			}
-
-			return _views;
-		}
-	}
+	public static IReadOnlyList<CoreApplicationView> Views => _views ??= new List<CoreApplicationView>() { _currentView };
 
 	/// <summary>
 	/// This property is kept in sync with the Application.RequestedTheme to enable

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataRequest.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataRequest.cs
@@ -1,22 +1,39 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using Uno.Helpers;
 
-namespace Windows.ApplicationModel.DataTransfer
+namespace Windows.ApplicationModel.DataTransfer;
+
+/// <summary>
+/// Lets your app supply the content the user wants to share or specify a message, if an error occurs.
+/// </summary>
+public partial class DataRequest
 {
-	public partial class DataRequest
+	internal DataRequest(Action<DataRequest> complete)
 	{
-		internal DataRequest(Action<DataRequest> complete)
-		{
-			DeferralManager = new DeferralManager<DataRequestDeferral>(h => new DataRequestDeferral(h));
-			DeferralManager.Completed += (s, e) => complete(this);
-		}
-
-		public DataPackage Data { get; set; } = new DataPackage();
-
-		public DateTimeOffset Deadline { get; }
-
-		internal DeferralManager<DataRequestDeferral> DeferralManager { get; }
-
-		public DataRequestDeferral GetDeferral() => DeferralManager.GetDeferral();
+		DeferralManager = new DeferralManager<DataRequestDeferral>(h => new DataRequestDeferral(h));
+		DeferralManager.Completed += (s, e) => complete(this);
 	}
+
+	/// <summary>
+	/// Sets or gets a DataPackage object that contains the content a user wants to share.
+	/// </summary>
+	public DataPackage Data { get; set; } = new DataPackage();
+
+	/// <summary>
+	/// Gets the deadline for finishing a delayed rendering operation. If execution goes beyond that deadline,
+	/// the results of delayed rendering are ignored.
+	/// </summary>
+	public DateTimeOffset Deadline { get; }
+
+	internal DeferralManager<DataRequestDeferral> DeferralManager { get; }
+
+	/// <summary>
+	/// Supports asynchronous sharing operations by creating and returning a DataRequestDeferral object.
+	/// </summary>
+	/// <returns>
+	/// Supports asynchronous sharing operations by creating and returning a DataRequestDeferral object.
+	/// </returns>
+	public DataRequestDeferral GetDeferral() => DeferralManager.GetDeferral();
 }

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataRequest.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataRequest.cs
@@ -5,29 +5,18 @@ namespace Windows.ApplicationModel.DataTransfer
 {
 	public partial class DataRequest
 	{
-		private readonly Action<DataRequest> _complete;
-
-		private DeferralManager<DataRequestDeferral> _deferralManager;
-
-		internal DataRequest(Action<DataRequest> complete) => _complete = complete;
+		internal DataRequest(Action<DataRequest> complete)
+		{
+			DeferralManager = new DeferralManager<DataRequestDeferral>(h => new DataRequestDeferral(h));
+			DeferralManager.Completed += (s, e) => complete(this);
+		}
 
 		public DataPackage Data { get; set; } = new DataPackage();
 
 		public DateTimeOffset Deadline { get; }
 
-		internal bool IsDeferred => _deferralManager != null;
+		internal DeferralManager<DataRequestDeferral> DeferralManager { get; }
 
-		internal void EventRaiseCompleted() => _deferralManager?.EventRaiseCompleted();
-
-		public DataRequestDeferral GetDeferral()
-		{
-			if (_deferralManager == null)
-			{
-				_deferralManager = new DeferralManager<DataRequestDeferral>(h => new DataRequestDeferral(h));
-				_deferralManager.Completed += (s, e) => _complete(this);
-			}
-
-			return _deferralManager.GetDeferral();
-		}
+		public DataRequestDeferral GetDeferral() => DeferralManager.GetDeferral();
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataRequestedEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataRequestedEventArgs.cs
@@ -2,15 +2,22 @@
 
 using System;
 
-namespace Windows.ApplicationModel.DataTransfer
-{
-	public partial class DataRequestedEventArgs
-	{
-		internal DataRequestedEventArgs(Action<DataRequest> deferralComplete)
-		{
-			Request = new DataRequest(deferralComplete);
-		}
+namespace Windows.ApplicationModel.DataTransfer;
 
-		public DataRequest Request { get; }
+/// <summary>
+/// Contains information about the DataRequested event. The system fires this
+/// event when the user invokes the Share UI.
+/// </summary>
+public partial class DataRequestedEventArgs
+{
+	internal DataRequestedEventArgs(Action<DataRequest> deferralComplete)
+	{
+		Request = new DataRequest(deferralComplete);
 	}
+
+	/// <summary>
+	/// Enables you to get the DataRequest object
+	/// and either give it data or a failure message.
+	/// </summary>
+	public DataRequest Request { get; }
 }

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataTransferManager.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataTransferManager.cs
@@ -2,11 +2,9 @@
 
 #if __WASM__ || __IOS__ || __ANDROID__ || __MACOS__ || __SKIA__
 using System;
-using Windows.Foundation;
-using Uno.Foundation.Logging;
-
-using Uno.Extensions;
 using System.Threading.Tasks;
+using Uno.Foundation.Logging;
+using Windows.Foundation;
 
 namespace Windows.ApplicationModel.DataTransfer
 {
@@ -27,18 +25,11 @@ namespace Windows.ApplicationModel.DataTransfer
 		public static void ShowShareUI(ShareUIOptions options)
 		{
 			var dataTransferManager = _instance.Value;
-			var args = new DataRequestedEventArgs((dataRequest)=>ContinueShowShareUI(options, dataRequest.Data));
+			var args = new DataRequestedEventArgs((dataRequest) => ContinueShowShareUI(options, dataRequest.Data));
 			dataTransferManager.DataRequested?.Invoke(dataTransferManager, args);
 
-			// Data retrieval may be done asynchronously, check for deferral use
-			if (!args.Request.IsDeferred)
-			{
-				ContinueShowShareUI(options, args.Request.Data);
-			}
-			else
-			{
-				args.Request.EventRaiseCompleted();
-			}
+			// Data retrieval may be done asynchronously
+			args.Request.DeferralManager.EventRaiseCompleted();
 		}
 
 		private static async void ContinueShowShareUI(ShareUIOptions options, DataPackage dataPackage)

--- a/src/Uno.UWP/ApplicationModel/EnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/EnteredBackgroundEventArgs.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Uno.Helpers;
 using Windows.Foundation;
@@ -9,7 +11,7 @@ namespace Windows.ApplicationModel;
 /// </summary>
 public partial class EnteredBackgroundEventArgs : IEnteredBackgroundEventArgs
 {
-	internal EnteredBackgroundEventArgs(Action onComplete)
+	internal EnteredBackgroundEventArgs(Action? onComplete)
 	{
 		DeferralManager = new DeferralManager<Deferral>(c => new Deferral(c));
 		DeferralManager.Completed += (s, e) => onComplete?.Invoke();
@@ -17,5 +19,11 @@ public partial class EnteredBackgroundEventArgs : IEnteredBackgroundEventArgs
 
 	internal DeferralManager<Deferral> DeferralManager { get; }
 
+	/// <summary>
+	/// Gets the deferral object which delays the transition from running in the background
+	/// state to the suspended state until the app calls Deferral.Complete or the deadline
+	/// for navigation has passed.
+	/// </summary>
+	/// <returns>The deferral object you will use to indicate when your processing is complete.</returns>
 	public Deferral GetDeferral() => DeferralManager.GetDeferral();
 }

--- a/src/Uno.UWP/ApplicationModel/EnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/EnteredBackgroundEventArgs.cs
@@ -1,9 +1,21 @@
-namespace Windows.ApplicationModel
+using System;
+using Uno.Helpers;
+using Windows.Foundation;
+
+namespace Windows.ApplicationModel;
+
+/// <summary>
+/// Gets the deferral object when an app has entered the background state.
+/// </summary>
+public partial class EnteredBackgroundEventArgs : IEnteredBackgroundEventArgs
 {
-	public partial class EnteredBackgroundEventArgs : IEnteredBackgroundEventArgs
+	internal EnteredBackgroundEventArgs(Action onComplete)
 	{
-		internal EnteredBackgroundEventArgs()
-		{
-		}
+		DeferralManager = new DeferralManager<Deferral>(c => new Deferral(c));
+		DeferralManager.Completed += (s, e) => onComplete?.Invoke();
 	}
+
+	internal DeferralManager<Deferral> DeferralManager { get; }
+
+	public Deferral GetDeferral() => DeferralManager.GetDeferral();
 }

--- a/src/Uno.UWP/ApplicationModel/IEnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/IEnteredBackgroundEventArgs.cs
@@ -1,7 +1,12 @@
+#nullable enable
+
 using Windows.Foundation;
 
 namespace Windows.ApplicationModel;
 
+/// <summary>
+/// Gets the deferral object when an app has entered the background state.
+/// </summary>
 public partial interface IEnteredBackgroundEventArgs
 {
 	/// <summary>

--- a/src/Uno.UWP/ApplicationModel/IEnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/IEnteredBackgroundEventArgs.cs
@@ -1,6 +1,18 @@
-namespace Windows.ApplicationModel
+using Windows.Foundation;
+
+namespace Windows.ApplicationModel;
+
+public partial interface IEnteredBackgroundEventArgs
 {
-	public partial interface IEnteredBackgroundEventArgs
-	{
-	}
+	/// <summary>
+	/// Gets the deferral object which delays the transition
+	/// from running in the background state to the suspended
+	/// state until the app calls Deferral.Complete or the deadline
+	/// for navigation has passed.
+	/// </summary>
+	/// <returns>
+	/// The deferral object you will use to indicate
+	/// that your processing is complete.
+	/// </returns>
+	Deferral GetDeferral();
 }

--- a/src/Uno.UWP/ApplicationModel/ILeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/ILeavingBackgroundEventArgs.cs
@@ -1,6 +1,20 @@
-namespace Windows.ApplicationModel
+using Windows.Foundation;
+
+namespace Windows.ApplicationModel;
+
+/// <summary>
+/// Gets the deferral object when the app is leaving the background state.
+/// </summary>
+public partial interface ILeavingBackgroundEventArgs
 {
-	public partial interface ILeavingBackgroundEventArgs
-	{
-	}
+	/// <summary>
+	/// Gets the deferral object which delays the transition from running
+	/// in the background to running in the foreground until the app calls
+	/// Deferral. Complete or the deadline for navigation has passed.
+	/// </summary>
+	/// <returns>
+	/// The deferral object you will use to indicate
+	/// that your processing is complete.
+	/// </returns>
+	Deferral GetDeferral();
 }

--- a/src/Uno.UWP/ApplicationModel/ILeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/ILeavingBackgroundEventArgs.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Windows.Foundation;
 
 namespace Windows.ApplicationModel;

--- a/src/Uno.UWP/ApplicationModel/ISuspendingDeferral.cs
+++ b/src/Uno.UWP/ApplicationModel/ISuspendingDeferral.cs
@@ -1,7 +1,14 @@
-﻿namespace Windows.ApplicationModel
+﻿#nullable enable
+
+namespace Windows.ApplicationModel;
+
+/// <summary>
+/// Manages a delayed app suspending operation.
+/// </summary>
+public partial interface ISuspendingDeferral
 {
-	public partial interface ISuspendingDeferral
-	{
-		void Complete();
-	}
+	/// <summary>
+	/// Notifies the system that the app has saved its data and is ready to be suspended.
+	/// </summary>
+	void Complete();
 }

--- a/src/Uno.UWP/ApplicationModel/ISuspendingEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/ISuspendingEventArgs.cs
@@ -1,7 +1,14 @@
-﻿namespace Windows.ApplicationModel
+﻿#nullable enable
+
+namespace Windows.ApplicationModel;
+
+/// <summary>
+/// Provides data for an app suspending event.
+/// </summary>
+public partial interface ISuspendingEventArgs
 {
-	public partial interface ISuspendingEventArgs
-	{
-		SuspendingOperation SuspendingOperation { get; }
-	}
+	/// <summary>
+	/// Gets the app suspending operation.
+	/// </summary>
+	SuspendingOperation SuspendingOperation { get; }
 }

--- a/src/Uno.UWP/ApplicationModel/ISuspendingOperation.cs
+++ b/src/Uno.UWP/ApplicationModel/ISuspendingOperation.cs
@@ -1,11 +1,22 @@
-﻿using System;
+﻿#nullable enable
 
-namespace Windows.ApplicationModel
+using System;
+
+namespace Windows.ApplicationModel;
+
+/// <summary>
+/// Provides information about an app suspending operation.
+/// </summary>
+public partial interface ISuspendingOperation
 {
-	public partial interface ISuspendingOperation
-	{
-		DateTimeOffset Deadline { get; }
+	/// <summary>
+	/// Gets the time remaining before a delayed app suspending operation continues.
+	/// </summary>
+	DateTimeOffset Deadline { get; }
 
-		SuspendingDeferral GetDeferral();
-	}
+	/// <summary>
+	/// Requests that the app suspending operation be delayed.
+	/// </summary>
+	/// <returns>The suspension deferral.</returns>
+	SuspendingDeferral GetDeferral();
 }

--- a/src/Uno.UWP/ApplicationModel/LeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/LeavingBackgroundEventArgs.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Uno.Helpers;
 using Windows.Foundation;
@@ -9,7 +11,7 @@ namespace Windows.ApplicationModel;
 /// </summary>
 public partial class LeavingBackgroundEventArgs : ILeavingBackgroundEventArgs
 {
-	internal LeavingBackgroundEventArgs(Action onComplete)
+	internal LeavingBackgroundEventArgs(Action? onComplete)
 	{
 		DeferralManager = new DeferralManager<Deferral>(c => new Deferral(c));
 		DeferralManager.Completed += (s, e) => onComplete?.Invoke();
@@ -17,5 +19,11 @@ public partial class LeavingBackgroundEventArgs : ILeavingBackgroundEventArgs
 
 	internal DeferralManager<Deferral> DeferralManager { get; }
 
+	/// <summary>
+	/// Gets the deferral object which delays the transition from running
+	/// in the background to running in the foreground until the app calls
+	/// Deferral.Complete or the deadline for navigation has passed.
+	/// </summary>
+	/// <returns>The deferral object you will use to indicate that your processing is done.</returns>
 	public Deferral GetDeferral() => DeferralManager.GetDeferral();
 }

--- a/src/Uno.UWP/ApplicationModel/LeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/LeavingBackgroundEventArgs.cs
@@ -1,9 +1,21 @@
-namespace Windows.ApplicationModel
+using System;
+using Uno.Helpers;
+using Windows.Foundation;
+
+namespace Windows.ApplicationModel;
+
+/// <summary>
+/// Gets the deferral object when the app is leaving the background state.
+/// </summary>
+public partial class LeavingBackgroundEventArgs : ILeavingBackgroundEventArgs
 {
-	public partial class LeavingBackgroundEventArgs : ILeavingBackgroundEventArgs
+	internal LeavingBackgroundEventArgs(Action onComplete)
 	{
-		internal LeavingBackgroundEventArgs()
-		{
-		}
+		DeferralManager = new DeferralManager<Deferral>(c => new Deferral(c));
+		DeferralManager.Completed += (s, e) => onComplete?.Invoke();
 	}
+
+	internal DeferralManager<Deferral> DeferralManager { get; }
+
+	public Deferral GetDeferral() => DeferralManager.GetDeferral();
 }

--- a/src/Uno.UWP/ApplicationModel/SuspendingDeferral.cs
+++ b/src/Uno.UWP/ApplicationModel/SuspendingDeferral.cs
@@ -4,28 +4,33 @@ using System;
 using System.Diagnostics;
 using Windows.Foundation;
 
-namespace Windows.ApplicationModel
+namespace Windows.ApplicationModel;
+
+/// <summary>
+/// Manages a delayed app suspending operation.
+/// </summary>
+public sealed partial class SuspendingDeferral : ISuspendingDeferral
 {
-	public sealed partial class SuspendingDeferral : ISuspendingDeferral
+	private readonly Action? _deferralDone;
+	private readonly DeferralCompletedHandler? _handler;
+
+	/// <summary>
+	/// This can be removed with other breaking changes
+	/// </summary>
+	/// <param name="deferralDone"></param>
+	[DebuggerHidden]
+	public SuspendingDeferral(Action? deferralDone) =>
+		_deferralDone = deferralDone;
+
+	internal SuspendingDeferral(DeferralCompletedHandler handler) =>
+		_handler = handler;
+
+	/// <summary>
+	/// Notifies the operating system that the app has saved its data and is ready to be suspended.
+	/// </summary>
+	public void Complete()
 	{
-		private readonly Action? _deferralDone;
-		private readonly DeferralCompletedHandler? _handler;
-
-		/// <summary>
-		/// This can be removed with other breaking changes
-		/// </summary>
-		/// <param name="deferralDone"></param>
-		[DebuggerHidden]
-		public SuspendingDeferral(Action? deferralDone)	=>
-			_deferralDone = deferralDone;
-
-		internal SuspendingDeferral(DeferralCompletedHandler handler) =>
-			_handler = handler;
-
-		public void Complete()
-		{
-			_deferralDone?.Invoke();
-			_handler?.Invoke();
-		}
+		_deferralDone?.Invoke();
+		_handler?.Invoke();
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/SuspendingEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/SuspendingEventArgs.cs
@@ -1,12 +1,21 @@
-namespace Windows.ApplicationModel
-{
-	public sealed partial class SuspendingEventArgs : ISuspendingEventArgs
-	{
-		internal SuspendingEventArgs(SuspendingOperation operation)
-		{
-			SuspendingOperation = operation;
-		}
+#nullable enable
 
-		public SuspendingOperation SuspendingOperation { get; }
+using System;
+
+namespace Windows.ApplicationModel;
+
+/// <summary>
+/// Provides data for an app suspending event.
+/// </summary>
+public sealed partial class SuspendingEventArgs : ISuspendingEventArgs
+{
+	internal SuspendingEventArgs(SuspendingOperation operation)
+	{
+		SuspendingOperation = operation ?? throw new ArgumentNullException(nameof(operation));
 	}
+
+	/// <summary>
+	/// Gets the app suspending operation.
+	/// </summary>
+	public SuspendingOperation SuspendingOperation { get; }
 }

--- a/src/Uno.UWP/ApplicationModel/SuspendingOperation.cs
+++ b/src/Uno.UWP/ApplicationModel/SuspendingOperation.cs
@@ -3,33 +3,30 @@
 using System;
 using Uno.Helpers;
 
-namespace Windows.ApplicationModel
+namespace Windows.ApplicationModel;
+
+/// <summary>
+/// Provides info about an app suspending operation.
+/// </summary>
+public sealed partial class SuspendingOperation : ISuspendingOperation
 {
-	public sealed partial class SuspendingOperation : ISuspendingOperation
+	internal SuspendingOperation(DateTimeOffset offset, Action? onComplete = null)
 	{
-		private DeferralManager<SuspendingDeferral>? _deferralManager;
-		private readonly Action? _deferralDone;
-
-		internal SuspendingOperation(DateTimeOffset offset, Action? deferralDone = null)
-		{
-			Deadline = offset;
-			_deferralDone = deferralDone;
-		}
-
-		internal bool IsDeferred => _deferralManager != null;
-
-		internal void EventRaiseCompleted() => _deferralManager?.EventRaiseCompleted();
-
-		public DateTimeOffset Deadline { get; }
-
-		public SuspendingDeferral GetDeferral()
-		{
-			if (_deferralManager == null)
-			{
-				_deferralManager = new DeferralManager<SuspendingDeferral>(h => new SuspendingDeferral(h));
-				_deferralManager.Completed += (s, e) => _deferralDone?.Invoke();
-			}
-			return _deferralManager.GetDeferral();
-		}		
+		Deadline = offset;
+		DeferralManager = new DeferralManager<SuspendingDeferral>(h => new SuspendingDeferral(h));
+		DeferralManager.Completed += (s, e) => onComplete?.Invoke();
 	}
+
+	/// <summary>
+	/// Gets the time when the delayed app suspending operation continues.
+	/// </summary>
+	public DateTimeOffset Deadline { get; }
+
+	internal DeferralManager<SuspendingDeferral> DeferralManager { get; }
+
+	/// <summary>
+	/// Requests that the app suspending operation be delayed.
+	/// </summary>
+	/// <returns>The suspension deferral.</returns>
+	public SuspendingDeferral GetDeferral() => DeferralManager.GetDeferral();
 }

--- a/src/Uno.UWP/ApplicationModel/SuspendingOperation.cs
+++ b/src/Uno.UWP/ApplicationModel/SuspendingOperation.cs
@@ -10,7 +10,7 @@ namespace Windows.ApplicationModel;
 /// </summary>
 public sealed partial class SuspendingOperation : ISuspendingOperation
 {
-	internal SuspendingOperation(DateTimeOffset offset, Action? onComplete = null)
+	internal SuspendingOperation(DateTimeOffset offset, Action? onComplete)
 	{
 		Deadline = offset;
 		DeferralManager = new DeferralManager<SuspendingDeferral>(h => new SuspendingDeferral(h));

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Core/CoreApplication.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Core/CoreApplication.cs
@@ -173,38 +173,8 @@ namespace Windows.ApplicationModel.Core
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static event global::System.EventHandler<global::Windows.ApplicationModel.EnteredBackgroundEventArgs> EnteredBackground
-		{
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Core.CoreApplication", "event EventHandler<EnteredBackgroundEventArgs> CoreApplication.EnteredBackground");
-			}
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Core.CoreApplication", "event EventHandler<EnteredBackgroundEventArgs> CoreApplication.EnteredBackground");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static event global::System.EventHandler<global::Windows.ApplicationModel.LeavingBackgroundEventArgs> LeavingBackground
-		{
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Core.CoreApplication", "event EventHandler<LeavingBackgroundEventArgs> CoreApplication.LeavingBackground");
-			}
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.Core.CoreApplication", "event EventHandler<LeavingBackgroundEventArgs> CoreApplication.LeavingBackground");
-			}
-		}
-		#endif
+		// Skipping already declared event Windows.ApplicationModel.Core.CoreApplication.EnteredBackground
+		// Skipping already declared event Windows.ApplicationModel.Core.CoreApplication.LeavingBackground
 		// Skipping already declared event Windows.ApplicationModel.Core.CoreApplication.Resuming
 		// Skipping already declared event Windows.ApplicationModel.Core.CoreApplication.Suspending
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/EnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/EnteredBackgroundEventArgs.cs
@@ -7,7 +7,7 @@ namespace Windows.ApplicationModel
 	#endif
 	public  partial class EnteredBackgroundEventArgs : global::Windows.ApplicationModel.IEnteredBackgroundEventArgs
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || false || false || false || false || false || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.Deferral GetDeferral()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/IEnteredBackgroundEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/IEnteredBackgroundEventArgs.cs
@@ -7,7 +7,7 @@ namespace Windows.ApplicationModel
 	#endif
 	public  partial interface IEnteredBackgroundEventArgs 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || false || false || false || false || false || false
 		global::Windows.Foundation.Deferral GetDeferral();
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/ILeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/ILeavingBackgroundEventArgs.cs
@@ -7,7 +7,7 @@ namespace Windows.ApplicationModel
 	#endif
 	public  partial interface ILeavingBackgroundEventArgs 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || false || false || false || false || false || false
 		global::Windows.Foundation.Deferral GetDeferral();
 		#endif
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/LeavingBackgroundEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel/LeavingBackgroundEventArgs.cs
@@ -7,13 +7,13 @@ namespace Windows.ApplicationModel
 	#endif
 	public  partial class LeavingBackgroundEventArgs : global::Windows.ApplicationModel.ILeavingBackgroundEventArgs
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false || false || false || false || false || false || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.Deferral GetDeferral()
 		{
 			throw new global::System.NotImplementedException("The member Deferral LeavingBackgroundEventArgs.GetDeferral() is not implemented in Uno.");
 		}
-		#endif
+#endif
 		// Processing: Windows.ApplicationModel.ILeavingBackgroundEventArgs
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core.Preview/SystemNavigationCloseRequestedPreviewEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core.Preview/SystemNavigationCloseRequestedPreviewEventArgs.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Core.Preview
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SystemNavigationCloseRequestedPreviewEventArgs 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  bool Handled
 		{
@@ -23,7 +23,7 @@ namespace Windows.UI.Core.Preview
 		#endif
 		// Forced skipping of method Windows.UI.Core.Preview.SystemNavigationCloseRequestedPreviewEventArgs.Handled.get
 		// Forced skipping of method Windows.UI.Core.Preview.SystemNavigationCloseRequestedPreviewEventArgs.Handled.set
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  global::Windows.Foundation.Deferral GetDeferral()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core.Preview/SystemNavigationManagerPreview.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core.Preview/SystemNavigationManagerPreview.cs
@@ -2,21 +2,21 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Core.Preview
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SystemNavigationManagerPreview 
 	{
 		// Forced skipping of method Windows.UI.Core.Preview.SystemNavigationManagerPreview.CloseRequested.add
 		// Forced skipping of method Windows.UI.Core.Preview.SystemNavigationManagerPreview.CloseRequested.remove
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public static global::Windows.UI.Core.Preview.SystemNavigationManagerPreview GetForCurrentView()
 		{
 			throw new global::System.NotImplementedException("The member SystemNavigationManagerPreview SystemNavigationManagerPreview.GetForCurrentView() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  event global::System.EventHandler<global::Windows.UI.Core.Preview.SystemNavigationCloseRequestedPreviewEventArgs> CloseRequested
 		{

--- a/src/Uno.UWP/Helpers/DeferralManager.cs
+++ b/src/Uno.UWP/Helpers/DeferralManager.cs
@@ -29,6 +29,8 @@ internal class DeferralManager<T>
 
 	internal event EventHandler? Completed;
 
+	internal bool CompletedSynchronously { get; set; }
+
 	public T GetDeferral()
 	{
 		_deferralsCount++;
@@ -57,7 +59,11 @@ internal class DeferralManager<T>
 	/// the Completed event.
 	/// </summary>
 	/// <returns>A value indicating whether the deferral completed synchronously.</returns>
-	internal bool EventRaiseCompleted() => DeferralCompleted();
+	internal bool EventRaiseCompleted()
+	{
+		CompletedSynchronously = DeferralCompleted();
+		return CompletedSynchronously;
+	}
 
 	internal Task WhenAllCompletedAsync() => _allDeferralsCompletedCompletionSource.Task;
 

--- a/src/Uno.UWP/Helpers/DeferralManager.cs
+++ b/src/Uno.UWP/Helpers/DeferralManager.cs
@@ -56,17 +56,21 @@ internal class DeferralManager<T>
 	/// In case the operation is not deferred, it will also synchronously raise
 	/// the Completed event.
 	/// </summary>
-	internal void EventRaiseCompleted() => DeferralCompleted();
+	/// <returns>A value indicating whether the deferral completed synchronously.</returns>
+	internal bool EventRaiseCompleted() => DeferralCompleted();
 
 	internal Task WhenAllCompletedAsync() => _allDeferralsCompletedCompletionSource.Task;
 
-	private void DeferralCompleted()
+	private bool DeferralCompleted()
 	{
 		_deferralsCount--;
 		if (_deferralsCount <= 0)
 		{
 			Completed?.Invoke(this, EventArgs.Empty);
 			_allDeferralsCompletedCompletionSource.TrySetResult(null);
+			return true;
 		}
+
+		return false;
 	}
 }

--- a/src/Uno.UWP/Helpers/DeferralManager.cs
+++ b/src/Uno.UWP/Helpers/DeferralManager.cs
@@ -1,72 +1,72 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.UI.Core;
 
-namespace Uno.Helpers
+namespace Uno.Helpers;
+
+/// <summary>
+/// Handles completion of deferrals. The deferred action is completed when all deferral objects that were taken have called Complete().
+/// </summary>
+/// <typeparam name="T"></typeparam>
+internal class DeferralManager<T>
 {
+	private readonly Func<DeferralCompletedHandler, T> _deferralFactory;
+	private readonly TaskCompletionSource<object?> _allDeferralsCompletedCompletionSource = new();
+
 	/// <summary>
-	/// Handles completion of deferrals. The deferred action is completed when all deferral objects that were taken have called Complete().
+	/// Start the count at 1, this ensures the deferral won't be completed until all subscribers to the corresponding event have had a
+	/// chance to take out a deferral object.
 	/// </summary>
-	/// <typeparam name="T"></typeparam>
-	internal class DeferralManager<T>
+	private int _deferralsCount = 1;
+
+	public DeferralManager(Func<DeferralCompletedHandler, T> deferralFactory)
 	{
-		private readonly Func<DeferralCompletedHandler, T> _deferralFactory;
-		private readonly TaskCompletionSource<object> _allDeferralsCompletedCompletionSource;
+		_deferralFactory = deferralFactory ?? throw new ArgumentNullException(nameof(deferralFactory));
+	}
 
-		/// <summary>
-		/// Start the count at 1, this ensures the deferral won't be completed until all subscribers to the corresponding event have had a
-		/// chance to take out a deferral object.
-		/// </summary>
-		private int _deferralsCount = 1;
+	internal event EventHandler? Completed;
 
-		public DeferralManager(Func<DeferralCompletedHandler, T> deferralFactory)
+	public T GetDeferral()
+	{
+		_deferralsCount++;
+		var isCompleted = false;
+		return _deferralFactory(OnDeferralCompleted);
+
+		void OnDeferralCompleted()
 		{
-			_deferralFactory = deferralFactory;
-			_allDeferralsCompletedCompletionSource = new TaskCompletionSource<object>();
-		}
-
-		internal event EventHandler Completed;
-
-		public T GetDeferral()
-		{
-			_deferralsCount++;
-			var isCompleted = false;
-			return _deferralFactory(OnDeferralCompleted);
-
-			void OnDeferralCompleted()
-			{
 #if !__WASM__ // Disable check on WASM until threading is supported
-				CoreDispatcher.CheckThreadAccess();
+			CoreDispatcher.CheckThreadAccess();
 #endif
-				if (isCompleted)
-				{
-					throw new InvalidOperationException("Deferral already completed.");
-				}
-
-				isCompleted = true;
-				DeferralCompleted();
-			}
-		}
-
-		/// <summary>
-		/// This marks the deferral as ready for completion.
-		/// Must be called after the related event finished invoking.
-		/// In case the operation is not deferred, it will also synchronously raise
-		/// the Completed event.
-		/// </summary>
-		internal void EventRaiseCompleted() => DeferralCompleted();
-
-		internal Task WhenAllCompletedAsync() => _allDeferralsCompletedCompletionSource.Task;
-
-		private void DeferralCompleted()
-		{
-			_deferralsCount--;
-			if (_deferralsCount <= 0)
+			if (isCompleted)
 			{
-				Completed?.Invoke(this, EventArgs.Empty);
-				_allDeferralsCompletedCompletionSource.TrySetResult(null);
+				throw new InvalidOperationException("Deferral already completed.");
 			}
+
+			isCompleted = true;
+			DeferralCompleted();
+		}
+	}
+
+	/// <summary>
+	/// This marks the deferral as ready for completion.
+	/// Must be called after the related event finished invoking.
+	/// In case the operation is not deferred, it will also synchronously raise
+	/// the Completed event.
+	/// </summary>
+	internal void EventRaiseCompleted() => DeferralCompleted();
+
+	internal Task WhenAllCompletedAsync() => _allDeferralsCompletedCompletionSource.Task;
+
+	private void DeferralCompleted()
+	{
+		_deferralsCount--;
+		if (_deferralsCount <= 0)
+		{
+			Completed?.Invoke(this, EventArgs.Empty);
+			_allDeferralsCompletedCompletionSource.TrySetResult(null);
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Core/Preview/Internal/ISystemNavigationManagerPreviewExtension.skia.cs
+++ b/src/Uno.UWP/UI/Core/Preview/Internal/ISystemNavigationManagerPreviewExtension.skia.cs
@@ -1,0 +1,6 @@
+﻿namespace Uno.UI.Core.Preview;
+
+public interface ISystemNavigationManagerPreviewExtension
+{
+	void RequestNativeAppClose();
+}

--- a/src/Uno.UWP/UI/Core/Preview/Internal/ISystemNavigationManagerPreviewExtension.skia.cs
+++ b/src/Uno.UWP/UI/Core/Preview/Internal/ISystemNavigationManagerPreviewExtension.skia.cs
@@ -1,6 +1,6 @@
 ﻿namespace Uno.UI.Core.Preview;
 
-public interface ISystemNavigationManagerPreviewExtension
+internal interface ISystemNavigationManagerPreviewExtension
 {
 	void RequestNativeAppClose();
 }

--- a/src/Uno.UWP/UI/Core/Preview/SystemNavigationCloseRequestedPreviewEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/Preview/SystemNavigationCloseRequestedPreviewEventArgs.cs
@@ -1,36 +1,22 @@
-﻿#if __MACOS__
+﻿#if __MACOS__ || __SKIA__
 using System;
 using Uno.Helpers;
 using Windows.Foundation;
 
-namespace Windows.UI.Core.Preview
+namespace Windows.UI.Core.Preview;
+
+public partial class SystemNavigationCloseRequestedPreviewEventArgs
 {
-	public partial class SystemNavigationCloseRequestedPreviewEventArgs
+	public SystemNavigationCloseRequestedPreviewEventArgs(Action<SystemNavigationCloseRequestedPreviewEventArgs> complete)
 	{
-		private DeferralManager<Deferral> _deferralManager;
-		private readonly Action<SystemNavigationCloseRequestedPreviewEventArgs> _complete;
-
-		public SystemNavigationCloseRequestedPreviewEventArgs(Action<SystemNavigationCloseRequestedPreviewEventArgs> complete)
-		{
-			_complete = complete;
-		}
-
-		public bool Handled { get; set; }
-
-		internal bool IsDeferred => _deferralManager != null;
-
-		internal void EventRaiseCompleted() => _deferralManager?.EventRaiseCompleted();
-
-		public Deferral GetDeferral()
-		{
-			if (_deferralManager == null)
-			{
-				_deferralManager = new DeferralManager<Deferral>(h => new Deferral(h));
-				_deferralManager.Completed += (s, e) => _complete(this);
-			}
-
-			return _deferralManager.GetDeferral();
-		}		
+		DeferralManager = new(h => new Deferral(h));
+		DeferralManager.Completed += (s, e) => complete?.Invoke(this);
 	}
+
+	public bool Handled { get; set; }
+
+	internal DeferralManager<Deferral> DeferralManager { get; }
+
+	public Deferral GetDeferral() => DeferralManager.GetDeferral();
 }
 #endif

--- a/src/Uno.UWP/UI/Core/Preview/SystemNavigationCloseRequestedPreviewEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/Preview/SystemNavigationCloseRequestedPreviewEventArgs.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Core.Preview;
 
 public partial class SystemNavigationCloseRequestedPreviewEventArgs
 {
-	public SystemNavigationCloseRequestedPreviewEventArgs(Action<SystemNavigationCloseRequestedPreviewEventArgs> complete)
+	internal SystemNavigationCloseRequestedPreviewEventArgs(Action<SystemNavigationCloseRequestedPreviewEventArgs> complete)
 	{
 		DeferralManager = new(h => new Deferral(h));
 		DeferralManager.Completed += (s, e) => complete?.Invoke(this);

--- a/src/Uno.UWP/UI/Core/Preview/SystemNavigationCloseRequestedPreviewEventArgs.others.cs
+++ b/src/Uno.UWP/UI/Core/Preview/SystemNavigationCloseRequestedPreviewEventArgs.others.cs
@@ -1,0 +1,11 @@
+﻿namespace Windows.UI.Core.Preview;
+
+public partial class SystemNavigationCloseRequestedPreviewEventArgs
+{
+	/// <summary>
+	/// Constructor is not public in UWP.
+	/// </summary>
+	private SystemNavigationCloseRequestedPreviewEventArgs()
+	{
+	}
+}

--- a/src/Uno.UWP/UI/Core/Preview/SystemNavigationManagerPreview.cs
+++ b/src/Uno.UWP/UI/Core/Preview/SystemNavigationManagerPreview.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace Windows.UI.Core.Preview;
 
+/// <summary>
+/// Provides a way for an app to respond to system provided close events.
+/// </summary>
 public partial class SystemNavigationManagerPreview
 {
 	private static readonly SystemNavigationManagerPreview _instance = new();
@@ -11,10 +14,17 @@ public partial class SystemNavigationManagerPreview
 
 	partial void InitializePlatform();
 
+	/// <summary>
+	/// Occurs when the user invokes the system button for close (the 'x' button in the corner of the app's title bar).
+	/// </summary>
 	public event EventHandler<SystemNavigationCloseRequestedPreviewEventArgs> CloseRequested;
 
 	internal bool HasConfirmedClose { get; private set; }
 
+	/// <summary>
+	/// Returns the SystemNavigationManagerPreview object associated with the current window.
+	/// </summary>
+	/// <returns>The SystemNavigationManagerPreview object associated with the current window.</returns>
 	public static SystemNavigationManagerPreview GetForCurrentView() => _instance;
 
 	internal bool RequestAppClose()

--- a/src/Uno.UWP/UI/Core/Preview/SystemNavigationManagerPreview.macOS.cs
+++ b/src/Uno.UWP/UI/Core/Preview/SystemNavigationManagerPreview.macOS.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+
+using AppKit;
+
+namespace Windows.UI.Core.Preview;
+
+public partial class SystemNavigationManagerPreview
+{
+	partial void CloseApp()
+    {
+		NSApplication.SharedApplication.KeyWindow.PerformClose(null);
+	}
+}

--- a/src/Uno.UWP/UI/Core/Preview/SystemNavigationManagerPreview.others.cs
+++ b/src/Uno.UWP/UI/Core/Preview/SystemNavigationManagerPreview.others.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+#if !__MACOS__ && !__SKIA__
+
+namespace Windows.UI.Core.Preview;
+
+public partial class SystemNavigationManagerPreview
+{
+	// The constructor is not public in UWP/WinUI
+	private SystemNavigationManagerPreview()
+	{
+	}
+}
+#endif

--- a/src/Uno.UWP/UI/Core/Preview/SystemNavigationManagerPreview.skia.cs
+++ b/src/Uno.UWP/UI/Core/Preview/SystemNavigationManagerPreview.skia.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+
+using Uno.Foundation.Extensibility;
+using Uno.UI.Core.Preview;
+
+namespace Windows.UI.Core.Preview;
+
+public partial class SystemNavigationManagerPreview
+{
+	private ISystemNavigationManagerPreviewExtension? _extension = null;
+
+	partial void InitializePlatform()
+	{
+		if (ApiExtensibility.CreateInstance<ISystemNavigationManagerPreviewExtension>(this, out var extension))
+		{
+			_extension = extension;
+		}
+	}
+
+	partial void CloseApp()
+	{
+		if (_extension == null)
+		{
+			// This platform cannot programmatically close app.
+			return;
+		}
+
+		_extension.RequestNativeAppClose();
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7711 

## PR Type

What kind of change does this PR introduce?

- Feature
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

- `GetDeferral` on `Entered`/`Leaving` background throws.
- Usage of `DeferralManager` is complex in code
- `CoreApplication.Entered/LeavingBackground` events are never raised

## What is the new behavior?

- Does not throw (but does not guarantee the app will wait for deferral completion on some targets.
- Simplified the usage of `DeferralManager` in the codebase.
- `CoreApplication.Entered/LeavingBackground` events are raised along with `Application` counterparts

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
