### PR TITLE
perf: Use `ArrayPool<T>` for `Grid`'s `CellCacheStackVector` inner storage

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
@@ -444,6 +444,9 @@ namespace Windows.UI.Xaml.Controls
 
 			// Cleanup
 			// return hr;
+
+			// Return allocated memory to the pool
+			spanStore.Dispose();
 		}
 
 		// Measure a child of the Grid by taking in consideration the properties of
@@ -1324,6 +1327,9 @@ namespace Windows.UI.Xaml.Controls
 
 				desiredSize.Width = GetDesiredInnerSize(m_pColumns) + combinedColumnSpacing;
 				desiredSize.Height = GetDesiredInnerSize(m_pRows) + combinedRowSpacing;
+
+				// Return memory to the array pool
+				cellCacheVector.Dispose();
 			}
 
 			desiredSize.Width += combinedThickness.Width;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7824

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

Reduces memory allocations during `Grid`'s measure pass.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
