### PR TITLE
fix(wasm): Textbox VisualState udpate

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -266,13 +266,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_IsEnabled_Set()
 		{
-			var color = new SolidColorBrush(Colors.Red);
+			var foregroundColor = new SolidColorBrush(Colors.Red);
+			var disabledColor = new SolidColorBrush(Colors.Blue);
 
 			var textbox = new TextBox
 			{
 				Text = "Original Text",
-				IsEnabled = false,
-				Foreground = color
+				Foreground = foregroundColor,
+				Style = TestsResourceHelper.GetResource<Style>("MaterialOutlinedTextBoxStyle"),
+				IsEnabled = false
 			};
 
 			var stackPanel = new StackPanel()
@@ -280,24 +282,22 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Children = { textbox }
 			};
 
+
 			WindowHelper.WindowContent = stackPanel;
 			await WindowHelper.WaitForLoaded(textbox);
 
-			textbox.Focus(FocusState.Programmatic);
+
+			var contentPresenter = (ScrollViewer)textbox.FindName("ContentElement");
 
 			await WindowHelper.WaitForIdle();
 
 			Assert.IsFalse(textbox.IsEnabled);
-
-#if !__SKIA__
-			// Skia disabled VisualState does not update the ForeGround
-			Assert.AreNotEqual(textbox.Foreground, color);
-#endif
+			Assert.AreEqual(contentPresenter.Foreground, disabledColor);
 
 			textbox.IsEnabled = true;
 
 			Assert.IsTrue(textbox.IsEnabled);
-			Assert.AreEqual(textbox.Foreground, color);
+			Assert.AreEqual(contentPresenter.Foreground, foregroundColor);
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -7,6 +7,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
 using Windows.UI.Xaml;
+using Windows.UI;
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -265,7 +266,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_IsEnabled_Set()
 		{
-			var color = SolidColorBrushHelper.Red;
+			var color = new SolidColorBrush(Colors.Red);
 
 			var textbox = new TextBox
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -288,7 +288,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			Assert.IsFalse(textbox.IsEnabled);
+
+#if !__SKIA__
+			// Skia disabled VisualState does not update the ForeGround
 			Assert.AreNotEqual(textbox.Foreground, color);
+#endif
 
 			textbox.IsEnabled = true;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -286,7 +286,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WindowHelper.WaitForIdle();
 
+			Assert.IsFalse(textbox.IsEnabled);
+			Assert.AreNotEqual(textbox.Foreground, color);
+
 			textbox.IsEnabled = true;
+
 			Assert.IsTrue(textbox.IsEnabled);
 			Assert.AreEqual(textbox.Foreground, color);
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -261,5 +261,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			textBox.Focus(FocusState.Programmatic);
 			Assert.AreEqual(3, textBox.SelectionStart);
 		}
