### PR TITLE
fix(reg): Fix wasm external components are not hit testable

### DIFF
--- a/doc/articles/interop/wasm-javascript-3.md
+++ b/doc/articles/interop/wasm-javascript-3.md
@@ -102,11 +102,6 @@ An easy way to achieve this is to add JavaScript code to load the CSS file direc
    
            public FlatpickrView()
            {
-               // XAML behavior: a non-null background is required on an element to be "visible to pointers".
-               // Uno reproduces this behavior, so we must set it here even if we're not using the background.
-               // Not doing this will lead to a `pointer-events: none` CSS style on the control.
-               Background = new SolidColorBrush(Colors.Transparent);
-   
                // Load Flatpickr using JavaScript
                LoadJavaScript();
            }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.wasm.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.wasm.cs
@@ -52,6 +52,20 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 		[TestMethod]
 		[RunsOnUIThread]
+		public async Task When_HTMLElement_ExternalElement_Override_Then_IsHitTestable()
+		{
+			var SUT = new MyCustomComponent();
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForIdle();
+			await TestServices.WindowHelper.WaitFor(() => SUT.IsLoaded);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(HitTestability.Visible, SUT.HitTestVisibility);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
 		public async Task When_HTMLElement_ExternalElement_Override_Twice()
 		{
 			var SUT = new MyLine2();
@@ -99,6 +113,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 	[HtmlElement("p")]
 	public class MyLineOverride : Line
+	{
+
+	}
+
+	[HtmlElement("div")]
+	public class MyCustomComponent : FrameworkElement
 	{
 
 	}

--- a/src/Uno.UI/UI/Xaml/HtmlElementHelper.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/HtmlElementHelper.wasm.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Uno.Core.Comparison;
+using Uno.Foundation.Runtime.WebAssembly.Interop;
+
+namespace Windows.UI.Xaml;
+
+internal static class HtmlElementHelper
+{
+	private static readonly Dictionary<Type, HtmlTag> _cache = new(FastTypeComparer.Default);
+	private static readonly Type _htmlElementAttribute;
+	private static readonly PropertyInfo _htmlElementAttributeTagGetter;
+	private static readonly Assembly _unoUIAssembly = typeof(UIElement).Assembly;
+
+	static HtmlElementHelper()
+	{
+		_htmlElementAttribute = GetUnoUIRuntimeWebAssembly().GetType("Uno.UI.Runtime.WebAssembly.HtmlElementAttribute", true);
+		_htmlElementAttributeTagGetter = _htmlElementAttribute.GetProperty("Tag");
+	}
+
+	private static Assembly GetUnoUIRuntimeWebAssembly()
+	{
+		const string UnoUIRuntimeWebAssemblyName = "Uno.UI.Runtime.WebAssembly";
+
+		if (PlatformHelper.IsNetCore)
+		{
+			// .NET Core fails to load assemblies property because of ALC issues: https://github.com/dotnet/runtime/issues/44269
+			return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == UnoUIRuntimeWebAssemblyName)
+				?? throw new InvalidOperationException($"Unable to find {UnoUIRuntimeWebAssemblyName} in the loaded assemblies");
+		}
+		else
+		{
+			return Assembly.Load(UnoUIRuntimeWebAssemblyName);
+		}
+	}
+
+	internal static HtmlTag GetHtmlTag(Type type, string defaultHtmlTag)
+	{
+		if (type.Assembly == _unoUIAssembly)
+		{
+			return new HtmlTag(defaultHtmlTag, IsExternallyDefined: false);
+		}
+
+		if (_cache.TryGetValue(type, out var tag))
+		{
+			return tag;
+		}
+
+		tag = type.GetCustomAttribute(_htmlElementAttribute, true) is Attribute attr
+			&& _htmlElementAttributeTagGetter.GetValue(attr, Array.Empty<object>()) is string tagName
+			? new HtmlTag(tagName, IsExternallyDefined: true)
+			: new HtmlTag(defaultHtmlTag, IsExternallyDefined: false);
+
+		_cache[type] = tag;
+
+		return tag;
+	}
+
+	/// <summary>
+	/// Info about the tag to use in the DOM for a UI element.
+	/// </summary>
+	/// <param name="Name">The name of the tag used in the DOM</param>
+	/// <param name="IsExternallyDefined">
+	/// Indicates if this tag is not the default one that has been defined in the Uno assembly
+	/// (using the HtmlElementAttribute).
+	/// </param>
+	internal record struct HtmlTag(string Name, bool IsExternallyDefined);
+}

--- a/src/Uno.UI/UI/Xaml/HtmlElementHelper.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/HtmlElementHelper.wasm.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -17,7 +19,7 @@ internal static class HtmlElementHelper
 	static HtmlElementHelper()
 	{
 		_htmlElementAttribute = GetUnoUIRuntimeWebAssembly().GetType("Uno.UI.Runtime.WebAssembly.HtmlElementAttribute", true);
-		_htmlElementAttributeTagGetter = _htmlElementAttribute.GetProperty("Tag");
+		_htmlElementAttributeTagGetter = _htmlElementAttribute.GetProperty("Tag") ?? throw new InvalidOperationException("Failed to resolve Tag property on HtmlElementAttribute.");
 	}
 
 	private static Assembly GetUnoUIRuntimeWebAssembly()

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -329,14 +329,20 @@ public partial class UIElement : DependencyObject
 			return HitTestability.Collapsed;
 		}
 
-		// If we're not hit (usually means we don't have a Background/Fill), we're invisible. Our children will be visible or not, depending on their state.
-		if (!IsViewHit())
+		// Special case for external html element, we are always considering them as hit testable.
+		if (HtmlTagIsExternallyDefined && !FeatureConfiguration.FrameworkElement.UseLegacyHitTest)
 		{
-			return HitTestability.Invisible;
+			return HitTestability.Visible;
 		}
 
-		// If we're not collapsed or invisible, we can be targeted by hit-testing. This means that we can be the source of pointer events.
-		return HitTestability.Visible;
+		// If we're not collapsed or invisible, we can be targeted by hit-testing. This means that we can be the source of pointer events.		
+		if (IsViewHit())
+		{
+			return HitTestability.Visible; 
+		}
+
+		// If we're not hit (usually means we don't have a Background/Fill), we're invisible. Our children will be visible or not, depending on their state.
+		return HitTestability.Invisible;
 	}
 
 	private protected virtual void OnHitTestVisibilityChanged(HitTestability oldValue, HitTestability newValue)


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/7848

## Bugfix
Regression: [WASM] External components does not allow pointers interaction

## What is the current behavior?
Since https://github.com/unoplatform/uno/pull/7571, setting the `Background` on `FrameworkElement` is no longer sufficient for an element to be hit testable. This breaks HTML external components which was (wrongly) relying on this to be hit testable (as stated in doc [here]( https://github.com/unoplatform/uno/blob/f8bd42650d69a41b4360f3e533e21c7e789984ae/doc/articles/interop/wasm-javascript-3.md?plain=1#L105)) and has no other way to enable pointers.

## What is the new behavior?
WASM external component are now always considered as hit testable.

## PR Checklist
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~, cf below
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
```
                                  *******************
                                  * BREAKING CHANGE *
                                  *******************
```

This was actually introduced by https://github.com/unoplatform/uno/pull/7571

Setting the `Background` of a `FrameworkElement` is no longer a valid way to force element to be hit testable. You can restore previous behavior by setting config flag `Uno.UI.FeatureConfiguration.FrameworkElement.UseLegacyHitTest` to `true`