### PR TITLE
fix(reg): Restore reflection extension support for fields

### DIFF
--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Reflection/DefaultReflectionExtensions.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Reflection/DefaultReflectionExtensions.cs
@@ -268,7 +268,7 @@ namespace Uno.Reflection
 				}
 				else
 				{
-#if false // !WINDOWS_PHONE && !NETFX_CORE && !HAS_CRIPPLEDREFLECTION
+#if !HAS_CRIPPLEDREFLECTION
 					return new FieldDescriptor(fieldInfo);
 #else
                     return null;

--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Reflection/FieldDescriptor.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Reflection/FieldDescriptor.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 // ******************************************************************
-#if false //!HAS_CRIPPLEDREFLECTION
+#if !HAS_CRIPPLEDREFLECTION
 using System;
 using System.Reflection;
 using System.Linq;
@@ -71,7 +71,8 @@ namespace Uno.Reflection
 		/// </remarks>
 		public static Action<object, object> ToCompiledSetValue(RuntimeTypeHandle typeHandle, RuntimeFieldHandle fieldHandle, bool strict)
         {
-            var fieldInfo = FieldInfo.GetFieldFromHandle(fieldHandle, typeHandle);
+#if NET6_0_OR_GREATER
+			var fieldInfo = FieldInfo.GetFieldFromHandle(fieldHandle, typeHandle);
 
             if (fieldInfo.IsStatic || fieldInfo.DeclaringType.IsValueType)
             {
@@ -110,7 +111,10 @@ namespace Uno.Reflection
             il.Emit(OpCodes.Ret);
 
             return method.CreateDelegate(typeof(Action<object, object>)) as Action<object, object>;
-        }
+#else
+			throw new NotSupportedException($"ToCompiledSetValue is not supported on this platform");
+#endif
+		}
 
 		/// <summary>
 		/// Creates a compiled method that will get the value of a field 
@@ -144,6 +148,7 @@ namespace Uno.Reflection
 		/// </remarks>
 		public static Func<object, object> ToCompiledGetValue(RuntimeTypeHandle typeHandle, RuntimeFieldHandle fieldHandle, bool strict)
         {
+#if NET6_0_OR_GREATER
             var fieldInfo = FieldInfo.GetFieldFromHandle(fieldHandle, typeHandle);
 
             if (fieldInfo.IsStatic || fieldInfo.DeclaringType.IsValueType)
@@ -177,7 +182,10 @@ namespace Uno.Reflection
             il.Emit(OpCodes.Ret);
 
             return method.CreateDelegate(typeof(Func<object, object>)) as Func<object, object>;
-        }
-    }
+#else
+			throw new NotSupportedException($"ToCompiledSetValue is not supported on this platform");
+#endif
+		}
+	}
 }
 #endif


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes invalid configuration for fields reflection: 

```
Failed to apply binding to property [DependencyPropertyDetails(TextAlignment)] on [Windows.UI.Xaml.Controls.TextBlock] (Not Supported)
dotnet.js:2310 System.ArgumentException: Not Supported
dotnet.js:2310    at Uno.Reflection.DefaultReflectionExtensions.GetDescriptor(MemberInfo mi) in C:\a\1\s\src\Uno.Foundation\Uno.Core.Extensions\Uno.Core.Extensions.Compatibility\Reflection\DefaultReflectionExtensions.cs:line 198
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