+
+		[TestMethod]
+		public async Task When_IsEnabled_Set()
+		{
+			var textbox = new TextBox
+			{
+				Text = "Original Text",
+				IsEnabled = false
+			};
+
+			var stackPanel = new StackPanel()
+			{
+				Children = { textbox }
+			};
+
+			WindowHelper.WindowContent = stackPanel;
+			await WindowHelper.WaitForLoaded(textbox);
+
+			textbox.Focus(FocusState.Programmatic);
+
+			await WindowHelper.WaitForIdle();
+
+			textbox.IsEnabled = true;
+			Assert.IsTrue(textbox.IsEnabled);
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -265,10 +265,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_IsEnabled_Set()
 		{
+			var color = SolidColorBrushHelper.Red;
+
 			var textbox = new TextBox
 			{
 				Text = "Original Text",
-				IsEnabled = false
+				IsEnabled = false,
+				Foreground = color
 			};
 
 			var stackPanel = new StackPanel()
@@ -285,6 +288,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			textbox.IsEnabled = true;
 			Assert.IsTrue(textbox.IsEnabled);
+			Assert.AreEqual(textbox.Foreground, color);
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TestsResources.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TestsResources.xaml
@@ -308,4 +308,224 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+
+	<!-- Material TextBox -->
+
+	<x:String x:Key="ClearGlyphPathData">M10.661012,7.5689991L7.5990001,10.650999 12.939089,15.997999 7.5990001,21.336999 10.661012,24.405 16.007082,19.065 21.369997,24.405 24.430058,21.336999 24.429081,21.336 19.088991,15.998999 24.429081,10.662001 21.345095,7.5819996 16.007082,12.919001z M15.997072,0C24.828983,0 31.994999,7.1770013 31.994999,15.999998 31.994999,24.826997 24.828007,31.999999 15.997072,31.999999 7.1569835,31.999999 1.5270052E-07,24.826997 0,15.999998 1.5270052E-07,7.1799997 7.1569835,0 15.997072,0z</x:String>
+
+	<Style x:Name="DeleteButtonStyle"
+		   TargetType="Button">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Button">
+					<Grid x:Name="ButtonLayoutGrid"
+						  Background="Transparent">
+
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="PointerOver" />
+								<VisualState x:Name="Pressed" />
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="ButtonLayoutGrid.Opacity"
+												Value="0" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<Path x:Name="GlyphElement"
+							  Data="{StaticResource ClearGlyphPathData}"
+							  Fill="{StaticResource TextBoxIconColorBrush}"
+							  VerticalAlignment="Center"
+							  HorizontalAlignment="Center"
+							  Stretch="Uniform"
+							  Width="16"
+							  Height="16"
+							  AutomationProperties.AccessibilityView="Raw" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
+
+	<Style x:Key="MaterialOutlinedTextBoxStyle"
+		   TargetType="TextBox">
+		<Setter Property="Background"
+				Value="Transparent" />
+		<Setter Property="Foreground"
+				Value="#000000" />
+		<Setter Property="PlaceholderForeground"
+				Value="#DEFFFFFF" />
+		<Setter Property="BorderThickness"
+				Value="1" />
+		<Setter Property="BorderBrush"
+				Value="#DEFFFFFF" />
+		<Setter Property="CornerRadius"
+				Value="4" />
+
+		<Setter Property="HorizontalContentAlignment"
+				Value="Left" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Center" />
+		<Setter Property="Padding"
+				Value="12,16" />
+		<Setter Property="MinHeight"
+				Value="50" />
+
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="TextBox">
+					<Grid x:Name="Root"
+						  Background="{TemplateBinding Background}"
+						  BorderBrush="{TemplateBinding BorderBrush}"
+						  BorderThickness="{TemplateBinding BorderThickness}"
+						  CornerRadius="{TemplateBinding CornerRadius}"
+						  Padding="{TemplateBinding Padding}">
+
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="PointerOver" />
+								<VisualState x:Name="Pressed" />
+
+								<VisualState x:Name="Disabled">
+									<VisualState.Setters>
+										<Setter Target="Root.BorderBrush"
+												Value="#000000" />
+
+										<!-- Important: There is a Test validating this value -->
+										<Setter Target="ContentElement.Foreground"
+												Value="#0000FF" />
+										<!-- In this case the opacity is not applied to the brush -->
+										<Setter Target="ContentElement.Opacity"
+												Value="0.38" />
+										<Setter Target="PlaceholderElement.Foreground"
+												Value="#000000" />
+									</VisualState.Setters>
+								</VisualState>
+
+								<VisualState x:Name="Focused">
+									<VisualState.Setters>
+										<Setter Target="Root.BorderBrush"
+												Value="#5B4CF5" />
+										<Setter Target="PlaceholderElement.Foreground"
+												Value="#5B4CF5" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="ButtonStates">
+								<VisualState x:Name="ButtonVisible">
+									<VisualState.Setters>
+										<Setter Target="DeleteButton.Visibility"
+												Value="Visible" />
+									</VisualState.Setters>
+								</VisualState>
+								<VisualState x:Name="ButtonCollapsed" />
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="HeaderStates">
+								<VisualState x:Name="NotEmpty">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
+														 Storyboard.TargetProperty="TranslateY"
+														 Duration="0:0:0.25"
+														 To="-11" >
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseInOut" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+
+										<!-- ContentElement TranslateY value changing depending if there is a PlaceholderText or not -->
+										<DoubleAnimation Storyboard.TargetName="ContentElement_CompositeTransform"
+														 Storyboard.TargetProperty="TranslateY"
+														 Duration="0:0:0.25">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseInOut" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+
+										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
+														 Storyboard.TargetProperty="ScaleX"
+														 Duration="0:0:0.25"
+														 To="0.7">
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseInOut" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+
+										<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
+														 Storyboard.TargetProperty="ScaleY"
+														 Duration="0:0:0.25"
+														 To="0.7" >
+											<DoubleAnimation.EasingFunction>
+												<CubicEase EasingMode="EaseInOut" />
+											</DoubleAnimation.EasingFunction>
+										</DoubleAnimation>
+									</Storyboard>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="Auto" />
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+
+						<ContentPresenter x:Name="IconPresenter"
+										  HorizontalAlignment="Center"
+										  MaxHeight="34"
+										  MaxWidth="34"
+										  MinWidth="25"
+										  Margin="0,0,8,0"
+										  VerticalAlignment="Bottom"
+										  Visibility="Visible" />
+
+						<ScrollViewer x:Name="ContentElement"
+									  Grid.Column="1"
+									  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+									  HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+									  IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+									  IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+									  IsTabStop="False"
+									  IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+									  VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+									  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+									  VerticalAlignment="Bottom"
+									  ZoomMode="Disabled"
+									  AutomationProperties.AccessibilityView="Raw">
+							<ScrollViewer.RenderTransform>
+								<CompositeTransform x:Name="ContentElement_CompositeTransform" />
+							</ScrollViewer.RenderTransform>
+						</ScrollViewer>
+
+						<TextBlock x:Name="PlaceholderElement"
+								   Grid.Column="1"
+								   Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}}"
+								   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								   IsHitTestVisible="False"
+								   RenderTransformOrigin="0,0.5"
+								   Text="{TemplateBinding PlaceholderText}"
+								   TextAlignment="{TemplateBinding TextAlignment}"
+								   TextWrapping="{TemplateBinding TextWrapping}"
+								   VerticalAlignment="Top">
+							<TextBlock.RenderTransform>
+								<CompositeTransform x:Name="PlaceholderElement_CompositeTransform" />
+							</TextBlock.RenderTransform>
+						</TextBlock>
+
+						<Button x:Name="DeleteButton"
+								Grid.Column="2"
+								Foreground="{TemplateBinding BorderBrush}"
+								IsTabStop="False"
+								Style="{StaticResource DeleteButtonStyle}"
+								VerticalAlignment="Bottom"
+								Visibility="Collapsed"
+								AutomationProperties.AccessibilityView="Raw" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>
 </ResourceDictionary>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -386,7 +386,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private protected override void OnIsEnabledChanged(IsEnabledChangedEventArgs e)
