### PR TITLE
docs: Add more details regarding the Runtime Tests filter option

### DIFF
--- a/doc/articles/uno-development/creating-runtime-tests.md
+++ b/doc/articles/uno-development/creating-runtime-tests.md
@@ -12,7 +12,7 @@ Since the Uno.UI.RuntimeTests tests run in the platform environment using the re
 
 1. Build and launch the SamplesApp, following [the instructions here](working-with-the-samples-apps.md). Note: if you're testing a mobile platform, it's recommended to run on a tablet in landscape mode. On a phone-sized layout, a few tests will fail because they don't have enough space to measure properly.
 2. From the sample menu, navigate to 'Unit Tests' > 'Unit Tests Runner'.
-3. (Optional) Add a filter string; only tests matching the filter will be run. Otherwise, all tests will run.
+3. (Optional) Add a filter string in the text input control at the top of the page (for example the name or part of the name of your test method); only tests matching the filter will be run. Otherwise, all tests will run.
 4. Press the 'Run' button. Tests will run in sequence, and the results will be shown.
 
 ## Authoring tests


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

The documentation regarding the Runtime Tests filter option is not quite clear


## What is the new behavior?

Added more details regarding the Runtime Tests filter option


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

