### PR TITLE
feat: Support more `ComboBox` visual states

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -127,7 +127,7 @@ namespace Windows.UI.Xaml.Controls
 					}
 				};
 
-				UpdateCommonStates();
+				UpdateVisualState(true);
 			}
 		}
 
@@ -310,6 +310,38 @@ namespace Windows.UI.Xaml.Controls
 			UpdateContentPresenter();
 		}
 
+		protected override void OnPointerEntered(PointerRoutedEventArgs e)
+		{
+			base.OnPointerEntered(e);
+			IsPointerOver = true;
+
+			UpdateVisualState();
+		}
+
+		protected override void OnPointerExited(PointerRoutedEventArgs e)
+		{
+			base.OnPointerEntered(e);
+			IsPointerOver = false;
+
+			UpdateVisualState();
+		}
+
+		protected override void OnPointerCanceled(PointerRoutedEventArgs e)
+		{
+			base.OnPointerCanceled(e);
+			IsPointerOver = false;
+
+			UpdateVisualState();
+		}
+
+		protected override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+		{
+			base.OnPointerCaptureLost(e);
+
+			IsPointerOver = false;
+			UpdateVisualState();
+		}
+
 		internal override void OnItemClicked(int clickedIndex)
 		{
 			base.OnItemClicked(clickedIndex);
@@ -424,7 +456,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnIsEnabledChanged(e);
 
-			UpdateCommonStates();
+			UpdateVisualState(true);
 		}
 
 		partial void OnIsDropDownOpenChangedPartial(bool oldIsDropDownOpen, bool newIsDropDownOpen)
@@ -467,6 +499,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnPointerPressed(args);
 
+			UpdateVisualState(true);
 			// On UWP ComboBox does handle the pressed event ... but does not capture it!
 			args.Handled = true;
 		}
@@ -477,6 +510,8 @@ namespace Windows.UI.Xaml.Controls
 
 			Focus(FocusState.Programmatic);
 			IsDropDownOpen = true;
+
+			UpdateVisualState(true);
 
 			// On UWP ComboBox does handle the released event.
 			args.Handled = true;
@@ -603,12 +638,6 @@ namespace Windows.UI.Xaml.Controls
 			VisualStateManager.GoToState(this, state, true);
 		}
 
-		private void UpdateCommonStates()
-		{
-			var state = IsEnabled ? "Normal" : "Disabled";
-			VisualStateManager.GoToState(this, state, true);
-		}
-
 		protected override AutomationPeer OnCreateAutomationPeer()
 		{
 			return new ComboBoxAutomationPeer(this);
@@ -620,9 +649,58 @@ namespace Windows.UI.Xaml.Controls
 
 		private protected override void ChangeVisualState(bool useTransitions)
 		{
-			if (FocusState != FocusState.Unfocused && IsEnabled)
+			if (!IsEnabled)
 			{
-				if (FocusState == FocusState.Pointer)
+				GoToState(useTransitions, "Disabled");
+			}
+			else if (IsDropDownOpen)
+			{
+				GoToState(useTransitions, "Highlighted");
+			}
+			else if (IsPointerPressed)
+			{
+				GoToState(useTransitions, "Pressed");
+			}
+			else if (IsPointerOver)
+			{
+				GoToState(useTransitions, "PointerOver");
+			}
+			else
+			{
+				GoToState(useTransitions, "Normal");
+			}
+
+			// FocusStates VisualStateGroup.
+			if (!IsEnabled)
+			{
+				GoToState(useTransitions, "Unfocused");
+			}
+			else if (IsDropDownOpen)
+			{
+				GoToState(useTransitions, "FocusedDropDown");
+			}
+			else
+			{
+				var focusVisualState = FocusState switch
+				{
+					FocusState.Unfocused => "Unfocused",
+					FocusState.Pointer => "PointerFocused",
+					FocusState.Keyboard => IsPointerPressed ? "FocusedPressed" : "Focused",
+					FocusState.Programmatic => throw new NotImplementedException(),
+					_ => "Unfocused"
+				};
+				GoToState(useTransitions, focusVisualState);
+				var focusState = FocusState;
+
+				if (focusState == FocusState.Unfocused)
+				{
+					GoToState(useTransitions, "Unfocused");
+				}
+				else if (IsPointerPressed)
+				{
+					GoToState(useTransitions, "FocusedPressed");
+				}
+				else if (focusState == FocusState.Pointer)
 				{
 					GoToState(useTransitions, "PointerFocused");
 				}
@@ -630,10 +708,6 @@ namespace Windows.UI.Xaml.Controls
 				{
 					GoToState(useTransitions, "Focused");
 				}
-			}
-			else
-			{
-				GoToState(useTransitions, "Unfocused");
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -313,7 +313,6 @@ namespace Windows.UI.Xaml.Controls
 		protected override void OnPointerEntered(PointerRoutedEventArgs e)
 		{
 			base.OnPointerEntered(e);
-			IsPointerOver = true;
 
 			UpdateVisualState();
 		}
@@ -321,7 +320,6 @@ namespace Windows.UI.Xaml.Controls
 		protected override void OnPointerExited(PointerRoutedEventArgs e)
 		{
 			base.OnPointerEntered(e);
-			IsPointerOver = false;
 
 			UpdateVisualState();
 		}
@@ -329,7 +327,6 @@ namespace Windows.UI.Xaml.Controls
 		protected override void OnPointerCanceled(PointerRoutedEventArgs e)
 		{
 			base.OnPointerCanceled(e);
-			IsPointerOver = false;
 
 			UpdateVisualState();
 		}
@@ -338,7 +335,6 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnPointerCaptureLost(e);
 
-			IsPointerOver = false;
 			UpdateVisualState();
 		}
 
@@ -493,6 +489,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			UpdateDropDownState();
+			ChangeVisualState(true);
 		}
 
 		protected override void OnPointerPressed(PointerRoutedEventArgs args)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7651 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Many visual states of `ComboBox` are not supported


## What is the new behavior?

Add support for supportable visual states (`IsEditable` and related not supported as features yet, so those are missing for now)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
