### PR TITLE
fix: Disposing WASM stream twice should not fail

### DIFF
--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -4023,8 +4023,10 @@ var Uno;
                 }
                 static async closeAsync(streamId) {
                     var instance = NativeFileWriteStream._streamMap.get(streamId);
-                    await instance._stream.close();
-                    NativeFileWriteStream._streamMap.delete(streamId);
+                    if (instance) {
+                        await instance._stream.close();
+                        NativeFileWriteStream._streamMap.delete(streamId);
+                    }
                     return "";
                 }
                 static async truncateAsync(streamId, length) {

--- a/src/Uno.UI/ts/Windows/Storage/Streams/NativeFileWriteStream.ts
+++ b/src/Uno.UI/ts/Windows/Storage/Streams/NativeFileWriteStream.ts
@@ -68,8 +68,11 @@
 
 		public static async closeAsync(streamId: string): Promise<string> {
 			var instance = NativeFileWriteStream._streamMap.get(streamId);
-			await instance._stream.close();
-			NativeFileWriteStream._streamMap.delete(streamId);
+			if (instance)
+			{
+				await instance._stream.close();
+				NativeFileWriteStream._streamMap.delete(streamId);
+			}
 			return "";
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7935

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?



## What is the new behavior?



## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.