+		partial void OnIsEnabledChangedPartial(IsEnabledChangedEventArgs e)
 		{
 			if (_textBoxView != null)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -969,6 +969,15 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void UpdateKeyboardThemePartial();
 
+		private protected override void OnIsEnabledChanged(IsEnabledChangedEventArgs e)
+		{
+			base.OnIsEnabledChanged(e);
+			UpdateVisualState();
+			OnIsEnabledChangedPartial(e);
+		}
+
+		partial void OnIsEnabledChangedPartial(IsEnabledChangedEventArgs e);
+
 		private bool ShouldFocusOnPointerPressed(PointerRoutedEventArgs args) =>
 			// For mouse and pen, the TextBox should focus on pointer press, for other input types on release
 			args.Pointer.PointerDeviceType != PointerDeviceType.Touch;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -108,7 +108,7 @@ namespace Windows.UI.Xaml.Controls
 		private protected override void OnIsEnabledChanged(IsEnabledChangedEventArgs e)
 		{
 			base.OnIsEnabledChanged(e);
-
+			UpdateVisualState();
 			ApplyEnabled(e.NewValue);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -105,10 +105,8 @@ namespace Windows.UI.Xaml.Controls
 			_textBoxView?.SetAttribute("spellcheck", IsSpellCheckEnabled.ToString());
 		}
 
-		private protected override void OnIsEnabledChanged(IsEnabledChangedEventArgs e)
+		partial void OnIsEnabledChangedPartial(IsEnabledChangedEventArgs e)
 		{
-			base.OnIsEnabledChanged(e);
-			UpdateVisualState();
 			ApplyEnabled(e.NewValue);
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7791 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Changing the `IsEnabled` property is not refreshing the VisualState

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
